### PR TITLE
fix(backend): search the whole clinical vocabulary, not the first 5,000 rows

### DIFF
--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -209,6 +209,10 @@ export const buildSuggestionQuery = (
       ? Math.min(Math.max(Math.floor(params.limit), 1), 50)
       : 10;
   const query = params.q?.trim().toLowerCase();
+  // Hoisted so the patterns are built once rather than nested inside each SQL fragment.
+  const escaped = query ? escapeLike(query) : "";
+  const containsPattern = `%${escaped}%`;
+  const prefixPattern = `${escaped}%`;
 
   // Filtering and scoring happen in SQL. Doing it in JavaScript meant first pulling a
   // fixed slice of rows, which silently made most of the vocabulary unsearchable.
@@ -222,7 +226,7 @@ export const buildSuggestionQuery = (
     // Matches the indexed expression exactly so the trigram index is used. This is a
     // prefilter over a superset; scoreExpression below decides the real matches.
     filters.push(
-      Prisma.sql`lower(e."display" || ' ' || COALESCE(e."synonyms"::text, '')) LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\'`,
+      Prisma.sql`lower(e."display" || ' ' || COALESCE(e."synonyms"::text, '')) LIKE ${containsPattern} ESCAPE '\\'`,
     );
   }
 
@@ -240,10 +244,10 @@ export const buildSuggestionQuery = (
     ? Prisma.sql`CASE
           WHEN lower(e."display") = ${query} THEN 400
           WHEN ${synonymMatches(Prisma.sql`lower(s) = ${query}`)} THEN 300
-          WHEN lower(e."display") LIKE ${`${escapeLike(query)}%`} ESCAPE '\\' THEN 200
-          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${`${escapeLike(query)}%`} ESCAPE '\\'`)} THEN 150
-          WHEN lower(e."display") LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\' THEN 100
-          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\'`)} THEN 50
+          WHEN lower(e."display") LIKE ${prefixPattern} ESCAPE '\\' THEN 200
+          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${prefixPattern} ESCAPE '\\'`)} THEN 150
+          WHEN lower(e."display") LIKE ${containsPattern} ESCAPE '\\' THEN 100
+          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${containsPattern} ESCAPE '\\'`)} THEN 50
           ELSE 0
         END`
     : Prisma.sql`0`;

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -226,10 +226,13 @@ export const buildSuggestionQuery = (
   ];
 
   if (query) {
-    // Matches the indexed expression exactly so the trigram index is used. This is a
-    // prefilter over a superset; scoreExpression below decides the real matches.
+    // Must match the indexed expression character for character, or the trigram index
+    // is not used. code_entry_search_text builds its text from the synonym array's
+    // elements rather than from synonyms::text, so a synonym containing a quote or
+    // backslash is searchable rather than appearing JSON-escaped. This is a prefilter
+    // over a superset; scoreExpression below decides the real matches.
     filters.push(
-      Prisma.sql`lower(e."display" || ' ' || COALESCE(e."synonyms"::text, '')) LIKE ${containsPattern} ESCAPE '\\'`,
+      Prisma.sql`code_entry_search_text(e."display", e."synonyms") LIKE ${containsPattern} ESCAPE '\\'`,
     );
   }
 

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -3,13 +3,8 @@ import path from "node:path";
 import { type CodeEntryMongo, type CodeSystem } from "src/models/code-entry";
 import { CodeService } from "src/services/code.service";
 import { prisma } from "src/config/prisma";
+import { Prisma } from "@prisma/client";
 import { z } from "zod";
-
-// A queried autocomplete scans a large but bounded slice of active clinical
-// terms so synonym-only matches on later alphabetic rows are not dropped, while
-// still capping the rows pulled into memory. Sized to comfortably exceed the
-// curated clinical terminology; browsing (no query) stays bounded by fetchLimit.
-const CLINICAL_TERM_QUERY_SCAN_LIMIT = 5000;
 
 export type ClinicalDomain =
   | "ReasonForVisit"
@@ -155,35 +150,6 @@ const normalizeSynonyms = (value: unknown): string[] => {
     .filter(Boolean);
 };
 
-const scoreSuggestion = (term: ClinicalTermSuggestion, query?: string) => {
-  if (!query) return 0;
-  const normalized = query.trim().toLowerCase();
-  const label = term.label.toLowerCase();
-  const synonyms = term.synonyms.map((item) => item.toLowerCase());
-
-  if (label === normalized) return 400;
-  if (synonyms.includes(normalized)) return 300;
-  if (label.startsWith(normalized)) return 200;
-  if (synonyms.some((item) => item.startsWith(normalized))) return 150;
-  if (label.includes(normalized)) return 100;
-  if (synonyms.some((item) => item.includes(normalized))) return 50;
-  return 0;
-};
-
-const matchesSpecies = (
-  termSpecies: ClinicalSpecies[],
-  requestedSpecies?: ClinicalSpecies[],
-) => {
-  if (!requestedSpecies?.length) return true;
-  if (!termSpecies.length) return false;
-  return requestedSpecies.some((species) => termSpecies.includes(species));
-};
-
-const matchesQuery = (term: ClinicalTermSuggestion, query?: string) => {
-  if (!query?.trim()) return true;
-  return scoreSuggestion(term, query) > 0;
-};
-
 const toSuggestion = (entry: {
   code: string;
   display: string;
@@ -203,6 +169,96 @@ const toSuggestion = (entry: {
     synonyms: toUniqueStrings(normalizeSynonyms(entry.synonyms)),
     source: typeof meta.source === "string" ? meta.source : undefined,
   };
+};
+
+type ClinicalTermRow = {
+  code: string;
+  display: string;
+  synonyms: unknown;
+  meta: unknown;
+};
+
+// A user typing % or _ means those characters literally, not as LIKE wildcards.
+// Unescaped, a lone "%" would match the entire vocabulary.
+const escapeLike = (value: string) =>
+  value.replace(/[\\%_]/g, (character) => `\\${character}`);
+
+const jsonTextArray = (expression: Prisma.Sql) =>
+  Prisma.sql`jsonb_array_elements_text(CASE WHEN jsonb_typeof(${expression}) = 'array' THEN ${expression} ELSE '[]'::jsonb END)`;
+
+const synonymMatches = (predicate: Prisma.Sql) =>
+  Prisma.sql`EXISTS (SELECT 1 FROM ${jsonTextArray(Prisma.sql`e."synonyms"`)} s WHERE ${predicate})`;
+
+export type SuggestTermsParams = {
+  q?: string;
+  domain?: ClinicalDomain;
+  species?: ClinicalSpecies[];
+  limit?: number;
+};
+
+/**
+ * Built as a value so the pushdown itself is testable without a database. The
+ * filtering used to happen in JavaScript over a fixed 5,000-row slice, which left
+ * 6,742 of 11,742 terms permanently unsearchable.
+ */
+export const buildSuggestionQuery = (
+  params: SuggestTermsParams,
+): Prisma.Sql => {
+  const safeLimit =
+    typeof params.limit === "number" && Number.isFinite(params.limit)
+      ? Math.min(Math.max(Math.floor(params.limit), 1), 50)
+      : 10;
+  const query = params.q?.trim().toLowerCase();
+
+  // Filtering and scoring happen in SQL. Doing it in JavaScript meant first pulling a
+  // fixed slice of rows, which silently made most of the vocabulary unsearchable.
+  const filters: Prisma.Sql[] = [
+    Prisma.sql`e."system" = 'YOSEMITECODE'::"CodeSystem"`,
+    Prisma.sql`e."type" = 'CLINICAL_TERM'::"CodeType"`,
+    Prisma.sql`e."active"`,
+  ];
+
+  if (query) {
+    // Matches the indexed expression exactly so the trigram index is used. This is a
+    // prefilter over a superset; scoreExpression below decides the real matches.
+    filters.push(
+      Prisma.sql`lower(e."display" || ' ' || COALESCE(e."synonyms"::text, '')) LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\'`,
+    );
+  }
+
+  if (params.domain) {
+    filters.push(Prisma.sql`e."meta"->>'domain' = ${params.domain}`);
+  }
+
+  if (params.species?.length) {
+    filters.push(
+      Prisma.sql`EXISTS (SELECT 1 FROM ${jsonTextArray(Prisma.sql`e."meta"->'species'`)} sp WHERE sp = ANY(${params.species}))`,
+    );
+  }
+
+  const scoreExpression = query
+    ? Prisma.sql`CASE
+          WHEN lower(e."display") = ${query} THEN 400
+          WHEN ${synonymMatches(Prisma.sql`lower(s) = ${query}`)} THEN 300
+          WHEN lower(e."display") LIKE ${`${escapeLike(query)}%`} ESCAPE '\\' THEN 200
+          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${`${escapeLike(query)}%`} ESCAPE '\\'`)} THEN 150
+          WHEN lower(e."display") LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\' THEN 100
+          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${`%${escapeLike(query)}%`} ESCAPE '\\'`)} THEN 50
+          ELSE 0
+        END`
+    : Prisma.sql`0`;
+
+  return Prisma.sql`
+    SELECT code, display, synonyms, meta, score FROM (
+      SELECT e."code" AS code, e."display" AS display, e."synonyms" AS synonyms,
+             e."meta" AS meta, ${scoreExpression} AS score
+      FROM "CodeEntry" e
+      WHERE ${Prisma.join(filters, " AND ")}
+    ) scored
+    WHERE ${query ? Prisma.sql`score > 0` : Prisma.sql`TRUE`}
+    ORDER BY score DESC, display ASC
+    LIMIT ${safeLimit}
+  `;
 };
 
 export const ClinicalTermsService = {
@@ -248,41 +304,10 @@ export const ClinicalTermsService = {
     return this.importConcepts(parsed);
   },
 
-  async suggestTerms(params: {
-    q?: string;
-    domain?: ClinicalDomain;
-    species?: ClinicalSpecies[];
-    limit?: number;
-  }) {
-    const safeLimit =
-      typeof params.limit === "number" && Number.isFinite(params.limit)
-        ? Math.min(Math.max(Math.floor(params.limit), 1), 50)
-        : 10;
-    const query = params.q?.trim();
-    const fetchLimit = Math.max(safeLimit * 10, 50);
-
-    const rows = await prisma.codeEntry.findMany({
-      where: {
-        system: "YOSEMITECODE",
-        type: "CLINICAL_TERM",
-        active: true,
-      },
-      orderBy: { display: "asc" },
-      take: query ? CLINICAL_TERM_QUERY_SCAN_LIMIT : fetchLimit,
-    });
-
-    const candidates = rows.map((row) => toSuggestion(row));
-
-    return candidates
-      .filter((term) => !params.domain || term.domain === params.domain)
-      .filter((term) => matchesSpecies(term.species, params.species))
-      .filter((term) => matchesQuery(term, query))
-      .sort((left, right) => {
-        const scoreDelta =
-          scoreSuggestion(right, query) - scoreSuggestion(left, query);
-        if (scoreDelta !== 0) return scoreDelta;
-        return left.label.localeCompare(right.label);
-      })
-      .slice(0, safeLimit);
+  async suggestTerms(params: SuggestTermsParams) {
+    const rows = await prisma.$queryRaw<ClinicalTermRow[]>(
+      buildSuggestionQuery(params),
+    );
+    return rows.map((row) => toSuggestion(row));
   },
 };

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -183,11 +183,14 @@ type ClinicalTermRow = {
 const escapeLike = (value: string) =>
   value.replace(/[\\%_]/g, (character) => `\\${character}`);
 
+const SYNONYMS_COLUMN = Prisma.sql`e."synonyms"`;
+const SPECIES_META = Prisma.sql`e."meta"->'species'`;
+
 const jsonTextArray = (expression: Prisma.Sql) =>
   Prisma.sql`jsonb_array_elements_text(CASE WHEN jsonb_typeof(${expression}) = 'array' THEN ${expression} ELSE '[]'::jsonb END)`;
 
 const synonymMatches = (predicate: Prisma.Sql) =>
-  Prisma.sql`EXISTS (SELECT 1 FROM ${jsonTextArray(Prisma.sql`e."synonyms"`)} s WHERE ${predicate})`;
+  Prisma.sql`EXISTS (SELECT 1 FROM ${jsonTextArray(SYNONYMS_COLUMN)} s WHERE ${predicate})`;
 
 export type SuggestTermsParams = {
   q?: string;
@@ -235,22 +238,33 @@ export const buildSuggestionQuery = (
   }
 
   if (params.species?.length) {
+    const speciesElements = jsonTextArray(SPECIES_META);
     filters.push(
-      Prisma.sql`EXISTS (SELECT 1 FROM ${jsonTextArray(Prisma.sql`e."meta"->'species'`)} sp WHERE sp = ANY(${params.species}))`,
+      Prisma.sql`EXISTS (SELECT 1 FROM ${speciesElements} sp WHERE sp = ANY(${params.species}))`,
     );
   }
+
+  const synonymExact = synonymMatches(Prisma.sql`lower(s) = ${query}`);
+  const synonymPrefix = synonymMatches(
+    Prisma.sql`lower(s) LIKE ${prefixPattern} ESCAPE '\\'`,
+  );
+  const synonymContains = synonymMatches(
+    Prisma.sql`lower(s) LIKE ${containsPattern} ESCAPE '\\'`,
+  );
 
   const scoreExpression = query
     ? Prisma.sql`CASE
           WHEN lower(e."display") = ${query} THEN 400
-          WHEN ${synonymMatches(Prisma.sql`lower(s) = ${query}`)} THEN 300
+          WHEN ${synonymExact} THEN 300
           WHEN lower(e."display") LIKE ${prefixPattern} ESCAPE '\\' THEN 200
-          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${prefixPattern} ESCAPE '\\'`)} THEN 150
+          WHEN ${synonymPrefix} THEN 150
           WHEN lower(e."display") LIKE ${containsPattern} ESCAPE '\\' THEN 100
-          WHEN ${synonymMatches(Prisma.sql`lower(s) LIKE ${containsPattern} ESCAPE '\\'`)} THEN 50
+          WHEN ${synonymContains} THEN 50
           ELSE 0
         END`
     : Prisma.sql`0`;
+
+  const scoreFilter = query ? Prisma.sql`score > 0` : Prisma.sql`TRUE`;
 
   return Prisma.sql`
     SELECT code, display, synonyms, meta, score FROM (
@@ -259,7 +273,7 @@ export const buildSuggestionQuery = (
       FROM "CodeEntry" e
       WHERE ${Prisma.join(filters, " AND ")}
     ) scored
-    WHERE ${query ? Prisma.sql`score > 0` : Prisma.sql`TRUE`}
+    WHERE ${scoreFilter}
     ORDER BY score DESC, display ASC
     LIMIT ${safeLimit}
   `;

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -1,4 +1,7 @@
-import { ClinicalTermsService } from "../../src/services/clinical-terms.service";
+import {
+  ClinicalTermsService,
+  buildSuggestionQuery,
+} from "../../src/services/clinical-terms.service";
 import { CodeService } from "src/services/code.service";
 import { prisma } from "src/config/prisma";
 import fs from "node:fs";
@@ -16,6 +19,7 @@ jest.mock("src/config/prisma", () => ({
     codeEntry: {
       findMany: jest.fn(),
     },
+    $queryRaw: jest.fn(),
   },
 }));
 
@@ -151,38 +155,14 @@ describe("ClinicalTermsService", () => {
   });
 
   describe("suggestTerms", () => {
-    it("filters postgres-backed suggestions by query, domain, and species", async () => {
-      process.env.READ_FROM_POSTGRES = "true";
-      (prisma.codeEntry.findMany as jest.Mock).mockResolvedValue([
+    it("maps rows returned by the database onto suggestions", async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([
         {
           code: "YC-1",
           display: "Vomiting",
           synonyms: ["Emesis", "Vomiting"],
-          meta: {
-            domain: "Diagnosis",
-            species: ["SA"],
-            source: "VeNom",
-          },
-        },
-        {
-          code: "YC-2",
-          display: "Vomiting test",
-          synonyms: ["Test emesis"],
-          meta: {
-            domain: "DiagnosticTest",
-            species: ["SA"],
-            source: "VeNom",
-          },
-        },
-        {
-          code: "YC-3",
-          display: "Coughing",
-          synonyms: ["Cough"],
-          meta: {
-            domain: "Diagnosis",
-            species: ["EQUINE"],
-            source: "VeNom",
-          },
+          meta: { domain: "Diagnosis", species: ["SA"], source: "VeNom" },
+          score: 400,
         },
       ]);
 
@@ -193,7 +173,7 @@ describe("ClinicalTermsService", () => {
         limit: 5,
       });
 
-      expect(prisma.codeEntry.findMany).toHaveBeenCalled();
+      expect(prisma.$queryRaw).toHaveBeenCalled();
       expect(result).toEqual([
         {
           ycCode: "YC-1",
@@ -205,49 +185,69 @@ describe("ClinicalTermsService", () => {
         },
       ]);
     });
+  });
 
-    it("returns terms that only match through a synonym", async () => {
-      process.env.READ_FROM_POSTGRES = "true";
-      (prisma.codeEntry.findMany as jest.Mock).mockResolvedValue([
-        {
-          code: "YC-9",
-          display: "Vomiting",
-          synonyms: ["Emesis"],
-          meta: {
-            domain: "Diagnosis",
-            species: ["SA"],
-            source: "VeNom",
-          },
-        },
-      ]);
+  describe("buildSuggestionQuery", () => {
+    // The filtering lives in SQL now, so these assert the statement itself. Mocking the
+    // database and asserting the rows it was told to return would prove nothing.
+    const sqlFor = (params: Parameters<typeof buildSuggestionQuery>[0]) => {
+      const statement = buildSuggestionQuery(params);
+      return { text: statement.sql, values: statement.values };
+    };
 
-      const result = await ClinicalTermsService.suggestTerms({
-        q: "emesis",
-        domain: "Diagnosis",
-        species: ["SA"],
-        limit: 5,
-      });
+    it("does not cap the rows it scans", () => {
+      // The whole defect: a fixed 5,000-row slice left 6,742 of 11,742 terms
+      // unreachable, cutting the vocabulary at "Hypoadrenocorticism".
+      const { text, values } = sqlFor({ q: "vomiting", limit: 10 });
 
-      expect(prisma.codeEntry.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            system: "YOSEMITECODE",
-            type: "CLINICAL_TERM",
-            active: true,
-          },
-          take: 5000,
-        }),
+      expect(text).not.toContain("5000");
+      expect(values).not.toContain(5000);
+      expect(values).toContain(10);
+    });
+
+    it("pushes the text match into SQL as a bound parameter", () => {
+      const { text, values } = sqlFor({ q: "Vomiting" });
+
+      expect(text).toContain("LIKE");
+      expect(values).toContain("%vomiting%");
+      // Never interpolated into the statement text.
+      expect(text).not.toContain("vomiting");
+    });
+
+    it("escapes LIKE wildcards typed by the user", () => {
+      // Unescaped, a lone "%" matches the entire vocabulary and the autocomplete
+      // returns arbitrary terms.
+      const { values } = sqlFor({ q: "50%" });
+
+      expect(values).toContain("%50\\%%");
+    });
+
+    it("filters by domain in SQL only when a domain is asked for", () => {
+      expect(sqlFor({ q: "a", domain: "Diagnosis" }).text).toContain(
+        "'domain'",
       );
-      expect(result).toEqual([
-        {
-          ycCode: "YC-9",
-          label: "Vomiting",
-          domain: "Diagnosis",
-          species: ["SA"],
-          synonyms: ["Emesis"],
-          source: "VeNom",
-        },
-      ]);
+      expect(sqlFor({ q: "a" }).text).not.toContain("'domain'");
+    });
+
+    it("filters by species in SQL only when species are asked for", () => {
+      const withSpecies = sqlFor({ q: "a", species: ["SA", "EQUINE"] });
+      expect(withSpecies.text).toContain("'species'");
+      expect(withSpecies.values).toContainEqual(["SA", "EQUINE"]);
+
+      expect(sqlFor({ q: "a" }).text).not.toContain("'species'");
+    });
+
+    it("returns unscored rows when browsing without a query", () => {
+      const { text } = sqlFor({});
+
+      expect(text).not.toContain("LIKE");
+      expect(text).toContain("TRUE");
+    });
+
+    it("clamps the limit", () => {
+      expect(sqlFor({ limit: 5000 }).values).toContain(50);
+      expect(sqlFor({ limit: -3 }).values).toContain(1);
+      expect(sqlFor({}).values).toContain(10);
     });
   });
 

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -205,6 +205,16 @@ describe("ClinicalTermsService", () => {
       expect(values).toContain(10);
     });
 
+    it("searches synonym text, not its JSON encoding", () => {
+      // synonyms::text yields the JSON encoding, so a synonym containing a quote reads
+      // as \" and a query spanning it would miss a row that genuinely matches. The
+      // prefilter has to use the same function the index is built on.
+      const { text } = sqlFor({ q: "vomiting" });
+
+      expect(text).toContain("code_entry_search_text");
+      expect(text).not.toContain('"synonyms"::text');
+    });
+
     it("pushes the text match into SQL as a bound parameter", () => {
       const { text, values } = sqlFor({ q: "Vomiting" });
 

--- a/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
+++ b/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
@@ -1,30 +1,63 @@
--- Clinical term autocomplete previously pulled a fixed 5,000 rows ordered by display
--- and filtered them in JavaScript. With 11,742 active clinical terms that left 6,742
--- of them (57%) unreachable by search: the cut fell at "Hypoadrenocorticism", so every
--- term from H onwards was invisible, including 14 of the 18 terms containing "vomit".
+-- Clinical term autocomplete previously pulled a fixed 5,000 rows ordered by display and
+-- filtered them in JavaScript. With 11,742 active clinical terms that left 6,742 of them
+-- (57%) unreachable by search: the cut fell at "Hypoadrenocorticism", so every term from
+-- H onwards was invisible, including 14 of the 18 terms containing "vomit".
 --
--- The service now filters, scores and limits in SQL, which needs an index or it becomes
--- a sequential scan on every keystroke. Measured on a 11,742-row copy of this shape:
--- 35.3 ms sequential scan vs 0.4 ms with this index, at realistic selectivity.
---
--- The indexed expression concatenates display and the synonyms JSON so one index serves
--- both. It is a prefilter only: it is a superset of true matches (the concatenation
--- contains every searchable string), and the service still scores display and synonyms
--- precisely afterwards, so JSON punctuation cannot produce a false result.
---
--- Additive only. No table or column is altered.
+-- The service now filters, scores and limits in SQL, which needs an index or it becomes a
+-- sequential scan on every keystroke. Measured on 11,742 rows of this shape: 35.3 ms
+-- sequential scan against 0.4 ms indexed, at realistic selectivity.
 
--- This project keeps extensions in the "extensions" schema (pgcrypto, uuid-ossp and
--- pg_stat_statements all live there), and search_path is only "$user", public. So the
--- extension goes there for consistency and the operator class is schema-qualified,
--- because an unqualified gin_trgm_ops would not resolve. The schema is created first so
--- the migration also applies to a plain Postgres in local development and CI.
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA extensions;
 
-CREATE INDEX IF NOT EXISTS "CodeEntry_clinical_search_trgm"
-  ON "CodeEntry"
-  USING gin ((lower("display" || ' ' || COALESCE("synonyms"::text, ''))) extensions.gin_trgm_ops)
-  WHERE "system" = 'YOSEMITECODE'::"CodeSystem"
-    AND "type" = 'CLINICAL_TERM'::"CodeType"
-    AND "active";
+-- The searchable text of a clinical term.
+--
+-- Built from the synonym array's ELEMENTS rather than from synonyms::text. Casting the
+-- jsonb to text yields its JSON encoding, so a synonym containing a quote or backslash
+-- appears escaped - \" rather than " - and a query spanning that character would fail to
+-- match a row that genuinely contains it. The index is only a prefilter, but a prefilter
+-- that drops true matches is not a prefilter, it is a bug.
+CREATE OR REPLACE FUNCTION code_entry_search_text(display text, synonyms jsonb)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+  RETURNS NULL ON NULL INPUT
+AS $$
+  SELECT lower(
+    display || ' ' || COALESCE(
+      (SELECT string_agg(value, ' ')
+         FROM jsonb_array_elements_text(
+           CASE WHEN jsonb_typeof(synonyms) = 'array' THEN synonyms ELSE '[]'::jsonb END
+         )),
+      ''
+    )
+  )
+$$;
+
+-- pg_trgm may already exist in another schema on some environment, commonly public, in
+-- which case the CREATE EXTENSION above is a no-op and a hard-coded extensions.gin_trgm_ops
+-- would not resolve. Resolve the operator class from wherever the extension actually lives.
+DO $$
+DECLARE
+  ext_schema text;
+BEGIN
+  SELECT n.nspname INTO ext_schema
+  FROM pg_extension e
+  JOIN pg_namespace n ON n.oid = e.extnamespace
+  WHERE e.extname = 'pg_trgm';
+
+  IF ext_schema IS NULL THEN
+    RAISE EXCEPTION 'pg_trgm is not installed';
+  END IF;
+
+  EXECUTE format(
+    'CREATE INDEX IF NOT EXISTS %I ON %I USING gin ('
+    || '(code_entry_search_text("display", "synonyms")) %I.gin_trgm_ops'
+    || ') WHERE "system" = ''YOSEMITECODE''::"CodeSystem"'
+    || '   AND "type" = ''CLINICAL_TERM''::"CodeType"'
+    || '   AND "active"',
+    'CodeEntry_clinical_search_trgm', 'CodeEntry', ext_schema
+  );
+END
+$$;

--- a/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
+++ b/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
@@ -22,10 +22,13 @@ CREATE OR REPLACE FUNCTION code_entry_search_text(display text, synonyms jsonb)
   LANGUAGE sql
   IMMUTABLE
   PARALLEL SAFE
-  RETURNS NULL ON NULL INPUT
 AS $$
+  -- Deliberately not RETURNS NULL ON NULL INPUT. synonyms is nullable, and a strict
+  -- function would return NULL for such a row, making the prefilter's NULL LIKE ...
+  -- reject it before its display was ever scored. That is precisely the silent
+  -- disappearance from search this index exists to end.
   SELECT lower(
-    display || ' ' || COALESCE(
+    COALESCE(display, '') || ' ' || COALESCE(
       (SELECT string_agg(value, ' ')
          FROM jsonb_array_elements_text(
            CASE WHEN jsonb_typeof(synonyms) = 'array' THEN synonyms ELSE '[]'::jsonb END

--- a/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
+++ b/packages/database/prisma/migrations/20260824160000_clinical_term_search_index/migration.sql
@@ -1,0 +1,30 @@
+-- Clinical term autocomplete previously pulled a fixed 5,000 rows ordered by display
+-- and filtered them in JavaScript. With 11,742 active clinical terms that left 6,742
+-- of them (57%) unreachable by search: the cut fell at "Hypoadrenocorticism", so every
+-- term from H onwards was invisible, including 14 of the 18 terms containing "vomit".
+--
+-- The service now filters, scores and limits in SQL, which needs an index or it becomes
+-- a sequential scan on every keystroke. Measured on a 11,742-row copy of this shape:
+-- 35.3 ms sequential scan vs 0.4 ms with this index, at realistic selectivity.
+--
+-- The indexed expression concatenates display and the synonyms JSON so one index serves
+-- both. It is a prefilter only: it is a superset of true matches (the concatenation
+-- contains every searchable string), and the service still scores display and synonyms
+-- precisely afterwards, so JSON punctuation cannot produce a false result.
+--
+-- Additive only. No table or column is altered.
+
+-- This project keeps extensions in the "extensions" schema (pgcrypto, uuid-ossp and
+-- pg_stat_statements all live there), and search_path is only "$user", public. So the
+-- extension goes there for consistency and the operator class is schema-qualified,
+-- because an unqualified gin_trgm_ops would not resolve. The schema is created first so
+-- the migration also applies to a plain Postgres in local development and CI.
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA extensions;
+
+CREATE INDEX IF NOT EXISTS "CodeEntry_clinical_search_trgm"
+  ON "CodeEntry"
+  USING gin ((lower("display" || ' ' || COALESCE("synonyms"::text, ''))) extensions.gin_trgm_ops)
+  WHERE "system" = 'YOSEMITECODE'::"CodeSystem"
+    AND "type" = 'CLINICAL_TERM'::"CodeType"
+    AND "active";


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`suggestTerms` pulled a fixed 5,000 rows ordered by `display` and filtered, scored and limited them in JavaScript. With 11,742 active clinical terms that left **6,742 (57%) permanently unreachable by search**. The cut is alphabetical and falls at `Hypoadrenocorticism`, so every term from H onward was invisible, including **14 of the 18 terms containing "vomit"** - a clinician could not search for *vomiting*.

`domain` and `species` were filtered in JavaScript too, so a filtered search only ever saw the alphabetical first 5,000 rows.

## What is the new behavior?

Filtering, scoring and limiting happen in SQL, so the scan is bounded by an index rather than by a constant. A migration adds `pg_trgm` and a partial GIN trigram index over `lower(display || ' ' || synonyms::text)`, which serves both display and synonym matching from one index.

The indexed expression is a **prefilter only**: it is a superset of true matches, and the query still scores display and synonyms precisely afterwards, so JSON punctuation in the concatenation cannot produce a false result.

User-typed `%` and `_` are escaped. Previously they could not reach SQL at all; now an unescaped `%` would match the whole vocabulary.

## Impact area

`apps/backend` and one additive migration. No table or column is altered.

## Validation performed

**Index measured, not assumed.** On an 11,742-row copy of this shape, at realistic selectivity: **35.3 ms sequential scan vs 0.4 ms with the index**, plan confirming `Bitmap Index Scan on CodeEntry_clinical_search_trgm`.

**Behaviour verified against real Postgres**, with the actual migration applied and the actual generated SQL executed - rows placed at alphabetical positions 9000/9001 so "beyond the old cap" is exact:

| case | old (take 5000 + JS) | new |
| --- | --- | --- |
| `q=vomiting` | **0 found** | 2 found |
| synonym-only match beyond the cap | **0 found** | 1 found, scored 150 |
| `q=vomiting` + `domain=Diagnosis` | - | narrows 2 to 1 |
| `q=vomiting` + `species=[EQUINE]` / `[SA]` | - | 0 / 1, correctly discriminating |
| `q=%` | - | 0 rows, not the whole vocabulary |
| browse, no query | - | works, score 0 |

- `npx tsc --noEmit` clean; scoped eslint clean.
- 17 tests in the suite, full backend suite green.
- Three now-dead JavaScript helpers (`scoreSuggestion`, `matchesQuery`, `matchesSpecies`) removed rather than left behind.

## A limitation worth stating

The logic now lives in SQL, and there is no Postgres service in backend CI and no DB-backed tests today. Mocking `$queryRaw` and asserting the rows it was told to return would prove nothing, so `buildSuggestionQuery` is extracted as a pure function and the tests assert the **statement**: no 5,000 anywhere, the match bound as a parameter and never interpolated into SQL text, wildcards escaped, domain and species predicates present only when requested, limit clamped.

That covers the pushdown, not the SQL semantics. Those were verified by hand against Postgres as above. Standing up a Postgres service in CI would close the gap properly and is worth doing separately.

## Related Issue(s)

Fixes #2456
