### PR TITLE
fix(frontend): say where the IDEXX order button actually goes

### DIFF
--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -1567,11 +1567,20 @@ const IdexxHubHeader = ({ subtitleSuffix }: { subtitleSuffix: React.ReactNode })
       </p>
     </div>
     <div className="flex flex-wrap items-center justify-end gap-2">
+      {/*
+        Lab orders are appointment-scoped: createIdexxLabOrder requires an
+        appointmentId, and the only ordering UI is the LabTests panel inside an
+        appointment. There is no way to start an order from this page, and the
+        appointments deep link needs an appointment id we do not have. So this button
+        sends the user to choose an appointment - and now says so. It previously read
+        "Create a new order" and landed them on a full calendar with nothing to say
+        they were mid-task.
+      */}
       <Primary
         href="/appointments"
-        text="New order"
+        text="Order from an appointment"
         icon={<IoAdd aria-hidden="true" />}
-        ariaLabel="Create a new order"
+        ariaLabel="Choose an appointment to order lab tests from"
       />
     </div>
   </div>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

On the IDEXX diagnostics page, the primary action reads **"New order"** with an add icon and the aria label "Create a new order". It is a bare `href="/appointments"`: no modal, no preselected patient, no carried state. Clicking it drops the user on the full appointments calendar with nothing to indicate they were mid-way through starting a lab order.

## Is the flow broken, or intended?

**Intended - the label is what is wrong.** Verified end to end:

- `createIdexxLabOrder` requires an `appointmentId` in its payload.
- The only ordering UI is the `LabTests` panel inside an appointment's detail view (`AppointmentInfo/LabTests.tsx`), which supplies `appointmentId` and `patientId` from its context.
- The appointments deep-link mechanism (`appointmentId` / `open` / `subLabel` params) returns `null` without an `appointmentId`, so it cannot bridge from a page that does not have one.

So sending the user to pick an appointment is the correct destination. The control just promised an action it does not perform.

## What is the new behavior?

The button reads **"Order from an appointment"**, the aria label matches, and a comment records *why* it cannot open an ordering modal from this page - so the next person does not re-investigate, or "fix" it back into dishonesty.

A genuine order-from-anywhere flow would need an appointment picker scoped to the task. That is a feature with its own design questions, not a label fix, and this PR deliberately does not attempt it.

## Validation performed

- 61 tests in the IdexxWorkspace suite pass; no test or code elsewhere references the old label.
- `tsc` clean, eslint clean.

## Related Issue(s)

Found during workflow QA for #2454; unrelated to that change.
