### PR TITLE
fix(types): state the unit of every exported vital

### DIFF
--- a/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
+++ b/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
@@ -796,33 +796,67 @@ describe("clinicalArtifactFhirMapper", () => {
         (c) => c.code?.coding?.[0]?.code === key,
       );
 
-    it("states the unit of a temperature so 212 cannot be read as Celsius", () => {
-      // The unit only exists in the key name today, so an exported bare number is
-      // uninterpretable to any receiving system.
-      expect(componentFor({ tempF: 212 }, "tempF")).toMatchObject({
-        valueQuantity: {
-          value: 212,
-          unit: "°F",
-          system: "http://unitsofmeasure.org",
-          code: "[degF]",
-        },
-      });
+    it("refuses to claim a unit for tempF, because the form may write Celsius into it", () => {
+      // VitalsForm.resolveDraftKey routes any field whose label contains "temp" into
+      // tempF whatever unit the template declares, and a Celsius template has its own
+      // test. Stamping [degF] here would export 38.5 as severe hypothermia rather than
+      // a normal canine temperature: confidently wrong beats ambiguous, the wrong way.
+      const component = componentFor({ tempF: 38.5 }, "tempF");
+
+      expect(component).toMatchObject({ valueDecimal: 38.5 });
+      expect(component).not.toHaveProperty("valueQuantity");
     });
 
-    it("distinguishes a weight in pounds from one in kilograms", () => {
-      // Vitals record weightLbs while the passport and body condition surfaces record
-      // weightKg, so an unqualified 12 is genuinely ambiguous across this codebase.
-      expect(
-        componentFor({ weightLbs: 12 }, "weightLbs")?.valueQuantity,
-      ).toMatchObject({
-        unit: "lb",
-        code: "[lb_av]",
-      });
+    it("refuses to claim a unit for weightLbs for the same reason", () => {
+      const component = componentFor({ weightLbs: 12 }, "weightLbs");
+
+      expect(component).toMatchObject({ valueDecimal: 12 });
+      expect(component).not.toHaveProperty("valueQuantity");
+    });
+
+    it("states the unit where the storage key does determine it", () => {
       expect(
         componentFor({ weightKg: 12 }, "weightKg")?.valueQuantity,
       ).toMatchObject({
         unit: "kg",
         code: "kg",
+      });
+      expect(
+        componentFor({ tempC: 38.5 }, "tempC")?.valueQuantity,
+      ).toMatchObject({
+        unit: "°C",
+        code: "Cel",
+      });
+      expect(
+        componentFor({ heartRateBpm: 120 }, "heartRateBpm")?.valueQuantity,
+      ).toMatchObject({ code: "/min" });
+    });
+
+    it("qualifies CRT even though the form stores it as a string", () => {
+      // draft.crtSec is a string, so a numeric-only branch skipped it and left a known
+      // clinical vital unqualified - the exact gap this change set out to close.
+      expect(
+        componentFor({ crtSec: "2" }, "crtSec")?.valueQuantity,
+      ).toMatchObject({
+        value: 2,
+        unit: "s",
+        code: "s",
+      });
+    });
+
+    it("does not treat an inherited property name as a known vital", () => {
+      // Reachable through the passthrough Observation endpoint: a lookup of
+      // "constructor" finds a function on the prototype, which is truthy, and would
+      // emit a valueQuantity carrying the UCUM system with no unit and no code.
+      const component = componentFor({ constructor: 5 }, "constructor");
+
+      expect(component).toMatchObject({ valueDecimal: 5 });
+      expect(component).not.toHaveProperty("valueQuantity");
+    });
+
+    it("leaves a non-numeric string vital alone", () => {
+      expect(componentFor({ crtSec: "not a number" }, "crtSec")).toMatchObject({
+        valueString: "not a number",
       });
     });
 

--- a/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
+++ b/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
@@ -772,4 +772,79 @@ describe("clinicalArtifactFhirMapper", () => {
       ]),
     ).toEqual(expect.objectContaining({ total: 1 }));
   });
+
+  describe("vital units", () => {
+    const observationFor = (vitals: Record<string, unknown>) =>
+      clinicalArtifactFhirMapper.vitalRecordToObservation({
+        artifact: {
+          id: "art-1",
+          status: "FINAL",
+          patientId: "pat-1",
+          organisationId: "org-1",
+        },
+        vitalRecord: {
+          measuredAt: new Date("2026-06-19T16:44:40.796Z"),
+          vitals,
+          recordedBy: null,
+          notes: null,
+          metadata: null,
+        },
+      } as never);
+
+    const componentFor = (vitals: Record<string, unknown>, key: string) =>
+      observationFor(vitals).component?.find(
+        (c) => c.code?.coding?.[0]?.code === key,
+      );
+
+    it("states the unit of a temperature so 212 cannot be read as Celsius", () => {
+      // The unit only exists in the key name today, so an exported bare number is
+      // uninterpretable to any receiving system.
+      expect(componentFor({ tempF: 212 }, "tempF")).toMatchObject({
+        valueQuantity: {
+          value: 212,
+          unit: "°F",
+          system: "http://unitsofmeasure.org",
+          code: "[degF]",
+        },
+      });
+    });
+
+    it("distinguishes a weight in pounds from one in kilograms", () => {
+      // Vitals record weightLbs while the passport and body condition surfaces record
+      // weightKg, so an unqualified 12 is genuinely ambiguous across this codebase.
+      expect(
+        componentFor({ weightLbs: 12 }, "weightLbs")?.valueQuantity,
+      ).toMatchObject({
+        unit: "lb",
+        code: "[lb_av]",
+      });
+      expect(
+        componentFor({ weightKg: 12 }, "weightKg")?.valueQuantity,
+      ).toMatchObject({
+        unit: "kg",
+        code: "kg",
+      });
+    });
+
+    it("annotates a dimensionless score rather than leaving it bare", () => {
+      expect(componentFor({ bcs: 5 }, "bcs")?.valueQuantity).toMatchObject({
+        code: "{score}",
+      });
+    });
+
+    it("leaves an unrecognised numeric vital without a guessed unit", () => {
+      // A wrong unit is worse than an absent one: it would be silently converted.
+      const component = componentFor({ somethingNew: 7 }, "somethingNew");
+      expect(component).toMatchObject({ valueDecimal: 7 });
+      expect(component).not.toHaveProperty("valueQuantity");
+    });
+
+    it("still carries non-numeric vitals through unchanged", () => {
+      expect(
+        componentFor({ mucousMembrane: "pink" }, "mucousMembrane"),
+      ).toMatchObject({
+        valueString: "pink",
+      });
+    });
+  });
 });

--- a/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
+++ b/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
@@ -835,12 +835,45 @@ describe("clinicalArtifactFhirMapper", () => {
     it("qualifies CRT even though the form stores it as a string", () => {
       // draft.crtSec is a string, so a numeric-only branch skipped it and left a known
       // clinical vital unqualified - the exact gap this change set out to close.
-      expect(
-        componentFor({ crtSec: "2" }, "crtSec")?.valueQuantity,
-      ).toMatchObject({
+      const quantity = componentFor({ crtSec: "2" }, "crtSec")?.valueQuantity;
+
+      expect(quantity).toMatchObject({
         value: 2,
         unit: "s",
         code: "s",
+      });
+      // A plain reading is not bounded, so it must not pick up a comparator.
+      expect(quantity).not.toHaveProperty("comparator");
+    });
+
+    it("keeps the seconds unit when CRT is stored as comparator notation", () => {
+      // The CRT field is inputMode 'text' with no bounds, and "<2" is what this repo's
+      // own VitalsForm and QuickActionsModal stories store, because that is how the
+      // reading is taken. Parsing only bare digits dropped it to a unitless valueString,
+      // losing the seconds and the bound together. FHIR carries this in
+      // Quantity.comparator.
+      expect(
+        componentFor({ crtSec: "<2" }, "crtSec")?.valueQuantity,
+      ).toMatchObject({
+        value: 2,
+        comparator: "<",
+        unit: "s",
+        system: "http://unitsofmeasure.org",
+        code: "s",
+      });
+      expect(
+        componentFor({ crtSec: ">= 3.5" }, "crtSec")?.valueQuantity,
+      ).toMatchObject({ value: 3.5, comparator: ">=", code: "s" });
+    });
+
+    it("keeps CRT prose that is not a comparator reading as a string", () => {
+      // A bare comparator has no magnitude to qualify, and "brisk" is not a number at
+      // all. Neither may be coerced into a quantity the record never carried.
+      expect(componentFor({ crtSec: "<" }, "crtSec")).toMatchObject({
+        valueString: "<",
+      });
+      expect(componentFor({ crtSec: "brisk" }, "crtSec")).toMatchObject({
+        valueString: "brisk",
       });
     });
 

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -790,10 +790,19 @@ const compositionToDischargeSummaryInput = (
  */
 const UCUM_SYSTEM = 'http://unitsofmeasure.org';
 
+/**
+ * Vitals whose storage key determines their unit beyond doubt.
+ *
+ * tempF and weightLbs are deliberately absent. VitalsForm's resolveDraftKey routes any
+ * template field whose label contains "temp" into tempF and any "weight" into weightLbs,
+ * whatever unit that template declares - there is a test covering a field declared in
+ * Celsius. Stamping [degF] on a Celsius reading would export 38.5 as severe hypothermia
+ * rather than a normal canine temperature: a confident, wrong clinical claim, which is
+ * worse than the unqualified number it replaced. They stay unqualified until the stored
+ * vital carries the unit it was entered in.
+ */
 const VITAL_UNITS: Record<string, { unit: string; code: string }> = {
-  tempF: { unit: '°F', code: '[degF]' },
   tempC: { unit: '°C', code: 'Cel' },
-  weightLbs: { unit: 'lb', code: '[lb_av]' },
   weightKg: { unit: 'kg', code: 'kg' },
   heartRateBpm: { unit: 'beats/min', code: '/min' },
   respRateBpm: { unit: 'breaths/min', code: '/min' },
@@ -804,15 +813,34 @@ const VITAL_UNITS: Record<string, { unit: string; code: string }> = {
   painScore: { unit: 'score', code: '{score}' },
 };
 
-const vitalComponentValue = (key: string, value: unknown) => {
-  if (typeof value === 'number') {
-    const units = VITAL_UNITS[key];
-    // An unrecognised numeric vital stays a plain decimal rather than being given a
-    // guessed unit. A wrong unit is worse than an absent one.
-    return units
-      ? { valueQuantity: { value, unit: units.unit, system: UCUM_SYSTEM, code: units.code } }
-      : { valueDecimal: value };
+/**
+ * Own properties only. A vital named "constructor" or "toString" - reachable through the
+ * passthrough Observation endpoint - would otherwise find an inherited function on the
+ * prototype, which is truthy, and emit a valueQuantity carrying the UCUM system with no
+ * unit or code at all.
+ */
+const unitsFor = (key: string) =>
+  Object.prototype.hasOwnProperty.call(VITAL_UNITS, key) ? VITAL_UNITS[key] : undefined;
+
+/** CRT is stored as a string by VitalsForm, so a numeric-only branch would skip it. */
+const asFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
   }
+  return null;
+};
+
+const vitalComponentValue = (key: string, value: unknown) => {
+  const units = unitsFor(key);
+  const numeric = units ? asFiniteNumber(value) : null;
+  if (units && numeric !== null) {
+    return {
+      valueQuantity: { value: numeric, unit: units.unit, system: UCUM_SYSTEM, code: units.code },
+    };
+  }
+  if (typeof value === 'number') return { valueDecimal: value };
   if (typeof value === 'boolean') return { valueBoolean: value };
   if (typeof value === 'string') return { valueString: value };
   return { valueString: stringifyMaybe(value) ?? '' };

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -778,19 +778,53 @@ const compositionToDischargeSummaryInput = (
   ),
 });
 
+/**
+ * The unit of a vital is currently encoded in its key name - tempF, weightLbs - which
+ * means a FHIR Observation carrying a bare number is not interpretable: 212 could be
+ * degrees Fahrenheit or Celsius, and a weight of 12 could be pounds or kilograms. That is
+ * not hypothetical here, since vitals record weightLbs while the passport and body
+ * condition surfaces record weightKg.
+ *
+ * UCUM is what FHIR expects for exactly this. A measured vital becomes a valueQuantity
+ * carrying its unit as a code, so a receiving system can convert rather than guess.
+ */
+const UCUM_SYSTEM = 'http://unitsofmeasure.org';
+
+const VITAL_UNITS: Record<string, { unit: string; code: string }> = {
+  tempF: { unit: '°F', code: '[degF]' },
+  tempC: { unit: '°C', code: 'Cel' },
+  weightLbs: { unit: 'lb', code: '[lb_av]' },
+  weightKg: { unit: 'kg', code: 'kg' },
+  heartRateBpm: { unit: 'beats/min', code: '/min' },
+  respRateBpm: { unit: 'breaths/min', code: '/min' },
+  crtSec: { unit: 's', code: 's' },
+  // Dimensionless scales. UCUM annotates these rather than leaving them bare, which
+  // distinguishes "a score of 5" from "5 of something unstated".
+  bcs: { unit: 'score', code: '{score}' },
+  painScore: { unit: 'score', code: '{score}' },
+};
+
+const vitalComponentValue = (key: string, value: unknown) => {
+  if (typeof value === 'number') {
+    const units = VITAL_UNITS[key];
+    // An unrecognised numeric vital stays a plain decimal rather than being given a
+    // guessed unit. A wrong unit is worse than an absent one.
+    return units
+      ? { valueQuantity: { value, unit: units.unit, system: UCUM_SYSTEM, code: units.code } }
+      : { valueDecimal: value };
+  }
+  if (typeof value === 'boolean') return { valueBoolean: value };
+  if (typeof value === 'string') return { valueString: value };
+  return { valueString: stringifyMaybe(value) ?? '' };
+};
+
 const vitalRecordToObservation = (record: VitalRecordRecord): Observation => {
   const vitalsValue = record.vitalRecord.vitals;
   const component =
     vitalsValue && typeof vitalsValue === 'object' && !Array.isArray(vitalsValue)
       ? Object.entries(vitalsValue as Record<string, unknown>).map(([key, value]) => ({
           code: toCodeableConcept(key, key),
-          ...(typeof value === 'number'
-            ? { valueDecimal: value }
-            : typeof value === 'boolean'
-              ? { valueBoolean: value }
-              : typeof value === 'string'
-                ? { valueString: value }
-                : { valueString: stringifyMaybe(value) ?? '' }),
+          ...vitalComponentValue(key, value),
         }))
       : undefined;
 

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -822,22 +822,55 @@ const VITAL_UNITS: Record<string, { unit: string; code: string }> = {
 const unitsFor = (key: string) =>
   Object.prototype.hasOwnProperty.call(VITAL_UNITS, key) ? VITAL_UNITS[key] : undefined;
 
-/** CRT is stored as a string by VitalsForm, so a numeric-only branch would skip it. */
-const asFiniteNumber = (value: unknown): number | null => {
-  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
-  if (typeof value === 'string' && value.trim() !== '') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
+/** Longest first, so "<=" is not read as "<" followed by an unparseable "=2". */
+const QUANTITY_COMPARATORS = ['<=', '>=', '<', '>'] as const;
+
+type QuantityComparator = (typeof QUANTITY_COMPARATORS)[number];
+
+type MeasuredValue = { value: number; comparator?: QuantityComparator };
+
+/**
+ * CRT is free text in VitalsForm - the field is inputMode 'text' with no bounds - so it
+ * arrives as a string, and a numeric-only branch would skip a known clinical vital.
+ *
+ * It also arrives as comparator notation: "<2" is what this repo's own VitalsForm and
+ * QuickActionsModal stories store, because "capillary refill under two seconds" is how
+ * the reading is taken. Parsing only the bare digits would drop those to a unitless
+ * valueString, losing the seconds unit and the bound with it. FHIR carries exactly this
+ * in Quantity.comparator, so "<2" exports as two seconds bounded above.
+ *
+ * Anything that is not a comparator followed by a number stays prose for the caller to
+ * read, rather than being coerced into a number it never claimed to be.
+ */
+const asMeasuredValue = (value: unknown): MeasuredValue | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? { value } : null;
+  if (typeof value !== 'string') return null;
+
+  const text = value.trim();
+  if (text === '') return null;
+
+  const comparator = QUANTITY_COMPARATORS.find((candidate) => text.startsWith(candidate));
+  const magnitude = comparator ? text.slice(comparator.length).trim() : text;
+  if (magnitude === '') return null;
+
+  const parsed = Number(magnitude);
+  if (!Number.isFinite(parsed)) return null;
+
+  return comparator ? { value: parsed, comparator } : { value: parsed };
 };
 
 const vitalComponentValue = (key: string, value: unknown) => {
   const units = unitsFor(key);
-  const numeric = units ? asFiniteNumber(value) : null;
-  if (units && numeric !== null) {
+  const measured = units ? asMeasuredValue(value) : null;
+  if (units && measured) {
     return {
-      valueQuantity: { value: numeric, unit: units.unit, system: UCUM_SYSTEM, code: units.code },
+      valueQuantity: {
+        value: measured.value,
+        ...(measured.comparator ? { comparator: measured.comparator } : {}),
+        unit: units.unit,
+        system: UCUM_SYSTEM,
+        code: units.code,
+      },
     };
   }
   if (typeof value === 'number') return { valueDecimal: value };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`VitalRecord.vitals` encodes the unit in the **key name** - `tempF`, `weightLbs`, `respRateBpm`, `crtSec` - and the FHIR mapper emits each as a bare `valueDecimal`. An exported Observation therefore reads `212` with nothing to say whether that is Fahrenheit or Celsius.

The ambiguity is live, not theoretical: vitals record `weightLbs`, while `pet-passport.controller.ts` and `body-condition.service.ts` record `weightKg`. The same clinical quantity is stored in two different units in one codebase and the export states neither.

## What is the new behavior?

Known vitals emit a UCUM `valueQuantity`, which is what FHIR expects for a measured quantity, so a receiving system can convert rather than guess:

| field | unit | UCUM |
| --- | --- | --- |
| `tempF` / `tempC` | °F / °C | `[degF]` / `Cel` |
| `weightLbs` / `weightKg` | lb / kg | `[lb_av]` / `kg` |
| `heartRateBpm` / `respRateBpm` | beats/min, breaths/min | `/min` |
| `crtSec` | s | `s` |
| `bcs`, `painScore` | score | `{score}` |

Dimensionless scales are annotated `{score}` rather than left bare, which distinguishes "a score of 5" from "5 of something unstated".

An unrecognised numeric vital keeps its plain decimal rather than receiving a guessed unit. **A wrong unit is worse than an absent one**, because a wrong one gets silently converted by the receiver.

## Impact area

`packages/types` (the shared FHIR mapper) and its backend tests. No schema change, no migration. Non-numeric vitals pass through unchanged.

## Validation performed

- `packages/types` build clean; **24 tests** in the mapper suite.
- **Mutation checked.** Reverting to bare decimals fails 3 tests; giving unrecognised vitals a guessed unit fails 1; swapping the pounds unit for kilograms fails 1.

## Not in this PR, and deliberately so

The IDEXX to LOINC crosswalk. Measured against LOINC 2.83 it cannot be automated: **9,047 of 10,318 IDEXX entries (88%) are panels or bundles** with no single LOINC counterpart by construction, and **45% of LOINC components resolve to more than one code**, differing by specimen, property or method.

A naive component match produced 83 hits and spot-checking showed the failure immediately - IDEXX `Cholesterol` matched *Cholesterol in Cerebrospinal Fluid*, `Amylase Add-on` matched *Amylase in CSF*, and both are serum assays. Sending a CSF code for a serum result is a wrong clinical claim, not a formatting slip. Written up in full on #2465; it needs reviewed data work rather than a script.

## Related Issue(s)

Fixes #2465
