### PR TITLE
fix(backend): scope GET /companion/org/:id to the caller's org

### DIFF
--- a/apps/backend/src/controllers/app/companion.controller.ts
+++ b/apps/backend/src/controllers/app/companion.controller.ts
@@ -189,6 +189,37 @@ export const CompanionController = {
     }
   },
 
+  getCompanionByIdPMS: async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+
+      if (!requireParam(res, id, "Companion ID is required.")) {
+        return;
+      }
+
+      const organisationId = resolveVerifiedOrganisationId(req);
+      if (!organisationId) {
+        return res
+          .status(400)
+          .json({ message: "Organisation context is required." });
+      }
+
+      const result = await CompanionService.getByIdForOrg(id, organisationId);
+      if (!result) {
+        return res.status(404).json({ message: "Companion not found." });
+      }
+
+      return res.status(200).json(result.response);
+    } catch (error) {
+      return handleCompanionError(
+        res,
+        error,
+        "Failed to fetch companion",
+        "Unable to fetch companion.",
+      );
+    }
+  },
+
   updateCompanion: async (req: Request, res: Response) => {
     try {
       const { id } = req.params;

--- a/apps/backend/src/routers/companion.router.ts
+++ b/apps/backend/src/routers/companion.router.ts
@@ -60,7 +60,13 @@ router.post(
 );
 
 // Get companion by id (PMS)
-router.get("/org/:id", requireWebAuth, CompanionController.getCompanionById);
+router.get(
+  "/org/:id",
+  requireWebAuth,
+  withOrgPermissions(),
+  requirePermission("companions:view:any"),
+  CompanionController.getCompanionByIdPMS,
+);
 
 // Update companion (PMS)
 router.put(

--- a/apps/backend/src/services/companion.service.ts
+++ b/apps/backend/src/services/companion.service.ts
@@ -555,6 +555,30 @@ export const CompanionService = {
     return { response: toFHIRFromPrisma(doc) };
   },
 
+  async getByIdForOrg(id: string, organisationId: string) {
+    if (!id || typeof id !== "string") return null;
+
+    const org = organisationId?.trim();
+    if (!org) {
+      throw new CompanionServiceError("Organisation is required.", 400);
+    }
+
+    // Scoped with a relation filter rather than a bare id lookup: `Patient` rows
+    // are not org-scoped in the schema, so `getById` would return any tenant's
+    // companion. Requiring an ACTIVE link keeps the read to the practice's own.
+    const doc = await prisma.patient.findFirst({
+      where: {
+        id,
+        organisations: {
+          some: { organisationId: org, status: "ACTIVE" },
+        },
+      },
+    });
+    if (!doc) return null;
+
+    return { response: toFHIRFromPrisma(doc) };
+  },
+
   /**
    * Companion name search, scoped to one organisation.
    *

--- a/apps/backend/test/controllers/companion.controller.test.ts
+++ b/apps/backend/test/controllers/companion.controller.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../src/services/companion.service", () => {
     CompanionService: {
       create: jest.fn(),
       getById: jest.fn(),
+      getByIdForOrg: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
       getByName: jest.fn(),
@@ -330,6 +331,67 @@ describe("CompanionController", () => {
         new Error("Test error"),
       );
       await CompanionController.getCompanionById(req, res);
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("getCompanionByIdPMS", () => {
+    // The route sits behind `withOrgPermissions`, which supplies the scope.
+    // Without an organisation the read would return any tenant's companion,
+    // because `Patient` rows are not org-scoped in the schema.
+    beforeEach(() => {
+      (req as { organisationId?: string }).organisationId = "org-1";
+    });
+
+    it("should return 400 if id is missing", async () => {
+      await CompanionController.getCompanionByIdPMS(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(CompanionService.getByIdForOrg).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when no organisation context is present", async () => {
+      req.params.id = "c1";
+      (req as { organisationId?: string }).organisationId = undefined;
+
+      await CompanionController.getCompanionByIdPMS(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(CompanionService.getByIdForOrg).not.toHaveBeenCalled();
+    });
+
+    it("should return 404 when the id is not in the caller's organisation", async () => {
+      req.params.id = "c1";
+      (CompanionService.getByIdForOrg as jest.Mock).mockResolvedValue(null);
+
+      await CompanionController.getCompanionByIdPMS(req, res);
+
+      expect(CompanionService.getByIdForOrg).toHaveBeenCalledWith(
+        "c1",
+        "org-1",
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("should return 200 on success", async () => {
+      req.params.id = "c1";
+      (CompanionService.getByIdForOrg as jest.Mock).mockResolvedValue({
+        response: "data",
+      });
+
+      await CompanionController.getCompanionByIdPMS(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith("data");
+    });
+
+    it("should handle errors", async () => {
+      req.params.id = "c1";
+      (CompanionService.getByIdForOrg as jest.Mock).mockRejectedValue(
+        new Error("Test error"),
+      );
+
+      await CompanionController.getCompanionByIdPMS(req, res);
+
       expect(res.status).toHaveBeenCalledWith(500);
     });
   });

--- a/apps/backend/test/routers/companion.router.test.ts
+++ b/apps/backend/test/routers/companion.router.test.ts
@@ -10,6 +10,7 @@ const requireCompanionPermission = jest.fn();
 const CompanionController = {
   createCompanionMobile: jest.fn(),
   getCompanionById: jest.fn(),
+  getCompanionByIdPMS: jest.fn(),
   updateCompanion: jest.fn(),
   deleteCompanion: jest.fn(),
   getProfileUploadUrl: jest.fn(),
@@ -62,7 +63,9 @@ describe("companion.router", () => {
 
     expect(route?.stack.map((layer) => layer.handle)).toEqual([
       requireWebAuth,
-      CompanionController.getCompanionById,
+      withOrgPermissionsMiddleware,
+      requirePermissionMiddleware,
+      CompanionController.getCompanionByIdPMS,
     ]);
   });
 

--- a/apps/backend/test/services/companion.service.test.ts
+++ b/apps/backend/test/services/companion.service.test.ts
@@ -15,6 +15,7 @@ jest.mock("src/config/prisma", () => ({
       create: jest.fn(),
       findMany: jest.fn(),
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
       deleteMany: jest.fn(),
     },
@@ -88,6 +89,7 @@ const mockedPrisma = prisma as unknown as {
     create: jest.Mock;
     findMany: jest.Mock;
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     update: jest.Mock;
     deleteMany: jest.Mock;
   };
@@ -524,6 +526,49 @@ describe("CompanionService", () => {
     expect(mockedPrisma.patient.findUnique).toHaveBeenCalledWith({
       where: { id: "patient-1" },
     });
+    expect(result?.response).toMatchObject({ id: "patient-1" });
+  });
+
+  it("returns null for an invalid id in the org-scoped read", async () => {
+    await expect(
+      CompanionService.getByIdForOrg("", "org-1"),
+    ).resolves.toBeNull();
+  });
+
+  // `Patient` rows are not org-scoped in the schema, so a read with no
+  // organisation would return any tenant's companion.
+  it("rejects an org-scoped read with no organisation context", async () => {
+    await expect(
+      CompanionService.getByIdForOrg("patient-1", "  "),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        message: "Organisation is required.",
+        statusCode: 400,
+      }),
+    );
+  });
+
+  it("returns null when the id is not linked to the organisation", async () => {
+    mockedPrisma.patient.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      CompanionService.getByIdForOrg("patient-1", "org-1"),
+    ).resolves.toBeNull();
+    expect(mockedPrisma.patient.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "patient-1",
+        organisations: {
+          some: { organisationId: "org-1", status: "ACTIVE" },
+        },
+      },
+    });
+  });
+
+  it("returns a mapped companion when the id is linked to the organisation", async () => {
+    mockedPrisma.patient.findFirst.mockResolvedValueOnce(createdPatient);
+
+    const result = await CompanionService.getByIdForOrg("patient-1", "org-1");
+
     expect(result?.response).toMatchObject({ id: "patient-1" });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`GET /companion/org/:id` ran only `requireWebAuth` and then called `CompanionService.getById`, a bare id lookup. Because `Patient` rows are not organisation-scoped in the schema, any authenticated staff member could read a companion belonging to another practice by supplying or enumerating its id. There was no check that the companion belonged to the caller's organisation.

## What is the new behavior?

The route is now scoped to the caller's organisation:

- Service: adds `getByIdForOrg(id, organisationId)`, which resolves the companion with a `prisma.patient.findFirst` constrained by an ACTIVE organisation link (`organisations.some: { organisationId, status: "ACTIVE" }`) rather than a bare id lookup. It returns `null` when no scoped row matches and throws a 400 `CompanionServiceError` when organisation context is missing.
- Controller: adds `getCompanionByIdPMS`, which resolves the verified organisation id from the request, returns 400 when organisation context is absent, 404 when the companion is not found or falls outside the caller's organisation, and otherwise the FHIR response.
- Router: `/org/:id` now runs `withOrgPermissions()` and `requirePermission("companions:view:any")` ahead of the new handler.

A separate fix corrects the service test's prisma mock factory, which declared `findFirst` in its TypeScript type but never registered a `jest.fn()`, causing the two new `getByIdForOrg` cases to throw at runtime.

### Validation performed

- Backend type-check: clean.
- Backend lint: clean.
- `npx jest companion`: 16 suites / 446 tests passing, including the new router, controller, and service cases.
- The mobile `GET /:id` route test stays green, confirming the shared `getById` path is untouched.

Note: verification ran in a fresh worktree, which first required `pnpm install`, building `@yosemite-crew/database` and `@yosemite-crew/auth`, and generating the Prisma client before the type-check could resolve. No manual/end-to-end request testing was performed; validation was type-check, lint, and the automated test suite only.

Impact area: backend companion API (PMS staff read path).

## Related Issue(s)

Fixes #2444

Closes #2444
