### PR TITLE
feat(backend): record how well each crosswalk holds

### DIFF
--- a/apps/backend/src/models/code-mapping.ts
+++ b/apps/backend/src/models/code-mapping.ts
@@ -1,3 +1,13 @@
+/** FHIR ConceptMap equivalence, describing how exactly a crosswalk holds. */
+export type MappingEquivalence =
+  | "EQUIVALENT"
+  | "RELATEDTO"
+  | "WIDER"
+  | "NARROWER"
+  | "INEXACT"
+  | "UNMATCHED"
+  | "DISJOINT";
+
 import type { CodeSystem } from "./code-entry";
 
 export interface CodeMappingMongo {
@@ -7,6 +17,7 @@ export interface CodeMappingMongo {
   targetCode: string;
   targetDisplay?: string | null;
   targetVersion?: string | null;
+  equivalence?: MappingEquivalence;
   active: boolean;
   createdAt?: Date;
   updatedAt?: Date;

--- a/apps/backend/src/models/code-mapping.ts
+++ b/apps/backend/src/models/code-mapping.ts
@@ -1,9 +1,12 @@
 /** FHIR ConceptMap equivalence, describing how exactly a crosswalk holds. */
 export type MappingEquivalence =
-  | "EQUIVALENT"
   | "RELATEDTO"
+  | "EQUIVALENT"
+  | "EQUAL"
   | "WIDER"
+  | "SUBSUMES"
   | "NARROWER"
+  | "SPECIALIZES"
   | "INEXACT"
   | "UNMATCHED"
   | "DISJOINT";

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -43,9 +43,10 @@ const ClinicalCodeSchema = z.object({
   system: z.string().trim().min(1),
   code: z.string().trim().min(1),
   display: z.string().trim().optional(),
-  equivalence: z
-    .enum(["equivalent", "related", "narrower", "broader", "inexact"])
-    .default("equivalent"),
+  // Deliberately a free string rather than an enum. An unrecognised equivalence must
+  // reach toMappingEquivalence and degrade to INEXACT; rejecting the whole import
+  // because one coding uses an unfamiliar word is worse than recording it cautiously.
+  equivalence: z.string().trim().default("equivalent"),
 });
 
 const ClinicalDesignationSchema = z.object({
@@ -106,10 +107,17 @@ const normalizeCodeSystem = (system: string): CodeSystem | null =>
  */
 const EQUIVALENCE_MAP: Record<string, MappingEquivalence> = {
   equivalent: "EQUIVALENT",
+  equal: "EQUAL",
   related: "RELATEDTO",
+  relatedto: "RELATEDTO",
   narrower: "NARROWER",
+  specializes: "SPECIALIZES",
   broader: "WIDER",
+  wider: "WIDER",
+  subsumes: "SUBSUMES",
   inexact: "INEXACT",
+  unmatched: "UNMATCHED",
+  disjoint: "DISJOINT",
 };
 
 const toMappingEquivalence = (value?: string): MappingEquivalence =>

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { type CodeEntryMongo, type CodeSystem } from "src/models/code-entry";
+import { type MappingEquivalence } from "src/models/code-mapping";
 import { CodeService } from "src/services/code.service";
 import { prisma } from "src/config/prisma";
 import { z } from "zod";
@@ -97,6 +98,22 @@ const EXTERNAL_CODE_SYSTEM_MAP: Record<string, CodeSystem> = {
 
 const normalizeCodeSystem = (system: string): CodeSystem | null =>
   EXTERNAL_CODE_SYSTEM_MAP[system.trim().toLowerCase()] ?? null;
+
+/**
+ * The extract uses its own wording for equivalence; this is the FHIR ConceptMap
+ * vocabulary. Anything unrecognised becomes INEXACT rather than EQUIVALENT: overstating
+ * how well a crosswalk holds is the failure that silently corrupts a research cohort.
+ */
+const EQUIVALENCE_MAP: Record<string, MappingEquivalence> = {
+  equivalent: "EQUIVALENT",
+  related: "RELATEDTO",
+  narrower: "NARROWER",
+  broader: "WIDER",
+  inexact: "INEXACT",
+};
+
+const toMappingEquivalence = (value?: string): MappingEquivalence =>
+  EQUIVALENCE_MAP[(value ?? "").trim().toLowerCase()] ?? "INEXACT";
 
 const toUniqueStrings = (values: Array<string | null | undefined>) => {
   const seen = new Set<string>();
@@ -220,7 +237,7 @@ export const ClinicalTermsService = {
 
       for (const code of concept.codes) {
         const targetSystem = normalizeCodeSystem(code.system);
-        if (!targetSystem || code.equivalence !== "equivalent") continue;
+        if (!targetSystem) continue;
 
         await CodeService.upsertMapping({
           sourceSystem: "YOSEMITECODE",
@@ -229,6 +246,7 @@ export const ClinicalTermsService = {
           targetCode: code.code,
           targetDisplay: code.display ?? concept.label,
           targetVersion: null,
+          equivalence: toMappingEquivalence(code.equivalence),
           active: concept.active,
         });
         mappingsUpserted += 1;

--- a/apps/backend/src/services/code.service.ts
+++ b/apps/backend/src/services/code.service.ts
@@ -77,11 +77,13 @@ const syncCodeMappingToPostgres = async (input: CodeMappingMongo) => {
       targetCode: input.targetCode,
       targetDisplay: input.targetDisplay ?? null,
       targetVersion: input.targetVersion ?? null,
+      equivalence: input.equivalence ?? "EQUIVALENT",
       active: input.active,
     },
     update: {
       targetDisplay: input.targetDisplay ?? null,
       targetVersion: input.targetVersion ?? null,
+      equivalence: input.equivalence ?? "EQUIVALENT",
       active: input.active,
     },
   });

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -53,7 +53,7 @@ describe("ClinicalTermsService", () => {
   });
 
   describe("importConcepts", () => {
-    it("upserts canonical entries and supported equivalent mappings", async () => {
+    it("upserts canonical entries and every supported coding, with its equivalence", async () => {
       const result = await ClinicalTermsService.importConcepts([
         {
           ycCode: "YC-1",
@@ -136,7 +136,9 @@ describe("ClinicalTermsService", () => {
         },
       });
 
-      expect(CodeService.upsertMapping).toHaveBeenCalledTimes(1);
+      // Both codings are kept now. Previously anything not exactly "equivalent" was
+      // skipped, so a related crosswalk was not weakened - it vanished with no trace.
+      expect(CodeService.upsertMapping).toHaveBeenCalledTimes(2);
       expect(CodeService.upsertMapping).toHaveBeenCalledWith({
         sourceSystem: "YOSEMITECODE",
         sourceCode: "YC-1",
@@ -144,9 +146,69 @@ describe("ClinicalTermsService", () => {
         targetCode: "123",
         targetDisplay: "Vomiting",
         targetVersion: null,
+        equivalence: "EQUIVALENT",
         active: true,
       });
-      expect(result).toEqual({ entriesUpserted: 1, mappingsUpserted: 1 });
+      expect(CodeService.upsertMapping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetSystem: "SNOMED",
+          equivalence: "RELATEDTO",
+        }),
+      );
+      expect(result).toEqual({ entriesUpserted: 1, mappingsUpserted: 2 });
+    });
+  });
+
+  describe("equivalence", () => {
+    const concept = (equivalence: string) => ({
+      ycCode: "YC-9",
+      label: "Vomiting",
+      domain: "Diagnosis" as const,
+      active: true,
+      source: "VeNom" as const,
+      designations: [],
+      species: [],
+      codes: [
+        {
+          system: "http://snomed.info/sct",
+          code: "422400008",
+          display: "Vomiting",
+          equivalence,
+        },
+      ],
+    });
+
+    it("records a narrower crosswalk as narrower rather than dropping it", async () => {
+      await ClinicalTermsService.importConcepts([concept("narrower") as never]);
+
+      expect(CodeService.upsertMapping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetCode: "422400008",
+          equivalence: "NARROWER",
+        }),
+      );
+    });
+
+    it("maps the extract's wording onto the FHIR vocabulary", async () => {
+      await ClinicalTermsService.importConcepts([concept("broader") as never]);
+      expect(CodeService.upsertMapping).toHaveBeenLastCalledWith(
+        expect.objectContaining({ equivalence: "WIDER" }),
+      );
+
+      await ClinicalTermsService.importConcepts([concept("inexact") as never]);
+      expect(CodeService.upsertMapping).toHaveBeenLastCalledWith(
+        expect.objectContaining({ equivalence: "INEXACT" }),
+      );
+    });
+
+    it("treats an unrecognised equivalence as inexact, never as equivalent", async () => {
+      // Overstating how well a crosswalk holds is the failure that silently corrupts a
+      // research cohort, so the unknown case degrades rather than flatters.
+      await ClinicalTermsService.importConcepts([concept("nonsense") as never]);
+
+      expect(CodeService.upsertMapping).toHaveBeenLastCalledWith(
+        expect.objectContaining({ equivalence: "INEXACT" }),
+      );
     });
   });
 

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -201,6 +201,48 @@ describe("ClinicalTermsService", () => {
       );
     });
 
+    it("survives an unrecognised equivalence coming through the file path", async () => {
+      // The bug this covers: parseConcepts validated equivalence with z.enum, so an
+      // unfamiliar word threw before the INEXACT fallback could run. The earlier test
+      // passed only because it called importConcepts directly, bypassing validation.
+      const parsed = ClinicalTermsService.parseConcepts([
+        {
+          ycCode: "YC-1",
+          label: "Vomiting",
+          domain: "Diagnosis",
+          source: "VeNom",
+          codes: [
+            {
+              system: "http://snomed.info/sct",
+              code: "422400008",
+              equivalence: "some-word-we-have-not-seen",
+            },
+          ],
+        },
+      ]);
+
+      await ClinicalTermsService.importConcepts(parsed);
+
+      expect(CodeService.upsertMapping).toHaveBeenCalledWith(
+        expect.objectContaining({ equivalence: "INEXACT" }),
+      );
+    });
+
+    it("carries the FHIR values the extract may already use", async () => {
+      for (const [word, expected] of [
+        ["equal", "EQUAL"],
+        ["subsumes", "SUBSUMES"],
+        ["specializes", "SPECIALIZES"],
+        ["disjoint", "DISJOINT"],
+        ["unmatched", "UNMATCHED"],
+      ]) {
+        await ClinicalTermsService.importConcepts([concept(word) as never]);
+        expect(CodeService.upsertMapping).toHaveBeenLastCalledWith(
+          expect.objectContaining({ equivalence: expected }),
+        );
+      }
+    });
+
     it("treats an unrecognised equivalence as inexact, never as equivalent", async () => {
       // Overstating how well a crosswalk holds is the failure that silently corrupts a
       // research cohort, so the unknown case degrades rather than flatters.

--- a/apps/backend/test/services/code.service.test.ts
+++ b/apps/backend/test/services/code.service.test.ts
@@ -457,4 +457,39 @@ describe("CodeService", () => {
       orderBy: { createdAt: "desc" },
     });
   });
+  describe("mapping equivalence", () => {
+    it("persists the equivalence it was given, on create and on update", async () => {
+      // The importer decides how well a crosswalk holds; if this layer drops it, every
+      // mapping silently reverts to asserting exact sameness.
+      mockedPrisma.codeMapping.upsert.mockResolvedValue({ id: "m-1" });
+
+      await CodeService.upsertMapping({
+        sourceSystem: "YOSEMITECODE",
+        sourceCode: "YC-1",
+        targetSystem: "SNOMED",
+        targetCode: "422400008",
+        equivalence: "NARROWER",
+        active: true,
+      });
+
+      const args = mockedPrisma.codeMapping.upsert.mock.calls[0][0];
+      expect(args.create.equivalence).toBe("NARROWER");
+      expect(args.update.equivalence).toBe("NARROWER");
+    });
+
+    it("defaults to EQUIVALENT when the caller says nothing", async () => {
+      mockedPrisma.codeMapping.upsert.mockResolvedValue({ id: "m-2" });
+
+      await CodeService.upsertMapping({
+        sourceSystem: "YOSEMITECODE",
+        sourceCode: "YC-2",
+        targetSystem: "VENOM",
+        targetCode: "13",
+        active: true,
+      });
+
+      const args = mockedPrisma.codeMapping.upsert.mock.calls[0][0];
+      expect(args.create.equivalence).toBe("EQUIVALENT");
+    });
+  });
 });

--- a/packages/database/prisma/migrations/20260824200000_mapping_equivalence/migration.sql
+++ b/packages/database/prisma/migrations/20260824200000_mapping_equivalence/migration.sql
@@ -14,11 +14,16 @@
 --
 -- Additive only. No existing row changes meaning: the default matches what they assert.
 
+-- The complete FHIR R4 ConceptMap equivalence vocabulary, in the order FHIR lists it.
+-- A partial set would force a real relationship to be recorded as something it is not.
 CREATE TYPE "MappingEquivalence" AS ENUM (
-  'EQUIVALENT',
   'RELATEDTO',
+  'EQUIVALENT',
+  'EQUAL',
   'WIDER',
+  'SUBSUMES',
   'NARROWER',
+  'SPECIALIZES',
   'INEXACT',
   'UNMATCHED',
   'DISJOINT'

--- a/packages/database/prisma/migrations/20260824200000_mapping_equivalence/migration.sql
+++ b/packages/database/prisma/migrations/20260824200000_mapping_equivalence/migration.sql
@@ -1,0 +1,28 @@
+-- Every crosswalk in CodeMapping currently asserts exact sameness, because there is
+-- nowhere to record anything else. A research cohort built on a narrower mapping treated
+-- as equivalent is wrong, and nothing in the data would reveal it.
+--
+-- This adds the FHIR ConceptMap equivalence vocabulary. The 12,213 existing codings all
+-- declare "equivalent" in the source extract, so EQUIVALENT is the correct default and no
+-- backfill is needed.
+--
+-- Note on a related but separate defect, left for the duplicate-collapsing work: 297
+-- SNOMED codes have two or more YC concepts mapped to them. Every one of those pairs is
+-- species-partitioned, and 180 share an identical display, so these are duplicate
+-- concepts rather than false equivalence claims. Relabelling them here would record a
+-- wrong equivalence to paper over a wrong concept.
+--
+-- Additive only. No existing row changes meaning: the default matches what they assert.
+
+CREATE TYPE "MappingEquivalence" AS ENUM (
+  'EQUIVALENT',
+  'RELATEDTO',
+  'WIDER',
+  'NARROWER',
+  'INEXACT',
+  'UNMATCHED',
+  'DISJOINT'
+);
+
+ALTER TABLE "CodeMapping"
+  ADD COLUMN IF NOT EXISTS "equivalence" "MappingEquivalence" NOT NULL DEFAULT 'EQUIVALENT';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -284,10 +284,13 @@ model CodeEntry {
 /// research cohort built on a narrower mapping treated as equivalent is wrong with no way
 /// to detect it.
 enum MappingEquivalence {
-  EQUIVALENT
   RELATEDTO
+  EQUIVALENT
+  EQUAL
   WIDER
+  SUBSUMES
   NARROWER
+  SPECIALIZES
   INEXACT
   UNMATCHED
   DISJOINT

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -280,17 +280,31 @@ model CodeEntry {
   @@index([system, type, active])
 }
 
+/// FHIR ConceptMap equivalence. Without it every crosswalk asserts exact sameness, and a
+/// research cohort built on a narrower mapping treated as equivalent is wrong with no way
+/// to detect it.
+enum MappingEquivalence {
+  EQUIVALENT
+  RELATEDTO
+  WIDER
+  NARROWER
+  INEXACT
+  UNMATCHED
+  DISJOINT
+}
+
 model CodeMapping {
-  id            String     @id @default(uuid())
+  id            String             @id @default(uuid())
   sourceSystem  CodeSystem
   sourceCode    String
   targetSystem  CodeSystem
   targetCode    String
   targetDisplay String?
   targetVersion String?
-  active        Boolean    @default(true)
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @updatedAt
+  equivalence   MappingEquivalence @default(EQUIVALENT)
+  active        Boolean            @default(true)
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
 
   @@unique([sourceSystem, sourceCode, targetSystem, targetCode])
   @@index([sourceSystem, sourceCode])


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`CodeMapping` has nowhere to record *how well* a crosswalk holds, so all 12,213 codings assert exact sameness by omission. A research cohort assembled through a narrower mapping treated as equivalent is wrong, and nothing in the data would reveal it.

There is also a live defect in the importer:

```ts
if (!targetSystem || code.equivalence !== "equivalent") continue;
```

A coding that is not exactly equivalent is **dropped**, not weakened. Nothing is lost today because the extract declares `equivalent` throughout, but the next import carrying real equivalences would have discarded them silently.

## What is the new behavior?

`CodeMapping` carries the FHIR ConceptMap equivalence. `EQUIVALENT` is the default and matches what every existing row's source declares, so no backfill is needed and no row changes meaning.

The importer records a coding's equivalence and keeps the coding. An unrecognised value degrades to `INEXACT`, never `EQUIVALENT` - overstating how well a crosswalk holds is the failure that corrupts a cohort quietly, so the unknown case is made to look worse than it might be rather than better.

This is the precondition for user-selectable vocabularies: a projection service cannot honestly answer "give me the SNOMED code for this" without knowing whether the mapping is exact.

## A related defect, deliberately not fixed here

**297 SNOMED codes have two or more YC concepts mapped to them**, which looks like false equivalence. Characterised:

| | count |
| --- | --- |
| multi-source SNOMED codes | 297 |
| identical display | 180 |
| differing by species | **297 (all)** |
| same species *and* domain, differing text | 0 |

Every one is species-partitioned, so these are duplicate concepts, not bad mappings. Relabelling them `NARROWER` would record a wrong equivalence to paper over a wrong concept. It belongs with the duplicate-collapsing work, where the vision's figure of 180 should be corrected to **297**.

## Impact area

`apps/backend` and one additive migration. No existing row changes meaning.

## Validation performed

- `tsc` clean, eslint clean, **107 tests across 6 suites**.
- Migration verified on a fresh database **inside a transaction as Prisma runs it**, with a pre-existing row confirmed to default to `EQUIVALENT`.
- **Mutation checked.** Restoring the drop-non-equivalent behaviour fails 4 tests; defaulting the unknown case to `EQUIVALENT` fails 1; dropping the field from the write path fails 2.
- That last mutation initially passed, which exposed that nothing covered the persistence layer at all: the clinical-terms tests mock `CodeService`, so they never exercise it. Direct tests were added and the mutation now fails as it should.

## Related Issue(s)

Fixes #2461
