### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -11,6 +11,13 @@ name: Deploy API
 # someone makes, not a side effect of merging. What this removes is the drift and
 # the laptop, not the judgement.
 on:
+  # The deploy itself stays manual (see below). The unit tests for its git-sync
+  # step do not: they are the only thing standing between a refspec edit and a
+  # deploy that stops on a ref-lock error, which is how this script first failed.
+  pull_request:
+    paths:
+      - 'scripts/deploy/**'
+      - '.github/workflows/deploy-api.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -31,11 +38,31 @@ permissions:
 # between `git checkout` and `pm2 restart` leaves the box on new source with an
 # old bundle.
 concurrency:
-  group: deploy-api-${{ inputs.environment }}
+  # Keyed by event as well as host: a PR running the unit tests must not queue
+  # behind a deploy, and two PRs must not serialise against each other.
+  group: deploy-api-${{ github.event_name }}-${{ inputs.environment || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  git-sync-tests:
+    name: git-sync unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run deploy git-sync tests
+        run: ./scripts/deploy/tests/git-sync.test.sh
+
   deploy:
+    # Only ever on an explicit dispatch. The pull_request trigger above exists for
+    # the unit-test job; without this guard it would also start a real deploy, with
+    # an empty `environment` input, on every PR that touches scripts/deploy.
+    if: github.event_name == 'workflow_dispatch'
+    # The tests gate the deploy rather than running beside it. Without this the two
+    # jobs start together on a dispatch, and a broken ref-sync change could reach a
+    # live host while its own suite was still going red in parallel.
+    needs: git-sync-tests
     name: Deploy API (${{ inputs.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -97,14 +124,20 @@ jobs:
           TARGET_REF="${REF:-$DEFAULT_REF}"
           echo "Deploying $TARGET_REF to $HOST ($REPO)"
 
-          # Ship the script from THIS checkout rather than trusting whatever
-          # version happens to be on the box.
-          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
-            scripts/deploy/api-deploy.sh "ubuntu@$HOST:/tmp/api-deploy.sh"
+          # Ship the whole deploy directory from THIS checkout rather than
+          # trusting whatever version happens to be on the box. The directory,
+          # not just the entry script: api-deploy.sh sources lib/git-sync.sh
+          # relative to its own location, so copying the one file would leave it
+          # looking for a helper that is not there and exit before preflight.
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes "ubuntu@$HOST" \
+            "rm -rf /tmp/yc-deploy && mkdir -p /tmp/yc-deploy"
+
+          scp -r -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            scripts/deploy/. "ubuntu@$HOST:/tmp/yc-deploy/"
 
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             -o ServerAliveInterval=30 "ubuntu@$HOST" \
-            "chmod +x /tmp/api-deploy.sh && /tmp/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
+            "chmod +x /tmp/yc-deploy/api-deploy.sh && /tmp/yc-deploy/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
 
       - name: Verify from outside
         shell: bash

--- a/apps/backend/src/controllers/app/task-recommendation.controller.ts
+++ b/apps/backend/src/controllers/app/task-recommendation.controller.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from "express";
+import logger from "src/utils/logger";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+/**
+ * Recommendations are read for ONE companion at a time, by the companion id in
+ * the path, so the route can sit behind the same co-parent gate as every other
+ * companion-scoped read. Matching happens on the server: the client never holds
+ * the rules, so a withdrawn rule stops appearing immediately rather than waiting
+ * out mobile adoption.
+ */
+export const TaskRecommendationController = {
+  listForCompanion: async (req: Request, res: Response) => {
+    try {
+      const { patientId } = req.params;
+      const recommendations =
+        await TaskRecommendationService.forCompanion(patientId);
+
+      return res.status(200).json({
+        recommendations,
+        // Sent with every response rather than hard-coded in the app, so the
+        // wording can be corrected without a release. The app shows it beside
+        // the list; the per-card citation is the substantive part.
+        //
+        // Deliberately does NOT say "for this breed and age". Not every rule is
+        // breed-specific or age-bounded - a species-wide life-stage task matches
+        // on neither - and a blanket claim would overstate what triggered the
+        // guidance. What each card was actually matched on is in its own
+        // `because` block, which is the honest place for it.
+        disclaimer:
+          "These are general husbandry suggestions, not a diagnosis or advice about your companion specifically. Each one shows what it was matched on and where it comes from. Your vet knows your companion; ask them before acting on anything here.",
+      });
+    } catch (error) {
+      if (error instanceof TaskRecommendationError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      logger.error("Failed to build companion recommendations", error);
+      return res
+        .status(500)
+        .json({ message: "Unable to load recommendations." });
+    }
+  },
+};

--- a/apps/backend/src/middlewares/companion-access.ts
+++ b/apps/backend/src/middlewares/companion-access.ts
@@ -26,6 +26,11 @@ import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
  *   - No link at all is a 404, not a 403, matching the existing convention on
  *     parent-facing routes: a uniform "not found" so the endpoint cannot be
  *     used to discover which patient ids exist.
+ *
+ * Two ways in. `requireCompanionPermission` is for routes that carry the
+ * patient id in the path. `requireCompanionPermissionForResource` is for routes
+ * keyed by a resource id (an expense, an invoice) where the companion has to be
+ * read off the row first - see the resolvers at the bottom of this file.
  */
 export type CompanionFeature =
   | "appointments"
@@ -36,6 +41,23 @@ export type CompanionFeature =
   | "expenses"
   | "medicalRecords"
   | "tasks";
+
+/**
+ * What a resolver concluded about the row behind a resource id.
+ *
+ * `allow` exists for rows that belong to the caller directly and have no
+ * companion to check against - an invoice raised against a parent rather than a
+ * patient. It is a deliberate, narrow escape hatch: a resolver may only return
+ * it after proving ownership itself, which is why resolvers are handed the
+ * caller's `parentId`.
+ */
+export type CompanionResourceScope =
+  { kind: "patient"; patientId: string } | { kind: "allow" } | { kind: "deny" };
+
+export type CompanionResourceResolver = (
+  req: Request,
+  parentId: string,
+) => Promise<CompanionResourceScope>;
 
 const FEATURE_LABELS: Record<CompanionFeature, string> = {
   appointments: "appointments",
@@ -56,60 +78,126 @@ const isGranted = (
   return (permissions as Record<string, unknown>)[feature] === true;
 };
 
+const notFound = (res: Response) =>
+  res.status(404).json({ message: "Companion not found." });
+
+const enforce = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  feature: CompanionFeature,
+  resolve: CompanionResourceResolver,
+) => {
+  try {
+    const userId = (req as Request & { userId?: string | null }).userId;
+    if (!userId) return notFound(res);
+
+    const parentId = await findParentIdForAuthUser(userId);
+    if (!parentId) return notFound(res);
+
+    const scope = await resolve(req, parentId);
+    if (scope.kind === "deny") return notFound(res);
+    if (scope.kind === "allow") return next();
+
+    // Load-bearing, and it must stay BEFORE the query.
+    //
+    // Prisma omits an `undefined` field from `where` rather than matching
+    // nothing, so `{ patientId: undefined, parentId }` silently becomes
+    // `{ parentId }` - a filter that matches this parent's link to ANY
+    // patient and would hand back a link, and therefore access. A route
+    // mounted with the wrong param name, or a resolver reading a column that
+    // turned out to be null, would do exactly that. The type says this is a
+    // string; the check is here because the cost of being wrong is a bypass.
+    //
+    // CodeQL flags this as js/user-controlled-bypass because a user-supplied
+    // value guards an authorisation decision. The direction is inverted: the
+    // falsy branch DENIES, and the value is used to look the permission up,
+    // never to decide whether to check it. Removing this guard is the
+    // vulnerability; having it is the fix.
+    if (!scope.patientId) return notFound(res);
+
+    const link = await prisma.parentPatient.findFirst({
+      where: {
+        patientId: scope.patientId,
+        parentId,
+        status: "ACTIVE",
+        role: { in: ["PRIMARY", "CO_PARENT"] },
+      },
+      select: { role: true, permissions: true },
+    });
+
+    if (!link) return notFound(res);
+
+    if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
+      return next();
+    }
+
+    // Worded so the app can show it as-is; it already says the same thing.
+    return res.status(403).json({
+      message: `Ask the primary parent to enable ${FEATURE_LABELS[feature]} access for you.`,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
 export const requireCompanionPermission =
   (feature: CompanionFeature, paramName = "patientId") =>
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const patientId = (req.params as Record<string, string | undefined>)[
-        paramName
-      ];
-      const userId = (req as Request & { userId?: string | null }).userId;
+  (req: Request, res: Response, next: NextFunction) => {
+    // Same guard as the one inside `enforce`, hoisted so a route mounted with
+    // the wrong param name is denied before it costs a query. See the comment
+    // there for why a falsy id must never reach a `where` clause.
+    const patientId = (req.params as Record<string, string | undefined>)[
+      paramName
+    ]?.trim();
+    if (!patientId) return notFound(res);
 
-      // Load-bearing, and it must stay BEFORE the query.
-      //
-      // Prisma omits an `undefined` field from `where` rather than matching
-      // nothing, so `{ patientId: undefined, parentId }` silently becomes
-      // `{ parentId }` - a filter that matches this parent's link to ANY
-      // patient and would hand back a link, and therefore access. A route
-      // mounted with the wrong param name would do exactly that.
-      //
-      // CodeQL flags this as js/user-controlled-bypass because a user-supplied
-      // value guards an authorisation decision. The direction is inverted: the
-      // falsy branch DENIES, and the value is used to look the permission up,
-      // never to decide whether to check it. Removing this guard is the
-      // vulnerability; having it is the fix.
-      if (!patientId || !userId) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      const parentId = await findParentIdForAuthUser(userId);
-      if (!parentId) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      const link = await prisma.parentPatient.findFirst({
-        where: {
-          patientId,
-          parentId,
-          status: "ACTIVE",
-          role: { in: ["PRIMARY", "CO_PARENT"] },
-        },
-        select: { role: true, permissions: true },
-      });
-
-      if (!link) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
-        return next();
-      }
-
-      // Worded so the app can show it as-is; it already says the same thing.
-      return res.status(403).json({
-        message: `Ask the primary parent to enable ${FEATURE_LABELS[feature]} access for you.`,
-      });
-    } catch (error) {
-      return next(error);
-    }
+    return enforce(req, res, next, feature, async () => ({
+      kind: "patient",
+      patientId,
+    }));
   };
+
+export const requireCompanionPermissionForResource =
+  (feature: CompanionFeature, resolve: CompanionResourceResolver) =>
+  (req: Request, res: Response, next: NextFunction) =>
+    enforce(req, res, next, feature, resolve);
+
+/**
+ * Expenses are keyed by a bare id, and the id space is shared: the route serves
+ * both `ExternalExpense` (a parent-recorded cost) and `Invoice` (raised by a
+ * practice), because `getExpenseById` falls through from one to the other.
+ * Both have to be resolved here or the fall-through becomes the bypass.
+ *
+ * An invoice may have no `patientId` - it can be raised against the parent
+ * directly - and there is no companion to authorise against in that case, so
+ * ownership is checked in place instead.
+ */
+export const resolveExpenseCompanion: CompanionResourceResolver = async (
+  req,
+  parentId,
+) => {
+  const expenseId = (
+    req.params as Record<string, string | undefined>
+  ).expenseId?.trim();
+  if (!expenseId) return { kind: "deny" };
+
+  const expense = await prisma.externalExpense.findUnique({
+    where: { id: expenseId },
+    select: { patientId: true },
+  });
+  if (expense?.patientId) {
+    return { kind: "patient", patientId: expense.patientId };
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id: expenseId },
+    select: { patientId: true, parentId: true },
+  });
+  if (!invoice) return { kind: "deny" };
+  if (invoice.patientId) {
+    return { kind: "patient", patientId: invoice.patientId };
+  }
+
+  return invoice.parentId === parentId ? { kind: "allow" } : { kind: "deny" };
+};

--- a/apps/backend/src/routers/companion.router.ts
+++ b/apps/backend/src/routers/companion.router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { CompanionController } from "../controllers/app/companion.controller";
 import { requireMobileAuth, requireWebAuth } from "src/middlewares/auth";
 import { withOrgPermissions, requirePermission } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -11,9 +12,19 @@ const router = Router();
 
 router.post("/", requireMobileAuth, CompanionController.createCompanionMobile);
 
-router.get("/:id", requireMobileAuth, CompanionController.getCompanionById);
+router.get(
+  "/:id",
+  requireMobileAuth,
+  requireCompanionPermission("companionProfile", "id"),
+  CompanionController.getCompanionById,
+);
 
-router.put("/:id", requireMobileAuth, CompanionController.updateCompanion);
+router.put(
+  "/:id",
+  requireMobileAuth,
+  requireCompanionPermission("companionProfile", "id"),
+  CompanionController.updateCompanion,
+);
 
 router.delete("/:id", requireMobileAuth, CompanionController.deleteCompanion);
 

--- a/apps/backend/src/routers/expense.router.ts
+++ b/apps/backend/src/routers/expense.router.ts
@@ -1,21 +1,43 @@
 import { Router } from "express";
 import { ExpenseController } from "../controllers/app/expense.controller";
 import { requireMobileAuth } from "src/middlewares/auth";
-import { requireCompanionPermission } from "src/middlewares/companion-access";
+import {
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+} from "src/middlewares/companion-access";
 
 const router = Router();
 
+// The by-id routes are keyed by an expense id, not a patient id, so the
+// companion is read off the row before the permission is checked.
+const requireExpenseAccess = requireCompanionPermissionForResource(
+  "expenses",
+  resolveExpenseCompanion,
+);
+
 router.post("/", requireMobileAuth, ExpenseController.createExpense);
 
-router.patch("/:expenseId", requireMobileAuth, ExpenseController.updateExpense);
+router.patch(
+  "/:expenseId",
+  requireMobileAuth,
+  requireExpenseAccess,
+  ExpenseController.updateExpense,
+);
 
 router.delete(
   "/:expenseId",
   requireMobileAuth,
+  requireExpenseAccess,
   ExpenseController.deleteExpense,
 );
 
-router.get("/:expenseId", requireMobileAuth, ExpenseController.getExpenseById);
+router.get(
+  "/:expenseId",
+  requireMobileAuth,
+  requireExpenseAccess,
+  ExpenseController.getExpenseById,
+);
 
 router.get(
   "/companion/:patientId/list",

--- a/apps/backend/src/routers/task.router.ts
+++ b/apps/backend/src/routers/task.router.ts
@@ -11,6 +11,7 @@ import {
   withTaskOrgPermissions,
 } from "src/middlewares/rbac";
 import { requireCompanionPermission } from "src/middlewares/companion-access";
+import { TaskRecommendationController } from "src/controllers/app/task-recommendation.controller";
 
 const router = Router();
 
@@ -37,6 +38,16 @@ router.get(
   requireMobileAuth,
   requireCompanionPermission("tasks", "patientId"),
   TaskController.listForCompanion,
+);
+
+// Behind the same co-parent gate as the companion's task list. The rules are
+// health-adjacent, and a co-parent whose tasks switch is off should not be able
+// to read what has been recommended for the companion either.
+router.get(
+  "/mobile/companion/:patientId/recommendations",
+  requireMobileAuth,
+  requireCompanionPermission("tasks", "patientId"),
+  TaskRecommendationController.listForCompanion,
 );
 
 /* ─────────────────────────────────────────────────

--- a/apps/backend/src/scripts/backfill-breed-codes.ts
+++ b/apps/backend/src/scripts/backfill-breed-codes.ts
@@ -1,0 +1,232 @@
+/**
+ * Backfill `speciesCode` and `breedCode` on Patient rows with no breed code.
+ *
+ * Selected on `breedCode` alone, not on both columns being null. The two are
+ * written together here, but a row with a species and no breed is exactly a row
+ * that needs repairing - requiring both to be null would skip it.
+ *
+ * Recommendation rules match on coded species and breed. On production today
+ * only 7 of 37 companions are coded - about 19 percent - so a matcher built on
+ * those columns would work for one companion in five. All 37 have breed text,
+ * and because the values come from a picker rather than a keyboard they match
+ * `CodeEntry.display` exactly, so the gap is closable without fuzzy matching.
+ *
+ * Two traps, both found in the data rather than imagined:
+ *
+ *   Same display, different species. `Abyssinian` is a cat breed AND a horse
+ *   breed; `Maltese` is a dog AND a cat. Matching on display alone would have
+ *   coded an Abyssinian cat as a horse and then handed it equine guidance. Every
+ *   lookup is therefore scoped by `Patient.type` first, which is required and
+ *   already correct.
+ *
+ *   Same breed, two spellings. The vocabulary holds 36 breeds under both
+ *   separator conventions (`SHIH_TZU` and `SHIH-TZU`). Candidates are compared
+ *   canonically so those collapse to one answer instead of reading as a conflict.
+ *
+ * Anything still ambiguous after both is SKIPPED and reported. A wrong code is
+ * worse than a missing one: a missing code shows no recommendations, a wrong one
+ * shows confident recommendations for the wrong animal.
+ *
+ * Dry run by default. Pass --apply to write:
+ *
+ *   pnpm --filter backend exec tsx src/scripts/backfill-breed-codes.ts
+ *   pnpm --filter backend exec tsx src/scripts/backfill-breed-codes.ts --apply
+ */
+import { prisma } from "src/config/prisma";
+import { canonicalBreedCode } from "src/services/shared/breed-code";
+
+const SPECIES_BY_TYPE: Record<string, { code: string; prefix: string }> = {
+  dog: { code: "YSPEC:CANINE", prefix: "YBREED:CANINE:" },
+  cat: { code: "YSPEC:FELINE", prefix: "YBREED:FELINE:" },
+  horse: { code: "YSPEC:EQUINE", prefix: "YBREED:EQUINE:" },
+};
+
+interface Outcome {
+  patientId: string;
+  breed: string;
+  type: string;
+  resolved: string | null;
+  reason: string;
+}
+
+/** Key for the per-species vocabulary map. Display is matched case-insensitively. */
+const vocabKey = (type: string, display: string) =>
+  `${type}::${display.trim().toLowerCase()}`;
+
+/**
+ * Every breed display this run needs, per species, resolved in one query each.
+ *
+ * One query per species rather than per companion: each lookup asks the same
+ * species-scoped question, so a round trip per row bought no new information.
+ */
+const loadVocabulary = async (
+  patients: Array<{ breed: string; type: string }>,
+): Promise<Map<string, string[]>> => {
+  const wanted = new Map<string, Set<string>>();
+  for (const patient of patients) {
+    const breed = patient.breed?.trim();
+    if (!breed || !SPECIES_BY_TYPE[patient.type]) continue;
+    const set = wanted.get(patient.type) ?? new Set<string>();
+    set.add(breed);
+    wanted.set(patient.type, set);
+  }
+
+  const vocabulary = new Map<string, string[]>();
+  for (const [type, breeds] of wanted) {
+    const species = SPECIES_BY_TYPE[type];
+    const entries = await prisma.codeEntry.findMany({
+      where: {
+        // Constrained to the live Yosemite breed vocabulary. Without
+        // system/type/active, an inactive entry - or one from another code
+        // system carrying a YBREED-shaped code and the same display - would be
+        // accepted, and the apply phase would persist a code that ordinary
+        // companion writes would never produce.
+        system: "YOSEMITECODE",
+        type: "BREED",
+        active: true,
+        code: { startsWith: species.prefix },
+        display: { in: [...breeds], mode: "insensitive" },
+      },
+      select: { code: true, display: true },
+    });
+    for (const entry of entries) {
+      const key = vocabKey(type, entry.display ?? "");
+      vocabulary.set(key, [...(vocabulary.get(key) ?? []), entry.code]);
+    }
+  }
+  return vocabulary;
+};
+
+/** What this run would do to one companion, and why. */
+const classify = (
+  patient: { id: string; breed: string; type: string },
+  vocabulary: Map<string, string[]>,
+): Outcome => {
+  const breed = patient.breed?.trim();
+  const base = {
+    patientId: patient.id,
+    breed: breed ?? "",
+    type: patient.type,
+  };
+
+  if (!breed) {
+    return { ...base, resolved: null, reason: "no breed text to match" };
+  }
+  if (!SPECIES_BY_TYPE[patient.type]) {
+    // `other`, or a species the breed vocabulary does not cover.
+    return {
+      ...base,
+      resolved: null,
+      reason: `species '${patient.type}' has no breed vocabulary`,
+    };
+  }
+
+  const distinct = [
+    ...new Set(
+      (vocabulary.get(vocabKey(patient.type, breed)) ?? [])
+        .map((code) => canonicalBreedCode(code))
+        .filter((code): code is string => Boolean(code)),
+    ),
+  ];
+
+  if (distinct.length === 1) {
+    return {
+      ...base,
+      resolved: distinct[0],
+      reason: "matched within its own species",
+    };
+  }
+  if (distinct.length === 0) {
+    return {
+      ...base,
+      resolved: null,
+      reason: "no vocabulary entry for this breed in this species",
+    };
+  }
+  return {
+    ...base,
+    resolved: null,
+    reason: `ambiguous: ${distinct.join(", ")}`,
+  };
+};
+
+export const planBackfill = async (): Promise<Outcome[]> => {
+  const patients = await prisma.patient.findMany({
+    where: { breedCode: null },
+    select: { id: true, breed: true, type: true },
+  });
+
+  const vocabulary = await loadVocabulary(patients);
+  return patients.map((patient) => classify(patient, vocabulary));
+};
+
+export const main = async () => {
+  const apply = process.argv.includes("--apply");
+  const outcomes = await planBackfill();
+
+  const resolved = outcomes.filter((o) => o.resolved);
+  const skipped = outcomes.filter((o) => !o.resolved);
+
+  console.log(`${outcomes.length} companions without a breed code`);
+  console.log(`  ${resolved.length} resolvable`);
+  console.log(`  ${skipped.length} skipped`);
+
+  for (const outcome of skipped) {
+    console.log(
+      `  SKIP ${outcome.type} "${outcome.breed}" - ${outcome.reason}`,
+    );
+  }
+
+  if (!apply) {
+    console.log("\ndry run; pass --apply to write");
+    return;
+  }
+
+  let written = 0;
+  let skippedConcurrent = 0;
+  for (const outcome of resolved) {
+    const species = SPECIES_BY_TYPE[outcome.type];
+    // Conditional on breedCode still being null, via updateMany rather than
+    // update. A parent editing their companion between the plan and this loop
+    // would otherwise have their newly chosen breed overwritten by a value
+    // planned from the row as it was before they touched it.
+    const result = await prisma.patient.updateMany({
+      where: { id: outcome.patientId, breedCode: null },
+      data: { speciesCode: species.code, breedCode: outcome.resolved },
+    });
+    if (result.count === 0) {
+      skippedConcurrent += 1;
+      continue;
+    }
+    written += 1;
+  }
+  console.log(`\nwrote ${written} companions`);
+  if (skippedConcurrent > 0) {
+    console.log(
+      `  ${skippedConcurrent} skipped - coded by someone else while this ran`,
+    );
+  }
+};
+
+/**
+ * Only run when this file IS the command, not when a test imports planBackfill.
+ *
+ * Unguarded, importing this module started main() before any test had mocked a
+ * result, so planBackfill threw and the catch set process.exitCode = 1. The suite
+ * reported 8 passing tests and jest still exited 1 - a red build with nothing red
+ * in the output to explain it.
+ *
+ * argv[1] rather than require.main, which is not defined under ESM.
+ */
+const invokedDirectly = (process.argv[1] ?? "").includes(
+  "backfill-breed-codes",
+);
+
+if (invokedDirectly) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/backend/src/services/shared/breed-code.ts
+++ b/apps/backend/src/services/shared/breed-code.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical form for a breed code.
+ *
+ * The vocabulary holds the same breed under two separator conventions. On
+ * production today `CodeEntry` has 1,749 breed codes that collapse to 1,713
+ * distinct ones: 36 breeds exist as BOTH `SHIH_TZU` and `SHIH-TZU`,
+ * `LHASA_APSO` and `LHASA-APSO`, and so on. Patient rows are split the same way
+ * - of the seven coded companions in production, four are hyphenated and three
+ * are not.
+ *
+ * The backend's own generator (`idexx-reference.service.ts`) emits underscores,
+ * so underscore is the canonical form here.
+ *
+ * This matters more than a tidiness fix. A recommendation rule keyed on one
+ * spelling would silently return nothing for every patient coded the other way,
+ * and a recommendation that is silently absent looks exactly like a breed with
+ * no guidance for it. Comparing canonical forms is what stops that.
+ */
+/**
+ * Collapse runs of separators, without a regular expression.
+ *
+ * `/_{2,}/g` would read more compactly, but the security scan flags a quantified
+ * pattern applied to caller-supplied text, and a breed code is not worth
+ * arguing the point over. This is also exact at the edges: a single leading or
+ * trailing separator survives, where a split/filter/join would silently eat it.
+ */
+const collapseSeparators = (value: string): string => {
+  let out = "";
+  let previousWasSeparator = false;
+  for (const char of value) {
+    const isSeparator = char === "_";
+    if (!isSeparator || !previousWasSeparator) out += char;
+    previousWasSeparator = isSeparator;
+  }
+  return out;
+};
+
+export const canonicalBreedCode = (
+  code: string | null | undefined,
+): string | null => {
+  if (typeof code !== "string") return null;
+  const trimmed = code.trim();
+  if (!trimmed) return null;
+  return collapseSeparators(trimmed.toUpperCase().replaceAll("-", "_"));
+};
+
+/** True when two breed codes name the same breed, whichever convention each uses. */
+export const breedCodesMatch = (
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean => {
+  const left = canonicalBreedCode(a);
+  const right = canonicalBreedCode(b);
+  // Two unknowns are not a match. This is used to decide whether a rule applies,
+  // so anything unreadable has to fall through to "no".
+  if (!left || !right) return false;
+  return left === right;
+};
+
+/**
+ * `Patient.speciesCode` uses the YSPEC vocabulary; `TaskLibraryDefinition` and
+ * the rules use the `TaskLibrarySpecies` enum. Only the three species the enum
+ * covers can map, and anything else yields null rather than a guess.
+ */
+const SPECIES_BY_CODE: Record<string, "dog" | "cat" | "horse"> = {
+  "YSPEC:CANINE": "dog",
+  "YSPEC:FELINE": "cat",
+  "YSPEC:EQUINE": "horse",
+};
+
+export const taskSpeciesForCode = (
+  speciesCode: string | null | undefined,
+): "dog" | "cat" | "horse" | null => {
+  if (typeof speciesCode !== "string") return null;
+  return SPECIES_BY_CODE[speciesCode.trim().toUpperCase()] ?? null;
+};
+
+/**
+ * Whole months from birth to `asOf`, floored, or null if the date of birth is
+ * unusable. A future date of birth yields null rather than a negative age: it is
+ * bad data, and a negative age would silently satisfy any `maxAgeMonths` bound.
+ */
+export const ageInMonths = (
+  dateOfBirth: Date | null | undefined,
+  asOf: Date,
+): number | null => {
+  if (!(dateOfBirth instanceof Date) || Number.isNaN(dateOfBirth.getTime())) {
+    return null;
+  }
+  if (dateOfBirth.getTime() > asOf.getTime()) return null;
+
+  let months =
+    (asOf.getFullYear() - dateOfBirth.getFullYear()) * 12 +
+    (asOf.getMonth() - dateOfBirth.getMonth());
+  // Not a whole month yet if the day of the month has not come round.
+  if (asOf.getDate() < dateOfBirth.getDate()) months -= 1;
+  return Math.max(0, months);
+};

--- a/apps/backend/src/services/task-recommendation.service.ts
+++ b/apps/backend/src/services/task-recommendation.service.ts
@@ -1,0 +1,310 @@
+import type { RelatedArtifact } from "@yosemite-crew/fhir";
+import { prisma } from "src/config/prisma";
+import {
+  ageInMonths,
+  canonicalBreedCode,
+  taskSpeciesForCode,
+} from "./shared/breed-code";
+
+/**
+ * Breed- and age-based husbandry recommendations for one companion.
+ *
+ * Rules live in the database rather than the app bundle so a rule later found to
+ * be wrong can be withdrawn the same day, instead of waiting out mobile adoption.
+ *
+ * Everything here recommends HUSBANDRY. "Log Gigi's weight monthly" and "book a
+ * dental check" are actions a parent takes. Nothing is phrased as a claim about
+ * the individual animal, which is both the safe framing and the honest one: a
+ * rule knows a breed and an age, not a patient.
+ */
+
+/**
+ * The evidence behind a recommendation, as a FHIR R4 `RelatedArtifact`.
+ *
+ * `RelatedArtifact` is the standard's own type for exactly this - the citation
+ * supporting a definitional resource - so there is no reason to invent a shape
+ * for it, and apps/backend/AGENTS.md says as much. The mapping:
+ *
+ *   type     "citation"
+ *   citation the bibliographic string
+ *   url      the DOI, or the source URL when there is no DOI
+ *   display  the specific claim relied on, which is what a vet argues with
+ *   label    the evidence grade, in words
+ *
+ * The attestation below is NOT part of it. `lastReviewedAt` / `reviewedBy` /
+ * `nextReviewDue` are this product's governance over its own rule table, not a
+ * property of the cited artifact, and FHIR has no slot for them here. Keeping
+ * them beside the artifact rather than inside it avoids overloading a standard
+ * type with a local meaning.
+ */
+export interface RecommendationEvidence {
+  artifact: RelatedArtifact;
+  /** Kept discrete so a client can sort or filter without parsing the citation. */
+  year: number;
+  grade: string;
+  attestation: {
+    lastReviewedAt: Date | null;
+    reviewedBy: string | null;
+    nextReviewDue: Date | null;
+  };
+}
+
+export interface CompanionRecommendation {
+  ruleId: string;
+  taskDefinitionId: string;
+  taskName: string;
+  taskCategory: string;
+  text: string;
+  /** What actually triggered this, for the "why am I seeing this?" affordance. */
+  because: {
+    species: string;
+    breedSpecific: boolean;
+    breedCode: string | null;
+    minAgeMonths: number | null;
+    maxAgeMonths: number | null;
+    ageMonths: number;
+  };
+  evidence: RecommendationEvidence;
+}
+
+export class TaskRecommendationError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "TaskRecommendationError";
+  }
+}
+
+/** The three species the task library covers. */
+type TaskSpecies = "dog" | "cat" | "horse";
+
+/** `Patient.type` and `TaskLibrarySpecies` share three values; `other` has none. */
+const TASK_SPECIES: Record<string, TaskSpecies | undefined> = {
+  dog: "dog",
+  cat: "cat",
+  horse: "horse",
+};
+
+/**
+ * Plain-language labels for the evidence grades.
+ *
+ * The citation is meant to be readable by the parent looking at the card, and
+ * `CONSENSUS_STATEMENT` is not that. The raw enum is kept alongside so a client
+ * can still sort or filter on it without parsing prose.
+ */
+const GRADE_LABELS: Record<string, string> = {
+  CONSENSUS_STATEMENT: "Consensus statement",
+  PRACTICE_GUIDELINE: "Practice guideline",
+  POPULATION_STUDY: "Population study",
+  COHORT_STUDY: "Cohort study",
+  CASE_SERIES: "Case series",
+  EXPERT_OPINION: "Expert opinion",
+};
+
+/**
+ * Half-open window: [min, max). A rule for "from seven years" is minAgeMonths 84
+ * with no upper bound; "under two" is maxAgeMonths 24. Half-open so adjacent
+ * life-stage rules meet exactly once rather than both firing on the boundary.
+ */
+const withinWindow = (
+  ageMonths: number,
+  min: number | null,
+  max: number | null,
+): boolean => {
+  if (min !== null && ageMonths < min) return false;
+  if (max !== null && ageMonths >= max) return false;
+  return true;
+};
+
+type LoadedPatient = {
+  speciesCode: string | null;
+  breedCode: string | null;
+  dateOfBirth: Date | null;
+  type: string;
+};
+
+type RuleWithDefinition = {
+  id: string;
+  breedCodes: string[];
+  minAgeMonths: number | null;
+  maxAgeMonths: number | null;
+  taskDefinitionId: string;
+  recommendationText: string;
+  citationAuthors: string;
+  citationTitle: string;
+  citationSource: string;
+  citationYear: number;
+  citationDoi: string | null;
+  citationUrl: string | null;
+  citationClaim: string;
+  evidenceGrade: string;
+  lastReviewedAt: Date | null;
+  reviewedBy: string | null;
+  nextReviewDue: Date | null;
+  taskDefinition: {
+    id: string;
+    name: string;
+    category: string;
+    isActive: boolean;
+    applicableSpecies: string[];
+  };
+};
+
+/**
+ * Which species' rules apply, or null when that cannot be answered safely.
+ *
+ * `speciesCode` first, `type` as the fallback. They carry the same three
+ * species, but `speciesCode` is optional and null on 30 of 37 production
+ * companions while `type` is required, so reading only the coded column
+ * returned nothing for four companions in five until the backfill ran. This is
+ * a fallback between two RECORDED values - `type` is what the parent picked -
+ * not an inference from free text, which is still not done.
+ *
+ * When both are present and disagree the answer is null. The companion's data
+ * is inconsistent, and choosing either would serve guidance for the wrong
+ * animal on exactly the rows already known to be wrong. Nothing upstream
+ * enforces agreement: validateCompanionCodes checks that each code is valid,
+ * not that the two describe one species.
+ */
+const resolveSpecies = (patient: LoadedPatient): TaskSpecies | null => {
+  const coded = taskSpeciesForCode(patient.speciesCode);
+  const declared = TASK_SPECIES[patient.type];
+  if (coded && declared && coded !== declared) return null;
+  return coded ?? declared ?? null;
+};
+
+/** Whether a rule applies to this companion. Every clause is a reason to say no. */
+const appliesTo = (
+  rule: RuleWithDefinition,
+  species: TaskSpecies,
+  ageMonths: number,
+  patientBreed: string | null,
+): boolean => {
+  // A blank reviewer is not a signature. The column is a nullable string, so ""
+  // and "   " both satisfy a NOT NULL check while naming nobody, and this is the
+  // gate that keeps unreviewed clinical guidance away from pet parents.
+  if ((rule.reviewedBy ?? "").trim().length === 0) return false;
+
+  if (!rule.taskDefinition?.isActive) return false;
+
+  // An EMPTY applicableSpecies means universal, not "applies to nothing" -
+  // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
+  // `{ has: species }` for that reason. Reading empty as a mismatch would
+  // silently drop every universal task.
+  const scope = rule.taskDefinition.applicableSpecies;
+  if (scope.length > 0 && !scope.includes(species)) return false;
+
+  if (!withinWindow(ageMonths, rule.minAgeMonths, rule.maxAgeMonths))
+    return false;
+
+  // No breed codes means species-wide - the life-stage tasks most animals get.
+  // Otherwise the companion's breed has to appear, compared canonically because
+  // the vocabulary holds both separator conventions.
+  if (rule.breedCodes.length === 0) return true;
+  if (!patientBreed) return false;
+  return rule.breedCodes.some(
+    (code) => canonicalBreedCode(code) === patientBreed,
+  );
+};
+
+const toRecommendation = (
+  rule: RuleWithDefinition,
+  species: TaskSpecies,
+  ageMonths: number,
+  patientBreed: string | null,
+): CompanionRecommendation => ({
+  ruleId: rule.id,
+  taskDefinitionId: rule.taskDefinitionId,
+  taskName: rule.taskDefinition.name,
+  taskCategory: rule.taskDefinition.category,
+  text: rule.recommendationText,
+  because: {
+    species,
+    breedSpecific: rule.breedCodes.length > 0,
+    breedCode: patientBreed,
+    minAgeMonths: rule.minAgeMonths,
+    maxAgeMonths: rule.maxAgeMonths,
+    ageMonths,
+  },
+  evidence: {
+    artifact: {
+      type: "citation",
+      label: GRADE_LABELS[rule.evidenceGrade] ?? rule.evidenceGrade,
+      display: rule.citationClaim,
+      citation: `${rule.citationAuthors}. ${rule.citationTitle}. ${rule.citationSource}. ${rule.citationYear}.`,
+      url:
+        rule.citationUrl ??
+        (rule.citationDoi ? `https://doi.org/${rule.citationDoi}` : undefined),
+    },
+    year: rule.citationYear,
+    grade: rule.evidenceGrade,
+    attestation: {
+      lastReviewedAt: rule.lastReviewedAt,
+      reviewedBy: rule.reviewedBy,
+      nextReviewDue: rule.nextReviewDue,
+    },
+  },
+});
+
+export const TaskRecommendationService = {
+  async forCompanion(patientId: string): Promise<CompanionRecommendation[]> {
+    const id = patientId?.trim();
+    if (!id) {
+      throw new TaskRecommendationError("Companion id is required.", 400);
+    }
+
+    const patient = await prisma.patient.findUnique({
+      where: { id },
+      select: {
+        speciesCode: true,
+        breedCode: true,
+        dateOfBirth: true,
+        type: true,
+      },
+    });
+    if (!patient) {
+      throw new TaskRecommendationError("Companion not found.", 404);
+    }
+
+    const species = resolveSpecies(patient);
+    if (!species) return [];
+
+    const ageMonths = ageInMonths(patient.dateOfBirth, new Date());
+    if (ageMonths === null) return [];
+
+    const rules = await prisma.taskRecommendationRule.findMany({
+      where: {
+        species,
+        isActive: true,
+        // Both conditions, not just isActive. A rule reaches a pet parent only
+        // once a named reviewer has signed it off; an active-but-unreviewed row
+        // is a seeding accident, not a recommendation. `appliesTo` rejects a
+        // blank name, which this predicate cannot.
+        reviewedBy: { not: null },
+      },
+      include: {
+        taskDefinition: {
+          select: {
+            id: true,
+            name: true,
+            category: true,
+            isActive: true,
+            applicableSpecies: true,
+          },
+        },
+      },
+    });
+
+    const patientBreed = canonicalBreedCode(patient.breedCode);
+
+    return rules
+      .filter((rule: RuleWithDefinition) =>
+        appliesTo(rule, species, ageMonths, patientBreed),
+      )
+      .map((rule: RuleWithDefinition) =>
+        toRecommendation(rule, species, ageMonths, patientBreed),
+      );
+  },
+};

--- a/apps/backend/test/controllers/task-recommendation.controller.test.ts
+++ b/apps/backend/test/controllers/task-recommendation.controller.test.ts
@@ -1,0 +1,100 @@
+jest.mock("src/services/task-recommendation.service", () => ({
+  TaskRecommendationService: { forCompanion: jest.fn() },
+  TaskRecommendationError: class extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+    }
+  },
+}));
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import type { Request, Response } from "express";
+import { TaskRecommendationController } from "src/controllers/app/task-recommendation.controller";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+const forCompanion = TaskRecommendationService.forCompanion as jest.Mock;
+
+const run = async (patientId = "pat-1") => {
+  const req = { params: { patientId } } as unknown as Request;
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  await TaskRecommendationController.listForCompanion(req, res);
+  return { res, json };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("TaskRecommendationController.listForCompanion", () => {
+  it("returns the recommendations with a disclaimer alongside them", async () => {
+    forCompanion.mockResolvedValue([{ ruleId: "r1" }]);
+
+    const { res, json } = await run();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = json.mock.calls[0][0];
+    expect(payload.recommendations).toEqual([{ ruleId: "r1" }]);
+    expect(typeof payload.disclaimer).toBe("string");
+  });
+
+  it("sends the disclaimer from the server, not from the app bundle", async () => {
+    // The wording is the part most likely to need correcting - by counsel, or
+    // after a vet reads it. Shipping it in the response means that correction
+    // does not wait out mobile adoption, which is the same reason the rules
+    // themselves are server-side.
+    forCompanion.mockResolvedValue([]);
+
+    const { json } = await run();
+    const { disclaimer } = json.mock.calls[0][0];
+
+    expect(disclaimer).toMatch(/not a diagnosis/i);
+    expect(disclaimer).toMatch(/ask them/i);
+    // Must NOT claim breed and age. Not every rule is breed-specific or
+    // age-bounded - a species-wide life-stage task matches on neither - so a
+    // blanket claim would overstate what triggered the guidance. The per-card
+    // `because` block carries what each one was actually matched on.
+    expect(disclaimer).not.toMatch(/this breed and age/i);
+  });
+
+  it("still returns the disclaimer when there is nothing to recommend", async () => {
+    forCompanion.mockResolvedValue([]);
+
+    const { json } = await run();
+
+    expect(json.mock.calls[0][0].recommendations).toEqual([]);
+    expect(json.mock.calls[0][0].disclaimer).toBeTruthy();
+  });
+
+  it("passes a service error's own status through", async () => {
+    forCompanion.mockRejectedValue(
+      new TaskRecommendationError("Companion not found.", 404),
+    );
+
+    const { res, json } = await run("nope");
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: "Companion not found." });
+  });
+
+  it("does not leak an unexpected error to the caller", async () => {
+    forCompanion.mockRejectedValue(
+      new Error("connection string: postgres://u:p@h/db"),
+    );
+
+    const { res, json } = await run();
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      message: "Unable to load recommendations.",
+    });
+    expect(JSON.stringify(json.mock.calls)).not.toContain("postgres://");
+  });
+});

--- a/apps/backend/test/middlewares/companion-access.test.ts
+++ b/apps/backend/test/middlewares/companion-access.test.ts
@@ -1,7 +1,11 @@
 import type { NextFunction, Request, Response } from "express";
 
 jest.mock("src/config/prisma", () => ({
-  prisma: { parentPatient: { findFirst: jest.fn() } },
+  prisma: {
+    parentPatient: { findFirst: jest.fn() },
+    externalExpense: { findUnique: jest.fn() },
+    invoice: { findUnique: jest.fn() },
+  },
 }));
 jest.mock("src/services/shared/parent-identity", () => ({
   findParentIdForAuthUser: jest.fn(),
@@ -9,7 +13,11 @@ jest.mock("src/services/shared/parent-identity", () => ({
 
 import { prisma } from "src/config/prisma";
 import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
-import { requireCompanionPermission } from "src/middlewares/companion-access";
+import {
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+} from "src/middlewares/companion-access";
 
 const findFirst = (
   prisma as unknown as {
@@ -17,6 +25,27 @@ const findFirst = (
   }
 ).parentPatient.findFirst;
 const findParent = findParentIdForAuthUser as jest.Mock;
+const expenseFindUnique = (
+  prisma as unknown as { externalExpense: { findUnique: jest.Mock } }
+).externalExpense.findUnique;
+const invoiceFindUnique = (
+  prisma as unknown as { invoice: { findUnique: jest.Mock } }
+).invoice.findUnique;
+
+const runExpenseMiddleware = async ({
+  expenseId = "exp-1",
+  userId = "provider-user-1",
+} = {}) => {
+  const req = { params: { expenseId }, userId } as unknown as Request;
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  const next = jest.fn() as NextFunction;
+  await requireCompanionPermissionForResource(
+    "expenses",
+    resolveExpenseCompanion,
+  )(req, res, next);
+  return { res, json, next };
+};
 
 const runMiddleware = async (
   feature: Parameters<typeof requireCompanionPermission>[0] = "documents",
@@ -180,5 +209,120 @@ describe("requireCompanionPermission", () => {
         }),
       }),
     );
+  });
+});
+
+describe("requireCompanionPermissionForResource (expenses)", () => {
+  beforeEach(() => {
+    expenseFindUnique.mockResolvedValue(null);
+    invoiceFindUnique.mockResolvedValue(null);
+  });
+
+  it("closes the cross-parent read: an expense on someone else's companion is a 404", async () => {
+    // The regression this guard exists for. Before it, `GET /expense/:id`
+    // resolved the row by id alone and handed it back to any signed-in parent.
+    // The caller here holds a session but no link to the expense's companion,
+    // so the link lookup finds nothing and the answer must be a bare 404 -
+    // never a 403, which would confirm the id belongs to someone.
+    expenseFindUnique.mockResolvedValue({ patientId: "someone-elses-pet" });
+    findFirst.mockResolvedValue(null);
+
+    const { next, res, json } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: "Companion not found." });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          patientId: "someone-elses-pet",
+          parentId: "par-1",
+        }),
+      }),
+    );
+  });
+
+  it("checks the permission against the companion named on the expense", async () => {
+    expenseFindUnique.mockResolvedValue({ patientId: "pat-9" });
+    findFirst.mockResolvedValue({
+      role: "CO_PARENT",
+      permissions: { ...ALL_FALSE, expenses: true },
+    });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("denies a co-parent whose expenses switch is off", async () => {
+    expenseFindUnique.mockResolvedValue({ patientId: "pat-9" });
+    findFirst.mockResolvedValue({ role: "CO_PARENT", permissions: ALL_FALSE });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("falls through to the invoice table, since the route serves both", async () => {
+    // `getExpenseById` reads ExternalExpense first and Invoice second. If the
+    // resolver stopped at the first table the fall-through would be the bypass.
+    invoiceFindUnique.mockResolvedValue({
+      patientId: "pat-7",
+      parentId: "par-1",
+    });
+    findFirst.mockResolvedValue({ role: "PRIMARY", permissions: ALL_FALSE });
+
+    const { next } = await runExpenseMiddleware();
+
+    expect(invoiceFindUnique).toHaveBeenCalled();
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: "pat-7" }),
+      }),
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("allows an invoice raised against the parent with no companion on it", async () => {
+    // Nothing to check a companion permission against, so ownership is the
+    // whole decision and the resolver proves it before saying yes.
+    invoiceFindUnique.mockResolvedValue({ patientId: null, parentId: "par-1" });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies a companion-less invoice belonging to another parent", async () => {
+    invoiceFindUnique.mockResolvedValue({
+      patientId: null,
+      parentId: "another-parent",
+    });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies an id that matches no row, without querying permissions", async () => {
+    const { next, res } = await runExpenseMiddleware({ expenseId: "nope" });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies a blank expense id", async () => {
+    const { next, res } = await runExpenseMiddleware({ expenseId: "   " });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(expenseFindUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/routers/companion.router.test.ts
+++ b/apps/backend/test/routers/companion.router.test.ts
@@ -4,6 +4,8 @@ const requireWebAuth = jest.fn((_req, _res, next) => next());
 const requireMobileAuth = jest.fn((_req, _res, next) => next());
 const withOrgPermissionsMiddleware = jest.fn((_req, _res, next) => next());
 const requirePermissionMiddleware = jest.fn((_req, _res, next) => next());
+const companionGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn();
 
 const CompanionController = {
   createCompanionMobile: jest.fn(),
@@ -24,6 +26,13 @@ jest.mock("../../src/middlewares/auth", () => ({
 jest.mock("../../src/middlewares/rbac", () => ({
   withOrgPermissions: () => withOrgPermissionsMiddleware,
   requirePermission: () => requirePermissionMiddleware,
+}));
+
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission: (...args: unknown[]) => {
+    requireCompanionPermission(...args);
+    return companionGuard;
+  },
 }));
 
 jest.mock("../../src/controllers/app/companion.controller", () => ({
@@ -83,6 +92,46 @@ describe("companion.router", () => {
   it("keeps the mobile routes on mobile auth", () => {
     expect(
       findRoute("/:id", "get")?.stack.map((layer) => layer.handle),
-    ).toEqual([requireMobileAuth, CompanionController.getCompanionById]);
+    ).toEqual([
+      requireMobileAuth,
+      companionGuard,
+      CompanionController.getCompanionById,
+    ]);
+  });
+
+  /**
+   * `Patient` rows are not scoped to a parent in the schema, and the handlers
+   * behind these two routes look the row up by id alone - `getById` runs a bare
+   * `findUnique`, and `update` writes with a bare `where: { id }`. Mobile auth
+   * on its own therefore let any signed-in parent read, and overwrite, any of
+   * the companions in the product. The guard is what supplies the ownership
+   * test, so its presence is the assertion.
+   */
+  it.each([
+    ["get", "read"],
+    ["put", "overwrite"],
+  ] as const)(
+    "gates %s /:id so a parent cannot %s another's companion",
+    (method) => {
+      const handles = findRoute("/:id", method)?.stack.map((l) => l.handle);
+      expect(handles).toContain(requireMobileAuth);
+      expect(handles).toContain(companionGuard);
+      expect(requireCompanionPermission).toHaveBeenCalledWith(
+        "companionProfile",
+        "id",
+      );
+    },
+  );
+
+  it("leaves delete to the service, which resolves the link itself", () => {
+    // CompanionService.delete already resolves the parent, finds the link and
+    // rejects a non-PRIMARY caller, including the role-specific behaviour the
+    // permission blob does not describe. Adding the blanket guard here would
+    // second-guess that with a coarser rule.
+    const handles = findRoute("/:id", "delete")?.stack.map((l) => l.handle);
+    expect(handles).toEqual([
+      requireMobileAuth,
+      CompanionController.deleteCompanion,
+    ]);
   });
 });

--- a/apps/backend/test/routers/expense.router.test.ts
+++ b/apps/backend/test/routers/expense.router.test.ts
@@ -1,0 +1,98 @@
+import type { Router } from "express";
+
+const requireMobileAuth = jest.fn((_req, _res, next) => next());
+const companionGuard = jest.fn((_req, _res, next) => next());
+const resourceGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn(() => companionGuard);
+const requireCompanionPermissionForResource = jest.fn(() => resourceGuard);
+const resolveExpenseCompanion = jest.fn();
+
+const ExpenseController = {
+  createExpense: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+  getExpenseById: jest.fn(),
+  getExpensesByCompanion: jest.fn(),
+  getExpenseSummary: jest.fn(),
+};
+
+jest.mock("../../src/middlewares/auth", () => ({ requireMobileAuth }));
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+}));
+jest.mock("../../src/controllers/app/expense.controller", () => ({
+  ExpenseController,
+}));
+
+const router = jest.requireActual("../../src/routers/expense.router")
+  .default as Router;
+
+type Layer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+};
+
+const findRoute = (path: string, method: string) =>
+  ((router as unknown as { stack: Layer[] }).stack ?? []).find(
+    (entry) =>
+      entry.route?.path === path && Boolean(entry.route?.methods?.[method]),
+  )?.route;
+
+describe("expense.router", () => {
+  /**
+   * These assert the middleware is MOUNTED, which the middleware's own unit
+   * tests cannot do. Deleting the guard from a route leaves every test in
+   * companion-access.test.ts green while reopening the hole it was written for:
+   * `/:expenseId` resolved the row by id alone, so any signed-in parent could
+   * read, edit, or delete another parent's expense.
+   */
+  it.each([
+    ["get", "reading"],
+    ["patch", "editing"],
+    ["delete", "deleting"],
+  ])("guards %s /:expenseId (%s another parent's expense)", (method) => {
+    const route = findRoute("/:expenseId", method);
+    expect(route).toBeDefined();
+    expect(route?.stack).toHaveLength(3);
+    const handles = route?.stack.map((l) => l.handle);
+    expect(handles).toContain(requireMobileAuth);
+    expect(handles).toContain(resourceGuard);
+  });
+
+  it("resolves the companion off the expense row, for the expenses feature", () => {
+    // The id in the path is an expense, not a patient, so the patient-param
+    // form of the guard would have nothing to read and must not be used here.
+    expect(requireCompanionPermissionForResource).toHaveBeenCalledWith(
+      "expenses",
+      resolveExpenseCompanion,
+    );
+  });
+
+  it("keeps the patient-param guard on the companion list and summary", () => {
+    for (const path of [
+      "/companion/:patientId/list",
+      "/companion/:patientId/summary",
+    ]) {
+      const route = findRoute(path, "get");
+      expect(route?.stack).toHaveLength(3);
+      expect(route?.stack.map((l) => l.handle)).toContain(companionGuard);
+    }
+    expect(requireCompanionPermission).toHaveBeenCalledWith(
+      "expenses",
+      "patientId",
+    );
+  });
+
+  it("leaves create unguarded by a companion check, since it has no id yet", () => {
+    // Ownership on create comes from the authenticated parent in the body path,
+    // not from a row that does not exist yet.
+    const route = findRoute("/", "post");
+    expect(route?.stack).toHaveLength(2);
+    expect(route?.stack.map((l) => l.handle)).toContain(requireMobileAuth);
+  });
+});

--- a/apps/backend/test/routers/task.router.test.ts
+++ b/apps/backend/test/routers/task.router.test.ts
@@ -39,6 +39,15 @@ const TaskTemplateController = {
   archive: jest.fn(),
 };
 
+const companionGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn(
+  (_feature: string, _paramName?: string) => companionGuard,
+);
+
+const TaskRecommendationController = {
+  listForCompanion: jest.fn(),
+};
+
 jest.mock("../../src/middlewares/auth", () => ({
   requireWebAuth,
   requireMobileAuth,
@@ -54,6 +63,17 @@ jest.mock("../../src/controllers/web/task.controller", () => ({
   TaskController,
   TaskLibraryController,
   TaskTemplateController,
+}));
+
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission: (feature: string, paramName?: string) => {
+    requireCompanionPermission(feature, paramName);
+    return companionGuard;
+  },
+}));
+
+jest.mock("../../src/controllers/app/task-recommendation.controller", () => ({
+  TaskRecommendationController,
 }));
 
 const taskRouter = jest.requireActual("../../src/routers/task.router")
@@ -146,5 +166,39 @@ describe("task.router", () => {
       "tasks:view:any",
       "tasks:view:own",
     ]);
+  });
+});
+
+describe("task.router recommendations", () => {
+  const PATH = "/mobile/companion/:patientId/recommendations";
+
+  it("puts recommendations behind mobile auth and the co-parent tasks gate", () => {
+    // The rules are health-adjacent. A co-parent whose tasks switch is off should
+    // not be able to read what has been recommended for the companion either, and
+    // the guard is the only thing that enforces that - the handler does not check.
+    const route = findRoute(PATH, "get");
+    expect(route).toBeDefined();
+    expect(route?.stack).toHaveLength(3);
+
+    const handles = route?.stack.map((l) => l.handle);
+    expect(handles).toContain(requireMobileAuth);
+    expect(handles).toContain(companionGuard);
+    expect(handles).toContain(TaskRecommendationController.listForCompanion);
+    expect(handles).not.toContain(requireWebAuth);
+  });
+
+  it("gates it on the same feature as the companion task list", () => {
+    expect(requireCompanionPermission).toHaveBeenCalledWith(
+      "tasks",
+      "patientId",
+    );
+  });
+
+  it("does not expose recommendations on a PMS path", () => {
+    // Clinic visibility is a separate surface with its own permission model; it
+    // must not arrive by accident on a route mounted for parents.
+    expect(
+      findRoute("/pms/companion/:patientId/recommendations", "get"),
+    ).toBeUndefined();
   });
 });

--- a/apps/backend/test/scripts/backfill-breed-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-breed-codes.test.ts
@@ -1,0 +1,207 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    patient: { findMany: jest.fn(), updateMany: jest.fn() },
+    codeEntry: { findMany: jest.fn() },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import { main, planBackfill } from "src/scripts/backfill-breed-codes";
+
+const patientFind = (prisma as unknown as { patient: { findMany: jest.Mock } })
+  .patient.findMany;
+const codeFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("planBackfill", () => {
+  it("scopes the lookup to the companion's own species", async () => {
+    // The trap this exists for. `Abyssinian` is a cat breed AND a horse breed;
+    // `Maltese` is a dog AND a cat. Matching on display alone would have coded an
+    // Abyssinian cat as a horse and then handed it equine guidance.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Abyssinian", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:FELINE:ABYSSINIAN", display: "Abyssinian" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(codeFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          code: { startsWith: "YBREED:FELINE:" },
+          display: { in: ["Abyssinian"], mode: "insensitive" },
+        }),
+      }),
+    );
+    expect(outcome.resolved).toBe("YBREED:FELINE:ABYSSINIAN");
+  });
+
+  it("collapses the two spellings of one breed instead of calling it a conflict", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "American Curl", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:FELINE:AMERICAN_CURL", display: "American Curl" },
+      { code: "YBREED:FELINE:AMERICAN-CURL", display: "American Curl" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBe("YBREED:FELINE:AMERICAN_CURL");
+  });
+
+  it("skips rather than guesses when two genuinely different codes remain", async () => {
+    // A wrong code is worse than a missing one: a missing code shows no
+    // recommendations, a wrong one shows confident recommendations for the
+    // wrong animal.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Maltese", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([
+      { code: "YBREED:CANINE:MALTESE", display: "Maltese" },
+      { code: "YBREED:CANINE:MALTESE_CANINE", display: "Maltese" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/ambiguous/);
+  });
+
+  it("skips a species with no breed vocabulary", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Something", type: "other" },
+    ]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no breed vocabulary/);
+    expect(codeFind).not.toHaveBeenCalled();
+  });
+
+  it("skips a companion with no breed text", async () => {
+    patientFind.mockResolvedValue([{ id: "p1", breed: "   ", type: "dog" }]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no breed text/);
+  });
+
+  it("reports a breed the vocabulary does not hold for that species", async () => {
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Nonesuch", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    const [outcome] = await planBackfill();
+
+    expect(outcome.resolved).toBeNull();
+    expect(outcome.reason).toMatch(/no vocabulary entry/);
+  });
+
+  it("only considers companions that have no code yet", async () => {
+    patientFind.mockResolvedValue([]);
+    await planBackfill();
+    expect(patientFind).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { breedCode: null } }),
+    );
+  });
+});
+
+describe("planBackfill query volume", () => {
+  it("asks the vocabulary once per species, not once per companion", async () => {
+    // Every lookup asks the same species-scoped question, so one round trip per
+    // companion bought no new information.
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Pug", type: "dog" },
+      { id: "p2", breed: "Beagle", type: "dog" },
+      { id: "p3", breed: "Boxer", type: "dog" },
+      { id: "p4", breed: "Abyssinian", type: "cat" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    await planBackfill();
+
+    // Two species present, so two queries - not four.
+    expect(codeFind).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("main", () => {
+  const patientUpdateMany = (
+    prisma as unknown as { patient: { updateMany: jest.Mock } }
+  ).patient.updateMany;
+
+  let log: jest.SpyInstance;
+  let argv: string[];
+
+  beforeEach(() => {
+    argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+    patientFind.mockResolvedValue([{ id: "p1", breed: "Pug", type: "dog" }]);
+    codeFind.mockResolvedValue([{ code: "YBREED:CANINE:PUG", display: "Pug" }]);
+    patientUpdateMany.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    process.argv = argv;
+    log.mockRestore();
+  });
+
+  const output = () => log.mock.calls.map((c) => String(c[0])).join("\n");
+
+  it("writes nothing without --apply", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts"];
+    await main();
+
+    expect(patientUpdateMany).not.toHaveBeenCalled();
+    expect(output()).toMatch(/dry run/);
+  });
+
+  it("writes only when --apply is passed, and only while the row is still uncoded", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts", "--apply"];
+    await main();
+
+    // updateMany with breedCode: null in the where, not update by id. A parent
+    // editing their companion between the plan and the write would otherwise
+    // have their new breed overwritten by a stale planned value.
+    expect(patientUpdateMany).toHaveBeenCalledWith({
+      where: { id: "p1", breedCode: null },
+      data: {
+        speciesCode: "YSPEC:CANINE",
+        breedCode: "YBREED:CANINE:PUG",
+      },
+    });
+    expect(output()).toMatch(/wrote 1 companions/);
+  });
+
+  it("reports a row that someone else coded while it was running", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts", "--apply"];
+    patientUpdateMany.mockResolvedValue({ count: 0 });
+
+    await main();
+
+    expect(output()).toMatch(/wrote 0 companions/);
+    expect(output()).toMatch(/coded by someone else/);
+  });
+
+  it("names every skipped companion and why", async () => {
+    process.argv = ["node", "backfill-breed-codes.ts"];
+    patientFind.mockResolvedValue([
+      { id: "p1", breed: "Nonesuch", type: "dog" },
+    ]);
+    codeFind.mockResolvedValue([]);
+
+    await main();
+
+    expect(output()).toMatch(/SKIP dog "Nonesuch"/);
+    expect(output()).toMatch(/no vocabulary entry/);
+  });
+});

--- a/apps/backend/test/services/breed-code.test.ts
+++ b/apps/backend/test/services/breed-code.test.ts
@@ -1,0 +1,109 @@
+import {
+  ageInMonths,
+  breedCodesMatch,
+  canonicalBreedCode,
+  taskSpeciesForCode,
+} from "src/services/shared/breed-code";
+
+describe("canonicalBreedCode", () => {
+  it("folds the two separator conventions in the vocabulary onto one", () => {
+    // Not hypothetical. Production CodeEntry holds 1,749 breed codes that collapse
+    // to 1,713: 36 breeds exist under both spellings, and patient rows are split
+    // the same way.
+    expect(canonicalBreedCode("YBREED:CANINE:SHIH-TZU")).toBe(
+      canonicalBreedCode("YBREED:CANINE:SHIH_TZU"),
+    );
+    expect(
+      canonicalBreedCode("YBREED:FELINE:AMERICAN-BOBTAIL-LONG-HAIRED"),
+    ).toBe("YBREED:FELINE:AMERICAN_BOBTAIL_LONG_HAIRED");
+  });
+
+  it("upper-cases and trims", () => {
+    expect(canonicalBreedCode("  ybreed:canine:pug  ")).toBe(
+      "YBREED:CANINE:PUG",
+    );
+  });
+
+  it("collapses repeated separators so two spellings cannot diverge on them", () => {
+    expect(canonicalBreedCode("YBREED:CANINE:A--B")).toBe("YBREED:CANINE:A_B");
+    expect(canonicalBreedCode("YBREED:CANINE:A__B")).toBe("YBREED:CANINE:A_B");
+  });
+
+  it("keeps a single separator at the edges rather than eating it", () => {
+    // A split/filter/join collapse would drop these. Not reachable from the
+    // picker, but the function is the one place codes are normalised and it
+    // should not quietly rewrite its input beyond what it claims to do.
+    expect(canonicalBreedCode("_A_B_")).toBe("_A_B_");
+    expect(canonicalBreedCode("__A__B__")).toBe("_A_B_");
+  });
+
+  it("returns null for anything unusable", () => {
+    expect(canonicalBreedCode(null)).toBeNull();
+    expect(canonicalBreedCode(undefined)).toBeNull();
+    expect(canonicalBreedCode("   ")).toBeNull();
+    expect(canonicalBreedCode(42 as unknown as string)).toBeNull();
+  });
+});
+
+describe("breedCodesMatch", () => {
+  it("matches across conventions", () => {
+    expect(
+      breedCodesMatch("YBREED:CANINE:LHASA-APSO", "YBREED:CANINE:LHASA_APSO"),
+    ).toBe(true);
+  });
+
+  it("does not match different breeds", () => {
+    expect(breedCodesMatch("YBREED:CANINE:PUG", "YBREED:CANINE:BOXER")).toBe(
+      false,
+    );
+  });
+
+  it("treats two unknowns as no match, not as equal", () => {
+    // This decides whether a rule applies, so anything unreadable must fall
+    // through to "no". Two nulls comparing equal would apply every breed-specific
+    // rule to every uncoded companion.
+    expect(breedCodesMatch(null, null)).toBe(false);
+    expect(breedCodesMatch("", "")).toBe(false);
+    expect(breedCodesMatch("YBREED:CANINE:PUG", null)).toBe(false);
+  });
+});
+
+describe("taskSpeciesForCode", () => {
+  it("maps the three coded species onto the task enum", () => {
+    expect(taskSpeciesForCode("YSPEC:CANINE")).toBe("dog");
+    expect(taskSpeciesForCode("YSPEC:FELINE")).toBe("cat");
+    expect(taskSpeciesForCode("YSPEC:EQUINE")).toBe("horse");
+  });
+
+  it("returns null rather than guessing for anything else", () => {
+    expect(taskSpeciesForCode("YSPEC:AVIAN")).toBeNull();
+    expect(taskSpeciesForCode(null)).toBeNull();
+    expect(taskSpeciesForCode("")).toBeNull();
+  });
+});
+
+describe("ageInMonths", () => {
+  const asOf = new Date("2026-08-24T12:00:00Z");
+
+  it("counts whole months only", () => {
+    expect(ageInMonths(new Date("2026-07-24T00:00:00Z"), asOf)).toBe(1);
+    // One day short of a month is still zero.
+    expect(ageInMonths(new Date("2026-07-25T00:00:00Z"), asOf)).toBe(0);
+  });
+
+  it("counts across years", () => {
+    expect(ageInMonths(new Date("2019-08-24T00:00:00Z"), asOf)).toBe(84);
+  });
+
+  it("returns null for a future date of birth rather than a negative age", () => {
+    // A negative age would silently satisfy every maxAgeMonths bound, so a bad
+    // date of birth would hand a puppy every senior recommendation there is.
+    expect(ageInMonths(new Date("2027-01-01T00:00:00Z"), asOf)).toBeNull();
+  });
+
+  it("returns null for an unusable date", () => {
+    expect(ageInMonths(null, asOf)).toBeNull();
+    expect(ageInMonths(undefined, asOf)).toBeNull();
+    expect(ageInMonths(new Date("nonsense"), asOf)).toBeNull();
+  });
+});

--- a/apps/backend/test/services/task-recommendation.service.test.ts
+++ b/apps/backend/test/services/task-recommendation.service.test.ts
@@ -1,0 +1,363 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    patient: { findUnique: jest.fn() },
+    taskRecommendationRule: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import {
+  TaskRecommendationError,
+  TaskRecommendationService,
+} from "src/services/task-recommendation.service";
+
+const patientFind = (
+  prisma as unknown as { patient: { findUnique: jest.Mock } }
+).patient.findUnique;
+const ruleFind = (
+  prisma as unknown as { taskRecommendationRule: { findMany: jest.Mock } }
+).taskRecommendationRule.findMany;
+
+const yearsAgo = (years: number) => {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  // Step back a day so a same-day boundary never makes the age flap.
+  d.setDate(d.getDate() - 1);
+  return d;
+};
+
+const rule = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: "rule-1",
+  breedCodes: [] as string[],
+  minAgeMonths: null,
+  maxAgeMonths: null,
+  taskDefinitionId: "task-1",
+  recommendationText: "Log their weight monthly.",
+  citationAuthors: "Author A, Author B",
+  citationTitle: "A title",
+  citationSource: "A journal",
+  citationYear: 2024,
+  citationDoi: "10.0000/example",
+  citationUrl: null,
+  citationClaim: "The specific sentence relied on.",
+  evidenceGrade: "CONSENSUS_STATEMENT",
+  lastReviewedAt: new Date("2026-01-01"),
+  reviewedBy: "vet-1",
+  nextReviewDue: new Date("2027-01-01"),
+  taskDefinition: {
+    id: "task-1",
+    name: "Log weight",
+    category: "Monitoring",
+    isActive: true,
+    applicableSpecies: ["dog", "cat", "horse"],
+  },
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  patientFind.mockResolvedValue({
+    speciesCode: "YSPEC:CANINE",
+    breedCode: "YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL",
+    dateOfBirth: yearsAgo(7),
+    type: "dog",
+  });
+  ruleFind.mockResolvedValue([]);
+});
+
+describe("TaskRecommendationService.forCompanion", () => {
+  it("only ever asks for active rules that a named reviewer signed off", async () => {
+    // isActive alone is not enough. An active-but-unreviewed row is a seeding
+    // accident, and this feature puts cited clinical guidance in front of pet
+    // parents - it must not be reachable without a person attached to it.
+    await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(ruleFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          species: "dog",
+          isActive: true,
+          reviewedBy: { not: null },
+        }),
+      }),
+    );
+  });
+
+  it("matches a breed rule across the two vocabulary conventions", async () => {
+    // The rule is stored hyphenated, the patient is coded with underscores. A
+    // literal comparison returns nothing here, and a recommendation that is
+    // silently absent looks exactly like a breed with no guidance for it.
+    ruleFind.mockResolvedValue([
+      rule({ breedCodes: ["YBREED:CANINE:CAVALIER-KING-CHARLES-SPANIEL"] }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out).toHaveLength(1);
+    expect(out[0].because.breedSpecific).toBe(true);
+  });
+
+  it("applies a species-wide rule to any breed, including an uncoded one", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(3),
+      type: "dog",
+    });
+    ruleFind.mockResolvedValue([rule({ breedCodes: [] })]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out).toHaveLength(1);
+    expect(out[0].because.breedSpecific).toBe(false);
+  });
+
+  it("does not apply a breed rule to a companion with no breed code", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(7),
+      type: "dog",
+    });
+    ruleFind.mockResolvedValue([
+      rule({ breedCodes: ["YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL"] }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("treats the age window as half-open so adjacent life stages do not overlap", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(7),
+      type: "dog",
+    });
+    ruleFind.mockResolvedValue([
+      rule({ id: "under-84", minAgeMonths: null, maxAgeMonths: 84 }),
+      rule({ id: "from-84", minAgeMonths: 84, maxAgeMonths: null }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.map((r) => r.ruleId)).toEqual(["from-84"]);
+  });
+
+  it("drops a rule whose task definition has been deactivated", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "x",
+          category: "y",
+          isActive: false,
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("returns nothing for a species with no rules vocabulary, rather than guessing", async () => {
+    // Guessing the species from free-text breed would put an unreviewed inference
+    // behind a cited recommendation.
+    patientFind.mockResolvedValue({
+      speciesCode: null,
+      breedCode: "YBREED:CANINE:PUG",
+      dateOfBirth: yearsAgo(4),
+      type: "other",
+    });
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+    expect(ruleFind).not.toHaveBeenCalled();
+  });
+
+  it("returns nothing when the date of birth is unusable", async () => {
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: null,
+      type: "dog",
+    });
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("carries the citation and the trigger through for the why-am-I-seeing-this panel", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        breedCodes: ["YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL"],
+        minAgeMonths: 60,
+      }),
+    ]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.evidence.artifact).toMatchObject({
+      type: "citation",
+      // The claim relied on, not the paper's abstract - this is what a vet argues with.
+      display: "The specific sentence relied on.",
+      citation: "Author A, Author B. A title. A journal. 2024.",
+      url: "https://doi.org/10.0000/example",
+    });
+    expect(out.evidence.grade).toBe("CONSENSUS_STATEMENT");
+    expect(out.evidence.attestation.reviewedBy).toBe("vet-1");
+    expect(out.because).toMatchObject({
+      species: "dog",
+      breedSpecific: true,
+      minAgeMonths: 60,
+    });
+    expect(out.because.ageMonths).toBeGreaterThanOrEqual(84);
+  });
+
+  it("404s an unknown companion and 400s a blank id", async () => {
+    patientFind.mockResolvedValue(null);
+    await expect(
+      TaskRecommendationService.forCompanion("nope"),
+    ).rejects.toThrow(TaskRecommendationError);
+
+    await expect(
+      TaskRecommendationService.forCompanion("   "),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+});
+
+describe("TaskRecommendationService hardening", () => {
+  it("falls back to the required type when speciesCode is missing", async () => {
+    // speciesCode is null on 30 of 37 production companions. Reading only the
+    // coded column returned nothing for four companions in five until the
+    // backfill ran. `type` is required and is what the parent picked, so this is
+    // a fallback between two recorded values, not an inference.
+    patientFind.mockResolvedValue({
+      speciesCode: null,
+      breedCode: null,
+      dateOfBirth: yearsAgo(5),
+      type: "cat",
+    });
+    ruleFind.mockResolvedValue([rule()]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(ruleFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ species: "cat" }),
+      }),
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it("does not treat a blank reviewer as a signature", async () => {
+    // The column is a nullable string, so "" and "   " both pass a NOT NULL
+    // check while naming nobody. This is the gate that keeps unreviewed clinical
+    // guidance away from pet parents.
+    ruleFind.mockResolvedValue([
+      rule({ id: "empty", reviewedBy: "" }),
+      rule({ id: "spaces", reviewedBy: "   " }),
+      rule({ id: "named", reviewedBy: "Dr Real Person" }),
+    ]);
+
+    const out = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.map((r) => r.ruleId)).toEqual(["named"]);
+  });
+
+  it("will not recommend a task the definition does not apply to that species", async () => {
+    // Nothing in the relation enforces this, so a curator pointing a canine rule
+    // at a feline-only task would otherwise ship it.
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "Cat-only thing",
+          category: "x",
+          isActive: true,
+          applicableSpecies: ["cat"],
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+  });
+
+  it("gives the evidence grade a readable label without dropping the raw value", async () => {
+    ruleFind.mockResolvedValue([
+      rule({ evidenceGrade: "CONSENSUS_STATEMENT" }),
+    ]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.evidence.grade).toBe("CONSENSUS_STATEMENT");
+    expect(out.evidence.artifact.label).toBe("Consensus statement");
+  });
+
+  it("falls back to the raw grade if a new one has no label yet", async () => {
+    ruleFind.mockResolvedValue([rule({ evidenceGrade: "SOMETHING_NEW" })]);
+
+    const [out] = await TaskRecommendationService.forCompanion("pat-1");
+
+    expect(out.evidence.artifact.label).toBe("SOMETHING_NEW");
+  });
+});
+
+describe("TaskRecommendationService evidence shape", () => {
+  it("prefers an explicit url over a DOI, and omits the link when there is neither", async () => {
+    ruleFind.mockResolvedValue([
+      rule({
+        id: "with-url",
+        citationUrl: "https://example.org/paper",
+        citationDoi: "10.1/x",
+      }),
+    ]);
+    const [withUrl] = await TaskRecommendationService.forCompanion("pat-1");
+    expect(withUrl.evidence.artifact.url).toBe("https://example.org/paper");
+
+    ruleFind.mockResolvedValue([
+      rule({ citationUrl: null, citationDoi: null }),
+    ]);
+    const [bare] = await TaskRecommendationService.forCompanion("pat-1");
+    // Not an empty string or a bare "https://doi.org/" - the field is simply absent.
+    expect(bare.evidence.artifact.url).toBeUndefined();
+  });
+});
+
+describe("TaskRecommendationService species integrity", () => {
+  it("returns nothing when speciesCode and type disagree", async () => {
+    // Nothing upstream enforces that the two agree - validateCompanionCodes
+    // checks each code is valid, not that they describe one species. Picking
+    // either would serve guidance for the wrong animal on exactly the rows
+    // already known to be inconsistent.
+    patientFind.mockResolvedValue({
+      speciesCode: "YSPEC:CANINE",
+      breedCode: null,
+      dateOfBirth: yearsAgo(5),
+      type: "cat",
+    });
+    ruleFind.mockResolvedValue([rule()]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toEqual([]);
+    expect(ruleFind).not.toHaveBeenCalled();
+  });
+
+  it("keeps a universal task definition, which declares no species at all", async () => {
+    // taskLibrary.service.ts matches `{ isEmpty: true }` alongside
+    // `{ has: species }`, so empty means universal rather than "applies to
+    // nothing". Reading it as a mismatch would drop every universal task.
+    ruleFind.mockResolvedValue([
+      rule({
+        taskDefinition: {
+          id: "task-1",
+          name: "Universal",
+          category: "x",
+          isActive: true,
+          applicableSpecies: [],
+        },
+      }),
+    ]);
+
+    expect(await TaskRecommendationService.forCompanion("pat-1")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
@@ -79,7 +79,11 @@ describe('github-releases route handler', () => {
 
     const res = await call(`${BASE}?list=1`);
 
-    expect(String(fetchMock.mock.calls[0][0])).toContain('/releases?per_page=30');
+    // 100, GitHub's maximum here, not a smaller default. The home page reads this
+    // list to show a lane per shipped component, and a component whose latest
+    // release has fallen off the page renders as an empty lane. At four
+    // components on a monthly cadence, 30 covered about seven months.
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/releases?per_page=100');
     expect(res.body).toHaveLength(2);
     expect((res.body as Release[])[0]).not.toHaveProperty('extra');
     expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');

--- a/apps/frontend/src/app/__tests__/features/marketing/site/ReleaseLanes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/ReleaseLanes.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import type { ReleaseLane } from '@/app/features/marketing/site/useGithubStats';
+
+const RESOLVED: ReleaseLane[] = [
+  {
+    key: 'pims',
+    label: 'PIMS',
+    tag: 'v2.3.0-beta',
+    date: 'Aug 19, 2026',
+    dateCompact: '19 Aug',
+    url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/pims-v2.3.0-beta',
+  },
+  {
+    key: 'desktop',
+    label: 'Desktop',
+    tag: 'v0.1.0-beta.4',
+    date: 'Aug 19, 2026',
+    dateCompact: '19 Aug',
+    url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/v0.1.0-beta.4',
+  },
+  {
+    key: 'mobile',
+    label: 'Mobile',
+    tag: 'v1.6.1',
+    date: 'Aug 21, 2026',
+    dateCompact: '21 Aug',
+    url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/mobile-v1.6.1',
+  },
+  {
+    key: 'backend',
+    label: 'Backend',
+    tag: null,
+    date: null,
+    dateCompact: null,
+    url: null,
+  },
+];
+
+let lanesValue: ReleaseLane[] = RESOLVED;
+const mockUseReleaseLanes = jest.fn((): ReleaseLane[] => lanesValue);
+
+jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
+  useReleaseLanes: () => mockUseReleaseLanes(),
+}));
+
+import { ReleaseLanes } from '@/app/features/marketing/site/ReleaseLanes';
+
+const RELEASES_INDEX = 'https://github.com/YosemiteCrew/Yosemite-Crew/releases';
+
+beforeEach(() => {
+  lanesValue = RESOLVED;
+  jest.clearAllMocks();
+});
+
+describe('ReleaseLanes', () => {
+  it('renders one link per shipped component', () => {
+    render(<ReleaseLanes />);
+    expect(screen.getAllByRole('link')).toHaveLength(4);
+    for (const label of ['PIMS', 'Desktop', 'Mobile', 'Backend']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('shows the version and compact date, and links to that release', () => {
+    render(<ReleaseLanes />);
+    const desktop = screen.getByRole('link', { name: /Desktop v0\.1\.0-beta\.4/ });
+    expect(desktop).toHaveAttribute('href', RESOLVED[1].url);
+    expect(desktop).toHaveAttribute('target', '_blank');
+    expect(desktop).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(screen.getByText('v0.1.0-beta.4')).toBeInTheDocument();
+    expect(screen.getAllByText('19 Aug').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('names the full date for assistive tech, not the abbreviated one', () => {
+    // The face is abbreviated to keep the strip short; the accessible name must not be.
+    render(<ReleaseLanes />);
+    expect(
+      screen.getByRole('link', { name: 'Mobile v1.6.1, released Aug 21, 2026' })
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the releases index for a lane with no release', () => {
+    // Backend resolved to nulls here. It must still lead somewhere useful, must not borrow
+    // another lane's URL, and must not print a version it does not have.
+    render(<ReleaseLanes />);
+    const backend = screen.getByRole('link', { name: 'Backend releases on GitHub' });
+    expect(backend).toHaveAttribute('href', RELEASES_INDEX);
+    expect(backend).toHaveTextContent('·');
+    expect(backend).not.toHaveTextContent(/v\d/);
+  });
+
+  it('renders placeholders for every lane before the fetch resolves', () => {
+    lanesValue = RESOLVED.map((lane) => ({
+      ...lane,
+      tag: null,
+      date: null,
+      dateCompact: null,
+      url: null,
+    }));
+    render(<ReleaseLanes />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(4);
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', RELEASES_INDEX);
+      expect(link).not.toHaveTextContent(/v\d/);
+    }
+  });
+
+  it('names a release that has a tag but no publish date', () => {
+    // GitHub can return a release with no published_at (a draft promoted oddly), which leaves
+    // the date null while the tag resolves. The name still has to read as a sentence.
+    lanesValue = [{ ...RESOLVED[0], date: null, dateCompact: null }];
+    render(<ReleaseLanes />);
+    expect(
+      screen.getByRole('link', { name: 'PIMS v2.3.0-beta, released recently' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('19 Aug')).not.toBeInTheDocument();
+  });
+
+  it('reaches every lane by keyboard, in the order they are read', async () => {
+    // Four links in a row is the whole interaction surface. Tab order has to
+    // match reading order, and each lane has to take focus - the hairlines and
+    // the dot between them are decorative and must not be stops.
+    const user = userEvent.setup();
+    render(<ReleaseLanes />);
+
+    const seen: string[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      await user.tab();
+      const active = document.activeElement as HTMLElement;
+      expect(active.tagName).toBe('A');
+      seen.push(active.getAttribute('aria-label') ?? '');
+    }
+    expect(seen.map((name) => name.split(' ')[0])).toEqual([
+      'PIMS',
+      'Desktop',
+      'Mobile',
+      'Backend',
+    ]);
+  });
+
+  it('activates a lane, opening that release in a new tab', async () => {
+    const user = userEvent.setup();
+    render(<ReleaseLanes />);
+
+    const mobile = screen.getByRole('link', { name: /^Mobile/ });
+    const onClick = jest.fn((event: Event) => event.preventDefault());
+    mobile.addEventListener('click', onClick);
+
+    await user.click(mobile);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(mobile).toHaveAttribute('href', RESOLVED[2].url);
+    expect(mobile).toHaveAttribute('target', '_blank');
+  });
+
+  it('separates the lanes without adding them to the accessible names', () => {
+    const { container } = render(<ReleaseLanes />);
+    // Three hairlines between four lanes, all hidden from the accessibility tree.
+    const hidden = container.querySelectorAll('span[aria-hidden="true"]');
+    expect(hidden.length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByRole('link', { name: /^PIMS/ })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
@@ -6,6 +6,7 @@ import {
   useLatestRelease,
   useMobileRelease,
   usePlatformRelease,
+  useReleaseLanes,
   type GithubStats,
   type ReleaseInfo,
 } from '@/app/features/marketing/site/useGithubStats';
@@ -441,5 +442,237 @@ describe('useGithubStats hooks', () => {
     const { result } = renderHook(() => useMobileRelease());
     await waitFor(() => expect(result.current.tag).toBe('m9.9'));
     expect(result.current.url).toBe('https://x/cached-m');
+  });
+});
+
+describe('useReleaseLanes', () => {
+  const THIS_YEAR = new Date().getFullYear();
+
+  /** Mirrors the real tag shapes documented in RELEASING.md, newest-first as GitHub returns them. */
+  const RELEASES = [
+    {
+      tag_name: 'mobile-v1.6.1',
+      published_at: `${THIS_YEAR}-08-21T10:00:00Z`,
+      html_url: 'https://x/mobile',
+    },
+    {
+      tag_name: 'v0.1.0-beta.4',
+      published_at: `${THIS_YEAR}-08-19T10:00:00Z`,
+      html_url: 'https://x/desktop',
+    },
+    {
+      tag_name: 'backend-v2.3.0-beta',
+      published_at: `${THIS_YEAR}-08-19T09:00:00Z`,
+      html_url: 'https://x/backend',
+    },
+    {
+      tag_name: 'pims-v2.3.0-beta',
+      published_at: `${THIS_YEAR}-08-19T08:00:00Z`,
+      html_url: 'https://x/pims',
+    },
+    {
+      tag_name: 'pims-v2.2.0-beta',
+      published_at: `${THIS_YEAR}-08-08T08:00:00Z`,
+      html_url: 'https://x/pims-old',
+    },
+  ];
+
+  // The endpoint is `/api/community/github-releases?list=1` - it contains `-releases`, not
+  // `/releases`, so match the route name itself.
+  const RELEASES_ROUTE = 'github-releases';
+
+  const lanesFetch = (list: unknown[]) =>
+    jest.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes(RELEASES_ROUTE)) return Promise.resolve(makeRes(list));
+      return Promise.resolve(makeRes(null));
+    });
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  const byKey = (lanes: ReturnType<typeof useReleaseLanes>, key: string) =>
+    lanes.find((lane) => lane.key === key)!;
+
+  it('buckets one releases response into the four shipped lanes', async () => {
+    globalThis.fetch = lanesFetch(RELEASES) as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'pims').tag).toBe('v2.3.0-beta'));
+
+    expect(byKey(result.current, 'pims').url).toBe('https://x/pims');
+    expect(byKey(result.current, 'mobile').tag).toBe('v1.6.1');
+    expect(byKey(result.current, 'backend').tag).toBe('v2.3.0-beta');
+    expect(result.current.map((lane) => lane.key)).toEqual([
+      'pims',
+      'desktop',
+      'mobile',
+      'backend',
+    ]);
+  });
+
+  it('claims the unprefixed tag for desktop', async () => {
+    // The one that a naive prefix match gets wrong. desktop-release.yml requires the tag to be a
+    // bare `v${version}` because electron-updater ignores non-semver tags, so the newest desktop
+    // release carries no product prefix at all - and it must not leak into another lane either.
+    globalThis.fetch = lanesFetch(RELEASES) as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'desktop').tag).toBe('v0.1.0-beta.4'));
+
+    expect(byKey(result.current, 'desktop').url).toBe('https://x/desktop');
+    expect(byKey(result.current, 'pims').tag).not.toBe('v0.1.0-beta.4');
+    expect(byKey(result.current, 'mobile').tag).not.toBe('v0.1.0-beta.4');
+  });
+
+  it('still matches the legacy pms- spelling and the early desktop- tags', async () => {
+    globalThis.fetch = lanesFetch([
+      {
+        tag_name: 'pms-v1.3.0-beta',
+        published_at: `${THIS_YEAR}-05-09T00:00:00Z`,
+        html_url: 'https://x/pms',
+      },
+      {
+        tag_name: 'desktop-v0.1.0-beta.2',
+        published_at: `${THIS_YEAR}-07-13T00:00:00Z`,
+        html_url: 'https://x/dt',
+      },
+    ]) as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'pims').url).toBe('https://x/pms'));
+    expect(byKey(result.current, 'desktop').url).toBe('https://x/dt');
+  });
+
+  it('takes the newest release per lane, not the first tag seen', async () => {
+    globalThis.fetch = lanesFetch(RELEASES) as unknown as FetchLike;
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'pims').tag).toBeTruthy());
+    // Two pims releases are present; the newer one leads the list and must win.
+    expect(byKey(result.current, 'pims').url).toBe('https://x/pims');
+  });
+
+  it('leaves a lane null rather than inventing a version for it', async () => {
+    // A lane with nothing on the fetched page must show its placeholder. Falling back to a
+    // hard-coded version would present a stale literal as a live release.
+    globalThis.fetch = lanesFetch([RELEASES[0]]) as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'mobile').tag).toBe('v1.6.1'));
+
+    for (const key of ['pims', 'desktop', 'backend']) {
+      expect(byKey(result.current, key).tag).toBeNull();
+      expect(byKey(result.current, key).url).toBeNull();
+      expect(byKey(result.current, key).dateCompact).toBeNull();
+    }
+  });
+
+  it('keeps every lane empty when the list is empty or the request fails', async () => {
+    globalThis.fetch = lanesFetch([]) as unknown as FetchLike;
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(result.current.every((lane) => lane.tag === null)).toBe(true);
+
+    globalThis.fetch = jest.fn(() => Promise.reject(new Error('network'))) as unknown as FetchLike;
+    const failed = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(failed.result.current.every((lane) => lane.tag === null)).toBe(true);
+  });
+
+  it('drops the year from the compact date only within the current year', async () => {
+    globalThis.fetch = lanesFetch([
+      {
+        tag_name: 'mobile-v1.6.1',
+        published_at: `${THIS_YEAR}-08-21T10:00:00Z`,
+        html_url: 'https://x/m',
+      },
+      {
+        tag_name: 'backend-v1.0.0',
+        published_at: `${THIS_YEAR - 2}-03-04T10:00:00Z`,
+        html_url: 'https://x/b',
+      },
+    ]) as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'mobile').dateCompact).toBeTruthy());
+
+    expect(byKey(result.current, 'mobile').dateCompact).toBe('21 Aug');
+    // An older release stays unambiguous by carrying a two-digit year.
+    expect(byKey(result.current, 'backend').dateCompact).toBe(
+      `4 Mar ${String(THIS_YEAR - 2).slice(-2)}`
+    );
+    // The full date is kept for the accessible name and tooltip.
+    expect(byKey(result.current, 'mobile').date).toContain(String(THIS_YEAR));
+  });
+
+  it('renders every lane empty on the server', () => {
+    const Probe = () => {
+      const lanes = useReleaseLanes();
+      return createElement('span', null, lanes.map((l) => l.tag ?? '-').join(','));
+    };
+    expect(renderToString(createElement(Probe))).toContain('-,-,-,-');
+  });
+
+  it('still renders the lanes when session storage cannot be written', async () => {
+    // Safari private browsing, a blocked third-party context, an exhausted quota.
+    // The response already arrived; a failed cache write must not swallow it.
+    const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    try {
+      globalThis.fetch = lanesFetch(RELEASES) as unknown as FetchLike;
+      const { result } = renderHook(() => useReleaseLanes());
+      await waitFor(() => expect(byKey(result.current, 'pims').tag).toBe('v2.3.0-beta'));
+      expect(byKey(result.current, 'desktop').tag).toBe('v0.1.0-beta.4');
+      expect(sessionStorage.getItem('yc_marketing_release_lanes_v1')).toBeNull();
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
+  it('replaces stale cached lanes even when the refresh cannot be written', async () => {
+    // The gap the first version of the fallback left. With lanes ALREADY cached
+    // and the refresh write failing, returning the store meant the fresh result
+    // was discarded on every render and the hero showed old releases forever.
+    sessionStorage.setItem(
+      'yc_marketing_release_lanes_v1',
+      JSON.stringify([
+        {
+          key: 'pims',
+          label: 'PIMS',
+          tag: 'v0.0.1-stale',
+          date: null,
+          dateCompact: null,
+          url: 'https://x/old',
+        },
+        { key: 'desktop', label: 'Desktop', tag: null, date: null, dateCompact: null, url: null },
+        { key: 'mobile', label: 'Mobile', tag: null, date: null, dateCompact: null, url: null },
+        { key: 'backend', label: 'Backend', tag: null, date: null, dateCompact: null, url: null },
+      ])
+    );
+    const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    try {
+      globalThis.fetch = lanesFetch(RELEASES) as unknown as FetchLike;
+      const { result } = renderHook(() => useReleaseLanes());
+      await waitFor(() => expect(byKey(result.current, 'pims').tag).toBe('v2.3.0-beta'));
+      expect(byKey(result.current, 'pims').tag).not.toBe('v0.0.1-stale');
+      expect(byKey(result.current, 'mobile').tag).toBe('v1.6.1');
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
+  it('fetches the releases list once for all four lanes', async () => {
+    const spy = lanesFetch(RELEASES);
+    globalThis.fetch = spy as unknown as FetchLike;
+
+    const { result } = renderHook(() => useReleaseLanes());
+    await waitFor(() => expect(byKey(result.current, 'pims').tag).toBeTruthy());
+
+    const releaseCalls = spy.mock.calls.filter((c) => String(c[0]).includes(RELEASES_ROUTE));
+    expect(releaseCalls).toHaveLength(1);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Home.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Home.marketing.test.tsx
@@ -43,7 +43,10 @@ jest.mock('@/app/features/marketing/site', () => {
     HeroVideo: () => null,
     HeroGlow: () => null,
     ctaBandContainerStyle: () => ({}),
-    ReleasePill: () => React_.createElement('span', null, 'Latest release'),
+    // A div, matching what the real component renders. A span here would hide a
+    // div-inside-span nesting error in the hero, which jest.setup turns into a
+    // test failure via console.error.
+    ReleaseLanes: () => React_.createElement('div', null, 'PIMS Desktop Mobile Backend'),
     CountUp: ({ value }: { value: string }) => React_.createElement('span', null, value),
     useMagnet: () => React_.createRef(),
     useParallax: () => React_.createRef(),
@@ -99,6 +102,23 @@ describe('Home marketing page', () => {
     expect(screen.getByText('Contributors')).toBeInTheDocument();
     expect(screen.getByText('Discord members')).toBeInTheDocument();
     expect(screen.getByText('Repo stars')).toBeInTheDocument();
+  });
+
+  it('wraps the release lanes in a block element, not a span', () => {
+    // ReleaseLanes renders a flex container. A div inside a span is invalid HTML
+    // that the browser repairs before React hydrates, which shows up as a
+    // hydration mismatch on the hero rather than as anything visible.
+    //
+    // Asserted structurally on purpose: React 19 emits no validateDOMNesting
+    // warning for this pair in this setup - verified with a probe render - so
+    // the console.error trap in jest.setup would not catch it.
+    render(<Home />);
+    // The wrapper matches this text too, since it holds nothing else. Document
+    // order puts it first, so the innermost match is the component itself.
+    const matches = screen.getAllByText('PIMS Desktop Mobile Backend');
+    const lanes = matches[matches.length - 1];
+    expect(lanes.tagName).toBe('DIV');
+    expect(lanes.parentElement?.tagName).not.toBe('SPAN');
   });
 
   it('renders the closing CTA', () => {

--- a/apps/frontend/src/app/api/community/github-releases/route.ts
+++ b/apps/frontend/src/app/api/community/github-releases/route.ts
@@ -20,7 +20,15 @@ import {
 
 const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
 const GITHUB_USER_AGENT = 'YosemiteCrew-Web (https://www.yosemitecrew.com, 1.0)';
-const RELEASE_PAGE_SIZE = 30;
+// One page has to be deep enough to hold the newest release of EVERY component,
+// not just the newest few overall. The home page reads this list to show a lane
+// per component, and a lane whose latest release has fallen off the page renders
+// as an empty placeholder even though the release exists. At four components on
+// a roughly monthly cadence, 30 covers about seven months - one quiet component
+// and it drops out. 100 is GitHub's maximum for this endpoint and covers years;
+// the response is trimmed to four fields per release below, so the extra entries
+// cost very little and the route is cached.
+const RELEASE_PAGE_SIZE = 100;
 
 export interface GithubRelease {
   tag_name?: string;

--- a/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
@@ -19,7 +19,7 @@ import {
   IoExtensionPuzzleOutline,
 } from 'react-icons/io5';
 import {
-  ReleasePill,
+  ReleaseLanes,
   Reveal,
   Spotlight,
   HeroVideo,
@@ -767,14 +767,18 @@ function Hero() {
           maxWidth: 1040,
         }}
       >
-        <span
+        {/* div, not span: ReleaseLanes renders a flex container, and a div inside a
+            span is invalid HTML that the browser repairs before React hydrates,
+            producing a mismatch on the hero. The pill this replaced returned an
+            anchor, which was legal here. */}
+        <div
           style={{
             opacity: 0,
             animation: 'ycHeroUp 0.9s cubic-bezier(0.16,1,0.3,1) 0.05s both',
           }}
         >
-          <ReleasePill variant="latest" version="v2.0 beta" />
-        </span>
+          <ReleaseLanes />
+        </div>
 
         <HeroHeading />
 

--- a/apps/frontend/src/app/features/marketing/site/ReleaseLanes.tsx
+++ b/apps/frontend/src/app/features/marketing/site/ReleaseLanes.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { IoLogoGithub } from 'react-icons/io5';
+import { GITHUB_REPO_URL } from './assets';
+import { useReleaseLanes, type ReleaseLane } from './useGithubStats';
+
+const RELEASES_INDEX_URL = `${GITHUB_REPO_URL}/releases`;
+
+const BAR_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  gap: 0,
+  padding: '5px 7px',
+  borderRadius: 9999,
+  border: '1px solid var(--hairline)',
+  background: 'var(--glass-95)',
+  backdropFilter: 'blur(40px)',
+  WebkitBackdropFilter: 'blur(40px)',
+};
+
+const SEGMENT_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'baseline',
+  gap: 6,
+  padding: '4px 11px',
+  borderRadius: 9999,
+  fontSize: 12.5,
+  fontWeight: 500,
+  letterSpacing: '-0.01em',
+  lineHeight: 1.45,
+  color: 'var(--ink-muted)',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+};
+
+const LABEL_STYLE: CSSProperties = { color: 'var(--ink)', fontWeight: 600 };
+const VERSION_STYLE: CSSProperties = {
+  color: 'var(--ink-body)',
+  fontVariantNumeric: 'tabular-nums',
+};
+// --ink-muted, not --ink-faint. Measured on the bar's own background, --ink-faint is 2.84:1 in
+// light (it clears 4.5:1 only in dark, at 5.67:1), and this is real information at 11.5px, not
+// decoration. --ink-muted is 5.71:1 light / 6.56:1 dark and still reads as subordinate to the
+// name and version above it.
+const DATE_STYLE: CSSProperties = { color: 'var(--ink-muted)', fontSize: 11.5 };
+
+const SEPARATOR_STYLE: CSSProperties = {
+  width: 1,
+  height: 11,
+  background: 'var(--divider)',
+  flex: 'none',
+};
+
+/** Shown in place of a version until the fetch resolves, or if a lane has no release on the page. */
+const PLACEHOLDER = '·';
+
+const Separator = () => <span style={SEPARATOR_STYLE} aria-hidden="true" />;
+
+/** The live dot every release pill on the site leads with. Same token, same size. */
+const Dot = () => (
+  <span
+    style={{
+      width: 7,
+      height: 7,
+      borderRadius: 9999,
+      background: 'var(--success)',
+      flex: 'none',
+      margin: '0 7px 0 8px',
+    }}
+    aria-hidden="true"
+  />
+);
+
+function LaneSegment({ lane }: Readonly<{ lane: ReleaseLane }>) {
+  // No release resolved yet (or none on the fetched page): the segment still links somewhere
+  // useful, and shows a placeholder rather than a stale or invented version.
+  const href = lane.url ?? RELEASES_INDEX_URL;
+  const accessibleName = lane.tag
+    ? `${lane.label} ${lane.tag}, released ${lane.date ?? 'recently'}`
+    : `${lane.label} releases on GitHub`;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={SEGMENT_STYLE}
+      title={accessibleName}
+      aria-label={accessibleName}
+      data-yc-lane
+    >
+      <span style={LABEL_STYLE}>{lane.label}</span>
+      <span style={VERSION_STYLE}>{lane.tag ?? PLACEHOLDER}</span>
+      {lane.dateCompact ? <span style={DATE_STYLE}>{lane.dateCompact}</span> : null}
+    </a>
+  );
+}
+
+/**
+ * Latest release for each shipped component, as one row of linked tags.
+ *
+ * Replaces a single "Latest release" pill that showed whichever release was newest repo-wide -
+ * always a desktop build, since desktop is the only component whose tag is bare semver and so the
+ * only one GitHub gives the Latest badge to. That undersold three of the four release lines and
+ * mislabelled the fourth.
+ *
+ * One glass bar with hairline-separated segments rather than four separate pills: four bordered
+ * pills read as four competing objects, where this reads as one status strip.
+ */
+export function ReleaseLanes() {
+  const lanes = useReleaseLanes();
+
+  return (
+    <div style={BAR_STYLE} data-yc-lanes>
+      <Dot />
+      {lanes.map((lane, index) => (
+        <span key={lane.key} style={{ display: 'inline-flex', alignItems: 'center' }}>
+          {index > 0 ? <Separator /> : null}
+          <LaneSegment lane={lane} />
+        </span>
+      ))}
+      <IoLogoGithub
+        style={{ fontSize: 14, color: 'var(--ink-faint)', flex: 'none', margin: '0 8px 0 6px' }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
+++ b/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
@@ -129,7 +129,9 @@ function StandardPillBody({
       />
       <span style={{ color: 'var(--ink)', fontWeight: 600 }}>{shownVersion}</span>
       {!isStatic && release.date ? (
-        <span style={{ color: 'var(--ink-faint)', fontWeight: 500 }}>{` · ${release.date}`}</span>
+        // --ink-muted: --ink-faint measures 2.84:1 on this background in light mode, under the
+        // 4.5:1 floor for text this size. Same fix as the release lanes on the home hero.
+        <span style={{ color: 'var(--ink-muted)', fontWeight: 500 }}>{` · ${release.date}`}</span>
       ) : null}
       <IoLogoGithub
         style={{ fontSize: 14, color: 'var(--ink-faint)', marginLeft: 1 }}

--- a/apps/frontend/src/app/features/marketing/site/index.ts
+++ b/apps/frontend/src/app/features/marketing/site/index.ts
@@ -3,6 +3,7 @@ export { SiteNav, type NavKey } from './SiteNav';
 export { SiteFooter } from './SiteFooter';
 export { AuthShell, AuthBrandContent, type AuthBrandPoint } from './AuthShell';
 export { ReleasePill } from './ReleasePill';
+export { ReleaseLanes } from './ReleaseLanes';
 export { LegalDoc, DocSection, type TocEntry } from './LegalDoc';
 export { ThemeToggle } from './ThemeToggle';
 export { useTheme, type Theme } from './useTheme';
@@ -25,8 +26,11 @@ export {
   useGithubStats,
   useLatestRelease,
   useMobileRelease,
+  useReleaseLanes,
   type GithubStats,
   type ReleaseInfo,
+  type ReleaseLane,
+  type ReleaseLaneKey,
 } from './useGithubStats';
 export { useGithubContributors, type GithubContributor } from './useGithubContributors';
 export {

--- a/apps/frontend/src/app/features/marketing/site/marketing.css
+++ b/apps/frontend/src/app/features/marketing/site/marketing.css
@@ -649,3 +649,91 @@ select.yc-field {
     display: flex !important;
   }
 }
+
+/* ---- Release lanes (Home hero eyebrow: latest release per shipped component) ---- */
+[data-yc-lane] {
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+[data-yc-lane]:hover {
+  background: var(--inset);
+}
+/* --blue-text, not --blue. --blue is a fill token: on the --inset hover surface
+   it measures 3.18:1 in light and 3.54:1 in dark, under the 4.5:1 floor for a
+   12.5px label. --blue-text is maintained for readable blue text and measures
+   5.04:1 and 7.02:1 on the same surface. */
+[data-yc-lane]:hover span:first-child {
+  color: var(--blue-text);
+}
+
+/* Narrow screens: a flex row wraps to one lane per line (four rows, ~120px) because the
+   longest segment is wider than half the bar. A two-column grid pins it to 2x2 instead, and
+   pins it there whatever a future version string is - the cell wraps its own text rather than
+   pushing the row. The bar squares off since a pill radius around a block reads wrong, the
+   github mark is dropped (it is repeated on every link's accessible name), and the separators
+   go with it because they no longer sit between items on a row. */
+/* 860px, not a round 768. The one-row bar is ~754px intrinsic and the hero adds
+   24px of padding either side, so it needs ~802px of viewport before it fits.
+   Below that the flex row wraps between segments and the strip goes ragged, so
+   the compact grid has to take over BEFORE that point, not after. 834 - the
+   tablet QA viewport - sits inside the broken zone and is now covered, and the
+   rest is headroom for a longer version string than today's. */
+@media (max-width: 860px) {
+  [data-yc-lanes] {
+    display: grid !important;
+    /* minmax(0, 1fr), not 1fr. A bare 1fr keeps an automatic min-content floor,
+       so a track cannot shrink below its widest unbreakable child - and the
+       segments are nowrap. RELEASING.md specifies mobile tags as
+       mobile-vX.Y.Z-iOS-vA.B, so a real one strips to v1.0.12-ios-v1.0.7, wide
+       enough to push both tracks past the hero and clip the strip. */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    border-radius: 16px !important;
+    padding: 4px !important;
+    gap: 2px;
+  }
+  /* The live dot and the github mark are chrome, not content - at 342px they would each
+     take a grid cell and break the 2x2. Every lane is a github link anyway, and each one
+     says so in its accessible name. */
+  [data-yc-lanes] > svg,
+  [data-yc-lanes] > span[aria-hidden='true'] {
+    display: none !important;
+  }
+  [data-yc-lanes] > span > span[aria-hidden='true'] {
+    display: none !important;
+  }
+  /* Each cell breaks in the same place: name + version on the first line, date on the
+     second. Letting it wrap naturally instead put the two longer lanes on three lines and
+     the two shorter ones on two, so the block came out ragged. The pieces are already
+     separate spans, so pushing the date onto its own flex line is enough - and each piece
+     keeps nowrap so a version never splits mid-token. */
+  [data-yc-lane] {
+    flex-wrap: wrap;
+    align-content: center;
+    padding: 5px 8px !important;
+    font-size: 12px !important;
+    line-height: 1.5;
+    min-width: 0;
+    /* Reserve the second line before the dates arrive.
+       On a cold cache the first paint has no date spans, and each one takes a
+       full flex line when it appears, so every cell grew 27px -> 50px and the
+       bar 65px -> 110px, shoving the hero heading and the CTAs down after
+       paint. Holding the resolved height from the start costs nothing while
+       loading and removes the shift entirely. */
+    min-height: 50px;
+  }
+  /* The product name stays on one line; the version is what can get long, so it
+     is the piece allowed to break. `anywhere` rather than `break-word` because
+     a version has no spaces to break at. */
+  [data-yc-lane] > span:nth-child(2) {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
+  /* The hero centres its text, which a full-width second line inherits - the date would sit
+     centred under a left-aligned name. */
+  [data-yc-lane] > span:nth-child(3) {
+    flex-basis: 100%;
+    text-align: left;
+  }
+}

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -262,6 +262,159 @@ const matchesMobileTag = (tag: string): boolean => /mobile|ios|android|app-v|exp
 const matchesPlatformTag = (tag: string): boolean => /^(pims|pms)[-_]/.test(tag);
 
 /**
+ * The four shipped components, and the tag each one releases under. Both the shapes and the
+ * `desktop` exception are documented in RELEASING.md; this mirrors it rather than guessing:
+ *
+ *   pims-v* (older releases used pms-v*)  apps/frontend, tagged manually
+ *   backend-v*                            apps/backend, tagged manually
+ *   mobile-v*                             apps/mobileAppYC, tagged manually
+ *   v*  - NO prefix                       apps/desktop, tagged on main, built by desktop-release.yml
+ *
+ * Desktop is the odd one out on purpose: electron-updater ignores any release whose tag is not
+ * valid semver, so a `desktop-v*` tag would make every desktop release invisible to the updater.
+ * Its tag is therefore a bare `vX.Y.Z`, which is also why it is matched last - the prefixed
+ * patterns are tried first, so only an unprefixed tag can fall through to it. A handful of early
+ * `desktop-v*` / `desktop-manual-v*` tags exist in history and are still matched.
+ */
+const matchesBackendTag = (tag: string): boolean => /^backend[-_]/.test(tag);
+const matchesLaneMobileTag = (tag: string): boolean => /^mobile[-_]/.test(tag);
+const matchesDesktopTag = (tag: string): boolean => /^desktop[-_]/.test(tag) || /^v\d/.test(tag);
+
+export type ReleaseLaneKey = 'pims' | 'desktop' | 'mobile' | 'backend';
+
+export interface ReleaseLane {
+  key: ReleaseLaneKey;
+  /** Product name shown on the tag, e.g. 'PIMS'. */
+  label: string;
+  /** Cleaned tag, e.g. 'v2.3.0-beta'. Null until the fetch resolves, or if this lane has no release. */
+  tag: string | null;
+  /** Full publish date, e.g. 'Aug 19, 2026'. Used for the accessible name and tooltip. */
+  date: string | null;
+  /** Compact publish date for the tag face, e.g. '19 Aug' ('19 Aug 25' outside the current year). */
+  dateCompact: string | null;
+  url: string | null;
+}
+
+const LANE_DEFINITIONS: ReadonlyArray<{
+  key: ReleaseLaneKey;
+  label: string;
+  matches: (tag: string) => boolean;
+}> = [
+  { key: 'pims', label: 'PIMS', matches: matchesPlatformTag },
+  { key: 'desktop', label: 'Desktop', matches: matchesDesktopTag },
+  { key: 'mobile', label: 'Mobile', matches: matchesLaneMobileTag },
+  { key: 'backend', label: 'Backend', matches: matchesBackendTag },
+];
+
+const LANES_CACHE_KEY = 'yc_marketing_release_lanes_v1';
+
+const EMPTY_LANES: ReleaseLane[] = LANE_DEFINITIONS.map(({ key, label }) => ({
+  key,
+  label,
+  tag: null,
+  date: null,
+  dateCompact: null,
+  url: null,
+}));
+
+/**
+ * Day + short month, with the year appended only when the release is not from the current year.
+ * Keeps the tag face short for the normal case (everything on the current cadence) without making
+ * an older release ambiguous. Safe to read the clock here: lanes only ever render after hydration,
+ * from the session cache, so this never runs during SSR and cannot cause a hydration mismatch.
+ */
+const formatCompactReleaseDate = (iso?: string): string | null => {
+  if (!iso) return null;
+  try {
+    const parsed = new Date(iso);
+    if (Number.isNaN(parsed.getTime())) return null;
+    const day = parsed.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+    const year = parsed.getFullYear();
+    return year === new Date().getFullYear() ? day : `${day} ${String(year).slice(-2)}`;
+  } catch {
+    return null;
+  }
+};
+
+const laneSnapshots = new Map<string, { raw: string | null; value: ReleaseLane[] }>();
+
+const getLanesSnapshot = (): ReleaseLane[] => {
+  const raw = getStorageItem('session', LANES_CACHE_KEY);
+  const memo = laneSnapshots.get(LANES_CACHE_KEY);
+  if (memo?.raw === raw) return memo.value;
+  const value = parseJson<ReleaseLane[]>(raw) ?? EMPTY_LANES;
+  laneSnapshots.set(LANES_CACHE_KEY, { raw, value });
+  return value;
+};
+
+const getServerLanes = (): ReleaseLane[] => EMPTY_LANES;
+
+const toLanes = (list: RawRelease[]): ReleaseLane[] =>
+  LANE_DEFINITIONS.map(({ key, label, matches }) => {
+    // Newest-first from the API, so the first tag this lane claims is its latest.
+    const match = list.find((entry) => matches((entry.tag_name ?? '').toLowerCase()));
+    if (!match?.html_url)
+      return { key, label, tag: null, date: null, dateCompact: null, url: null };
+    const info = toReleaseInfo(match);
+    return {
+      key,
+      label,
+      tag: info.tag,
+      date: info.date,
+      dateCompact: formatCompactReleaseDate(match.published_at),
+      url: info.url,
+    };
+  });
+
+/**
+ * Latest release per shipped component, from a SINGLE releases request.
+ *
+ * The per-variant pills each mount their own hook so a page only fetches what it shows; a row of
+ * four lanes would turn that into four identical `?list=1` calls against the same unauthenticated
+ * quota, so this buckets one response instead.
+ *
+ * A lane with no match keeps its nulls - the row renders that lane in its loading/absent state and
+ * links to the releases index. It must never fall back to a hard-coded version: a stale literal
+ * presented as a live release is worse than an empty slot, and it would poison the shared cache.
+ */
+export function useReleaseLanes(): ReleaseLane[] {
+  const cached = useSyncExternalStore(subscribeToSessionCache, getLanesSnapshot, getServerLanes);
+
+  // What THIS instance fetched, used only when the cache could not take it.
+  // Writing to session storage can fail - Safari private browsing, a blocked
+  // third-party context, an exhausted quota - and the store is the only path
+  // from response to screen, so without this a successful fetch would render
+  // placeholders forever. Component state rather than a module variable, so a
+  // failed write in one place cannot leak a stale value into another.
+  const [fetched, setFetched] = useState<ReleaseLane[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const list = (await fetchJson(`${GITHUB_RELEASES_ENDPOINT}?list=1`)) as RawRelease[] | null;
+      if (!active || !Array.isArray(list) || list.length === 0) return;
+      const resolved = toLanes(list);
+      setJsonStorageItem('session', LANES_CACHE_KEY, resolved);
+      emitSessionCacheChange();
+      setFetched(resolved);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Prefer what this instance actually fetched.
+  //
+  // An earlier version returned the store whenever it held anything, which only
+  // covered a cold cache: with STALE lanes already cached and the refresh write
+  // then failing, the store stayed non-empty and the fresh result was discarded
+  // on every render, so the hero kept showing old releases forever. Preferring
+  // the fetched value is never worse - when the write succeeds the two agree,
+  // and when it fails this is the only copy of the newer data.
+  return fetched ?? cached;
+}
+
+/**
  * Newest release from the repo's releases list whose TAG matches `matchesTag`. Matching on the tag
  * (not the free-text title) keeps e.g. a backend release that merely mentions "mobile" from being
  * picked; the list is newest-first, so the first match is the latest. Shared by useMobileRelease

--- a/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
+++ b/packages/database/prisma/migrations/20260824010000_add_task_recommendation_rules/migration.sql
@@ -1,0 +1,72 @@
+-- Recommendation rules: a husbandry task tied to a species, breed and age window,
+-- carrying the clinical source it rests on.
+--
+-- Additive only. Nothing existing is altered; TaskLibraryDefinition gains a
+-- back-relation, which is a Prisma-level concept and needs no column here.
+
+CREATE TYPE "RecommendationEvidenceGrade" AS ENUM (
+  'CONSENSUS_STATEMENT',
+  'PRACTICE_GUIDELINE',
+  'POPULATION_STUDY',
+  'COHORT_STUDY',
+  'CASE_SERIES',
+  'EXPERT_OPINION'
+);
+
+CREATE TABLE "TaskRecommendationRule" (
+  "id"                 TEXT NOT NULL,
+  "species"            "TaskLibrarySpecies" NOT NULL,
+  -- No NOT NULL here: Prisma treats a scalar list as implicitly non-null and does
+  -- not emit the constraint, so adding it would read as drift against the schema.
+  "breedCodes"         TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "minAgeMonths"       INTEGER,
+  "maxAgeMonths"       INTEGER,
+  "taskDefinitionId"   TEXT NOT NULL,
+  "recommendationText" TEXT NOT NULL,
+  "citationAuthors"    TEXT NOT NULL,
+  "citationTitle"      TEXT NOT NULL,
+  "citationSource"     TEXT NOT NULL,
+  "citationYear"       INTEGER NOT NULL,
+  "citationDoi"        TEXT,
+  "citationUrl"        TEXT,
+  "citationClaim"      TEXT NOT NULL,
+  "evidenceGrade"      "RecommendationEvidenceGrade" NOT NULL,
+  "lastReviewedAt"     TIMESTAMP(3),
+  "reviewedBy"         TEXT,
+  "nextReviewDue"      TIMESTAMP(3),
+  -- Defaults to FALSE, unlike almost every other isActive in this schema. A rule
+  -- reaches pet parents only once a named reviewer has signed it off, so a row
+  -- inserted by a seed or a migration is inert until someone does.
+  "isActive"           BOOLEAN NOT NULL DEFAULT false,
+  "createdAt"          TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"          TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "TaskRecommendationRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "TaskRecommendationRule_species_isActive_idx"
+  ON "TaskRecommendationRule"("species", "isActive");
+
+CREATE INDEX "TaskRecommendationRule_taskDefinitionId_idx"
+  ON "TaskRecommendationRule"("taskDefinitionId");
+
+ALTER TABLE "TaskRecommendationRule"
+  ADD CONSTRAINT "TaskRecommendationRule_taskDefinitionId_fkey"
+  FOREIGN KEY ("taskDefinitionId") REFERENCES "TaskLibraryDefinition"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Enable row level security, matching 20260818090000_enable_row_level_security.
+--
+-- That migration switches RLS on by looping over every table in `public`, which
+-- makes it idempotent but only covers tables that existed when it ran. A table
+-- created by a later migration ships with RLS off, and the CI step "Check row
+-- level security is enabled on every public table" fails on it - which is how
+-- this was caught here, and how it was caught on CareReminderOptOut before it.
+--
+-- Enabling with no policy is the intended default: the API connects as the
+-- owning role and bypasses RLS, so Prisma queries are unaffected, while
+-- Supabase's PostgREST surface to the `anon` and `authenticated` keys is denied.
+-- That matters here because these rows carry clinical guidance that is only safe
+-- to read once a reviewer has signed it off - the `isActive` and `reviewedBy`
+-- gate lives in the application, and PostgREST would go straight past it.
+ALTER TABLE "TaskRecommendationRule" ENABLE ROW LEVEL SECURITY;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -8,8 +8,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -226,7 +226,7 @@ model ContactRequest {
   userId           String?
   email            String?
   organisationId   String?
-  patientId      String?
+  patientId        String?
   parentId         String?
   dsarDetails      Json?
   complaintContext Json?
@@ -245,20 +245,20 @@ model ContactRequest {
 }
 
 model IntegrationAccount {
-  id             String              @id @default(uuid())
-  organisationId String
-  provider       IntegrationProvider
-  status         IntegrationStatus   @default(disabled)
-  enabledAt      DateTime?
-  disabledAt     DateTime?
-  lastSyncAt     DateTime?
-  lastError      String?
+  id                String                       @id @default(uuid())
+  organisationId    String
+  provider          IntegrationProvider
+  status            IntegrationStatus            @default(disabled)
+  enabledAt         DateTime?
+  disabledAt        DateTime?
+  lastSyncAt        DateTime?
+  lastError         String?
   credentialsStatus IntegrationCredentialsStatus @default(missing)
   lastValidatedAt   DateTime?
-  credentials    Json?
-  config         Json?
-  createdAt      DateTime            @default(now())
-  updatedAt      DateTime            @updatedAt
+  credentials       Json?
+  config            Json?
+  createdAt         DateTime                     @default(now())
+  updatedAt         DateTime                     @updatedAt
 
   @@unique([organisationId, provider])
   @@index([organisationId])
@@ -314,7 +314,7 @@ model LabOrder {
   id                     String           @id @default(uuid())
   organisationId         String
   provider               String
-  patientId            String
+  patientId              String
   parentId               String
   appointmentId          String?
   createdByUserId        String?
@@ -346,28 +346,28 @@ model LabOrder {
 }
 
 model LabResult {
-  id                    String   @id @default(uuid())
-  organisationId        String?
-  provider              String
-  resultId              String
-  orderId               String?
-  requisitionId         String?
-  accessionId           String?
-  diagnosticSetId       String?
-  status                String?
-  statusDetail          String?
-  modality              String?
-  patientId             String?
-  patientName           String?
-  clientId              String?
-  clientFirstName       String?
-  clientLastName        String?
-  updatedDate           String?
-  updatedAuditDate      String?
+  id                     String   @id @default(uuid())
+  organisationId         String?
+  provider               String
+  resultId               String
+  orderId                String?
+  requisitionId          String?
+  accessionId            String?
+  diagnosticSetId        String?
+  status                 String?
+  statusDetail           String?
+  modality               String?
+  patientId              String?
+  patientName            String?
+  clientId               String?
+  clientFirstName        String?
+  clientLastName         String?
+  updatedDate            String?
+  updatedAuditDate       String?
   specimenCollectionDate String?
-  rawPayload            Json?
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  rawPayload             Json?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   @@unique([provider, resultId])
   @@index([provider, orderId])
@@ -375,52 +375,52 @@ model LabResult {
 }
 
 model LabResultSyncState {
-  id           String   @id @default(uuid())
-  provider     String   @unique
-  lastBatchId  String?
+  id            String    @id @default(uuid())
+  provider      String    @unique
+  lastBatchId   String?
   lastTimestamp String?
-  lastPolledAt DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  lastPolledAt  DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 }
 
 model Patient {
-  id               String        @id @default(uuid())
-  name             String
-  type             PatientType
-  breed            String
-  speciesCode      String?
-  breedCode        String?
-  dateOfBirth      DateTime
-  gender           Gender
-  photoUrl         String?
-  currentWeight    Float?
-  colour           String?
-  allergy          String?
-  bloodGroup       String?
-  isNeutered       Boolean?
-  ageWhenNeutered  String?
-  microchipNumber  String?
+  id                   String        @id @default(uuid())
+  name                 String
+  type                 PatientType
+  breed                String
+  speciesCode          String?
+  breedCode            String?
+  dateOfBirth          DateTime
+  gender               Gender
+  photoUrl             String?
+  currentWeight        Float?
+  colour               String?
+  allergy              String?
+  bloodGroup           String?
+  isNeutered           Boolean?
+  ageWhenNeutered      String?
+  microchipNumber      String?
   microchipImplantedAt DateTime?
-  microchipLocation String?
-  passportNumber   String?
-  isInsured        Boolean       @default(false)
-  insurance        Json?
-  countryOfOrigin  String?
-  source           SourceType?
-  status           RecordStatus?
-  physicalAttribute Json?
-  breedingInfo     Json?
-  medicalRecords   Json?
-  alerts           Json?
-  isProfileComplete Boolean      @default(false)
-  createdAt        DateTime      @default(now())
-  updatedAt        DateTime      @updatedAt
+  microchipLocation    String?
+  passportNumber       String?
+  isInsured            Boolean       @default(false)
+  insurance            Json?
+  countryOfOrigin      String?
+  source               SourceType?
+  status               RecordStatus?
+  physicalAttribute    Json?
+  breedingInfo         Json?
+  medicalRecords       Json?
+  alerts               Json?
+  isProfileComplete    Boolean       @default(false)
+  createdAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
 
-  documents         Document[]
-  formAssignments   FormAssignment[]
-  organisations     PatientOrganisation[]
-  parentLinks       ParentPatient[]
+  documents            Document[]
+  formAssignments      FormAssignment[]
+  organisations        PatientOrganisation[]
+  parentLinks          ParentPatient[]
   companionShareTokens CompanionShareToken[]
   petPassports         PetPassport[]
 
@@ -429,24 +429,24 @@ model Patient {
 }
 
 model Document {
-  id                 String               @id @default(uuid())
-  patientId        String
-  appointmentId      String?
-  category           String
-  subcategory        String?
-  visitType          String?
-  title              String
+  id                  String    @id @default(uuid())
+  patientId           String
+  appointmentId       String?
+  category            String
+  subcategory         String?
+  visitType           String?
+  title               String
   issuingBusinessName String?
-  issueDate          DateTime?
-  uploadedByParentId String?
+  issueDate           DateTime?
+  uploadedByParentId  String?
   uploadedByPmsUserId String?
-  pmsVisible         Boolean              @default(false)
-  syncedFromPms      Boolean              @default(false)
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
+  pmsVisible          Boolean   @default(false)
+  syncedFromPms       Boolean   @default(false)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
-  patient          Patient            @relation(fields: [patientId], references: [id])
-  attachments        DocumentAttachment[]
+  patient     Patient              @relation(fields: [patientId], references: [id])
+  attachments DocumentAttachment[]
 
   @@index([patientId])
   @@index([patientId, category])
@@ -455,56 +455,56 @@ model Document {
 }
 
 model DocumentAttachment {
-  id         String   @id @default(uuid())
+  id         String @id @default(uuid())
   documentId String
   key        String
   mimeType   String
   size       Int?
 
-  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
 
   @@index([documentId])
 }
 
 model PatientOrganisation {
-  id                    String                     @id @default(uuid())
-  patientId           String
-  organisationId        String?
-  linkedByParentId      String?
-  linkedByPmsUserId     String?
-  organisationType      OrganisationType
-  role                  PatientOrganisationRole  @default(ORGANISATION)
-  status                PatientOrganisationStatus @default(ACTIVE)
-  invitedViaEmail       String?
-  organisationName      String?
-  organisationPlacesId  String?
-  inviteToken           String?
-  acceptedAt            DateTime?
-  rejectedAt            DateTime?
-  createdAt             DateTime                   @default(now())
-  updatedAt             DateTime                   @updatedAt
+  id                   String                    @id @default(uuid())
+  patientId            String
+  organisationId       String?
+  linkedByParentId     String?
+  linkedByPmsUserId    String?
+  organisationType     OrganisationType
+  role                 PatientOrganisationRole   @default(ORGANISATION)
+  status               PatientOrganisationStatus @default(ACTIVE)
+  invitedViaEmail      String?
+  organisationName     String?
+  organisationPlacesId String?
+  inviteToken          String?
+  acceptedAt           DateTime?
+  rejectedAt           DateTime?
+  createdAt            DateTime                  @default(now())
+  updatedAt            DateTime                  @updatedAt
 
-  patient             Patient                  @relation(fields: [patientId], references: [id])
+  patient Patient @relation(fields: [patientId], references: [id])
+  // Partial unique index for ACTIVE rows is maintained via SQL migration because
+  // Prisma schema cannot express `WHERE status = 'ACTIVE'`.
 
   @@index([patientId])
   @@index([organisationId])
-  // Partial unique index for ACTIVE rows is maintained via SQL migration because
-  // Prisma schema cannot express `WHERE status = 'ACTIVE'`.
 }
 
 model ParentPatient {
-  id                String               @id @default(uuid())
+  id                String              @id @default(uuid())
   parentId          String
-  patientId       String
+  patientId         String
   role              ParentPatientRole
   status            ParentPatientStatus @default(ACTIVE)
   permissions       Json
   invitedByParentId String?
   acceptedAt        DateTime?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
 
-  patient         Patient            @relation(fields: [patientId], references: [id])
+  patient Patient @relation(fields: [patientId], references: [id])
 
   @@unique([parentId, patientId])
   @@index([parentId])
@@ -541,7 +541,7 @@ model CompanionShareToken {
   createdAt               DateTime              @default(now())
   updatedAt               DateTime              @updatedAt
 
-  patient                 Patient               @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
   @@index([organisationId])
@@ -570,17 +570,17 @@ enum ParasiteTreatmentType {
 }
 
 model PetPassport {
-  id                String        @id @default(uuid())
-  patientId         String
-  organisationId    String
-  passportNumber    String        @unique
-  issuingCountry    String?
-  issuingAuthority  String?
-  issuingVetId      String?
-  issuingVetName    String?
-  issuingVetLicense String?
-  issueDate         DateTime      @default(now())
-  status            RecordStatus?
+  id                           String        @id @default(uuid())
+  patientId                    String
+  organisationId               String
+  passportNumber               String        @unique
+  issuingCountry               String?
+  issuingAuthority             String?
+  issuingVetId                 String?
+  issuingVetName               String?
+  issuingVetLicense            String?
+  issueDate                    DateTime      @default(now())
+  status                       RecordStatus?
   // Credential for the public QR / wallet verification page. The patient id must
   // never be used for this: it is an internal identifier already handed to
   // authenticated clients and embedded in app routes, so it can be neither
@@ -591,9 +591,9 @@ model PetPassport {
   // baked into the QR of Apple and Google Wallet passes that already live on
   // owners' phones, and regenerating a pass must not invalidate the copies
   // already issued - which requires reading the value back.
-  publicToken       String?       @unique
-  publicTokenIssuedAt DateTime?
-  publicTokenRevokedAt DateTime?
+  publicToken                  String?       @unique
+  publicTokenIssuedAt          DateTime?
+  publicTokenRevokedAt         DateTime?
   // Staff-facing wallet passes carry THIS token, never `publicToken`.
   //
   // The owner's public token resolves with "owner" scope, which shows every
@@ -605,13 +605,13 @@ model PetPassport {
   // "practice" scope, so it grants strictly less than the staff member already
   // has. Minting it from a staff session is therefore safe, unlike the public
   // token, which only the owner may create.
-  practiceWalletToken       String?       @unique
-  practiceWalletTokenIssuedAt DateTime?
+  practiceWalletToken          String?       @unique
+  practiceWalletTokenIssuedAt  DateTime?
   practiceWalletTokenRevokedAt DateTime?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  createdAt                    DateTime      @default(now())
+  updatedAt                    DateTime      @updatedAt
 
-  patient           Patient       @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
 
   @@index([patientId])
   @@index([organisationId])
@@ -657,36 +657,37 @@ model PassportShareConsent {
 }
 
 model Appointment {
-  id                String            @id @default(uuid())
+  id              String            @id @default(uuid())
   patient         Json
-  lead              Json?
-  supportStaff      Json?
-  room              Json?
-  appointmentType   Json?
-  caseId            String?
-  encounterId       String?
-  productItemId     String?
-  appointmentKind   AppointmentKind   @default(OUTPATIENT)
-  idempotencyKey    String?
-  organisationId    String
-  appointmentDate   DateTime
-  startTime         DateTime
-  endTime           DateTime
-  timeSlot          String
-  durationMinutes   Int
-  status            AppointmentStatus @default(REQUESTED)
-  isEmergency       Boolean           @default(false)
-  concern           String?
-  attachments       Json?
-  formIds           String[]
-  expiresAt         DateTime?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  lead            Json?
+  supportStaff    Json?
+  room            Json?
+  appointmentType Json?
+  caseId          String?
+  encounterId     String?
+  productItemId   String?
+  appointmentKind AppointmentKind   @default(OUTPATIENT)
+  idempotencyKey  String?
+  organisationId  String
+  appointmentDate DateTime
+  startTime       DateTime
+  endTime         DateTime
+  timeSlot        String
+  durationMinutes Int
+  status          AppointmentStatus @default(REQUESTED)
+  isEmergency     Boolean           @default(false)
+  concern         String?
+  attachments     Json?
+  formIds         String[]
+  expiresAt       DateTime?
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 
-  caseRecord        Case?             @relation("CaseAppointments", fields: [caseId], references: [id], onDelete: SetNull)
-  encounter         Encounter?        @relation("EncounterAppointments", fields: [encounterId], references: [id], onDelete: SetNull)
-  formAssignments   FormAssignment[]
+  caseRecord      Case?            @relation("CaseAppointments", fields: [caseId], references: [id], onDelete: SetNull)
+  encounter       Encounter?       @relation("EncounterAppointments", fields: [encounterId], references: [id], onDelete: SetNull)
+  formAssignments FormAssignment[]
 
+  @@unique([organisationId, idempotencyKey])
   @@index([organisationId, appointmentDate])
   @@index([organisationId])
   @@index([organisationId, productItemId])
@@ -694,13 +695,12 @@ model Appointment {
   @@index([encounterId])
   @@index([status])
   @@index([expiresAt])
-  @@unique([organisationId, idempotencyKey])
 }
 
 model Case {
   id              String          @id @default(uuid())
   organisationId  String
-  patientId     String
+  patientId       String
   parentId        String?
   status          String
   appointmentKind AppointmentKind @default(OUTPATIENT)
@@ -709,8 +709,8 @@ model Case {
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 
-  appointments    Appointment[]   @relation("CaseAppointments")
-  encounters      Encounter[]
+  appointments Appointment[] @relation("CaseAppointments")
+  encounters   Encounter[]
 
   @@index([organisationId, status])
   @@index([organisationId, appointmentKind])
@@ -722,7 +722,7 @@ model Encounter {
   id              String          @id @default(uuid())
   caseId          String
   organisationId  String
-  patientId     String
+  patientId       String
   parentId        String?
   status          String
   encounterClass  String
@@ -734,8 +734,8 @@ model Encounter {
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 
-  caseRecord      Case            @relation(fields: [caseId], references: [id], onDelete: Cascade)
-  appointments    Appointment[]   @relation("EncounterAppointments")
+  caseRecord      Case                 @relation(fields: [caseId], references: [id], onDelete: Cascade)
+  appointments    Appointment[]        @relation("EncounterAppointments")
   admission       Admission?
   unitAssignments RoomUnitAssignment[]
 
@@ -747,20 +747,20 @@ model Encounter {
 }
 
 model Admission {
-  encounterId       String   @id
-  organisationId    String
-  patientId       String
-  unitId            String?
-  expectedStayDays  Int?
-  admittedAt        DateTime
-  admittedBy        String?
-  dischargedAt      DateTime?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  encounterId      String    @id
+  organisationId   String
+  patientId        String
+  unitId           String?
+  expectedStayDays Int?
+  admittedAt       DateTime
+  admittedBy       String?
+  dischargedAt     DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  encounter         Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
-  currentUnit       RoomUnit? @relation("AdmissionCurrentUnit", fields: [unitId], references: [id], onDelete: SetNull)
-  assignments       RoomUnitAssignment[]
+  encounter   Encounter            @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  currentUnit RoomUnit?            @relation("AdmissionCurrentUnit", fields: [unitId], references: [id], onDelete: SetNull)
+  assignments RoomUnitAssignment[]
 
   @@index([organisationId, admittedAt])
   @@index([organisationId, dischargedAt])
@@ -768,27 +768,27 @@ model Admission {
 }
 
 model ChatSession {
-  id              String            @id @default(uuid())
-  type            ChatSessionType
-  appointmentId   String?
-  channelId       String
-  organisationId  String
+  id                        String            @id @default(uuid())
+  type                      ChatSessionType
+  appointmentId             String?
+  channelId                 String
+  organisationId            String
   counterpartOrganisationId String?
-  patientId     String?
-  parentId        String?
-  vetId           String?
-  supportStaffIds String[]
-  createdBy       String?
-  title           String?
-  isPrivate       Boolean           @default(true)
-  members         String[]
-  participants    Json?
-  status          ChatSessionStatus @default(PENDING)
-  allowedFrom     DateTime?
-  allowedUntil    DateTime?
-  closedAt        DateTime?
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+  patientId                 String?
+  parentId                  String?
+  vetId                     String?
+  supportStaffIds           String[]
+  createdBy                 String?
+  title                     String?
+  isPrivate                 Boolean           @default(true)
+  members                   String[]
+  participants              Json?
+  status                    ChatSessionStatus @default(PENDING)
+  allowedFrom               DateTime?
+  allowedUntil              DateTime?
+  closedAt                  DateTime?
+  createdAt                 DateTime          @default(now())
+  updatedAt                 DateTime          @updatedAt
 
   @@index([type])
   @@index([appointmentId])
@@ -835,93 +835,93 @@ model SharedChatEntity {
 }
 
 model Parent {
-  id               String            @id @default(uuid())
-  firstName        String
-  lastName         String?
-  birthDate        DateTime?
-  email            String
-  phoneNumber      String?
-  currency         String?
-  timezone         String?
-  profileImageUrl  String?
-  isProfileComplete Boolean          @default(false)
-  linkedUserId     String?
-  createdFrom      ParentCreatedFrom
-  address          ParentAddress?
-  alerts           Json?
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
+  id                String            @id @default(uuid())
+  firstName         String
+  lastName          String?
+  birthDate         DateTime?
+  email             String
+  phoneNumber       String?
+  currency          String?
+  timezone          String?
+  profileImageUrl   String?
+  isProfileComplete Boolean           @default(false)
+  linkedUserId      String?
+  createdFrom       ParentCreatedFrom
+  address           ParentAddress?
+  alerts            Json?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
 
   @@index([email])
 }
 
 model ParentAddress {
-  id           String   @id @default(uuid())
-  parentId     String   @unique
-  addressLine  String?
-  country      String?
-  city         String?
-  state        String?
-  postalCode   String?
-  latitude     Float?
-  longitude    Float?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id          String   @id @default(uuid())
+  parentId    String   @unique
+  addressLine String?
+  country     String?
+  city        String?
+  state       String?
+  postalCode  String?
+  latitude    Float?
+  longitude   Float?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  parent       Parent   @relation(fields: [parentId], references: [id], onDelete: Cascade)
+  parent Parent @relation(fields: [parentId], references: [id], onDelete: Cascade)
 }
 
 model Organization {
-  id                          String           @id @default(uuid())
-  fhirId                      String?
-  name                        String
-  taxId                       String
-  dunsNumber                  String?
-  imageUrl                    String?
-  type                        OrganizationType
-  petNamePreference           PetNamePreference? @default(PATIENT)
-  phoneNo                     String
-  email                       String?
-  website                     String?
-  documensoTeamId             String?
-  documensoApiKey             String?
-  address                     OrganizationAddress?
-  isVerified                  Boolean          @default(false)
-  verificationOverride        Boolean?
-  isActive                    Boolean          @default(true)
-  typeCoding                  Json?
-  healthAndSafetyCertNo       String?
-  animalWelfareComplianceCertNo String?
-  fireAndEmergencyCertNo      String?
-  googlePlacesId              String?
-  stripeAccountId             String?
-  averageRating               Float            @default(0)
-  ratingCount                 Int              @default(0)
-  appointmentCheckInBufferMinutes Int          @default(5)
-  appointmentCheckInRadiusMeters  Int          @default(200)
+  id                                     String               @id @default(uuid())
+  fhirId                                 String?
+  name                                   String
+  taxId                                  String
+  dunsNumber                             String?
+  imageUrl                               String?
+  type                                   OrganizationType
+  petNamePreference                      PetNamePreference?   @default(PATIENT)
+  phoneNo                                String
+  email                                  String?
+  website                                String?
+  documensoTeamId                        String?
+  documensoApiKey                        String?
+  address                                OrganizationAddress?
+  isVerified                             Boolean              @default(false)
+  verificationOverride                   Boolean?
+  isActive                               Boolean              @default(true)
+  typeCoding                             Json?
+  healthAndSafetyCertNo                  String?
+  animalWelfareComplianceCertNo          String?
+  fireAndEmergencyCertNo                 String?
+  googlePlacesId                         String?
+  stripeAccountId                        String?
+  averageRating                          Float                @default(0)
+  ratingCount                            Int                  @default(0)
+  appointmentCheckInBufferMinutes        Int                  @default(5)
+  appointmentCheckInRadiusMeters         Int                  @default(200)
   appointmentLockWindowOutpatientMinutes Int?
-  appointmentLockWindowInpatientMinutes   Int?
-  crossOrgMessagingEnabled    Boolean          @default(false)
-  maxOverallDiscountPercent   Float?
-  createdAt                   DateTime         @default(now())
-  updatedAt                   DateTime         @updatedAt
+  appointmentLockWindowInpatientMinutes  Int?
+  crossOrgMessagingEnabled               Boolean              @default(false)
+  maxOverallDiscountPercent              Float?
+  createdAt                              DateTime             @default(now())
+  updatedAt                              DateTime             @updatedAt
 
   @@index([googlePlacesId, name])
 }
 
 model OrganizationAddress {
-  id           String       @id @default(uuid())
-  organizationId String     @unique
-  addressLine  String?
-  country      String?
-  city         String?
-  state        String?
-  postalCode   String?
-  latitude     Float?
-  longitude    Float?
-  location     Json?
-  createdAt    DateTime     @default(now())
-  updatedAt    DateTime     @updatedAt
+  id             String   @id @default(uuid())
+  organizationId String   @unique
+  addressLine    String?
+  country        String?
+  city           String?
+  state          String?
+  postalCode     String?
+  latitude       Float?
+  longitude      Float?
+  location       Json?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 }
@@ -940,14 +940,14 @@ model User {
 }
 
 model UserProfile {
-  id                  String            @id @default(uuid())
+  id                  String              @id @default(uuid())
   userId              String
   organizationId      String
   personalDetails     Json?
   professionalDetails Json?
-  status              UserProfileStatus @default(DRAFT)
-  createdAt           DateTime          @default(now())
-  updatedAt           DateTime          @updatedAt
+  status              UserProfileStatus   @default(DRAFT)
+  createdAt           DateTime            @default(now())
+  updatedAt           DateTime            @updatedAt
   address             UserProfileAddress?
 
   @@unique([userId, organizationId])
@@ -956,8 +956,8 @@ model UserProfile {
 }
 
 model UserProfileAddress {
-  id            String      @id @default(uuid())
-  userProfileId String      @unique
+  id            String   @id @default(uuid())
+  userProfileId String   @unique
   addressLine   String?
   country       String?
   city          String?
@@ -965,25 +965,25 @@ model UserProfileAddress {
   postalCode    String?
   latitude      Float?
   longitude     Float?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
-  userProfile   UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
+  userProfile UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
 }
 
 model UserOrganization {
-  id                      String   @id @default(uuid())
-  fhirId                  String?
-  practitionerReference   String
-  organizationReference   String
-  roleCode                String
-  roleDisplay             String?
-  active                  Boolean  @default(true)
-  extraPermissions        String[]
-  revokedPermissions      String[]
-  effectivePermissions    String[]
-  createdAt               DateTime @default(now())
-  updatedAt               DateTime @updatedAt
+  id                    String   @id @default(uuid())
+  fhirId                String?
+  practitionerReference String
+  organizationReference String
+  roleCode              String
+  roleDisplay           String?
+  active                Boolean  @default(true)
+  extraPermissions      String[]
+  revokedPermissions    String[]
+  effectivePermissions  String[]
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
 
   @@unique([practitionerReference, organizationReference, roleCode], map: "unique_user_org_role")
 }
@@ -1161,18 +1161,18 @@ model OrganizationBilling {
 }
 
 model SubscriptionEntitlement {
-  id            String   @id @default(uuid())
-  orgId         String
-  code          String
-  name          String?
-  value         Json?
-  source        String   @default("MANUAL")
-  status        String   @default("ACTIVE")
-  grantedAt     DateTime @default(now())
-  expiresAt     DateTime?
-  metadata      Json?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id        String    @id @default(uuid())
+  orgId     String
+  code      String
+  name      String?
+  value     Json?
+  source    String    @default("MANUAL")
+  status    String    @default("ACTIVE")
+  grantedAt DateTime  @default(now())
+  expiresAt DateTime?
+  metadata  Json?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@unique([orgId, code])
   @@index([orgId, status])
@@ -1180,17 +1180,17 @@ model SubscriptionEntitlement {
 }
 
 model FinanceProviderLink {
-  id                     String   @id @default(uuid())
-  orgId                  String
-  provider               String
-  externalCustomerId     String?
-  externalSubscriptionId String?
+  id                         String   @id @default(uuid())
+  orgId                      String
+  provider                   String
+  externalCustomerId         String?
+  externalSubscriptionId     String?
   externalSubscriptionItemId String?
-  externalPriceId        String?
-  externalProductId      String?
-  metadata               Json?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  externalPriceId            String?
+  externalProductId          String?
+  metadata                   Json?
+  createdAt                  DateTime @default(now())
+  updatedAt                  DateTime @updatedAt
 
   @@unique([orgId, provider])
   @@index([externalSubscriptionId])
@@ -1199,18 +1199,18 @@ model FinanceProviderLink {
 }
 
 model UsageEvent {
-  id                String   @id @default(uuid())
-  orgId             String
-  usageKey          String
-  quantity          Int      @default(1)
-  billableQuantity  Int      @default(1)
-  source            String
-  referenceType     String?
-  referenceId       String?
-  metadata          Json?
-  occurredAt        DateTime @default(now())
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  id               String   @id @default(uuid())
+  orgId            String
+  usageKey         String
+  quantity         Int      @default(1)
+  billableQuantity Int      @default(1)
+  source           String
+  referenceType    String?
+  referenceId      String?
+  metadata         Json?
+  occurredAt       DateTime @default(now())
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   @@index([orgId, usageKey, occurredAt])
   @@index([orgId, referenceType, referenceId])
@@ -1235,16 +1235,16 @@ model UsageSnapshot {
 }
 
 model FinanceEvent {
-  id            String   @id @default(uuid())
+  id             String    @id @default(uuid())
   organisationId String?
-  eventType     String
-  entityType    String
-  entityId      String
-  payload       Json
-  occurredAt    DateTime @default(now())
-  processedAt   DateTime?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  eventType      String
+  entityType     String
+  entityId       String
+  payload        Json
+  occurredAt     DateTime  @default(now())
+  processedAt    DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@index([organisationId])
   @@index([eventType])
@@ -1255,31 +1255,31 @@ model FinanceEvent {
 }
 
 model OrganizationDocument {
-  id              String                @id @default(uuid())
-  organisationId  String
-  title           String
-  description     String?               @default("")
-  category        OrgDocumentCategory
-  fileUrl         String?
-  fileName        String?
-  fileType        String?
-  fileSize        Int?
-  visibility      OrgDocumentVisibility @default(INTERNAL)
-  version         Int                   @default(1)
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  id             String                @id @default(uuid())
+  organisationId String
+  title          String
+  description    String?               @default("")
+  category       OrgDocumentCategory
+  fileUrl        String?
+  fileName       String?
+  fileType       String?
+  fileSize       Int?
+  visibility     OrgDocumentVisibility @default(INTERNAL)
+  version        Int                   @default(1)
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
 
   @@index([organisationId])
 }
 
 model OrganizationDocumentAcknowledgement {
-  id             String               @id @default(uuid())
+  id             String              @id @default(uuid())
   organisationId String
   documentId     String
   category       OrgDocumentCategory
   version        Int
   userId         String
-  acknowledgedAt DateTime             @default(now())
+  acknowledgedAt DateTime            @default(now())
 
   @@unique([userId, organisationId, documentId, category, version])
   @@index([organisationId, documentId, category])
@@ -1288,26 +1288,26 @@ model OrganizationDocumentAcknowledgement {
 }
 
 model OrganisationRoom {
-  id                    String                @id @default(uuid())
+  id                    String               @id @default(uuid())
   organisationId        String
   name                  String
   code                  String
   description           String?
   type                  RoomType
-  occupancyStatus       RoomOccupancyStatus   @default(VACANT)
-  availableNow          Boolean               @default(true)
-  availabilityMode      RoomAvailabilityMode  @default(ALL_DAY)
-  availabilityDays      String[]              @default([])
-  availabilityStartTime  String?
-  availabilityEndTime    String?
-  capabilities          String[]              @default([])
-  createdAt             DateTime              @default(now())
-  updatedAt             DateTime              @updatedAt
+  occupancyStatus       RoomOccupancyStatus  @default(VACANT)
+  availableNow          Boolean              @default(true)
+  availabilityMode      RoomAvailabilityMode @default(ALL_DAY)
+  availabilityDays      String[]             @default([])
+  availabilityStartTime String?
+  availabilityEndTime   String?
+  capabilities          String[]             @default([])
+  createdAt             DateTime             @default(now())
+  updatedAt             DateTime             @updatedAt
 
-  units                 RoomUnit[]
-  unitGroups            RoomUnitGroup[]
-  specialityLinks       OrganisationRoomSpeciality[]
-  staffLinks            OrganisationRoomStaff[]
+  units           RoomUnit[]
+  unitGroups      RoomUnitGroup[]
+  specialityLinks OrganisationRoomSpeciality[]
+  staffLinks      OrganisationRoomStaff[]
 
   @@unique([organisationId, code])
   @@index([organisationId])
@@ -1322,8 +1322,8 @@ model OrganisationRoomSpeciality {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  speciality     Speciality       @relation(fields: [specialityId], references: [id], onDelete: Cascade)
+  room       OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  speciality Speciality       @relation(fields: [specialityId], references: [id], onDelete: Cascade)
 
   @@unique([roomId, specialityId])
   @@index([organisationId])
@@ -1339,8 +1339,8 @@ model OrganisationRoomStaff {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  staff          User             @relation(fields: [staffUserId], references: [userId], onDelete: Cascade)
+  room  OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  staff User             @relation(fields: [staffUserId], references: [userId], onDelete: Cascade)
 
   @@unique([roomId, staffUserId])
   @@index([organisationId])
@@ -1361,10 +1361,10 @@ model RoomUnit {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  room               OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  unitGroup          RoomUnitGroup?       @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
-  currentAdmissions  Admission[]          @relation("AdmissionCurrentUnit")
-  assignments        RoomUnitAssignment[]
+  room              OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  unitGroup         RoomUnitGroup?       @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
+  currentAdmissions Admission[]          @relation("AdmissionCurrentUnit")
+  assignments       RoomUnitAssignment[]
 
   @@unique([roomId, code])
   @@index([organisationId])
@@ -1374,42 +1374,42 @@ model RoomUnit {
 }
 
 model RoomUnitGroup {
-  id                  String   @id @default(uuid())
-  organisationId      String
-  roomId              String
-  name                String
-  size                String?
-  unitCount           Int      @default(0)
-  speciesConstraints   Json?
-  capabilities        String[] @default([])
-  isActive            Boolean  @default(true)
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  id                 String   @id @default(uuid())
+  organisationId     String
+  roomId             String
+  name               String
+  size               String?
+  unitCount          Int      @default(0)
+  speciesConstraints Json?
+  capabilities       String[] @default([])
+  isActive           Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
-  room                OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  units               RoomUnit[]
+  room  OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  units RoomUnit[]
 
+  @@unique([roomId, name])
   @@index([organisationId])
   @@index([roomId])
   @@index([isActive])
-  @@unique([roomId, name])
 }
 
 model RoomUnitAssignment {
-  id           String   @id @default(uuid())
-  encounterId  String
-  admissionId  String
-  unitId       String
-  assignedAt   DateTime
-  releasedAt   DateTime?
-  assignedBy   String?
-  reason       String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id          String    @id @default(uuid())
+  encounterId String
+  admissionId String
+  unitId      String
+  assignedAt  DateTime
+  releasedAt  DateTime?
+  assignedBy  String?
+  reason      String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
-  encounter    Encounter  @relation(fields: [encounterId], references: [id], onDelete: Cascade)
-  admission    Admission  @relation(fields: [admissionId], references: [encounterId], onDelete: Cascade)
-  unit         RoomUnit   @relation(fields: [unitId], references: [id], onDelete: Cascade)
+  encounter Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  admission Admission @relation(fields: [admissionId], references: [encounterId], onDelete: Cascade)
+  unit      RoomUnit  @relation(fields: [unitId], references: [id], onDelete: Cascade)
 
   @@index([encounterId, assignedAt])
   @@index([admissionId, assignedAt])
@@ -1418,20 +1418,20 @@ model RoomUnitAssignment {
 }
 
 model OrganisationInvite {
-  id               String                      @id @default(uuid())
-  organisationId   String
-  invitedByUserId  String
-  departmentIds    String[]
-  inviteeEmail     String
-  inviteeName      String?
-  role             String
-  employmentType   OrganisationInviteEmploymentType?
-  token            String                      @unique
-  status           OrganisationInviteStatus    @default(PENDING)
-  expiresAt        DateTime
-  acceptedAt       DateTime?
-  createdAt        DateTime                    @default(now())
-  updatedAt        DateTime                    @updatedAt
+  id              String                            @id @default(uuid())
+  organisationId  String
+  invitedByUserId String
+  departmentIds   String[]
+  inviteeEmail    String
+  inviteeName     String?
+  role            String
+  employmentType  OrganisationInviteEmploymentType?
+  token           String                            @unique
+  status          OrganisationInviteStatus          @default(PENDING)
+  expiresAt       DateTime
+  acceptedAt      DateTime?
+  createdAt       DateTime                          @default(now())
+  updatedAt       DateTime                          @updatedAt
 
   @@index([organisationId])
   @@index([token])
@@ -1440,30 +1440,30 @@ model OrganisationInvite {
 }
 
 model OrganisationRating {
-  id              String   @id @default(uuid())
-  organizationId  String
-  userId          String
-  rating          Int
-  review          String?  @default("")
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String   @id @default(uuid())
+  organizationId String
+  userId         String
+  rating         Int
+  review         String?  @default("")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@unique([organizationId, userId])
 }
 
 model OrganizationUsageCounter {
-  id                   String   @id @default(uuid())
-  orgId                String   @unique
-  appointmentsUsed     Int      @default(0)
-  toolsUsed            Int      @default(0)
-  usersActiveCount     Int      @default(0)
-  usersBillableCount   Int      @default(0)
-  freeAppointmentsLimit Int     @default(120)
-  freeToolsLimit       Int      @default(200)
-  freeUsersLimit       Int      @default(10)
-  freeLimitReachedAt   DateTime?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  id                    String    @id @default(uuid())
+  orgId                 String    @unique
+  appointmentsUsed      Int       @default(0)
+  toolsUsed             Int       @default(0)
+  usersActiveCount      Int       @default(0)
+  usersBillableCount    Int       @default(0)
+  freeAppointmentsLimit Int       @default(120)
+  freeToolsLimit        Int       @default(200)
+  freeUsersLimit        Int       @default(10)
+  freeLimitReachedAt    DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
 
   @@index([freeLimitReachedAt])
   @@map("OrgUsageCounters")
@@ -2131,6 +2131,7 @@ enum DayOfWeek {
   SATURDAY
   SUNDAY
 }
+
 enum ObservationFieldType {
   TEXT
   NUMBER
@@ -2155,44 +2156,45 @@ enum AdverseEventStatus {
 }
 
 model CoParentInvite {
-  id               String   @id @default(uuid())
-  email            String
-  inviteeName      String?
-  patientId      String
+  id                String    @id @default(uuid())
+  email             String
+  inviteeName       String?
+  patientId         String
   invitedByParentId String
-  inviteToken      String   @unique
-  expiresAt        DateTime
-  acceptedAt       DateTime?
-  diclinedAt       DateTime?
-  consumed         Boolean  @default(false)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  inviteToken       String    @unique
+  expiresAt         DateTime
+  acceptedAt        DateTime?
+  diclinedAt        DateTime?
+  consumed          Boolean   @default(false)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([email])
 }
+
 model ExternalExpense {
-  id            String   @id @default(uuid())
-  patientId   String
-  parentId      String
-  category      String
-  subcategory   String?
-  visitType     String?
-  expenseName   String
-  businessName  String?
-  date          DateTime
-  amount        Float
-  currency      String   @default("USD")
-  attachments   Json?
-  notes         String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id           String   @id @default(uuid())
+  patientId    String
+  parentId     String
+  category     String
+  subcategory  String?
+  visitType    String?
+  expenseName  String
+  businessName String?
+  date         DateTime
+  amount       Float
+  currency     String   @default("USD")
+  attachments  Json?
+  notes        String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   @@index([patientId])
   @@index([parentId])
 }
 
 model Form {
-  id             String             @id @default(uuid())
+  id             String              @id @default(uuid())
   orgId          String
   businessType   OrganizationType?
   name           String
@@ -2202,16 +2204,16 @@ model Form {
   serviceId      String[]
   speciesFilter  String[]
   requiredSigner FormRequiredSigner?
-  status         FormStatus         @default(draft)
+  status         FormStatus          @default(draft)
   schema         Json
   createdBy      String
   updatedBy      String
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
-  fields         FormField[]
-  versions       FormVersion[]
-  submissions    FormSubmission[]
+  fields      FormField[]
+  versions    FormVersion[]
+  submissions FormSubmission[]
 
   @@index([orgId, status])
   @@index([orgId, category])
@@ -2235,7 +2237,7 @@ model FormField {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  form        Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@index([formId])
   @@index([type])
@@ -2251,7 +2253,7 @@ model FormVersion {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  form           Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@unique([formId, version])
   @@index([formId])
@@ -2262,7 +2264,7 @@ model FormSubmission {
   formId        String
   formVersion   Int
   appointmentId String?
-  patientId   String?
+  patientId     String?
   parentId      String?
   submittedBy   String?
   answers       Json
@@ -2271,7 +2273,7 @@ model FormSubmission {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  form          Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   @@index([formId])
   @@index([formId, formVersion])
@@ -2307,9 +2309,9 @@ model FormAssignment {
   createdAt       DateTime             @default(now())
   updatedAt       DateTime             @updatedAt
 
-  template        Template             @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  appointment     Appointment?         @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
-  companion       Patient?             @relation(fields: [companionId], references: [id], onDelete: SetNull)
+  template    Template     @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  appointment Appointment? @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+  companion   Patient?     @relation(fields: [companionId], references: [id], onDelete: SetNull)
 
   @@index([organisationId, appointmentId])
   @@index([organisationId, companionId])
@@ -2318,27 +2320,27 @@ model FormAssignment {
 }
 
 model Template {
-  id                 String               @id @default(uuid())
-  organisationId     String?
-  ownerUserId        String?
-  ownership          TemplateOwnershipType @default(ORG_TEMPLATE)
-  kind               TemplateKind
-  name               String
-  description        String?
-  status             TemplateStatus       @default(DRAFT)
-  scope              TemplateScope        @default(ORGANISATION)
-  rules              Json?
-  latestVersion      Int                  @default(1)
-  publishedVersion   Int?
-  createdBy          String
-  updatedBy          String
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
+  id               String                @id @default(uuid())
+  organisationId   String?
+  ownerUserId      String?
+  ownership        TemplateOwnershipType @default(ORG_TEMPLATE)
+  kind             TemplateKind
+  name             String
+  description      String?
+  status           TemplateStatus        @default(DRAFT)
+  scope            TemplateScope         @default(ORGANISATION)
+  rules            Json?
+  latestVersion    Int                   @default(1)
+  publishedVersion Int?
+  createdBy        String
+  updatedBy        String
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 
-  versions           TemplateVersion[]
-  instances          TemplateInstance[]
-  formAssignments   FormAssignment[]
-  catalogLinks       TemplateCatalogLink[]
+  versions        TemplateVersion[]
+  instances       TemplateInstance[]
+  formAssignments FormAssignment[]
+  catalogLinks    TemplateCatalogLink[]
 
   @@index([organisationId, ownership, kind, status])
   @@index([organisationId, scope])
@@ -2347,19 +2349,19 @@ model Template {
 }
 
 model TemplateVersion {
-  id                    String   @id @default(uuid())
-  templateId            String
-  version               Int
-  schemaSnapshot        Json
-  renderConfigSnapshot   Json?
-  validationSnapshot    Json?
-  publishedAt           DateTime?
-  createdBy             String
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  id                   String    @id @default(uuid())
+  templateId           String
+  version              Int
+  schemaSnapshot       Json
+  renderConfigSnapshot Json?
+  validationSnapshot   Json?
+  publishedAt          DateTime?
+  createdBy            String
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
-  template              Template @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  clinicalArtifacts     ClinicalArtifact[]
+  template          Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  clinicalArtifacts ClinicalArtifact[]
 
   @@unique([templateId, version])
   @@index([templateId])
@@ -2367,14 +2369,14 @@ model TemplateVersion {
 }
 
 model TemplateCatalogLink {
-  id             String   @id @default(uuid())
-  templateId     String
-  catalogItemId  String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id            String   @id @default(uuid())
+  templateId    String
+  catalogItemId String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
-  template       Template   @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  catalogItem    ProductItem @relation(fields: [catalogItemId], references: [id], onDelete: Cascade)
+  template    Template    @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  catalogItem ProductItem @relation(fields: [catalogItemId], references: [id], onDelete: Cascade)
 
   @@unique([templateId, catalogItemId])
   @@index([templateId])
@@ -2382,7 +2384,7 @@ model TemplateCatalogLink {
 }
 
 model TemplateInstance {
-  id              String                @id @default(uuid())
+  id              String                 @id @default(uuid())
   templateId      String
   templateVersion Int
   organisationId  String
@@ -2396,11 +2398,11 @@ model TemplateInstance {
   signedAt        DateTime?
   generatedPdfUrl String?
   generatedPdf    Json?
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
 
-  template        Template              @relation(fields: [templateId], references: [id], onDelete: Cascade)
-  taskSchedule    TaskSchedule?
+  template          Template           @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  taskSchedule      TaskSchedule?
   renderedDocuments RenderedDocument[]
 
   @@index([templateId])
@@ -2411,31 +2413,31 @@ model TemplateInstance {
 }
 
 model RenderedDocument {
-  id                String                    @id @default(uuid())
-  organisationId    String
-  sourceKind        RenderedDocumentSourceKind
-  sourceId          String
-  templateInstanceId String?                  @unique
-  clinicalArtifactId String?                  @unique
-  templateId        String?
-  templateVersion   Int?
-  templateVersionId String?
-  kind              TemplateKind
-  version           Int                       @default(1)
-  title             String
-  mimeType          String                    @default("application/pdf")
-  status            RenderedDocumentStatus    @default(DRAFT)
-  signable          Boolean                   @default(true)
-  pdfUrl            String?
-  pdf               Json?
-  signing           Json?
-  signedBy          String?
-  signedAt          DateTime?
-  createdAt         DateTime                  @default(now())
-  updatedAt         DateTime                  @updatedAt
+  id                 String                     @id @default(uuid())
+  organisationId     String
+  sourceKind         RenderedDocumentSourceKind
+  sourceId           String
+  templateInstanceId String?                    @unique
+  clinicalArtifactId String?                    @unique
+  templateId         String?
+  templateVersion    Int?
+  templateVersionId  String?
+  kind               TemplateKind
+  version            Int                        @default(1)
+  title              String
+  mimeType           String                     @default("application/pdf")
+  status             RenderedDocumentStatus     @default(DRAFT)
+  signable           Boolean                    @default(true)
+  pdfUrl             String?
+  pdf                Json?
+  signing            Json?
+  signedBy           String?
+  signedAt           DateTime?
+  createdAt          DateTime                   @default(now())
+  updatedAt          DateTime                   @updatedAt
 
-  templateInstance  TemplateInstance?         @relation(fields: [templateInstanceId], references: [id], onDelete: SetNull)
-  clinicalArtifact  ClinicalArtifact?         @relation(fields: [clinicalArtifactId], references: [id], onDelete: SetNull)
+  templateInstance TemplateInstance?  @relation(fields: [templateInstanceId], references: [id], onDelete: SetNull)
+  clinicalArtifact ClinicalArtifact?  @relation(fields: [clinicalArtifactId], references: [id], onDelete: SetNull)
   signature        DocumentSignature?
 
   @@index([organisationId, kind, status])
@@ -2445,7 +2447,7 @@ model RenderedDocument {
 }
 
 model WorkspaceDocumentPacket {
-  id             String                     @id @default(uuid())
+  id             String                        @id @default(uuid())
   organisationId String
   appointmentId  String?
   encounterId    String
@@ -2456,8 +2458,8 @@ model WorkspaceDocumentPacket {
   signedBy       String?
   signedByName   String?
   signedAt       DateTime?
-  createdAt      DateTime                   @default(now())
-  updatedAt      DateTime                   @updatedAt
+  createdAt      DateTime                      @default(now())
+  updatedAt      DateTime                      @updatedAt
 
   @@index([organisationId])
   @@index([organisationId, encounterId])
@@ -2466,7 +2468,7 @@ model WorkspaceDocumentPacket {
 }
 
 model WorkspaceTreatmentItem {
-  id                 String   @id @default(uuid())
+  id                 String    @id @default(uuid())
   organisationId     String
   appointmentId      String?
   encounterId        String
@@ -2474,16 +2476,16 @@ model WorkspaceTreatmentItem {
   productVersion     Int?
   productSnapshot    Json
   servicePackageKind String
-  quantity           Int      @default(1)
+  quantity           Int       @default(1)
   priceSnapshot      Json
-  billingStatus      String   @default("UNBILLED")
+  billingStatus      String    @default("UNBILLED")
   invoiceRowId       String?
   settledInvoiceId   String?
   settledAt          DateTime?
   lockState          Json?
   prescriptionId     String?
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
   @@index([organisationId, encounterId])
   @@index([organisationId, appointmentId])
@@ -2494,50 +2496,50 @@ model WorkspaceTreatmentItem {
 }
 
 model DocumentSignature {
-  id                 String                   @id @default(uuid())
-  renderedDocumentId String                   @unique
-  signerId          String
-  signerType        DocumentSignatureSignerType
-  signatureText     String?
-  signedAt          DateTime                  @default(now())
-  createdAt         DateTime                  @default(now())
-  updatedAt         DateTime                  @updatedAt
+  id                 String                      @id @default(uuid())
+  renderedDocumentId String                      @unique
+  signerId           String
+  signerType         DocumentSignatureSignerType
+  signatureText      String?
+  signedAt           DateTime                    @default(now())
+  createdAt          DateTime                    @default(now())
+  updatedAt          DateTime                    @updatedAt
 
-  renderedDocument  RenderedDocument          @relation(fields: [renderedDocumentId], references: [id], onDelete: Cascade)
+  renderedDocument RenderedDocument @relation(fields: [renderedDocumentId], references: [id], onDelete: Cascade)
 
   @@index([renderedDocumentId])
   @@index([signerId])
 }
 
 model ClinicalArtifact {
-  id              String                  @id @default(uuid())
-  organisationId  String
-  appointmentId   String?
-  caseId          String?
-  encounterId     String?
-  kind            ClinicalArtifactKind
-  status          ClinicalArtifactStatus  @default(DRAFT)
-  templateId      String?
-  templateVersion Int?
+  id                String                 @id @default(uuid())
+  organisationId    String
+  appointmentId     String?
+  caseId            String?
+  encounterId       String?
+  kind              ClinicalArtifactKind
+  status            ClinicalArtifactStatus @default(DRAFT)
+  templateId        String?
+  templateVersion   Int?
   templateVersionId String?
-  authorId        String?
-  signedBy        String?
-  signedAt        DateTime?
-  summary         String?
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  authorId          String?
+  signedBy          String?
+  signedAt          DateTime?
+  summary           String?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
 
-  soapNote        SoapNote?
-  prescription    Prescription?
-  dischargeSummary DischargeSummary?
-  vitalRecord     VitalRecord?
-  immunization    Immunization?
-  rabiesTitration RabiesTitration?
-  parasiteTreatment ParasiteTreatment?
-  clinicalExamination ClinicalExamination?
-  attestation     ClinicalArtifactAttestation?
-  templateVersionRecord TemplateVersion?   @relation(fields: [templateVersionId], references: [id], onDelete: SetNull)
-  renderedDocuments RenderedDocument[]
+  soapNote              SoapNote?
+  prescription          Prescription?
+  dischargeSummary      DischargeSummary?
+  vitalRecord           VitalRecord?
+  immunization          Immunization?
+  rabiesTitration       RabiesTitration?
+  parasiteTreatment     ParasiteTreatment?
+  clinicalExamination   ClinicalExamination?
+  attestation           ClinicalArtifactAttestation?
+  templateVersionRecord TemplateVersion?             @relation(fields: [templateVersionId], references: [id], onDelete: SetNull)
+  renderedDocuments     RenderedDocument[]
 
   @@index([organisationId, kind, status])
   @@index([organisationId, appointmentId])
@@ -2548,117 +2550,117 @@ model ClinicalArtifact {
 }
 
 model SoapNote {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  subjective      Json?
-  objective       Json?
-  assessment      Json?
-  plan            Json?
-  diagnoses       Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id         String   @id @default(uuid())
+  artifactId String   @unique
+  subjective Json?
+  objective  Json?
+  assessment Json?
+  plan       Json?
+  diagnoses  Json?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model Prescription {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  items           PrescriptionItem[]
+  id               String                        @id @default(uuid())
+  artifactId       String                        @unique
+  items            PrescriptionItem[]
   dispenseRequests PrescriptionDispenseRequest[]
-  medications     Json?
-  instructions    Json?
-  notes           Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  medications      Json?
+  instructions     Json?
+  notes            Json?
+  metadata         Json?
+  createdAt        DateTime                      @default(now())
+  updatedAt        DateTime                      @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model PrescriptionItem {
-  id             String       @id @default(uuid())
-  prescriptionId String
-  sourceLineKey  String?
-  medication     String
-  strength       String?
-  dosage         String?
-  route          String?
-  frequency      String?
-  duration       String?
-  quantity       String?
-  instructions   String?
-  refill         String?
-  inventoryItemId String?
+  id               String    @id @default(uuid())
+  prescriptionId   String
+  sourceLineKey    String?
+  medication       String
+  strength         String?
+  dosage           String?
+  route            String?
+  frequency        String?
+  duration         String?
+  quantity         String?
+  instructions     String?
+  refill           String?
+  inventoryItemId  String?
   inventoryItemSku String?
-  batchId        String?
-  batchNumber    String?
-  lotNumber      String?
-  expiryDate     DateTime?
-  metadata       Json?
-  sortOrder      Int          @default(0)
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  batchId          String?
+  batchNumber      String?
+  lotNumber        String?
+  expiryDate       DateTime?
+  metadata         Json?
+  sortOrder        Int       @default(0)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
-  prescription   Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
+  prescription Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
 
   @@index([prescriptionId, sortOrder])
 }
 
 model PrescriptionDispenseRequest {
-  id             String                              @id @default(uuid())
+  id             String                            @id @default(uuid())
   prescriptionId String
   organisationId String
-  status         PrescriptionDispenseRequestStatus   @default(PENDING)
+  status         PrescriptionDispenseRequestStatus @default(PENDING)
   medications    Json
   metadata       Json?
   requestedBy    String?
   reviewedBy     String?
-  requestedAt    DateTime                            @default(now())
+  requestedAt    DateTime                          @default(now())
   reviewedAt     DateTime?
-  createdAt      DateTime                            @default(now())
-  updatedAt      DateTime                            @updatedAt
+  createdAt      DateTime                          @default(now())
+  updatedAt      DateTime                          @updatedAt
 
-  prescription   Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
+  prescription Prescription @relation(fields: [prescriptionId], references: [id], onDelete: Cascade)
 
   @@index([prescriptionId, status, requestedAt])
   @@index([organisationId, status])
 }
 
 model DischargeSummary {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  summary         Json?
-  diagnoses       Json?
-  medications     Json?
-  followUp        Json?
-  instructions    Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id           String   @id @default(uuid())
+  artifactId   String   @unique
+  summary      Json?
+  diagnoses    Json?
+  medications  Json?
+  followUp     Json?
+  instructions Json?
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
 
 model VitalRecord {
-  id              String           @id @default(uuid())
-  artifactId      String           @unique
-  measuredAt      DateTime
-  recordedBy      String?
-  vitals          Json
-  notes           Json?
-  metadata        Json?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
+  id         String   @id @default(uuid())
+  artifactId String   @unique
+  measuredAt DateTime
+  recordedBy String?
+  vitals     Json
+  notes      Json?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  artifact        ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([measuredAt])
@@ -2668,9 +2670,9 @@ model VitalRecord {
 // Immunization / Observation / Procedure). The administering/verifying vet and
 // the legally-binding signature live on ClinicalArtifactAttestation, not here.
 model Immunization {
-  id               String           @id @default(uuid())
-  artifactId       String           @unique
-  vaccineType      VaccineType      @default(OTHER)
+  id               String      @id @default(uuid())
+  artifactId       String      @unique
+  vaccineType      VaccineType @default(OTHER)
   vaccineName      String
   manufacturer     String?
   batchNumber      String?
@@ -2683,27 +2685,27 @@ model Immunization {
   route            String?
   notes            String?
   metadata         Json?
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
 
-  artifact         ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([validUntil])
 }
 
 model RabiesTitration {
-  id          String           @id @default(uuid())
-  artifactId  String           @unique
+  id          String   @id @default(uuid())
+  artifactId  String   @unique
   approvedLab String
   sampleDate  DateTime
   resultIuMl  Float
   reportUrl   String?
   metadata    Json?
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  artifact    ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
@@ -2720,7 +2722,7 @@ model ParasiteTreatment {
   createdAt     DateTime              @default(now())
   updatedAt     DateTime              @updatedAt
 
-  artifact      ClinicalArtifact      @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
 }
@@ -2728,18 +2730,18 @@ model ParasiteTreatment {
 // Pre-travel clinical examination ("fit to travel" attestation): the EU passport
 // section a vet signs shortly before movement.
 model ClinicalExamination {
-  id           String           @id @default(uuid())
-  artifactId   String           @unique
+  id           String   @id @default(uuid())
+  artifactId   String   @unique
   examinedAt   DateTime
-  fitForTravel Boolean          @default(true)
+  fitForTravel Boolean  @default(true)
   findings     String?
   weightKg     Float?
   temperatureC Float?
   metadata     Json?
-  createdAt    DateTime         @default(now())
-  updatedAt    DateTime         @updatedAt
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  artifact     ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([examinedAt])
@@ -2751,9 +2753,9 @@ model ClinicalExamination {
 // legally-binding notary record. A SIGNED artifact is immutable; corrections
 // supersede and revocations propagate to the wallet pass + public page.
 model ClinicalArtifactAttestation {
-  id                  String           @id @default(uuid())
-  artifactId          String           @unique
-  primarySource       Boolean          @default(true)
+  id                  String    @id @default(uuid())
+  artifactId          String    @unique
+  primarySource       Boolean   @default(true)
   signatoryUserId     String?
   signatoryName       String?
   signatoryLicence    String?
@@ -2765,10 +2767,10 @@ model ClinicalArtifactAttestation {
   revokedAt           DateTime?
   revokedReason       String?
   supersededById      String?
-  createdAt           DateTime         @default(now())
-  updatedAt           DateTime         @updatedAt
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
-  artifact            ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
+  artifact ClinicalArtifact @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([artifactId])
   @@index([signatoryUserId])
@@ -2795,22 +2797,22 @@ model Service {
 }
 
 model ProductItem {
-  id              String               @id @default(uuid())
+  id              String                @id @default(uuid())
   organisationId  String
   name            String
   description     String?
   code            String?
-  kind            ProductKind          @default(CONSULTATION)
+  kind            ProductKind           @default(CONSULTATION)
   specialityId    String?
-  legacyServiceId String?              @unique
-  isActive        Boolean              @default(true)
-  version         Int                  @default(1)
-  createdAt       DateTime             @default(now())
-  updatedAt       DateTime             @updatedAt
+  legacyServiceId String?               @unique
+  isActive        Boolean               @default(true)
+  version         Int                   @default(1)
+  createdAt       DateTime              @default(now())
+  updatedAt       DateTime              @updatedAt
   prices          ProductPrice[]
   bookable        ProductBookable?
   package         ProductPackage?
-  packageItems    ProductPackageItem[] @relation("ProductPackageComponent")
+  packageItems    ProductPackageItem[]  @relation("ProductPackageComponent")
   templateLinks   TemplateCatalogLink[]
 
   @@index([organisationId])
@@ -2882,10 +2884,10 @@ model ProductPackageItem {
 }
 
 model Task {
-  id                String       @id @default(uuid())
+  id                String        @id @default(uuid())
   organisationId    String?
   appointmentId     String?
-  patientId       String?
+  patientId         String?
   createdBy         String
   assignedBy        String?
   assignedTo        String
@@ -2908,12 +2910,12 @@ model Task {
   syncWithCalendar  Boolean?
   calendarEventId   String?
   attachments       Json?
-  status            TaskStatus   @default(PENDING)
+  status            TaskStatus    @default(PENDING)
   priority          TaskPriority?
   completedAt       DateTime?
   completedBy       String?
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
 
   @@index([assignedTo, dueAt])
   @@index([assignedGroupId, dueAt])
@@ -2923,30 +2925,30 @@ model Task {
 }
 
 model TaskSchedule {
-  id                String            @id @default(uuid())
-  templateInstanceId String            @unique
-  templateId        String
-  templateVersion   Int
-  templateKind      TemplateKind
-  organisationId    String
-  appointmentId     String?
-  caseId            String?
-  encounterId      String?
-  patientId       String?
-  createdBy         String
-  activatedBy       String?
-  activatedAt       DateTime?
-  completedAt       DateTime?
+  id                 String             @id @default(uuid())
+  templateInstanceId String             @unique
+  templateId         String
+  templateVersion    Int
+  templateKind       TemplateKind
+  organisationId     String
+  appointmentId      String?
+  caseId             String?
+  encounterId        String?
+  patientId          String?
+  createdBy          String
+  activatedBy        String?
+  activatedAt        DateTime?
+  completedAt        DateTime?
   lastMaterializedAt DateTime?
-  status            TaskScheduleStatus @default(DRAFT)
-  scheduleInput     Json?
-  materializedSeeds Json?
-  generatedTaskIds  Json?
-  metadata          Json?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  status             TaskScheduleStatus @default(DRAFT)
+  scheduleInput      Json?
+  materializedSeeds  Json?
+  generatedTaskIds   Json?
+  metadata           Json?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
 
-  templateInstance  TemplateInstance   @relation(fields: [templateInstanceId], references: [id], onDelete: Cascade)
+  templateInstance TemplateInstance @relation(fields: [templateInstanceId], references: [id], onDelete: Cascade)
 
   @@index([organisationId, status])
   @@index([templateId, templateVersion])
@@ -2956,54 +2958,56 @@ model TaskSchedule {
 }
 
 model TaskCompletion {
-  id          String   @id @default(uuid())
-  taskId      String
+  id        String   @id @default(uuid())
+  taskId    String
   patientId String
-  filledBy    String
-  answers     Json
-  score       Float?
-  summary     String?
-  createdAt   DateTime @default(now())
+  filledBy  String
+  answers   Json
+  score     Float?
+  summary   String?
+  createdAt DateTime @default(now())
 
   @@index([taskId])
   @@index([patientId])
 }
 
 model TaskTemplate {
-  id                          String          @id @default(uuid())
-  source                      TaskSource      @default(ORG_TEMPLATE)
-  organisationId              String
-  libraryTaskId               String?
-  category                    String
-  name                        String
-  description                 String?
-  kind                        TaskKind
-  defaultRole                 TaskTemplateRole
-  inpatientOnly               Boolean         @default(false)
-  defaultMedication           Json?
-  defaultObservationToolId    String?
-  defaultRecurrence           Json?
+  id                           String           @id @default(uuid())
+  source                       TaskSource       @default(ORG_TEMPLATE)
+  organisationId               String
+  libraryTaskId                String?
+  category                     String
+  name                         String
+  description                  String?
+  kind                         TaskKind
+  defaultRole                  TaskTemplateRole
+  inpatientOnly                Boolean          @default(false)
+  defaultMedication            Json?
+  defaultObservationToolId     String?
+  defaultRecurrence            Json?
   defaultReminderOffsetMinutes Int?
-  isActive                    Boolean         @default(true)
-  createdBy                   String
-  createdAt                   DateTime        @default(now())
-  updatedAt                   DateTime        @updatedAt
+  isActive                     Boolean          @default(true)
+  createdBy                    String
+  createdAt                    DateTime         @default(now())
+  updatedAt                    DateTime         @updatedAt
 
   @@index([organisationId])
 }
 
 model TaskLibraryDefinition {
-  id                 String             @id @default(uuid())
-  source             TaskSource         @default(YC_LIBRARY)
+  id                 String               @id @default(uuid())
+  source             TaskSource           @default(YC_LIBRARY)
   kind               TaskKind
   category           String
   name               String
   defaultDescription String?
   schema             Json
   applicableSpecies  TaskLibrarySpecies[]
-  isActive           Boolean            @default(true)
-  createdAt          DateTime           @default(now())
-  updatedAt          DateTime           @updatedAt
+  isActive           Boolean              @default(true)
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+
+  recommendationRules TaskRecommendationRule[]
 
   @@index([kind])
   @@index([category])
@@ -3025,9 +3029,9 @@ model ReminderJob {
 }
 
 model AuditTrail {
-  id             String         @id @default(uuid())
+  id             String           @id @default(uuid())
   organisationId String
-  patientId    String
+  patientId      String
   eventType      AuditEventType
   actorType      AuditActorType?
   actorId        String?
@@ -3035,9 +3039,9 @@ model AuditTrail {
   entityType     AuditEntityType?
   entityId       String?
   metadata       Json?
-  occurredAt     DateTime       @default(now())
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
+  occurredAt     DateTime         @default(now())
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
 
   @@index([organisationId])
   @@index([patientId])
@@ -3067,45 +3071,45 @@ model AccountWithdrawal {
 }
 
 model InventoryItem {
-  id                        String               @id @default(uuid())
-  organisationId            String
-  businessType              InventoryBusinessType
-  itemType                  InventoryItemType     @default(NON_MEDICAL)
-  name                      String
-  sku                       String?
-  category                  String
-  subCategory               String?
-  description               String?
-  imageUrl                  String?
-  stockUnitType             String?
-  attachments               Json?
-  attributes                Json                 @default("{}")
-  genericName               String?
-  strength                  String?
-  dosageForm                String?
-  routeOfAdministration     String?
-  drugClass                 String?
-  prescriptionRequired      Boolean              @default(false)
-  controlledItem            Boolean              @default(false)
-  storageInstructions       String?
-  expiryTrackingRequired    Boolean              @default(false)
-  unitOfMeasure             String?
-  packageQuantity           Int?
-  storageLocation           String?
-  onHand                    Int                  @default(0)
-  allocated                 Int                  @default(0)
-  minimumStock              Int?
-  emergencyStockLevel       Int?
-  reorderLevel              Int?
-  unitCost                  Float?
-  sellingPrice              Float?
-  taxRate                   Float?
-  currency                  String?
-  vendorId                  String?
-  status                    InventoryItemStatus   @default(ACTIVE)
-  createdAt                 DateTime             @default(now())
-  updatedAt                 DateTime             @updatedAt
-  packageItemsAsInventory    ProductPackageItem[]  @relation("ProductPackageInventoryComponent")
+  id                      String                @id @default(uuid())
+  organisationId          String
+  businessType            InventoryBusinessType
+  itemType                InventoryItemType     @default(NON_MEDICAL)
+  name                    String
+  sku                     String?
+  category                String
+  subCategory             String?
+  description             String?
+  imageUrl                String?
+  stockUnitType           String?
+  attachments             Json?
+  attributes              Json                  @default("{}")
+  genericName             String?
+  strength                String?
+  dosageForm              String?
+  routeOfAdministration   String?
+  drugClass               String?
+  prescriptionRequired    Boolean               @default(false)
+  controlledItem          Boolean               @default(false)
+  storageInstructions     String?
+  expiryTrackingRequired  Boolean               @default(false)
+  unitOfMeasure           String?
+  packageQuantity         Int?
+  storageLocation         String?
+  onHand                  Int                   @default(0)
+  allocated               Int                   @default(0)
+  minimumStock            Int?
+  emergencyStockLevel     Int?
+  reorderLevel            Int?
+  unitCost                Float?
+  sellingPrice            Float?
+  taxRate                 Float?
+  currency                String?
+  vendorId                String?
+  status                  InventoryItemStatus   @default(ACTIVE)
+  createdAt               DateTime              @default(now())
+  updatedAt               DateTime              @updatedAt
+  packageItemsAsInventory ProductPackageItem[]  @relation("ProductPackageInventoryComponent")
 
   @@unique([organisationId, sku])
   @@index([organisationId, name])
@@ -3116,21 +3120,21 @@ model InventoryItem {
 }
 
 model InventoryBatch {
-  id                   String   @id @default(uuid())
-  itemId               String
-  organisationId       String
-  batchNumber          String?
-  lotNumber            String?
-  regulatoryTrackingId String?
-  expiryWarningBefore  String?
-  barcode              String?
-  manufactureDate      DateTime?
-  expiryDate           DateTime?
+  id                    String    @id @default(uuid())
+  itemId                String
+  organisationId        String
+  batchNumber           String?
+  lotNumber             String?
+  regulatoryTrackingId  String?
+  expiryWarningBefore   String?
+  barcode               String?
+  manufactureDate       DateTime?
+  expiryDate            DateTime?
   minShelfLifeAlertDate DateTime?
-  quantity             Int      @default(0)
-  allocated            Int      @default(0)
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  quantity              Int       @default(0)
+  allocated             Int       @default(0)
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
 
   @@index([itemId])
   @@index([organisationId])
@@ -3139,7 +3143,7 @@ model InventoryBatch {
 }
 
 model InventoryVendor {
-  id                String   @id @default(uuid())
+  id                String    @id @default(uuid())
   organisationId    String
   name              String
   brand             String?
@@ -3153,36 +3157,36 @@ model InventoryVendor {
   deliveryFrequency String?
   leadTimeDays      Int?
   contactInfo       Json?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([organisationId, name])
   @@index([organisationId, vendorItemCode])
 }
 
 model InventoryCategory {
-  id            String   @id @default(uuid())
-  code          String   @unique
-  name          String
-  isMedical     Boolean  @default(false)
-  sortOrder     Int      @default(0)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id        String   @id @default(uuid())
+  code      String   @unique
+  name      String
+  isMedical Boolean  @default(false)
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  subcategories  InventorySubcategory[]
+  subcategories InventorySubcategory[]
 }
 
 model InventorySubcategory {
-  id            String   @id @default(uuid())
-  categoryId    String
-  code          String
-  name          String
-  sortOrder     Int      @default(0)
-  isActive      Boolean  @default(true)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id         String   @id @default(uuid())
+  categoryId String
+  code       String
+  name       String
+  sortOrder  Int      @default(0)
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  category      InventoryCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  category InventoryCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
 
   @@unique([categoryId, code])
   @@index([categoryId])
@@ -3228,16 +3232,16 @@ enum InventoryConsumptionAction {
 }
 
 model InventoryConsumptionRule {
-  id                 String                        @id @default(uuid())
+  id                 String                         @id @default(uuid())
   organisationId     String
   sourceType         InventoryConsumptionSourceType
   sourceKey          String
   inventoryItemId    String
-  quantityMultiplier Float                         @default(1)
+  quantityMultiplier Float                          @default(1)
   notes              String?
-  active             Boolean                       @default(true)
-  createdAt          DateTime                      @default(now())
-  updatedAt          DateTime                      @updatedAt
+  active             Boolean                        @default(true)
+  createdAt          DateTime                       @default(now())
+  updatedAt          DateTime                       @updatedAt
 
   @@unique([organisationId, sourceType, sourceKey, inventoryItemId])
   @@index([organisationId, sourceType, sourceKey])
@@ -3245,7 +3249,7 @@ model InventoryConsumptionRule {
 }
 
 model InventoryConsumptionEvent {
-  id              String                        @id @default(uuid())
+  id              String                         @id @default(uuid())
   organisationId  String
   sourceType      InventoryConsumptionSourceType
   sourceId        String
@@ -3305,7 +3309,7 @@ model ObservationToolSubmission {
   id                      String   @id @default(uuid())
   toolId                  String
   taskId                  String?
-  patientId             String
+  patientId               String
   filledBy                String
   answers                 Json
   score                   Float?
@@ -3320,22 +3324,22 @@ model ObservationToolSubmission {
 }
 
 model Occupancy {
-  id             String             @id @default(uuid())
+  id             String              @id @default(uuid())
   userId         String
   organisationId String
   startTime      DateTime
   endTime        DateTime
   sourceType     OccupancySourceType @default(APPOINTMENT)
   referenceId    String?
-  createdAt      DateTime           @default(now())
-  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
   @@index([userId, startTime, endTime])
   @@index([userId, organisationId, startTime])
 }
 
 model RegulatoryAuthority {
-  id            String   @id @default(uuid())
+  id            String  @id @default(uuid())
   country       String?
   iso2          String?
   iso3          String?
@@ -3352,7 +3356,7 @@ model AdverseEventReport {
   organisationId String?
   appointmentId  String?
   reporter       Json
-  patient      Json
+  patient        Json
   product        Json
   destinations   Json
   consent        Json
@@ -3380,11 +3384,12 @@ model Speciality {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  roomLinks          OrganisationRoomSpeciality[]
+  roomLinks OrganisationRoomSpeciality[]
 
   @@index([organisationId])
   @@index([organisationId, isActive])
 }
+
 model DeviceToken {
   id          String         @id @default(uuid())
   userId      String
@@ -3412,41 +3417,42 @@ model Notification {
 }
 
 model Invoice {
-  id                       String                   @id @default(uuid())
-  parentId                 String?
-  patientId              String?
-  organisationId           String?
-  appointmentId            String?
-  items                    Json
-  subtotal                 Float
-  discountTotal            Float                    @default(0)
-  invoiceDiscountType      String?
-  invoiceDiscountValue     Float?
-  invoiceDiscountTotal     Float                    @default(0)
-  taxTotal                 Float                    @default(0)
-  taxPercent               Float                    @default(0)
-  taxProvider              TaxProvider?
-  totalAmount              Float
-  currency                 String
-  paymentCollectionMethod  PaymentCollectionMethod  @default(PAYMENT_INTENT)
-  billingCollectionMode    BillingCollectionMode    @default(PREPAY_AT_BOOKING)
-  visitBillingStage        InvoiceVisitBillingStage  @default(DRAFT)
-  readyForBillingAt        DateTime?
-  readyForBillingActorId   String?
-  depositTargetAmount      Float                    @default(0)
-  depositCollectedAmount   Float                    @default(0)
-  status                   InvoiceStatus            @default(PENDING)
-  metadata                 Json?
-  paidAt                   DateTime?
-  finalizedAt              DateTime?
-  createdAt                DateTime                 @default(now())
-  updatedAt                DateTime                 @updatedAt
+  id                      String                   @id @default(uuid())
+  parentId                String?
+  patientId               String?
+  organisationId          String?
+  appointmentId           String?
+  items                   Json
+  subtotal                Float
+  discountTotal           Float                    @default(0)
+  invoiceDiscountType     String?
+  invoiceDiscountValue    Float?
+  invoiceDiscountTotal    Float                    @default(0)
+  taxTotal                Float                    @default(0)
+  taxPercent              Float                    @default(0)
+  taxProvider             TaxProvider?
+  totalAmount             Float
+  currency                String
+  paymentCollectionMethod PaymentCollectionMethod  @default(PAYMENT_INTENT)
+  billingCollectionMode   BillingCollectionMode    @default(PREPAY_AT_BOOKING)
+  visitBillingStage       InvoiceVisitBillingStage @default(DRAFT)
+  readyForBillingAt       DateTime?
+  readyForBillingActorId  String?
+  depositTargetAmount     Float                    @default(0)
+  depositCollectedAmount  Float                    @default(0)
+  status                  InvoiceStatus            @default(PENDING)
+  metadata                Json?
+  paidAt                  DateTime?
+  finalizedAt             DateTime?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
 
-  taxSnapshot              InvoiceTaxSnapshot?
-  paymentAttempts          PaymentAttempt[]
-  payments                 Payment[]
-  creditNotes              CreditNote[]
+  taxSnapshot     InvoiceTaxSnapshot?
+  paymentAttempts PaymentAttempt[]
+  payments        Payment[]
+  creditNotes     CreditNote[]
 
+  @@unique([appointmentId])
   @@index([parentId])
   @@index([organisationId])
   @@index([appointmentId])
@@ -3456,7 +3462,6 @@ model Invoice {
   @@index([visitBillingStage])
   @@index([readyForBillingAt])
   @@index([taxProvider])
-  @@unique([appointmentId])
 }
 
 model InvoiceTaxSnapshot {
@@ -3475,33 +3480,33 @@ model InvoiceTaxSnapshot {
   createdAt           DateTime     @default(now())
   updatedAt           DateTime     @updatedAt
 
-  invoice             Invoice      @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  invoice Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 }
 
 model PaymentAttempt {
-  id                      String               @id @default(uuid())
-  invoiceId               String
-  provider                PaymentProvider
-  settlementChannel       SettlementChannel?
-  providerPaymentIntentId String?
+  id                        String                 @id @default(uuid())
+  invoiceId                 String
+  provider                  PaymentProvider
+  settlementChannel         SettlementChannel?
+  providerPaymentIntentId   String?
   providerCheckoutSessionId String?
-  providerPaymentLinkId   String?
-  status                  PaymentAttemptStatus @default(REQUIRES_PAYMENT_METHOD)
-  amountRequested         Float                @default(0)
-  amountCaptured          Float                @default(0)
-  amountApplied           Float                @default(0)
-  currency                String
-  failureCode             String?
-  failureMessage          String?
-  collectionMode          BillingCollectionMode?
-  isOffline               Boolean              @default(false)
-  isPartial               Boolean              @default(false)
-  rawProviderPayload      Json?
-  createdAt               DateTime             @default(now())
-  updatedAt               DateTime             @updatedAt
+  providerPaymentLinkId     String?
+  status                    PaymentAttemptStatus   @default(REQUIRES_PAYMENT_METHOD)
+  amountRequested           Float                  @default(0)
+  amountCaptured            Float                  @default(0)
+  amountApplied             Float                  @default(0)
+  currency                  String
+  failureCode               String?
+  failureMessage            String?
+  collectionMode            BillingCollectionMode?
+  isOffline                 Boolean                @default(false)
+  isPartial                 Boolean                @default(false)
+  rawProviderPayload        Json?
+  createdAt                 DateTime               @default(now())
+  updatedAt                 DateTime               @updatedAt
 
-  invoice                 Invoice              @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  payment                 Payment?
+  invoice Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  payment Payment?
 
   @@index([invoiceId])
   @@index([provider])
@@ -3512,25 +3517,25 @@ model PaymentAttempt {
 }
 
 model Payment {
-  id                    String          @id @default(uuid())
-  invoiceId             String
-  paymentAttemptId      String?         @unique
-  provider              PaymentProvider
-  settlementChannel     SettlementChannel?
-  collectionMode        BillingCollectionMode?
-  providerPaymentId     String?
-  amount                Float
-  currency              String
-  status                PaymentStatus   @default(PENDING)
-  paidAt                DateTime?
-  receiptUrl            String?
-  rawProviderPayload    Json?
-  createdAt             DateTime        @default(now())
-  updatedAt             DateTime        @updatedAt
+  id                 String                 @id @default(uuid())
+  invoiceId          String
+  paymentAttemptId   String?                @unique
+  provider           PaymentProvider
+  settlementChannel  SettlementChannel?
+  collectionMode     BillingCollectionMode?
+  providerPaymentId  String?
+  amount             Float
+  currency           String
+  status             PaymentStatus          @default(PENDING)
+  paidAt             DateTime?
+  receiptUrl         String?
+  rawProviderPayload Json?
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @updatedAt
 
-  invoice               Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  paymentAttempt        PaymentAttempt? @relation(fields: [paymentAttemptId], references: [id])
-  refunds               Refund[]
+  invoice        Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  paymentAttempt PaymentAttempt? @relation(fields: [paymentAttemptId], references: [id])
+  refunds        Refund[]
 
   @@index([invoiceId])
   @@index([paymentAttemptId])
@@ -3540,19 +3545,19 @@ model Payment {
 }
 
 model Refund {
-  id                    String         @id @default(uuid())
-  paymentId             String
-  provider              PaymentProvider
-  providerRefundId      String?
-  amount                Float
-  currency              String
-  status                RefundStatus   @default(PENDING)
-  reason                String?
-  rawProviderPayload    Json?
-  createdAt             DateTime       @default(now())
-  updatedAt             DateTime       @updatedAt
+  id                 String          @id @default(uuid())
+  paymentId          String
+  provider           PaymentProvider
+  providerRefundId   String?
+  amount             Float
+  currency           String
+  status             RefundStatus    @default(PENDING)
+  reason             String?
+  rawProviderPayload Json?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
 
-  payment               Payment        @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  payment Payment @relation(fields: [paymentId], references: [id], onDelete: Cascade)
 
   @@index([paymentId])
   @@index([provider])
@@ -3571,7 +3576,7 @@ model CreditNote {
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
 
-  invoice          Invoice          @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  invoice Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 
   @@index([invoiceId])
   @@index([status])
@@ -3799,7 +3804,6 @@ model PatientAllergy {
   @@map("PatientAllergy")
 }
 
-
 // ---------------------------------------------------------------------------
 // Medication Administration Record (MAR)
 // ---------------------------------------------------------------------------
@@ -3856,17 +3860,17 @@ enum PreventiveCareStatus {
 }
 
 model PreventiveCarePlan {
-  id                String                  @id @default(uuid())
-  organisationId    String
-  patientId         String
-  name              String
-  description       String?
-  status            PreventiveCareStatus    @default(ACTIVE)
-  createdBy         String?
-  createdAt         DateTime                @default(now())
-  updatedAt         DateTime                @updatedAt
+  id             String               @id @default(uuid())
+  organisationId String
+  patientId      String
+  name           String
+  description    String?
+  status         PreventiveCareStatus @default(ACTIVE)
+  createdBy      String?
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
 
-  items             PreventiveCareItem[]
+  items PreventiveCareItem[]
 
   @@index([organisationId, patientId, status])
   @@index([organisationId, patientId])
@@ -3874,19 +3878,19 @@ model PreventiveCarePlan {
 }
 
 model PreventiveCareItem {
-  id              String                  @id @default(uuid())
-  planId          String
-  organisationId  String
-  careType        String
-  frequency       PreventiveCareFrequency
-  intervalDays    Int?
-  lastDoneAt      DateTime?
-  nextDueAt       DateTime?
-  notes           String?
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  id             String                  @id @default(uuid())
+  planId         String
+  organisationId String
+  careType       String
+  frequency      PreventiveCareFrequency
+  intervalDays   Int?
+  lastDoneAt     DateTime?
+  nextDueAt      DateTime?
+  notes          String?
+  createdAt      DateTime                @default(now())
+  updatedAt      DateTime                @updatedAt
 
-  plan            PreventiveCarePlan @relation(fields: [planId], references: [id], onDelete: Cascade)
+  plan PreventiveCarePlan @relation(fields: [planId], references: [id], onDelete: Cascade)
 
   @@index([organisationId, nextDueAt])
   @@index([planId])
@@ -4069,7 +4073,6 @@ model DiagnosticImage {
   @@map("DiagnosticImage")
 }
 
-
 // ---------------------------------------------------------------------------
 // Blood Transfusion Records
 // ---------------------------------------------------------------------------
@@ -4094,26 +4097,26 @@ enum TransfusionReaction {
 }
 
 model BloodTransfusion {
-  id              String              @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  donorId         String?
-  productType     String
-  bloodType       BloodType
-  volumeMl        Float
-  startedAt       DateTime
-  endedAt         DateTime?
-  durationMinutes Int?
-  reaction        TransfusionReaction @default(NONE)
-  reactionNotes   String?
-  administeredBy  String?
-  crossMatchDone  Boolean             @default(false)
-  crossMatchResult String?
-  preTransfusionPCV Float?
+  id                 String              @id @default(uuid())
+  organisationId     String
+  patientId          String
+  encounterId        String?
+  donorId            String?
+  productType        String
+  bloodType          BloodType
+  volumeMl           Float
+  startedAt          DateTime
+  endedAt            DateTime?
+  durationMinutes    Int?
+  reaction           TransfusionReaction @default(NONE)
+  reactionNotes      String?
+  administeredBy     String?
+  crossMatchDone     Boolean             @default(false)
+  crossMatchResult   String?
+  preTransfusionPCV  Float?
   postTransfusionPCV Float?
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4143,25 +4146,25 @@ enum FluidTherapyStatus {
 }
 
 model FluidTherapyPlan {
-  id               String             @id @default(uuid())
-  organisationId   String
-  patientId        String
-  encounterId      String?
-  admissionId      String?
-  fluidType        FluidType
-  customFluidName  String?
-  additives        String?
-  rateMlPerHour    Float
-  totalVolumeMl    Float?
-  durationHours    Float?
-  startedAt        DateTime
-  endedAt          DateTime?
-  status           FluidTherapyStatus @default(ACTIVE)
-  indication       String?
-  prescribedBy     String?
-  notes            String?
-  createdAt        DateTime           @default(now())
-  updatedAt        DateTime           @updatedAt
+  id              String             @id @default(uuid())
+  organisationId  String
+  patientId       String
+  encounterId     String?
+  admissionId     String?
+  fluidType       FluidType
+  customFluidName String?
+  additives       String?
+  rateMlPerHour   Float
+  totalVolumeMl   Float?
+  durationHours   Float?
+  startedAt       DateTime
+  endedAt         DateTime?
+  status          FluidTherapyStatus @default(ACTIVE)
+  indication      String?
+  prescribedBy    String?
+  notes           String?
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4179,27 +4182,27 @@ enum NutritionPlanStatus {
 }
 
 model NutritionPlan {
-  id              String              @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  status          NutritionPlanStatus @default(ACTIVE)
-  dietName        String
-  calories        Float?
-  calorieUnit     String?
-  protein         Float?
-  fat             Float?
-  fibre           Float?
+  id               String              @id @default(uuid())
+  organisationId   String
+  patientId        String
+  encounterId      String?
+  status           NutritionPlanStatus @default(ACTIVE)
+  dietName         String
+  calories         Float?
+  calorieUnit      String?
+  protein          Float?
+  fat              Float?
+  fibre            Float?
   feedingFrequency String?
-  portionSize     String?
-  waterIntake     String?
-  restrictions    String?
-  indication      String?
-  prescribedBy    String?
-  reviewDate      DateTime?
-  notes           String?
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  portionSize      String?
+  waterIntake      String?
+  restrictions     String?
+  indication       String?
+  prescribedBy     String?
+  reviewDate       DateTime?
+  notes            String?
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4217,27 +4220,27 @@ enum PostOpCareStatus {
 }
 
 model PostOpCarePlan {
-  id                String          @id @default(uuid())
-  organisationId    String
-  patientId         String
-  encounterId       String?
-  surgicalProcedureId String?
-  status            PostOpCareStatus @default(ACTIVE)
-  painScore         Int?
-  analgesiaProtocol String?
+  id                    String           @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  surgicalProcedureId   String?
+  status                PostOpCareStatus @default(ACTIVE)
+  painScore             Int?
+  analgesiaProtocol     String?
   woundCareInstructions String?
   activityRestrictions  String?
-  dietaryNotes      String?
-  fluidTherapyNotes String?
-  monitoringParams  String?
-  firstReviewAt     DateTime?
-  nextReviewAt      DateTime?
-  reviewedBy        String?
-  reviewNotes       String?
-  prescribedBy      String?
-  notes             String?
-  createdAt         DateTime        @default(now())
-  updatedAt         DateTime        @updatedAt
+  dietaryNotes          String?
+  fluidTherapyNotes     String?
+  monitoringParams      String?
+  firstReviewAt         DateTime?
+  nextReviewAt          DateTime?
+  reviewedBy            String?
+  reviewNotes           String?
+  prescribedBy          String?
+  notes                 String?
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4295,35 +4298,35 @@ enum PhysiotherapyStatus {
 }
 
 model PhysiotherapyPlan {
-  id                   String              @id @default(uuid())
-  organisationId       String
-  patientId            String
-  encounterId          String?
-  surgicalProcedureId  String?
-  diagnosis            String
-  goals                String?
-  frequency            String?
-  durationMinutes      Int?
-  totalSessions        Int?
-  exercisePrescription String?
-  hydrotherapy         Boolean             @default(false)
-  laserTherapy         Boolean             @default(false)
-  therapeuticUltrasound Boolean            @default(false)
-  massage              Boolean             @default(false)
-  acupuncture          Boolean             @default(false)
-  tapeApplication      Boolean             @default(false)
-  precautions          String?
-  homeExercises        String?
-  startDate            DateTime?
-  endDate              DateTime?
-  lastSessionAt        DateTime?
-  nextSessionAt        DateTime?
-  therapist            String?
-  prescribedBy         String?
-  status               PhysiotherapyStatus @default(ACTIVE)
-  notes                String?
-  createdAt            DateTime            @default(now())
-  updatedAt            DateTime            @updatedAt
+  id                    String              @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  surgicalProcedureId   String?
+  diagnosis             String
+  goals                 String?
+  frequency             String?
+  durationMinutes       Int?
+  totalSessions         Int?
+  exercisePrescription  String?
+  hydrotherapy          Boolean             @default(false)
+  laserTherapy          Boolean             @default(false)
+  therapeuticUltrasound Boolean             @default(false)
+  massage               Boolean             @default(false)
+  acupuncture           Boolean             @default(false)
+  tapeApplication       Boolean             @default(false)
+  precautions           String?
+  homeExercises         String?
+  startDate             DateTime?
+  endDate               DateTime?
+  lastSessionAt         DateTime?
+  nextSessionAt         DateTime?
+  therapist             String?
+  prescribedBy          String?
+  status                PhysiotherapyStatus @default(ACTIVE)
+  notes                 String?
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@index([encounterId])
@@ -4688,21 +4691,21 @@ enum DentalGrade {
 }
 
 model DentalExamination {
-  id              String      @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  examinedAt      DateTime
-  examinedBy      String?
-  overallGrade    DentalGrade
-  findings        Json
-  calculusScore   Int?
-  plaqueScore     Int?
-  gingivalScore   Int?
-  procedures      String[]
-  notes           String?
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  id             String      @id @default(uuid())
+  organisationId String
+  patientId      String
+  encounterId    String?
+  examinedAt     DateTime
+  examinedBy     String?
+  overallGrade   DentalGrade
+  findings       Json
+  calculusScore  Int?
+  plaqueScore    Int?
+  gingivalScore  Int?
+  procedures     String[]
+  notes          String?
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
 
   @@index([organisationId, patientId])
   @@map("DentalExamination")
@@ -4730,27 +4733,27 @@ enum PregnancyStatus {
 }
 
 model ReproductiveRecord {
-  id                    String              @id @default(uuid())
-  organisationId        String
-  patientId             String
-  reproductiveStatus    ReproductiveStatus
-  lastHeatDate          DateTime?
-  nextHeatExpected      DateTime?
-  matingDate            DateTime?
-  sireId                String?
-  sireName              String?
-  pregnancyStatus       PregnancyStatus?
-  pregnancyConfirmedAt  DateTime?
-  expectedWhelp         DateTime?
-  litterSizeUltrasound  Int?
-  litterSizeXray        Int?
-  actualWhelp           DateTime?
-  litterSizeBorn        Int?
-  litterSizeAlive       Int?
-  recordedBy            String?
-  notes                 String?
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
+  id                   String             @id @default(uuid())
+  organisationId       String
+  patientId            String
+  reproductiveStatus   ReproductiveStatus
+  lastHeatDate         DateTime?
+  nextHeatExpected     DateTime?
+  matingDate           DateTime?
+  sireId               String?
+  sireName             String?
+  pregnancyStatus      PregnancyStatus?
+  pregnancyConfirmedAt DateTime?
+  expectedWhelp        DateTime?
+  litterSizeUltrasound Int?
+  litterSizeXray       Int?
+  actualWhelp          DateTime?
+  litterSizeBorn       Int?
+  litterSizeAlive      Int?
+  recordedBy           String?
+  notes                String?
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@map("ReproductiveRecord")
@@ -4774,32 +4777,32 @@ enum PLRResponse {
 }
 
 model OphthalmologyExamination {
-  id                  String       @id @default(uuid())
-  organisationId      String
-  patientId           String
-  encounterId         String?
-  examinedAt          DateTime
-  examinedBy          String?
-  visionLeft          VisionStatus?
-  visionRight         VisionStatus?
-  menaceLeft          Boolean?
-  menaceRight         Boolean?
-  plrDirectLeft       PLRResponse?
-  plrDirectRight      PLRResponse?
-  plrConsensualLeft   PLRResponse?
-  plrConsensualRight  PLRResponse?
-  sttLeft             Int?
-  sttRight            Int?
-  iopLeft             Decimal?
-  iopRight            Decimal?
-  fluoresceinLeft     Boolean?
-  fluoresceinRight    Boolean?
-  findingsLeft        Json?
-  findingsRight       Json?
-  diagnoses           String[]
-  notes               String?
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
+  id                 String        @id @default(uuid())
+  organisationId     String
+  patientId          String
+  encounterId        String?
+  examinedAt         DateTime
+  examinedBy         String?
+  visionLeft         VisionStatus?
+  visionRight        VisionStatus?
+  menaceLeft         Boolean?
+  menaceRight        Boolean?
+  plrDirectLeft      PLRResponse?
+  plrDirectRight     PLRResponse?
+  plrConsensualLeft  PLRResponse?
+  plrConsensualRight PLRResponse?
+  sttLeft            Int?
+  sttRight           Int?
+  iopLeft            Decimal?
+  iopRight           Decimal?
+  fluoresceinLeft    Boolean?
+  fluoresceinRight   Boolean?
+  findingsLeft       Json?
+  findingsRight      Json?
+  diagnoses          String[]
+  notes              String?
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
 
   @@index([organisationId, patientId])
   @@map("OphthalmologyExamination")
@@ -4840,7 +4843,7 @@ enum AcvimClass {
 }
 
 model CardiologyAssessment {
-  id                   String      @id @default(uuid())
+  id                   String       @id @default(uuid())
   organisationId       String
   patientId            String
   encounterId          String?
@@ -4861,8 +4864,8 @@ model CardiologyAssessment {
   findings             Json?
   diagnoses            String[]
   notes                String?
-  createdAt            DateTime    @default(now())
-  updatedAt            DateTime    @updatedAt
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@map("CardiologyAssessment")
@@ -4889,24 +4892,24 @@ enum HandlingTolerance {
 }
 
 model BehaviorAssessment {
-  id                    String            @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  fasScore              FasScore?
-  nailTrimTolerance     HandlingTolerance?
-  handlingTolerance     HandlingTolerance?
-  aggressionTriggers    String[]
-  aversionBehaviors     String[]
-  trainingHistory       String?
-  diagnoses             String[]
-  referralRecommended   Boolean?
-  fearFreeNotes         String?
-  notes                 String?
-  createdAt             DateTime          @default(now())
-  updatedAt             DateTime          @updatedAt
+  id                  String             @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String?
+  assessedAt          DateTime
+  assessedBy          String?
+  fasScore            FasScore?
+  nailTrimTolerance   HandlingTolerance?
+  handlingTolerance   HandlingTolerance?
+  aggressionTriggers  String[]
+  aversionBehaviors   String[]
+  trainingHistory     String?
+  diagnoses           String[]
+  referralRecommended Boolean?
+  fearFreeNotes       String?
+  notes               String?
+  createdAt           DateTime           @default(now())
+  updatedAt           DateTime           @updatedAt
 
   @@index([organisationId, patientId])
   @@map("BehaviorAssessment")
@@ -4917,25 +4920,25 @@ model BehaviorAssessment {
 // ---------------------------------------------------------------------------
 
 model DermatologyAssessment {
-  id                    String    @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  pruritusScore         Int?
-  affectedRegions       String[]
-  primaryLesions        String[]
-  secondaryLesions      String[]
-  coatQuality           String?
-  lesionMap             Json?
+  id                     String   @id @default(uuid())
+  organisationId         String
+  patientId              String
+  encounterId            String?
+  assessedAt             DateTime
+  assessedBy             String?
+  pruritusScore          Int?
+  affectedRegions        String[]
+  primaryLesions         String[]
+  secondaryLesions       String[]
+  coatQuality            String?
+  lesionMap              Json?
   environmentalAllergens String[]
-  foodTrialStatus       String?
-  cades04Score          Int?
-  diagnoses             String[]
-  notes                 String?
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
+  foodTrialStatus        String?
+  cades04Score           Int?
+  diagnoses              String[]
+  notes                  String?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   @@index([organisationId, patientId])
   @@map("DermatologyAssessment")
@@ -4961,25 +4964,25 @@ enum GaitScore {
 }
 
 model NeurologyAssessment {
-  id                    String             @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  assessedAt            DateTime
-  assessedBy            String?
-  consciousnessLevel    ConsciousnessLevel?
-  gaitScore             GaitScore?
-  cranialNerveFindings  String?
-  spinalReflexGrades    Json?
-  deepPainPresent       Boolean?
-  proprioceptionIntact  Boolean?
-  seizureHistory        Boolean?
-  seizureFrequency      String?
-  mriRecommended        Boolean?
-  diagnoses             String[]
-  notes                 String?
-  createdAt             DateTime           @default(now())
-  updatedAt             DateTime           @updatedAt
+  id                   String              @id @default(uuid())
+  organisationId       String
+  patientId            String
+  encounterId          String?
+  assessedAt           DateTime
+  assessedBy           String?
+  consciousnessLevel   ConsciousnessLevel?
+  gaitScore            GaitScore?
+  cranialNerveFindings String?
+  spinalReflexGrades   Json?
+  deepPainPresent      Boolean?
+  proprioceptionIntact Boolean?
+  seizureHistory       Boolean?
+  seizureFrequency     String?
+  mriRecommended       Boolean?
+  diagnoses            String[]
+  notes                String?
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
 
   @@index([organisationId, patientId])
   @@map("NeurologyAssessment")
@@ -5004,26 +5007,26 @@ enum OncologyStage {
 }
 
 model OncologyAssessment {
-  id                      String        @id @default(uuid())
-  organisationId          String
-  patientId               String
-  encounterId             String?
-  assessedAt              DateTime
-  assessedBy              String?
-  tumorType               String?
-  primaryTumorStage       String?
-  nodeStage               String?
-  metastasisStage         String?
-  overallStage            OncologyStage?
-  chemotherapyProtocol    String?
-  chemotherapyStartDate   DateTime?
-  chemotherapyCycles      Int?
-  qualityOfLifeScore      Int?
-  prognosis               String?
-  diagnoses               String[]
-  notes                   String?
-  createdAt               DateTime      @default(now())
-  updatedAt               DateTime      @updatedAt
+  id                    String         @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  assessedAt            DateTime
+  assessedBy            String?
+  tumorType             String?
+  primaryTumorStage     String?
+  nodeStage             String?
+  metastasisStage       String?
+  overallStage          OncologyStage?
+  chemotherapyProtocol  String?
+  chemotherapyStartDate DateTime?
+  chemotherapyCycles    Int?
+  qualityOfLifeScore    Int?
+  prognosis             String?
+  diagnoses             String[]
+  notes                 String?
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
 
   @@index([organisationId, patientId])
   @@map("OncologyAssessment")
@@ -5050,27 +5053,27 @@ enum FeedingRoute {
 }
 
 model NutritionAssessment {
-  id                        String        @id @default(uuid())
-  organisationId            String
-  patientId                 String
-  encounterId               String?
-  assessedAt                DateTime
-  assessedBy                String?
-  appetiteScore             AppetiteScore?
-  bodyConditionScore        Int?
-  muscleConditionScore      Int?
-  currentWeightKg           Float?
-  idealWeightKg             Float?
-  restingEnergyRequirement  Float?
-  feedingRoute              FeedingRoute?
-  currentDiet               String?
-  feedingPlan               String?
-  supplementation           String[]
-  hydrationStatus           String?
-  diagnoses                 String[]
-  notes                     String?
-  createdAt                 DateTime      @default(now())
-  updatedAt                 DateTime      @updatedAt
+  id                       String         @id @default(uuid())
+  organisationId           String
+  patientId                String
+  encounterId              String?
+  assessedAt               DateTime
+  assessedBy               String?
+  appetiteScore            AppetiteScore?
+  bodyConditionScore       Int?
+  muscleConditionScore     Int?
+  currentWeightKg          Float?
+  idealWeightKg            Float?
+  restingEnergyRequirement Float?
+  feedingRoute             FeedingRoute?
+  currentDiet              String?
+  feedingPlan              String?
+  supplementation          String[]
+  hydrationStatus          String?
+  diagnoses                String[]
+  notes                    String?
+  createdAt                DateTime       @default(now())
+  updatedAt                DateTime       @updatedAt
 
   @@index([organisationId, patientId])
   @@map("NutritionAssessment")
@@ -5096,23 +5099,23 @@ enum PocTestType {
 }
 
 model PointOfCareLab {
-  id                  String       @id @default(uuid())
-  organisationId      String
-  patientId           String
-  encounterId         String?
-  conductedAt         DateTime
-  conductedBy         String?
-  testType            PocTestType
-  analyzerName        String?
-  sampleType          String?
-  results             Json
+  id                    String      @id @default(uuid())
+  organisationId        String
+  patientId             String
+  encounterId           String?
+  conductedAt           DateTime
+  conductedBy           String?
+  testType              PocTestType
+  analyzerName          String?
+  sampleType            String?
+  results               Json
   overallInterpretation String?
-  abnormalFlags       String[]
-  criticalFlags       String[]
-  followUpRecommended Boolean?
-  notes               String?
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
+  abnormalFlags         String[]
+  criticalFlags         String[]
+  followUpRecommended   Boolean?
+  notes                 String?
+  createdAt             DateTime    @default(now())
+  updatedAt             DateTime    @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, testType])
@@ -5144,7 +5147,7 @@ enum OrthoRating {
 }
 
 model GeneticHealthScreen {
-  id                  String            @id @default(uuid())
+  id                  String       @id @default(uuid())
   organisationId      String
   patientId           String
   encounterId         String?
@@ -5160,8 +5163,8 @@ model GeneticHealthScreen {
   certificateNumber   String?
   certificationExpiry DateTime?
   notes               String?
-  createdAt           DateTime          @default(now())
-  updatedAt           DateTime          @updatedAt
+  createdAt           DateTime     @default(now())
+  updatedAt           DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@map("GeneticHealthScreen")
@@ -5172,26 +5175,26 @@ model GeneticHealthScreen {
 // ---------------------------------------------------------------------------
 
 model QualityOfLifeAssessment {
-  id               String    @id @default(uuid())
-  organisationId   String
-  patientId        String
-  encounterId      String?
-  assessedAt       DateTime
-  assessedBy       String?
-  hhhhhmmScore     Int?
-  painScore        Int?
-  appetiteScore    Int?
-  hygieneScore     Int?
-  happinessScore   Int?
-  mobilityScore    Int?
-  moreDaysGood     Boolean?
-  overallScore     Int?
-  ownerAssessed    Boolean   @default(false)
-  clinicianNotes   String?
-  ownerNotes       String?
+  id                  String   @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String?
+  assessedAt          DateTime
+  assessedBy          String?
+  hhhhhmmScore        Int?
+  painScore           Int?
+  appetiteScore       Int?
+  hygieneScore        Int?
+  happinessScore      Int?
+  mobilityScore       Int?
+  moreDaysGood        Boolean?
+  overallScore        Int?
+  ownerAssessed       Boolean  @default(false)
+  clinicianNotes      String?
+  ownerNotes          String?
   euthanasiaDiscussed Boolean?
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   @@index([organisationId, patientId])
   @@map("QualityOfLifeAssessment")
@@ -5425,22 +5428,22 @@ enum BodyDispositionType {
 }
 
 model DeceasedRecord {
-  id                 String              @id @default(uuid())
+  id                 String               @id @default(uuid())
   organisationId     String
-  patientId          String              @unique
+  patientId          String               @unique
   deceasedAt         DateTime
   causeOfDeathType   CauseOfDeathType
   causeOfDeathDetail String?
   bodyWeightKg       Float?
   bodyConditionScore Int?
-  necropsyRequested  Boolean             @default(false)
+  necropsyRequested  Boolean              @default(false)
   necropsyFacility   String?
   bodyDisposition    BodyDispositionType?
   ownerNotifiedAt    DateTime?
   certifiedBy        String?
   notes              String?
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
 
   @@index([organisationId, deceasedAt])
   @@map("DeceasedRecord")
@@ -5464,17 +5467,17 @@ enum ChecklistStatus {
 }
 
 model SurgicalChecklist {
-  id              String          @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String
-  phase           ChecklistPhase  @default(SIGN_IN)
-  status          ChecklistStatus @default(PENDING)
-  conductedBy     String?
-  completedAt     DateTime?
-  notes           String?
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  id             String          @id @default(uuid())
+  organisationId String
+  patientId      String
+  encounterId    String
+  phase          ChecklistPhase  @default(SIGN_IN)
+  status         ChecklistStatus @default(PENDING)
+  conductedBy    String?
+  completedAt    DateTime?
+  notes          String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   items SurgicalChecklistItem[]
 
@@ -5484,16 +5487,16 @@ model SurgicalChecklist {
 }
 
 model SurgicalChecklistItem {
-  id          String   @id @default(uuid())
+  id          String    @id @default(uuid())
   checklistId String
   label       String
-  isChecked   Boolean  @default(false)
+  isChecked   Boolean   @default(false)
   checkedBy   String?
   checkedAt   DateTime?
   notes       String?
-  sortOrder   Int      @default(0)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  sortOrder   Int       @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   checklist SurgicalChecklist @relation(fields: [checklistId], references: [id], onDelete: Cascade)
 
@@ -5645,28 +5648,28 @@ enum AsaClass {
 }
 
 model PreOpAssessment {
-  id                   String    @id @default(uuid())
-  organisationId       String
-  patientId            String
-  encounterId          String
-  asaClass             AsaClass  @default(ASA_I)
-  fastingStartedAt     DateTime?
-  labsReviewed         Boolean   @default(false)
-  ecgReviewed          Boolean   @default(false)
-  ownerConsentSigned   Boolean   @default(false)
-  anesthetistId        String?
-  surgeonId            String?
-  plannedProcedure     String?
-  anesthesiaType       String?
-  knownAllergies       String?
-  currentMedications   String?
-  airwayNotes          String?
-  cardiovascularNotes  String?
-  notes                String?
-  assessedBy           String?
-  assessedAt           DateTime  @default(now())
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
+  id                  String    @id @default(uuid())
+  organisationId      String
+  patientId           String
+  encounterId         String
+  asaClass            AsaClass  @default(ASA_I)
+  fastingStartedAt    DateTime?
+  labsReviewed        Boolean   @default(false)
+  ecgReviewed         Boolean   @default(false)
+  ownerConsentSigned  Boolean   @default(false)
+  anesthetistId       String?
+  surgeonId           String?
+  plannedProcedure    String?
+  anesthesiaType      String?
+  knownAllergies      String?
+  currentMedications  String?
+  airwayNotes         String?
+  cardiovascularNotes String?
+  notes               String?
+  assessedBy          String?
+  assessedAt          DateTime  @default(now())
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, encounterId])
@@ -5699,20 +5702,20 @@ enum IsolationLevel {
 }
 
 model IsolationProtocol {
-  id              String         @id @default(uuid())
-  organisationId  String
-  patientId       String
-  reason          IsolationReason @default(OTHER)
-  level           IsolationLevel  @default(CONTACT)
-  unitId          String?
-  startedAt       DateTime
-  endedAt         DateTime?
-  initiatedBy     String?
-  endedBy         String?
-  ppe             String[]
-  notes           String?
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  id             String          @id @default(uuid())
+  organisationId String
+  patientId      String
+  reason         IsolationReason @default(OTHER)
+  level          IsolationLevel  @default(CONTACT)
+  unitId         String?
+  startedAt      DateTime
+  endedAt        DateTime?
+  initiatedBy    String?
+  endedBy        String?
+  ppe            String[]
+  notes          String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, endedAt])
@@ -5732,25 +5735,25 @@ enum TransferType {
 }
 
 model PatientTransfer {
-  id                    String       @id @default(uuid())
-  organisationId        String
-  patientId             String
-  encounterId           String?
-  transferType          TransferType
-  receivingFacility     String
-  receivingVetName      String?
-  receivingVetContact   String?
-  transferredAt         DateTime
-  transferredBy         String?
-  chiefComplaint        String?
-  currentDiagnoses      String?
-  ongoingTreatments     String?
-  medicationsDispensed  String?
-  caseSummary           String?
-  criticalAlerts        String?
-  ownerInformed         Boolean      @default(false)
-  createdAt             DateTime     @default(now())
-  updatedAt             DateTime     @updatedAt
+  id                   String       @id @default(uuid())
+  organisationId       String
+  patientId            String
+  encounterId          String?
+  transferType         TransferType
+  receivingFacility    String
+  receivingVetName     String?
+  receivingVetContact  String?
+  transferredAt        DateTime
+  transferredBy        String?
+  chiefComplaint       String?
+  currentDiagnoses     String?
+  ongoingTreatments    String?
+  medicationsDispensed String?
+  caseSummary          String?
+  criticalAlerts       String?
+  ownerInformed        Boolean      @default(false)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, transferredAt])
@@ -5779,7 +5782,7 @@ enum EquipmentStatus {
 }
 
 model ClinicEquipment {
-  id              String          @id @default(uuid())
+  id              String                    @id @default(uuid())
   organisationId  String
   name            String
   model           String?
@@ -5787,32 +5790,32 @@ model ClinicEquipment {
   manufacturer    String?
   purchasedAt     DateTime?
   warrantyExpiry  DateTime?
-  status          EquipmentStatus @default(OPERATIONAL)
+  status          EquipmentStatus           @default(OPERATIONAL)
   locationNotes   String?
   notes           String?
   maintenanceLogs EquipmentMaintenanceLog[]
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  createdAt       DateTime                  @default(now())
+  updatedAt       DateTime                  @updatedAt
 
   @@index([organisationId])
   @@map("ClinicEquipment")
 }
 
 model EquipmentMaintenanceLog {
-  id            String          @id @default(uuid())
-  equipmentId   String
-  equipment     ClinicEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+  id              String          @id @default(uuid())
+  equipmentId     String
+  equipment       ClinicEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
   maintenanceType MaintenanceType
-  performedBy   String?
-  vendor        String?
-  scheduledAt   DateTime?
-  performedAt   DateTime
-  nextDueAt     DateTime?
-  cost          Float?
-  currency      String?
-  passed        Boolean?
-  notes         String?
-  createdAt     DateTime        @default(now())
+  performedBy     String?
+  vendor          String?
+  scheduledAt     DateTime?
+  performedAt     DateTime
+  nextDueAt       DateTime?
+  cost            Float?
+  currency        String?
+  passed          Boolean?
+  notes           String?
+  createdAt       DateTime        @default(now())
 
   @@index([equipmentId])
   @@index([equipmentId, performedAt])
@@ -5884,21 +5887,21 @@ enum ClinicalAlertSeverity {
 }
 
 model ClinicalAlertLog {
-  id              String                @id @default(uuid())
-  organisationId  String
-  patientId       String
-  encounterId     String?
-  alertType       ClinicalAlertType
-  severity        ClinicalAlertSeverity @default(WARNING)
-  title           String
-  body            String?
-  triggeredBy     String?
-  acknowledgedAt  DateTime?
-  acknowledgedBy  String?
+  id               String                @id @default(uuid())
+  organisationId   String
+  patientId        String
+  encounterId      String?
+  alertType        ClinicalAlertType
+  severity         ClinicalAlertSeverity @default(WARNING)
+  title            String
+  body             String?
+  triggeredBy      String?
+  acknowledgedAt   DateTime?
+  acknowledgedBy   String?
   acknowledgedNote String?
-  dismissed       Boolean               @default(false)
-  createdAt       DateTime              @default(now())
-  updatedAt       DateTime              @updatedAt
+  dismissed        Boolean               @default(false)
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, severity])
@@ -5926,24 +5929,24 @@ enum TelemedicineStatus {
 }
 
 model TelemedicineSession {
-  id               String               @id @default(uuid())
-  organisationId   String
-  appointmentId    String?
-  clientId         String
-  patientId        String?
-  platform         TelemedicinePlatform
-  status           TelemedicineStatus   @default(SCHEDULED)
-  startedAt        DateTime?
-  endedAt          DateTime?
-  durationMinutes  Int?
-  conductedBy      String?
-  chiefComplaint   String?
-  clinicianNotes   String?
-  followUpRequired Boolean              @default(false)
-  recordingUrl     String?
+  id                String               @id @default(uuid())
+  organisationId    String
+  appointmentId     String?
+  clientId          String
+  patientId         String?
+  platform          TelemedicinePlatform
+  status            TelemedicineStatus   @default(SCHEDULED)
+  startedAt         DateTime?
+  endedAt           DateTime?
+  durationMinutes   Int?
+  conductedBy       String?
+  chiefComplaint    String?
+  clinicianNotes    String?
+  followUpRequired  Boolean              @default(false)
+  recordingUrl      String?
   externalSessionId String?
-  createdAt        DateTime             @default(now())
-  updatedAt        DateTime             @updatedAt
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
 
   @@index([organisationId, clientId])
   @@index([organisationId, status])
@@ -5964,23 +5967,23 @@ enum CheckInStatus {
 }
 
 model PatientCheckIn {
-  id              String         @id @default(uuid())
-  organisationId  String
-  patientId       String
-  clientId        String
-  appointmentId   String?
-  arrivedAt       DateTime
-  triagePriority  TriagePriority @default(NON_URGENT)
-  triageNote      String?
-  assignedRoomId  String?
-  checkedInBy     String?
-  waitStartedAt   DateTime?
-  seenAt          DateTime?
-  waitMinutes     Int?
-  status          CheckInStatus  @default(WAITING)
-  notes           String?
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  id             String         @id @default(uuid())
+  organisationId String
+  patientId      String
+  clientId       String
+  appointmentId  String?
+  arrivedAt      DateTime
+  triagePriority TriagePriority @default(NON_URGENT)
+  triageNote     String?
+  assignedRoomId String?
+  checkedInBy    String?
+  waitStartedAt  DateTime?
+  seenAt         DateTime?
+  waitMinutes    Int?
+  status         CheckInStatus  @default(WAITING)
+  notes          String?
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
   @@index([organisationId, status])
   @@index([organisationId, patientId])
@@ -6000,7 +6003,7 @@ enum AnaesthesiaStatus {
 }
 
 model AnaesthesiaRecord {
-  id                  String             @id @default(uuid())
+  id                  String            @id @default(uuid())
   organisationId      String
   patientId           String
   encounterId         String?
@@ -6019,9 +6022,9 @@ model AnaesthesiaRecord {
   intraOpNotes        Json?
   complications       String?
   recoveryNotes       String?
-  status              AnaesthesiaStatus  @default(PLANNED)
-  createdAt           DateTime           @default(now())
-  updatedAt           DateTime           @updatedAt
+  status              AnaesthesiaStatus @default(PLANNED)
+  createdAt           DateTime          @default(now())
+  updatedAt           DateTime          @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, status])
@@ -6109,27 +6112,27 @@ enum MedicalCertificateStatus {
 }
 
 model MedicalCertificate {
-  id              String                   @id @default(uuid())
-  organisationId  String
-  patientId       String
-  clientId        String
-  encounterId     String?
-  appointmentId   String?
-  certificateType MedicalCertificateType
-  status          MedicalCertificateStatus @default(DRAFT)
-  issueNumber     String?                  @unique
-  issuedAt        DateTime?
-  expiresAt       DateTime?
-  issuedBy        String?
-  validForTravel  Boolean                  @default(false)
+  id                 String                   @id @default(uuid())
+  organisationId     String
+  patientId          String
+  clientId           String
+  encounterId        String?
+  appointmentId      String?
+  certificateType    MedicalCertificateType
+  status             MedicalCertificateStatus @default(DRAFT)
+  issueNumber        String?                  @unique
+  issuedAt           DateTime?
+  expiresAt          DateTime?
+  issuedBy           String?
+  validForTravel     Boolean                  @default(false)
   destinationCountry String?
   clinicalFindings   String?
   restrictions       String?
   notes              String?
   revokedAt          DateTime?
   revokedReason      String?
-  createdAt       DateTime                 @default(now())
-  updatedAt       DateTime                 @updatedAt
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
 
   @@index([organisationId, patientId])
   @@index([organisationId, status])
@@ -6178,7 +6181,7 @@ model PatientFlag {
 }
 
 model InventoryCount {
-  id              String   @id @default(uuid())
+  id              String    @id @default(uuid())
   organisationId  String
   inventoryItemId String
   countedBy       String?
@@ -6187,11 +6190,11 @@ model InventoryCount {
   physicalCount   Int
   discrepancy     Int
   notes           String?
-  reconciled      Boolean  @default(false)
+  reconciled      Boolean   @default(false)
   reconciledAt    DateTime?
   reconciledBy    String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   @@index([organisationId, inventoryItemId])
   @@index([organisationId, countedAt])
@@ -6234,13 +6237,13 @@ model ClinicNote {
 // ─── ActivityPub Federation ───────────────────────────────────────────────────
 
 model APActor {
-  id                String       @id @default(uuid())
-  organisationId    String?      @unique
-  uri               String       @unique
-  preferredUsername String       @unique
+  id                String   @id @default(uuid())
+  organisationId    String?  @unique
+  uri               String   @unique
+  preferredUsername String   @unique
   publicKeyPem      String
   privateKeyPem     String
-  publicKeyId       String       @unique
+  publicKeyId       String   @unique
   inboxUri          String
   outboxUri         String
   followersUri      String
@@ -6249,13 +6252,13 @@ model APActor {
   summary           String?
   iconUrl           String?
   licenseToken      String?
-  directoryListed   Boolean      @default(false)
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  directoryListed   Boolean  @default(false)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  followers         APFollower[] @relation("LocalActorFollowers")
-  following         APFollowing[]
-  activities        APActivity[]
+  followers  APFollower[]  @relation("LocalActorFollowers")
+  following  APFollowing[]
+  activities APActivity[]
 }
 
 model APFollower {
@@ -6269,7 +6272,7 @@ model APFollower {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
 
-  localActor     APActor         @relation("LocalActorFollowers", fields: [localActorId], references: [id])
+  localActor APActor @relation("LocalActorFollowers", fields: [localActorId], references: [id])
 
   @@unique([localActorId, remoteActorUri])
   @@index([localActorId])
@@ -6287,7 +6290,7 @@ model APFollowing {
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
 
-  localActor     APActor          @relation(fields: [localActorId], references: [id])
+  localActor APActor @relation(fields: [localActorId], references: [id])
 
   @@unique([localActorId, remoteActorUri])
   @@index([localActorId])
@@ -6313,22 +6316,22 @@ model APRemoteActor {
 }
 
 model APActivity {
-  id            String       @id @default(uuid())
-  uri           String       @unique
-  type          String
-  localActorId  String
-  objectUri     String?
-  objectJson    Json?
-  targetUri     String?
-  toAddresses   String[]
-  ccAddresses   String[]
-  published     DateTime
-  processed     Boolean      @default(false)
-  direction     APDirection  @default(OUTBOUND)
-  rawJson       Json
-  createdAt     DateTime     @default(now())
+  id           String      @id @default(uuid())
+  uri          String      @unique
+  type         String
+  localActorId String
+  objectUri    String?
+  objectJson   Json?
+  targetUri    String?
+  toAddresses  String[]
+  ccAddresses  String[]
+  published    DateTime
+  processed    Boolean     @default(false)
+  direction    APDirection @default(OUTBOUND)
+  rawJson      Json
+  createdAt    DateTime    @default(now())
 
-  localActor    APActor      @relation(fields: [localActorId], references: [id])
+  localActor APActor @relation(fields: [localActorId], references: [id])
 
   @@index([localActorId])
   @@index([type])
@@ -6337,20 +6340,20 @@ model APActivity {
 }
 
 model APReferral {
-  id              String             @id @default(uuid())
-  activityUri     String             @unique
+  id              String            @id @default(uuid())
+  activityUri     String            @unique
   fromActorUri    String
   toActorUri      String
   fromOrgId       String?
   toOrgId         String?
   patientSummary  Json
   clinicalContext String?
-  urgency         APReferralUrgency  @default(ROUTINE)
-  state           APReferralState    @default(PENDING)
+  urgency         APReferralUrgency @default(ROUTINE)
+  state           APReferralState   @default(PENDING)
   acceptedAt      DateTime?
   declinedAt      DateTime?
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 
   @@index([fromActorUri])
   @@index([toActorUri])
@@ -6386,4 +6389,89 @@ enum APReferralUrgency {
   ROUTINE
   URGENT
   EMERGENCY
+}
+
+/// Strength of the source behind a recommendation rule.
+///
+/// An ACVIM consensus statement and a single forty-dog retrospective are not the
+/// same thing, and a table that treats them alike will not survive contact with a
+/// vet. Ordered strongest first.
+enum RecommendationEvidenceGrade {
+  CONSENSUS_STATEMENT
+  PRACTICE_GUIDELINE
+  POPULATION_STUDY
+  COHORT_STUDY
+  CASE_SERIES
+  EXPERT_OPINION
+}
+
+/// A husbandry task recommended for a species, breed and age window, with the
+/// source it comes from.
+///
+/// Separate from TaskLibraryDefinition on purpose. The definition is the TASK
+/// ("Log weight"); this is the INDICATION ("for a Cavalier over five, because
+/// MMVD"). One definition can be recommended by several rules with different age
+/// windows and different sources, which breed arrays bolted onto the definition
+/// could not express.
+///
+/// Recommends husbandry, never diagnosis. The rendered copy says "commonly
+/// recommended for this breed" with the citation visible; nothing here may be
+/// phrased as a claim about the individual animal.
+model TaskRecommendationRule {
+  id String @id @default(uuid())
+
+  /// Matches TaskLibraryDefinition.applicableSpecies, so a rule cannot recommend
+  /// a task to a species the task does not support.
+  species TaskLibrarySpecies
+
+  /// Canonical breed codes this applies to, e.g. YBREED:CANINE:CAVALIER_KING_CHARLES_SPANIEL.
+  /// Empty means the rule is species-wide - the life-stage tasks most animals get.
+  ///
+  /// Stored canonically (hyphens folded to underscores, upper case) because the
+  /// vocabulary holds 36 breeds under BOTH separator conventions; comparing these
+  /// literally would silently miss every patient coded the other way.
+  breedCodes String[] @default([])
+
+  /// Half-open age window in months: [minAgeMonths, maxAgeMonths). Null is open.
+  /// Months rather than years because the feline and canine life-stage guidelines
+  /// are finer than a year in the first two.
+  minAgeMonths Int?
+  maxAgeMonths Int?
+
+  taskDefinitionId String
+  taskDefinition   TaskLibraryDefinition @relation(fields: [taskDefinitionId], references: [id])
+
+  /// Shown as-is to the parent. Husbandry phrasing, no diagnosis.
+  recommendationText String
+
+  /// Structured so the app can render a real citation rather than a bare link.
+  citationAuthors String
+  citationTitle   String
+  citationSource  String
+  citationYear    Int
+  citationDoi     String?
+  citationUrl     String?
+
+  /// The specific claim in the source that this rule rests on. This is what a vet
+  /// argues with, so it has to be the sentence, not the paper.
+  citationClaim String
+
+  evidenceGrade RecommendationEvidenceGrade
+
+  /// Attestation, same shape the passport already uses. A citation with no review
+  /// date rots silently: three years on, nobody knows whether it still stands.
+  lastReviewedAt DateTime?
+  reviewedBy     String?
+  nextReviewDue  DateTime?
+
+  /// Both must hold before a rule is served. `isActive` alone is not enough - a
+  /// rule reaches pet parents only once a named reviewer has signed it off, which
+  /// is why seeded rules land inactive and unreviewed.
+  isActive Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([species, isActive])
+  @@index([taskDefinitionId])
 }

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -38,6 +38,18 @@ GIT_REF="${3:?git ref required}"
 SMOKE_PORT="${4:-8099}"
 
 NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
+
+# lib/ has to travel WITH this script. Copying api-deploy.sh alone leaves this
+# looking for a helper that is not on the box, and bash exits before preflight
+# with a bare "No such file or directory" - so say what is actually wrong.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -r "$SCRIPT_DIR/lib/git-sync.sh" ]; then
+  echo "missing $SCRIPT_DIR/lib/git-sync.sh" >&2
+  echo "Copy the whole scripts/deploy directory to the host, not just this file." >&2
+  exit 1
+fi
+# shellcheck source=lib/git-sync.sh
+. "$SCRIPT_DIR/lib/git-sync.sh"
 export PATH="$NODE_BIN:$PATH"
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
 
@@ -56,18 +68,11 @@ cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
 echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
 
 say "checkout $GIT_REF"
-# --prune is load-bearing. A remote branch named `fix` had been deleted upstream
-# while the box still held refs/remotes/origin/fix, so every refs/remotes/origin/fix/*
-# the fetch tried to create failed to lock, the whole fetch failed, and the deploy
-# stopped at "couldn't find remote ref". Pruning clears the deleted parent ref first.
-#
-# The ref is accepted as either `dev` or `origin/dev`; `git rev-parse` below adds the
-# remote itself, and passing the qualified form asked the remote for a branch called
-# `origin/dev`, which does not exist.
-GIT_REF="${GIT_REF#origin/}"
-git fetch --quiet --prune origin "$GIT_REF" || git fetch --quiet --prune origin
-git checkout --detach "$(git rev-parse "origin/$GIT_REF" 2>/dev/null || echo "$GIT_REF")" --quiet
-git rev-parse --short HEAD
+# Fetch and checkout live in lib/git-sync.sh so their two failure modes - a stale
+# parent ref breaking the whole fetch, and a qualified `origin/dev` being sent to
+# the remote as a branch name - are covered by tests/git-sync.test.sh against a
+# real remote, rather than only being found on a live box.
+deploy_git_sync "$REPO_DIR" "$GIT_REF"
 
 say "install"
 pnpm install --frozen-lockfile

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -56,7 +56,16 @@ cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
 echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
 
 say "checkout $GIT_REF"
-git fetch --quiet origin "$GIT_REF" || git fetch --quiet origin
+# --prune is load-bearing. A remote branch named `fix` had been deleted upstream
+# while the box still held refs/remotes/origin/fix, so every refs/remotes/origin/fix/*
+# the fetch tried to create failed to lock, the whole fetch failed, and the deploy
+# stopped at "couldn't find remote ref". Pruning clears the deleted parent ref first.
+#
+# The ref is accepted as either `dev` or `origin/dev`; `git rev-parse` below adds the
+# remote itself, and passing the qualified form asked the remote for a branch called
+# `origin/dev`, which does not exist.
+GIT_REF="${GIT_REF#origin/}"
+git fetch --quiet --prune origin "$GIT_REF" || git fetch --quiet --prune origin
 git checkout --detach "$(git rev-parse "origin/$GIT_REF" 2>/dev/null || echo "$GIT_REF")" --quiet
 git rev-parse --short HEAD
 

--- a/scripts/deploy/lib/git-sync.sh
+++ b/scripts/deploy/lib/git-sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Move a deploy checkout onto a requested ref.
+#
+# Extracted from api-deploy.sh so the two failure modes below can be tested
+# against a real remote instead of only being discovered on a live box.
+#
+# deploy_git_sync <repo-dir> <git-ref>
+#
+# Echoes the resolved short SHA. Returns non-zero if the ref cannot be resolved -
+# the caller runs under `set -e`, and a deploy that cannot find its ref must stop
+# rather than build whatever happens to be checked out.
+
+deploy_git_sync() {
+  local repo_dir="${1:?repo dir required}"
+  local git_ref="${2:?git ref required}"
+
+  cd "$repo_dir" || return 1
+
+  # Accept `dev` or `origin/dev`. The remote is added back below, so passing the
+  # qualified form asked the remote for a branch literally named `origin/dev`,
+  # which does not exist, and the deploy stopped at "couldn't find remote ref".
+  git_ref="${git_ref#origin/}"
+
+  # Prune first, on its own, every time.
+  #
+  # When a remote branch is deleted upstream the box keeps its remote-tracking
+  # ref. If a branch is later created UNDER that name - `fix` deleted, then
+  # `fix/passport-under-health` created - git cannot write
+  # refs/remotes/origin/fix/* while a ref still sits at refs/remotes/origin/fix.
+  # Every child fails to lock and takes the whole fetch down with it, including
+  # the unrelated ref the deploy actually wanted. That is what stopped the first
+  # real run of this script.
+  #
+  # This is a separate step rather than `fetch --prune` because a fetch that
+  # names a single refspec only prunes within that refspec: `fetch --prune
+  # origin dev` succeeds while leaving the dead parent in place, so the box stays
+  # armed for the next caller that needs a full fetch. Clearing it unconditionally
+  # repairs the checkout instead of stepping around it.
+  git remote prune origin >/dev/null 2>&1 || true
+
+  git fetch --quiet --prune origin "$git_ref" || git fetch --quiet --prune origin
+
+  local resolved
+  resolved="$(git rev-parse --verify --quiet "origin/$git_ref" \
+    || git rev-parse --verify --quiet "$git_ref")" || {
+    echo "could not resolve '$git_ref' (or 'origin/$git_ref') after fetch" >&2
+    return 1
+  }
+
+  git checkout --detach "$resolved" --quiet
+  git rev-parse --short HEAD
+}

--- a/scripts/deploy/tests/git-sync.test.sh
+++ b/scripts/deploy/tests/git-sync.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Regression tests for deploy_git_sync, run against a real temporary remote.
+#
+# Both cases below actually happened on the dev API box and deployed nothing
+# while the deploy step still looked like it had run. Neither is expressible as
+# a unit test with a mocked git - they are refspec and ref-locking semantics, so
+# the test builds a bare remote and a clone and drives real git.
+#
+# Usage: scripts/deploy/tests/git-sync.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/git-sync.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+ok() { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL + 1)); }
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "expected '$2', got '$3'"; fi
+}
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t "$@"; }
+
+# A bare remote with a `dev` branch, plus a `fix` branch that is later deleted and
+# replaced by branches nested under that same name.
+setup_remote() {
+  local remote="$WORK/remote.git" seed="$WORK/seed"
+  rm -rf "$remote" "$seed"
+  git_quiet init --quiet --bare "$remote"
+  git_quiet clone --quiet "$remote" "$seed" 2>/dev/null
+  (
+    cd "$seed"
+    echo one > file.txt
+    git_quiet add file.txt
+    git_quiet commit --quiet -m "one"
+    git_quiet push --quiet origin HEAD:refs/heads/dev
+    git_quiet push --quiet origin HEAD:refs/heads/fix
+  )
+  # Point the bare repo's HEAD at a branch that exists, so a clone lands on a
+  # commit. Without this the default HEAD names a branch that was never pushed,
+  # clones come up empty, and `rev-parse HEAD` has nothing to read.
+  git_quiet -C "$remote" symbolic-ref HEAD refs/heads/dev
+  echo "$remote"
+}
+
+# A working copy that has already fetched, so it holds refs/remotes/origin/fix.
+setup_clone() {
+  local remote="$1" clone="$WORK/clone"
+  rm -rf "$clone"
+  git_quiet clone --quiet "$remote" "$clone" 2>/dev/null
+  (cd "$clone" && git_quiet fetch --quiet origin)
+  echo "$clone"
+}
+
+advance_dev() { # advance_dev <remote> -> echoes the new full sha
+  local remote="$1" bump="$WORK/bump"
+  rm -rf "$bump"
+  git_quiet clone --quiet --branch dev "$remote" "$bump" 2>/dev/null
+  (
+    cd "$bump"
+    echo two >> file.txt
+    git_quiet add file.txt
+    git_quiet commit --quiet -m "two"
+    git_quiet push --quiet origin HEAD:refs/heads/dev
+    git rev-parse HEAD
+  )
+}
+
+echo "deploy_git_sync"
+
+# ---------------------------------------------------------------------------
+# 1. The failure as it actually happened, which needs BOTH conditions at once.
+#
+#    A single-refspec fetch (`git fetch origin dev`) never tries to create
+#    refs/remotes/origin/fix/*, so a stale parent ref alone does not break it.
+#    What broke the box was the qualified ref: `git fetch origin origin/dev` asks
+#    the remote for a branch that does not exist, fails, and falls through to the
+#    full `git fetch origin` - and THAT is the fetch the stale parent ref kills.
+#
+#    Testing the two conditions separately is why the first version of this file
+#    passed with --prune removed.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+(
+  cd "$WORK/seed"
+  git_quiet push --quiet origin --delete fix
+  git_quiet push --quiet origin HEAD:refs/heads/fix/passport-under-health
+)
+WANT="$(advance_dev "$REMOTE")"
+
+# Preconditions, or the test proves nothing.
+if git -C "$CLONE" show-ref --verify --quiet refs/remotes/origin/fix; then
+  ok "precondition: clone holds the stale refs/remotes/origin/fix"
+else
+  no "precondition: clone holds the stale refs/remotes/origin/fix" "ref absent"
+fi
+if git -C "$CLONE" fetch origin >/dev/null 2>&1; then
+  no "precondition: a plain fetch is broken by the stale ref" "plain fetch succeeded"
+else
+  ok "precondition: a plain fetch is broken by the stale ref"
+fi
+
+GOT="$(deploy_git_sync "$CLONE" origin/dev 2>/dev/null || echo SYNC_FAILED)"
+check "recovers when the fallback fetch hits a stale parent ref" \
+  "$(git -C "$CLONE" rev-parse --short "$WANT")" "$GOT"
+check "checks out the requested commit, not whatever was there" \
+  "$WANT" "$(git -C "$CLONE" rev-parse HEAD)"
+
+# The dead parent must be GONE, not merely stepped around. A single-refspec
+# fetch can succeed while leaving it in place, which leaves the checkout armed
+# for the next caller that needs a full fetch.
+if git -C "$CLONE" show-ref --verify --quiet refs/remotes/origin/fix; then
+  no "clears the stale parent ref rather than working around it" "ref still present"
+else
+  ok "clears the stale parent ref rather than working around it"
+fi
+if git -C "$CLONE" fetch origin >/dev/null 2>&1; then
+  ok "a plain fetch works again afterwards"
+else
+  no "a plain fetch works again afterwards" "still broken"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The bare form resolves without asking the remote for a branch that cannot
+#    exist. The qualified form still WORKS without the normalisation, because
+#    the rev-parse fallback below covers it - what the normalisation buys is not
+#    spending a doomed fetch first, so that is what is asserted.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+WANT="$(advance_dev "$REMOTE")"
+
+ERRS="$(deploy_git_sync "$CLONE" origin/dev 2>&1 >/dev/null || true)"
+check "qualified form lands on the requested commit" \
+  "$WANT" "$(git -C "$CLONE" rev-parse HEAD)"
+if printf '%s' "$ERRS" | grep -q "couldn't find remote ref"; then
+  no "qualified form does not ask the remote for 'origin/dev'" "$ERRS"
+else
+  ok "qualified form does not ask the remote for 'origin/dev'"
+fi
+
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+WANT="$(advance_dev "$REMOTE")"
+check "bare form lands on the same commit" \
+  "$(git -C "$CLONE" rev-parse --short "$WANT")" \
+  "$(deploy_git_sync "$CLONE" dev 2>/dev/null || echo SYNC_FAILED)"
+
+# ---------------------------------------------------------------------------
+# 3. An unresolvable ref must fail, not silently build whatever is checked out.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+BEFORE="$(git -C "$CLONE" rev-parse HEAD)"
+
+if deploy_git_sync "$CLONE" no-such-branch >/dev/null 2>&1; then
+  no "fails on an unresolvable ref" "returned success"
+else
+  ok "fails on an unresolvable ref"
+fi
+check "leaves the checkout untouched when the ref cannot be resolved" \
+  "$BEFORE" "$(git -C "$CLONE" rev-parse HEAD)"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` is behind `dev` by ten commits, and one of them closes a live cross-parent data exposure.

## What is the new behavior?

Promotes:

| PR | What |
| --- | --- |
| #2431 | the chat upload blocklist is actually applied |
| #2433 | deploy the API from CI; a failed security control is visible |
| #2435 | co-parent permissions enforced on the server |
| #2437 | `medicalRecords` as its own permission, with the read audited |
| #2440 | expired mobile sessions recover; home headline unsticks |
| #2443 | **companion and expense by-id routes scoped to the caller** |
| #2446, #2447 | API deploy prunes stale refs, with regression tests |
| #2445 | every product's latest release on the home hero |
| #2449 | breed and age based husbandry recommendations |

### The one that matters most

#2443 closes two IDORs, not a permission gap:

- `GET/PATCH/DELETE /expense/:expenseId` resolved the row by id alone at every layer, so any signed-in parent could read, edit or delete another parent's expense. The read also falls through to `Invoice`.
- `GET/PUT /companion/:id` read and wrote with a bare `where: { id }`. `Patient` is not parent-scoped in the schema, so that was **37 companion profiles readable and overwritable** by any mobile account.

Production was serving both until the deploy below.

## Deploy state at time of raising

Backend deployed to `5f1718cdb` on **both** hosts by the deploy script, migrations applied to both databases, before raising this - per the ordering rule, since merging fires the Amplify webhook and the frontend must not land against an API without its routes.

Verified from outside rather than asserted:

```
api.yosemitecrew.com/health                                   200
api.yosemitecrew.com/v1/expense/<uuid>                        401   guarded
api.yosemitecrew.com/v1/task/mobile/companion/<uuid>/recommendations
                                                              401   route present, gated
```

`TaskRecommendationRule` exists on both databases with RLS enabled and zero policies, which is the intended default: the API connects as the owning role and bypasses RLS, while Supabase's PostgREST surface to the `anon` and `authenticated` keys is denied. The table holds no rules, and cannot serve one until a named reviewer signs it off.

## Correction

An earlier version of this body claimed `main` had been rolled back past merged promotion #2438 and that production was running an orphaned commit. **That was wrong** - see the correction comment below. `git fetch origin main` does not update `refs/remotes/origin/main`, so every check ran against a stale pointer. #2438 is on `main`; nothing was rolled back.

The deploy state and the promotion contents above are unaffected: those were verified against the live hosts and databases, not against a git ref.
