### PR TITLE
fix(frontend): read reduced motion through useSyncExternalStore

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -30,6 +30,45 @@ const setReducedMotion = (matches: boolean) => {
     }));
 };
 
+/**
+ * matchMedia stub that retains its listeners, so a preference change can be
+ * delivered the way the OS delivers one. The plain setReducedMotion above swaps
+ * the value but never notifies, which is enough for a snapshot read and not for
+ * the subscription.
+ */
+const liveReducedMotion = (initial: boolean) => {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  let matches = initial;
+  (globalThis as unknown as { matchMedia: unknown }).matchMedia = jest
+    .fn()
+    .mockImplementation((query: string) => ({
+      get matches() {
+        return matches;
+      },
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      // Only 'change' registrations are honoured, because that is the only event
+      // a real MediaQueryList dispatches. A stub that accepted any name would keep
+      // these tests green if the subscription's event name ever regressed.
+      addEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (type === 'change') listeners.add(cb);
+      },
+      removeEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (type === 'change') listeners.delete(cb);
+      },
+      dispatchEvent: jest.fn(),
+    }));
+  return {
+    set(next: boolean) {
+      matches = next;
+      for (const cb of listeners) cb({ matches: next } as MediaQueryListEvent);
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
 class FiringIO {
   private readonly cb: IntersectionObserverCallback;
   constructor(cb: IntersectionObserverCallback) {
@@ -138,6 +177,90 @@ describe('motion primitives', () => {
     setReducedMotion(true);
     const { result } = renderHook(() => useReducedMotion());
     expect(result.current).toBe(true);
+  });
+
+  it('useReducedMotion server-renders false so the hydrating render matches', () => {
+    // A server cannot read the preference, so the snapshot React reuses while
+    // hydrating has to be the same on both sides regardless of what the OS says.
+    setReducedMotion(true);
+    const Probe = () => <span>{String(useReducedMotion())}</span>;
+    expect(renderToString(<Probe />)).toContain('false');
+  });
+
+  it('useReducedMotion follows a preference change without a re-render loop', () => {
+    const media = liveReducedMotion(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+    act(() => media.set(true));
+    expect(result.current).toBe(true);
+    act(() => media.set(false));
+    expect(result.current).toBe(false);
+  });
+
+  it('useReducedMotion drops its listener on unmount', () => {
+    const media = liveReducedMotion(true);
+    const { unmount } = renderHook(() => useReducedMotion());
+    expect(media.listenerCount()).toBeGreaterThan(0);
+    unmount();
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('useReducedMotion reports false when matchMedia is unavailable', () => {
+    const original = (globalThis as unknown as { matchMedia: unknown }).matchMedia;
+    (globalThis as unknown as { matchMedia: unknown }).matchMedia = undefined;
+    try {
+      const { result } = renderHook(() => useReducedMotion());
+      expect(result.current).toBe(false);
+    } finally {
+      (globalThis as unknown as { matchMedia: unknown }).matchMedia = original;
+    }
+  });
+
+  it('HeroVideo hydrates without a mismatch when the reader prefers reduced motion', () => {
+    // HeroVideo returns null under reduced motion, so the preference decides the
+    // markup rather than only an effect. The server has to emit the video and the
+    // hydrating render has to agree, or React reports a mismatch it will not patch.
+    setReducedMotion(true);
+    const html = renderToString(<HeroVideo src="https://x/v.mp4" />);
+    expect(html).toContain('<video');
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    // A spec-compliant parser sets the muted IDL property from the content
+    // attribute at element creation; jsdom leaves it false (it only sets
+    // defaultMuted), and React hydration compares the property. Verified: React
+    // 19's renderToString emits muted="", so in a browser this is not a
+    // mismatch. Make jsdom faithful rather than loosening the assertions.
+    container.querySelectorAll('video').forEach((v) => {
+      v.muted = v.hasAttribute('muted');
+    });
+    document.body.appendChild(container);
+
+    const recoverable: unknown[] = [];
+    const errors: unknown[] = [];
+    const spy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args);
+    });
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    try {
+      act(() => {
+        root = hydrateRoot(container, <HeroVideo src="https://x/v.mp4" />, {
+          onRecoverableError: (error) => recoverable.push(error),
+        });
+      });
+    } finally {
+      spy.mockRestore();
+      act(() => root?.unmount());
+      container.remove();
+    }
+
+    expect(errors).toEqual([]);
+    expect(recoverable).toEqual([]);
+    // The settle is the second half of the contract: hydration reuses the server
+    // snapshot (video present), then the client snapshot reads the preference and
+    // unmounts it. Without this the handoff to "the component removes it" that
+    // the marketing.css comment relies on would be unpinned.
+    expect(container.querySelector('video')).toBeNull();
   });
 
   it('Reveal arms off-screen, then plays when it scrolls into view', () => {

--- a/apps/frontend/src/app/features/marketing/site/marketing.css
+++ b/apps/frontend/src/app/features/marketing/site/marketing.css
@@ -240,6 +240,27 @@
   }
 }
 
+/* ---- Hero video (HeroVideo in site/motion.tsx) ---- */
+/* The loop is decorative, and HeroVideo drops it from the tree once the client
+   reads the preference. That is necessarily a post-hydration decision: a server
+   cannot know prefers-reduced-motion, so the markup ships either way and a reader
+   who asked for less motion would otherwise watch it paint before it disappears.
+   Hiding it here means it never paints for them; the component still removes it,
+   which is what stops the playback (display alone does not), and the media
+   attribute on the <source> is what stops the download when scripting never runs.
+
+   The scrim selector is scoped to the one HeroVideo renders beside its video.
+   The attribute is not exclusive: PetParents places its own standalone
+   [data-hero-scrim] as a page-level readability wash over unconditional glow
+   layers, and that one must keep painting for reduced-motion readers - it is the
+   contrast surface the headline sits on, in both themes. */
+@media (prefers-reduced-motion: reduce) {
+  [data-hero-video],
+  [data-hero-video] + [data-hero-scrim] {
+    display: none;
+  }
+}
+
 /* ---- Buttons ---- */
 .yc-btn-primary {
   position: relative;

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -52,20 +52,36 @@ const SCROLL_PROGRESS_STYLE: CSSProperties = {
   pointerEvents: 'none',
 };
 
-/** True when the user asked the OS to reduce motion. Recomputed on preference change. */
+const REDUCED_MOTION = '(prefers-reduced-motion: reduce)';
+
+/** Subscribe a reduced-motion read to the media query (for useSyncExternalStore). */
+const subscribeToReducedMotion = (onStoreChange: () => void): (() => void) => {
+  const mq = globalThis.window?.matchMedia?.(REDUCED_MOTION);
+  if (!mq) return () => undefined;
+  mq.addEventListener('change', onStoreChange);
+  return () => mq.removeEventListener('change', onStoreChange);
+};
+
+/**
+ * True when the user asked the OS to reduce motion. Recomputed on preference change.
+ *
+ * Read through useSyncExternalStore rather than mirrored into state by an effect:
+ * the preference is external, and syncing it with setState made every consumer
+ * render once before the value arrived.
+ *
+ * The server snapshot is `false` because a server cannot know the preference, and
+ * React reuses that snapshot for the hydrating render, so the first paint always
+ * says "motion is fine" and settles immediately after. That is a property of SSR,
+ * not of this hook, so anything that must honour the preference from the very
+ * first frame belongs in a `prefers-reduced-motion` media query instead - which is
+ * what marketing.css does for the scroll reveals and the hero loop.
+ */
 export function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-
-  useEffect(() => {
-    if (!globalThis.window?.matchMedia) return undefined;
-    const mq = globalThis.window.matchMedia('(prefers-reduced-motion: reduce)');
-    const sync = () => setReduced(mq.matches);
-    sync();
-    mq.addEventListener('change', sync);
-    return () => mq.removeEventListener('change', sync);
-  }, []);
-
-  return reduced;
+  return useSyncExternalStore(
+    subscribeToReducedMotion,
+    () => globalThis.window?.matchMedia?.(REDUCED_MOTION).matches ?? false,
+    () => false
+  );
 }
 
 interface RevealProps extends React.HTMLAttributes<HTMLElement> {
@@ -314,7 +330,12 @@ export function HeroVideo({ src, poster, position = 'center 42%' }: Readonly<Her
         onError={() => setFailed(true)}
         style={{ ...HERO_VIDEO_STYLE, objectPosition: position }}
       >
-        <source src={src} type="video/mp4" />
+        {/* The media gate stops the FETCH for reduced-motion readers even when
+            hydration never runs (scripting off, a blocked bundle): a source whose
+            media query does not match is never selected. Browsers without media
+            support on video sources ignore it and fall back to the CSS guard
+            plus the unmount above. */}
+        <source src={src} type="video/mp4" media="(prefers-reduced-motion: no-preference)" />
       </video>
       <div data-hero-scrim="" style={HERO_SCRIM_STYLE} />
     </div>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`useReducedMotion` mirrors an external preference into state with an effect: `useState(false)` plus a `useEffect` that reads `matchMedia` and calls `setState`. The server render and the first client render both claim "motion is fine", every one of the eight consumers renders once more before the real value arrives, and react-doctor flags the pattern as `no-initialize-state`. The worst consequence is `HeroVideo`: for a reduced-motion reader the looping hero video paints and starts fetching before the effect settles and unmounts it, and when hydration never runs (blocked bundle, scripting off) the multi-megabyte loop fetches and plays invisibly for the whole session.

## What is the new behavior?

**The hook reads through `useSyncExternalStore`**, subscribed to the `matchMedia('(prefers-reduced-motion: reduce)')` change event - the same shape as `useScrolled` in this file. The hydrating render reuses the server snapshot so it can never mismatch, and the client snapshot is read synchronously from the first post-hydration render for all eight consumers. A preference flipped mid-session propagates through the change event.

**Where the first frame matters, CSS does the job instead of the hook** (SSR cannot know the preference, so any JS hook is inherently one paint late):

- a `prefers-reduced-motion` media query hides HeroVideo's video and its own scrim from first paint
- the `<source>` carries `media="(prefers-reduced-motion: no-preference)"`, so the video fetch never starts for reduced-motion readers even when hydration never runs; browsers without media support on video sources ignore it and fall back to the CSS guard plus the unmount
- the component unmount remains what stops playback - verified empirically that `display: none` alone does not pause a playing video

**The scrim selector is scoped**: `[data-hero-video] + [data-hero-scrim]` targets only the scrim HeroVideo renders beside its video. The attribute is not exclusive - PetParents places its own standalone `data-hero-scrim` as the page-level readability wash over unconditional glow layers, and an unscoped selector (an earlier revision of this change) hid it permanently for reduced-motion readers in both themes. Found by adversarial review before commit; verified fixed on the running page.

## Impact area

`apps/frontend` marketing surface: the motion primitives file, one CSS block, tests. No caller changed; no markup changed outside HeroVideo's `<source>`.

## Validation performed

- 47 tests across the two motion suites pass, including five new ones: the server snapshot stays `false` even when the OS says reduce; a live preference change propagates both directions; the listener is dropped on unmount; the no-`matchMedia` fallback; and HeroVideo hydrates silently under reduced motion and then settles to unmounted.
- The matchMedia stub honours only `'change'` registrations - the only event a real MediaQueryList dispatches - so an event-name regression in the subscription fails the tests rather than staying green.
- The HeroVideo hydration test syncs jsdom's `muted` property from the content attribute the way a spec-compliant parser does. Verified React 19's `renderToString` emits `muted=""`, so the mismatch jsdom reports without that sync does not exist in a browser; the sync makes the test browser-faithful rather than loosening its assertions.
- `pnpm --filter frontend run type-check` exit 0; lint 0 errors; prettier clean.
- Coverage on `motion.tsx` above the dev baseline on every metric: statements 98.99 to 99.01 percent, branches 89.93 to 90.85 percent, functions held at 100 percent.
- react-doctor: the `no-initialize-state` finding on `reduced` is gone (file diagnostics 5 to 4; the remainder pre-date this change and belong to other components).
- On the running dev server: no hydration errors on the home page; forcing the media condition hides HeroVideo's video and scrim and leaves PetParents' standalone wash painting, and restoring it brings the video back; the served HTML carries the media-gated `<source>` on both pages.
- Adversarial review: a 10-agent panel (four lenses, each finding independently refuted) confirmed four findings - the PetParents scrim regression, the fetch gap when hydration never runs, and two test-hardening gaps - all fixed in this revision; two further claims were refuted with reasoning.

## Related Issue(s)

Fixes #2475
