### PR TITLE
feat(backend): project coded records into a chosen vocabulary

### DIFF
--- a/apps/backend/sonar-project.properties
+++ b/apps/backend/sonar-project.properties
@@ -19,6 +19,19 @@ sonar.test.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,s
 # behaviour is covered by test/services/integration.service.test.ts.
 sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/tests/**,src/models/**,**/migrations/**, **/data/**, src/services/integration.service.ts
 
+# S5332 ("use https instead") reads every http:// literal as an address. FHIR
+# terminology system URIs are identifiers, not addresses: the specification fixes
+# SNOMED CT's system as the exact string "http://snomed.info/sct", nothing ever
+# dereferences it, and writing https there produces a Coding that no terminology
+# server will match. packages/types carries a dozen HL7 URIs of the same shape
+# (appointment.ts, encounter.ts, companion.ts) for the same reason; it simply is
+# not inside this Sonar project, which is why this is the first one to surface.
+# Scoped to the one file that declares them so a genuine http:// call elsewhere
+# in the backend still fails the gate.
+sonar.issue.ignore.multicriteria=fhirSystemUri
+sonar.issue.ignore.multicriteria.fhirSystemUri.ruleKey=typescript:S5332
+sonar.issue.ignore.multicriteria.fhirSystemUri.resourceKey=**/terminology-projection.service.ts
+
 # Ignore non-relevant languages
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-

--- a/apps/backend/src/services/terminology-projection.service.ts
+++ b/apps/backend/src/services/terminology-projection.service.ts
@@ -1,0 +1,182 @@
+import { prisma } from "src/config/prisma";
+import { Prisma } from "@prisma/client";
+import type { MappingEquivalence } from "src/models/code-mapping";
+
+/**
+ * Projecting a coded record into another vocabulary is where a crosswalk stops being a
+ * reference table and starts making clinical claims. Two rules hold throughout:
+ *
+ * 1. Never fall back. If a term has no counterpart in the requested system, say so. The
+ *    tempting alternatives - emit the YC code as though it were SNOMED, or substitute a
+ *    parent concept - both produce an export that looks complete and is not.
+ * 2. Never let the preference narrow input. It governs output only. SNOMED covers 344 of
+ *    our 4,819 exotics terms; a preference that filtered the picker would leave an
+ *    exotics vet unable to record what is in front of them.
+ */
+export type ProjectionTarget = "YOSEMITECODE" | "VENOM" | "SNOMED";
+
+export type ProjectedCode =
+  | {
+      status: "mapped";
+      ycCode: string;
+      system: ProjectionTarget;
+      code: string;
+      display: string | null;
+      equivalence: MappingEquivalence;
+    }
+  | { status: "unmapped"; ycCode: string; system: ProjectionTarget }
+  | { status: "unknown"; ycCode: string; system: ProjectionTarget };
+
+export type VocabularyCoverage = {
+  system: ProjectionTarget;
+  species: string | null;
+  terms: number;
+  mapped: number;
+  /** Whole percent, floored: 6% must not round up to 7% in a disclosure. */
+  percent: number;
+};
+
+const isTerminal = (system: ProjectionTarget) => system === "YOSEMITECODE";
+
+export const TerminologyProjectionService = {
+  /**
+   * Projects several codes at once. Batched deliberately: a SOAP note or an export runs
+   * to hundreds of codes, and one query per code would make the honest path the slow one.
+   */
+  async projectCodes(
+    ycCodes: string[],
+    system: ProjectionTarget,
+  ): Promise<ProjectedCode[]> {
+    const wanted = [
+      ...new Set(ycCodes.map((code) => code.trim()).filter(Boolean)),
+    ];
+    if (wanted.length === 0) return [];
+
+    // Asking for our own vocabulary is not a projection; it still has to confirm the
+    // code exists rather than echoing whatever it was handed.
+    if (isTerminal(system)) {
+      const known = await prisma.codeEntry.findMany({
+        where: { system: "YOSEMITECODE", code: { in: wanted }, active: true },
+        select: { code: true, display: true },
+      });
+      const byCode = new Map(known.map((row) => [row.code, row.display]));
+      return wanted.map((ycCode) =>
+        byCode.has(ycCode)
+          ? {
+              status: "mapped" as const,
+              ycCode,
+              system,
+              code: ycCode,
+              display: byCode.get(ycCode) ?? null,
+              equivalence: "EQUIVALENT" as MappingEquivalence,
+            }
+          : { status: "unknown" as const, ycCode, system },
+      );
+    }
+
+    const [mappings, known] = await Promise.all([
+      prisma.codeMapping.findMany({
+        where: {
+          sourceSystem: "YOSEMITECODE",
+          sourceCode: { in: wanted },
+          targetSystem: system,
+          active: true,
+        },
+        select: {
+          sourceCode: true,
+          targetCode: true,
+          targetDisplay: true,
+          equivalence: true,
+        },
+        // A term can carry more than one code in a system. Deterministic order so the
+        // same record projects the same way every time.
+        orderBy: { targetCode: "asc" },
+      }),
+      prisma.codeEntry.findMany({
+        where: { system: "YOSEMITECODE", code: { in: wanted }, active: true },
+        select: { code: true },
+      }),
+    ]);
+
+    const mapped = new Map(mappings.map((row) => [row.sourceCode, row]));
+    const exists = new Set(known.map((row) => row.code));
+
+    return wanted.map((ycCode) => {
+      const hit = mapped.get(ycCode);
+      if (hit) {
+        return {
+          status: "mapped" as const,
+          ycCode,
+          system,
+          code: hit.targetCode,
+          display: hit.targetDisplay,
+          equivalence: hit.equivalence,
+        };
+      }
+      // An unknown code and a code with no counterpart are different failures: the first
+      // is a bug in the caller, the second is a real gap in the target vocabulary.
+      return exists.has(ycCode)
+        ? { status: "unmapped" as const, ycCode, system }
+        : { status: "unknown" as const, ycCode, system };
+    });
+  },
+
+  async projectCode(
+    ycCode: string,
+    system: ProjectionTarget,
+  ): Promise<ProjectedCode> {
+    const [only] = await this.projectCodes([ycCode], system);
+    return only ?? { status: "unknown", ycCode, system };
+  },
+
+  /**
+   * What a practice needs to see before choosing. The honest number is per species,
+   * because the aggregate hides the cases that matter: SNOMED reaches 50% of small
+   * animal terms and 7% of exotics.
+   */
+  async vocabularyCoverage(
+    system: ProjectionTarget,
+    species?: string,
+  ): Promise<VocabularyCoverage> {
+    const speciesFilter = species
+      ? Prisma.sql`AND EXISTS (
+          SELECT 1 FROM jsonb_array_elements_text(
+            CASE WHEN jsonb_typeof(e."meta"->'species') = 'array'
+                 THEN e."meta"->'species' ELSE '[]'::jsonb END
+          ) sp WHERE sp = ${species}
+        )`
+      : Prisma.empty;
+
+    const mappedExpression = isTerminal(system)
+      ? Prisma.sql`COUNT(*)`
+      : Prisma.sql`COUNT(*) FILTER (WHERE EXISTS (
+          SELECT 1 FROM "CodeMapping" m
+          WHERE m."sourceCode" = e."code"
+            AND m."sourceSystem" = 'YOSEMITECODE'::"CodeSystem"
+            AND m."targetSystem" = ${system}::"CodeSystem"
+            AND m."active"
+        ))`;
+
+    const [row] = await prisma.$queryRaw<
+      Array<{ terms: bigint; mapped: bigint }>
+    >`
+      SELECT COUNT(*) AS terms, ${mappedExpression} AS mapped
+      FROM "CodeEntry" e
+      WHERE e."system" = 'YOSEMITECODE'::"CodeSystem"
+        AND e."type" = 'CLINICAL_TERM'::"CodeType"
+        AND e."active"
+        ${speciesFilter}
+    `;
+
+    const terms = Number(row?.terms ?? 0);
+    const mapped = Number(row?.mapped ?? 0);
+
+    return {
+      system,
+      species: species ?? null,
+      terms,
+      mapped,
+      percent: terms === 0 ? 0 : Math.floor((mapped * 100) / terms),
+    };
+  },
+};

--- a/apps/backend/src/services/terminology-projection.service.ts
+++ b/apps/backend/src/services/terminology-projection.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "src/config/prisma";
 import { Prisma } from "@prisma/client";
+import type { Coding } from "@yosemite-crew/fhir";
 import type { MappingEquivalence } from "src/models/code-mapping";
 
 /**
@@ -15,17 +16,59 @@ import type { MappingEquivalence } from "src/models/code-mapping";
  */
 export type ProjectionTarget = "YOSEMITECODE" | "VENOM" | "SNOMED";
 
+/** Terminology system URIs, so a projection is quotable as a FHIR Coding. */
+export const SYSTEM_URI: Record<ProjectionTarget, string> = {
+  YOSEMITECODE: "https://yosemitecrew.com/fhir/CodeSystem/yosemite",
+  VENOM: "urn:venom",
+  SNOMED: "http://snomed.info/sct",
+};
+
+/**
+ * A FHIR Coding for the mapped case, wrapped in a result that can also say "no
+ * counterpart" or "unknown". Coding alone cannot express either, and collapsing them
+ * into an absent Coding is what makes an export look complete when it is not.
+ */
 export type ProjectedCode =
   | {
       status: "mapped";
       ycCode: string;
       system: ProjectionTarget;
-      code: string;
-      display: string | null;
+      coding: Coding;
       equivalence: MappingEquivalence;
     }
   | { status: "unmapped"; ycCode: string; system: ProjectionTarget }
   | { status: "unknown"; ycCode: string; system: ProjectionTarget };
+
+/**
+ * Equivalences that assert a usable counterpart. UNMATCHED means no counterpart exists
+ * and DISJOINT means the two do not overlap, so counting either as coverage would
+ * overstate what the target vocabulary can express - the opposite of what a coverage
+ * disclosure is for.
+ */
+const USABLE_EQUIVALENCES: MappingEquivalence[] = [
+  "RELATEDTO",
+  "EQUIVALENT",
+  "EQUAL",
+  "WIDER",
+  "SUBSUMES",
+  "NARROWER",
+  "SPECIALIZES",
+  "INEXACT",
+];
+
+/** Strongest first. A term with several codes in one system should project its best. */
+const EQUIVALENCE_RANK: MappingEquivalence[] = [
+  "EQUAL",
+  "EQUIVALENT",
+  "NARROWER",
+  "SPECIALIZES",
+  "WIDER",
+  "SUBSUMES",
+  "RELATEDTO",
+  "INEXACT",
+  "UNMATCHED",
+  "DISJOINT",
+];
 
 export type VocabularyCoverage = {
   system: ProjectionTarget;
@@ -66,8 +109,11 @@ export const TerminologyProjectionService = {
               status: "mapped" as const,
               ycCode,
               system,
-              code: ycCode,
-              display: byCode.get(ycCode) ?? null,
+              coding: {
+                system: SYSTEM_URI[system],
+                code: ycCode,
+                display: byCode.get(ycCode) ?? undefined,
+              },
               equivalence: "EQUIVALENT" as MappingEquivalence,
             }
           : { status: "unknown" as const, ycCode, system },
@@ -98,26 +144,47 @@ export const TerminologyProjectionService = {
       }),
     ]);
 
-    const mapped = new Map(mappings.map((row) => [row.sourceCode, row]));
     const exists = new Set(known.map((row) => row.code));
 
+    // One term can hold several codes in a system. Keep the strongest equivalence
+    // rather than whichever target code happens to sort first.
+    const rank = (equivalence: string) => {
+      const index = EQUIVALENCE_RANK.indexOf(equivalence as MappingEquivalence);
+      return index === -1 ? EQUIVALENCE_RANK.length : index;
+    };
+    const mapped = new Map<string, (typeof mappings)[number]>();
+    for (const row of mappings) {
+      const held = mapped.get(row.sourceCode);
+      if (!held || rank(row.equivalence) < rank(held.equivalence)) {
+        mapped.set(row.sourceCode, row);
+      }
+    }
+
     return wanted.map((ycCode) => {
+      // Existence first. A mapping can outlive the concept it maps from - the entry is
+      // retired while its CodeMapping row stays active - and trusting the mapping would
+      // project a concept we no longer hold as though it were current.
+      if (!exists.has(ycCode)) {
+        return { status: "unknown" as const, ycCode, system };
+      }
+
       const hit = mapped.get(ycCode);
       if (hit) {
         return {
           status: "mapped" as const,
           ycCode,
           system,
-          code: hit.targetCode,
-          display: hit.targetDisplay,
+          coding: {
+            system: SYSTEM_URI[system],
+            code: hit.targetCode,
+            display: hit.targetDisplay ?? undefined,
+          },
           equivalence: hit.equivalence,
         };
       }
-      // An unknown code and a code with no counterpart are different failures: the first
-      // is a bug in the caller, the second is a real gap in the target vocabulary.
-      return exists.has(ycCode)
-        ? { status: "unmapped" as const, ycCode, system }
-        : { status: "unknown" as const, ycCode, system };
+      // A concept we hold with no counterpart is a real gap in the target vocabulary,
+      // which is a different thing from a code we never had.
+      return { status: "unmapped" as const, ycCode, system };
     });
   },
 
@@ -155,6 +222,7 @@ export const TerminologyProjectionService = {
             AND m."sourceSystem" = 'YOSEMITECODE'::"CodeSystem"
             AND m."targetSystem" = ${system}::"CodeSystem"
             AND m."active"
+            AND m."equivalence" = ANY(${USABLE_EQUIVALENCES}::"MappingEquivalence"[])
         ))`;
 
     const [row] = await prisma.$queryRaw<

--- a/apps/backend/src/services/terminology-projection.service.ts
+++ b/apps/backend/src/services/terminology-projection.service.ts
@@ -81,6 +81,98 @@ export type VocabularyCoverage = {
 
 const isTerminal = (system: ProjectionTarget) => system === "YOSEMITECODE";
 
+/**
+ * Our own vocabulary is not projected, but a code must still be confirmed to exist
+ * rather than echoed back: echoing would make a nonexistent code look valid.
+ */
+const projectOwnVocabulary = async (
+  wanted: string[],
+  system: ProjectionTarget,
+): Promise<ProjectedCode[]> => {
+  const known = await prisma.codeEntry.findMany({
+    where: { system: "YOSEMITECODE", code: { in: wanted }, active: true },
+    select: { code: true, display: true },
+  });
+  const byCode = new Map(known.map((row) => [row.code, row.display]));
+  return wanted.map((ycCode) =>
+    byCode.has(ycCode)
+      ? {
+          status: "mapped" as const,
+          ycCode,
+          system,
+          coding: {
+            system: SYSTEM_URI[system],
+            code: ycCode,
+            display: byCode.get(ycCode) ?? undefined,
+          },
+          equivalence: "EQUIVALENT" as MappingEquivalence,
+        }
+      : { status: "unknown" as const, ycCode, system },
+  );
+};
+
+type MappingRow = {
+  sourceCode: string;
+  targetCode: string;
+  targetDisplay: string | null;
+  equivalence: string;
+};
+
+const equivalenceRank = (equivalence: string) => {
+  const index = EQUIVALENCE_RANK.indexOf(equivalence as MappingEquivalence);
+  return index === -1 ? EQUIVALENCE_RANK.length : index;
+};
+
+/**
+ * One term can hold several codes in a system. Keep the strongest equivalence rather
+ * than whichever target code happens to sort first.
+ */
+const strongestMappingPerSource = (rows: MappingRow[]) => {
+  const mapped = new Map<string, MappingRow>();
+  for (const row of rows) {
+    const held = mapped.get(row.sourceCode);
+    if (
+      !held ||
+      equivalenceRank(row.equivalence) < equivalenceRank(held.equivalence)
+    ) {
+      mapped.set(row.sourceCode, row);
+    }
+  }
+  return mapped;
+};
+
+const projectOne = (
+  ycCode: string,
+  system: ProjectionTarget,
+  exists: Set<string>,
+  mapped: Map<string, MappingRow>,
+): ProjectedCode => {
+  // Existence first. A mapping can outlive the concept it maps from - the entry is
+  // retired while its CodeMapping row stays active - and trusting the mapping would
+  // project a concept we no longer hold as though it were current.
+  if (!exists.has(ycCode)) {
+    return { status: "unknown", ycCode, system };
+  }
+
+  const hit = mapped.get(ycCode);
+  if (hit) {
+    return {
+      status: "mapped",
+      ycCode,
+      system,
+      coding: {
+        system: SYSTEM_URI[system],
+        code: hit.targetCode,
+        display: hit.targetDisplay ?? undefined,
+      },
+      equivalence: hit.equivalence as MappingEquivalence,
+    };
+  }
+  // A concept we hold with no counterpart is a real gap in the target vocabulary,
+  // which is a different thing from a code we never had.
+  return { status: "unmapped", ycCode, system };
+};
+
 export const TerminologyProjectionService = {
   /**
    * Projects several codes at once. Batched deliberately: a SOAP note or an export runs
@@ -94,31 +186,7 @@ export const TerminologyProjectionService = {
       ...new Set(ycCodes.map((code) => code.trim()).filter(Boolean)),
     ];
     if (wanted.length === 0) return [];
-
-    // Asking for our own vocabulary is not a projection; it still has to confirm the
-    // code exists rather than echoing whatever it was handed.
-    if (isTerminal(system)) {
-      const known = await prisma.codeEntry.findMany({
-        where: { system: "YOSEMITECODE", code: { in: wanted }, active: true },
-        select: { code: true, display: true },
-      });
-      const byCode = new Map(known.map((row) => [row.code, row.display]));
-      return wanted.map((ycCode) =>
-        byCode.has(ycCode)
-          ? {
-              status: "mapped" as const,
-              ycCode,
-              system,
-              coding: {
-                system: SYSTEM_URI[system],
-                code: ycCode,
-                display: byCode.get(ycCode) ?? undefined,
-              },
-              equivalence: "EQUIVALENT" as MappingEquivalence,
-            }
-          : { status: "unknown" as const, ycCode, system },
-      );
-    }
+    if (isTerminal(system)) return projectOwnVocabulary(wanted, system);
 
     const [mappings, known] = await Promise.all([
       prisma.codeMapping.findMany({
@@ -134,8 +202,8 @@ export const TerminologyProjectionService = {
           targetDisplay: true,
           equivalence: true,
         },
-        // A term can carry more than one code in a system. Deterministic order so the
-        // same record projects the same way every time.
+        // Deterministic order, so a term with several codes projects the same way
+        // every time even before ranking breaks the tie.
         orderBy: { targetCode: "asc" },
       }),
       prisma.codeEntry.findMany({
@@ -145,47 +213,8 @@ export const TerminologyProjectionService = {
     ]);
 
     const exists = new Set(known.map((row) => row.code));
-
-    // One term can hold several codes in a system. Keep the strongest equivalence
-    // rather than whichever target code happens to sort first.
-    const rank = (equivalence: string) => {
-      const index = EQUIVALENCE_RANK.indexOf(equivalence as MappingEquivalence);
-      return index === -1 ? EQUIVALENCE_RANK.length : index;
-    };
-    const mapped = new Map<string, (typeof mappings)[number]>();
-    for (const row of mappings) {
-      const held = mapped.get(row.sourceCode);
-      if (!held || rank(row.equivalence) < rank(held.equivalence)) {
-        mapped.set(row.sourceCode, row);
-      }
-    }
-
-    return wanted.map((ycCode) => {
-      // Existence first. A mapping can outlive the concept it maps from - the entry is
-      // retired while its CodeMapping row stays active - and trusting the mapping would
-      // project a concept we no longer hold as though it were current.
-      if (!exists.has(ycCode)) {
-        return { status: "unknown" as const, ycCode, system };
-      }
-
-      const hit = mapped.get(ycCode);
-      if (hit) {
-        return {
-          status: "mapped" as const,
-          ycCode,
-          system,
-          coding: {
-            system: SYSTEM_URI[system],
-            code: hit.targetCode,
-            display: hit.targetDisplay ?? undefined,
-          },
-          equivalence: hit.equivalence,
-        };
-      }
-      // A concept we hold with no counterpart is a real gap in the target vocabulary,
-      // which is a different thing from a code we never had.
-      return { status: "unmapped" as const, ycCode, system };
-    });
+    const mapped = strongestMappingPerSource(mappings);
+    return wanted.map((ycCode) => projectOne(ycCode, system, exists, mapped));
   },
 
   async projectCode(

--- a/apps/backend/test/services/terminology-projection.service.test.ts
+++ b/apps/backend/test/services/terminology-projection.service.test.ts
@@ -312,4 +312,78 @@ describe("vocabularyCoverage", () => {
       expect(call).not.toContain("DISJOINT");
     });
   });
+
+  describe("edge branches", () => {
+    it("carries a null display as an absent Coding.display, in both branches", async () => {
+      // FHIR Coding.display is optional; null must become undefined rather than a
+      // literal null in the emitted Coding. Covers the terminal branch and the mapped
+      // branch fallbacks.
+      entryFind.mockResolvedValue([{ code: "YC-1", display: null }]);
+
+      const [own] = await TerminologyProjectionService.projectCodes(
+        ["YC-1"],
+        "YOSEMITECODE",
+      );
+      expect(own.status).toBe("mapped");
+      if (own.status === "mapped") {
+        expect(own.coding.display).toBeUndefined();
+      }
+
+      mappingFind.mockResolvedValue([
+        {
+          sourceCode: "YC-1",
+          targetCode: "422400008",
+          targetDisplay: null,
+          equivalence: "EQUIVALENT",
+        },
+      ]);
+      const [mapped] = await TerminologyProjectionService.projectCodes(
+        ["YC-1"],
+        "SNOMED",
+      );
+      expect(mapped.status).toBe("mapped");
+      if (mapped.status === "mapped") {
+        expect(mapped.coding.display).toBeUndefined();
+      }
+    });
+
+    it("ranks an equivalence it does not recognise below every known one", async () => {
+      // The enum can grow before this table does. An unknown value must lose to any
+      // known one rather than win by accident of indexOf returning -1.
+      entryFind.mockResolvedValue([{ code: "YC-1" }]);
+      mappingFind.mockResolvedValue([
+        {
+          sourceCode: "YC-1",
+          targetCode: "111",
+          targetDisplay: "future",
+          equivalence: "SOME_FUTURE_VALUE",
+        },
+        {
+          sourceCode: "YC-1",
+          targetCode: "222",
+          targetDisplay: "known",
+          equivalence: "INEXACT",
+        },
+      ]);
+
+      const [result] = await TerminologyProjectionService.projectCodes(
+        ["YC-1"],
+        "SNOMED",
+      );
+
+      expect(result.status).toBe("mapped");
+      if (result.status === "mapped") {
+        expect(result.coding.code).toBe("222");
+      }
+    });
+
+    it("reports zero coverage when the query returns no row at all", async () => {
+      queryRaw.mockResolvedValue([]);
+
+      const coverage =
+        await TerminologyProjectionService.vocabularyCoverage("SNOMED");
+
+      expect(coverage).toMatchObject({ terms: 0, mapped: 0, percent: 0 });
+    });
+  });
 });

--- a/apps/backend/test/services/terminology-projection.service.test.ts
+++ b/apps/backend/test/services/terminology-projection.service.test.ts
@@ -1,0 +1,202 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeEntry: { findMany: jest.fn() },
+    codeMapping: { findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import { TerminologyProjectionService } from "src/services/terminology-projection.service";
+
+const entryFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+const mappingFind = (
+  prisma as unknown as { codeMapping: { findMany: jest.Mock } }
+).codeMapping.findMany;
+const queryRaw = (prisma as unknown as { $queryRaw: jest.Mock }).$queryRaw;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("projectCodes", () => {
+  it("returns the mapped code with the equivalence it actually holds", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockResolvedValue([
+      {
+        sourceCode: "YC-1",
+        targetCode: "422400008",
+        targetDisplay: "Vomiting",
+        equivalence: "NARROWER",
+      },
+    ]);
+
+    const [result] = await TerminologyProjectionService.projectCodes(
+      ["YC-1"],
+      "SNOMED",
+    );
+
+    expect(result).toEqual({
+      status: "mapped",
+      ycCode: "YC-1",
+      system: "SNOMED",
+      code: "422400008",
+      display: "Vomiting",
+      equivalence: "NARROWER",
+    });
+  });
+
+  it("reports a term with no counterpart rather than falling back", async () => {
+    // The failure this guards against: emitting the YC code as though it were SNOMED, or
+    // substituting a parent. Both produce an export that looks complete and is not.
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockResolvedValue([]);
+
+    const [result] = await TerminologyProjectionService.projectCodes(
+      ["YC-1"],
+      "SNOMED",
+    );
+
+    expect(result).toEqual({
+      status: "unmapped",
+      ycCode: "YC-1",
+      system: "SNOMED",
+    });
+  });
+
+  it("separates a code we do not hold from one with no counterpart", async () => {
+    // Different failures: the first is a caller bug, the second a real gap in the target
+    // vocabulary. Collapsing them would hide whichever one you were not looking for.
+    entryFind.mockResolvedValue([]);
+    mappingFind.mockResolvedValue([]);
+
+    const [result] = await TerminologyProjectionService.projectCodes(
+      ["YC-nope"],
+      "SNOMED",
+    );
+
+    expect(result.status).toBe("unknown");
+  });
+
+  it("verifies the code exists even when the target is our own vocabulary", async () => {
+    entryFind.mockResolvedValue([]);
+
+    const [result] = await TerminologyProjectionService.projectCodes(
+      ["YC-ghost"],
+      "YOSEMITECODE",
+    );
+
+    // Echoing the input back unchecked would make a nonexistent code look valid.
+    expect(result.status).toBe("unknown");
+    expect(mappingFind).not.toHaveBeenCalled();
+  });
+
+  it("projects our own vocabulary onto itself as exactly equivalent", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1", display: "Vomiting" }]);
+
+    const [result] = await TerminologyProjectionService.projectCodes(
+      ["YC-1"],
+      "YOSEMITECODE",
+    );
+
+    expect(result).toMatchObject({
+      status: "mapped",
+      code: "YC-1",
+      equivalence: "EQUIVALENT",
+    });
+  });
+
+  it("asks the database once for many codes", async () => {
+    // A SOAP note or export runs to hundreds of codes; one query each would make the
+    // honest path the slow one and invite a shortcut.
+    entryFind.mockResolvedValue([{ code: "YC-1" }, { code: "YC-2" }]);
+    mappingFind.mockResolvedValue([]);
+
+    await TerminologyProjectionService.projectCodes(["YC-1", "YC-2"], "SNOMED");
+
+    expect(mappingFind).toHaveBeenCalledTimes(1);
+    expect(mappingFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sourceCode: { in: ["YC-1", "YC-2"] },
+        }),
+      }),
+    );
+  });
+
+  it("deduplicates and ignores blank input", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockResolvedValue([]);
+
+    const results = await TerminologyProjectionService.projectCodes(
+      ["YC-1", " YC-1 ", "", "   "],
+      "SNOMED",
+    );
+
+    expect(results).toHaveLength(1);
+  });
+
+  it("asks for a deterministic order when a term carries several target codes", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockResolvedValue([]);
+
+    await TerminologyProjectionService.projectCodes(["YC-1"], "SNOMED");
+
+    expect(mappingFind).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { targetCode: "asc" } }),
+    );
+  });
+});
+
+describe("vocabularyCoverage", () => {
+  it("reports the share of terms the target system can express", async () => {
+    queryRaw.mockResolvedValue([{ terms: BigInt(4378), mapped: BigInt(1252) }]);
+
+    const coverage = await TerminologyProjectionService.vocabularyCoverage(
+      "SNOMED",
+      "EQUINE",
+    );
+
+    expect(coverage).toEqual({
+      system: "SNOMED",
+      species: "EQUINE",
+      terms: 4378,
+      mapped: 1252,
+      percent: 28,
+    });
+  });
+
+  it("floors the percentage so thin coverage is never flattered", async () => {
+    // 15 of 228 avian terms is 6.6%. Rounding it to 7% overstates the case in exactly
+    // the disclosure meant to warn against choosing that vocabulary.
+    queryRaw.mockResolvedValue([{ terms: BigInt(228), mapped: BigInt(15) }]);
+
+    const coverage = await TerminologyProjectionService.vocabularyCoverage(
+      "SNOMED",
+      "AVIAN",
+    );
+
+    expect(coverage.percent).toBe(6);
+  });
+
+  it("does not divide by zero for a species with no terms", async () => {
+    queryRaw.mockResolvedValue([{ terms: BigInt(0), mapped: BigInt(0) }]);
+
+    const coverage = await TerminologyProjectionService.vocabularyCoverage(
+      "SNOMED",
+      "NONE",
+    );
+
+    expect(coverage.percent).toBe(0);
+  });
+
+  it("reports our own vocabulary as fully covered", async () => {
+    queryRaw.mockResolvedValue([
+      { terms: BigInt(11742), mapped: BigInt(11742) },
+    ]);
+
+    const coverage =
+      await TerminologyProjectionService.vocabularyCoverage("YOSEMITECODE");
+
+    expect(coverage).toMatchObject({ percent: 100, species: null });
+  });
+});

--- a/apps/backend/test/services/terminology-projection.service.test.ts
+++ b/apps/backend/test/services/terminology-projection.service.test.ts
@@ -39,8 +39,11 @@ describe("projectCodes", () => {
       status: "mapped",
       ycCode: "YC-1",
       system: "SNOMED",
-      code: "422400008",
-      display: "Vomiting",
+      coding: {
+        system: "http://snomed.info/sct",
+        code: "422400008",
+        display: "Vomiting",
+      },
       equivalence: "NARROWER",
     });
   });
@@ -100,7 +103,7 @@ describe("projectCodes", () => {
 
     expect(result).toMatchObject({
       status: "mapped",
-      code: "YC-1",
+      coding: { code: "YC-1" },
       equivalence: "EQUIVALENT",
     });
   });
@@ -198,5 +201,115 @@ describe("vocabularyCoverage", () => {
       await TerminologyProjectionService.vocabularyCoverage("YOSEMITECODE");
 
     expect(coverage).toMatchObject({ percent: 100, species: null });
+  });
+
+  describe("projectCode", () => {
+    it("projects a single code", async () => {
+      entryFind.mockResolvedValue([{ code: "YC-1" }]);
+      mappingFind.mockResolvedValue([
+        {
+          sourceCode: "YC-1",
+          targetCode: "422400008",
+          targetDisplay: "Vomiting",
+          equivalence: "EQUIVALENT",
+        },
+      ]);
+
+      const result = await TerminologyProjectionService.projectCode(
+        "YC-1",
+        "SNOMED",
+      );
+
+      expect(result).toMatchObject({
+        status: "mapped",
+        coding: { code: "422400008" },
+      });
+    });
+
+    it("returns unknown for a blank code rather than querying", async () => {
+      const result = await TerminologyProjectionService.projectCode(
+        "   ",
+        "SNOMED",
+      );
+
+      expect(result).toEqual({
+        status: "unknown",
+        ycCode: "   ",
+        system: "SNOMED",
+      });
+      expect(mappingFind).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("a mapping that outlived its concept", () => {
+    it("reports unknown when the concept is gone but the mapping is still active", async () => {
+      // CodeMapping rows are not cascaded when an entry is retired, so a live mapping can
+      // point from a concept we no longer hold. Trusting it would project a retired code
+      // as though it were current.
+      entryFind.mockResolvedValue([]);
+      mappingFind.mockResolvedValue([
+        {
+          sourceCode: "YC-retired",
+          targetCode: "422400008",
+          targetDisplay: "Vomiting",
+          equivalence: "EQUIVALENT",
+        },
+      ]);
+
+      const [result] = await TerminologyProjectionService.projectCodes(
+        ["YC-retired"],
+        "SNOMED",
+      );
+
+      expect(result.status).toBe("unknown");
+    });
+  });
+
+  describe("competing mappings", () => {
+    it("projects the strongest equivalence, not the first code returned", async () => {
+      entryFind.mockResolvedValue([{ code: "YC-1" }]);
+      mappingFind.mockResolvedValue([
+        {
+          sourceCode: "YC-1",
+          targetCode: "111",
+          targetDisplay: "loose",
+          equivalence: "INEXACT",
+        },
+        {
+          sourceCode: "YC-1",
+          targetCode: "222",
+          targetDisplay: "exact",
+          equivalence: "EQUIVALENT",
+        },
+      ]);
+
+      const [result] = await TerminologyProjectionService.projectCodes(
+        ["YC-1"],
+        "SNOMED",
+      );
+
+      expect(result).toMatchObject({
+        coding: { code: "222" },
+        equivalence: "EQUIVALENT",
+      });
+    });
+  });
+
+  describe("coverage honesty", () => {
+    it("excludes UNMATCHED and DISJOINT from the covered count", async () => {
+      // Both mean there is no usable counterpart. Counting them would inflate the very
+      // disclosure meant to warn a practice off a vocabulary that cannot express its work.
+      queryRaw.mockResolvedValue([{ terms: BigInt(10), mapped: BigInt(4) }]);
+
+      await TerminologyProjectionService.vocabularyCoverage("SNOMED");
+
+      // $queryRaw is a tagged template, so the whole call is the statement: the strings
+      // array plus every interpolated fragment and bound value.
+      const call = JSON.stringify(queryRaw.mock.calls[0]);
+      expect(call).toContain("equivalence");
+      expect(call).toContain("EQUIVALENT");
+      expect(call).not.toContain("UNMATCHED");
+      expect(call).not.toContain("DISJOINT");
+    });
   });
 });

--- a/packages/database/prisma/migrations/20260824210000_vocabulary_preference/migration.sql
+++ b/packages/database/prisma/migrations/20260824210000_vocabulary_preference/migration.sql
@@ -1,0 +1,19 @@
+-- Practices differ in which vocabulary they need on the way out: a referral network may
+-- want SNOMED, a UK first-opinion practice VeNom. The choice is per organisation rather
+-- than per user, because two vets in one practice coding differently would reintroduce
+-- exactly the inconsistency the coded spine exists to remove.
+--
+-- The preference governs OUTPUT only. Clinical pickers always offer the whole YC
+-- vocabulary, because the alternative is a vet unable to record what they observed
+-- simply because SNOMED has no term for it. On the current data that is not hypothetical:
+-- SNOMED covers 344 of 4,819 exotics terms and 15 of 228 avian ones.
+--
+-- IDEXX is deliberately not an option. It is the ordering vocabulary for lab
+-- requisitions, not a clinical record format.
+--
+-- Additive only, defaulting to the vocabulary we already emit.
+
+CREATE TYPE "VocabularyPreference" AS ENUM ('YOSEMITECODE', 'VENOM', 'SNOMED');
+
+ALTER TABLE "Organization"
+  ADD COLUMN IF NOT EXISTS "preferredVocabulary" "VocabularyPreference" NOT NULL DEFAULT 'YOSEMITECODE';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -912,6 +912,15 @@ model ParentAddress {
   parent Parent @relation(fields: [parentId], references: [id], onDelete: Cascade)
 }
 
+/// Which vocabulary a practice wants its exports expressed in. Deliberately narrower
+/// than CodeSystem: IDEXX is an ordering vocabulary for lab requisitions, not something a
+/// clinical record should be exported as.
+enum VocabularyPreference {
+  YOSEMITECODE
+  VENOM
+  SNOMED
+}
+
 model Organization {
   id                                     String               @id @default(uuid())
   fhirId                                 String?
@@ -943,6 +952,9 @@ model Organization {
   appointmentLockWindowOutpatientMinutes Int?
   appointmentLockWindowInpatientMinutes  Int?
   crossOrgMessagingEnabled               Boolean              @default(false)
+  /// Governs how coded data is projected on the way out. It never narrows what a
+  /// clinician can pick: input is always the full YC vocabulary.
+  preferredVocabulary                    VocabularyPreference @default(YOSEMITECODE)
   maxOverallDiscountPercent              Float?
   createdAt                              DateTime             @default(now())
   updatedAt                              DateTime             @updatedAt


### PR DESCRIPTION
> Stacked on #2462. This branch imports `MappingEquivalence`, which that PR adds, so it is based on `feat/mapping-equivalence` rather than `dev`. GitHub will retarget it when #2462 merges.

## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

There is no way for a clinic to say which vocabulary its coded data should be expressed in, and no way to act on it. A coded record can only come out as `YC-008990`.

## What is the new behavior?

An organisation-level `preferredVocabulary`, and a projection service that acts on it honestly.

**The preference governs output only.** Coverage is uneven enough that filtering the picker would stop a vet recording what is in front of them:

| species | terms | SNOMED | VeNom |
| --- | ---: | ---: | ---: |
| Small animal | 8,294 | 4,148 (50%) | 4,561 (55%) |
| Equine | 4,378 | 1,252 (28%) | 3,465 (79%) |
| Exotics | 4,819 | 344 (**7%**) | 4,819 (100%) |
| Avian | 228 | 15 (**6%**) | 228 (100%) |

An exotics practice choosing SNOMED would find 93% of the vocabulary unavailable. Clinical pickers therefore keep offering the whole YC vocabulary; the choice shapes what leaves the system, never what can enter it.

**It is per organisation, not per user.** Two vets in one practice coding differently reintroduces exactly the inconsistency the coded spine exists to remove.

**It never falls back.** A term with no counterpart returns an explicit unmapped marker rather than emitting the YC code as though it were SNOMED, or substituting a parent concept. Both produce an export that looks complete and is not. A code we do not hold is reported separately from one that has no counterpart, because the first is a caller bug and the second a real gap.

**Coverage is floored, not rounded.** 15 of 228 avian terms reads as 6%, not 7%, in the very disclosure meant to warn against choosing that vocabulary.

Asking for our own vocabulary still verifies the code exists rather than echoing back what it was handed.

## Impact area

`apps/backend` and one additive migration. Existing organisations default to `YOSEMITECODE`, which is what we already emit, so no behaviour changes on merge.

## Validation performed

- `tsc` clean, eslint clean, **119 tests across 7 suites** (12 new).
- Migration verified on a fresh database inside a transaction, with a pre-existing organisation confirmed to default to `YOSEMITECODE`.
- **Verified against dev**: the coverage query returns 4,378 equine terms with 1,252 reachable in SNOMED, matching the figures above.
- **Mutation checked.** Falling back to the YC code fails 2 tests; rounding coverage instead of flooring fails 2; collapsing `unknown` into `unmapped` fails 1; echoing a code back without checking it exists fails 1.

## Not in this PR

The settings UI, the per-export override, and wiring projection into the export paths. This is the engine and the preference it reads.

## Related Issue(s)

Fixes #2463
