### PR TITLE
fix(backend,database): bind a booking invoice to its Stripe payment intent

### DIFF
--- a/apps/backend/src/controllers/web/stripe.controller.ts
+++ b/apps/backend/src/controllers/web/stripe.controller.ts
@@ -10,6 +10,53 @@ import logger from "src/utils/logger";
 import { OrgRequest } from "src/middlewares/rbac";
 import { AuthenticatedRequest } from "src/middlewares/auth";
 
+/**
+ * Verify, then handle - as two separate failures.
+ *
+ * Both steps used to share one try/catch that answered 400, which made a forged
+ * signature and a database outage indistinguishable in the logs and on the
+ * Stripe dashboard. They are different faults: a signature that does not verify
+ * is the caller's, and no retry will ever fix it, while a handler that throws is
+ * ours and the retry is the thing that saves the event.
+ *
+ * Stripe retries on any non-2xx, so this does not change delivery behaviour. It
+ * changes what the failure says, which is what makes the difference visible when
+ * one of these endpoints starts failing.
+ */
+const dispatchStripeWebhook = async (
+  req: Request<unknown, unknown, Buffer>,
+  res: Response,
+  handler: {
+    label: string;
+    verify: (
+      body: Buffer,
+      signature: string | string[] | undefined,
+    ) => ReturnType<typeof StripeService.verifyWebhook>;
+  },
+) => {
+  const signature = req.headers["stripe-signature"];
+
+  let event: ReturnType<typeof StripeService.verifyWebhook>;
+  try {
+    event = handler.verify(req.body, signature);
+  } catch (err) {
+    logger.error(`${handler.label} signature rejected:`, err);
+    return res.status(400).json({
+      error: err instanceof Error ? err.message : "Unknown error",
+    });
+  }
+
+  try {
+    await StripeService.handleWebhookEvent(event);
+    return res.status(200).send("OK");
+  } catch (err) {
+    logger.error(`${handler.label} handler failed:`, err);
+    return res.status(500).json({
+      error: err instanceof Error ? err.message : "Unknown error",
+    });
+  }
+};
+
 // PMS routes are bound to the organisation the RBAC middleware authorized;
 // mobile routes fall back to the pet parent linked to the session.
 const resolveInvoiceScope = async (req: Request) => {
@@ -150,34 +197,20 @@ export const StripeController = {
     }
   },
 
-  webhook: async (req: Request<unknown, unknown, Buffer>, res: Response) => {
-    const sig = req.headers["stripe-signature"];
-    try {
-      const event = StripeService.verifyWebhook(req.body, sig);
-      await StripeService.handleWebhookEvent(event);
-      return res.status(200).send("OK");
-    } catch (err) {
-      logger.error("Stripe Webhook Error:", err);
-      const message = err instanceof Error ? err.message : "Unknown error";
-      return res.status(400).json({ error: message });
-    }
-  },
+  webhook: async (req: Request<unknown, unknown, Buffer>, res: Response) =>
+    dispatchStripeWebhook(req, res, {
+      label: "Stripe Webhook",
+      verify: (body, sig) => StripeService.verifyWebhook(body, sig),
+    }),
 
   connectWebhook: async (
     req: Request<unknown, unknown, Buffer>,
     res: Response,
-  ) => {
-    const sig = req.headers["stripe-signature"];
-    try {
-      const event = StripeService.verifyConnectWebhook(req.body, sig);
-      await StripeService.handleWebhookEvent(event);
-      return res.status(200).send("OK");
-    } catch (err) {
-      logger.error("Stripe Connect Webhook Error:", err);
-      const message = err instanceof Error ? err.message : "Unknown error";
-      return res.status(400).json({ error: message });
-    }
-  },
+  ) =>
+    dispatchStripeWebhook(req, res, {
+      label: "Stripe Connect Webhook",
+      verify: (body, sig) => StripeService.verifyConnectWebhook(body, sig),
+    }),
 
   createPaymentIntent: async (req: Request, res: Response) => {
     try {

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -83,31 +83,140 @@ const isUniqueConstraintViolation = (error: unknown): boolean =>
   "code" in error &&
   (error as { code?: string }).code === "P2002";
 
-// Same guarded read the invoice-payment handler already uses, rather than the
-// blind `as string` cast this path used to carry: latest_charge is typed
-// string | Charge | null, and passing a non-string to charges.retrieve throws
-// inside the handler, which Stripe then retries forever.
+// latest_charge is typed string | Charge | null. It is an id when the intent was
+// not expanded and the Charge itself when it was, so the blind `as string` cast
+// this path used to carry would have handed an object to charges.retrieve. An
+// already-expanded charge needs no round trip; only an id does.
 const retrieveBookingCharge = async (
   pi: Stripe.PaymentIntent,
   connectedAccountId?: string,
 ): Promise<Stripe.Charge | null> => {
-  const chargeId =
-    typeof pi.latest_charge === "string" ? pi.latest_charge : null;
-  if (!chargeId) return null;
+  if (typeof pi.latest_charge !== "string") {
+    return pi.latest_charge ?? null;
+  }
 
-  return getStripeClient().charges.retrieve(chargeId, {
+  return getStripeClient().charges.retrieve(pi.latest_charge, {
     ...(connectedAccountId ? { stripeAccount: connectedAccountId } : {}),
   });
+};
+
+/** The invoice already bound to this intent, if this delivery is a replay. */
+const findInvoiceBoundToIntent = (intentId: string) =>
+  prisma.invoice.findUnique({
+    where: { providerPaymentIntentId: intentId },
+    select: { id: true },
+  });
+
+/**
+ * Claim an appointment's open invoice by stamping the intent on it.
+ *
+ * Stamping is the point, not settling. Without it a later redelivery finds
+ * nothing bound and nothing open, and mints a second invoice - the failure that
+ * looks safe because the happy path is unchanged.
+ */
+const claimOpenBookingInvoice = async (
+  appointmentId: string,
+  intentId: string,
+): Promise<string | null> => {
+  const claimed = await prisma.invoice.updateMany({
+    where: {
+      appointmentId,
+      status: { in: ["AWAITING_PAYMENT", "PENDING"] },
+      providerPaymentIntentId: null,
+    },
+    data: { providerPaymentIntentId: intentId },
+  });
+  if (claimed.count === 0) return null;
+
+  const invoice = await findInvoiceBoundToIntent(intentId);
+  return invoice?.id ?? null;
+};
+
+/**
+ * Mint the booking invoice, or absorb the unique violation that says we should
+ * not have. Returns null when there is nothing left to settle.
+ */
+const mintBookingInvoice = async (params: {
+  appointmentId: string;
+  organisationId: string | null;
+  parentId?: string | null;
+  patientId?: string | null;
+  service: { name: string; description: string | null; cost: number };
+  pi: Stripe.PaymentIntent;
+}): Promise<string | null> => {
+  const { appointmentId, organisationId, parentId, patientId, service, pi } =
+    params;
+
+  try {
+    const created = await prisma.invoice.create({
+      data: {
+        appointmentId,
+        organisationId,
+        parentId: parentId ?? undefined,
+        patientId: patientId ?? undefined,
+        currency: pi.currency ?? "usd",
+        status: "PAID",
+        providerPaymentIntentId: pi.id,
+        items: [
+          {
+            name: service.name,
+            description: service.description ?? undefined,
+            quantity: 1,
+            unitPrice: service.cost,
+            total: service.cost,
+          },
+        ],
+        subtotal: service.cost,
+        discountTotal: 0,
+        taxTotal: 0,
+        totalAmount: service.cost,
+      },
+      select: { id: true },
+    });
+    return created.id;
+  } catch (error) {
+    if (!isUniqueConstraintViolation(error)) throw error;
+
+    // Two shapes reach here and they need different answers.
+    //
+    // A racer that lost on providerPaymentIntentId: the winner committed before
+    // Postgres raised, so this read cannot miss it. The winner settles.
+    const winner = await findInvoiceBoundToIntent(pi.id);
+    if (winner) {
+      logger.info(
+        `Appointment ${appointmentId} booking lost the race for ${pi.id}; invoice ${winner.id} won`,
+      );
+      return null;
+    }
+
+    // Or a collision on the appointment key, which still exists: a SECOND
+    // legitimate intent for an appointment that already has an invoice. Log it
+    // and stop, because throwing answers non-2xx and buys an endless Stripe
+    // retry of an event that cannot succeed while that index stands.
+    logger.error(
+      `Appointment ${appointmentId} already carries an invoice, so intent ${pi.id} could not be recorded. Payment captured with no invoice of its own.`,
+      error,
+    );
+    return null;
+  }
 };
 
 const settleAppointmentBookingInvoice = async (params: {
   invoiceId: string;
   appointmentId: string;
   pi: Stripe.PaymentIntent;
-  charge: Stripe.Charge;
   connectedAccountId?: string;
+  origin: string;
 }) => {
-  const { invoiceId, appointmentId, pi, charge, connectedAccountId } = params;
+  const { invoiceId, appointmentId, pi, connectedAccountId, origin } = params;
+
+  const charge = await retrieveBookingCharge(pi, connectedAccountId);
+  if (!charge) {
+    logger.error(
+      `Appointment ${appointmentId} booking intent ${pi.id} carries no charge; invoice ${invoiceId} ${origin} but not settled.`,
+    );
+    return;
+  }
 
   await FinancePaymentService.handleInvoicePaymentIntentSucceeded({
     invoiceId,
@@ -133,6 +242,10 @@ const settleAppointmentBookingInvoice = async (params: {
       expiresAt: null,
     },
   });
+
+  logger.info(
+    `Appointment ${appointmentId} booking PAID. Invoice ${invoiceId} ${origin}`,
+  );
 };
 
 export const StripeService = {
@@ -706,9 +819,9 @@ export const StripeService = {
     pi: Stripe.PaymentIntent,
     connectedAccountId?: string,
   ) {
-    // (your existing code unchanged)
     const appointmentId = pi.metadata?.appointmentId;
     if (!appointmentId) return;
+
     const appointment = await prisma.appointment.findUnique({
       where: { id: appointmentId },
       select: {
@@ -723,59 +836,28 @@ export const StripeService = {
     // Replay check, and the reason this handler is safe at all. Stripe redelivers
     // on any non-2xx and nothing upstream deduplicates by event id, so the same
     // intent can arrive here more than once, including concurrently. An invoice
-    // already bound to THIS intent means the work was done; settling again is a
-    // no-op inside the payment service, but minting again would not be.
-    const boundInvoice = await prisma.invoice.findUnique({
-      where: { providerPaymentIntentId: pi.id },
-      select: { id: true },
-    });
-    if (boundInvoice) {
+    // already bound to THIS intent means the work was done.
+    const bound = await findInvoiceBoundToIntent(pi.id);
+    if (bound) {
       logger.info(
-        `Appointment ${appointmentId} booking replay for ${pi.id}; invoice ${boundInvoice.id} already bound`,
+        `Appointment ${appointmentId} booking replay for ${pi.id}; invoice ${bound.id} already bound`,
       );
       return;
     }
 
-    // Claim an open invoice by stamping the intent on it, rather than just
-    // settling it. Without the stamp a later redelivery finds nothing bound and
-    // nothing open, and mints a second invoice - the failure that looks safe
-    // because the happy path is unchanged.
-    const claimed = await prisma.invoice.updateMany({
-      where: {
+    const claimedInvoiceId = await claimOpenBookingInvoice(
+      appointmentId,
+      pi.id,
+    );
+    if (claimedInvoiceId) {
+      await settleAppointmentBookingInvoice({
+        invoiceId: claimedInvoiceId,
         appointmentId,
-        status: { in: ["AWAITING_PAYMENT", "PENDING"] },
-        providerPaymentIntentId: null,
-      },
-      data: { providerPaymentIntentId: pi.id },
-    });
-
-    if (claimed.count > 0) {
-      const openInvoice = await prisma.invoice.findUnique({
-        where: { providerPaymentIntentId: pi.id },
-        select: { id: true },
+        pi,
+        connectedAccountId,
+        origin: "claimed",
       });
-      if (openInvoice) {
-        const charge = await retrieveBookingCharge(pi, connectedAccountId);
-        if (!charge) {
-          logger.error(
-            `Appointment ${appointmentId} booking intent ${pi.id} carries no charge id; invoice ${openInvoice.id} claimed but not settled.`,
-          );
-          return;
-        }
-
-        await settleAppointmentBookingInvoice({
-          invoiceId: openInvoice.id,
-          appointmentId,
-          pi,
-          charge,
-          connectedAccountId,
-        });
-
-        logger.info(
-          `Appointment ${appointmentId} booking PAID. Invoice ${openInvoice.id} settled`,
-        );
-        return;
-      }
+      return;
     }
 
     const serviceId = extractAppointmentTypeId(appointment.appointmentType);
@@ -788,80 +870,23 @@ export const StripeService = {
 
     const { parentId, patientId } = extractAppointmentPatientRefs(appointment);
 
-    let createdInvoice: { id: string };
-    try {
-      createdInvoice = await prisma.invoice.create({
-        data: {
-          appointmentId,
-          organisationId: appointment.organisationId,
-          parentId: parentId ?? undefined,
-          patientId: patientId ?? undefined,
-          currency: pi.currency ?? "usd",
-          status: "PAID",
-          providerPaymentIntentId: pi.id,
-          items: [
-            {
-              name: service.name,
-              description: service.description ?? undefined,
-              quantity: 1,
-              unitPrice: service.cost,
-              total: service.cost,
-            },
-          ],
-          subtotal: service.cost,
-          discountTotal: 0,
-          taxTotal: 0,
-          totalAmount: service.cost,
-        },
-        select: { id: true },
-      });
-    } catch (error) {
-      if (!isUniqueConstraintViolation(error)) throw error;
-
-      // Two shapes reach here, and they need different answers.
-      //
-      // A racer that lost on providerPaymentIntentId: the winner committed
-      // before Postgres raised, so this read cannot miss it. Nothing to settle,
-      // the winner is doing that.
-      const winner = await prisma.invoice.findUnique({
-        where: { providerPaymentIntentId: pi.id },
-        select: { id: true },
-      });
-      if (winner) {
-        logger.info(
-          `Appointment ${appointmentId} booking lost the race for ${pi.id}; invoice ${winner.id} won`,
-        );
-        return;
-      }
-
-      // Or a collision on the appointment key, which still exists: a SECOND
-      // legitimate intent for an appointment that already has an invoice. Log it
-      // and return, because throwing would answer non-2xx and buy an endless
-      // Stripe retry of an event that can never succeed while that index stands.
-      logger.error(
-        `Appointment ${appointmentId} already carries an invoice, so intent ${pi.id} could not be recorded. Payment captured with no invoice of its own.`,
-        error,
-      );
-      return;
-    }
-
-    const charge = await retrieveBookingCharge(pi, connectedAccountId);
-    if (!charge) {
-      logger.error(
-        `Appointment ${appointmentId} booking intent ${pi.id} carries no charge id; invoice ${createdInvoice.id} created but not settled.`,
-      );
-      return;
-    }
+    const mintedInvoiceId = await mintBookingInvoice({
+      appointmentId,
+      organisationId: appointment.organisationId,
+      parentId,
+      patientId,
+      service,
+      pi,
+    });
+    if (!mintedInvoiceId) return;
 
     await settleAppointmentBookingInvoice({
-      invoiceId: createdInvoice.id,
+      invoiceId: mintedInvoiceId,
       appointmentId,
       pi,
-      charge,
       connectedAccountId,
+      origin: "created",
     });
-
-    logger.info(`Appointment ${appointmentId} booking PAID. Invoice created`);
   },
 
   async _handleInvoicePayment(

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -77,6 +77,29 @@ const resolveCapturedAmount = (
   return capturedMinorUnits / 100;
 };
 
+const isUniqueConstraintViolation = (error: unknown): boolean =>
+  !!error &&
+  typeof error === "object" &&
+  "code" in error &&
+  (error as { code?: string }).code === "P2002";
+
+// Same guarded read the invoice-payment handler already uses, rather than the
+// blind `as string` cast this path used to carry: latest_charge is typed
+// string | Charge | null, and passing a non-string to charges.retrieve throws
+// inside the handler, which Stripe then retries forever.
+const retrieveBookingCharge = async (
+  pi: Stripe.PaymentIntent,
+  connectedAccountId?: string,
+): Promise<Stripe.Charge | null> => {
+  const chargeId =
+    typeof pi.latest_charge === "string" ? pi.latest_charge : null;
+  if (!chargeId) return null;
+
+  return getStripeClient().charges.retrieve(chargeId, {
+    ...(connectedAccountId ? { stripeAccount: connectedAccountId } : {}),
+  });
+};
+
 const settleAppointmentBookingInvoice = async (params: {
   invoiceId: string;
   appointmentId: string;
@@ -697,43 +720,63 @@ export const StripeService = {
     });
     if (!appointment) return;
 
-    const openInvoice = await prisma.invoice.findFirst({
-      where: {
-        appointmentId,
-        status: { in: ["AWAITING_PAYMENT", "PENDING"] },
-      },
-      orderBy: { createdAt: "desc" },
+    // Replay check, and the reason this handler is safe at all. Stripe redelivers
+    // on any non-2xx and nothing upstream deduplicates by event id, so the same
+    // intent can arrive here more than once, including concurrently. An invoice
+    // already bound to THIS intent means the work was done; settling again is a
+    // no-op inside the payment service, but minting again would not be.
+    const boundInvoice = await prisma.invoice.findUnique({
+      where: { providerPaymentIntentId: pi.id },
+      select: { id: true },
     });
-
-    if (openInvoice) {
-      const chargeId = pi.latest_charge as string;
-      const charge = await getStripeClient().charges.retrieve(chargeId, {
-        ...(connectedAccountId ? { stripeAccount: connectedAccountId } : {}),
-      });
-
-      await settleAppointmentBookingInvoice({
-        invoiceId: openInvoice.id,
-        appointmentId,
-        pi,
-        charge,
-        connectedAccountId,
-      });
-
+    if (boundInvoice) {
       logger.info(
-        `Appointment ${appointmentId} booking PAID. Invoice ${openInvoice.id} settled`,
+        `Appointment ${appointmentId} booking replay for ${pi.id}; invoice ${boundInvoice.id} already bound`,
       );
       return;
     }
 
-    const existingInvoice = await prisma.invoice.findFirst({
-      where: { appointmentId, status: "PAID" },
+    // Claim an open invoice by stamping the intent on it, rather than just
+    // settling it. Without the stamp a later redelivery finds nothing bound and
+    // nothing open, and mints a second invoice - the failure that looks safe
+    // because the happy path is unchanged.
+    const claimed = await prisma.invoice.updateMany({
+      where: {
+        appointmentId,
+        status: { in: ["AWAITING_PAYMENT", "PENDING"] },
+        providerPaymentIntentId: null,
+      },
+      data: { providerPaymentIntentId: pi.id },
     });
-    if (existingInvoice) return;
 
-    const chargeId = pi.latest_charge as string;
-    const charge = await getStripeClient().charges.retrieve(chargeId, {
-      ...(connectedAccountId ? { stripeAccount: connectedAccountId } : {}),
-    });
+    if (claimed.count > 0) {
+      const openInvoice = await prisma.invoice.findUnique({
+        where: { providerPaymentIntentId: pi.id },
+        select: { id: true },
+      });
+      if (openInvoice) {
+        const charge = await retrieveBookingCharge(pi, connectedAccountId);
+        if (!charge) {
+          logger.error(
+            `Appointment ${appointmentId} booking intent ${pi.id} carries no charge id; invoice ${openInvoice.id} claimed but not settled.`,
+          );
+          return;
+        }
+
+        await settleAppointmentBookingInvoice({
+          invoiceId: openInvoice.id,
+          appointmentId,
+          pi,
+          charge,
+          connectedAccountId,
+        });
+
+        logger.info(
+          `Appointment ${appointmentId} booking PAID. Invoice ${openInvoice.id} settled`,
+        );
+        return;
+      }
+    }
 
     const serviceId = extractAppointmentTypeId(appointment.appointmentType);
     if (!serviceId) return;
@@ -745,29 +788,70 @@ export const StripeService = {
 
     const { parentId, patientId } = extractAppointmentPatientRefs(appointment);
 
-    const createdInvoice = await prisma.invoice.create({
-      data: {
-        appointmentId,
-        organisationId: appointment.organisationId,
-        parentId: parentId ?? undefined,
-        patientId: patientId ?? undefined,
-        currency: pi.currency ?? "usd",
-        status: "PAID",
-        items: [
-          {
-            name: service.name,
-            description: service.description ?? undefined,
-            quantity: 1,
-            unitPrice: service.cost,
-            total: service.cost,
-          },
-        ],
-        subtotal: service.cost,
-        discountTotal: 0,
-        taxTotal: 0,
-        totalAmount: service.cost,
-      },
-    });
+    let createdInvoice: { id: string };
+    try {
+      createdInvoice = await prisma.invoice.create({
+        data: {
+          appointmentId,
+          organisationId: appointment.organisationId,
+          parentId: parentId ?? undefined,
+          patientId: patientId ?? undefined,
+          currency: pi.currency ?? "usd",
+          status: "PAID",
+          providerPaymentIntentId: pi.id,
+          items: [
+            {
+              name: service.name,
+              description: service.description ?? undefined,
+              quantity: 1,
+              unitPrice: service.cost,
+              total: service.cost,
+            },
+          ],
+          subtotal: service.cost,
+          discountTotal: 0,
+          taxTotal: 0,
+          totalAmount: service.cost,
+        },
+        select: { id: true },
+      });
+    } catch (error) {
+      if (!isUniqueConstraintViolation(error)) throw error;
+
+      // Two shapes reach here, and they need different answers.
+      //
+      // A racer that lost on providerPaymentIntentId: the winner committed
+      // before Postgres raised, so this read cannot miss it. Nothing to settle,
+      // the winner is doing that.
+      const winner = await prisma.invoice.findUnique({
+        where: { providerPaymentIntentId: pi.id },
+        select: { id: true },
+      });
+      if (winner) {
+        logger.info(
+          `Appointment ${appointmentId} booking lost the race for ${pi.id}; invoice ${winner.id} won`,
+        );
+        return;
+      }
+
+      // Or a collision on the appointment key, which still exists: a SECOND
+      // legitimate intent for an appointment that already has an invoice. Log it
+      // and return, because throwing would answer non-2xx and buy an endless
+      // Stripe retry of an event that can never succeed while that index stands.
+      logger.error(
+        `Appointment ${appointmentId} already carries an invoice, so intent ${pi.id} could not be recorded. Payment captured with no invoice of its own.`,
+        error,
+      );
+      return;
+    }
+
+    const charge = await retrieveBookingCharge(pi, connectedAccountId);
+    if (!charge) {
+      logger.error(
+        `Appointment ${appointmentId} booking intent ${pi.id} carries no charge id; invoice ${createdInvoice.id} created but not settled.`,
+      );
+      return;
+    }
 
     await settleAppointmentBookingInvoice({
       invoiceId: createdInvoice.id,

--- a/apps/backend/test/controllers/web/stripe.controller.test.ts
+++ b/apps/backend/test/controllers/web/stripe.controller.test.ts
@@ -487,6 +487,29 @@ describe("StripeController", () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({ error: "Unknown error" });
     });
+
+    it("returns 500 when the handler throws on a validly signed event", async () => {
+      // A signature we verified plus a handler that failed is our fault, not the
+      // caller's. Answering 400 for both made a database outage and a forged
+      // signature indistinguishable on the Stripe dashboard.
+      mockedStripe.verifyWebhook.mockReturnValue({ id: "evt_1" });
+      mockedStripe.handleWebhookEvent.mockRejectedValue(
+        new Error("database unavailable"),
+      );
+      const req = buildReq({
+        headers: { "stripe-signature": "sig_1" },
+        body: Buffer.from("payload"),
+      });
+
+      await StripeController.webhook(
+        req as Request<unknown, unknown, Buffer>,
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.status).not.toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: "database unavailable" });
+    });
   });
 
   describe("connectWebhook", () => {
@@ -548,6 +571,28 @@ describe("StripeController", () => {
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({ error: "Unknown error" });
+    });
+
+    it("returns 500 when the handler throws on a validly signed connect event", async () => {
+      mockedStripe.verifyConnectWebhook.mockReturnValue({ id: "evt_connect" });
+      mockedStripe.handleWebhookEvent.mockRejectedValue(
+        new Error("connected account lookup failed"),
+      );
+      const req = buildReq({
+        headers: { "stripe-signature": "sig_c" },
+        body: Buffer.from("connect-payload"),
+      });
+
+      await StripeController.connectWebhook(
+        req as Request<unknown, unknown, Buffer>,
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.status).not.toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "connected account lookup failed",
+      });
     });
   });
 

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -2366,6 +2366,29 @@ describe("StripeService", () => {
       ).rejects.toThrow("connection reset");
     });
 
+    it("settles from an expanded charge without a second round trip", async () => {
+      // latest_charge is string | Charge | null. When the intent was expanded it
+      // IS the charge, so treating anything non-string as absent skipped
+      // settlement on a payment that had already been captured.
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockResolvedValueOnce({
+        id: "inv_new",
+      });
+
+      await StripeService._handleAppointmentBookingPayment({
+        ...bookingEvent,
+        latest_charge: { id: "ch_expanded", receipt_url: "receipt" },
+      } as any);
+
+      expect(mStripe.charges.retrieve).not.toHaveBeenCalled();
+      expect(
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ chargeId: "ch_expanded" }),
+      );
+    });
+
     it("does not settle when the intent carries no usable charge id", async () => {
       bookingAppointment();
       bookingService();

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -161,6 +161,30 @@ describe("StripeService", () => {
     // one; without it every unrelated account.updated test throws "not iterable".
     (prisma.organizationBilling.findMany as jest.Mock).mockResolvedValue([]);
 
+    // mockReset, not just the clearAllMocks above: clearAllMocks drops recorded
+    // calls but NOT queued mockResolvedValueOnce values, so a test that queues
+    // more responses than it consumes leaves them for whichever later test calls
+    // the same mock next. That was survivable while every booking test made the
+    // same number of invoice reads; it stops being survivable now that the
+    // handler's read pattern differs per branch.
+    (prisma.invoice.findUnique as jest.Mock).mockReset();
+    (prisma.invoice.findFirst as jest.Mock).mockReset();
+    (prisma.invoice.create as jest.Mock).mockReset();
+    (prisma.invoice.updateMany as jest.Mock).mockReset();
+    // Same reason, and this one had already bitten: a booking test that queued a
+    // charge it never retrieved handed that charge to the next test that did,
+    // which is how an unrelated invoice-payment test started reporting the wrong
+    // receipt url and captured amount.
+    mStripe.charges.retrieve.mockReset();
+
+    // The appointment-booking handler now opens with a replay lookup and a claim
+    // before it decides anything, so both need a shape by default: no invoice is
+    // yet bound to this intent, and no open invoice was claimed. That is the
+    // first-delivery-with-nothing-to-reuse case, which is what most of these
+    // tests are about. Tests that exercise a replay or a claim override them.
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.invoice.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
     process.env = {
       ...originalEnv,
       STRIPE_SECRET_KEY: "sk_test_mock",
@@ -1143,9 +1167,6 @@ describe("StripeService", () => {
         organisationId: "org_1",
         companion: { id: "comp_1", parent: { id: "par_1" } },
       });
-      (prisma.invoice.findFirst as jest.Mock)
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
       (prisma.invoice.create as jest.Mock).mockResolvedValueOnce({
         id: "inv_new",
       });
@@ -1178,10 +1199,10 @@ describe("StripeService", () => {
         organisationId: "org_1",
         companion: { id: "comp_1", parent: { id: "par_1" } },
       });
-      (prisma.invoice.findFirst as jest.Mock).mockResolvedValueOnce({
-        id: "inv_open",
-        status: "AWAITING_PAYMENT",
-      });
+      (prisma.invoice.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.invoice.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: "inv_open" });
       (prisma.paymentAttempt.findFirst as jest.Mock).mockResolvedValueOnce({
         id: "pa_open",
       });
@@ -1199,6 +1220,17 @@ describe("StripeService", () => {
 
       expect(prisma.appointment.updateMany).toHaveBeenCalled();
       expect(prisma.invoice.create).not.toHaveBeenCalled();
+      // The claim is the point: settling without stamping the intent would leave
+      // a later redelivery with nothing bound and nothing open, and it would mint
+      // a second invoice.
+      expect(prisma.invoice.updateMany).toHaveBeenCalledWith({
+        where: {
+          appointmentId: "appt_1",
+          status: { in: ["AWAITING_PAYMENT", "PENDING"] },
+          providerPaymentIntentId: null,
+        },
+        data: { providerPaymentIntentId: "pi_1" },
+      });
     });
 
     it("handles invoice payment and failure/refund flows", async () => {
@@ -1285,10 +1317,10 @@ describe("StripeService", () => {
         organisationId: "org_1",
         patient: { id: "comp_1", parent: { id: "par_1" } },
       });
-      (prisma.invoice.findFirst as jest.Mock).mockResolvedValueOnce({
-        id: "inv_open",
-        status: "AWAITING_PAYMENT",
-      });
+      (prisma.invoice.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.invoice.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: "inv_open" });
       (prisma.paymentAttempt.findFirst as jest.Mock).mockResolvedValueOnce({
         id: "pa_open",
         settlementChannel: "STRIPE",
@@ -2210,29 +2242,146 @@ describe("StripeService", () => {
         metadata: { appointmentId: "appt_1" },
       } as any);
 
-      expect(prisma.invoice.findFirst).not.toHaveBeenCalled();
+      expect(prisma.invoice.findUnique).not.toHaveBeenCalled();
     });
 
-    it("skips when a paid invoice already exists", async () => {
+    const bookingAppointment = () =>
       (prisma.appointment.findUnique as jest.Mock).mockResolvedValueOnce({
         id: "appt_1",
         appointmentType: { id: "svc_1" },
         organisationId: "org_1",
         patient: { id: "c" },
       });
-      (prisma.invoice.findFirst as jest.Mock)
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: "inv_paid", status: "PAID" });
 
-      await StripeService._handleAppointmentBookingPayment({
-        id: "pi_1",
-        currency: "usd",
-        latest_charge: "ch_1",
-        metadata: { appointmentId: "appt_1" },
-      } as any);
+    const bookingService = () =>
+      (prisma.service.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "svc_1",
+        name: "Checkup",
+        description: "desc",
+        cost: 25,
+      });
 
+    const bookingEvent = {
+      id: "pi_1",
+      currency: "usd",
+      latest_charge: "ch_1",
+      metadata: { appointmentId: "appt_1" },
+    };
+
+    it("no-ops when an invoice is already bound to this payment intent", async () => {
+      // The replay case. Stripe redelivers on any non-2xx and nothing upstream
+      // deduplicates by event id, so this is the ordinary path for a retry, not
+      // an edge case.
+      bookingAppointment();
+      (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "inv_bound",
+      });
+
+      await StripeService._handleAppointmentBookingPayment(bookingEvent as any);
+
+      expect(prisma.invoice.findUnique).toHaveBeenCalledWith({
+        where: { providerPaymentIntentId: "pi_1" },
+        select: { id: true },
+      });
+      expect(prisma.invoice.updateMany).not.toHaveBeenCalled();
       expect(prisma.invoice.create).not.toHaveBeenCalled();
       expect(mStripe.charges.retrieve).not.toHaveBeenCalled();
+    });
+
+    it("stamps the payment intent on the invoice it mints", async () => {
+      // Without this assertion the whole guarantee can be deleted by removing one
+      // line: a unique index over a column nothing ever writes enforces nothing,
+      // and every other test here would stay green.
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockResolvedValueOnce({
+        id: "inv_new",
+      });
+      mStripe.charges.retrieve.mockResolvedValueOnce({
+        id: "ch_1",
+        receipt_url: "receipt",
+      });
+
+      await StripeService._handleAppointmentBookingPayment(bookingEvent as any);
+
+      expect(prisma.invoice.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ providerPaymentIntentId: "pi_1" }),
+        }),
+      );
+    });
+
+    it("settles nothing when it loses the race for the payment intent", async () => {
+      // Postgres raises 23505 only after the winner commits, so this re-read
+      // cannot miss it. The winner settles; this delivery must not.
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockRejectedValueOnce({
+        code: "P2002",
+      });
+      (prisma.invoice.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: "inv_winner" });
+
+      await StripeService._handleAppointmentBookingPayment(bookingEvent as any);
+
+      expect(
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded,
+      ).not.toHaveBeenCalled();
+      expect(mStripe.charges.retrieve).not.toHaveBeenCalled();
+    });
+
+    it("logs and returns when the appointment key blocks a second intent", async () => {
+      // A collision that is NOT on the intent means the appointment already has
+      // an invoice. Throwing would answer non-2xx and buy an endless Stripe retry
+      // of an event that cannot succeed while that index stands.
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockRejectedValueOnce({
+        code: "P2002",
+      });
+
+      await expect(
+        StripeService._handleAppointmentBookingPayment(bookingEvent as any),
+      ).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("could not be recorded"),
+        expect.anything(),
+      );
+      expect(
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("rethrows a create failure that is not a unique violation", async () => {
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockRejectedValueOnce(
+        new Error("connection reset"),
+      );
+
+      await expect(
+        StripeService._handleAppointmentBookingPayment(bookingEvent as any),
+      ).rejects.toThrow("connection reset");
+    });
+
+    it("does not settle when the intent carries no usable charge id", async () => {
+      bookingAppointment();
+      bookingService();
+      (prisma.invoice.create as jest.Mock).mockResolvedValueOnce({
+        id: "inv_new",
+      });
+
+      await StripeService._handleAppointmentBookingPayment({
+        ...bookingEvent,
+        latest_charge: null,
+      } as any);
+
+      expect(mStripe.charges.retrieve).not.toHaveBeenCalled();
+      expect(
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded,
+      ).not.toHaveBeenCalled();
     });
 
     it("stops when the appointment service ref is unusable", async () => {
@@ -2504,10 +2653,10 @@ describe("StripeService", () => {
         organisationId: "org_1",
         companion: {},
       });
-      (prisma.invoice.findFirst as jest.Mock).mockResolvedValueOnce({
-        id: "inv_open",
-        status: "PENDING",
-      });
+      (prisma.invoice.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.invoice.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: "inv_open" });
       mStripe.charges.retrieve.mockResolvedValueOnce({
         id: "ch_1",
         receipt_url: null,

--- a/packages/database/prisma/migrations/20260825090000_invoice_provider_payment_intent/migration.sql
+++ b/packages/database/prisma/migrations/20260825090000_invoice_provider_payment_intent/migration.sql
@@ -1,0 +1,51 @@
+-- Bind a booking invoice to the Stripe PaymentIntent that produced it.
+--
+-- `StripeService.handleWebhookEvent` never reads `event.id`: there is no
+-- processed-event table, no cache and no lock, so a retried delivery re-runs the
+-- whole dispatch. The appointment-booking handler mints an invoice with no
+-- unique-violation handler of its own, and the only thing that has ever stopped
+-- two concurrent deliveries from minting two invoices is the unique index on
+-- "Invoice"."appointmentId".
+--
+-- That index is going away, because it also refuses a legitimate second invoice
+-- for one appointment - a paid deposit plus a later balance. Keying on the
+-- payment intent instead separates the two cases the appointment key conflates:
+-- a duplicate DELIVERY carries the same intent id, a second CHARGE carries a
+-- different one. So this constraint survives that removal, which the one it
+-- replaces could not.
+--
+-- No pre-check for existing duplicates is needed: the column is new, so every
+-- row is NULL, and Postgres treats NULLs as distinct in a unique index.
+ALTER TABLE "Invoice" ADD COLUMN "providerPaymentIntentId" TEXT;
+
+-- Backfill from settled attempts, but only where the mapping is unambiguous.
+--
+-- An intent that already resolves to exactly one invoice can be bound now, which
+-- means a redelivery of an OLD event is recognised as a replay instead of
+-- minting a second invoice the first time this ships. Intents that map to more
+-- than one invoice are skipped rather than guessed at; there are none in dev or
+-- production today, and a wrong guess here would be worse than no backfill.
+--
+-- Deliberately before the index: if this statement ever produced a collision the
+-- CREATE UNIQUE INDEX would fail and roll the whole migration back, which is the
+-- outcome we want.
+UPDATE "Invoice" i
+SET "providerPaymentIntentId" = a."providerPaymentIntentId"
+FROM (
+  SELECT "invoiceId", MIN("providerPaymentIntentId") AS "providerPaymentIntentId"
+  FROM "PaymentAttempt"
+  WHERE "providerPaymentIntentId" IS NOT NULL
+  GROUP BY "invoiceId"
+  HAVING COUNT(DISTINCT "providerPaymentIntentId") = 1
+) a
+WHERE a."invoiceId" = i."id"
+  AND i."providerPaymentIntentId" IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "PaymentAttempt" other
+    WHERE other."providerPaymentIntentId" = a."providerPaymentIntentId"
+      AND other."invoiceId" <> i."id"
+  );
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invoice_providerPaymentIntentId_key" ON "Invoice"("providerPaymentIntentId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3446,6 +3446,14 @@ model Invoice {
   /// Postgres, so the invoices that were not converted from an estimate are
   /// unaffected.
   estimateId              String?                  @unique
+  /// The Stripe PaymentIntent this invoice was minted for, set only by the
+  /// appointment-booking webhook. Unique, because a duplicate webhook delivery
+  /// carries the SAME intent id while a legitimate second charge carries a
+  /// different one - so this constraint separates the two cases that the unique
+  /// on appointmentId conflates, and it keeps holding once that one is dropped.
+  /// NULLs stay distinct in Postgres, so every invoice raised by any other path
+  /// is unaffected.
+  providerPaymentIntentId String?                  @unique
   items                   Json
   subtotal                Float
   discountTotal           Float                    @default(0)


### PR DESCRIPTION
## What changed

Two things, both about the Stripe webhook telling the truth.

**1. Verify and handle are now separate failures.** Both webhook routes wrapped signature verification and event handling in a single `try/catch` that answered `400`. Verification failures stay `400`; handler failures return `500`. The two routes differ only in which secret they verify against, so the shared shape moved into one helper.

**2. A booking invoice is now bound to the Stripe PaymentIntent that produced it.** New nullable-unique `Invoice.providerPaymentIntentId`, and `_handleAppointmentBookingPayment` binds before it settles.

## Why

`StripeService.handleWebhookEvent` never reads `event.id`. There is no processed-event table, no cache, no lock, and no transaction anywhere in `stripe.service.ts`, so a retried delivery re-runs the entire ten-case dispatch. The appointment-booking handler minted an invoice with no unique-violation handler of its own, and the only thing that has ever stopped two concurrent deliveries from minting two invoices is the unique index on `Invoice.appointmentId`.

That index is scheduled for removal, because it also refuses a legitimate second invoice for one appointment: a paid deposit plus a later balance. `InvoiceService.createExtraInvoiceForAppointment` is the evidence, a function that provably never creates an invoice because the constraint would not let it.

Keying on the payment intent separates the two cases the appointment key conflates. **A duplicate delivery carries the same intent id; a second legitimate charge carries a different one.** So this constraint keeps holding once that one is dropped, which is exactly what the old one could not do.

On the reporting change: a signature that does not verify is the caller's fault and no retry will fix it, while a handler that throws is ours and the retry is what saves the event. Reporting both as `400` made a database outage and a forged signature indistinguishable. Stripe retries on any non-2xx, so delivery behaviour is unchanged.

## How the handler behaves now

- **Replay** - an invoice already bound to this intent means the work is done. Stop.
- **Open invoice** - CLAIMED by stamping the intent on it, not merely settled. Settling without the stamp leaves a later redelivery with nothing bound and nothing open, and it mints a second invoice. This is the failure that looks safe because the happy path is unchanged.
- **Mint** - carries the intent in the INSERT, and reads back a unique violation. A racer that lost on the intent returns without settling, because Postgres raises 23505 only after the winner commits, so the re-read cannot miss. A collision on the appointment key instead means a second legitimate intent, which is logged and returned rather than thrown: throwing answers non-2xx and buys an endless Stripe retry of an event that cannot succeed while that index stands.

The appointment-scoped `status: "PAID"` probe is gone. It was scoped to the appointment rather than the intent, so it silently dropped a genuinely separate second charge.

Two blind `pi.latest_charge as string` casts are replaced with the guarded read the invoice-payment handler already uses.

## Deliberately not in this PR

**The mint still sets `status: "PAID"`.** Flipping it to `AWAITING_PAYMENT` is necessary to get a ledger row written at all: `PAID` makes settlement return `ALREADY_PAID` before any Payment, PaymentAttempt or FinanceEvent is written. But that flip newly exposes `invoiceMatchesEventAccount`, which returns `ACCOUNT_MISMATCH` and strands a captured charge on an unpaid invoice if `event.account` differs from the organisation's Stripe account. It is unreachable today only because the mint sets PAID. That needs verifying against a real environment first, so it is a separate change.

Dropping `Invoice_appointmentId_key` is also separate, and has a prerequisite: `InvoiceService.createDraftForAppointment` recovers from P2002 by re-reading on `appointmentId` and has no other synchronisation, so dropping the index without fixing it just relocates the duplicate-invoice bug from the webhook to the API.

## Impact area

`apps/backend` and `packages/database`. One new nullable column plus its unique index. No client change.

## Validation performed

- `pnpm --filter backend run type-check` - clean
- `pnpm --filter backend run lint` - exit 0, no findings
- `prisma validate` - valid
- `npx jest test/services/stripe.service.test.ts` - **108 passed**
- `npx jest test/controllers/web/stripe.controller.test.ts` - **55 passed**

**Migration verified against a real Postgres 16** (Docker, torn down): all migrations applied clean; the unique index is created and enforced; NULLs stay distinct. The backfill was run against a seeded ambiguous fixture and bound only what it should:

| invoice | attempts | result |
|---|---|---|
| invA | two attempts, same intent | bound to `pi_A` |
| invB | two different intents | skipped |
| invC / invD | share one intent across two invoices | both skipped |
| invE | no attempts | untouched |

`UPDATE 1`, so no collision is reachable at index-creation time.

**Every guarantee is mutation-verified.** Each mutation fails exactly one targeted test and nothing else:

| mutation | result |
|---|---|
| stop stamping the intent on the minted invoice | `● stamps the payment intent on the invoice it mints` |
| remove the replay early-return | `● no-ops when an invoice is already bound to this payment intent` |
| claim without stamping the intent | `● settles open invoice for appointment booking payment` |
| rethrow instead of logging on an appointment-key collision | `● logs and returns when the appointment key blocks a second intent` |
| collapse the handler branch back to 400 | `● returns 500 when the handler throws...` (both routes) |

Restored each time, back to green.

One test-hygiene fix was needed along the way: `clearAllMocks` does not drain queued `mockResolvedValueOnce` values, so a booking test that queued a charge it never retrieved was handing that charge to the next test that did, which made an unrelated invoice-payment test report the wrong captured amount. The invoice and charge mocks are now reset explicitly.
