### PR TITLE
fix(backend): make imported translations reachable by search

### DIFF
--- a/apps/backend/src/scripts/import-venom-designations.ts
+++ b/apps/backend/src/scripts/import-venom-designations.ts
@@ -29,6 +29,13 @@ export type Designation = {
 export type PlannedConcept = {
   ycCode: string;
   designations: Designation[];
+  /**
+   * The full synonym list after the import, existing entries first. Search reads
+   * synonyms, not meta.designations - importConcepts folds every designation term into
+   * synonyms for exactly that reason - so an importer that wrote only the designations
+   * would land 12,738 translations that no search can ever return.
+   */
+  synonyms: string[];
   added: number;
 };
 
@@ -40,13 +47,24 @@ export type DesignationPlan = {
 const key = (term: string, lang: string) =>
   `${term.trim().toLowerCase()}|${lang.trim().toLowerCase()}`;
 
+export type ExistingConcept = {
+  designations: Designation[];
+  synonyms: string[];
+};
+
 export const planDesignations = (
   extract: DesignationExtract,
-  existing: Map<string, Designation[]>,
+  existing: Map<string, ExistingConcept>,
 ): DesignationPlan => {
   const merged = new Map<
     string,
-    { current: Designation[]; seen: Set<string>; added: number }
+    {
+      current: Designation[];
+      seen: Set<string>;
+      synonyms: string[];
+      synonymKeys: Set<string>;
+      added: number;
+    }
   >();
   const skipped: DesignationPlan["skipped"] = [];
 
@@ -67,8 +85,12 @@ export const planDesignations = (
         continue;
       }
       entry = {
-        current: [...current],
-        seen: new Set(current.map((d) => key(d.term, d.lang))),
+        current: [...current.designations],
+        seen: new Set(current.designations.map((d) => key(d.term, d.lang))),
+        synonyms: [...current.synonyms],
+        synonymKeys: new Set(
+          current.synonyms.map((synonym) => synonym.trim().toLowerCase()),
+        ),
         added: 0,
       };
       merged.set(ycCode, entry);
@@ -80,6 +102,14 @@ export const planDesignations = (
     }
 
     entry.seen.add(key(trimmed, lang));
+    // Fold the term into synonyms too, matching importConcepts. Search matches on
+    // display and synonyms only, so a designation that never reaches synonyms exists
+    // in the record and nowhere a query can see.
+    const synonymKey = trimmed.toLowerCase();
+    if (!entry.synonymKeys.has(synonymKey)) {
+      entry.synonymKeys.add(synonymKey);
+      entry.synonyms.push(trimmed);
+    }
     entry.current.push({
       term: trimmed,
       lang: lang.trim(),
@@ -97,6 +127,7 @@ export const planDesignations = (
       .map(([ycCode, value]) => ({
         ycCode,
         designations: value.current,
+        synonyms: value.synonyms,
         added: value.added,
       })),
     skipped,
@@ -121,15 +152,33 @@ const asDesignations = (value: unknown): Designation[] => {
   );
 };
 
+const asSynonyms = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
 export const loadExistingDesignations = async () => {
   const entries = await prisma.codeEntry.findMany({
-    where: { system: "YOSEMITECODE", type: "CLINICAL_TERM", active: true },
-    select: { code: true, meta: true },
+    // BREED included: VeNom's file carries designations for breeds too - the two en-GB
+    // synonyms target a YBREED code - and a CLINICAL_TERM-only load skipped them as
+    // "concept not found".
+    where: {
+      system: "YOSEMITECODE",
+      type: { in: ["CLINICAL_TERM", "BREED"] },
+      active: true,
+    },
+    select: { code: true, meta: true, synonyms: true },
   });
-  const index = new Map<string, Designation[]>();
+  const index = new Map<string, ExistingConcept>();
   for (const entry of entries) {
     const meta = entry.meta as { designations?: unknown } | null;
-    index.set(entry.code, asDesignations(meta?.designations));
+    index.set(entry.code, {
+      designations: asDesignations(meta?.designations),
+      synonyms: asSynonyms(entry.synonyms),
+    });
   }
   return index;
 };
@@ -177,6 +226,7 @@ export const main = async () => {
               '{designations}',
               ${JSON.stringify(concept.designations)}::jsonb
             ),
+            "synonyms" = ${JSON.stringify(concept.synonyms)}::jsonb,
             "updatedAt" = NOW()
         WHERE "system" = 'YOSEMITECODE'::"CodeSystem" AND "code" = ${concept.ycCode}
       `,

--- a/apps/backend/test/scripts/import-venom-designations.test.ts
+++ b/apps/backend/test/scripts/import-venom-designations.test.ts
@@ -32,7 +32,16 @@ const extract = (
   designations,
 });
 
-const existing = (pairs: Array<[string, Designation[]]>) => new Map(pairs);
+const existing = (
+  pairs: Array<[string, Designation[]]>,
+  synonyms: Record<string, string[]> = {},
+) =>
+  new Map(
+    pairs.map(([code, designations]) => [
+      code,
+      { designations, synonyms: synonyms[code] ?? [] },
+    ]),
+  );
 
 describe("planDesignations", () => {
   it("adds a translation to an existing concept rather than creating a new term", () => {
@@ -253,6 +262,51 @@ describe("planDesignations", () => {
   });
 });
 
+describe("search visibility", () => {
+  it("folds every added designation into synonyms, where search actually looks", () => {
+    // The defect this exists for: --apply wrote meta.designations only, while
+    // suggestTerms matches on display and synonyms. 12,738 translations imported
+    // cleanly and none of them could ever be returned by a search.
+    const plan = planDesignations(
+      extract([
+        ["YC-1", "Anomalía de comportamiento", "es-ES", "name"],
+        ["YC-1", "Alteração de comportamento", "pt-BR", "name"],
+      ]),
+      existing([["YC-1", []]], { "YC-1": ["Behavioural abnormality"] }),
+    );
+
+    expect(plan.concepts[0].synonyms).toEqual([
+      "Behavioural abnormality",
+      "Anomalía de comportamiento",
+      "Alteração de comportamento",
+    ]);
+  });
+
+  it("does not duplicate a synonym the entry already carries", () => {
+    const plan = planDesignations(
+      extract([["YC-1", "Alopecia", "es-ES", "name"]]),
+      existing([["YC-1", []]], { "YC-1": ["alopecia", "Hair loss"] }),
+    );
+
+    // Case-insensitively already present, so the synonym list is unchanged; the
+    // designation itself is still added, because es-ES did not carry it yet.
+    expect(plan.concepts[0].synonyms).toEqual(["alopecia", "Hair loss"]);
+    expect(plan.concepts[0].added).toBe(1);
+  });
+
+  it("keeps existing synonyms first so display ordering is stable", () => {
+    const plan = planDesignations(
+      extract([["YC-1", "Sangrado", "es-ES", "name"]]),
+      existing([["YC-1", []]], { "YC-1": ["Bleeding", "Haemorrhage"] }),
+    );
+
+    expect(plan.concepts[0].synonyms.slice(0, 2)).toEqual([
+      "Bleeding",
+      "Haemorrhage",
+    ]);
+  });
+});
+
 describe("loadDesignations", () => {
   afterEach(() => jest.restoreAllMocks());
 
@@ -291,9 +345,38 @@ describe("loadExistingDesignations", () => {
 
     const index = await loadExistingDesignations();
 
-    expect(index.get("YC-1")).toEqual([
-      { term: "Vomiting", lang: "en", source: "venom", preferred: true },
+    expect(index.get("YC-1")).toEqual({
+      designations: [
+        { term: "Vomiting", lang: "en", source: "venom", preferred: true },
+      ],
+      synonyms: [],
+    });
+  });
+
+  it("loads breed entries too, so VeNom's breed designations resolve", async () => {
+    // The file's two en-GB synonyms target a YBREED code; a CLINICAL_TERM-only load
+    // skipped them as "concept not found".
+    prismaMock.codeEntry.findMany.mockResolvedValue([]);
+
+    await loadExistingDesignations();
+
+    expect(prismaMock.codeEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: { in: ["CLINICAL_TERM", "BREED"] },
+        }),
+      }),
+    );
+  });
+
+  it("reads the synonyms column, which is where search looks", async () => {
+    prismaMock.codeEntry.findMany.mockResolvedValue([
+      { code: "YC-1", meta: null, synonyms: ["Vomiting", "  Emesis  ", 7, ""] },
     ]);
+
+    const index = await loadExistingDesignations();
+
+    expect(index.get("YC-1")?.synonyms).toEqual(["Vomiting", "Emesis"]);
   });
 
   it("treats malformed meta as no designations rather than throwing", async () => {
@@ -306,9 +389,9 @@ describe("loadExistingDesignations", () => {
 
     const index = await loadExistingDesignations();
 
-    expect(index.get("YC-1")).toEqual([]);
-    expect(index.get("YC-2")).toEqual([]);
-    expect(index.get("YC-3")).toEqual([]);
+    expect(index.get("YC-1")?.designations).toEqual([]);
+    expect(index.get("YC-2")?.designations).toEqual([]);
+    expect(index.get("YC-3")?.designations).toEqual([]);
   });
 });
 
@@ -356,6 +439,14 @@ describe("main", () => {
     await main();
 
     expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    // The statement itself must write synonyms, not only meta.designations. A write
+    // that skips synonyms lands translations search can never see - which is the
+    // defect this importer shipped with, and a planner-only test would miss it again.
+    const statements = JSON.stringify(prismaMock.$transaction.mock.calls[0][0]);
+    expect(statements).toContain('\\"synonyms\\" =');
+    // The bare-array form is the synonyms parameter; the designation object also
+    // mentions the term, so match the shape that only synonyms produces.
+    expect(statements).toContain('[\\"Sangrado\\"]');
     expect(output()).toMatch(/wrote 1 designations across 1 concepts/);
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2468 imported 12,738 VeNom translations as `meta.designations`. **None of them is searchable.** `suggestTerms` matches on `display` and `synonyms` only - `importConcepts` folds designation terms into `synonyms` for exactly that reason - but the designation importer's `--apply` wrote only `meta.designations`. A Spanish-speaking clinician typing "anomalía" gets nothing for a concept whose Spanish label imported cleanly.

Separately, the extract's two `en-GB` rows target a `YBREED:` code, and the `CLINICAL_TERM`-only loader skipped them as "concept not found".

## What is the new behavior?

- The planner folds each added designation term into the entry's `synonyms`: case-insensitive dedup, existing entries kept first so display ordering is stable.
- The `--apply` statement writes `synonyms` alongside `meta.designations`, in the same single transaction.
- The loader includes `BREED` entries, so the German Shepherd entry gains `gsd` and `German shepherd dog`.

## Validation performed

**End to end with nothing mocked**: a scratch Postgres seeded with the real concept, the real search-index migration applied, the real importer run with `--apply`, and the real generated search SQL executed:

| | "anomalía" |
| --- | ---: |
| before the import | 0 matches |
| after | **1 match** (score 150, synonym prefix) |

"alteração" (pt-BR) also matches, and the breed row's synonyms read `["gsd","German shepherd dog"]`.

- 24 tests; `tsc` and eslint clean.
- **Mutation checked**: removing the synonyms fold fails 1, reverting to CLINICAL_TERM-only loading fails 1, and dropping the synonyms write from the SQL fails 1. That last mutation *initially survived* - the planner was covered, the statement was not, the same unit-green-journey-dead shape as the defect itself - so the apply test now pins the statement text.

## After merge

Dev needs `pnpm import:venom-designations --apply` re-run; the importer is idempotent over the earlier designations-only state, so it completes rather than duplicates.

## Related Issue(s)

Fixes #2478
