### PR TITLE
feat(backend,database): breed and age based husbandry recommendations

### DIFF
--- a/apps/backend/src/controllers/app/task-recommendation.controller.ts
+++ b/apps/backend/src/controllers/app/task-recommendation.controller.ts
@@ -24,8 +24,14 @@ export const TaskRecommendationController = {
         // Sent with every response rather than hard-coded in the app, so the
         // wording can be corrected without a release. The app shows it beside
         // the list; the per-card citation is the substantive part.
+        //
+        // Deliberately does NOT say "for this breed and age". Not every rule is
+        // breed-specific or age-bounded - a species-wide life-stage task matches
+        // on neither - and a blanket claim would overstate what triggered the
+        // guidance. What each card was actually matched on is in its own
+        // `because` block, which is the honest place for it.
         disclaimer:
-          "These are general husbandry suggestions commonly recommended for this breed and age. They are not a diagnosis or advice about your companion specifically. Your vet knows your companion; ask them before acting on anything here.",
+          "These are general husbandry suggestions, not a diagnosis or advice about your companion specifically. Each one shows what it was matched on and where it comes from. Your vet knows your companion; ask them before acting on anything here.",
       });
     } catch (error) {
       if (error instanceof TaskRecommendationError) {

--- a/apps/backend/src/controllers/app/task-recommendation.controller.ts
+++ b/apps/backend/src/controllers/app/task-recommendation.controller.ts
@@ -1,0 +1,40 @@
+import type { Request, Response } from "express";
+import logger from "src/utils/logger";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+/**
+ * Recommendations are read for ONE companion at a time, by the companion id in
+ * the path, so the route can sit behind the same co-parent gate as every other
+ * companion-scoped read. Matching happens on the server: the client never holds
+ * the rules, so a withdrawn rule stops appearing immediately rather than waiting
+ * out mobile adoption.
+ */
+export const TaskRecommendationController = {
+  listForCompanion: async (req: Request, res: Response) => {
+    try {
+      const { patientId } = req.params;
+      const recommendations =
+        await TaskRecommendationService.forCompanion(patientId);
+
+      return res.status(200).json({
+        recommendations,
+        // Sent with every response rather than hard-coded in the app, so the
+        // wording can be corrected without a release. The app shows it beside
+        // the list; the per-card citation is the substantive part.
+        disclaimer:
+          "These are general husbandry suggestions commonly recommended for this breed and age. They are not a diagnosis or advice about your companion specifically. Your vet knows your companion; ask them before acting on anything here.",
+      });
+    } catch (error) {
+      if (error instanceof TaskRecommendationError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      logger.error("Failed to build companion recommendations", error);
+      return res
+        .status(500)
+        .json({ message: "Unable to load recommendations." });
+    }
+  },
+};

--- a/apps/backend/src/routers/task.router.ts
+++ b/apps/backend/src/routers/task.router.ts
@@ -11,6 +11,7 @@ import {
   withTaskOrgPermissions,
 } from "src/middlewares/rbac";
 import { requireCompanionPermission } from "src/middlewares/companion-access";
+import { TaskRecommendationController } from "src/controllers/app/task-recommendation.controller";
 
 const router = Router();
 
@@ -37,6 +38,16 @@ router.get(
   requireMobileAuth,
   requireCompanionPermission("tasks", "patientId"),
   TaskController.listForCompanion,
+);
+
+// Behind the same co-parent gate as the companion's task list. The rules are
+// health-adjacent, and a co-parent whose tasks switch is off should not be able
+// to read what has been recommended for the companion either.
+router.get(
+  "/mobile/companion/:patientId/recommendations",
+  requireMobileAuth,
+  requireCompanionPermission("tasks", "patientId"),
+  TaskRecommendationController.listForCompanion,
 );
 
 /* ─────────────────────────────────────────────────

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -164,7 +164,7 @@ export const planBackfill = async (): Promise<Outcome[]> => {
   return outcomes;
 };
 
-const main = async () => {
+export const main = async () => {
   const apply = process.argv.includes("--apply");
   const outcomes = await planBackfill();
 
@@ -187,15 +187,29 @@ const main = async () => {
   }
 
   let written = 0;
+  let skippedConcurrent = 0;
   for (const outcome of resolved) {
     const species = SPECIES_BY_TYPE[outcome.type];
-    await prisma.patient.update({
-      where: { id: outcome.patientId },
+    // Conditional on breedCode still being null, via updateMany rather than
+    // update. A parent editing their companion between the plan and this loop
+    // would otherwise have their newly chosen breed overwritten by a value
+    // planned from the row as it was before they touched it.
+    const result = await prisma.patient.updateMany({
+      where: { id: outcome.patientId, breedCode: null },
       data: { speciesCode: species.code, breedCode: outcome.resolved },
     });
+    if (result.count === 0) {
+      skippedConcurrent += 1;
+      continue;
+    }
     written += 1;
   }
   console.log(`\nwrote ${written} companions`);
+  if (skippedConcurrent > 0) {
+    console.log(
+      `  ${skippedConcurrent} skipped - coded by someone else while this ran`,
+    );
+  }
 };
 
 /**

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -76,6 +76,14 @@ export const planBackfill = async (): Promise<Outcome[]> => {
     const species = SPECIES_BY_TYPE[type];
     const entries = await prisma.codeEntry.findMany({
       where: {
+        // Constrained to the live Yosemite breed vocabulary. Without system/type/
+        // active, an inactive entry - or one from another code system that happens
+        // to carry a YBREED-shaped code and the same display - would be accepted,
+        // and the apply phase would persist a code that ordinary companion writes
+        // would never produce.
+        system: "YOSEMITECODE",
+        type: "BREED",
+        active: true,
         code: { startsWith: species.prefix },
         display: { in: [...breeds], mode: "insensitive" },
       },
@@ -190,9 +198,25 @@ const main = async () => {
   console.log(`\nwrote ${written} companions`);
 };
 
-main()
-  .catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  })
-  .finally(() => prisma.$disconnect());
+/**
+ * Only run when this file IS the command, not when a test imports planBackfill.
+ *
+ * Unguarded, importing this module started main() before any test had mocked a
+ * result, so planBackfill threw and the catch set process.exitCode = 1. The suite
+ * reported 8 passing tests and jest still exited 1 - a red build with nothing red
+ * in the output to explain it.
+ *
+ * argv[1] rather than require.main, which is not defined under ESM.
+ */
+const invokedDirectly = (process.argv[1] ?? "").includes(
+  "backfill-breed-codes",
+);
+
+if (invokedDirectly) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -53,15 +53,15 @@ interface Outcome {
 const vocabKey = (type: string, display: string) =>
   `${type}::${display.trim().toLowerCase()}`;
 
-export const planBackfill = async (): Promise<Outcome[]> => {
-  const patients = await prisma.patient.findMany({
-    where: { breedCode: null },
-    select: { id: true, breed: true, type: true },
-  });
-
-  // One vocabulary query per species, not per patient. Every lookup in the loop
-  // below asks the same species-scoped question, so issuing it once per companion
-  // was a round trip per row for no new information.
+/**
+ * Every breed display this run needs, per species, resolved in one query each.
+ *
+ * One query per species rather than per companion: each lookup asks the same
+ * species-scoped question, so a round trip per row bought no new information.
+ */
+const loadVocabulary = async (
+  patients: Array<{ breed: string; type: string }>,
+): Promise<Map<string, string[]>> => {
   const wanted = new Map<string, Set<string>>();
   for (const patient of patients) {
     const breed = patient.breed?.trim();
@@ -76,11 +76,11 @@ export const planBackfill = async (): Promise<Outcome[]> => {
     const species = SPECIES_BY_TYPE[type];
     const entries = await prisma.codeEntry.findMany({
       where: {
-        // Constrained to the live Yosemite breed vocabulary. Without system/type/
-        // active, an inactive entry - or one from another code system that happens
-        // to carry a YBREED-shaped code and the same display - would be accepted,
-        // and the apply phase would persist a code that ordinary companion writes
-        // would never produce.
+        // Constrained to the live Yosemite breed vocabulary. Without
+        // system/type/active, an inactive entry - or one from another code
+        // system carrying a YBREED-shaped code and the same display - would be
+        // accepted, and the apply phase would persist a code that ordinary
+        // companion writes would never produce.
         system: "YOSEMITECODE",
         type: "BREED",
         active: true,
@@ -94,74 +94,70 @@ export const planBackfill = async (): Promise<Outcome[]> => {
       vocabulary.set(key, [...(vocabulary.get(key) ?? []), entry.code]);
     }
   }
+  return vocabulary;
+};
 
-  const outcomes: Outcome[] = [];
+/** What this run would do to one companion, and why. */
+const classify = (
+  patient: { id: string; breed: string; type: string },
+  vocabulary: Map<string, string[]>,
+): Outcome => {
+  const breed = patient.breed?.trim();
+  const base = {
+    patientId: patient.id,
+    breed: breed ?? "",
+    type: patient.type,
+  };
 
-  for (const patient of patients) {
-    const breed = patient.breed?.trim();
-    const species = SPECIES_BY_TYPE[patient.type];
-
-    if (!breed) {
-      outcomes.push({
-        patientId: patient.id,
-        breed: patient.breed ?? "",
-        type: patient.type,
-        resolved: null,
-        reason: "no breed text to match",
-      });
-      continue;
-    }
-
-    if (!species) {
-      // `other`, or a species the breed vocabulary does not cover.
-      outcomes.push({
-        patientId: patient.id,
-        breed,
-        type: patient.type,
-        resolved: null,
-        reason: `species '${patient.type}' has no breed vocabulary`,
-      });
-      continue;
-    }
-
-    const candidates = vocabulary.get(vocabKey(patient.type, breed)) ?? [];
-
-    const distinct = [
-      ...new Set(
-        candidates
-          .map((code) => canonicalBreedCode(code))
-          .filter((code): code is string => Boolean(code)),
-      ),
-    ];
-
-    if (distinct.length === 1) {
-      outcomes.push({
-        patientId: patient.id,
-        breed,
-        type: patient.type,
-        resolved: distinct[0],
-        reason: "matched within its own species",
-      });
-    } else if (distinct.length === 0) {
-      outcomes.push({
-        patientId: patient.id,
-        breed,
-        type: patient.type,
-        resolved: null,
-        reason: "no vocabulary entry for this breed in this species",
-      });
-    } else {
-      outcomes.push({
-        patientId: patient.id,
-        breed,
-        type: patient.type,
-        resolved: null,
-        reason: `ambiguous: ${distinct.join(", ")}`,
-      });
-    }
+  if (!breed) {
+    return { ...base, resolved: null, reason: "no breed text to match" };
+  }
+  if (!SPECIES_BY_TYPE[patient.type]) {
+    // `other`, or a species the breed vocabulary does not cover.
+    return {
+      ...base,
+      resolved: null,
+      reason: `species '${patient.type}' has no breed vocabulary`,
+    };
   }
 
-  return outcomes;
+  const distinct = [
+    ...new Set(
+      (vocabulary.get(vocabKey(patient.type, breed)) ?? [])
+        .map((code) => canonicalBreedCode(code))
+        .filter((code): code is string => Boolean(code)),
+    ),
+  ];
+
+  if (distinct.length === 1) {
+    return {
+      ...base,
+      resolved: distinct[0],
+      reason: "matched within its own species",
+    };
+  }
+  if (distinct.length === 0) {
+    return {
+      ...base,
+      resolved: null,
+      reason: "no vocabulary entry for this breed in this species",
+    };
+  }
+  return {
+    ...base,
+    resolved: null,
+    reason: `ambiguous: ${distinct.join(", ")}`,
+  };
+};
+
+export const planBackfill = async (): Promise<Outcome[]> => {
+  const patients = await prisma.patient.findMany({
+    where: { breedCode: null },
+    select: { id: true, breed: true, type: true },
+  });
+
+  const vocabulary = await loadVocabulary(patients);
+  return patients.map((patient) => classify(patient, vocabulary));
 };
 
 export const main = async () => {

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -1,5 +1,9 @@
 /**
- * Backfill `speciesCode` and `breedCode` on Patient rows that have neither.
+ * Backfill `speciesCode` and `breedCode` on Patient rows with no breed code.
+ *
+ * Selected on `breedCode` alone, not on both columns being null. The two are
+ * written together here, but a row with a species and no breed is exactly a row
+ * that needs repairing - requiring both to be null would skip it.
  *
  * Recommendation rules match on coded species and breed. On production today
  * only 7 of 37 companions are coded - about 19 percent - so a matcher built on
@@ -45,11 +49,43 @@ interface Outcome {
   reason: string;
 }
 
+/** Key for the per-species vocabulary map. Display is matched case-insensitively. */
+const vocabKey = (type: string, display: string) =>
+  `${type}::${display.trim().toLowerCase()}`;
+
 export const planBackfill = async (): Promise<Outcome[]> => {
   const patients = await prisma.patient.findMany({
     where: { breedCode: null },
     select: { id: true, breed: true, type: true },
   });
+
+  // One vocabulary query per species, not per patient. Every lookup in the loop
+  // below asks the same species-scoped question, so issuing it once per companion
+  // was a round trip per row for no new information.
+  const wanted = new Map<string, Set<string>>();
+  for (const patient of patients) {
+    const breed = patient.breed?.trim();
+    if (!breed || !SPECIES_BY_TYPE[patient.type]) continue;
+    const set = wanted.get(patient.type) ?? new Set<string>();
+    set.add(breed);
+    wanted.set(patient.type, set);
+  }
+
+  const vocabulary = new Map<string, string[]>();
+  for (const [type, breeds] of wanted) {
+    const species = SPECIES_BY_TYPE[type];
+    const entries = await prisma.codeEntry.findMany({
+      where: {
+        code: { startsWith: species.prefix },
+        display: { in: [...breeds], mode: "insensitive" },
+      },
+      select: { code: true, display: true },
+    });
+    for (const entry of entries) {
+      const key = vocabKey(type, entry.display ?? "");
+      vocabulary.set(key, [...(vocabulary.get(key) ?? []), entry.code]);
+    }
+  }
 
   const outcomes: Outcome[] = [];
 
@@ -80,18 +116,12 @@ export const planBackfill = async (): Promise<Outcome[]> => {
       continue;
     }
 
-    const candidates = await prisma.codeEntry.findMany({
-      where: {
-        code: { startsWith: species.prefix },
-        display: { equals: breed, mode: "insensitive" },
-      },
-      select: { code: true },
-    });
+    const candidates = vocabulary.get(vocabKey(patient.type, breed)) ?? [];
 
     const distinct = [
       ...new Set(
         candidates
-          .map((entry) => canonicalBreedCode(entry.code))
+          .map((code) => canonicalBreedCode(code))
           .filter((code): code is string => Boolean(code)),
       ),
     ];

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -1,0 +1,168 @@
+/**
+ * Backfill `speciesCode` and `breedCode` on Patient rows that have neither.
+ *
+ * Recommendation rules match on coded species and breed. On production today
+ * only 7 of 37 companions are coded - about 19 percent - so a matcher built on
+ * those columns would work for one companion in five. All 37 have breed text,
+ * and because the values come from a picker rather than a keyboard they match
+ * `CodeEntry.display` exactly, so the gap is closable without fuzzy matching.
+ *
+ * Two traps, both found in the data rather than imagined:
+ *
+ *   Same display, different species. `Abyssinian` is a cat breed AND a horse
+ *   breed; `Maltese` is a dog AND a cat. Matching on display alone would have
+ *   coded an Abyssinian cat as a horse and then handed it equine guidance. Every
+ *   lookup is therefore scoped by `Patient.type` first, which is required and
+ *   already correct.
+ *
+ *   Same breed, two spellings. The vocabulary holds 36 breeds under both
+ *   separator conventions (`SHIH_TZU` and `SHIH-TZU`). Candidates are compared
+ *   canonically so those collapse to one answer instead of reading as a conflict.
+ *
+ * Anything still ambiguous after both is SKIPPED and reported. A wrong code is
+ * worse than a missing one: a missing code shows no recommendations, a wrong one
+ * shows confident recommendations for the wrong animal.
+ *
+ * Dry run by default. Pass --apply to write:
+ *
+ *   pnpm --filter backend exec tsx src/scripts/backfill-breed-codes.ts
+ *   pnpm --filter backend exec tsx src/scripts/backfill-breed-codes.ts --apply
+ */
+import { prisma } from "src/config/prisma";
+import { canonicalBreedCode } from "src/services/shared/breed-code";
+
+const SPECIES_BY_TYPE: Record<string, { code: string; prefix: string }> = {
+  dog: { code: "YSPEC:CANINE", prefix: "YBREED:CANINE:" },
+  cat: { code: "YSPEC:FELINE", prefix: "YBREED:FELINE:" },
+  horse: { code: "YSPEC:EQUINE", prefix: "YBREED:EQUINE:" },
+};
+
+interface Outcome {
+  patientId: string;
+  breed: string;
+  type: string;
+  resolved: string | null;
+  reason: string;
+}
+
+export const planBackfill = async (): Promise<Outcome[]> => {
+  const patients = await prisma.patient.findMany({
+    where: { breedCode: null },
+    select: { id: true, breed: true, type: true },
+  });
+
+  const outcomes: Outcome[] = [];
+
+  for (const patient of patients) {
+    const breed = patient.breed?.trim();
+    const species = SPECIES_BY_TYPE[patient.type];
+
+    if (!breed) {
+      outcomes.push({
+        patientId: patient.id,
+        breed: patient.breed ?? "",
+        type: patient.type,
+        resolved: null,
+        reason: "no breed text to match",
+      });
+      continue;
+    }
+
+    if (!species) {
+      // `other`, or a species the breed vocabulary does not cover.
+      outcomes.push({
+        patientId: patient.id,
+        breed,
+        type: patient.type,
+        resolved: null,
+        reason: `species '${patient.type}' has no breed vocabulary`,
+      });
+      continue;
+    }
+
+    const candidates = await prisma.codeEntry.findMany({
+      where: {
+        code: { startsWith: species.prefix },
+        display: { equals: breed, mode: "insensitive" },
+      },
+      select: { code: true },
+    });
+
+    const distinct = [
+      ...new Set(
+        candidates
+          .map((entry) => canonicalBreedCode(entry.code))
+          .filter((code): code is string => Boolean(code)),
+      ),
+    ];
+
+    if (distinct.length === 1) {
+      outcomes.push({
+        patientId: patient.id,
+        breed,
+        type: patient.type,
+        resolved: distinct[0],
+        reason: "matched within its own species",
+      });
+    } else if (distinct.length === 0) {
+      outcomes.push({
+        patientId: patient.id,
+        breed,
+        type: patient.type,
+        resolved: null,
+        reason: "no vocabulary entry for this breed in this species",
+      });
+    } else {
+      outcomes.push({
+        patientId: patient.id,
+        breed,
+        type: patient.type,
+        resolved: null,
+        reason: `ambiguous: ${distinct.join(", ")}`,
+      });
+    }
+  }
+
+  return outcomes;
+};
+
+const main = async () => {
+  const apply = process.argv.includes("--apply");
+  const outcomes = await planBackfill();
+
+  const resolved = outcomes.filter((o) => o.resolved);
+  const skipped = outcomes.filter((o) => !o.resolved);
+
+  console.log(`${outcomes.length} companions without a breed code`);
+  console.log(`  ${resolved.length} resolvable`);
+  console.log(`  ${skipped.length} skipped`);
+
+  for (const outcome of skipped) {
+    console.log(
+      `  SKIP ${outcome.type} "${outcome.breed}" - ${outcome.reason}`,
+    );
+  }
+
+  if (!apply) {
+    console.log("\ndry run; pass --apply to write");
+    return;
+  }
+
+  let written = 0;
+  for (const outcome of resolved) {
+    const species = SPECIES_BY_TYPE[outcome.type];
+    await prisma.patient.update({
+      where: { id: outcome.patientId },
+      data: { speciesCode: species.code, breedCode: outcome.resolved },
+    });
+    written += 1;
+  }
+  console.log(`\nwrote ${written} companions`);
+};
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/backend/src/services/shared/breed-code.ts
+++ b/apps/backend/src/services/shared/breed-code.ts
@@ -22,7 +22,7 @@ export const canonicalBreedCode = (
   if (typeof code !== "string") return null;
   const trimmed = code.trim();
   if (!trimmed) return null;
-  return trimmed.toUpperCase().replace(/-/g, "_").replace(/_{2,}/g, "_");
+  return trimmed.toUpperCase().replaceAll("-", "_").replaceAll(/_{2,}/g, "_");
 };
 
 /** True when two breed codes name the same breed, whichever convention each uses. */
@@ -75,5 +75,5 @@ export const ageInMonths = (
     (asOf.getMonth() - dateOfBirth.getMonth());
   // Not a whole month yet if the day of the month has not come round.
   if (asOf.getDate() < dateOfBirth.getDate()) months -= 1;
-  return months < 0 ? 0 : months;
+  return Math.max(0, months);
 };

--- a/apps/backend/src/services/shared/breed-code.ts
+++ b/apps/backend/src/services/shared/breed-code.ts
@@ -16,13 +16,32 @@
  * and a recommendation that is silently absent looks exactly like a breed with
  * no guidance for it. Comparing canonical forms is what stops that.
  */
+/**
+ * Collapse runs of separators, without a regular expression.
+ *
+ * `/_{2,}/g` would read more compactly, but the security scan flags a quantified
+ * pattern applied to caller-supplied text, and a breed code is not worth
+ * arguing the point over. This is also exact at the edges: a single leading or
+ * trailing separator survives, where a split/filter/join would silently eat it.
+ */
+const collapseSeparators = (value: string): string => {
+  let out = "";
+  let previousWasSeparator = false;
+  for (const char of value) {
+    const isSeparator = char === "_";
+    if (!isSeparator || !previousWasSeparator) out += char;
+    previousWasSeparator = isSeparator;
+  }
+  return out;
+};
+
 export const canonicalBreedCode = (
   code: string | null | undefined,
 ): string | null => {
   if (typeof code !== "string") return null;
   const trimmed = code.trim();
   if (!trimmed) return null;
-  return trimmed.toUpperCase().replaceAll("-", "_").replaceAll(/_{2,}/g, "_");
+  return collapseSeparators(trimmed.toUpperCase().replaceAll("-", "_"));
 };
 
 /** True when two breed codes name the same breed, whichever convention each uses. */

--- a/apps/backend/src/services/shared/breed-code.ts
+++ b/apps/backend/src/services/shared/breed-code.ts
@@ -1,0 +1,79 @@
+/**
+ * Canonical form for a breed code.
+ *
+ * The vocabulary holds the same breed under two separator conventions. On
+ * production today `CodeEntry` has 1,749 breed codes that collapse to 1,713
+ * distinct ones: 36 breeds exist as BOTH `SHIH_TZU` and `SHIH-TZU`,
+ * `LHASA_APSO` and `LHASA-APSO`, and so on. Patient rows are split the same way
+ * - of the seven coded companions in production, four are hyphenated and three
+ * are not.
+ *
+ * The backend's own generator (`idexx-reference.service.ts`) emits underscores,
+ * so underscore is the canonical form here.
+ *
+ * This matters more than a tidiness fix. A recommendation rule keyed on one
+ * spelling would silently return nothing for every patient coded the other way,
+ * and a recommendation that is silently absent looks exactly like a breed with
+ * no guidance for it. Comparing canonical forms is what stops that.
+ */
+export const canonicalBreedCode = (
+  code: string | null | undefined,
+): string | null => {
+  if (typeof code !== "string") return null;
+  const trimmed = code.trim();
+  if (!trimmed) return null;
+  return trimmed.toUpperCase().replace(/-/g, "_").replace(/_{2,}/g, "_");
+};
+
+/** True when two breed codes name the same breed, whichever convention each uses. */
+export const breedCodesMatch = (
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean => {
+  const left = canonicalBreedCode(a);
+  const right = canonicalBreedCode(b);
+  // Two unknowns are not a match. This is used to decide whether a rule applies,
+  // so anything unreadable has to fall through to "no".
+  if (!left || !right) return false;
+  return left === right;
+};
+
+/**
+ * `Patient.speciesCode` uses the YSPEC vocabulary; `TaskLibraryDefinition` and
+ * the rules use the `TaskLibrarySpecies` enum. Only the three species the enum
+ * covers can map, and anything else yields null rather than a guess.
+ */
+const SPECIES_BY_CODE: Record<string, "dog" | "cat" | "horse"> = {
+  "YSPEC:CANINE": "dog",
+  "YSPEC:FELINE": "cat",
+  "YSPEC:EQUINE": "horse",
+};
+
+export const taskSpeciesForCode = (
+  speciesCode: string | null | undefined,
+): "dog" | "cat" | "horse" | null => {
+  if (typeof speciesCode !== "string") return null;
+  return SPECIES_BY_CODE[speciesCode.trim().toUpperCase()] ?? null;
+};
+
+/**
+ * Whole months from birth to `asOf`, floored, or null if the date of birth is
+ * unusable. A future date of birth yields null rather than a negative age: it is
+ * bad data, and a negative age would silently satisfy any `maxAgeMonths` bound.
+ */
+export const ageInMonths = (
+  dateOfBirth: Date | null | undefined,
+  asOf: Date,
+): number | null => {
+  if (!(dateOfBirth instanceof Date) || Number.isNaN(dateOfBirth.getTime())) {
+    return null;
+  }
+  if (dateOfBirth.getTime() > asOf.getTime()) return null;
+
+  let months =
+    (asOf.getFullYear() - dateOfBirth.getFullYear()) * 12 +
+    (asOf.getMonth() - dateOfBirth.getMonth());
+  // Not a whole month yet if the day of the month has not come round.
+  if (asOf.getDate() < dateOfBirth.getDate()) months -= 1;
+  return months < 0 ? 0 : months;
+};

--- a/apps/backend/src/services/task-recommendation.service.ts
+++ b/apps/backend/src/services/task-recommendation.service.ts
@@ -77,8 +77,11 @@ export class TaskRecommendationError extends Error {
   }
 }
 
+/** The three species the task library covers. */
+type TaskSpecies = "dog" | "cat" | "horse";
+
 /** `Patient.type` and `TaskLibrarySpecies` share three values; `other` has none. */
-const TASK_SPECIES: Record<string, "dog" | "cat" | "horse" | undefined> = {
+const TASK_SPECIES: Record<string, TaskSpecies | undefined> = {
   dog: "dog",
   cat: "cat",
   horse: "horse",
@@ -115,6 +118,136 @@ const withinWindow = (
   return true;
 };
 
+type LoadedPatient = {
+  speciesCode: string | null;
+  breedCode: string | null;
+  dateOfBirth: Date | null;
+  type: string;
+};
+
+type RuleWithDefinition = {
+  id: string;
+  breedCodes: string[];
+  minAgeMonths: number | null;
+  maxAgeMonths: number | null;
+  taskDefinitionId: string;
+  recommendationText: string;
+  citationAuthors: string;
+  citationTitle: string;
+  citationSource: string;
+  citationYear: number;
+  citationDoi: string | null;
+  citationUrl: string | null;
+  citationClaim: string;
+  evidenceGrade: string;
+  lastReviewedAt: Date | null;
+  reviewedBy: string | null;
+  nextReviewDue: Date | null;
+  taskDefinition: {
+    id: string;
+    name: string;
+    category: string;
+    isActive: boolean;
+    applicableSpecies: string[];
+  };
+};
+
+/**
+ * Which species' rules apply, or null when that cannot be answered safely.
+ *
+ * `speciesCode` first, `type` as the fallback. They carry the same three
+ * species, but `speciesCode` is optional and null on 30 of 37 production
+ * companions while `type` is required, so reading only the coded column
+ * returned nothing for four companions in five until the backfill ran. This is
+ * a fallback between two RECORDED values - `type` is what the parent picked -
+ * not an inference from free text, which is still not done.
+ *
+ * When both are present and disagree the answer is null. The companion's data
+ * is inconsistent, and choosing either would serve guidance for the wrong
+ * animal on exactly the rows already known to be wrong. Nothing upstream
+ * enforces agreement: validateCompanionCodes checks that each code is valid,
+ * not that the two describe one species.
+ */
+const resolveSpecies = (patient: LoadedPatient): TaskSpecies | null => {
+  const coded = taskSpeciesForCode(patient.speciesCode);
+  const declared = TASK_SPECIES[patient.type];
+  if (coded && declared && coded !== declared) return null;
+  return coded ?? declared ?? null;
+};
+
+/** Whether a rule applies to this companion. Every clause is a reason to say no. */
+const appliesTo = (
+  rule: RuleWithDefinition,
+  species: TaskSpecies,
+  ageMonths: number,
+  patientBreed: string | null,
+): boolean => {
+  // A blank reviewer is not a signature. The column is a nullable string, so ""
+  // and "   " both satisfy a NOT NULL check while naming nobody, and this is the
+  // gate that keeps unreviewed clinical guidance away from pet parents.
+  if ((rule.reviewedBy ?? "").trim().length === 0) return false;
+
+  if (!rule.taskDefinition?.isActive) return false;
+
+  // An EMPTY applicableSpecies means universal, not "applies to nothing" -
+  // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
+  // `{ has: species }` for that reason. Reading empty as a mismatch would
+  // silently drop every universal task.
+  const scope = rule.taskDefinition.applicableSpecies;
+  if (scope.length > 0 && !scope.includes(species)) return false;
+
+  if (!withinWindow(ageMonths, rule.minAgeMonths, rule.maxAgeMonths))
+    return false;
+
+  // No breed codes means species-wide - the life-stage tasks most animals get.
+  // Otherwise the companion's breed has to appear, compared canonically because
+  // the vocabulary holds both separator conventions.
+  if (rule.breedCodes.length === 0) return true;
+  if (!patientBreed) return false;
+  return rule.breedCodes.some(
+    (code) => canonicalBreedCode(code) === patientBreed,
+  );
+};
+
+const toRecommendation = (
+  rule: RuleWithDefinition,
+  species: TaskSpecies,
+  ageMonths: number,
+  patientBreed: string | null,
+): CompanionRecommendation => ({
+  ruleId: rule.id,
+  taskDefinitionId: rule.taskDefinitionId,
+  taskName: rule.taskDefinition.name,
+  taskCategory: rule.taskDefinition.category,
+  text: rule.recommendationText,
+  because: {
+    species,
+    breedSpecific: rule.breedCodes.length > 0,
+    breedCode: patientBreed,
+    minAgeMonths: rule.minAgeMonths,
+    maxAgeMonths: rule.maxAgeMonths,
+    ageMonths,
+  },
+  evidence: {
+    artifact: {
+      type: "citation",
+      label: GRADE_LABELS[rule.evidenceGrade] ?? rule.evidenceGrade,
+      display: rule.citationClaim,
+      citation: `${rule.citationAuthors}. ${rule.citationTitle}. ${rule.citationSource}. ${rule.citationYear}.`,
+      url:
+        rule.citationUrl ??
+        (rule.citationDoi ? `https://doi.org/${rule.citationDoi}` : undefined),
+    },
+    year: rule.citationYear,
+    grade: rule.evidenceGrade,
+    attestation: {
+      lastReviewedAt: rule.lastReviewedAt,
+      reviewedBy: rule.reviewedBy,
+      nextReviewDue: rule.nextReviewDue,
+    },
+  },
+});
+
 export const TaskRecommendationService = {
   async forCompanion(patientId: string): Promise<CompanionRecommendation[]> {
     const id = patientId?.trim();
@@ -135,31 +268,11 @@ export const TaskRecommendationService = {
       throw new TaskRecommendationError("Companion not found.", 404);
     }
 
-    // `speciesCode` first, `type` as the fallback. They carry the same three
-    // species, but `speciesCode` is optional and null on 30 of 37 production
-    // companions, while `type` is required. Reading only the coded column would
-    // have returned nothing for four companions in five until the backfill ran.
-    //
-    // This is a fallback between two recorded values, not an inference: `type` is
-    // what the parent picked. Guessing a species from free-text breed would be a
-    // different thing and is still not done.
-    const coded = taskSpeciesForCode(patient.speciesCode);
-    const declared = TASK_SPECIES[patient.type];
-
-    // If both are recorded and they disagree, the companion's data is
-    // inconsistent and neither value can be trusted to pick the rules.
-    // Returning nothing is the only safe answer: choosing one would serve
-    // guidance for the wrong animal on exactly the rows where we already know
-    // something is wrong. Nothing upstream enforces agreement -
-    // validateCompanionCodes checks each code is valid, not that the two
-    // describe the same species.
-    if (coded && declared && coded !== declared) return [];
-
-    const species = coded ?? declared;
+    const species = resolveSpecies(patient);
     if (!species) return [];
 
-    const age = ageInMonths(patient.dateOfBirth, new Date());
-    if (age === null) return [];
+    const ageMonths = ageInMonths(patient.dateOfBirth, new Date());
+    if (ageMonths === null) return [];
 
     const rules = await prisma.taskRecommendationRule.findMany({
       where: {
@@ -167,11 +280,8 @@ export const TaskRecommendationService = {
         isActive: true,
         // Both conditions, not just isActive. A rule reaches a pet parent only
         // once a named reviewer has signed it off; an active-but-unreviewed row
-        // is a seeding accident, not a recommendation.
-        //
-        // NOT null is not enough on its own: the column is a nullable string, so
-        // "" and "   " both satisfy it while naming nobody. This is the safety
-        // gate, so it rejects anything that is not an actual name.
+        // is a seeding accident, not a recommendation. `appliesTo` rejects a
+        // blank name, which this predicate cannot.
         reviewedBy: { not: null },
       },
       include: {
@@ -189,71 +299,12 @@ export const TaskRecommendationService = {
 
     const patientBreed = canonicalBreedCode(patient.breedCode);
 
-    return (
-      rules
-        .filter((rule) => (rule.reviewedBy ?? "").trim().length > 0)
-        .filter((rule) => rule.taskDefinition?.isActive)
-        // A rule for dogs must not recommend a task the definition does not apply
-        // to dogs. Nothing in the relation enforces that, so a curator pointing a
-        // canine rule at a feline-only task would otherwise ship it.
-        //
-        // An EMPTY applicableSpecies means universal, not "applies to nothing" -
-        // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
-        // `{ has: species }` for exactly that reason. Treating empty as a
-        // mismatch here would silently drop every universal task.
-        .filter(
-          (rule) =>
-            rule.taskDefinition.applicableSpecies.length === 0 ||
-            rule.taskDefinition.applicableSpecies.includes(species),
-        )
-        .filter((rule) =>
-          withinWindow(age, rule.minAgeMonths, rule.maxAgeMonths),
-        )
-        .filter((rule) => {
-          // No breed codes means the rule is species-wide - the life-stage tasks
-          // most animals get. Otherwise the patient's breed has to appear, compared
-          // canonically because the vocabulary holds both separator conventions.
-          if (rule.breedCodes.length === 0) return true;
-          if (!patientBreed) return false;
-          return rule.breedCodes.some(
-            (code) => canonicalBreedCode(code) === patientBreed,
-          );
-        })
-        .map((rule) => ({
-          ruleId: rule.id,
-          taskDefinitionId: rule.taskDefinitionId,
-          taskName: rule.taskDefinition.name,
-          taskCategory: rule.taskDefinition.category,
-          text: rule.recommendationText,
-          because: {
-            species,
-            breedSpecific: rule.breedCodes.length > 0,
-            breedCode: patientBreed,
-            minAgeMonths: rule.minAgeMonths,
-            maxAgeMonths: rule.maxAgeMonths,
-            ageMonths: age,
-          },
-          evidence: {
-            artifact: {
-              type: "citation",
-              label: GRADE_LABELS[rule.evidenceGrade] ?? rule.evidenceGrade,
-              display: rule.citationClaim,
-              citation: `${rule.citationAuthors}. ${rule.citationTitle}. ${rule.citationSource}. ${rule.citationYear}.`,
-              url:
-                rule.citationUrl ??
-                (rule.citationDoi
-                  ? `https://doi.org/${rule.citationDoi}`
-                  : undefined),
-            },
-            year: rule.citationYear,
-            grade: rule.evidenceGrade,
-            attestation: {
-              lastReviewedAt: rule.lastReviewedAt,
-              reviewedBy: rule.reviewedBy,
-              nextReviewDue: rule.nextReviewDue,
-            },
-          },
-        }))
-    );
+    return rules
+      .filter((rule: RuleWithDefinition) =>
+        appliesTo(rule, species, ageMonths, patientBreed),
+      )
+      .map((rule: RuleWithDefinition) =>
+        toRecommendation(rule, species, ageMonths, patientBreed),
+      );
   },
 };

--- a/apps/backend/src/services/task-recommendation.service.ts
+++ b/apps/backend/src/services/task-recommendation.service.ts
@@ -1,3 +1,4 @@
+import type { RelatedArtifact } from "@yosemite-crew/fhir";
 import { prisma } from "src/config/prisma";
 import {
   ageInMonths,
@@ -17,19 +18,35 @@ import {
  * rule knows a breed and an age, not a patient.
  */
 
-export interface RecommendationCitation {
-  authors: string;
-  title: string;
-  source: string;
+/**
+ * The evidence behind a recommendation, as a FHIR R4 `RelatedArtifact`.
+ *
+ * `RelatedArtifact` is the standard's own type for exactly this - the citation
+ * supporting a definitional resource - so there is no reason to invent a shape
+ * for it, and apps/backend/AGENTS.md says as much. The mapping:
+ *
+ *   type     "citation"
+ *   citation the bibliographic string
+ *   url      the DOI, or the source URL when there is no DOI
+ *   display  the specific claim relied on, which is what a vet argues with
+ *   label    the evidence grade, in words
+ *
+ * The attestation below is NOT part of it. `lastReviewedAt` / `reviewedBy` /
+ * `nextReviewDue` are this product's governance over its own rule table, not a
+ * property of the cited artifact, and FHIR has no slot for them here. Keeping
+ * them beside the artifact rather than inside it avoids overloading a standard
+ * type with a local meaning.
+ */
+export interface RecommendationEvidence {
+  artifact: RelatedArtifact;
+  /** Kept discrete so a client can sort or filter without parsing the citation. */
   year: number;
-  doi: string | null;
-  url: string | null;
-  /** The specific claim relied on, so a vet can argue with the rule, not the paper. */
-  claim: string;
   grade: string;
-  lastReviewedAt: Date | null;
-  reviewedBy: string | null;
-  nextReviewDue: Date | null;
+  attestation: {
+    lastReviewedAt: Date | null;
+    reviewedBy: string | null;
+    nextReviewDue: Date | null;
+  };
 }
 
 export interface CompanionRecommendation {
@@ -47,7 +64,7 @@ export interface CompanionRecommendation {
     maxAgeMonths: number | null;
     ageMonths: number;
   };
-  citation: RecommendationCitation;
+  evidence: RecommendationEvidence;
 }
 
 export class TaskRecommendationError extends Error {
@@ -59,6 +76,29 @@ export class TaskRecommendationError extends Error {
     this.name = "TaskRecommendationError";
   }
 }
+
+/** `Patient.type` and `TaskLibrarySpecies` share three values; `other` has none. */
+const TASK_SPECIES: Record<string, "dog" | "cat" | "horse" | undefined> = {
+  dog: "dog",
+  cat: "cat",
+  horse: "horse",
+};
+
+/**
+ * Plain-language labels for the evidence grades.
+ *
+ * The citation is meant to be readable by the parent looking at the card, and
+ * `CONSENSUS_STATEMENT` is not that. The raw enum is kept alongside so a client
+ * can still sort or filter on it without parsing prose.
+ */
+const GRADE_LABELS: Record<string, string> = {
+  CONSENSUS_STATEMENT: "Consensus statement",
+  PRACTICE_GUIDELINE: "Practice guideline",
+  POPULATION_STUDY: "Population study",
+  COHORT_STUDY: "Cohort study",
+  CASE_SERIES: "Case series",
+  EXPERT_OPINION: "Expert opinion",
+};
 
 /**
  * Half-open window: [min, max). A rule for "from seven years" is minAgeMonths 84
@@ -84,16 +124,27 @@ export const TaskRecommendationService = {
 
     const patient = await prisma.patient.findUnique({
       where: { id },
-      select: { speciesCode: true, breedCode: true, dateOfBirth: true },
+      select: {
+        speciesCode: true,
+        breedCode: true,
+        dateOfBirth: true,
+        type: true,
+      },
     });
     if (!patient) {
       throw new TaskRecommendationError("Companion not found.", 404);
     }
 
-    // A companion with no coded species cannot be matched. Returning nothing is
-    // correct: guessing the species from free-text breed here would put an
-    // unreviewed inference behind a cited recommendation.
-    const species = taskSpeciesForCode(patient.speciesCode);
+    // `speciesCode` first, `type` as the fallback. They carry the same three
+    // species, but `speciesCode` is optional and null on 30 of 37 production
+    // companions, while `type` is required. Reading only the coded column would
+    // have returned nothing for four companions in five until the backfill ran.
+    //
+    // This is a fallback between two recorded values, not an inference: `type` is
+    // what the parent picked. Guessing a species from free-text breed would be a
+    // different thing and is still not done.
+    const species =
+      taskSpeciesForCode(patient.speciesCode) ?? TASK_SPECIES[patient.type];
     if (!species) return [];
 
     const age = ageInMonths(patient.dateOfBirth, new Date());
@@ -106,57 +157,85 @@ export const TaskRecommendationService = {
         // Both conditions, not just isActive. A rule reaches a pet parent only
         // once a named reviewer has signed it off; an active-but-unreviewed row
         // is a seeding accident, not a recommendation.
-        NOT: { reviewedBy: null },
+        //
+        // NOT null is not enough on its own: the column is a nullable string, so
+        // "" and "   " both satisfy it while naming nobody. This is the safety
+        // gate, so it rejects anything that is not an actual name.
+        reviewedBy: { not: null },
       },
       include: {
         taskDefinition: {
-          select: { id: true, name: true, category: true, isActive: true },
+          select: {
+            id: true,
+            name: true,
+            category: true,
+            isActive: true,
+            applicableSpecies: true,
+          },
         },
       },
     });
 
     const patientBreed = canonicalBreedCode(patient.breedCode);
 
-    return rules
-      .filter((rule) => rule.taskDefinition?.isActive)
-      .filter((rule) => withinWindow(age, rule.minAgeMonths, rule.maxAgeMonths))
-      .filter((rule) => {
-        // No breed codes means the rule is species-wide - the life-stage tasks
-        // most animals get. Otherwise the patient's breed has to appear, compared
-        // canonically because the vocabulary holds both separator conventions.
-        if (rule.breedCodes.length === 0) return true;
-        if (!patientBreed) return false;
-        return rule.breedCodes.some(
-          (code) => canonicalBreedCode(code) === patientBreed,
-        );
-      })
-      .map((rule) => ({
-        ruleId: rule.id,
-        taskDefinitionId: rule.taskDefinitionId,
-        taskName: rule.taskDefinition.name,
-        taskCategory: rule.taskDefinition.category,
-        text: rule.recommendationText,
-        because: {
-          species,
-          breedSpecific: rule.breedCodes.length > 0,
-          breedCode: patientBreed,
-          minAgeMonths: rule.minAgeMonths,
-          maxAgeMonths: rule.maxAgeMonths,
-          ageMonths: age,
-        },
-        citation: {
-          authors: rule.citationAuthors,
-          title: rule.citationTitle,
-          source: rule.citationSource,
-          year: rule.citationYear,
-          doi: rule.citationDoi,
-          url: rule.citationUrl,
-          claim: rule.citationClaim,
-          grade: rule.evidenceGrade,
-          lastReviewedAt: rule.lastReviewedAt,
-          reviewedBy: rule.reviewedBy,
-          nextReviewDue: rule.nextReviewDue,
-        },
-      }));
+    return (
+      rules
+        .filter((rule) => (rule.reviewedBy ?? "").trim().length > 0)
+        .filter((rule) => rule.taskDefinition?.isActive)
+        // A rule for dogs must not recommend a task the definition does not apply
+        // to dogs. Nothing in the relation enforces that, so a curator pointing a
+        // canine rule at a feline-only task would otherwise ship it.
+        .filter((rule) =>
+          rule.taskDefinition.applicableSpecies.includes(species),
+        )
+        .filter((rule) =>
+          withinWindow(age, rule.minAgeMonths, rule.maxAgeMonths),
+        )
+        .filter((rule) => {
+          // No breed codes means the rule is species-wide - the life-stage tasks
+          // most animals get. Otherwise the patient's breed has to appear, compared
+          // canonically because the vocabulary holds both separator conventions.
+          if (rule.breedCodes.length === 0) return true;
+          if (!patientBreed) return false;
+          return rule.breedCodes.some(
+            (code) => canonicalBreedCode(code) === patientBreed,
+          );
+        })
+        .map((rule) => ({
+          ruleId: rule.id,
+          taskDefinitionId: rule.taskDefinitionId,
+          taskName: rule.taskDefinition.name,
+          taskCategory: rule.taskDefinition.category,
+          text: rule.recommendationText,
+          because: {
+            species,
+            breedSpecific: rule.breedCodes.length > 0,
+            breedCode: patientBreed,
+            minAgeMonths: rule.minAgeMonths,
+            maxAgeMonths: rule.maxAgeMonths,
+            ageMonths: age,
+          },
+          evidence: {
+            artifact: {
+              type: "citation",
+              label: GRADE_LABELS[rule.evidenceGrade] ?? rule.evidenceGrade,
+              display: rule.citationClaim,
+              citation: `${rule.citationAuthors}. ${rule.citationTitle}. ${rule.citationSource}. ${rule.citationYear}.`,
+              url:
+                rule.citationUrl ??
+                (rule.citationDoi
+                  ? `https://doi.org/${rule.citationDoi}`
+                  : undefined),
+            },
+            year: rule.citationYear,
+            grade: rule.evidenceGrade,
+            attestation: {
+              lastReviewedAt: rule.lastReviewedAt,
+              reviewedBy: rule.reviewedBy,
+              nextReviewDue: rule.nextReviewDue,
+            },
+          },
+        }))
+    );
   },
 };

--- a/apps/backend/src/services/task-recommendation.service.ts
+++ b/apps/backend/src/services/task-recommendation.service.ts
@@ -1,0 +1,162 @@
+import { prisma } from "src/config/prisma";
+import {
+  ageInMonths,
+  canonicalBreedCode,
+  taskSpeciesForCode,
+} from "./shared/breed-code";
+
+/**
+ * Breed- and age-based husbandry recommendations for one companion.
+ *
+ * Rules live in the database rather than the app bundle so a rule later found to
+ * be wrong can be withdrawn the same day, instead of waiting out mobile adoption.
+ *
+ * Everything here recommends HUSBANDRY. "Log Gigi's weight monthly" and "book a
+ * dental check" are actions a parent takes. Nothing is phrased as a claim about
+ * the individual animal, which is both the safe framing and the honest one: a
+ * rule knows a breed and an age, not a patient.
+ */
+
+export interface RecommendationCitation {
+  authors: string;
+  title: string;
+  source: string;
+  year: number;
+  doi: string | null;
+  url: string | null;
+  /** The specific claim relied on, so a vet can argue with the rule, not the paper. */
+  claim: string;
+  grade: string;
+  lastReviewedAt: Date | null;
+  reviewedBy: string | null;
+  nextReviewDue: Date | null;
+}
+
+export interface CompanionRecommendation {
+  ruleId: string;
+  taskDefinitionId: string;
+  taskName: string;
+  taskCategory: string;
+  text: string;
+  /** What actually triggered this, for the "why am I seeing this?" affordance. */
+  because: {
+    species: string;
+    breedSpecific: boolean;
+    breedCode: string | null;
+    minAgeMonths: number | null;
+    maxAgeMonths: number | null;
+    ageMonths: number;
+  };
+  citation: RecommendationCitation;
+}
+
+export class TaskRecommendationError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "TaskRecommendationError";
+  }
+}
+
+/**
+ * Half-open window: [min, max). A rule for "from seven years" is minAgeMonths 84
+ * with no upper bound; "under two" is maxAgeMonths 24. Half-open so adjacent
+ * life-stage rules meet exactly once rather than both firing on the boundary.
+ */
+const withinWindow = (
+  ageMonths: number,
+  min: number | null,
+  max: number | null,
+): boolean => {
+  if (min !== null && ageMonths < min) return false;
+  if (max !== null && ageMonths >= max) return false;
+  return true;
+};
+
+export const TaskRecommendationService = {
+  async forCompanion(patientId: string): Promise<CompanionRecommendation[]> {
+    const id = patientId?.trim();
+    if (!id) {
+      throw new TaskRecommendationError("Companion id is required.", 400);
+    }
+
+    const patient = await prisma.patient.findUnique({
+      where: { id },
+      select: { speciesCode: true, breedCode: true, dateOfBirth: true },
+    });
+    if (!patient) {
+      throw new TaskRecommendationError("Companion not found.", 404);
+    }
+
+    // A companion with no coded species cannot be matched. Returning nothing is
+    // correct: guessing the species from free-text breed here would put an
+    // unreviewed inference behind a cited recommendation.
+    const species = taskSpeciesForCode(patient.speciesCode);
+    if (!species) return [];
+
+    const age = ageInMonths(patient.dateOfBirth, new Date());
+    if (age === null) return [];
+
+    const rules = await prisma.taskRecommendationRule.findMany({
+      where: {
+        species,
+        isActive: true,
+        // Both conditions, not just isActive. A rule reaches a pet parent only
+        // once a named reviewer has signed it off; an active-but-unreviewed row
+        // is a seeding accident, not a recommendation.
+        NOT: { reviewedBy: null },
+      },
+      include: {
+        taskDefinition: {
+          select: { id: true, name: true, category: true, isActive: true },
+        },
+      },
+    });
+
+    const patientBreed = canonicalBreedCode(patient.breedCode);
+
+    return rules
+      .filter((rule) => rule.taskDefinition?.isActive)
+      .filter((rule) => withinWindow(age, rule.minAgeMonths, rule.maxAgeMonths))
+      .filter((rule) => {
+        // No breed codes means the rule is species-wide - the life-stage tasks
+        // most animals get. Otherwise the patient's breed has to appear, compared
+        // canonically because the vocabulary holds both separator conventions.
+        if (rule.breedCodes.length === 0) return true;
+        if (!patientBreed) return false;
+        return rule.breedCodes.some(
+          (code) => canonicalBreedCode(code) === patientBreed,
+        );
+      })
+      .map((rule) => ({
+        ruleId: rule.id,
+        taskDefinitionId: rule.taskDefinitionId,
+        taskName: rule.taskDefinition.name,
+        taskCategory: rule.taskDefinition.category,
+        text: rule.recommendationText,
+        because: {
+          species,
+          breedSpecific: rule.breedCodes.length > 0,
+          breedCode: patientBreed,
+          minAgeMonths: rule.minAgeMonths,
+          maxAgeMonths: rule.maxAgeMonths,
+          ageMonths: age,
+        },
+        citation: {
+          authors: rule.citationAuthors,
+          title: rule.citationTitle,
+          source: rule.citationSource,
+          year: rule.citationYear,
+          doi: rule.citationDoi,
+          url: rule.citationUrl,
+          claim: rule.citationClaim,
+          grade: rule.evidenceGrade,
+          lastReviewedAt: rule.lastReviewedAt,
+          reviewedBy: rule.reviewedBy,
+          nextReviewDue: rule.nextReviewDue,
+        },
+      }));
+  },
+};

--- a/apps/backend/src/services/task-recommendation.service.ts
+++ b/apps/backend/src/services/task-recommendation.service.ts
@@ -143,8 +143,19 @@ export const TaskRecommendationService = {
     // This is a fallback between two recorded values, not an inference: `type` is
     // what the parent picked. Guessing a species from free-text breed would be a
     // different thing and is still not done.
-    const species =
-      taskSpeciesForCode(patient.speciesCode) ?? TASK_SPECIES[patient.type];
+    const coded = taskSpeciesForCode(patient.speciesCode);
+    const declared = TASK_SPECIES[patient.type];
+
+    // If both are recorded and they disagree, the companion's data is
+    // inconsistent and neither value can be trusted to pick the rules.
+    // Returning nothing is the only safe answer: choosing one would serve
+    // guidance for the wrong animal on exactly the rows where we already know
+    // something is wrong. Nothing upstream enforces agreement -
+    // validateCompanionCodes checks each code is valid, not that the two
+    // describe the same species.
+    if (coded && declared && coded !== declared) return [];
+
+    const species = coded ?? declared;
     if (!species) return [];
 
     const age = ageInMonths(patient.dateOfBirth, new Date());
@@ -185,8 +196,15 @@ export const TaskRecommendationService = {
         // A rule for dogs must not recommend a task the definition does not apply
         // to dogs. Nothing in the relation enforces that, so a curator pointing a
         // canine rule at a feline-only task would otherwise ship it.
-        .filter((rule) =>
-          rule.taskDefinition.applicableSpecies.includes(species),
+        //
+        // An EMPTY applicableSpecies means universal, not "applies to nothing" -
+        // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
+        // `{ has: species }` for exactly that reason. Treating empty as a
+        // mismatch here would silently drop every universal task.
+        .filter(
+          (rule) =>
+            rule.taskDefinition.applicableSpecies.length === 0 ||
+            rule.taskDefinition.applicableSpecies.includes(species),
         )
         .filter((rule) =>
           withinWindow(age, rule.minAgeMonths, rule.maxAgeMonths),

--- a/apps/backend/test/controllers/task-recommendation.controller.test.ts
+++ b/apps/backend/test/controllers/task-recommendation.controller.test.ts
@@ -57,6 +57,11 @@ describe("TaskRecommendationController.listForCompanion", () => {
 
     expect(disclaimer).toMatch(/not a diagnosis/i);
     expect(disclaimer).toMatch(/ask them/i);
+    // Must NOT claim breed and age. Not every rule is breed-specific or
+    // age-bounded - a species-wide life-stage task matches on neither - so a
+    // blanket claim would overstate what triggered the guidance. The per-card
+    // `because` block carries what each one was actually matched on.
+    expect(disclaimer).not.toMatch(/this breed and age/i);
   });
 
   it("still returns the disclaimer when there is nothing to recommend", async () => {

--- a/apps/backend/test/controllers/task-recommendation.controller.test.ts
+++ b/apps/backend/test/controllers/task-recommendation.controller.test.ts
@@ -1,0 +1,95 @@
+jest.mock("src/services/task-recommendation.service", () => ({
+  TaskRecommendationService: { forCompanion: jest.fn() },
+  TaskRecommendationError: class extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+    }
+  },
+}));
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import type { Request, Response } from "express";
+import { TaskRecommendationController } from "src/controllers/app/task-recommendation.controller";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+const forCompanion = TaskRecommendationService.forCompanion as jest.Mock;
+
+const run = async (patientId = "pat-1") => {
+  const req = { params: { patientId } } as unknown as Request;
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  await TaskRecommendationController.listForCompanion(req, res);
+  return { res, json };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("TaskRecommendationController.listForCompanion", () => {
+  it("returns the recommendations with a disclaimer alongside them", async () => {
+    forCompanion.mockResolvedValue([{ ruleId: "r1" }]);
+
+    const { res, json } = await run();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = json.mock.calls[0][0];
+    expect(payload.recommendations).toEqual([{ ruleId: "r1" }]);
+    expect(typeof payload.disclaimer).toBe("string");
+  });
+
+  it("sends the disclaimer from the server, not from the app bundle", async () => {
+    // The wording is the part most likely to need correcting - by counsel, or
+    // after a vet reads it. Shipping it in the response means that correction
+    // does not wait out mobile adoption, which is the same reason the rules
+    // themselves are server-side.
+    forCompanion.mockResolvedValue([]);
+
+    const { json } = await run();
+    const { disclaimer } = json.mock.calls[0][0];
+
+    expect(disclaimer).toMatch(/not a diagnosis/i);
+    expect(disclaimer).toMatch(/ask them/i);
+  });
+
+  it("still returns the disclaimer when there is nothing to recommend", async () => {
+    forCompanion.mockResolvedValue([]);
+
+    const { json } = await run();
+
+    expect(json.mock.calls[0][0].recommendations).toEqual([]);
+    expect(json.mock.calls[0][0].disclaimer).toBeTruthy();
+  });
+
+  it("passes a service error's own status through", async () => {
+    forCompanion.mockRejectedValue(
+      new TaskRecommendationError("Companion not found.", 404),
+    );
+
+    const { res, json } = await run("nope");
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: "Companion not found." });
+  });
+
+  it("does not leak an unexpected error to the caller", async () => {
+    forCompanion.mockRejectedValue(
+      new Error("connection string: postgres://u:p@h/db"),
+    );
+
+    const { res, json } = await run();
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      message: "Unable to load recommendations.",
+    });
+    expect(JSON.stringify(json.mock.calls)).not.toContain("postgres://");
+  });
+});

--- a/apps/backend/test/routers/task.router.test.ts
+++ b/apps/backend/test/routers/task.router.test.ts
@@ -39,6 +39,15 @@ const TaskTemplateController = {
   archive: jest.fn(),
 };
 
+const companionGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn(
+  (_feature: string, _paramName?: string) => companionGuard,
+);
+
+const TaskRecommendationController = {
+  listForCompanion: jest.fn(),
+};
+
 jest.mock("../../src/middlewares/auth", () => ({
   requireWebAuth,
   requireMobileAuth,
@@ -54,6 +63,17 @@ jest.mock("../../src/controllers/web/task.controller", () => ({
   TaskController,
   TaskLibraryController,
   TaskTemplateController,
+}));
+
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission: (feature: string, paramName?: string) => {
+    requireCompanionPermission(feature, paramName);
+    return companionGuard;
+  },
+}));
+
+jest.mock("../../src/controllers/app/task-recommendation.controller", () => ({
+  TaskRecommendationController,
 }));
 
 const taskRouter = jest.requireActual("../../src/routers/task.router")
@@ -146,5 +166,39 @@ describe("task.router", () => {
       "tasks:view:any",
       "tasks:view:own",
     ]);
+  });
+});
+
+describe("task.router recommendations", () => {
+  const PATH = "/mobile/companion/:patientId/recommendations";
+
+  it("puts recommendations behind mobile auth and the co-parent tasks gate", () => {
+    // The rules are health-adjacent. A co-parent whose tasks switch is off should
+    // not be able to read what has been recommended for the companion either, and
+    // the guard is the only thing that enforces that - the handler does not check.
+    const route = findRoute(PATH, "get");
+    expect(route).toBeDefined();
+    expect(route?.stack).toHaveLength(3);
+
+    const handles = route?.stack.map((l) => l.handle);
+    expect(handles).toContain(requireMobileAuth);
+    expect(handles).toContain(companionGuard);
+    expect(handles).toContain(TaskRecommendationController.listForCompanion);
+    expect(handles).not.toContain(requireWebAuth);
+  });
+
+  it("gates it on the same feature as the companion task list", () => {
+    expect(requireCompanionPermission).toHaveBeenCalledWith(
+      "tasks",
+      "patientId",
+    );
+  });
+
+  it("does not expose recommendations on a PMS path", () => {
+    // Clinic visibility is a separate surface with its own permission model; it
+    // must not arrive by accident on a route mounted for parents.
+    expect(
+      findRoute("/pms/companion/:patientId/recommendations", "get"),
+    ).toBeUndefined();
   });
 });

--- a/apps/backend/test/scripts/backfill-breed-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-breed-codes.test.ts
@@ -1,13 +1,13 @@
 jest.mock("src/config/prisma", () => ({
   prisma: {
-    patient: { findMany: jest.fn(), update: jest.fn() },
+    patient: { findMany: jest.fn(), updateMany: jest.fn() },
     codeEntry: { findMany: jest.fn() },
     $disconnect: jest.fn(),
   },
 }));
 
 import { prisma } from "src/config/prisma";
-import { planBackfill } from "src/scripts/backfill-breed-codes";
+import { main, planBackfill } from "src/scripts/backfill-breed-codes";
 
 const patientFind = (prisma as unknown as { patient: { findMany: jest.Mock } })
   .patient.findMany;
@@ -131,5 +131,77 @@ describe("planBackfill query volume", () => {
 
     // Two species present, so two queries - not four.
     expect(codeFind).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("main", () => {
+  const patientUpdateMany = (
+    prisma as unknown as { patient: { updateMany: jest.Mock } }
+  ).patient.updateMany;
+
+  let log: jest.SpyInstance;
+  let argv: string[];
+
+  beforeEach(() => {
+    argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+    patientFind.mockResolvedValue([{ id: "p1", breed: "Pug", type: "dog" }]);
+    codeFind.mockResolvedValue([{ code: "YBREED:CANINE:PUG", display: "Pug" }]);
+    patientUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    process.argv = argv;
+    log.mockRestore();
+  });
+
+  const output = () => log.mock.calls.map((c) => String(c[0])).join("\n");
+
+  it("writes nothing without --apply", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts"];
+    await main();
+
+    expect(patientUpdateMany).not.toHaveBeenCalled();
+    expect(output()).toMatch(/dry run/);
+  });
+
+  it("writes only when --apply is passed, and only while the row is still uncoded", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts", "--apply"];
+    await main();
+
+    // updateMany with breedCode: null in the where, not update by id. A parent
+    // editing their companion between the plan and the write would otherwise
+    // have their new breed overwritten by a stale planned value.
+    expect(patientUpdateMany).toHaveBeenCalledWith({
+      where: { id: "p1", breedCode: null },
+      data: {
+        speciesCode: "YSPEC:CANINE",
+        breedCode: "YBREED:CANINE:PUG",
+      },
+    });
+    expect(output()).toMatch(/wrote 1 companions/);
+  });
+
+  it("reports a row that someone else coded while it was running", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts", "--apply"];
+    patientUpdateMany.mockResolvedValue({ count: 0 });
+
+    await main();
+
+    expect(output()).toMatch(/wrote 0 companions/);
+    expect(output()).toMatch(/coded by someone else/);
+  });
+
+  it("names every skipped companion and why", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts"];
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Nonesuch", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    await main();
+
+    expect(output()).toMatch(/SKIP dog "Nonesuch"/);
+    expect(output()).toMatch(/no vocabulary entry/);
   });
 });

--- a/apps/backend/test/scripts/backfill-breed-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-breed-codes.test.ts
@@ -1,0 +1,113 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    patient: { findMany: jest.fn(), update: jest.fn() },
+    codeEntry: { findMany: jest.fn() },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import { planBackfill } from "src/scripts/backfill-breed-codes";
+
+const patientFind = (prisma as unknown as { patient: { findMany: jest.Mock } })
+  .patient.findMany;
+const codeFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("planBackfill", () => {
+  it("scopes the lookup to the companion's own species", async () => {
+    // The trap this exists for. `Abyssinian` is a cat breed AND a horse breed;
+    // `Maltese` is a dog AND a cat. Matching on display alone would have coded an
+    // Abyssinian cat as a horse and then handed it equine guidance.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Abyssinian", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([{ code: "YBREED:FELINE:ABYSSINIAN" }]);
+
+    const [outcome] = await planBackfill();
+
+    expect(codeFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          code: { startsWith: "YBREED:FELINE:" },
+        }),
+      }),
+    );
+    expect(outcome.resolved).toBe("YBREED:FELINE:ABYSSINIAN");
+  });
+
+  it("collapses the two spellings of one breed instead of calling it a conflict", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "American Curl", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:FELINE:AMERICAN_CURL" },
+      { code: "YBREED:FELINE:AMERICAN-CURL" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBe("YBREED:FELINE:AMERICAN_CURL");
+  });
+
+  it("skips rather than guesses when two genuinely different codes remain", async () => {
+    // A wrong code is worse than a missing one: a missing code shows no
+    // recommendations, a wrong one shows confident recommendations for the
+    // wrong animal.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Maltese", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:CANINE:MALTESE" },
+      { code: "YBREED:CANINE:MALTESE_CANINE" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/ambiguous/);
+  });
+
+  it("skips a species with no breed vocabulary", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Something", type: "other" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no breed vocabulary/);
+    expect(codeFind).not.toHaveBeenCalled();
+  });
+
+  it("skips a companion with no breed text", async () => {
+    patientFind.mockResolvedValue([{ id: "p1", breed: "   ", type: "dog" }]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no breed text/);
+  });
+
+  it("reports a breed the vocabulary does not hold for that species", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Nonesuch", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no vocabulary entry/);
+  });
+
+  it("only considers companions that have no code yet", async () => {
+    patientFind.mockResolvedValue([]);
+    await planBackfill();
+    expect(patientFind).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { breedCode: null } }),
+    );
+  });
+});

--- a/apps/backend/test/scripts/backfill-breed-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-breed-codes.test.ts
@@ -24,7 +24,9 @@ describe("planBackfill", () => {
     patientFind.mockResolvedValue([
       { id: "p1", breed: "Abyssinian", type: "cat" },
     ]);
-    codeFind.mockResolvedValue([{ code: "YBREED:FELINE:ABYSSINIAN" }]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:FELINE:ABYSSINIAN", display: "Abyssinian" },
+    ]);
 
     const [outcome] = await planBackfill();
 
@@ -32,6 +34,7 @@ describe("planBackfill", () => {
       expect.objectContaining({
         where: expect.objectContaining({
           code: { startsWith: "YBREED:FELINE:" },
+          display: { in: ["Abyssinian"], mode: "insensitive" },
         }),
       }),
     );
@@ -43,8 +46,8 @@ describe("planBackfill", () => {
       { id: "p1", breed: "American Curl", type: "cat" },
     ]);
     codeFind.mockResolvedValue([
-      { code: "YBREED:FELINE:AMERICAN_CURL" },
-      { code: "YBREED:FELINE:AMERICAN-CURL" },
+      { code: "YBREED:FELINE:AMERICAN_CURL", display: "American Curl" },
+      { code: "YBREED:FELINE:AMERICAN-CURL", display: "American Curl" },
     ]);
 
     const [outcome] = await planBackfill();
@@ -60,8 +63,8 @@ describe("planBackfill", () => {
       { id: "p1", breed: "Maltese", type: "dog" },
     ]);
     codeFind.mockResolvedValue([
-      { code: "YBREED:CANINE:MALTESE" },
-      { code: "YBREED:CANINE:MALTESE_CANINE" },
+      { code: "YBREED:CANINE:MALTESE", display: "Maltese" },
+      { code: "YBREED:CANINE:MALTESE_CANINE", display: "Maltese" },
     ]);
 
     const [outcome] = await planBackfill();
@@ -109,5 +112,24 @@ describe("planBackfill", () => {
     expect(patientFind).toHaveBeenCalledWith(
       expect.objectContaining({ where: { breedCode: null } }),
     );
+  });
+});
+
+describe("planBackfill query volume", () => {
+  it("asks the vocabulary once per species, not once per companion", async () => {
+    // Every lookup asks the same species-scoped question, so one round trip per
+    // companion bought no new information.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Pug", type: "dog" },
+      { id: "p2", breed: "Beagle", type: "dog" },
+      { id: "p3", breed: "Boxer", type: "dog" },
+      { id: "p4", breed: "Abyssinian", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    await planBackfill();
+
+    // Two species present, so two queries - not four.
+    expect(codeFind).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/backend/test/services/breed-code.test.ts
+++ b/apps/backend/test/services/breed-code.test.ts
@@ -29,6 +29,14 @@ describe("canonicalBreedCode", () => {
     expect(canonicalBreedCode("YBREED:CANINE:A__B")).toBe("YBREED:CANINE:A_B");
   });
 
+  it("keeps a single separator at the edges rather than eating it", () => {
+    // A split/filter/join collapse would drop these. Not reachable from the
+    // picker, but the function is the one place codes are normalised and it
+    // should not quietly rewrite its input beyond what it claims to do.
+    expect(canonicalBreedCode("_A_B_")).toBe("_A_B_");
+    expect(canonicalBreedCode("__A__B__")).toBe("_A_B_");
+  });
+
   it("returns null for anything unusable", () => {
     expect(canonicalBreedCode(null)).toBeNull();
     expect(canonicalBreedCode(undefined)).toBeNull();

--- a/apps/backend/test/services/breed-code.test.ts
+++ b/apps/backend/test/services/breed-code.test.ts
@@ -1,0 +1,101 @@
+import {
+  ageInMonths,
+  breedCodesMatch,
+  canonicalBreedCode,
+  taskSpeciesForCode,
+} from "src/services/shared/breed-code";
+
+describe("canonicalBreedCode", () => {
+  it("folds the two separator conventions in the vocabulary onto one", () => {
+    // Not hypothetical. Production CodeEntry holds 1,749 breed codes that collapse
+    // to 1,713: 36 breeds exist under both spellings, and patient rows are split
+    // the same way.
+    expect(canonicalBreedCode("YBREED:CANINE:SHIH-TZU")).toBe(
+      canonicalBreedCode("YBREED:CANINE:SHIH_TZU"),
+    );
+    expect(
+      canonicalBreedCode("YBREED:FELINE:AMERICAN-BOBTAIL-LONG-HAIRED"),
+    ).toBe("YBREED:FELINE:AMERICAN_BOBTAIL_LONG_HAIRED");
+  });
+
+  it("upper-cases and trims", () => {
+    expect(canonicalBreedCode("  ybreed:canine:pug  ")).toBe(
+      "YBREED:CANINE:PUG",
+    );
+  });
+
+  it("collapses repeated separators so two spellings cannot diverge on them", () => {
+    expect(canonicalBreedCode("YBREED:CANINE:A--B")).toBe("YBREED:CANINE:A_B");
+    expect(canonicalBreedCode("YBREED:CANINE:A__B")).toBe("YBREED:CANINE:A_B");
+  });
+
+  it("returns null for anything unusable", () => {
+    expect(canonicalBreedCode(null)).toBeNull();
+    expect(canonicalBreedCode(undefined)).toBeNull();
+    expect(canonicalBreedCode("   ")).toBeNull();
+    expect(canonicalBreedCode(42 as unknown as string)).toBeNull();
+  });
+});
+
+describe("breedCodesMatch", () => {
+  it("matches across conventions", () => {
+    expect(
+      breedCodesMatch("YBREED:CANINE:LHASA-APSO", "YBREED:CANINE:LHASA_APSO"),
+    ).toBe(true);
+  });
+
+  it("does not match different breeds", () => {
+    expect(breedCodesMatch("YBREED:CANINE:PUG", "YBREED:CANINE:BOXER")).toBe(
+      false,
+    );
+  });
+
+  it("treats two unknowns as no match, not as equal", () => {
+    // This decides whether a rule applies, so anything unreadable must fall
+    // through to "no". Two nulls comparing equal would apply every breed-specific
+    // rule to every uncoded companion.
+    expect(breedCodesMatch(null, null)).toBe(false);
+    expect(breedCodesMatch("", "")).toBe(false);
+    expect(breedCodesMatch("YBREED:CANINE:PUG", null)).toBe(false);
+  });
+});
+
+describe("taskSpeciesForCode", () => {
+  it("maps the three coded species onto the task enum", () => {
+    expect(taskSpeciesForCode("YSPEC:CANINE")).toBe("dog");
+    expect(taskSpeciesForCode("YSPEC:FELINE")).toBe("cat");
+    expect(taskSpeciesForCode("YSPEC:EQUINE")).toBe("horse");
+  });
+
+  it("returns null rather than guessing for anything else", () => {
+    expect(taskSpeciesForCode("YSPEC:AVIAN")).toBeNull();
+    expect(taskSpeciesForCode(null)).toBeNull();
+    expect(taskSpeciesForCode("")).toBeNull();
+  });
+});
+
+describe("ageInMonths", () => {
+  const asOf = new Date("2026-08-24T12:00:00Z");
+
+  it("counts whole months only", () => {
+    expect(ageInMonths(new Date("2026-07-24T00:00:00Z"), asOf)).toBe(1);
+    // One day short of a month is still zero.
+    expect(ageInMonths(new Date("2026-07-25T00:00:00Z"), asOf)).toBe(0);
+  });
+
+  it("counts across years", () => {
+    expect(ageInMonths(new Date("2019-08-24T00:00:00Z"), asOf)).toBe(84);
+  });
+
+  it("returns null for a future date of birth rather than a negative age", () => {
+    // A negative age would silently satisfy every maxAgeMonths bound, so a bad
+    // date of birth would hand a puppy every senior recommendation there is.
+    expect(ageInMonths(new Date("2027-01-01T00:00:00Z"), asOf)).toBeNull();
+  });
+
+  it("returns null for an unusable date", () => {
+    expect(ageInMonths(null, asOf)).toBeNull();
+    expect(ageInMonths(undefined, asOf)).toBeNull();
+    expect(ageInMonths(new Date("nonsense"), asOf)).toBeNull();
+  });
+});

--- a/apps/backend/test/services/task-recommendation.service.test.ts
+++ b/apps/backend/test/services/task-recommendation.service.test.ts
@@ -49,6 +49,7 @@ const rule = (over: Partial<Record<string, unknown>> = {}) => ({
     name: "Log weight",
     category: "Monitoring",
     isActive: true,
+    applicableSpecies: ["dog", "cat", "horse"],
   },
   ...over,
 });
@@ -59,6 +60,7 @@ beforeEach(() => {
     speciesCode: "YSPEC:CANINE",
     breedCode: "YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL",
     dateOfBirth: yearsAgo(7),
+    type: "dog",
   });
   ruleFind.mockResolvedValue([]);
 });
@@ -75,7 +77,7 @@ describe("TaskRecommendationService.forCompanion", () => {
         where: expect.objectContaining({
           species: "dog",
           isActive: true,
-          NOT: { reviewedBy: null },
+          reviewedBy: { not: null },
         }),
       }),
     );
@@ -100,6 +102,7 @@ describe("TaskRecommendationService.forCompanion", () => {
       speciesCode: "YSPEC:CANINE",
       breedCode: null,
       dateOfBirth: yearsAgo(3),
+      type: "dog",
     });
     ruleFind.mockResolvedValue([rule({ breedCodes: [] })]);
 
@@ -114,6 +117,7 @@ describe("TaskRecommendationService.forCompanion", () => {
       speciesCode: "YSPEC:CANINE",
       breedCode: null,
       dateOfBirth: yearsAgo(7),
+      type: "dog",
     });
     ruleFind.mockResolvedValue([
       rule({ breedCodes: ["YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL"] }),
@@ -127,6 +131,7 @@ describe("TaskRecommendationService.forCompanion", () => {
       speciesCode: "YSPEC:CANINE",
       breedCode: null,
       dateOfBirth: yearsAgo(7),
+      type: "dog",
     });
     ruleFind.mockResolvedValue([
       rule({ id: "under-84", minAgeMonths: null, maxAgeMonths: 84 }),
@@ -153,13 +158,14 @@ describe("TaskRecommendationService.forCompanion", () => {
     expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
   });
 
-  it("returns nothing for a species it cannot code, rather than guessing", async () => {
+  it("returns nothing for a species with no rules vocabulary, rather than guessing", async () => {
     // Guessing the species from free-text breed would put an unreviewed inference
     // behind a cited recommendation.
     patientFind.mockResolvedValue({
       speciesCode: null,
       breedCode: "YBREED:CANINE:PUG",
       dateOfBirth: yearsAgo(4),
+      type: "other",
     });
 
     expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
@@ -171,6 +177,7 @@ describe("TaskRecommendationService.forCompanion", () => {
       speciesCode: "YSPEC:CANINE",
       breedCode: null,
       dateOfBirth: null,
+      type: "dog",
     });
 
     expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
@@ -186,14 +193,15 @@ describe("TaskRecommendationService.forCompanion", () => {
 
     const [out] = await TaskRecommendationService.forCompanion("pat-1");
 
-    expect(out.citation).toMatchObject({
-      authors: "Author A, Author B",
-      year: 2024,
-      doi: "10.0000/example",
-      claim: "The specific sentence relied on.",
-      grade: "CONSENSUS_STATEMENT",
-      reviewedBy: "vet-1",
+    expect(out.evidence.artifact).toMatchObject({
+      type: "citation",
+      // The claim relied on, not the paper's abstract - this is what a vet argues with.
+      display: "The specific sentence relied on.",
+      citation: "Author A, Author B. A title. A journal. 2024.",
+      url: "https://doi.org/10.0000/example",
     });
+    expect(out.evidence.grade).toBe("CONSENSUS_STATEMENT");
+    expect(out.evidence.attestation.reviewedBy).toBe("vet-1");
     expect(out.because).toMatchObject({
       species: "dog",
       breedSpecific: true,
@@ -213,5 +221,103 @@ describe("TaskRecommendationService.forCompanion", () => {
     ).rejects.toMatchObject({
       statusCode: 400,
     });
+  });
+});
+
+describe("TaskRecommendationService hardening", () => {
+  it("falls back to the required type when speciesCode is missing", async () => {
+    // speciesCode is null on 30 of 37 production companions. Reading only the
+    // coded column returned nothing for four companions in five until the
+    // backfill ran. `type` is required and is what the parent picked, so this is
+    // a fallback between two recorded values, not an inference.
+    patientFind.mockResolvedValue({
+      speciesCode: null,
+      breedCode: null,
+      dateOfBirth: yearsAgo(5),
+      type: "cat",
+    });
+    ruleFind.mockResolvedValue([rule()]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(ruleFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ species: "cat" }),
+      }),
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it("does not treat a blank reviewer as a signature", async () => {
+    // The column is a nullable string, so "" and "   " both pass a NOT NULL
+    // check while naming nobody. This is the gate that keeps unreviewed clinical
+    // guidance away from pet parents.
+    ruleFind.mockResolvedValue([
+      rule({ id: "empty", reviewedBy: "" }),
+      rule({ id: "spaces", reviewedBy: "   " }),
+      rule({ id: "named", reviewedBy: "Dr Real Person" }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.map((r) => r.ruleId)).toEqual(["named"]);
+  });
+
+  it("will not recommend a task the definition does not apply to that species", async () => {
+    // Nothing in the relation enforces this, so a curator pointing a canine rule
+    // at a feline-only task would otherwise ship it.
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "Cat-only thing",
+          category: "x",
+          isActive: true,
+          applicableSpecies: ["cat"],
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("gives the evidence grade a readable label without dropping the raw value", async () => {
+    ruleFind.mockResolvedValue([
+      rule({ evidenceGrade: "CONSENSUS_STATEMENT" }),
+    ]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.evidence.grade).toBe("CONSENSUS_STATEMENT");
+    expect(out.evidence.artifact.label).toBe("Consensus statement");
+  });
+
+  it("falls back to the raw grade if a new one has no label yet", async () => {
+    ruleFind.mockResolvedValue([rule({ evidenceGrade: "SOMETHING_NEW" })]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.evidence.artifact.label).toBe("SOMETHING_NEW");
+  });
+});
+
+describe("TaskRecommendationService evidence shape", () => {
+  it("prefers an explicit url over a DOI, and omits the link when there is neither", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        id: "with-url",
+        citationUrl: "https://example.org/paper",
+        citationDoi: "10.1/x",
+      }),
+    ]);
+    const [withUrl] = await TaskRecommendationService.forCompanion("pat-1");
+    expect(withUrl.evidence.artifact.url).toBe("https://example.org/paper");
+
+    ruleFind.mockResolvedValue([
+      rule({ citationUrl: null, citationDoi: null }),
+    ]);
+    const [bare] = await TaskRecommendationService.forCompanion("pat-1");
+    // Not an empty string or a bare "https://doi.org/" - the field is simply absent.
+    expect(bare.evidence.artifact.url).toBeUndefined();
   });
 });

--- a/apps/backend/test/services/task-recommendation.service.test.ts
+++ b/apps/backend/test/services/task-recommendation.service.test.ts
@@ -321,3 +321,43 @@ describe("TaskRecommendationService evidence shape", () => {
     expect(bare.evidence.artifact.url).toBeUndefined();
   });
 });
+
+describe("TaskRecommendationService species integrity", () => {
+  it("returns nothing when speciesCode and type disagree", async () => {
+    // Nothing upstream enforces that the two agree - validateCompanionCodes
+    // checks each code is valid, not that they describe one species. Picking
+    // either would serve guidance for the wrong animal on exactly the rows
+    // already known to be inconsistent.
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(5),
+      type: "cat",
+    });
+    ruleFind.mockResolvedValue([rule()]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+    expect(ruleFind).not.toHaveBeenCalled();
+  });
+
+  it("keeps a universal task definition, which declares no species at all", async () => {
+    // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
+    // `{ has: species }`, so empty means universal rather than "applies to
+    // nothing". Reading it as a mismatch would drop every universal task.
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "Universal",
+          category: "x",
+          isActive: true,
+          applicableSpecies: [],
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/apps/backend/test/services/task-recommendation.service.test.ts
+++ b/apps/backend/test/services/task-recommendation.service.test.ts
@@ -1,0 +1,217 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    patient: { findUnique: jest.fn() },
+    taskRecommendationRule: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+const patientFind = (
+  prisma as unknown as { patient: { findUnique: jest.Mock } }
+).patient.findUnique;
+const ruleFind = (
+  prisma as unknown as { taskRecommendationRule: { findMany: jest.Mock } }
+).taskRecommendationRule.findMany;
+
+const yearsAgo = (years: number) => {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  // Step back a day so a same-day boundary never makes the age flap.
+  d.setDate(d.getDate() - 1);
+  return d;
+};
+
+const rule = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: "rule-1",
+  breedCodes: [] as string[],
+  minAgeMonths: null,
+  maxAgeMonths: null,
+  taskDefinitionId: "task-1",
+  recommendationText: "Log their weight monthly.",
+  citationAuthors: "Author A, Author B",
+  citationTitle: "A title",
+  citationSource: "A journal",
+  citationYear: 2024,
+  citationDoi: "10.0000/example",
+  citationUrl: null,
+  citationClaim: "The specific sentence relied on.",
+  evidenceGrade: "CONSENSUS_STATEMENT",
+  lastReviewedAt: new Date("2026-01-01"),
+  reviewedBy: "vet-1",
+  nextReviewDue: new Date("2027-01-01"),
+  taskDefinition: {
+    id: "task-1",
+    name: "Log weight",
+    category: "Monitoring",
+    isActive: true,
+  },
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  patientFind.mockResolvedValue({
+    speciesCode: "YSPEC:CANINE",
+    breedCode: "YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL",
+    dateOfBirth: yearsAgo(7),
+  });
+  ruleFind.mockResolvedValue([]);
+});
+
+describe("TaskRecommendationService.forCompanion", () => {
+  it("only ever asks for active rules that a named reviewer signed off", async () => {
+    // isActive alone is not enough. An active-but-unreviewed row is a seeding
+    // accident, and this feature puts cited clinical guidance in front of pet
+    // parents - it must not be reachable without a person attached to it.
+    await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(ruleFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          species: "dog",
+          isActive: true,
+          NOT: { reviewedBy: null },
+        }),
+      }),
+    );
+  });
+
+  it("matches a breed rule across the two vocabulary conventions", async () => {
+    // The rule is stored hyphenated, the patient is coded with underscores. A
+    // literal comparison returns nothing here, and a recommendation that is
+    // silently absent looks exactly like a breed with no guidance for it.
+    ruleFind.mockResolvedValue([
+      rule({ breedCodes: ["YBREED:CANINE:CAVALIER-KING-CHARLES-SPANIEL"] }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out).toHaveLength(1);
+    expect(out[0].because.breedSpecific).toBe(true);
+  });
+
+  it("applies a species-wide rule to any breed, including an uncoded one", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(3),
+    });
+    ruleFind.mockResolvedValue([rule({ breedCodes: [] })]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out).toHaveLength(1);
+    expect(out[0].because.breedSpecific).toBe(false);
+  });
+
+  it("does not apply a breed rule to a companion with no breed code", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(7),
+    });
+    ruleFind.mockResolvedValue([
+      rule({ breedCodes: ["YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL"] }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("treats the age window as half-open so adjacent life stages do not overlap", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(7),
+    });
+    ruleFind.mockResolvedValue([
+      rule({ id: "under-84", minAgeMonths: null, maxAgeMonths: 84 }),
+      rule({ id: "from-84", minAgeMonths: 84, maxAgeMonths: null }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.map((r) => r.ruleId)).toEqual(["from-84"]);
+  });
+
+  it("drops a rule whose task definition has been deactivated", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "x",
+          category: "y",
+          isActive: false,
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("returns nothing for a species it cannot code, rather than guessing", async () => {
+    // Guessing the species from free-text breed would put an unreviewed inference
+    // behind a cited recommendation.
+    patientFind.mockResolvedValue({
+      speciesCode: null,
+      breedCode: "YBREED:CANINE:PUG",
+      dateOfBirth: yearsAgo(4),
+    });
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+    expect(ruleFind).not.toHaveBeenCalled();
+  });
+
+  it("returns nothing when the date of birth is unusable", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: null,
+    });
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("carries the citation and the trigger through for the why-am-I-seeing-this panel", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        breedCodes: ["YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL"],
+        minAgeMonths: 60,
+      }),
+    ]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.citation).toMatchObject({
+      authors: "Author A, Author B",
+      year: 2024,
+      doi: "10.0000/example",
+      claim: "The specific sentence relied on.",
+      grade: "CONSENSUS_STATEMENT",
+      reviewedBy: "vet-1",
+    });
+    expect(out.because).toMatchObject({
+      species: "dog",
+      breedSpecific: true,
+      minAgeMonths: 60,
+    });
+    expect(out.because.ageMonths).toBeGreaterThanOrEqual(84);
+  });
+
+  it("404s an unknown companion and 400s a blank id", async () => {
+    patientFind.mockResolvedValue(null);
+    await expect(
+      TaskRecommendationService.forCompanion("nope"),
+    ).rejects.toThrow(TaskRecommendationError);
+
+    await expect(
+      TaskRecommendationService.forCompanion("   "),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+});

--- a/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
+++ b/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
@@ -54,3 +54,19 @@ ALTER TABLE "TaskRecommendationRule"
   ADD CONSTRAINT "TaskRecommendationRule_taskDefinitionId_fkey"
   FOREIGN KEY ("taskDefinitionId") REFERENCES "TaskLibraryDefinition"("id")
   ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Enable row level security, matching 20260818090000_enable_row_level_security.
+--
+-- That migration switches RLS on by looping over every table in `public`, which
+-- makes it idempotent but only covers tables that existed when it ran. A table
+-- created by a later migration ships with RLS off, and the CI step "Check row
+-- level security is enabled on every public table" fails on it - which is how
+-- this was caught here, and how it was caught on CareReminderOptOut before it.
+--
+-- Enabling with no policy is the intended default: the API connects as the
+-- owning role and bypasses RLS, so Prisma queries are unaffected, while
+-- Supabase's PostgREST surface to the `anon` and `authenticated` keys is denied.
+-- That matters here because these rows carry clinical guidance that is only safe
+-- to read once a reviewer has signed it off - the `isActive` and `reviewedBy`
+-- gate lives in the application, and PostgREST would go straight past it.
+ALTER TABLE "TaskRecommendationRule" ENABLE ROW LEVEL SECURITY;

--- a/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
+++ b/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
@@ -1,0 +1,56 @@
+-- Recommendation rules: a husbandry task tied to a species, breed and age window,
+-- carrying the clinical source it rests on.
+--
+-- Additive only. Nothing existing is altered; TaskLibraryDefinition gains a
+-- back-relation, which is a Prisma-level concept and needs no column here.
+
+CREATE TYPE "RecommendationEvidenceGrade" AS ENUM (
+  'CONSENSUS_STATEMENT',
+  'PRACTICE_GUIDELINE',
+  'POPULATION_STUDY',
+  'COHORT_STUDY',
+  'CASE_SERIES',
+  'EXPERT_OPINION'
+);
+
+CREATE TABLE "TaskRecommendationRule" (
+  "id"                 TEXT NOT NULL,
+  "species"            "TaskLibrarySpecies" NOT NULL,
+  -- No NOT NULL here: Prisma treats a scalar list as implicitly non-null and does
+  -- not emit the constraint, so adding it would read as drift against the schema.
+  "breedCodes"         TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "minAgeMonths"       INTEGER,
+  "maxAgeMonths"       INTEGER,
+  "taskDefinitionId"   TEXT NOT NULL,
+  "recommendationText" TEXT NOT NULL,
+  "citationAuthors"    TEXT NOT NULL,
+  "citationTitle"      TEXT NOT NULL,
+  "citationSource"     TEXT NOT NULL,
+  "citationYear"       INTEGER NOT NULL,
+  "citationDoi"        TEXT,
+  "citationUrl"        TEXT,
+  "citationClaim"      TEXT NOT NULL,
+  "evidenceGrade"      "RecommendationEvidenceGrade" NOT NULL,
+  "lastReviewedAt"     TIMESTAMP(3),
+  "reviewedBy"         TEXT,
+  "nextReviewDue"      TIMESTAMP(3),
+  -- Defaults to FALSE, unlike almost every other isActive in this schema. A rule
+  -- reaches pet parents only once a named reviewer has signed it off, so a row
+  -- inserted by a seed or a migration is inert until someone does.
+  "isActive"           BOOLEAN NOT NULL DEFAULT false,
+  "createdAt"          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"          TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "TaskRecommendationRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "TaskRecommendationRule_species_isActive_idx"
+  ON "TaskRecommendationRule"("species", "isActive");
+
+CREATE INDEX "TaskRecommendationRule_taskDefinitionId_idx"
+  ON "TaskRecommendationRule"("taskDefinitionId");
+
+ALTER TABLE "TaskRecommendationRule"
+  ADD CONSTRAINT "TaskRecommendationRule_taskDefinitionId_fkey"
+  FOREIGN KEY ("taskDefinitionId") REFERENCES "TaskLibraryDefinition"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -8,8 +8,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -226,7 +226,7 @@ model ContactRequest {
   userId           String?
   email            String?
   organisationId   String?
-  patientId      String?
+  patientId        String?
   parentId         String?
   dsarDetails      Json?
   complaintContext Json?
@@ -245,20 +245,20 @@ model ContactRequest {
 }
 
 model IntegrationAccount {
-  id             String              @id @default(uuid())
-  organisationId String
-  provider       IntegrationProvider
-  status         IntegrationStatus   @default(disabled)
-  enabledAt      DateTime?
-  disabledAt     DateTime?
-  lastSyncAt     DateTime?
-  lastError      String?
+  id                String                       @id @default(uuid())
+  organisationId    String
+  provider          IntegrationProvider
+  status            IntegrationStatus            @default(disabled)
+  enabledAt         DateTime?
+  disabledAt        DateTime?
+  lastSyncAt        DateTime?
+  lastError         String?
   credentialsStatus IntegrationCredentialsStatus @default(missing)
   lastValidatedAt   DateTime?
-  credentials    Json?
-  config         Json?
-  createdAt      DateTime            @default(now())
-  updatedAt      DateTime            @updatedAt
+  credentials       Json?
+  config            Json?
+  createdAt         DateTime                     @default(now())
+  updatedAt         DateTime                     @updatedAt
 
   @@unique([organisationId, provider])
   @@index([organisationId])
@@ -314,7 +314,7 @@ model LabOrder {
   id                     String           @id @default(uuid())
   organisationId         String
   provider               String
-  patientId            String
+  patientId              String
   parentId               String
   appointmentId          String?
   createdByUserId        String?
@@ -346,28 +346,28 @@ model LabOrder {
 }
 
 model LabResult {
-  id                    String   @id @default(uuid())
-  organisationId        String?
-  provider              String
-  resultId              String
-  orderId               String?
-  requisitionId         String?
-  accessionId           String?
-  diagnosticSetId       String?
-  status                String?
-  statusDetail          String?
-  modality              String?
-  patientId             String?
-  patientName           String?
-  clientId              String?
-  clientFirstName       String?
-  clientLastName        String?
-  updatedDate           String?
-  updatedAuditDate      String?
+  id                     String   @id @default(uuid())
+  organisationId         String?
+  provider               String
+  resultId               String
+  orderId                String?
+  requisitionId          String?
+  accessionId            String?
+  diagnosticSetId        String?
+  status                 String?
+  statusDetail           String?
+  modality               String?
+  patientId              String?
+  patientName            String?
+  clientId               String?
+  clientFirstName        String?
+  clientLastName         String?
+  updatedDate            String?
+  updatedAuditDate       String?
   specimenCollectionDate String?
-  rawPayload            Json?
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  rawPayload             Json?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   @@unique([provider, resultId])
   @@index([provider, orderId])
@@ -375,52 +375,52 @@ model LabResult {
 }
 
 model LabResultSyncState {
-  id           String   @id @default(uuid())
-  provider     String   @unique
-  lastBatchId  String?
+  id            String    @id @default(uuid())
+  provider      String    @unique
+  lastBatchId   String?
   lastTimestamp String?
-  lastPolledAt DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  lastPolledAt  DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 }
 
 model Patient {
-  id               String        @id @default(uuid())
-  name             String
-  type             PatientType
-  breed            String
-  speciesCode      String?
-  breedCode        String?
-  dateOfBirth      DateTime
-  gender           Gender
-  photoUrl         String?
-  currentWeight    Float?
-  colour           String?
-  allergy          String?
-  bloodGroup       String?
-  isNeutered       Boolean?
-  ageWhenNeutered  String?
-  microchipNumber  String?
+  id                   String        @id @default(uuid())
+  name                 String
+  type                 PatientType
+  breed                String
+  speciesCode          String?
+  breedCode            String?
+  dateOfBirth          DateTime
+  gender               Gender
+  photoUrl             String?
+  currentWeight        Float?
+  colour               String?
+  allergy              String?
+  bloodGroup           String?
+  isNeutered           Boolean?
+  ageWhenNeutered      String?
+  microchipNumber      String?
   microchipImplantedAt DateTime?
-  microchipLocation String?
-  passportNumber   String?
-  isInsured        Boolean       @default(false)
-  insurance        Json?
-  countryOfOrigin  String?
-  source           SourceType?
-  status           RecordStatus?
-  physicalAttribute Json?
-  breedingInfo     Json?
-  medicalRecords   Json?
-  alerts           Json?
-  isProfileComplete Boolean      @default(false)
-  createdAt        DateTime      @default(now())
-  updatedAt        DateTime      @updatedAt
+  microchipLocation    String?
+  passportNumber       String?
+  isInsured            Boolean       @default(false)
+  insurance            Json?
+  countryOfOrigin      String?
+  source               SourceType?
+  status               RecordStatus?
+  physicalAttribute    Json?
+  breedingInfo         Json?
+  medicalRecords       Json?
+  alerts               Json?
+  isProfileComplete    Boolean       @default(false)
+  createdAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
 
-  documents         Document[]
-  formAssignments   FormAssignment[]
-  organisations     PatientOrganisation[]
-  parentLinks       ParentPatient[]
+  documents            Document[]
+  formAssignments      FormAssignment[]
+  organisations        PatientOrganisation[]
+  parentLinks          ParentPatient[]
   companionShareTokens CompanionShareToken[]
   petPassports         PetPassport[]
 
@@ -429,24 +429,24 @@ model Patient {
 }
 
 model Document {
-  id                 String               @id @default(uuid())
-  patientId        String
-  appointmentId      String?
-  category           String
-  subcategory        String?
-  visitType          String?
-  title              String
+  id                  String    @id @default(uuid())
+  patientId           String
+  appointmentId       String?
+  category            String
+  subcategory         String?
+  visitType           String?
+  title               String
   issuingBusinessName String?
-  issueDate          DateTime?
-  uploadedByParentId String?
+  issueDate           DateTime?
+  uploadedByParentId  String?
   uploadedByPmsUserId String?
-  pmsVisible         Boolean              @default(false)
-  syncedFromPms      Boolean              @default(false)
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
+  pmsVisible          Boolean   @default(false)
+  syncedFromPms       Boolean   @default(false)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
-  patient          Patient            @relation(fields: [patientId], references: [id])
-  attachments        DocumentAttachment[]
+  patient     Patient              @relation(fields: [patientId], references: [id])
+  attachments DocumentAttachment[]
 
   @@index([patientId])
   @@index([patientId, category])
@@ -455,56 +455,56 @@ model Document {
 }
 
 model DocumentAttachment {
-  id         String   @id @default(uuid())
+  id         String @id @default(uuid())
   documentId String
   key        String
   mimeType   String
   size       Int?
 
-  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
 
   @@index([documentId])
 }
 
 model PatientOrganisation {
-  id                    String                     @id @default(uuid())
-  patientId           String
-  organisationId        String?
-  linkedByParentId      String?
-  linkedByPmsUserId     String?
-  organisationType      OrganisationType
-  role                  PatientOrganisationRole  @default(ORGANISATION)
-  status                PatientOrganisationStatus @default(ACTIVE)
-  invitedViaEmail       String?
-  organisationName      String?
-  organisationPlacesId  String?
-  inviteToken           String?
-  acceptedAt            DateTime?
-  rejectedAt            DateTime?
-  createdAt             DateTime                   @default(now())
-  updatedAt             DateTime                   @updatedAt
+  id                   String                    @id @default(uuid())
+  patientId            String
+  organisationId       String?
+  linkedByParentId     String?
+  linkedByPmsUserId    String?
+  organisationType     OrganisationType
+  role                 PatientOrganisationRole   @default(ORGANISATION)
+  status               PatientOrganisationStatus @default(ACTIVE)
+  invitedViaEmail      String?
+  organisationName     String?
+  organisationPlacesId String?
+  inviteToken          String?
+  acceptedAt           DateTime?
+  rejectedAt           DateTime?
+  createdAt            DateTime                  @default(now())
+  updatedAt            DateTime                  @updatedAt
 
-  patient             Patient                  @relation(fields: [patientId], references: [id])
+  patient Patient @relation(fields: [patientId], references: [id])
+  // Partial unique index for ACTIVE rows is maintained via SQL migration because
+  // Prisma schema cannot express `WHERE status = 'ACTIVE'`.
 
   @@index([patientId])
   @@index([organisationId])
-  // Partial unique index for ACTIVE rows is maintained via SQL migration because
-  // Prisma schema cannot express `WHERE status = 'ACTIVE'`.
 }
 
 model ParentPatient {
-  id                String               @id @default(uuid())
+  id                String              @id @default(uuid())
   parentId          String
-  patientId       String
+  patientId         String
   role              ParentPatientRole
   status            ParentPatientStatus @default(ACTIVE)
   permissions       Json
   invitedByParentId String?
   acceptedAt        DateTime?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
 
-  patient         Patient            @relation(fields: [patientId], references: [id])
+  patient Patient @relation(fields: [patientId], references: [id])
 
   @@unique([parentId, patientId])
   @@index([parentId])
@@ -541,7 +541,7 @@ model CompanionShareToken {
   createdAt               DateTime              @default(now())
   updatedAt               DateTime              @updatedAt
 
-  patient                 Patient               @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
   @@index([organisationId])
@@ -570,17 +570,17 @@ enum ParasiteTreatmentType {
 }
 
 model PetPassport {
-  id                String        @id @default(uuid())
-  patientId         String
-  organisationId    String
-  passportNumber    String        @unique
-  issuingCountry    String?
-  issuingAuthority  String?
-  issuingVetId      String?
-  issuingVetName    String?
-  issuingVetLicense String?
-  issueDate         DateTime      @default(now())
-  status            RecordStatus?
+  id                           String        @id @default(uuid())
+  patientId                    String
+  organisationId               String
+  passportNumber               String        @unique
+  issuingCountry               String?
+  issuingAuthority             String?
+  issuingVetId                 String?
+  issuingVetName               String?
+  issuingVetLicense            String?
+  issueDate                    DateTime      @default(now())
+  status                       RecordStatus?
   // Credential for the public QR / wallet verification page. The patient id must
   // never be used for this: it is an internal identifier already handed to
   // authenticated clients and embedded in app routes, so it can be neither
@@ -591,9 +591,9 @@ model PetPassport {
   // baked into the QR of Apple and Google Wallet passes that already live on
   // owners' phones, and regenerating a pass must not invalidate the copies
   // already issued - which requires reading the value back.
-  publicToken       String?       @unique
-  publicTokenIssuedAt DateTime?
-  publicTokenRevokedAt DateTime?
+  publicToken                  String?       @unique
+  publicTokenIssuedAt          DateTime?
+  publicTokenRevokedAt         DateTime?
   // Staff-facing wallet passes carry THIS token, never `publicToken`.
   //
   // The owner's public token resolves with "owner" scope, which shows every
@@ -605,13 +605,13 @@ model PetPassport {
   // "practice" scope, so it grants strictly less than the staff member already
   // has. Minting it from a staff session is therefore safe, unlike the public
   // token, which only the owner may create.
-  practiceWalletToken       String?       @unique
-  practiceWalletTokenIssuedAt DateTime?
+  practiceWalletToken          String?       @unique
+  practiceWalletTokenIssuedAt  DateTime?
   practiceWalletTokenRevokedAt DateTime?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  createdAt                    DateTime      @default(now())
+  updatedAt                    DateTime      @updatedAt
 
-  patient           Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
   @@index([organisationId])
@@ -657,36 +657,37 @@ model PassportShareConsent {
 }
 
 model Appointment {
-  id                String            @id @default(uuid())
+  id              String            @id @default(uuid())
   patient         Json
-  lead              Json?
-  supportStaff      Json?
-  room              Json?
-  appointmentType   Json?
-  caseId            String?
-  encounterId       String?
-  productItemId     String?
-  appointmentKind   AppointmentKind   @default(OUTPATIENT)
-  idempotencyKey    String?
-  organisationId    String
-  appointmentDate   DateTime
-  startTime         DateTime
-  endTime           DateTime
-  timeSlot          String
-  durationMinutes   Int
-  status            AppointmentStatus @default(REQUESTED)
-  isEmergency       Boolean           @default(false)
-  concern           String?
-  attachments       Json?
-  formIds           String[]
-  expiresAt         DateTime?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  lead            Json?
+  supportStaff    Json?
+  room            Json?
+  appointmentType Json?
+  caseId          String?
+  encounterId     String?
+  productItemId   String?
+  appointmentKind AppointmentKind   @default(OUTPATIENT)
+  idempotencyKey  String?
+  organisationId  String
+  appointmentDate DateTime
+  startTime       DateTime
+  endTime         DateTime
+  timeSlot        String
+  durationMinutes Int
+  status          AppointmentStatus @default(REQUESTED)
+  isEmergency     Boolean           @default(false)
+  concern         String?
+  attachments     Json?
+  formIds         String[]
+  expiresAt       DateTime?
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 
-  caseRecord        Case?             @relation("CaseAppointments", fields: [caseId], references: [id], onDelete: SetNull)
-  encounter         Encounter?        @relation("EncounterAppointments", fields: [encounterId], references: [id], onDelete: SetNull)
-  formAssignments   FormAssignment[]
+  caseRecord      Case?            @relation("CaseAppointments", fields: [caseId], references: [id], onDelete: SetNull)
+  encounter       Encounter?       @relation("EncounterAppointments", fields: [encounterId], references: [id], onDelete: SetNull)
+  formAssignments FormAssignment[]
 
+  @@unique([organisationId, idempotencyKey])
   @@index([organisationId, appointmentDate])
   @@index([organisationId])
   @@index([organisationId, productItemId])
@@ -694,13 +695,12 @@ model Appointment {
   @@index([encounterId])
   @@index([status])
   @@index([expiresAt])
-  @@unique([organisationId, idempotencyKey])
 }
 
 model Case {
   id              String          @id @default(uuid())
   organisationId  String
-  patientId     String
+  patientId       String
   parentId        String?
   status          String
   appointmentKind AppointmentKind @default(OUTPATIENT)
@@ -709,8 +709,8 @@ model Case {
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 
-  appointments    Appointment[]   @relation("CaseAppointments")
-  encounters      Encounter[]
+  appointments Appointment[] @relation("CaseAppointments")
+  encounters   Encounter[]
 
   @@index([organisationId, status])
   @@index([organisationId, appointmentKind])
@@ -722,7 +722,7 @@ model Encounter {
   id              String          @id @default(uuid())
   caseId          String
   organisationId  String
-  patientId     String
+  patientId       String
   parentId        String?
   status          String
   encounterClass  String
@@ -734,8 +734,8 @@ model Encounter {
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 
-  caseRecord      Case            @relation(fields: [caseId], references: [id], onDelete: Cascade)
-  appointments    Appointment[]   @relation("EncounterAppointments")
+  caseRecord      Case                 @relation(fields: [caseId], references: [id], onDelete: Cascade)
+  appointments    Appointment[]        @relation("EncounterAppointments")
   admission       Admission?
   unitAssignments RoomUnitAssignment[]
 
@@ -747,20 +747,20 @@ model Encounter {
 }
 
 model Admission {
-  encounterId       String   @id
-  organisationId    String
-  patientId       String
-  unitId            String?
-  expectedStayDays  Int?
-  admittedAt        DateTime
-  admittedBy        String?
-  dischargedAt      DateTime?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  encounterId      String    @id
+  organisationId   String
+  patientId        String
+  unitId           String?
+  expectedStayDays Int?
+  admittedAt       DateTime
+  admittedBy       String?
+  dischargedAt     DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  encounter         Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
-  currentUnit       RoomUnit? @relation("AdmissionCurrentUnit", fields: [unitId], references: [id], onDelete: SetNull)
-  assignments       RoomUnitAssignment[]
+  encounter   Encounter            @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  currentUnit RoomUnit?            @relation("AdmissionCurrentUnit", fields: [unitId], references: [id], onDelete: SetNull)
+  assignments RoomUnitAssignment[]
 
   @@index([organisationId, admittedAt])
   @@index([organisationId, dischargedAt])
@@ -768,27 +768,27 @@ model Admission {
 }
 
 model ChatSession {
-  id              String            @id @default(uuid())
-  type            ChatSessionType
-  appointmentId   String?
-  channelId       String
-  organisationId  String
+  id                        String            @id @default(uuid())
+  type                      ChatSessionType
+  appointmentId             String?
+  channelId                 String
+  organisationId            String
   counterpartOrganisationId String?
-  patientId     String?
-  parentId        String?
-  vetId           String?
-  supportStaffIds String[]
-  createdBy       String?
-  title           String?
-  isPrivate       Boolean           @default(true)
-  members         String[]
-  participants    Json?
-  status          ChatSessionStatus @default(PENDING)
-  allowedFrom     DateTime?
-  allowedUntil    DateTime?
-  closedAt        DateTime?
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+  patientId                 String?
+  parentId                  String?
+  vetId                     String?
+  supportStaffIds           String[]
+  createdBy                 String?
+  title                     String?
+  isPrivate                 Boolean           @default(true)
+  members                   String[]
+  participants              Json?
+  status                    ChatSessionStatus @default(PENDING)
+  allowedFrom               DateTime?
+  allowedUntil              DateTime?
+  closedAt                  DateTime?
+  createdAt                 DateTime          @default(now())
+  updatedAt                 DateTime          @updatedAt
 
   @@index([type])
   @@index([appointmentId])
@@ -835,93 +835,93 @@ model SharedChatEntity {
 }
 
 model Parent {
-  id               String            @id @default(uuid())
-  firstName        String
-  lastName         String?
-  birthDate        DateTime?
-  email            String
-  phoneNumber      String?
-  currency         String?
-  timezone         String?
-  profileImageUrl  String?
-  isProfileComplete Boolean          @default(false)
-  linkedUserId     String?
-  createdFrom      ParentCreatedFrom
-  address          ParentAddress?
-  alerts           Json?
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
+  id                String            @id @default(uuid())
+  firstName         String
+  lastName          String?
+  birthDate         DateTime?
+  email             String
+  phoneNumber       String?
+  currency          String?
+  timezone          String?
+  profileImageUrl   String?
+  isProfileComplete Boolean           @default(false)
+  linkedUserId      String?
+  createdFrom       ParentCreatedFrom
+  address           ParentAddress?
+  alerts            Json?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
 
   @@index([email])
 }
 
 model ParentAddress {
-  id           String   @id @default(uuid())
-  parentId     String   @unique
-  addressLine  String?
-  country      String?
-  city         String?
-  state        String?
-  postalCode   String?
-  latitude     Float?
-  longitude    Float?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id          String   @id @default(uuid())
+  parentId    String   @unique
+  addressLine String?
+  country     String?
+  city        String?
+  state       String?
+  postalCode  String?
+  latitude    Float?
+  longitude   Float?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  parent       Parent   @relation(fields: [parentId], references: [id], onDelete: Cascade)
+  parent Parent @relation(fields: [parentId], references: [id], onDelete: Cascade)
 }
 
 model Organization {
-  id                          String           @id @default(uuid())
-  fhirId                      String?
-  name                        String
-  taxId                       String
-  dunsNumber                  String?
-  imageUrl                    String?
-  type                        OrganizationType
-  petNamePreference           PetNamePreference? @default(PATIENT)
-  phoneNo                     String
-  email                       String?
-  website                     String?
-  documensoTeamId             String?
-  documensoApiKey             String?
-  address                     OrganizationAddress?
-  isVerified                  Boolean          @default(false)
-  verificationOverride        Boolean?
-  isActive                    Boolean          @default(true)
-  typeCoding                  Json?
-  healthAndSafetyCertNo       String?
-  animalWelfareComplianceCertNo String?
-  fireAndEmergencyCertNo      String?
-  googlePlacesId              String?
-  stripeAccountId             String?
-  averageRating               Float            @default(0)
-  ratingCount                 Int              @default(0)
-  appointmentCheckInBufferMinutes Int          @default(5)
-  appointmentCheckInRadiusMeters  Int          @default(200)
+  id                                     String               @id @default(uuid())
+  fhirId                                 String?
+  name                                   String
+  taxId                                  String
+  dunsNumber                             String?
+  imageUrl                               String?
+  type                                   OrganizationType
+  petNamePreference                      PetNamePreference?   @default(PATIENT)
+  phoneNo                                String
+  email                                  String?
+  website                                String?
+  documensoTeamId                        String?
+  documensoApiKey                        String?
+  address                                OrganizationAddress?
+  isVerified                             Boolean              @default(false)
+  verificationOverride                   Boolean?
+  isActive                               Boolean              @default(true)
+  typeCoding                             Json?
+  healthAndSafetyCertNo                  String?
+  animalWelfareComplianceCertNo          String?
+  fireAndEmergencyCertNo                 String?
+  googlePlacesId                         String?
+  stripeAccountId                        String?
+  averageRating                          Float                @default(0)
+  ratingCount                            Int                  @default(0)
+  appointmentCheckInBufferMinutes        Int                  @default(5)
+  appointmentCheckInRadiusMeters         Int                  @default(200)
   appointmentLockWindowOutpatientMinutes Int?
-  appointmentLockWindowInpatientMinutes   Int?
-  crossOrgMessagingEnabled    Boolean          @default(false)
-  maxOverallDiscountPercent   Float?
-  createdAt                   DateTime         @default(now())
-  updatedAt                   DateTime         @updatedAt
+  appointmentLockWindowInpatientMinutes  Int?
+  crossOrgMessagingEnabled               Boolean              @default(false)
+  maxOverallDiscountPercent              Float?
+  createdAt                              DateTime             @default(now())
+  updatedAt                              DateTime             @updatedAt
 
   @@index([googlePlacesId, name])
 }
 
 model OrganizationAddress {
-  id           String       @id @default(uuid())
-  organizationId String     @unique
-  addressLine  String?
-  country      String?
-  city         String?
-  state        String?
-  postalCode   String?
-  latitude     Float?
-  longitude    Float?
-  location     Json?
-  createdAt    DateTime     @default(now())
-  updatedAt    DateTime     @updatedAt
+  id             String   @id @default(uuid())
+  organizationId String   @unique
+  addressLine    String?
+  country        String?
+  city           String?
+  state          String?
+  postalCode     String?
+  latitude       Float?
+  longitude      Float?
+  location       Json?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 }
@@ -940,14 +940,14 @@ model User {
 }
 
 model UserProfile {
-  id                  String            @id @default(uuid())
+  id                  String              @id @default(uuid())
   userId              String
   organizationId      String
   personalDetails     Json?
   professionalDetails Json?
-  status              UserProfileStatus @default(DRAFT)
-  createdAt           DateTime          @default(now())
-  updatedAt           DateTime          @updatedAt
+  status              UserProfileStatus   @default(DRAFT)
+  createdAt           DateTime            @default(now())
+  updatedAt           DateTime            @updatedAt
   address             UserProfileAddress?
 
   @@unique([userId, organizationId])
@@ -956,8 +956,8 @@ model UserProfile {
 }
 
 model UserProfileAddress {
-  id            String      @id @default(uuid())
-  userProfileId String      @unique
+  id            String   @id @default(uuid())
+  userProfileId String   @unique
   addressLine   String?
   country       String?
   city          String?
@@ -965,25 +965,25 @@ model UserProfileAddress {
   postalCode    String?
   latitude      Float?
   longitude     Float?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
-  userProfile   UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
+  userProfile UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
 }
 
 model UserOrganization {
-  id                      String   @id @default(uuid())
-  fhirId                  String?
-  practitionerReference   String
-  organizationReference   String
-  roleCode                String
-  roleDisplay             String?
-  active                  Boolean  @default(true)
-  extraPermissions        String[]
-  revokedPermissions      String[]
-  effectivePermissions    String[]
-  createdAt               DateTime @default(now())
-  updatedAt               DateTime @updatedAt
+  id                    String   @id @default(uuid())
+  fhirId                String?
+  practitionerReference String
+  organizationReference String
+  roleCode              String
+  roleDisplay           String?
+  active                Boolean  @default(true)
+  extraPermissions      String[]
+  revokedPermissions    String[]
+  effectivePermissions  String[]
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
 
   @@unique([practitionerReference, organizationReference, roleCode], map: "unique_user_org_role")
 }
@@ -1161,18 +1161,18 @@ model OrganizationBilling {
 }
 
 model SubscriptionEntitlement {
-  id            String   @id @default(uuid())
-  orgId         String
-  code          String
-  name          String?
-  value         Json?
-  source        String   @default("MANUAL")
-  status        String   @default("ACTIVE")
-  grantedAt     DateTime @default(now())
-  expiresAt     DateTime?
-  metadata      Json?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id        String    @id @default(uuid())
+  orgId     String
+  code      String
+  name      String?
+  value     Json?
+  source    String    @default("MANUAL")
+  status    String    @default("ACTIVE")
+  grantedAt DateTime  @default(now())
+  expiresAt DateTime?
+  metadata  Json?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@unique([orgId, code])
   @@index([orgId, status])
@@ -1180,17 +1180,17 @@ model SubscriptionEntitlement {
 }
 
 model FinanceProviderLink {
-  id                     String   @id @default(uuid())
-  orgId                  String
-  provider               String
-  externalCustomerId     String?
-  externalSubscriptionId String?
+  id                         String   @id @default(uuid())
+  orgId                      String
+  provider                   String
+  externalCustomerId         String?
+  externalSubscriptionId     String?
   externalSubscriptionItemId String?
-  externalPriceId        String?
-  externalProductId      String?
-  metadata               Json?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  externalPriceId            String?
+  externalProductId          String?
+  metadata                   Json?
+  createdAt                  DateTime @default(now())
+  updatedAt                  DateTime @updatedAt
 
   @@unique([orgId, provider])
   @@index([externalSubscriptionId])
@@ -1199,18 +1199,18 @@ model FinanceProviderLink {
 }
 
 model UsageEvent {
-  id                String   @id @default(uuid())
-  orgId             String
-  usageKey          String
-  quantity          Int      @default(1)
-  billableQuantity  Int      @default(1)
-  source            String
-  referenceType     String?
-  referenceId       String?
-  metadata          Json?
-  occurredAt        DateTime @default(now())
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  id               String   @id @default(uuid())
+  orgId            String
+  usageKey         String
+  quantity         Int      @default(1)
+  billableQuantity Int      @default(1)
+  source           String
+  referenceType    String?
+  referenceId      String?
+  metadata         Json?
+  occurredAt       DateTime @default(now())
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   @@index([orgId, usageKey, occurredAt])
   @@index([orgId, referenceType, referenceId])
@@ -1235,16 +1235,16 @@ model UsageSnapshot {
 }
 
 model FinanceEvent {
-  id            String   @id @default(uuid())
+  id             String    @id @default(uuid())
   organisationId String?
-  eventType     String
-  entityType    String
-  entityId      String
-  payload       Json
-  occurredAt    DateTime @default(now())
-  processedAt   DateTime?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  eventType      String
+  entityType     String
+  entityId       String
+  payload        Json
+  occurredAt     DateTime  @default(now())
+  processedAt    DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@index([organisationId])
   @@index([eventType])
@@ -1255,31 +1255,31 @@ model FinanceEvent {
 }
 
 model OrganizationDocument {
-  id              String                @id @default(uuid())
-  organisationId  String
-  title           String
-  description     String?               @default("")
-  category        OrgDocumentCategory
-  fileUrl         String?
-  fileName        String?
-  fileType        String?
-  fileSize        Int?
-  visibility      OrgDocumentVisibility @default(INTERNAL)
-  version         Int                   @default(1)
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  id             String                @id @default(uuid())
+  organisationId String
+  title          String
+  description    String?               @default("")
+  category       OrgDocumentCategory
+  fileUrl        String?
+  fileName       String?
+  fileType       String?
+  fileSize       Int?
+  visibility     OrgDocumentVisibility @default(INTERNAL)
+  version        Int                   @default(1)
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
 
   @@index([organisationId])
 }
 
 model OrganizationDocumentAcknowledgement {
-  id             String               @id @default(uuid())
+  id             String              @id @default(uuid())
   organisationId String
   documentId     String
   category       OrgDocumentCategory
   version        Int
   userId         String
-  acknowledgedAt DateTime             @default(now())
+  acknowledgedAt DateTime            @default(now())
 
   @@unique([userId, organisationId, documentId, category, version])
   @@index([organisationId, documentId, category])
@@ -1288,26 +1288,26 @@ model OrganizationDocumentAcknowledgement {
 }
 
 model OrganisationRoom {
-  id                    String                @id @default(uuid())
+  id                    String               @id @default(uuid())
   organisationId        String
   name                  String
   code                  String
   description           String?
   type                  RoomType
-  occupancyStatus       RoomOccupancyStatus   @default(VACANT)
-  availableNow          Boolean               @default(true)
-  availabilityMode      RoomAvailabilityMode  @default(ALL_DAY)
-  availabilityDays      String[]              @default([])
-  availabilityStartTime  String?
-  availabilityEndTime    String?
-  capabilities          String[]              @default([])
-  createdAt             DateTime              @default(now())
-  updatedAt             DateTime              @updatedAt
+  occupancyStatus       RoomOccupancyStatus  @default(VACANT)
+  availableNow          Boolean              @default(true)
+  availabilityMode      RoomAvailabilityMode @default(ALL_DAY)
+  availabilityDays      String[]             @default([])
+  availabilityStartTime String?
+  availabilityEndTime   String?
+  capabilities          String[]             @default([])
+  createdAt             DateTime             @default(now())
+  updatedAt             DateTime             @updatedAt
 
-  units                 RoomUnit[]
-  unitGroups            RoomUnitGroup[]
-  specialityLinks       OrganisationRoomSpeciality[]
-  staffLinks            OrganisationRoomStaff[]
+  units           RoomUnit[]
+  unitGroups      RoomUnitGroup[]
+  specialityLinks OrganisationRoomSpeciality[]
+  staffLinks      OrganisationRoomStaff[]
 
   @@unique([organisationId, code])
   @@index([organisationId])
@@ -1322,8 +1322,8 @@ model OrganisationRoomSpeciality {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  speciality     Speciality       @relation(fields: [specialityId], references: [id], onDelete: Cascade)
+  room       OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  speciality Speciality       @relation(fields: [specialityId], references: [id], onDelete: Cascade)
 
   @@unique([roomId, specialityId])
   @@index([organisationId])
@@ -1339,8 +1339,8 @@ model OrganisationRoomStaff {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  staff          User             @relation(fields: [staffUserId], references: [userId], onDelete: Cascade)
+  room  OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  staff User             @relation(fields: [staffUserId], references: [userId], onDelete: Cascade)
 
   @@unique([roomId, staffUserId])
   @@index([organisationId])
@@ -1361,10 +1361,10 @@ model RoomUnit {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  room               OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  unitGroup          RoomUnitGroup?       @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
-  currentAdmissions  Admission[]          @relation("AdmissionCurrentUnit")
-  assignments        RoomUnitAssignment[]
+  room              OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  unitGroup         RoomUnitGroup?       @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
+  currentAdmissions Admission[]          @relation("AdmissionCurrentUnit")
+  assignments       RoomUnitAssignment[]
 
   @@unique([roomId, code])
   @@index([organisationId])
@@ -1374,42 +1374,42 @@ model RoomUnit {
 }
 
 model RoomUnitGroup {
-  id                  String   @id @default(uuid())
-  organisationId      String
-  roomId              String
-  name                String
-  size                String?
-  unitCount           Int      @default(0)
-  speciesConstraints   Json?
-  capabilities        String[] @default([])
-  isActive            Boolean  @default(true)
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  id                 String   @id @default(uuid())
+  organisationId     String
+  roomId             String
+  name               String
+  size               String?
+  unitCount          Int      @default(0)
+  speciesConstraints Json?
+  capabilities       String[] @default([])
+  isActive           Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
-  room                OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  units               RoomUnit[]
+  room  OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  units RoomUnit[]
 
+  @@unique([roomId, name])
   @@index([organisationId])
   @@index([roomId])
   @@index([isActive])
-  @@unique([roomId, name])
 }
 
 model RoomUnitAssignment {
-  id           String   @id @default(uuid())
-  encounterId  String
-  admissionId  String
-  unitId       String
-  assignedAt   DateTime
-  releasedAt   DateTime?
-  assignedBy   String?
-  reason       String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id          String    @id @default(uuid())
+  encounterId String
+  admissionId String
+  unitId      String
+  assignedAt  DateTime
+  releasedAt  DateTime?
+  assignedBy  String?
+  reason      String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
-  encounter    Encounter  @relation(fields: [encounterId], references: [id], onDelete: Cascade)
-  admission    Admission  @relation(fields: [admissionId], references: [encounterId], onDelete: Cascade)
-  unit         RoomUnit   @relation(fields: [unitId], references: [id], onDelete: Cascade)
+  encounter Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  admission Admission @relation(fields: [admissionId], references: [encounterId], onDelete: Cascade)
+  unit      RoomUnit  @relation(fields: [unitId], references: [id], onDelete: Cascade)
 
   @@index([encounterId, assignedAt])
   @@index([admissionId, assignedAt])
@@ -1418,20 +1418,20 @@ model RoomUnitAssignment {
 }
 
 model OrganisationInvite {
-  id               String                      @id @default(uuid())
-  organisationId   String
-  invitedByUserId  String
-  departmentIds    String[]
-  inviteeEmail     String
-  inviteeName      String?
-  role             String
-  employmentType   OrganisationInviteEmploymentType?
-  token            String                      @unique
-  status           OrganisationInviteStatus    @default(PENDING)
-  expiresAt        DateTime
-  acceptedAt       DateTime?
-  createdAt        DateTime                    @default(now())
-  updatedAt        DateTime                    @updatedAt
+  id              String                            @id @default(uuid())
+  organisationId  String
+  invitedByUserId String
+  departmentIds   String[]
+  inviteeEmail    String
+  inviteeName     String?
+  role            String
+  employmentType  OrganisationInviteEmploymentType?
+  token           String                            @unique
+  status          OrganisationInviteStatus          @default(PENDING)
+  expiresAt       DateTime
+  acceptedAt      DateTime?
+  createdAt       DateTime                          @default(now())
+  updatedAt       DateTime                          @updatedAt
 
   @@index([organisationId])
   @@index([token])
@@ -1440,30 +1440,30 @@ model OrganisationInvite {
 }
 
 model OrganisationRating {
-  id              String   @id @default(uuid())
-  organizationId  String
-  userId          String
-  rating          Int
-  review          String?  @default("")
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String   @id @default(uuid())
+  organizationId String
+  userId         String
+  rating         Int
+  review         String?  @default("")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@unique([organizationId, userId])
 }
 
 model OrganizationUsageCounter {
-  id                   String   @id @default(uuid())
-  orgId                String   @unique
-  appointmentsUsed     Int      @default(0)
-  toolsUsed            Int      @default(0)
-  usersActiveCount     Int      @default(0)
-  usersBillableCount   Int      @default(0)
-  freeAppointmentsLimit Int     @default(120)
-  freeToolsLimit       Int      @default(200)
-  freeUsersLimit       Int      @default(10)
-  freeLimitReachedAt   DateTime?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  id                    String    @id @default(uuid())
+  orgId                 String    @unique
+  appointmentsUsed      Int       @default(0)
+  toolsUsed             Int       @default(0)
+  usersActiveCount      Int       @default(0)
+  usersBillableCount    Int       @default(0)
+  freeAppointmentsLimit Int       @default(120)
+  freeToolsLimit        Int       @default(200)
+  freeUsersLimit        Int       @default(10)
+  freeLimitReachedAt    DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
 
   @@index([freeLimitReachedAt])
   @@map("OrgUsageCounters")
@@ -2131,6 +2131,7 @@ enum DayOfWeek {
   SATURDAY
   SUNDAY
 }
+
 enum ObservationFieldType {
   TEXT
   NUMBER
@@ -2155,44 +2156,45 @@ enum AdverseEventStatus {
 }
 
 model CoParentInvite {
-  id               String   @id @default(uuid())
-  email            String
-  inviteeName      String?
-  patientId      String
+  id                String    @id @default(uuid())
+  email             String
+  inviteeName       String?
+  patientId         String
   invitedByParentId String
-  inviteToken      String   @unique
-  expiresAt        DateTime
-  acceptedAt       DateTime?
-  diclinedAt       DateTime?
-  consumed         Boolean  @default(false)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  inviteToken       String    @unique
+  expiresAt         DateTime
+  acceptedAt        DateTime?
+  diclinedAt        DateTime?
+  consumed          Boolean   @default(false)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([email])
 }
+
 model ExternalExpense {
-  id            String   @id @default(uuid())
-  patientId   String
-  parentId      String
-  category      String
-  subcategory   String?
-  visitType     String?
-  expenseName   String
-  businessName  String?
-  date          DateTime
-  amount        Float
-  currency      String   @default("USD")
-  attachments   Json?
-  notes         String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id           String   @id @default(uuid())
+  patientId    String
+  parentId     String
+  category     String
+  subcategory  String?
+  visitType    String?
+  expenseName  String
+  businessName String?
+  date         DateTime
+  amount       Float
+  currency     String   @default("USD")
+  attachments  Json?
+  notes        String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   @@index([patientId])
   @@index([parentId])
 }
 
 model Form {
-  id             String             @id @default(uuid())
+  id             String              @id @default(uuid())
   orgId          String
   businessType   OrganizationType?
   name           String
@@ -2202,16 +2204,16 @@ model Form {
   serviceId      String[]
   speciesFilter  String[]
   requiredSigner FormRequiredSigner?
-  status         FormStatus         @default(draft)
+  status         FormStatus          @default(draft)
   schema         Json
   createdBy      String
   updatedBy      String
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
-  fields         FormField[]
-  versions       FormVersion[]
-  submissions    FormSubmission[]
+  fields      FormField[]
+  versions    FormVersion[]
+  submissions FormSubmission[]
 
   @@index([orgId, status])
   @@index([orgId, category])
@@ -2235,7 +2237,7 @@ model FormField {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  form        Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@index([formId])
   @@index([type])
@@ -2251,7 +2253,7 @@ model FormVersion {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  form           Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@unique([formId, version])
   @@index([formId])
@@ -2262,7 +2264,7 @@ model FormSubmission {
   formId        String
   formVersion   Int
   appointmentId String?
-  patientId   String?
+  patientId     String?
   parentId      String?
   submittedBy   String?
   answers       Json
@@ -2271,7 +2273,7 @@ model FormSubmission {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  form          Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@index([formId])
   @@index([formId, formVersion])
@@ -2307,9 +2309,9 @@ model FormAssignment {
   createdAt       DateTime             @default(now())
   updatedAt       DateTime             @updatedAt
 
-  template        Template             @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  appointment     Appointment?         @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
-  companion       Patient?             @relation(fields: [companionId], references: [id], onDelete: SetNull)
+  template    Template     @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  appointment Appointment? @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+  companion   Patient?     @relation(fields: [companionId], references: [id], onDelete: SetNull)
 
   @@index([organisationId, appointmentId])
   @@index([organisationId, companionId])
@@ -2318,27 +2320,27 @@ model FormAssignment {
 }
 
 model Template {
-  id                 String               @id @default(uuid())
-  organisationId     String?
-  ownerUserId        String?
-  ownership          TemplateOwnershipType @default(ORG_TEMPLATE)
-  kind               TemplateKind
-  name               String
-  description        String?
-  status             TemplateStatus       @default(DRAFT)
-  scope              TemplateScope        @default(ORGANISATION)
-  rules              Json?
-  latestVersion      Int                  @default(1)
-  publishedVersion   Int?
-  createdBy          String
-  updatedBy          String
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
+  id               String                @id @default(uuid())
+  organisationId   String?
+  ownerUserId      String?
+  ownership        TemplateOwnershipType @default(ORG_TEMPLATE)
+  kind             TemplateKind
+  name             String
+  description      String?
+  status           TemplateStatus        @default(DRAFT)
+  scope            TemplateScope         @default(ORGANISATION)
+  rules            Json?
+  latestVersion    Int                   @default(1)
+  publishedVersion Int?
+  createdBy        String
+  updatedBy        String
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 
-  versions           TemplateVersion[]
-  instances          TemplateInstance[]
-  formAssignments   FormAssignment[]
-  catalogLinks       TemplateCatalogLink[]
+  versions        TemplateVersion[]
+  instances       TemplateInstance[]
+  formAssignments FormAssignment[]
+  catalogLinks    TemplateCatalogLink[]
 
   @@index([organisationId, ownership, kind, status])
   @@index([organisationId, scope])
@@ -2347,19 +2349,19 @@ model Template {
 }
 
 model TemplateVersion {
-  id                    String   @id @default(uuid())
-  templateId            String
-  version               Int
-  schemaSnapshot        Json
-  renderConfigSnapshot   Json?
-  validationSnapshot    Json?
-  publishedAt           DateTime?
-  createdBy             String
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  id                   String    @id @default(uuid())
+  templateId           String
+  version              Int
+  schemaSnapshot       Json
+  renderConfigSnapshot Json?
+  validationSnapshot   Json?
+  publishedAt          DateTime?
+  createdBy            String
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
-  template              Template @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  clinicalArtifacts     ClinicalArtifact[]
+  template          Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  clinicalArtifacts ClinicalArtifact[]
 
   @@unique([templateId, version])
   @@index([templateId])
@@ -2367,14 +2369,14 @@ model TemplateVersion {
 }
 
 model TemplateCatalogLink {
-  id             String   @id @default(uuid())
-  templateId     String
-  catalogItemId  String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id            String   @id @default(uuid())
+  templateId    String
+  catalogItemId String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
-  template       Template   @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  catalogItem    ProductItem @relation(fields: [catalogItemId], references: [id], onDelete: Cascade)
+  template    Template    @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  catalogItem ProductItem @relation(fields: [catalogItemId], references: [id], onDelete: Cascade)
 
   @@unique([templateId, catalogItemId])
   @@index([templateId])
@@ -2382,7 +2384,7 @@ model TemplateCatalogLink {
 }
 
 model TemplateInstance {
-  id              String                @id @default(uuid())
+  id              String                 @id @default(uuid())
   templateId      String
   templateVersion Int
   organisationId  String
@@ -2396,11 +2398,11 @@ model TemplateInstance {
   signedAt        DateTime?
   generatedPdfUrl String?
   generatedPdf    Json?
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
 
-  template        Template              @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  taskSchedule    TaskSchedule?
+  template          Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  taskSchedule      TaskSchedule?
   renderedDocuments RenderedDocument[]
 
   @@index([templateId])
@@ -2411,31 +2413,31 @@ model TemplateInstance {
 }
 
 model RenderedDocument {
-  id                String                    @id @default(uuid())
-  organisationId    String
-  sourceKind        RenderedDocumentSourceKind
-  sourceId          String
-  templateInstanceId String?                  @unique
-  clinicalArtifactId String?                  @unique
-  templateId        String?
-  templateVersion   Int?
-  templateVersionId String?
-  kind              TemplateKind
-  version           Int                       @default(1)
-  title             String
-  mimeType          String                    @default("application/pdf")
-  status            RenderedDocumentStatus    @default(DRAFT)
-  signable          Boolean                   @default(true)
-  pdfUrl            String?
-  pdf               Json?
-  signing           Json?
-  signedBy          String?
-  signedAt          DateTime?
-  createdAt         DateTime                  @default(now())
-  updatedAt         DateTime                  @updatedAt
+  id                 String                     @id @default(uuid())
+  organisationId     String
+  sourceKind         RenderedDocumentSourceKind
+  sourceId           String
+  templateInstanceId String?                    @unique
+  clinicalArtifactId String?                    @unique
+  templateId         String?
+  templateVersion    Int?
+  templateVersionId  String?
+  kind               TemplateKind
+  version            Int                        @default(1)
+  title              String
+  mimeType           String                     @default("application/pdf")
+  status             RenderedDocumentStatus     @default(DRAFT)
+  signable           Boolean                    @default(true)
+  pdfUrl             String?
+  pdf                Json?
+  signing            Json?
+  signedBy           String?
+  signedAt           DateTime?
+  createdAt          DateTime                   @default(now())
+  updatedAt          DateTime                   @updatedAt
 
-  templateInstance  TemplateInstance?         @relation(fields: [templateInstanceId], references: [id], onDelete: SetNull)
-  clinicalArtifact  ClinicalArtifact?         @relation(fields: [clinicalArtifactId], references: [id], onDelete: SetNull)
+  templateInstance TemplateInstance?  @relation(fields: [templateInstanceId], references: [id], onDelete: SetNull)
+  clinicalArtifact ClinicalArtifact?  @relation(fields: [clinicalArtifactId], references: [id], onDelete: SetNull)
   signature        DocumentSignature?
 
   @@index([organisationId, kind, status])
@@ -2445,7 +2447,7 @@ model RenderedDocument {
 }
 
 model WorkspaceDocumentPacket {
-  id             String                     @id @default(uuid())
+  id             String                        @id @default(uuid())
   organisationId String
   appointmentId  String?
   encounterId    String
@@ -2456,8 +2458,8 @@ model WorkspaceDocumentPacket {
   signedBy       String?
   signedByName   String?
   signedAt       DateTime?
-  createdAt      DateTime                   @default(now())
-  updatedAt      DateTime                   @updatedAt
+  createdAt      DateTime                      @default(now())
+  updatedAt      DateTime                      @updatedAt
 
   @@index([organisationId])
   @@index([organisationId, encounterId])
@@ -2466,7 +2468,7 @@ model WorkspaceDocumentPacket {
 }
 
 model WorkspaceTreatmentItem {
-  id                 String   @id @default(uuid())
+  id                 String    @id @default(uuid())
   organisationId     String
   appointmentId      String?
   encounterId        String
@@ -2474,16 +2476,16 @@ model WorkspaceTreatmentItem {
   productVersion     Int?
   productSnapshot    Json
   servicePackageKind String
-  quantity           Int      @default(1)
+  quantity           Int       @default(1)
   priceSnapshot      Json
-  billingStatus      String   @default("UNBILLED")
+  billingStatus      String    @default("UNBILLED")
   invoiceRowId       String?
   settledInvoiceId   String?
   settledAt          DateTime?
   lockState          Json?
   prescriptionId     String?
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
   @@index([organisationId, encounterId])
   @@index([organisationId, appointmentId])
@@ -2494,50 +2496,50 @@ model WorkspaceTreatmentItem {
 }
 
 model DocumentSignature {
-  id                 String                   @id @default(uuid())
-  renderedDocumentId String                   @unique
-  signerId          String
-  signerType        DocumentSignatureSignerType
-  signatureText     String?
-  signedAt          DateTime                  @default(now())
-  createdAt         DateTime                  @default(now())
-  updatedAt         DateTime                  @updatedAt
+  id                 String                      @id @default(uuid())
+  renderedDocumentId String                      @unique
+  signerId           String
+  signerType         DocumentSignatureSignerType
+  signatureText      String?
+  signedAt           DateTime                    @default(now())
+  createdAt          DateTime                    @default(now())
+  updatedAt          DateTime                    @updatedAt
 
-  renderedDocument  RenderedDocument          @relation(fields: [renderedDocumentId], references: [id], onDelete: Cascade)
+  renderedDocument RenderedDocument @relation(fields: [renderedDocumentId], references: [id], onDelete: Cascade)
 
   @@index([renderedDocumentId])
   @@index([signerId])
 }
 
 model ClinicalArtifact {
-  id              String                  @id @default(uuid())
-  organisationId  String
-  appointmentId   String?
-  caseId          String?
-  encounterId     String?
-  kind            ClinicalArtifactKind
-  status          ClinicalArtifactStatus  @default(DRAFT)
-  templateId      String?
-  templateVersion Int?
+  id                String                 @id @default(uuid())
+  organisationId    String
+  appointmentId     String?
+  caseId            String?
+  encounterId       String?
+  kind              ClinicalArtifactKind
+  status            ClinicalArtifactStatus @default(DRAFT)
+  templateId        String?
+  templateVersion   Int?
   templateVersionId String?
-  authorId        String?
-  signedBy        String?
-  signedAt        DateTime?
-  summary         String?
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  authorId          String?
+  signedBy          String?
+  signedAt          DateTime?
+  summary           String?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
 
-  soapNote        SoapNote?
-  prescription    Prescription?
-  dischargeSummary DischargeSummary?
-  vitalRecord     VitalRecord?
-  immunization    Immunization?
-  rabiesTitration RabiesTitration?
-  parasiteTreatment ParasiteTreatment?
-  clinicalExamination ClinicalExamination?
-  attestation     ClinicalArtifactAttestation?
-  templateVersionRecord TemplateVersion?   @relation(fields: [templateVersionId], references: [id], onDelete: SetNull)
-  renderedDocuments RenderedDocument[]
+  soapNote              SoapNote?
+  prescription          Prescription?
+  dischargeSummary      DischargeSummary?
+  vitalRecord           VitalRecord?
+  immunization          Immunization?
+  rabiesTitration       RabiesTitration?
+  parasiteTreatment     ParasiteTreatment?
+  clinicalExamination   ClinicalExamination?
+  attestation           ClinicalArtifactAttestation?
+  templateVersionRecord TemplateVersion?             @relation(fields: [templateVersionId], references: [id], onDelete: SetNull)
+  renderedDocuments     RenderedDocument[]
 
   @@index([organisationId, kind, status])
   @@index([organisationId, appointmentId])
@@ -2548,117 +2550,117 @@ model ClinicalArtifact {
 }
 
 model SoapNote {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  subjective      Json?
-  objective       Json?
-  assessment      Json?
-  plan            Json?
-  diagnoses       Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id         String   @id @default(uuid())
+  artifactId String   @unique
+  subjective Json?
+  objective  Json?
+  assessment Json?
+  plan       Json?
+  diagnoses  Json?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model Prescription {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  items           PrescriptionItem[]
+  id               String                        @id @default(uuid())
+  artifactId       String                        @unique
+  items            PrescriptionItem[]
   dispenseRequests PrescriptionDispenseRequest[]
-  medications     Json?
-  instructions    Json?
-  notes           Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  medications      Json?
+  instructions     Json?
+  notes            Json?
+  metadata         Json?
+  createdAt        DateTime                      @default(now())
+  updatedAt        DateTime                      @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model PrescriptionItem {
-  id             String       @id @default(uuid())
-  prescriptionId String
-  sourceLineKey  String?
-  medication     String
-  strength       String?
-  dosage         String?
-  route          String?
-  frequency      String?
-  duration       String?
-  quantity       String?
-  instructions   String?
-  refill         String?
-  inventoryItemId String?
+  id               String    @id @default(uuid())
+  prescriptionId   String
+  sourceLineKey    String?
+  medication       String
+  strength         String?
+  dosage           String?
+  route            String?
+  frequency        String?
+  duration         String?
+  quantity         String?
+  instructions     String?
+  refill           String?
+  inventoryItemId  String?
   inventoryItemSku String?
-  batchId        String?
-  batchNumber    String?
-  lotNumber      String?
-  expiryDate     DateTime?
-  metadata       Json?
-  sortOrder      Int          @default(0)
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  batchId          String?
+  batchNumber      String?
+  lotNumber        String?
+  expiryDate       DateTime?
+  metadata         Json?
+  sortOrder        Int       @default(0)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  prescription   Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
+  prescription Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
 
   @@index([prescriptionId, sortOrder])
 }
 
 model PrescriptionDispenseRequest {
-  id             String                              @id @default(uuid())
+  id             String                            @id @default(uuid())
   prescriptionId String
   organisationId String
-  status         PrescriptionDispenseRequestStatus   @default(PENDING)
+  status         PrescriptionDispenseRequestStatus @default(PENDING)
   medications    Json
   metadata       Json?
   requestedBy    String?
   reviewedBy     String?
-  requestedAt    DateTime                            @default(now())
+  requestedAt    DateTime                          @default(now())
   reviewedAt     DateTime?
-  createdAt      DateTime                            @default(now())
-  updatedAt      DateTime                            @updatedAt
+  createdAt      DateTime                          @default(now())
+  updatedAt      DateTime                          @updatedAt
 
-  prescription   Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
+  prescription Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
 
   @@index([prescriptionId, status, requestedAt])
   @@index([organisationId, status])
 }
 
 model DischargeSummary {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  summary         Json?
-  diagnoses       Json?
-  medications     Json?
-  followUp        Json?
-  instructions    Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id           String   @id @default(uuid())
+  artifactId   String   @unique
+  summary      Json?
+  diagnoses    Json?
+  medications  Json?
+  followUp     Json?
+  instructions Json?
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model VitalRecord {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  measuredAt      DateTime
-  recordedBy      String?
-  vitals          Json
-  notes           Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id         String   @id @default(uuid())
+  artifactId String   @unique
+  measuredAt DateTime
+  recordedBy String?
+  vitals     Json
+  notes      Json?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([measuredAt])
@@ -2668,9 +2670,9 @@ model VitalRecord {
 // Immunization / Observation / Procedure). The administering/verifying vet and
 // the legally-binding signature live on ClinicalArtifactAttestation, not here.
 model Immunization {
-  id               String           @id @default(uuid())
-  artifactId       String           @unique
-  vaccineType      VaccineType      @default(OTHER)
+  id               String      @id @default(uuid())
+  artifactId       String      @unique
+  vaccineType      VaccineType @default(OTHER)
   vaccineName      String
   manufacturer     String?
   batchNumber      String?
@@ -2683,27 +2685,27 @@ model Immunization {
   route            String?
   notes            String?
   metadata         Json?
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
 
-  artifact         ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([validUntil])
 }
 
 model RabiesTitration {
-  id          String           @id @default(uuid())
-  artifactId  String           @unique
+  id          String   @id @default(uuid())
+  artifactId  String   @unique
   approvedLab String
   sampleDate  DateTime
   resultIuMl  Float
   reportUrl   String?
   metadata    Json?
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  artifact    ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
@@ -2720,7 +2722,7 @@ model ParasiteTreatment {
   createdAt     DateTime              @default(now())
   updatedAt     DateTime              @updatedAt
 
-  artifact      ClinicalArtifact      @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
@@ -2728,18 +2730,18 @@ model ParasiteTreatment {
 // Pre-travel clinical examination ("fit to travel" attestation): the EU passport
 // section a vet signs shortly before movement.
 model ClinicalExamination {
-  id           String           @id @default(uuid())
-  artifactId   String           @unique
+  id           String   @id @default(uuid())
+  artifactId   String   @unique
   examinedAt   DateTime
-  fitForTravel Boolean          @default(true)
+  fitForTravel Boolean  @default(true)
   findings     String?
   weightKg     Float?
   temperatureC Float?
   metadata     Json?
-  createdAt    DateTime         @default(now())
-  updatedAt    DateTime         @updatedAt
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  artifact     ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([examinedAt])
@@ -2751,9 +2753,9 @@ model ClinicalExamination {
 // legally-binding notary record. A SIGNED artifact is immutable; corrections
 // supersede and revocations propagate to the wallet pass + public page.
 model ClinicalArtifactAttestation {
-  id                  String           @id @default(uuid())
-  artifactId          String           @unique
-  primarySource       Boolean          @default(true)
+  id                  String    @id @default(uuid())
+  artifactId          String    @unique
+  primarySource       Boolean   @default(true)
   signatoryUserId     String?
   signatoryName       String?
   signatoryLicence    String?
@@ -2765,10 +2767,10 @@ model ClinicalArtifactAttestation {
   revokedAt           DateTime?
   revokedReason       String?
   supersededById      String?
-  createdAt           DateTime         @default(now())
-  updatedAt           DateTime         @updatedAt
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
-  artifact            ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([signatoryUserId])
@@ -2795,22 +2797,22 @@ model Service {
 }
 
 model ProductItem {
-  id              String               @id @default(uuid())
+  id              String                @id @default(uuid())
   organisationId  String
   name            String
   description     String?
   code            String?
-  kind            ProductKind          @default(CONSULTATION)
+  kind            ProductKind           @default(CONSULTATION)
   specialityId    String?
-  legacyServiceId String?              @unique
-  isActive        Boolean              @default(true)
-  version         Int                  @default(1)
-  createdAt       DateTime             @default(now())
-  updatedAt       DateTime             @updatedAt
+  legacyServiceId String?               @unique
+  isActive        Boolean               @default(true)
+  version         Int                   @default(1)
+  createdAt       DateTime              @default(now())
+  updatedAt       DateTime              @updatedAt
   prices          ProductPrice[]
   bookable        ProductBookable?
   package         ProductPackage?
-  packageItems    ProductPackageItem[] @relation("ProductPackageComponent")
+  packageItems    ProductPackageItem[]  @relation("ProductPackageComponent")
   templateLinks   TemplateCatalogLink[]
 
   @@index([organisationId])
@@ -2882,10 +2884,10 @@ model ProductPackageItem {
 }
 
 model Task {
-  id                String       @id @default(uuid())
+  id                String        @id @default(uuid())
   organisationId    String?
   appointmentId     String?
-  patientId       String?
+  patientId         String?
   createdBy         String
   assignedBy        String?
   assignedTo        String
@@ -2908,12 +2910,12 @@ model Task {
   syncWithCalendar  Boolean?
   calendarEventId   String?
   attachments       Json?
-  status            TaskStatus   @default(PENDING)
+  status            TaskStatus    @default(PENDING)
   priority          TaskPriority?
   completedAt       DateTime?
   completedBy       String?
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
 
   @@index([assignedTo, dueAt])
   @@index([assignedGroupId, dueAt])
@@ -2923,30 +2925,30 @@ model Task {
 }
 
 model TaskSchedule {
-  id                String            @id @default(uuid())
-  templateInstanceId String            @unique
-  templateId        String
-  templateVersion   Int
-  templateKind      TemplateKind
-  organisationId    String
-  appointmentId     String?
-  caseId            String?
-  encounterId      String?
-  patientId       String?
-  createdBy         String
-  activatedBy       String?
-  activatedAt       DateTime?
-  completedAt       DateTime?
+  id                 String             @id @default(uuid())
+  templateInstanceId String             @unique
+  templateId         String
+  templateVersion    Int
+  templateKind       TemplateKind
+  organisationId     String
+  appointmentId      String?
+  caseId             String?
+  encounterId        String?
+  patientId          String?
+  createdBy          String
+  activatedBy        String?
+  activatedAt        DateTime?
+  completedAt        DateTime?
   lastMaterializedAt DateTime?
-  status            TaskScheduleStatus @default(DRAFT)
-  scheduleInput     Json?
-  materializedSeeds Json?
-  generatedTaskIds  Json?
-  metadata          Json?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  status             TaskScheduleStatus @default(DRAFT)
+  scheduleInput      Json?
+  materializedSeeds  Json?
+  generatedTaskIds   Json?
+  metadata           Json?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
 
-  templateInstance  TemplateInstance   @relation(fields: [templateInstanceId], references: [id], onDelete: Cascade)
+  templateInstance TemplateInstance @relation(fields: [templateInstanceId], references: [id], onDelete: Cascade)
 
   @@index([organisationId, status])
   @@index([templateId, templateVersion])
@@ -2956,54 +2958,56 @@ model TaskSchedule {
 }
 
 model TaskCompletion {
-  id          String   @id @default(uuid())
-  taskId      String
+  id        String   @id @default(uuid())
+  taskId    String
   patientId String
-  filledBy    String
-  answers     Json
-  score       Float?
-  summary     String?
-  createdAt   DateTime @default(now())
+  filledBy  String
+  answers   Json
+  score     Float?
+  summary   String?
+  createdAt DateTime @default(now())
 
   @@index([taskId])
   @@index([patientId])
 }
 
 model TaskTemplate {
-  id                          String          @id @default(uuid())
-  source                      TaskSource      @default(ORG_TEMPLATE)
-  organisationId              String
-  libraryTaskId               String?
-  category                    String
-  name                        String
-  description                 String?
-  kind                        TaskKind
-  defaultRole                 TaskTemplateRole
-  inpatientOnly               Boolean         @default(false)
-  defaultMedication           Json?
-  defaultObservationToolId    String?
-  defaultRecurrence           Json?
+  id                           String           @id @default(uuid())
+  source                       TaskSource       @default(ORG_TEMPLATE)
+  organisationId               String
+  libraryTaskId                String?
+  category                     String
+  name                         String
+  description                  String?
+  kind                         TaskKind
+  defaultRole                  TaskTemplateRole
+  inpatientOnly                Boolean          @default(false)
+  defaultMedication            Json?
+  defaultObservationToolId     String?
+  defaultRecurrence            Json?
   defaultReminderOffsetMinutes Int?
-  isActive                    Boolean         @default(true)
-  createdBy                   String
-  createdAt                   DateTime        @default(now())
-  updatedAt                   DateTime        @updatedAt
+  isActive                     Boolean          @default(true)
+  createdBy                    String
+  createdAt                    DateTime         @default(now())
+  updatedAt                    DateTime         @updatedAt
 
   @@index([organisationId])
 }
 
 model TaskLibraryDefinition {
-  id                 String             @id @default(uuid())
-  source             TaskSource         @default(YC_LIBRARY)
+  id                 String               @id @default(uuid())
+  source             TaskSource           @default(YC_LIBRARY)
   kind               TaskKind
   category           String
   name               String
   defaultDescription String?
   schema             Json
   applicableSpecies  TaskLibrarySpecies[]
-  isActive           Boolean            @default(true)
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @updatedAt
+  isActive           Boolean              @default(true)
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+
+  recommendationRules TaskRecommendationRule[]
 
   @@index([kind])
   @@index([category])
@@ -3025,9 +3029,9 @@ model ReminderJob {
 }
 
 model AuditTrail {
-  id             String         @id @default(uuid())
+  id             String           @id @default(uuid())
   organisationId String
-  patientId    String
+  patientId      String
   eventType      AuditEventType
   actorType      AuditActorType?
   actorId        String?
@@ -3035,9 +3039,9 @@ model AuditTrail {
   entityType     AuditEntityType?
   entityId       String?
   metadata       Json?
-  occurredAt     DateTime       @default(now())
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
+  occurredAt     DateTime         @default(now())
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
 
   @@index([organisationId])
   @@index([patientId])
@@ -3067,45 +3071,45 @@ model AccountWithdrawal {
 }
 
 model InventoryItem {
-  id                        String               @id @default(uuid())
-  organisationId            String
-  businessType              InventoryBusinessType
-  itemType                  InventoryItemType     @default(NON_MEDICAL)
-  name                      String
-  sku                       String?
-  category                  String
-  subCategory               String?
-  description               String?
-  imageUrl                  String?
-  stockUnitType             String?
-  attachments               Json?
-  attributes                Json                 @default("{}")
-  genericName               String?
-  strength                  String?
-  dosageForm                String?
-  routeOfAdministration     String?
-  drugClass                 String?
-  prescriptionRequired      Boolean              @default(false)
-  controlledItem            Boolean              @default(false)
-  storageInstructions       String?
-  expiryTrackingRequired    Boolean              @default(false)
-  unitOfMeasure             String?
-  packageQuantity           Int?
-  storageLocation           String?
-  onHand                    Int                  @default(0)
-  allocated                 Int                  @default(0)
-  minimumStock              Int?
-  emergencyStockLevel       Int?
-  reorderLevel              Int?
-  unitCost                  Float?
-  sellingPrice              Float?
-  taxRate                   Float?
-  currency                  String?
-  vendorId                  String?
-  status                    InventoryItemStatus   @default(ACTIVE)
-  createdAt                 DateTime             @default(now())
-  updatedAt                 DateTime             @updatedAt
-  packageItemsAsInventory    ProductPackageItem[]  @relation("ProductPackageInventoryComponent")
+  id                      String                @id @default(uuid())
+  organisationId          String
+  businessType            InventoryBusinessType
+  itemType                InventoryItemType     @default(NON_MEDICAL)
+  name                    String
+  sku                     String?
+  category                String
+  subCategory             String?
+  description             String?
+  imageUrl                String?
+  stockUnitType           String?
+  attachments             Json?
+  attributes              Json                  @default("{}")
+  genericName             String?
+  strength                String?
+  dosageForm              String?
+  routeOfAdministration   String?
+  drugClass               String?
+  prescriptionRequired    Boolean               @default(false)
+  controlledItem          Boolean               @default(false)
+  storageInstructions     String?
+  expiryTrackingRequired  Boolean               @default(false)
+  unitOfMeasure           String?
+  packageQuantity         Int?
+  storageLocation         String?
+  onHand                  Int                   @default(0)
+  allocated               Int                   @default(0)
+  minimumStock            Int?
+  emergencyStockLevel     Int?
+  reorderLevel            Int?
+  unitCost                Float?
+  sellingPrice            Float?
+  taxRate                 Float?
+  currency                String?
+  vendorId                String?
+  status                  InventoryItemStatus   @default(ACTIVE)
+  createdAt               DateTime              @default(now())
+  updatedAt               DateTime              @updatedAt
+  packageItemsAsInventory ProductPackageItem[]  @relation("ProductPackageInventoryComponent")
 
   @@unique([organisationId, sku])
   @@index([organisationId, name])
@@ -3116,21 +3120,21 @@ model InventoryItem {
 }
 
 model InventoryBatch {
-  id                   String   @id @default(uuid())
-  itemId               String
-  organisationId       String
-  batchNumber          String?
-  lotNumber            String?
-  regulatoryTrackingId String?
-  expiryWarningBefore  String?
-  barcode              String?
-  manufactureDate      DateTime?
-  expiryDate           DateTime?
+  id                    String    @id @default(uuid())
+  itemId                String
+  organisationId        String
+  batchNumber           String?
+  lotNumber             String?
+  regulatoryTrackingId  String?
+  expiryWarningBefore   String?
+  barcode               String?
+  manufactureDate       DateTime?
+  expiryDate            DateTime?
   minShelfLifeAlertDate DateTime?
-  quantity             Int      @default(0)
-  allocated            Int      @default(0)
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  quantity              Int       @default(0)
+  allocated             Int       @default(0)
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
 
   @@index([itemId])
   @@index([organisationId])
@@ -3139,7 +3143,7 @@ model InventoryBatch {
 }
 
 model InventoryVendor {
-  id                String   @id @default(uuid())
+  id                String    @id @default(uuid())
   organisationId    String
   name              String
   brand             String?
@@ -3153,36 +3157,36 @@ model InventoryVendor {
   deliveryFrequency String?
   leadTimeDays      Int?
   contactInfo       Json?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([organisationId, name])
   @@index([organisationId, vendorItemCode])
 }
 
 model InventoryCategory {
-  id            String   @id @default(uuid())
-  code          String   @unique
-  name          String
-  isMedical     Boolean  @default(false)
-  sortOrder     Int      @default(0)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id        String   @id @default(uuid())
+  code      String   @unique
+  name      String
+  isMedical Boolean  @default(false)
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  subcategories  InventorySubcategory[]
+  subcategories InventorySubcategory[]
 }
 
 model InventorySubcategory {
-  id            String   @id @default(uuid())
-  categoryId    String
-  code          String
-  name          String
-  sortOrder     Int      @default(0)
-  isActive      Boolean  @default(true)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id         String   @id @default(uuid())
+  categoryId String
+  code       String
+  name       String
+  sortOrder  Int      @default(0)
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  category      InventoryCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  category InventoryCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
 
   @@unique([categoryId, code])
   @@index([categoryId])
@@ -3228,16 +3232,16 @@ enum InventoryConsumptionAction {
 }
 
 model InventoryConsumptionRule {
-  id                 String                        @id @default(uuid())
+  id                 String                         @id @default(uuid())
   organisationId     String
   sourceType         InventoryConsumptionSourceType
   sourceKey          String
   inventoryItemId    String
-  quantityMultiplier Float                         @default(1)
+  quantityMultiplier Float                          @default(1)
   notes              String?
-  active             Boolean                       @default(true)
-  createdAt          DateTime                      @default(now())
-  updatedAt          DateTime                      @updatedAt
+  active             Boolean                        @default(true)
+  createdAt          DateTime                       @default(now())
+  updatedAt          DateTime                       @updatedAt
 
   @@unique([organisationId, sourceType, sourceKey, inventoryItemId])
   @@index([organisationId, sourceType, sourceKey])
@@ -3245,7 +3249,7 @@ model InventoryConsumptionRule {
 }
 
 model InventoryConsumptionEvent {
-  id              String                        @id @default(uuid())
+  id              String                         @id @default(uuid())
   organisationId  String
   sourceType      InventoryConsumptionSourceType
   sourceId        String
@@ -3305,7 +3309,7 @@ model ObservationToolSubmission {
   id                      String   @id @default(uuid())
   toolId                  String
   taskId                  String?
-  patientId             String
+  patientId               String
   filledBy                String
   answers                 Json
   score                   Float?
@@ -3320,22 +3324,22 @@ model ObservationToolSubmission {
 }
 
 model Occupancy {
-  id             String             @id @default(uuid())
+  id             String              @id @default(uuid())
   userId         String
   organisationId String
   startTime      DateTime
   endTime        DateTime
   sourceType     OccupancySourceType @default(APPOINTMENT)
   referenceId    String?
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
   @@index([userId, startTime, endTime])
   @@index([userId, organisationId, startTime])
 }
 
 model RegulatoryAuthority {
-  id            String   @id @default(uuid())
+  id            String  @id @default(uuid())
   country       String?
   iso2          String?
   iso3          String?
@@ -3352,7 +3356,7 @@ model AdverseEventReport {
   organisationId String?
   appointmentId  String?
   reporter       Json
-  patient      Json
+  patient        Json
   product        Json
   destinations   Json
   consent        Json
@@ -3380,11 +3384,12 @@ model Speciality {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  roomLinks          OrganisationRoomSpeciality[]
+  roomLinks OrganisationRoomSpeciality[]
 
   @@index([organisationId])
   @@index([organisationId, isActive])
 }
+
 model DeviceToken {
   id          String         @id @default(uuid())
   userId      String
@@ -3412,41 +3417,42 @@ model Notification {
 }
 
 model Invoice {
-  id                       String                   @id @default(uuid())
-  parentId                 String?
-  patientId              String?
-  organisationId           String?
-  appointmentId            String?
-  items                    Json
-  subtotal                 Float
-  discountTotal            Float                    @default(0)
-  invoiceDiscountType      String?
-  invoiceDiscountValue     Float?
-  invoiceDiscountTotal     Float                    @default(0)
-  taxTotal                 Float                    @default(0)
-  taxPercent               Float                    @default(0)
-  taxProvider              TaxProvider?
-  totalAmount              Float
-  currency                 String
-  paymentCollectionMethod  PaymentCollectionMethod  @default(PAYMENT_INTENT)
-  billingCollectionMode    BillingCollectionMode    @default(PREPAY_AT_BOOKING)
-  visitBillingStage        InvoiceVisitBillingStage  @default(DRAFT)
-  readyForBillingAt        DateTime?
-  readyForBillingActorId   String?
-  depositTargetAmount      Float                    @default(0)
-  depositCollectedAmount   Float                    @default(0)
-  status                   InvoiceStatus            @default(PENDING)
-  metadata                 Json?
-  paidAt                   DateTime?
-  finalizedAt              DateTime?
-  createdAt                DateTime                 @default(now())
-  updatedAt                DateTime                 @updatedAt
+  id                      String                   @id @default(uuid())
+  parentId                String?
+  patientId               String?
+  organisationId          String?
+  appointmentId           String?
+  items                   Json
+  subtotal                Float
+  discountTotal           Float                    @default(0)
+  invoiceDiscountType     String?
+  invoiceDiscountValue    Float?
+  invoiceDiscountTotal    Float                    @default(0)
+  taxTotal                Float                    @default(0)
+  taxPercent              Float                    @default(0)
+  taxProvider             TaxProvider?
+  totalAmount             Float
+  currency                String
+  paymentCollectionMethod PaymentCollectionMethod  @default(PAYMENT_INTENT)
+  billingCollectionMode   BillingCollectionMode    @default(PREPAY_AT_BOOKING)
+  visitBillingStage       InvoiceVisitBillingStage @default(DRAFT)
+  readyForBillingAt       DateTime?
+  readyForBillingActorId  String?
+  depositTargetAmount     Float                    @default(0)
+  depositCollectedAmount  Float                    @default(0)
+  status                  InvoiceStatus            @default(PENDING)
+  metadata                Json?
+  paidAt                  DateTime?
+  finalizedAt             DateTime?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
 
-  taxSnapshot              InvoiceTaxSnapshot?
-  paymentAttempts          PaymentAttempt[]
-  payments                 Payment[]
-  creditNotes              CreditNote[]
+  taxSnapshot     InvoiceTaxSnapshot?
+  paymentAttempts PaymentAttempt[]
+  payments        Payment[]
+  creditNotes     CreditNote[]
 
+  @@unique([appointmentId])
   @@index([parentId])
   @@index([organisationId])
   @@index([appointmentId])
@@ -3456,7 +3462,6 @@ model Invoice {
   @@index([visitBillingStage])
   @@index([readyForBillingAt])
   @@index([taxProvider])
-  @@unique([appointmentId])
 }
 
 model InvoiceTaxSnapshot {
@@ -3475,33 +3480,33 @@ model InvoiceTaxSnapshot {
   createdAt           DateTime     @default(now())
   updatedAt           DateTime     @updatedAt
 
-  invoice             Invoice      @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  invoice Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 }
 
 model PaymentAttempt {
-  id                      String               @id @default(uuid())
-  invoiceId               String
-  provider                PaymentProvider
-  settlementChannel       SettlementChannel?
-  providerPaymentIntentId String?
+  id                        String                 @id @default(uuid())
+  invoiceId                 String
+  provider                  PaymentProvider
+  settlementChannel         SettlementChannel?
+  providerPaymentIntentId   String?
   providerCheckoutSessionId String?
-  providerPaymentLinkId   String?
-  status                  PaymentAttemptStatus @default(REQUIRES_PAYMENT_METHOD)
-  amountRequested         Float                @default(0)
-  amountCaptured          Float                @default(0)
-  amountApplied           Float                @default(0)
-  currency                String
-  failureCode             String?
-  failureMessage          String?
-  collectionMode          BillingCollectionMode?
-  isOffline               Boolean              @default(false)
-  isPartial               Boolean              @default(false)
-  rawProviderPayload      Json?
-  createdAt               DateTime             @default(now())
-  updatedAt               DateTime             @updatedAt
+  providerPaymentLinkId     String?
+  status                    PaymentAttemptStatus   @default(REQUIRES_PAYMENT_METHOD)
+  amountRequested           Float                  @default(0)
+  amountCaptured            Float                  @default(0)
+  amountApplied             Float                  @default(0)
+  currency                  String
+  failureCode               String?
+  failureMessage            String?
+  collectionMode            BillingCollectionMode?
+  isOffline                 Boolean                @default(false)
+  isPartial                 Boolean                @default(false)
+  rawProviderPayload        Json?
+  createdAt                 DateTime               @default(now())
+  updatedAt                 DateTime               @updatedAt
 
-  invoice                 Invoice              @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  payment                 Payment?
+  invoice Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  payment Payment?
 
   @@index([invoiceId])
   @@index([provider])
@@ -3512,25 +3517,25 @@ model PaymentAttempt {
 }
 
 model Payment {
-  id                    String          @id @default(uuid())
-  invoiceId             String
-  paymentAttemptId      String?         @unique
-  provider              PaymentProvider
-  settlementChannel     SettlementChannel?
-  collectionMode        BillingCollectionMode?
-  providerPaymentId     String?
-  amount                Float
-  currency              String
-  status                PaymentStatus   @default(PENDING)
-  paidAt                DateTime?
-  receiptUrl            String?
-  rawProviderPayload    Json?
-  createdAt             DateTime        @default(now())
-  updatedAt             DateTime        @updatedAt
+  id                 String                 @id @default(uuid())
+  invoiceId          String
+  paymentAttemptId   String?                @unique
+  provider           PaymentProvider
+  settlementChannel  SettlementChannel?
+  collectionMode     BillingCollectionMode?
+  providerPaymentId  String?
+  amount             Float
+  currency           String
+  status             PaymentStatus          @default(PENDING)
+  paidAt             DateTime?
+  receiptUrl         String?
+  rawProviderPayload Json?
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @updatedAt
 
-  invoice               Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  paymentAttempt        PaymentAttempt? @relation(fields: [paymentAttemptId], references: [id])
-  refunds               Refund[]
+  invoice        Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  paymentAttempt PaymentAttempt? @relation(fields: [paymentAttemptId], references: [id])
+  refunds        Refund[]
 
   @@index([invoiceId])
   @@index([paymentAttemptId])
@@ -3540,19 +3545,19 @@ model Payment {
 }
 
 model Refund {
-  id                    String         @id @default(uuid())
-  paymentId             String
-  provider              PaymentProvider
-  providerRefundId      String?
-  amount                Float
-  currency              String
-  status                RefundStatus   @default(PENDING)
-  reason                String?
-  rawProviderPayload    Json?
-  createdAt             DateTime       @default(now())
-  updatedAt             DateTime       @updatedAt
+  id                 String          @id @default(uuid())
+  paymentId          String
+  provider           PaymentProvider
+  providerRefundId   String?
+  amount             Float
+  currency           String
+  status             RefundStatus    @default(PENDING)
+  reason             String?
+  rawProviderPayload Json?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
 
-  payment               Payment        @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  payment Payment @relation(fields: [paymentId], references: [id], onDelete: Cascade)
 
   @@index([paymentId])
   @@index([provider])
@@ -3571,7 +3576,7 @@ model CreditNote {
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
 
-  invoice          Invoice          @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  invoice Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 
   @@index([invoiceId])
   @@index([status])
@@ -3799,7 +3804,6 @@ model PatientAllergy {
   @@map("PatientAllergy")
 }
 
-
 // ---------------------------------------------------------------------------
 // Medication Administration Record (MAR)
 // ---------------------------------------------------------------------------
@@ -3856,17 +3860,17 @@ enum PreventiveCareStatus {
 }
 
 model PreventiveCarePlan {
-  id                String                  @id @default(uuid())
-  organisationId    String
-  patientId         String
-  name              String
-  description       String?
-  status            PreventiveCareStatus    @default(ACTIVE)
-  createdBy         String?
-  createdAt         DateTime                @default(now())
-  updatedAt         DateTime                @updatedAt
+  id             String               @id @default(uuid())
+  organisationId String
+  patientId      String
+  name           String
+  description    String?
+  status         PreventiveCareStatus @default(ACTIVE)
+  createdBy      String?
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
 
-  items             PreventiveCareItem[]
+  items PreventiveCareItem[]
 
   @@index([organisationId, patientId, status])
   @@index([organisationId, patientId])
@@ -3874,19 +3878,19 @@ model PreventiveCarePlan {
 }
 
 model PreventiveCareItem {
-  id              String                  @id @default(uuid())
-  planId          String
-  organisationId  String
-  careType        String
-  frequency       PreventiveCareFrequency
-  intervalDays    Int?
-  lastDoneAt      DateTime?
-  nextDueAt       DateTime?
-  notes           String?
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  id             String                  @id @default(uuid())
+  planId         String
+  organisationId String
+  careType       String
+  frequency      PreventiveCareFrequency
+  intervalDays   Int?
+  lastDoneAt     DateTime?
+  nextDueAt      DateTime?
+  notes          String?
+  createdAt      DateTime                @default(now())
+  updatedAt      DateTime                @updatedAt
 
-  plan            PreventiveCarePlan @relation(fields: [planId], references: [id], onDelete: Cascade)
+  plan PreventiveCarePlan @relation(fields: [planId], references: [id], onDelete: Cascade)
 
   @@index([organisationId, nextDueAt])
   @@index([planId])
@@ -4069,7 +4073,6 @@ model DiagnosticImage {
   @@map("DiagnosticImage")
 }
 
-
 // ---------------------------------------------------------------------------
 // Blood Transfusion Records
 // ---------------------------------------------------------------------------
@@ -4094,26 +4097,26 @@ enum TransfusionReaction {
 }
 
 model BloodTransfusion {
-  id              String              @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  donorId         String?
-  productType     String
-  bloodType       BloodType
-  volumeMl        Float
-  startedAt       DateTime
-  endedAt         DateTime?
-  durationMinutes Int?
-  reaction        TransfusionReaction @default(NONE)
-  reactionNotes   String?
-  administeredBy  String?
-  crossMatchDone  Boolean             @default(false)
-  crossMatchResult String?
-  preTransfusionPCV Float?
+  id                 String              @id @default(uuid())
+  organisationId     String
+  patientId          String
+  encounterId        String?
+  donorId            String?
+  productType        String
+  bloodType          BloodType
+  volumeMl           Float
+  startedAt          DateTime
+  endedAt            DateTime?
+  durationMinutes    Int?
+  reaction           TransfusionReaction @default(NONE)
+  reactionNotes      String?
+  administeredBy     String?
+  crossMatchDone     Boolean             @default(false)
+  crossMatchResult   String?
+  preTransfusionPCV  Float?
   postTransfusionPCV Float?
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4143,25 +4146,25 @@ enum FluidTherapyStatus {
 }
 
 model FluidTherapyPlan {
-  id               String             @id @default(uuid())
-  organisationId   String
-  patientId        String
-  encounterId      String?
-  admissionId      String?
-  fluidType        FluidType
-  customFluidName  String?
-  additives        String?
-  rateMlPerHour    Float
-  totalVolumeMl    Float?
-  durationHours    Float?
-  startedAt        DateTime
-  endedAt          DateTime?
-  status           FluidTherapyStatus @default(ACTIVE)
-  indication       String?
-  prescribedBy     String?
-  notes            String?
-  createdAt        DateTime           @default(now())
-  updatedAt        DateTime           @updatedAt
+  id              String             @id @default(uuid())
+  organisationId  String
+  patientId       String
+  encounterId     String?
+  admissionId     String?
+  fluidType       FluidType
+  customFluidName String?
+  additives       String?
+  rateMlPerHour   Float
+  totalVolumeMl   Float?
+  durationHours   Float?
+  startedAt       DateTime
+  endedAt         DateTime?
+  status          FluidTherapyStatus @default(ACTIVE)
+  indication      String?
+  prescribedBy    String?
+  notes           String?
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4179,27 +4182,27 @@ enum NutritionPlanStatus {
 }
 
 model NutritionPlan {
-  id              String              @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  status          NutritionPlanStatus @default(ACTIVE)
-  dietName        String
-  calories        Float?
-  calorieUnit     String?
-  protein         Float?
-  fat             Float?
-  fibre           Float?
+  id               String              @id @default(uuid())
+  organisationId   String
+  patientId        String
+  encounterId      String?
+  status           NutritionPlanStatus @default(ACTIVE)
+  dietName         String
+  calories         Float?
+  calorieUnit      String?
+  protein          Float?
+  fat              Float?
+  fibre            Float?
   feedingFrequency String?
-  portionSize     String?
-  waterIntake     String?
-  restrictions    String?
-  indication      String?
-  prescribedBy    String?
-  reviewDate      DateTime?
-  notes           String?
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  portionSize      String?
+  waterIntake      String?
+  restrictions     String?
+  indication       String?
+  prescribedBy     String?
+  reviewDate       DateTime?
+  notes            String?
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4217,27 +4220,27 @@ enum PostOpCareStatus {
 }
 
 model PostOpCarePlan {
-  id                String          @id @default(uuid())
-  organisationId    String
-  patientId         String
-  encounterId       String?
-  surgicalProcedureId String?
-  status            PostOpCareStatus @default(ACTIVE)
-  painScore         Int?
-  analgesiaProtocol String?
+  id                    String           @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  surgicalProcedureId   String?
+  status                PostOpCareStatus @default(ACTIVE)
+  painScore             Int?
+  analgesiaProtocol     String?
   woundCareInstructions String?
   activityRestrictions  String?
-  dietaryNotes      String?
-  fluidTherapyNotes String?
-  monitoringParams  String?
-  firstReviewAt     DateTime?
-  nextReviewAt      DateTime?
-  reviewedBy        String?
-  reviewNotes       String?
-  prescribedBy      String?
-  notes             String?
-  createdAt         DateTime        @default(now())
-  updatedAt         DateTime        @updatedAt
+  dietaryNotes          String?
+  fluidTherapyNotes     String?
+  monitoringParams      String?
+  firstReviewAt         DateTime?
+  nextReviewAt          DateTime?
+  reviewedBy            String?
+  reviewNotes           String?
+  prescribedBy          String?
+  notes                 String?
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4295,35 +4298,35 @@ enum PhysiotherapyStatus {
 }
 
 model PhysiotherapyPlan {
-  id                   String              @id @default(uuid())
-  organisationId       String
-  patientId            String
-  encounterId          String?
-  surgicalProcedureId  String?
-  diagnosis            String
-  goals                String?
-  frequency            String?
-  durationMinutes      Int?
-  totalSessions        Int?
-  exercisePrescription String?
-  hydrotherapy         Boolean             @default(false)
-  laserTherapy         Boolean             @default(false)
-  therapeuticUltrasound Boolean            @default(false)
-  massage              Boolean             @default(false)
-  acupuncture          Boolean             @default(false)
-  tapeApplication      Boolean             @default(false)
-  precautions          String?
-  homeExercises        String?
-  startDate            DateTime?
-  endDate              DateTime?
-  lastSessionAt        DateTime?
-  nextSessionAt        DateTime?
-  therapist            String?
-  prescribedBy         String?
-  status               PhysiotherapyStatus @default(ACTIVE)
-  notes                String?
-  createdAt            DateTime            @default(now())
-  updatedAt            DateTime            @updatedAt
+  id                    String              @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  surgicalProcedureId   String?
+  diagnosis             String
+  goals                 String?
+  frequency             String?
+  durationMinutes       Int?
+  totalSessions         Int?
+  exercisePrescription  String?
+  hydrotherapy          Boolean             @default(false)
+  laserTherapy          Boolean             @default(false)
+  therapeuticUltrasound Boolean             @default(false)
+  massage               Boolean             @default(false)
+  acupuncture           Boolean             @default(false)
+  tapeApplication       Boolean             @default(false)
+  precautions           String?
+  homeExercises         String?
+  startDate             DateTime?
+  endDate               DateTime?
+  lastSessionAt         DateTime?
+  nextSessionAt         DateTime?
+  therapist             String?
+  prescribedBy          String?
+  status                PhysiotherapyStatus @default(ACTIVE)
+  notes                 String?
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4688,21 +4691,21 @@ enum DentalGrade {
 }
 
 model DentalExamination {
-  id              String      @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  examinedAt      DateTime
-  examinedBy      String?
-  overallGrade    DentalGrade
-  findings        Json
-  calculusScore   Int?
-  plaqueScore     Int?
-  gingivalScore   Int?
-  procedures      String[]
-  notes           String?
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  id             String      @id @default(uuid())
+  organisationId String
+  patientId      String
+  encounterId    String?
+  examinedAt     DateTime
+  examinedBy     String?
+  overallGrade   DentalGrade
+  findings       Json
+  calculusScore  Int?
+  plaqueScore    Int?
+  gingivalScore  Int?
+  procedures     String[]
+  notes          String?
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
 
   @@index([organisationId, patientId])
   @@map("DentalExamination")
@@ -4730,27 +4733,27 @@ enum PregnancyStatus {
 }
 
 model ReproductiveRecord {
-  id                    String              @id @default(uuid())
-  organisationId        String
-  patientId             String
-  reproductiveStatus    ReproductiveStatus
-  lastHeatDate          DateTime?
-  nextHeatExpected      DateTime?
-  matingDate            DateTime?
-  sireId                String?
-  sireName              String?
-  pregnancyStatus       PregnancyStatus?
-  pregnancyConfirmedAt  DateTime?
-  expectedWhelp         DateTime?
-  litterSizeUltrasound  Int?
-  litterSizeXray        Int?
-  actualWhelp           DateTime?
-  litterSizeBorn        Int?
-  litterSizeAlive       Int?
-  recordedBy            String?
-  notes                 String?
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
+  id                   String             @id @default(uuid())
+  organisationId       String
+  patientId            String
+  reproductiveStatus   ReproductiveStatus
+  lastHeatDate         DateTime?
+  nextHeatExpected     DateTime?
+  matingDate           DateTime?
+  sireId               String?
+  sireName             String?
+  pregnancyStatus      PregnancyStatus?
+  pregnancyConfirmedAt DateTime?
+  expectedWhelp        DateTime?
+  litterSizeUltrasound Int?
+  litterSizeXray       Int?
+  actualWhelp          DateTime?
+  litterSizeBorn       Int?
+  litterSizeAlive      Int?
+  recordedBy           String?
+  notes                String?
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@map("ReproductiveRecord")
@@ -4774,32 +4777,32 @@ enum PLRResponse {
 }
 
 model OphthalmologyExamination {
-  id                  String       @id @default(uuid())
-  organisationId      String
-  patientId           String
-  encounterId         String?
-  examinedAt          DateTime
-  examinedBy          String?
-  visionLeft          VisionStatus?
-  visionRight         VisionStatus?
-  menaceLeft          Boolean?
-  menaceRight         Boolean?
-  plrDirectLeft       PLRResponse?
-  plrDirectRight      PLRResponse?
-  plrConsensualLeft   PLRResponse?
-  plrConsensualRight  PLRResponse?
-  sttLeft             Int?
-  sttRight            Int?
-  iopLeft             Decimal?
-  iopRight            Decimal?
-  fluoresceinLeft     Boolean?
-  fluoresceinRight    Boolean?
-  findingsLeft        Json?
-  findingsRight       Json?
-  diagnoses           String[]
-  notes               String?
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
+  id                 String        @id @default(uuid())
+  organisationId     String
+  patientId          String
+  encounterId        String?
+  examinedAt         DateTime
+  examinedBy         String?
+  visionLeft         VisionStatus?
+  visionRight        VisionStatus?
+  menaceLeft         Boolean?
+  menaceRight        Boolean?
+  plrDirectLeft      PLRResponse?
+  plrDirectRight     PLRResponse?
+  plrConsensualLeft  PLRResponse?
+  plrConsensualRight PLRResponse?
+  sttLeft            Int?
+  sttRight           Int?
+  iopLeft            Decimal?
+  iopRight           Decimal?
+  fluoresceinLeft    Boolean?
+  fluoresceinRight   Boolean?
+  findingsLeft       Json?
+  findingsRight      Json?
+  diagnoses          String[]
+  notes              String?
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
 
   @@index([organisationId, patientId])
   @@map("OphthalmologyExamination")
@@ -4840,7 +4843,7 @@ enum AcvimClass {
 }
 
 model CardiologyAssessment {
-  id                   String      @id @default(uuid())
+  id                   String       @id @default(uuid())
   organisationId       String
   patientId            String
   encounterId          String?
@@ -4861,8 +4864,8 @@ model CardiologyAssessment {
   findings             Json?
   diagnoses            String[]
   notes                String?
-  createdAt            DateTime    @default(now())
-  updatedAt            DateTime    @updatedAt
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@map("CardiologyAssessment")
@@ -4889,24 +4892,24 @@ enum HandlingTolerance {
 }
 
 model BehaviorAssessment {
-  id                    String            @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  fasScore              FasScore?
-  nailTrimTolerance     HandlingTolerance?
-  handlingTolerance     HandlingTolerance?
-  aggressionTriggers    String[]
-  aversionBehaviors     String[]
-  trainingHistory       String?
-  diagnoses             String[]
-  referralRecommended   Boolean?
-  fearFreeNotes         String?
-  notes                 String?
-  createdAt             DateTime          @default(now())
-  updatedAt             DateTime          @updatedAt
+  id                  String             @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String?
+  assessedAt          DateTime
+  assessedBy          String?
+  fasScore            FasScore?
+  nailTrimTolerance   HandlingTolerance?
+  handlingTolerance   HandlingTolerance?
+  aggressionTriggers  String[]
+  aversionBehaviors   String[]
+  trainingHistory     String?
+  diagnoses           String[]
+  referralRecommended Boolean?
+  fearFreeNotes       String?
+  notes               String?
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@map("BehaviorAssessment")
@@ -4917,25 +4920,25 @@ model BehaviorAssessment {
 // ---------------------------------------------------------------------------
 
 model DermatologyAssessment {
-  id                    String    @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  pruritusScore         Int?
-  affectedRegions       String[]
-  primaryLesions        String[]
-  secondaryLesions      String[]
-  coatQuality           String?
-  lesionMap             Json?
+  id                     String   @id @default(uuid())
+  organisationId         String
+  patientId              String
+  encounterId            String?
+  assessedAt             DateTime
+  assessedBy             String?
+  pruritusScore          Int?
+  affectedRegions        String[]
+  primaryLesions         String[]
+  secondaryLesions       String[]
+  coatQuality            String?
+  lesionMap              Json?
   environmentalAllergens String[]
-  foodTrialStatus       String?
-  cades04Score          Int?
-  diagnoses             String[]
-  notes                 String?
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
+  foodTrialStatus        String?
+  cades04Score           Int?
+  diagnoses              String[]
+  notes                  String?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   @@index([organisationId, patientId])
   @@map("DermatologyAssessment")
@@ -4961,25 +4964,25 @@ enum GaitScore {
 }
 
 model NeurologyAssessment {
-  id                    String             @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  consciousnessLevel    ConsciousnessLevel?
-  gaitScore             GaitScore?
-  cranialNerveFindings  String?
-  spinalReflexGrades    Json?
-  deepPainPresent       Boolean?
-  proprioceptionIntact  Boolean?
-  seizureHistory        Boolean?
-  seizureFrequency      String?
-  mriRecommended        Boolean?
-  diagnoses             String[]
-  notes                 String?
-  createdAt             DateTime           @default(now())
-  updatedAt             DateTime           @updatedAt
+  id                   String              @id @default(uuid())
+  organisationId       String
+  patientId            String
+  encounterId          String?
+  assessedAt           DateTime
+  assessedBy           String?
+  consciousnessLevel   ConsciousnessLevel?
+  gaitScore            GaitScore?
+  cranialNerveFindings String?
+  spinalReflexGrades   Json?
+  deepPainPresent      Boolean?
+  proprioceptionIntact Boolean?
+  seizureHistory       Boolean?
+  seizureFrequency     String?
+  mriRecommended       Boolean?
+  diagnoses            String[]
+  notes                String?
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@map("NeurologyAssessment")
@@ -5004,26 +5007,26 @@ enum OncologyStage {
 }
 
 model OncologyAssessment {
-  id                      String        @id @default(uuid())
-  organisationId          String
-  patientId               String
-  encounterId             String?
-  assessedAt              DateTime
-  assessedBy              String?
-  tumorType               String?
-  primaryTumorStage       String?
-  nodeStage               String?
-  metastasisStage         String?
-  overallStage            OncologyStage?
-  chemotherapyProtocol    String?
-  chemotherapyStartDate   DateTime?
-  chemotherapyCycles      Int?
-  qualityOfLifeScore      Int?
-  prognosis               String?
-  diagnoses               String[]
-  notes                   String?
-  createdAt               DateTime      @default(now())
-  updatedAt               DateTime      @updatedAt
+  id                    String         @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  assessedAt            DateTime
+  assessedBy            String?
+  tumorType             String?
+  primaryTumorStage     String?
+  nodeStage             String?
+  metastasisStage       String?
+  overallStage          OncologyStage?
+  chemotherapyProtocol  String?
+  chemotherapyStartDate DateTime?
+  chemotherapyCycles    Int?
+  qualityOfLifeScore    Int?
+  prognosis             String?
+  diagnoses             String[]
+  notes                 String?
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
 
   @@index([organisationId, patientId])
   @@map("OncologyAssessment")
@@ -5050,27 +5053,27 @@ enum FeedingRoute {
 }
 
 model NutritionAssessment {
-  id                        String        @id @default(uuid())
-  organisationId            String
-  patientId                 String
-  encounterId               String?
-  assessedAt                DateTime
-  assessedBy                String?
-  appetiteScore             AppetiteScore?
-  bodyConditionScore        Int?
-  muscleConditionScore      Int?
-  currentWeightKg           Float?
-  idealWeightKg             Float?
-  restingEnergyRequirement  Float?
-  feedingRoute              FeedingRoute?
-  currentDiet               String?
-  feedingPlan               String?
-  supplementation           String[]
-  hydrationStatus           String?
-  diagnoses                 String[]
-  notes                     String?
-  createdAt                 DateTime      @default(now())
-  updatedAt                 DateTime      @updatedAt
+  id                       String         @id @default(uuid())
+  organisationId           String
+  patientId                String
+  encounterId              String?
+  assessedAt               DateTime
+  assessedBy               String?
+  appetiteScore            AppetiteScore?
+  bodyConditionScore       Int?
+  muscleConditionScore     Int?
+  currentWeightKg          Float?
+  idealWeightKg            Float?
+  restingEnergyRequirement Float?
+  feedingRoute             FeedingRoute?
+  currentDiet              String?
+  feedingPlan              String?
+  supplementation          String[]
+  hydrationStatus          String?
+  diagnoses                String[]
+  notes                    String?
+  createdAt                DateTime       @default(now())
+  updatedAt                DateTime       @updatedAt
 
   @@index([organisationId, patientId])
   @@map("NutritionAssessment")
@@ -5096,23 +5099,23 @@ enum PocTestType {
 }
 
 model PointOfCareLab {
-  id                  String       @id @default(uuid())
-  organisationId      String
-  patientId           String
-  encounterId         String?
-  conductedAt         DateTime
-  conductedBy         String?
-  testType            PocTestType
-  analyzerName        String?
-  sampleType          String?
-  results             Json
+  id                    String      @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  conductedAt           DateTime
+  conductedBy           String?
+  testType              PocTestType
+  analyzerName          String?
+  sampleType            String?
+  results               Json
   overallInterpretation String?
-  abnormalFlags       String[]
-  criticalFlags       String[]
-  followUpRecommended Boolean?
-  notes               String?
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
+  abnormalFlags         String[]
+  criticalFlags         String[]
+  followUpRecommended   Boolean?
+  notes                 String?
+  createdAt             DateTime    @default(now())
+  updatedAt             DateTime    @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, testType])
@@ -5144,7 +5147,7 @@ enum OrthoRating {
 }
 
 model GeneticHealthScreen {
-  id                  String            @id @default(uuid())
+  id                  String       @id @default(uuid())
   organisationId      String
   patientId           String
   encounterId         String?
@@ -5160,8 +5163,8 @@ model GeneticHealthScreen {
   certificateNumber   String?
   certificationExpiry DateTime?
   notes               String?
-  createdAt           DateTime          @default(now())
-  updatedAt           DateTime          @updatedAt
+  createdAt           DateTime     @default(now())
+  updatedAt           DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@map("GeneticHealthScreen")
@@ -5172,26 +5175,26 @@ model GeneticHealthScreen {
 // ---------------------------------------------------------------------------
 
 model QualityOfLifeAssessment {
-  id               String    @id @default(uuid())
-  organisationId   String
-  patientId        String
-  encounterId      String?
-  assessedAt       DateTime
-  assessedBy       String?
-  hhhhhmmScore     Int?
-  painScore        Int?
-  appetiteScore    Int?
-  hygieneScore     Int?
-  happinessScore   Int?
-  mobilityScore    Int?
-  moreDaysGood     Boolean?
-  overallScore     Int?
-  ownerAssessed    Boolean   @default(false)
-  clinicianNotes   String?
-  ownerNotes       String?
+  id                  String   @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String?
+  assessedAt          DateTime
+  assessedBy          String?
+  hhhhhmmScore        Int?
+  painScore           Int?
+  appetiteScore       Int?
+  hygieneScore        Int?
+  happinessScore      Int?
+  mobilityScore       Int?
+  moreDaysGood        Boolean?
+  overallScore        Int?
+  ownerAssessed       Boolean  @default(false)
+  clinicianNotes      String?
+  ownerNotes          String?
   euthanasiaDiscussed Boolean?
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   @@index([organisationId, patientId])
   @@map("QualityOfLifeAssessment")
@@ -5425,22 +5428,22 @@ enum BodyDispositionType {
 }
 
 model DeceasedRecord {
-  id                 String              @id @default(uuid())
+  id                 String               @id @default(uuid())
   organisationId     String
-  patientId          String              @unique
+  patientId          String               @unique
   deceasedAt         DateTime
   causeOfDeathType   CauseOfDeathType
   causeOfDeathDetail String?
   bodyWeightKg       Float?
   bodyConditionScore Int?
-  necropsyRequested  Boolean             @default(false)
+  necropsyRequested  Boolean              @default(false)
   necropsyFacility   String?
   bodyDisposition    BodyDispositionType?
   ownerNotifiedAt    DateTime?
   certifiedBy        String?
   notes              String?
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
 
   @@index([organisationId, deceasedAt])
   @@map("DeceasedRecord")
@@ -5464,17 +5467,17 @@ enum ChecklistStatus {
 }
 
 model SurgicalChecklist {
-  id              String          @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String
-  phase           ChecklistPhase  @default(SIGN_IN)
-  status          ChecklistStatus @default(PENDING)
-  conductedBy     String?
-  completedAt     DateTime?
-  notes           String?
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  id             String          @id @default(uuid())
+  organisationId String
+  patientId      String
+  encounterId    String
+  phase          ChecklistPhase  @default(SIGN_IN)
+  status         ChecklistStatus @default(PENDING)
+  conductedBy    String?
+  completedAt    DateTime?
+  notes          String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   items SurgicalChecklistItem[]
 
@@ -5484,16 +5487,16 @@ model SurgicalChecklist {
 }
 
 model SurgicalChecklistItem {
-  id          String   @id @default(uuid())
+  id          String    @id @default(uuid())
   checklistId String
   label       String
-  isChecked   Boolean  @default(false)
+  isChecked   Boolean   @default(false)
   checkedBy   String?
   checkedAt   DateTime?
   notes       String?
-  sortOrder   Int      @default(0)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  sortOrder   Int       @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   checklist SurgicalChecklist @relation(fields: [checklistId], references: [id], onDelete: Cascade)
 
@@ -5645,28 +5648,28 @@ enum AsaClass {
 }
 
 model PreOpAssessment {
-  id                   String    @id @default(uuid())
-  organisationId       String
-  patientId            String
-  encounterId          String
-  asaClass             AsaClass  @default(ASA_I)
-  fastingStartedAt     DateTime?
-  labsReviewed         Boolean   @default(false)
-  ecgReviewed          Boolean   @default(false)
-  ownerConsentSigned   Boolean   @default(false)
-  anesthetistId        String?
-  surgeonId            String?
-  plannedProcedure     String?
-  anesthesiaType       String?
-  knownAllergies       String?
-  currentMedications   String?
-  airwayNotes          String?
-  cardiovascularNotes  String?
-  notes                String?
-  assessedBy           String?
-  assessedAt           DateTime  @default(now())
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
+  id                  String    @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String
+  asaClass            AsaClass  @default(ASA_I)
+  fastingStartedAt    DateTime?
+  labsReviewed        Boolean   @default(false)
+  ecgReviewed         Boolean   @default(false)
+  ownerConsentSigned  Boolean   @default(false)
+  anesthetistId       String?
+  surgeonId           String?
+  plannedProcedure    String?
+  anesthesiaType      String?
+  knownAllergies      String?
+  currentMedications  String?
+  airwayNotes         String?
+  cardiovascularNotes String?
+  notes               String?
+  assessedBy          String?
+  assessedAt          DateTime  @default(now())
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, encounterId])
@@ -5699,20 +5702,20 @@ enum IsolationLevel {
 }
 
 model IsolationProtocol {
-  id              String         @id @default(uuid())
-  organisationId  String
-  patientId       String
-  reason          IsolationReason @default(OTHER)
-  level           IsolationLevel  @default(CONTACT)
-  unitId          String?
-  startedAt       DateTime
-  endedAt         DateTime?
-  initiatedBy     String?
-  endedBy         String?
-  ppe             String[]
-  notes           String?
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  id             String          @id @default(uuid())
+  organisationId String
+  patientId      String
+  reason         IsolationReason @default(OTHER)
+  level          IsolationLevel  @default(CONTACT)
+  unitId         String?
+  startedAt      DateTime
+  endedAt        DateTime?
+  initiatedBy    String?
+  endedBy        String?
+  ppe            String[]
+  notes          String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, endedAt])
@@ -5732,25 +5735,25 @@ enum TransferType {
 }
 
 model PatientTransfer {
-  id                    String       @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  transferType          TransferType
-  receivingFacility     String
-  receivingVetName      String?
-  receivingVetContact   String?
-  transferredAt         DateTime
-  transferredBy         String?
-  chiefComplaint        String?
-  currentDiagnoses      String?
-  ongoingTreatments     String?
-  medicationsDispensed  String?
-  caseSummary           String?
-  criticalAlerts        String?
-  ownerInformed         Boolean      @default(false)
-  createdAt             DateTime     @default(now())
-  updatedAt             DateTime     @updatedAt
+  id                   String       @id @default(uuid())
+  organisationId       String
+  patientId            String
+  encounterId          String?
+  transferType         TransferType
+  receivingFacility    String
+  receivingVetName     String?
+  receivingVetContact  String?
+  transferredAt        DateTime
+  transferredBy        String?
+  chiefComplaint       String?
+  currentDiagnoses     String?
+  ongoingTreatments    String?
+  medicationsDispensed String?
+  caseSummary          String?
+  criticalAlerts       String?
+  ownerInformed        Boolean      @default(false)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, transferredAt])
@@ -5779,7 +5782,7 @@ enum EquipmentStatus {
 }
 
 model ClinicEquipment {
-  id              String          @id @default(uuid())
+  id              String                    @id @default(uuid())
   organisationId  String
   name            String
   model           String?
@@ -5787,32 +5790,32 @@ model ClinicEquipment {
   manufacturer    String?
   purchasedAt     DateTime?
   warrantyExpiry  DateTime?
-  status          EquipmentStatus @default(OPERATIONAL)
+  status          EquipmentStatus           @default(OPERATIONAL)
   locationNotes   String?
   notes           String?
   maintenanceLogs EquipmentMaintenanceLog[]
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  createdAt       DateTime                  @default(now())
+  updatedAt       DateTime                  @updatedAt
 
   @@index([organisationId])
   @@map("ClinicEquipment")
 }
 
 model EquipmentMaintenanceLog {
-  id            String          @id @default(uuid())
-  equipmentId   String
-  equipment     ClinicEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+  id              String          @id @default(uuid())
+  equipmentId     String
+  equipment       ClinicEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
   maintenanceType MaintenanceType
-  performedBy   String?
-  vendor        String?
-  scheduledAt   DateTime?
-  performedAt   DateTime
-  nextDueAt     DateTime?
-  cost          Float?
-  currency      String?
-  passed        Boolean?
-  notes         String?
-  createdAt     DateTime        @default(now())
+  performedBy     String?
+  vendor          String?
+  scheduledAt     DateTime?
+  performedAt     DateTime
+  nextDueAt       DateTime?
+  cost            Float?
+  currency        String?
+  passed          Boolean?
+  notes           String?
+  createdAt       DateTime        @default(now())
 
   @@index([equipmentId])
   @@index([equipmentId, performedAt])
@@ -5884,21 +5887,21 @@ enum ClinicalAlertSeverity {
 }
 
 model ClinicalAlertLog {
-  id              String                @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  alertType       ClinicalAlertType
-  severity        ClinicalAlertSeverity @default(WARNING)
-  title           String
-  body            String?
-  triggeredBy     String?
-  acknowledgedAt  DateTime?
-  acknowledgedBy  String?
+  id               String                @id @default(uuid())
+  organisationId   String
+  patientId        String
+  encounterId      String?
+  alertType        ClinicalAlertType
+  severity         ClinicalAlertSeverity @default(WARNING)
+  title            String
+  body             String?
+  triggeredBy      String?
+  acknowledgedAt   DateTime?
+  acknowledgedBy   String?
   acknowledgedNote String?
-  dismissed       Boolean               @default(false)
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  dismissed        Boolean               @default(false)
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, severity])
@@ -5926,24 +5929,24 @@ enum TelemedicineStatus {
 }
 
 model TelemedicineSession {
-  id               String               @id @default(uuid())
-  organisationId   String
-  appointmentId    String?
-  clientId         String
-  patientId        String?
-  platform         TelemedicinePlatform
-  status           TelemedicineStatus   @default(SCHEDULED)
-  startedAt        DateTime?
-  endedAt          DateTime?
-  durationMinutes  Int?
-  conductedBy      String?
-  chiefComplaint   String?
-  clinicianNotes   String?
-  followUpRequired Boolean              @default(false)
-  recordingUrl     String?
+  id                String               @id @default(uuid())
+  organisationId    String
+  appointmentId     String?
+  clientId          String
+  patientId         String?
+  platform          TelemedicinePlatform
+  status            TelemedicineStatus   @default(SCHEDULED)
+  startedAt         DateTime?
+  endedAt           DateTime?
+  durationMinutes   Int?
+  conductedBy       String?
+  chiefComplaint    String?
+  clinicianNotes    String?
+  followUpRequired  Boolean              @default(false)
+  recordingUrl      String?
   externalSessionId String?
-  createdAt        DateTime             @default(now())
-  updatedAt        DateTime             @updatedAt
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
 
   @@index([organisationId, clientId])
   @@index([organisationId, status])
@@ -5964,23 +5967,23 @@ enum CheckInStatus {
 }
 
 model PatientCheckIn {
-  id              String         @id @default(uuid())
-  organisationId  String
-  patientId       String
-  clientId        String
-  appointmentId   String?
-  arrivedAt       DateTime
-  triagePriority  TriagePriority @default(NON_URGENT)
-  triageNote      String?
-  assignedRoomId  String?
-  checkedInBy     String?
-  waitStartedAt   DateTime?
-  seenAt          DateTime?
-  waitMinutes     Int?
-  status          CheckInStatus  @default(WAITING)
-  notes           String?
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  id             String         @id @default(uuid())
+  organisationId String
+  patientId      String
+  clientId       String
+  appointmentId  String?
+  arrivedAt      DateTime
+  triagePriority TriagePriority @default(NON_URGENT)
+  triageNote     String?
+  assignedRoomId String?
+  checkedInBy    String?
+  waitStartedAt  DateTime?
+  seenAt         DateTime?
+  waitMinutes    Int?
+  status         CheckInStatus  @default(WAITING)
+  notes          String?
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
   @@index([organisationId, status])
   @@index([organisationId, patientId])
@@ -6000,7 +6003,7 @@ enum AnaesthesiaStatus {
 }
 
 model AnaesthesiaRecord {
-  id                  String             @id @default(uuid())
+  id                  String            @id @default(uuid())
   organisationId      String
   patientId           String
   encounterId         String?
@@ -6019,9 +6022,9 @@ model AnaesthesiaRecord {
   intraOpNotes        Json?
   complications       String?
   recoveryNotes       String?
-  status              AnaesthesiaStatus  @default(PLANNED)
-  createdAt           DateTime           @default(now())
-  updatedAt           DateTime           @updatedAt
+  status              AnaesthesiaStatus @default(PLANNED)
+  createdAt           DateTime          @default(now())
+  updatedAt           DateTime          @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, status])
@@ -6109,27 +6112,27 @@ enum MedicalCertificateStatus {
 }
 
 model MedicalCertificate {
-  id              String                   @id @default(uuid())
-  organisationId  String
-  patientId       String
-  clientId        String
-  encounterId     String?
-  appointmentId   String?
-  certificateType MedicalCertificateType
-  status          MedicalCertificateStatus @default(DRAFT)
-  issueNumber     String?                  @unique
-  issuedAt        DateTime?
-  expiresAt       DateTime?
-  issuedBy        String?
-  validForTravel  Boolean                  @default(false)
+  id                 String                   @id @default(uuid())
+  organisationId     String
+  patientId          String
+  clientId           String
+  encounterId        String?
+  appointmentId      String?
+  certificateType    MedicalCertificateType
+  status             MedicalCertificateStatus @default(DRAFT)
+  issueNumber        String?                  @unique
+  issuedAt           DateTime?
+  expiresAt          DateTime?
+  issuedBy           String?
+  validForTravel     Boolean                  @default(false)
   destinationCountry String?
   clinicalFindings   String?
   restrictions       String?
   notes              String?
   revokedAt          DateTime?
   revokedReason      String?
-  createdAt       DateTime                 @default(now())
-  updatedAt       DateTime                 @updatedAt
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, status])
@@ -6178,7 +6181,7 @@ model PatientFlag {
 }
 
 model InventoryCount {
-  id              String   @id @default(uuid())
+  id              String    @id @default(uuid())
   organisationId  String
   inventoryItemId String
   countedBy       String?
@@ -6187,11 +6190,11 @@ model InventoryCount {
   physicalCount   Int
   discrepancy     Int
   notes           String?
-  reconciled      Boolean  @default(false)
+  reconciled      Boolean   @default(false)
   reconciledAt    DateTime?
   reconciledBy    String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   @@index([organisationId, inventoryItemId])
   @@index([organisationId, countedAt])
@@ -6234,13 +6237,13 @@ model ClinicNote {
 // ─── ActivityPub Federation ───────────────────────────────────────────────────
 
 model APActor {
-  id                String       @id @default(uuid())
-  organisationId    String?      @unique
-  uri               String       @unique
-  preferredUsername String       @unique
+  id                String   @id @default(uuid())
+  organisationId    String?  @unique
+  uri               String   @unique
+  preferredUsername String   @unique
   publicKeyPem      String
   privateKeyPem     String
-  publicKeyId       String       @unique
+  publicKeyId       String   @unique
   inboxUri          String
   outboxUri         String
   followersUri      String
@@ -6249,13 +6252,13 @@ model APActor {
   summary           String?
   iconUrl           String?
   licenseToken      String?
-  directoryListed   Boolean      @default(false)
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  directoryListed   Boolean  @default(false)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  followers         APFollower[] @relation("LocalActorFollowers")
-  following         APFollowing[]
-  activities        APActivity[]
+  followers  APFollower[]  @relation("LocalActorFollowers")
+  following  APFollowing[]
+  activities APActivity[]
 }
 
 model APFollower {
@@ -6269,7 +6272,7 @@ model APFollower {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
 
-  localActor     APActor         @relation("LocalActorFollowers", fields: [localActorId], references: [id])
+  localActor APActor @relation("LocalActorFollowers", fields: [localActorId], references: [id])
 
   @@unique([localActorId, remoteActorUri])
   @@index([localActorId])
@@ -6287,7 +6290,7 @@ model APFollowing {
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
 
-  localActor     APActor          @relation(fields: [localActorId], references: [id])
+  localActor APActor @relation(fields: [localActorId], references: [id])
 
   @@unique([localActorId, remoteActorUri])
   @@index([localActorId])
@@ -6313,22 +6316,22 @@ model APRemoteActor {
 }
 
 model APActivity {
-  id            String       @id @default(uuid())
-  uri           String       @unique
-  type          String
-  localActorId  String
-  objectUri     String?
-  objectJson    Json?
-  targetUri     String?
-  toAddresses   String[]
-  ccAddresses   String[]
-  published     DateTime
-  processed     Boolean      @default(false)
-  direction     APDirection  @default(OUTBOUND)
-  rawJson       Json
-  createdAt     DateTime     @default(now())
+  id           String      @id @default(uuid())
+  uri          String      @unique
+  type         String
+  localActorId String
+  objectUri    String?
+  objectJson   Json?
+  targetUri    String?
+  toAddresses  String[]
+  ccAddresses  String[]
+  published    DateTime
+  processed    Boolean     @default(false)
+  direction    APDirection @default(OUTBOUND)
+  rawJson      Json
+  createdAt    DateTime    @default(now())
 
-  localActor    APActor      @relation(fields: [localActorId], references: [id])
+  localActor APActor @relation(fields: [localActorId], references: [id])
 
   @@index([localActorId])
   @@index([type])
@@ -6337,20 +6340,20 @@ model APActivity {
 }
 
 model APReferral {
-  id              String             @id @default(uuid())
-  activityUri     String             @unique
+  id              String            @id @default(uuid())
+  activityUri     String            @unique
   fromActorUri    String
   toActorUri      String
   fromOrgId       String?
   toOrgId         String?
   patientSummary  Json
   clinicalContext String?
-  urgency         APReferralUrgency  @default(ROUTINE)
-  state           APReferralState    @default(PENDING)
+  urgency         APReferralUrgency @default(ROUTINE)
+  state           APReferralState   @default(PENDING)
   acceptedAt      DateTime?
   declinedAt      DateTime?
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 
   @@index([fromActorUri])
   @@index([toActorUri])
@@ -6386,4 +6389,89 @@ enum APReferralUrgency {
   ROUTINE
   URGENT
   EMERGENCY
+}
+
+/// Strength of the source behind a recommendation rule.
+///
+/// An ACVIM consensus statement and a single forty-dog retrospective are not the
+/// same thing, and a table that treats them alike will not survive contact with a
+/// vet. Ordered strongest first.
+enum RecommendationEvidenceGrade {
+  CONSENSUS_STATEMENT
+  PRACTICE_GUIDELINE
+  POPULATION_STUDY
+  COHORT_STUDY
+  CASE_SERIES
+  EXPERT_OPINION
+}
+
+/// A husbandry task recommended for a species, breed and age window, with the
+/// source it comes from.
+///
+/// Separate from TaskLibraryDefinition on purpose. The definition is the TASK
+/// ("Log weight"); this is the INDICATION ("for a Cavalier over five, because
+/// MMVD"). One definition can be recommended by several rules with different age
+/// windows and different sources, which breed arrays bolted onto the definition
+/// could not express.
+///
+/// Recommends husbandry, never diagnosis. The rendered copy says "commonly
+/// recommended for this breed" with the citation visible; nothing here may be
+/// phrased as a claim about the individual animal.
+model TaskRecommendationRule {
+  id String @id @default(uuid())
+
+  /// Matches TaskLibraryDefinition.applicableSpecies, so a rule cannot recommend
+  /// a task to a species the task does not support.
+  species TaskLibrarySpecies
+
+  /// Canonical breed codes this applies to, e.g. YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL.
+  /// Empty means the rule is species-wide - the life-stage tasks most animals get.
+  ///
+  /// Stored canonically (hyphens folded to underscores, upper case) because the
+  /// vocabulary holds 36 breeds under BOTH separator conventions; comparing these
+  /// literally would silently miss every patient coded the other way.
+  breedCodes String[] @default([])
+
+  /// Half-open age window in months: [minAgeMonths, maxAgeMonths). Null is open.
+  /// Months rather than years because the feline and canine life-stage guidelines
+  /// are finer than a year in the first two.
+  minAgeMonths Int?
+  maxAgeMonths Int?
+
+  taskDefinitionId String
+  taskDefinition   TaskLibraryDefinition @relation(fields: [taskDefinitionId], references: [id])
+
+  /// Shown as-is to the parent. Husbandry phrasing, no diagnosis.
+  recommendationText String
+
+  /// Structured so the app can render a real citation rather than a bare link.
+  citationAuthors String
+  citationTitle   String
+  citationSource  String
+  citationYear    Int
+  citationDoi     String?
+  citationUrl     String?
+
+  /// The specific claim in the source that this rule rests on. This is what a vet
+  /// argues with, so it has to be the sentence, not the paper.
+  citationClaim String
+
+  evidenceGrade RecommendationEvidenceGrade
+
+  /// Attestation, same shape the passport already uses. A citation with no review
+  /// date rots silently: three years on, nobody knows whether it still stands.
+  lastReviewedAt DateTime?
+  reviewedBy     String?
+  nextReviewDue  DateTime?
+
+  /// Both must hold before a rule is served. `isActive` alone is not enough - a
+  /// rule reaches pet parents only once a named reviewer has signed it off, which
+  /// is why seeded rules land inactive and unreviewed.
+  isActive Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([species, isActive])
+  @@index([taskDefinitionId])
 }


### PR DESCRIPTION
Closes the engineering half of #2442: the rule table, the matcher, one authenticated endpoint, and the breed-code backfill the issue named as a prerequisite.

**No rules are seeded.** The schema is built so that seeding without a reviewer cannot reach anyone — see *Curation* below.

## Shape

`TaskRecommendationRule` is separate from `TaskLibraryDefinition` because the definition is the **task** ("Log weight") and a rule is the **indication** ("for a Cavalier over five, because MMVD"). One definition can be recommended by several rules with different age windows and different sources, which breed arrays bolted onto the definition could not express.

Each rule carries a structured citation (authors, title, source, year, DOI, and the specific claim relied on), an evidence grade, and the same attestation triple the passport uses — `lastReviewedAt`, `reviewedBy`, `nextReviewDue`.

Matching is server-side, behind `requireCompanionPermission('tasks')`, so a co-parent whose tasks switch is off cannot read what has been recommended either. The disclaimer ships in the response rather than the app bundle, for the same reason the rules do: it is the part most likely to need correcting, and a correction should not wait out mobile adoption.

## Curation, and why nothing is seeded

A rule is served only when `isActive` **and** a named reviewer has signed it off. `isActive` therefore defaults to `false`, unlike almost every other `isActive` in this schema, and the matcher filters on `NOT: { reviewedBy: null }` as well.

That means a row inserted by a seed or a migration is inert until a person attaches their name to it. I have not written the clinical rules: the issue is right that curation is the real work, and a citation I cannot verify is worse than an empty table. The mechanism to stop an unreviewed rule reaching a pet parent is in place and tested.

## Two assumptions in the issue that did not hold

Both found in production data, not reasoning.

**`TaskLibraryDefinition` is empty — zero rows.** The issue says "most of the infrastructure is already there... `TaskLibraryDefinition` exists". The table exists; nothing has ever populated it. Rules reference it, so the feature has nothing to recommend until the library is seeded. Which husbandry tasks exist is a product decision, so it is not made here — but it is now a blocker on the same critical path.

**The breed vocabulary is split across two separator conventions.** `CodeEntry` holds 1,749 breed codes that collapse to 1,713 distinct ones: 36 breeds exist as *both* `SHIH_TZU` and `SHIH-TZU`, `LHASA_APSO` and `LHASA-APSO`. Patient rows are split the same way — four of the seven coded companions are hyphenated, three are not.

A rule keyed on one spelling returns nothing for every patient coded the other way. That failure is silent, and a silently absent recommendation looks exactly like a breed with no guidance for it. Codes are compared canonically everywhere: in the matcher, in the backfill, and in the helper both share.

## The backfill

The prerequisite the issue *did* name: `breedCode` was populated on **7 of 37** companions, so a matcher on those columns would work for one companion in five.

All 37 have breed text, and because it comes from a picker rather than a keyboard it matches `CodeEntry.display` exactly. Scoped by `Patient.type`, **all 30 uncoded companions resolve with zero ambiguity** (verified against production; no companion has `type = 'other'`).

That scoping is load-bearing rather than tidy:

| breed | matches |
| --- | --- |
| `Abyssinian` | `YBREED:EQUINE:ABYSSINIAN` **and** `YBREED:FELINE:ABYSSINIAN` |
| `Maltese` | `YBREED:CANINE:MALTESE`, `YBREED:CANINE:MALTESE_CANINE`, `YBREED:FELINE:MALTESE` |

Matching on display alone would have coded an Abyssinian **cat** as a **horse**, and then handed it equine guidance. Anything still ambiguous after species scoping and canonicalisation is skipped and reported — a wrong code is worse than a missing one, because a missing code shows nothing while a wrong one shows confident recommendations for the wrong animal.

The script is dry-run by default; `--apply` writes.

## Safety framing

Husbandry, never diagnosis. Rules recommend actions a parent takes ("log their weight monthly"), phrased as "commonly recommended for this breed", with the citation visible. Nothing is expressed as a claim about the individual animal — a rule knows a breed and an age, not a patient.

The `because` block on every recommendation carries what actually triggered it (species, whether it was breed-specific, the age window, the companion's age) so the "why am I seeing this?" affordance has something real to show. That is the stronger control; the disclaimer is belt and braces.

## Validation

- **434 suites, 10,362 tests** green across the backend.
- Migration DDL diffed against `prisma migrate diff` output — **identical**, after dropping a `NOT NULL` I had added to the array column that Prisma does not emit and which would have read as drift.
- `tsc --noEmit` and eslint clean.
- **Mutation-checked**, seven ways, each failing at least one test:

| mutation | result |
| --- | --- |
| unreviewed rules become servable | 1 fail |
| breed compared literally, not canonically | 1 fail |
| age window closed instead of half-open | 1 fail |
| deactivated task definitions still recommended | 1 fail |
| backfill species scoping dropped | 1 fail |
| backfill picks first candidate when ambiguous | 1 fail |
| backfill compares candidates literally | 1 fail |
| route guard removed | 1 fail |

## Not in this PR

- The clinical rules themselves (needs veterinary sign-off; the gate is built)
- Seeding `TaskLibraryDefinition` (product decision on which tasks exist)
- The mobile surface and the "why am I seeing this?" UI
- PIMS visibility
