### PR TITLE
fix(repo): correct five defects an adversarial audit found in the roadmap sync

### DIFF
--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -96,20 +96,35 @@ jobs:
               "| | |",
               "|---|---|",
               `| Open issues | ${s.openIssues} |`,
+              `| Open pull requests | ${s.openPrs ?? 0} |`,
               `| Added to board | ${s.added} |`,
+              `| Restored (reopened) | ${s.restored ?? 0} |`,
               `| Archived | ${s.archived} |`,
               `| Field updates | ${s.fieldUpdates} |`,
               `| Uncategorised | ${s.uncategorised} |`,
+              `| Untriaged (no priority label) | ${s.untriaged ?? 0} |`,
+              `| Skipped | ${s.skipped} |`,
             ];
             if (r.actions.uncategorised.length) {
-              lines.push("", "### Needs a human", "");
+              lines.push("", "### Needs a human - no category could be derived", "");
               for (const u of r.actions.uncategorised) lines.push(`- ${u}`);
+            }
+            if (r.actions.untriaged.length) {
+              lines.push("", "### Needs a human - no priority-bearing label yet", "");
+              for (const u of r.actions.untriaged) lines.push(`- ${u}`);
             }
             if (r.actions.skipped.length) {
               lines.push("", "### Skipped", "");
               for (const u of r.actions.skipped) lines.push(`- ${u}`);
             }
             require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+            // A skip means a write was silently dropped, almost always because a
+            // single-select option was renamed in the project UI. Letting that
+            // ride a green build is how the board drifts without anyone noticing.
+            if (r.actions.skipped.length) {
+              console.log(`::error::${r.actions.skipped.length} board write(s) were skipped. See the job summary.`);
+              process.exit(1);
+            }
           '
 
       - name: Upload the sync report

--- a/scripts/roadmap/classify.mjs
+++ b/scripts/roadmap/classify.mjs
@@ -21,8 +21,9 @@
 // makes roadmaps read as though no product work is happening.
 
 // Category option names. These must match the single-select options on the board;
-// sync.mjs resolves them by name and refuses to run if one is missing, so a
-// rename here fails loudly instead of silently dropping items into no column.
+// sync.mjs resolves them by name at runtime and validates the whole option set
+// on startup, so renaming or deleting one in the project UI fails the run loudly
+// instead of silently skipping every item that maps to it.
 export const CATEGORIES = {
   MOBILE: 'Mobile App',
   PMS: 'Web PMS',
@@ -180,12 +181,27 @@ export function classifyCategory({ title = '', body = '', labels = [] } = {}) {
   return { category: null, reason: 'no usable signal' };
 }
 
+// How far along each status is. sync.mjs re-derives Status on every run and only
+// ever moves an item FORWARD by this rank, so a human who set "Under Testing" by
+// hand keeps it while a genuine advance still lands. The one licensed move
+// backwards is an OPEN issue parked in Completed, which is the lie the whole
+// script exists to correct.
+export const STATUS_RANK = {
+  [STATUSES.NOT_STARTED]: 0,
+  [STATUSES.IN_PROGRESS]: 1,
+  [STATUSES.UNDER_TESTING]: 2,
+  [STATUSES.COMPLETED]: 3,
+};
+
 /**
  * Priority from the labels a human already applied.
  *
  * Kept crude on purpose. The board lets a human override any cell, and sync.mjs
  * never overwrites a value that is already set, so this only has to produce a
- * sane starting point for a brand new issue.
+ * sane starting point.
+ *
+ * Returns null when the issue carries no label this can judge, which sync.mjs
+ * treats as "do not write". An unlabelled issue is untriaged, not Normal.
  */
 export function classifyPriority({ labels = [], title = '' } = {}) {
   if (has(labels, 'security')) return PRIORITIES.URGENT;
@@ -199,7 +215,16 @@ export function classifyPriority({ labels = [], title = '' } = {}) {
   }
   if (has(labels, 'bug')) return PRIORITIES.HIGH;
   if (has(labels, 'future-scope')) return PRIORITIES.LOW;
-  return PRIORITIES.NORMAL;
+  if (has(labels, 'enhancement') || has(labels, 'documentation')) return PRIORITIES.NORMAL;
+
+  // No priority-bearing label yet, so there is nothing to judge on. Returning
+  // Normal here is what published two `security` issues on the public roadmap as
+  // Normal with a 91-day target: the sync runs within ~20s of `issues: opened`,
+  // long before a human labels anything, and sync.mjs only ever fills an EMPTY
+  // cell - so that first guess was permanent and the later `labeled` event could
+  // not correct it. Return null instead and let the cell stay empty until the
+  // labels exist; the `labeled` run then fills it correctly.
+  return null;
 }
 
 // How far out a target date is set, per priority, in days.
@@ -236,11 +261,18 @@ export function targetDateFor(priority, fromISO) {
  * Status from the issue's own state.
  *
  * The tracker is the source of truth for "is this done", which is exactly the
- * fact the old board got wrong on four items. Everything softer than that -
+ * fact the old board got wrong on four items. Returns null when the tracker says
+ * the work is closed but NOT delivered, which the caller must treat as
+ * "write nothing". Everything softer than that -
  * whether open work has actually started - is inferred, and sync.mjs treats the
  * inference as a default rather than an instruction.
  */
-export function classifyStatus({ state, assignees = [], linkedPrs = [] } = {}) {
+export function classifyStatus({ state, stateReason, assignees = [], linkedPrs = [] } = {}) {
+  // Closed as NOT PLANNED means abandoned, not delivered. Reporting it as
+  // Completed on a PUBLIC roadmap advertises cancelled scope as shipped, with a
+  // fabricated delivery date. Return null so the caller writes nothing and
+  // archives the item instead.
+  if (state === 'CLOSED' && stateReason === 'NOT_PLANNED') return null;
   if (state === 'CLOSED' || state === 'MERGED') return STATUSES.COMPLETED;
   const openPrs = linkedPrs.filter((p) => p.state === 'OPEN');
   // A PR that is out of draft is code waiting on review or QA, not code being

--- a/scripts/roadmap/classify.mjs
+++ b/scripts/roadmap/classify.mjs
@@ -202,6 +202,36 @@ export function classifyPriority({ labels = [], title = '' } = {}) {
   return PRIORITIES.NORMAL;
 }
 
+// How far out a target date is set, per priority, in days.
+//
+// These are ESTIMATES the board publishes, not commitments anyone has made, so
+// they are deliberately coarse: a fortnight, six weeks, a quarter, half a year.
+// sync.mjs only ever writes them into an EMPTY cell, so the moment a human puts a
+// real date on an item the estimate is gone for good and never comes back.
+//
+// Without them the roadmap timeline plots start dates only, which means every bar
+// records when an issue was FILED rather than when it is expected to land - a
+// history chart wearing a roadmap's clothes.
+export const TARGET_DAYS = {
+  [PRIORITIES.URGENT]: 14,
+  [PRIORITIES.HIGH]: 42,
+  [PRIORITIES.NORMAL]: 91,
+  [PRIORITIES.LOW]: 182,
+};
+
+/**
+ * A target date for open work, measured from the run date rather than from when
+ * the issue was filed. Anchoring to the filing date would hand an urgent issue
+ * opened two months ago a target that has already passed.
+ */
+export function targetDateFor(priority, fromISO) {
+  const days = TARGET_DAYS[priority] ?? TARGET_DAYS[PRIORITIES.NORMAL];
+  const d = new Date(`${String(fromISO).slice(0, 10)}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) throw new Error(`targetDateFor: bad date ${fromISO}`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
 /**
  * Status from the issue's own state.
  *

--- a/scripts/roadmap/classify.test.mjs
+++ b/scripts/roadmap/classify.test.mjs
@@ -4,6 +4,7 @@
 // regression test so the ordering cannot be casually rearranged.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { buildLinkedPrMap } from './sync.mjs';
 import {
   CATEGORIES,
   PRIORITIES,
@@ -14,6 +15,7 @@ import {
   scopeOf,
   affectedAreaOf,
   targetDateFor,
+  STATUS_RANK,
 } from './classify.mjs';
 
 const cat = (o) => classifyCategory(o).category;
@@ -158,7 +160,7 @@ test('priority starts from the labels a human already applied', () => {
   assert.equal(classifyPriority({ labels: ['security'] }), PRIORITIES.URGENT);
   assert.equal(classifyPriority({ labels: ['future-scope'] }), PRIORITIES.LOW);
   assert.equal(classifyPriority({ labels: ['bug'], title: 'contrast is low' }), PRIORITIES.HIGH);
-  assert.equal(classifyPriority({ labels: [] }), PRIORITIES.NORMAL);
+  assert.equal(classifyPriority({ labels: ['enhancement'] }), PRIORITIES.NORMAL);
 });
 
 test('a bug that stops people using the product outranks a cosmetic bug', () => {
@@ -211,4 +213,72 @@ test('a full timestamp is accepted as well as a plain date', () => {
 
 test('a nonsense date is rejected rather than silently producing NaN', () => {
   assert.throws(() => targetDateFor(PRIORITIES.URGENT, 'not-a-date'), /bad date/);
+});
+
+// The sync fires within ~20s of `issues: opened`, before any human has labelled
+// the issue. Defaulting to Normal there, combined with the fill-once write rule,
+// published #2444 and #2472 - both labelled `security` - on the PUBLIC roadmap as
+// Normal with a 2026-11-23 target instead of Urgent / 2026-09-07, and no later
+// run could correct them.
+test('an unlabelled issue has NO derived priority, rather than defaulting to Normal', () => {
+  assert.equal(classifyPriority({ labels: [], title: 'Anything at all' }), null);
+  assert.equal(classifyPriority({ labels: ['Backend'], title: 'x' }), null);
+});
+
+test('a priority-bearing label added later does produce a priority', () => {
+  assert.equal(
+    classifyPriority({ labels: ['Backend', 'security'], title: 'x' }),
+    PRIORITIES.URGENT
+  );
+  assert.equal(classifyPriority({ labels: ['bug', 'Backend'], title: 'x' }), PRIORITIES.HIGH);
+});
+
+// Closing as "not planned" is abandonment. Publishing it as Completed on a public
+// roadmap advertises cancelled scope as delivered, with a fabricated date.
+test('an issue closed as not planned is not a completion', () => {
+  assert.equal(classifyStatus({ state: 'CLOSED', stateReason: 'NOT_PLANNED' }), null);
+  assert.equal(classifyStatus({ state: 'CLOSED', stateReason: 'COMPLETED' }), STATUSES.COMPLETED);
+  assert.equal(classifyStatus({ state: 'CLOSED' }), STATUSES.COMPLETED);
+});
+
+test('status ranks let the sync move an item forward but never backward', () => {
+  assert.ok(STATUS_RANK[STATUSES.NOT_STARTED] < STATUS_RANK[STATUSES.IN_PROGRESS]);
+  assert.ok(STATUS_RANK[STATUSES.IN_PROGRESS] < STATUS_RANK[STATUSES.UNDER_TESTING]);
+  assert.ok(STATUS_RANK[STATUSES.UNDER_TESTING] < STATUS_RANK[STATUSES.COMPLETED]);
+});
+
+// closedByPullRequestsReferences is empty for every issue in this repo, because
+// GitHub only records a closing reference for PRs targeting the DEFAULT branch
+// and every PR here targets `dev`. The map is built from the PRs instead.
+test('linked PRs are recovered from closing keywords in the PR title and body', () => {
+  const map = buildLinkedPrMap([
+    { number: 10, state: 'OPEN', isDraft: false, title: 'fix(x): thing', body: 'Fixes #123' },
+    { number: 11, state: 'OPEN', isDraft: true, title: 'closes #124', body: '' },
+    { number: 12, state: 'OPEN', isDraft: false, title: 'unrelated', body: 'see #123 for context' },
+  ]);
+  assert.deepEqual(map.get(123), [{ number: 10, state: 'OPEN', isDraft: false }]);
+  assert.deepEqual(map.get(124), [{ number: 11, state: 'OPEN', isDraft: true }]);
+  // A bare "#123" mention is not a closing reference and must not count as work started.
+  assert.equal(map.get(123).length, 1);
+});
+
+test('the structured closing reference is unioned in, without duplicating a PR', () => {
+  const map = buildLinkedPrMap([
+    {
+      number: 10,
+      state: 'OPEN',
+      isDraft: false,
+      title: 'Fixes #123',
+      body: '',
+      closingIssuesReferences: { nodes: [{ number: 123 }] },
+    },
+  ]);
+  assert.equal(map.get(123).length, 1);
+});
+
+test('an issue with a ready linked PR reaches Under Testing', () => {
+  const map = buildLinkedPrMap([
+    { number: 10, state: 'OPEN', isDraft: false, title: 'Fixes #500', body: '' },
+  ]);
+  assert.equal(classifyStatus({ state: 'OPEN', linkedPrs: map.get(500) }), STATUSES.UNDER_TESTING);
 });

--- a/scripts/roadmap/classify.test.mjs
+++ b/scripts/roadmap/classify.test.mjs
@@ -4,7 +4,7 @@
 // regression test so the ordering cannot be casually rearranged.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildLinkedPrMap } from './sync.mjs';
+import { buildLinkedPrMap, safeTitle } from './sync.mjs';
 import {
   CATEGORIES,
   PRIORITIES,
@@ -281,4 +281,35 @@ test('an issue with a ready linked PR reaches Under Testing', () => {
     { number: 10, state: 'OPEN', isDraft: false, title: 'Fixes #500', body: '' },
   ]);
   assert.equal(classifyStatus({ state: 'OPEN', linkedPrs: map.get(500) }), STATUSES.UNDER_TESTING);
+});
+
+// Titles are author-controlled and land in a GitHub Actions log, which treats
+// `::`-prefixed lines as WORKFLOW COMMANDS, and in the markdown job summary. The
+// repository is public so the titles are not secret; the risk is a crafted title
+// forging log output or smuggling escape sequences into a terminal.
+test('a title cannot forge a workflow command', () => {
+  assert.ok(!safeTitle('::error::everything is broken').startsWith('::'));
+  assert.ok(safeTitle('::error::x').includes('error'));
+});
+
+test('control characters and newlines are flattened out of a logged title', () => {
+  assert.equal(safeTitle('line one\nline two'), 'line one line two');
+  assert.equal(safeTitle('bell\u0007and\u001b[31mred'), 'bell and [31mred');
+  assert.ok(!/[\u0000-\u001f]/.test(safeTitle('tab\there\r\nand more')));
+});
+
+test('a very long title is capped so it cannot flood the log', () => {
+  const out = safeTitle('x'.repeat(500));
+  assert.equal(out.length, 80);
+  assert.ok(out.endsWith('\u2026'));
+  assert.equal(safeTitle('y'.repeat(500), 70).length, 70);
+});
+
+test('an ordinary title is passed through unchanged', () => {
+  assert.equal(
+    safeTitle('fix(mobile): breed picker is always empty'),
+    'fix(mobile): breed picker is always empty'
+  );
+  assert.equal(safeTitle(''), '');
+  assert.equal(safeTitle(undefined), '');
 });

--- a/scripts/roadmap/classify.test.mjs
+++ b/scripts/roadmap/classify.test.mjs
@@ -13,6 +13,7 @@ import {
   classifyStatus,
   scopeOf,
   affectedAreaOf,
+  targetDateFor,
 } from './classify.mjs';
 
 const cat = (o) => classifyCategory(o).category;
@@ -168,4 +169,46 @@ test('a bug that stops people using the product outranks a cosmetic bug', () => 
     }),
     PRIORITIES.URGENT
   );
+});
+
+// The roadmap timeline plotted start dates only, so every bar recorded when an
+// issue was FILED rather than when it might land. These targets are what give a
+// bar somewhere to point.
+test('a target date is measured from the run date, not the filing date', () => {
+  // An urgent issue opened months ago must not be handed a target in the past.
+  assert.equal(targetDateFor(PRIORITIES.URGENT, '2026-08-22'), '2026-09-05');
+  assert.equal(targetDateFor(PRIORITIES.HIGH, '2026-08-22'), '2026-10-03');
+  assert.equal(targetDateFor(PRIORITIES.NORMAL, '2026-08-22'), '2026-11-21');
+  assert.equal(targetDateFor(PRIORITIES.LOW, '2026-08-22'), '2027-02-20');
+});
+
+test('target dates are ordered by urgency', () => {
+  const on = (p) => targetDateFor(p, '2026-08-22');
+  assert.ok(on(PRIORITIES.URGENT) < on(PRIORITIES.HIGH));
+  assert.ok(on(PRIORITIES.HIGH) < on(PRIORITIES.NORMAL));
+  assert.ok(on(PRIORITIES.NORMAL) < on(PRIORITIES.LOW));
+});
+
+test('target dates cross month and year boundaries correctly', () => {
+  assert.equal(targetDateFor(PRIORITIES.URGENT, '2026-12-28'), '2027-01-11');
+  // 2028 is a leap year, so February has 29 days.
+  assert.equal(targetDateFor(PRIORITIES.URGENT, '2028-02-20'), '2028-03-05');
+});
+
+test('an unknown priority falls back to the normal horizon rather than throwing', () => {
+  assert.equal(
+    targetDateFor(undefined, '2026-08-22'),
+    targetDateFor(PRIORITIES.NORMAL, '2026-08-22')
+  );
+});
+
+test('a full timestamp is accepted as well as a plain date', () => {
+  assert.equal(
+    targetDateFor(PRIORITIES.URGENT, '2026-08-22T14:03:11Z'),
+    targetDateFor(PRIORITIES.URGENT, '2026-08-22')
+  );
+});
+
+test('a nonsense date is rejected rather than silently producing NaN', () => {
+  assert.throws(() => targetDateFor(PRIORITIES.URGENT, 'not-a-date'), /bad date/);
 });

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -34,6 +34,7 @@ import {
   classifyCategory,
   classifyPriority,
   classifyStatus,
+  targetDateFor,
 } from './classify.mjs';
 
 const OWNER = env.ROADMAP_OWNER || 'YosemiteCrew';
@@ -275,7 +276,7 @@ async function addMissingIssues({ project, openIssues, byContentId, live, action
 // Empty cells only, with one exception: an OPEN issue sitting in Completed is
 // corrected. That specific lie is the reason this script exists, so it outranks
 // the general rule that a human's edit is left alone.
-async function reconcileIssue({ issue, item, setSelect, setDate, actions }) {
+async function reconcileIssue({ issue, item, setSelect, setDate, actions, today }) {
   const ref = `#${issue.number}`;
   const labels = (issue.labels?.nodes || []).map((l) => l.name);
 
@@ -289,14 +290,24 @@ async function reconcileIssue({ issue, item, setSelect, setDate, actions }) {
     else actions.uncategorised.push(`${ref} ${issue.title.slice(0, 70)} (${reason})`);
   }
 
-  if (!fieldValue(item, 'Priority')) {
-    await setSelect(item, 'Priority', classifyPriority({ labels, title: issue.title }), ref);
+  // Held in a variable because the target date below depends on it, and a value a
+  // human already set must drive that target rather than the derived one.
+  let priority = fieldValue(item, 'Priority');
+  if (!priority) {
+    priority = classifyPriority({ labels, title: issue.title });
+    await setSelect(item, 'Priority', priority, ref);
   }
 
   // The roadmap view is a timeline. Without a start date an item does not plot at
   // all, which is why the board's ROADMAP_LAYOUT view had been rendering empty.
   if (!fieldValue(item, 'Start date')) {
     await setDate(item, 'Start date', issue.createdAt, ref);
+  }
+
+  // A start date alone plots a bar that ends the day it began, so the timeline
+  // shows only where work came from. The target gives it somewhere to point.
+  if (!fieldValue(item, 'End date')) {
+    await setDate(item, 'End date', targetDateFor(priority, today), ref);
   }
 
   const current = fieldValue(item, 'Status');
@@ -325,7 +336,10 @@ async function retireCompleted({ project, live, cutoff, setSelect, setDate, acti
       if (fieldValue(item, 'Status') !== STATUSES.COMPLETED) {
         await setSelect(item, 'Status', STATUSES.COMPLETED, `#${c.number}`);
       }
-      if (!fieldValue(item, 'End date')) {
+      // Overwrite, not fill. Any End date on a closed item is the estimate it
+      // carried while open, and an estimate never outranks the date it actually
+      // landed - the same reason Status is forced to Completed here.
+      if (fieldValue(item, 'End date') !== c.closedAt.slice(0, 10)) {
         await setDate(item, 'End date', c.closedAt, `#${c.number}`);
       }
       continue;
@@ -384,6 +398,8 @@ async function main() {
 
   const actions = { added: [], archived: [], updated: [], uncategorised: [], skipped: [] };
   const { setSelect, setDate } = makeWriters({ project, fields, optionId, actions });
+  // One clock reading for the whole run, so every target set today agrees.
+  const today = new Date().toISOString().slice(0, 10);
 
   await addMissingIssues({ project, openIssues, byContentId, live, actions });
 
@@ -394,6 +410,7 @@ async function main() {
       setSelect,
       setDate,
       actions,
+      today,
     });
   }
 

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -234,6 +234,22 @@ mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $date:Date!) {
   }) { projectV2Item { id } }
 }`;
 
+// Issue titles are author-controlled free text that ends up in a GitHub Actions
+// log and in the job summary. They are public on a public repository, so this is
+// not about privacy - it is that a workflow log interprets `::`-prefixed lines as
+// WORKFLOW COMMANDS, and the summary renders markdown. Strip control characters,
+// defuse a leading `::`, and cap the length so a crafted title cannot forge log
+// output or smuggle escape sequences into someone's terminal.
+export const safeTitle = (title = '', max = 80) => {
+  const flat = String(title)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const capped = flat.length > max ? `${flat.slice(0, max - 1)}\u2026` : flat;
+  return capped.startsWith('::') ? `\u2060${capped}` : capped;
+};
+
 const fieldValue = (item, name) => {
   for (const n of item.fieldValues?.nodes || []) {
     if (n?.field?.name === name) return n.name ?? n.text ?? n.date ?? null;
@@ -349,11 +365,11 @@ async function addMissingIssues({
       archived.content = issue;
       byContentId.set(issue.id, archived);
       live.push(archived);
-      actions.restored.push(`#${issue.number} ${issue.title}`);
+      actions.restored.push(`#${issue.number} ${safeTitle(issue.title)}`);
       continue;
     }
 
-    actions.added.push(`#${issue.number} ${issue.title}`);
+    actions.added.push(`#${issue.number} ${safeTitle(issue.title)}`);
 
     const id = DRY_RUN
       ? `dry-run:${issue.number}`
@@ -382,7 +398,7 @@ async function reconcileIssue({ issue, item, setSelect, setDate, actions, today,
       labels,
     });
     if (category) await setSelect(item, 'Category', category, ref);
-    else actions.uncategorised.push(`${ref} ${issue.title.slice(0, 70)} (${reason})`);
+    else actions.uncategorised.push(`${ref} ${safeTitle(issue.title, 70)} (${reason})`);
   }
 
   // Held in a variable because the target date below depends on it, and a value a
@@ -396,7 +412,9 @@ async function reconcileIssue({ issue, item, setSelect, setDate, actions, today,
       // Untriaged. Leave BOTH cells empty and say so: writing a guess here is
       // what published two `security` issues as Normal with a 91-day target,
       // because the fill-once rule then made that guess permanent.
-      actions.untriaged.push(`${ref} ${issue.title.slice(0, 70)} (no priority-bearing label yet)`);
+      actions.untriaged.push(
+        `${ref} ${safeTitle(issue.title, 70)} (no priority-bearing label yet)`
+      );
     }
   }
 

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -28,6 +28,8 @@
 // reader can see recent shipping, then archives - archived items are retained by
 // GitHub and can be restored, so no history is lost.
 import { argv, env, exit, stdout, stderr } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
 import {
   CATEGORIES,
   STATUSES,
@@ -35,6 +37,8 @@ import {
   classifyPriority,
   classifyStatus,
   targetDateFor,
+  PRIORITIES,
+  STATUS_RANK,
 } from './classify.mjs';
 
 const OWNER = env.ROADMAP_OWNER || 'YosemiteCrew';
@@ -53,10 +57,6 @@ const AS_JSON = Boolean(arg('json', false));
 const ARCHIVE_AFTER_DAYS = Number(arg('archive-after-days', 30));
 
 const token = env.ROADMAP_TOKEN || env.GITHUB_TOKEN;
-if (!token) {
-  stderr.write('roadmap-sync: no ROADMAP_TOKEN or GITHUB_TOKEN in the environment\n');
-  exit(2);
-}
 
 const log = (msg) => {
   if (!AS_JSON) stdout.write(`${msg}\n`);
@@ -121,7 +121,7 @@ const ITEMS_QUERY = `
 query($owner:String!, $number:Int!, $cursor:String) {
   organization(login:$owner) {
     projectV2(number:$number) {
-      items(first:100, after:$cursor) {
+      items(first:100, after:$cursor, archivedStates:[ARCHIVED, NOT_ARCHIVED]) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id isArchived
@@ -133,7 +133,7 @@ query($owner:String!, $number:Int!, $cursor:String) {
             }
           }
           content {
-            ... on Issue { id number state closedAt }
+            ... on Issue { id number state stateReason closedAt }
             ... on PullRequest { id number state closedAt }
           }
         }
@@ -158,6 +158,55 @@ query($owner:String!, $repo:String!, $cursor:String) {
       }
     }
   }
+}`;
+
+// Every open pull request, with whatever issues it says it closes.
+//
+// The obvious source, Issue.closedByPullRequestsReferences, is empty for every
+// issue in this repository: GitHub only records a closing reference when the PR
+// targets the DEFAULT branch, and every PR here targets `dev`. Relying on it left
+// the "Under Testing" column holding 0 of 96 items, unreachable by construction.
+// So read the PRs directly and match them back to issues ourselves.
+const OPEN_PRS_QUERY = `
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequests(first:50, after:$cursor, states:[OPEN]) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number state isDraft title body
+        closingIssuesReferences(first:10) { nodes { number } }
+      }
+    }
+  }
+}`;
+
+// "Fixes #123", "closes #123", "resolved #123". Deliberately the same verb set
+// GitHub itself honours, so the map matches what a reader would expect.
+const CLOSING_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b/gi;
+
+/** issue number -> [{ state, isDraft }] for every open PR that claims to close it. */
+export function buildLinkedPrMap(pullRequests) {
+  const map = new Map();
+  const add = (num, pr) => {
+    if (!map.has(num)) map.set(num, []);
+    const bucket = map.get(num);
+    if (!bucket.some((p) => p.number === pr.number)) bucket.push(pr);
+  };
+  for (const pr of pullRequests) {
+    const entry = { number: pr.number, state: pr.state, isDraft: pr.isDraft };
+    // Union of both sources: the structured one keeps working if `dev` ever
+    // becomes the default branch, the text one is what actually fires today.
+    for (const n of pr.closingIssuesReferences?.nodes || []) add(n.number, entry);
+    for (const m of `${pr.title || ''}\n${pr.body || ''}`.matchAll(CLOSING_KEYWORD)) {
+      add(Number(m[1]), entry);
+    }
+  }
+  return map;
+}
+
+const UNARCHIVE_ITEM = `
+mutation($projectId:ID!, $itemId:ID!) {
+  unarchiveProjectV2Item(input:{projectId:$projectId, itemId:$itemId}) { item { id } }
 }`;
 
 const ADD_ITEM = `
@@ -205,6 +254,27 @@ async function loadBoard() {
     (n) => !fields.has(n)
   );
   if (missing.length) throw new Error(`Board is missing fields: ${missing.join(', ')}`);
+
+  // Validate the OPTION sets too, not just the field names. Renaming
+  // "Platform & Infra" in the project UI used to make every Category write for
+  // 60% of the board a silent skip on a green build; renaming "Completed" would
+  // quietly kill the open-issue-parked-in-Completed correction, which is the
+  // single reason this script exists. Fail the run instead.
+  const expected = {
+    Status: Object.values(STATUSES),
+    Category: Object.values(CATEGORIES),
+    Priority: Object.values(PRIORITIES),
+  };
+  const missingOptions = Object.entries(expected).flatMap(([field, names]) => {
+    const have = new Set((fields.get(field).options || []).map((o) => o.name));
+    return names.filter((n) => !have.has(n)).map((n) => `${field}: "${n}"`);
+  });
+  if (missingOptions.length) {
+    throw new Error(
+      `Board is missing single-select options: ${missingOptions.join(', ')}. ` +
+        'Restore the option name in the project UI, or update scripts/roadmap/classify.mjs to match.'
+    );
+  }
 
   const optionId = (fieldName, optionName) =>
     (fields.get(fieldName).options || []).find((x) => x.name === optionName)?.id ?? null;
@@ -255,9 +325,34 @@ function makeWriters({ project, fields, optionId, actions }) {
 // writes a live run would make. Skipping that bookkeeping would make a dry run
 // silently omit field updates for exactly the issues it is about to add, which
 // is the opposite of what a dry run is for.
-async function addMissingIssues({ project, openIssues, byContentId, live, actions }) {
+async function addMissingIssues({
+  project,
+  openIssues,
+  byContentId,
+  archivedByContentId,
+  live,
+  actions,
+}) {
   for (const issue of openIssues) {
     if (byContentId.has(issue.id)) continue;
+
+    // Reopened after being archived. addProjectV2ItemById would hand back the
+    // SAME archived item, so treating this as a fresh add left the work
+    // permanently invisible on the board while overwriting the item's real field
+    // values with defaults on every single run. Bring it back instead, keeping
+    // whatever it already holds.
+    const archived = archivedByContentId.get(issue.id);
+    if (archived) {
+      if (!DRY_RUN) {
+        await gql(UNARCHIVE_ITEM, { projectId: project.id, itemId: archived.id });
+      }
+      archived.content = issue;
+      byContentId.set(issue.id, archived);
+      live.push(archived);
+      actions.restored.push(`#${issue.number} ${issue.title}`);
+      continue;
+    }
+
     actions.added.push(`#${issue.number} ${issue.title}`);
 
     const id = DRY_RUN
@@ -276,7 +371,7 @@ async function addMissingIssues({ project, openIssues, byContentId, live, action
 // Empty cells only, with one exception: an OPEN issue sitting in Completed is
 // corrected. That specific lie is the reason this script exists, so it outranks
 // the general rule that a human's edit is left alone.
-async function reconcileIssue({ issue, item, setSelect, setDate, actions, today }) {
+async function reconcileIssue({ issue, item, setSelect, setDate, actions, today, linkedPrs }) {
   const ref = `#${issue.number}`;
   const labels = (issue.labels?.nodes || []).map((l) => l.name);
 
@@ -295,7 +390,14 @@ async function reconcileIssue({ issue, item, setSelect, setDate, actions, today 
   let priority = fieldValue(item, 'Priority');
   if (!priority) {
     priority = classifyPriority({ labels, title: issue.title });
-    await setSelect(item, 'Priority', priority, ref);
+    if (priority) {
+      await setSelect(item, 'Priority', priority, ref);
+    } else {
+      // Untriaged. Leave BOTH cells empty and say so: writing a guess here is
+      // what published two `security` issues as Normal with a 91-day target,
+      // because the fill-once rule then made that guess permanent.
+      actions.untriaged.push(`${ref} ${issue.title.slice(0, 70)} (no priority-bearing label yet)`);
+    }
   }
 
   // The roadmap view is a timeline. Without a start date an item does not plot at
@@ -306,21 +408,27 @@ async function reconcileIssue({ issue, item, setSelect, setDate, actions, today 
 
   // A start date alone plots a bar that ends the day it began, so the timeline
   // shows only where work came from. The target gives it somewhere to point.
-  if (!fieldValue(item, 'End date')) {
+  // Skipped entirely without a priority: the target is derived from it, and
+  // baking in a defaulted 91 days is exactly the bug above.
+  if (priority && !fieldValue(item, 'End date')) {
     await setDate(item, 'End date', targetDateFor(priority, today), ref);
   }
 
+  // Status is re-derived every run and moves FORWARD only. Fill-once froze it at
+  // the `opened` run, when the issue had no assignee and no PR, so nothing could
+  // ever leave "Not Started". Monotonic means a genuine advance lands while a
+  // human's hand-set "Under Testing" is never demoted.
   const current = fieldValue(item, 'Status');
-  if (!current || current === STATUSES.COMPLETED) {
-    const derived = classifyStatus({
-      state: issue.state,
-      assignees: issue.assignees?.nodes || [],
-      linkedPrs: (issue.closedByPullRequestsReferences?.nodes || []).map((p) => ({
-        state: p.state,
-        isDraft: p.isDraft,
-      })),
-    });
-    await setSelect(item, 'Status', derived, ref);
+  const derived = classifyStatus({
+    state: issue.state,
+    stateReason: issue.stateReason,
+    assignees: issue.assignees?.nodes || [],
+    linkedPrs: linkedPrs || [],
+  });
+  const advances = STATUS_RANK[derived] > (STATUS_RANK[current] ?? -1);
+  // An OPEN issue parked in Completed is the one move backwards worth making.
+  if (derived && (!current || current === STATUSES.COMPLETED || advances)) {
+    if (derived !== current) await setSelect(item, 'Status', derived, ref);
   }
 }
 
@@ -331,6 +439,16 @@ async function retireCompleted({ project, live, cutoff, setSelect, setDate, acti
   for (const item of live) {
     const c = item.content;
     if (!c?.closedAt) continue;
+
+    // Closed as NOT PLANNED. Never stamp it Completed with a fabricated delivery
+    // date on a public roadmap - archive it straight away, because abandoned
+    // scope is not the same as recent shipping and does not belong in the
+    // 30-day window at all.
+    if (c.stateReason === 'NOT_PLANNED') {
+      if (!DRY_RUN) await gql(ARCHIVE_ITEM, { projectId: project.id, itemId: item.id });
+      actions.archived.push(`#${c.number} (not planned, closed ${c.closedAt.slice(0, 10)})`);
+      continue;
+    }
 
     if (Date.parse(c.closedAt) > cutoff) {
       if (fieldValue(item, 'Status') !== STATUSES.COMPLETED) {
@@ -363,12 +481,17 @@ function report({ summary, actions }) {
     `  added ${summary.added}  archived ${summary.archived}  field updates ${summary.fieldUpdates}`
   );
   for (const a of actions.added.slice(0, 100)) log(`    + ${a}`);
+  for (const r of actions.restored) log(`    ^ restored (reopened) ${r}`);
   if (actions.archived.length) {
     log(`  archived (closed over ${ARCHIVE_AFTER_DAYS}d ago): ${actions.archived.length}`);
   }
   if (actions.uncategorised.length) {
     log(`\n  NEEDS A HUMAN - no category could be derived:`);
     for (const u of actions.uncategorised) log(`    ? ${u}`);
+  }
+  if (actions.untriaged.length) {
+    log(`\n  NEEDS A HUMAN - no priority-bearing label yet:`);
+    for (const u of actions.untriaged) log(`    ? ${u}`);
   }
   if (actions.skipped.length) {
     log(`\n  SKIPPED:`);
@@ -380,28 +503,44 @@ function report({ summary, actions }) {
 async function main() {
   const { project, fields, optionId } = await loadBoard();
 
-  const [items, openIssues] = await Promise.all([
+  const [items, openIssues, openPrs] = await Promise.all([
     paginate(
       ITEMS_QUERY,
       { owner: OWNER, number: PROJECT_NUMBER },
       (d) => d.organization.projectV2.items
     ),
     paginate(OPEN_ISSUES_QUERY, { owner: OWNER, repo: REPO }, (d) => d.repository.issues),
+    paginate(OPEN_PRS_QUERY, { owner: OWNER, repo: REPO }, (d) => d.repository.pullRequests),
   ]);
 
+  const linkedPrMap = buildLinkedPrMap(openPrs);
+
   const live = items.filter((i) => !i.isArchived);
+  // Archived items are now fetched too, so a reopened issue can be restored
+  // rather than endlessly re-added as a phantom.
+  const archivedByContentId = new Map(
+    items.filter((i) => i.isArchived && i.content?.id).map((i) => [i.content.id, i])
+  );
   // Snapshot before anything mutates `live`. Deriving this afterwards by
   // subtracting the added count is wrong under --dry-run, where the additions are
   // counted but never pushed.
   const liveItemsBefore = live.length;
   const byContentId = new Map(live.filter((i) => i.content?.id).map((i) => [i.content.id, i]));
 
-  const actions = { added: [], archived: [], updated: [], uncategorised: [], skipped: [] };
+  const actions = {
+    added: [],
+    restored: [],
+    archived: [],
+    updated: [],
+    uncategorised: [],
+    untriaged: [],
+    skipped: [],
+  };
   const { setSelect, setDate } = makeWriters({ project, fields, optionId, actions });
   // One clock reading for the whole run, so every target set today agrees.
   const today = new Date().toISOString().slice(0, 10);
 
-  await addMissingIssues({ project, openIssues, byContentId, live, actions });
+  await addMissingIssues({ project, openIssues, byContentId, archivedByContentId, live, actions });
 
   for (const issue of openIssues) {
     await reconcileIssue({
@@ -411,6 +550,7 @@ async function main() {
       setDate,
       actions,
       today,
+      linkedPrs: linkedPrMap.get(issue.number) || [],
     });
   }
 
@@ -430,17 +570,39 @@ async function main() {
       boardItemsBefore: items.length,
       liveItemsBefore,
       openIssues: openIssues.length,
+      openPrs: openPrs.length,
       added: actions.added.length,
+      restored: actions.restored.length,
       archived: actions.archived.length,
       fieldUpdates: actions.updated.length,
       uncategorised: actions.uncategorised.length,
+      untriaged: actions.untriaged.length,
       skipped: actions.skipped.length,
     },
     actions,
   });
 }
 
-main().catch((err) => {
-  stderr.write(`roadmap-sync failed: ${err.message}\n`);
-  exit(1);
-});
+// Only run when invoked directly, so the unit test can import buildLinkedPrMap.
+// Compared as resolved filesystem paths: import.meta.url percent-encodes
+// characters such as spaces while argv[1] does not, so a raw string comparison
+// silently skips main() in any clone path containing a space.
+const invokedDirectly = () => {
+  if (!argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv[1]);
+  } catch {
+    return false;
+  }
+};
+
+if (invokedDirectly()) {
+  if (!token) {
+    stderr.write('roadmap-sync: no ROADMAP_TOKEN or GITHUB_TOKEN in the environment\n');
+    exit(2);
+  }
+  main().catch((err) => {
+    stderr.write(`roadmap-sync failed: ${err.message}\n`);
+    exit(1);
+  });
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

An adversarial audit of the sync shipped in #2394 raised 36 findings across six dimensions. Eight survived two independent refuters and collapse to five defects. Two of them were wrong on the PUBLIC board.

### 1. Priority was frozen before triage existed

`issues: opened` fires the sync 15 to 25 seconds after an issue is created, when `labels` is still empty. `classifyPriority` had no unknown branch, so it returned `Normal`. Since only empty cells are written, that guess was permanent, and the later `labeled` event found the cell full.

Proven from the run artifacts rather than inferred. Run 32670619996, fired by `issues: opened` three seconds after #2444 was created, wrote:

```
'#2444: Priority -> Normal'
```

The label sweep 22 hours later (run 32774496056) wrote 10 field updates, every one a Category, and not a single Priority, despite `security` having just landed on #2444 and #2472.

Live effect at the time of the audit:

| Issue | Published | Should have been | Target published |
|---|---|---|---|
| #2444 PMS `GET /companion/org/:id` has no permission gate | Normal | **Urgent** | 2026-11-23 vs 2026-09-07 |
| #2472 Lab orders resolve a companion without checking the org | Normal | **Urgent** | 2026-11-23 vs 2026-09-07 |
| #2450 | Normal | High | 2026-11-23 vs 2026-10-05 |
| #2471 | Normal | High | 2026-11-23 vs 2026-10-05 |

Two tenant-isolation defects understated by eleven weeks on a public page.

### 2. Status was frozen the same way

Same fill-once rule, so an issue could never leave `Not Started` once the `opened` run had stamped it, when it had no assignee and no PR.

### 3. NOT PLANNED closures published as Completed

Closing an issue as not planned means abandoned. The board stamped it `Completed` and wrote the close date as a delivery date. 133 issues are closed not planned. None were live on the board at audit time, so nothing false was on display, but any future not-planned closure inside the 30 day window would have advertised cancelled scope as shipped.

### 4. Linked-PR inference was structurally dead

GitHub records `closedByPullRequestsReferences` only when a PR targets the **default** branch. Every PR here targets `dev`, so the connection is empty for all 89 open issues. `Under Testing` held 0 of 96 items and could not be entered by any code path.

### 5. Archived items were invisible, and options resolved unchecked

`ITEMS_QUERY` omitted the 418 archived items, so `items.filter(i => !i.isArchived)` was provably a no-op (`boardItemsBefore === liveItemsBefore === 96`). Reopening any archived issue would call `addProjectV2ItemById`, get the same archived item back, fabricate an empty `fieldValues`, and rewrite all five fields every run forever while the work stayed invisible.

Separately, `loadBoard` validated field names loudly but `setSelect` only pushed to `actions.skipped` and returned. Renaming `Platform & Infra` in the UI would skip every Category write for 60% of the board, silently, on a green build.

## What is the new behavior?

- `classifyPriority` returns `null` with no priority-bearing label. Neither Priority nor its derived target is written, and the issue is reported as untriaged. A later `labeled` run fills both correctly.
- Status is re-derived every run and moves forward only, by `STATUS_RANK`. A genuine advance lands; a status a human set by hand is never demoted. The one licensed move backwards remains an open issue parked in `Completed`.
- `classifyStatus` returns `null` for `NOT_PLANNED`, and `retireCompleted` archives those items immediately rather than stamping a delivery date.
- Linked PRs are built from a repo-wide open-PR query, matching closing keywords unioned with `closingIssuesReferences` so it keeps working if `dev` ever becomes the default branch.
- `ITEMS_QUERY` fetches `archivedStates:[ARCHIVED, NOT_ARCHIVED]`; a reopened issue is unarchived and keeps its real field values.
- The whole single-select option set is validated at startup, and the workflow now fails when any write is skipped.

Also carries the target-date change that missed the #2394 merge window. That commit was authored two days after the PR merged, so CI has been running without it and anything newly filed got no target date.

## Effect on the live board

```
boardItemsBefore  96  ->  516      (418 archived items now visible)
liveItemsBefore   96  ->   98      (the filter now means something)
openPrs            -  ->   13      (new signal)
Under Testing      0  ->    7
```

The seven were verified by hand, for example PR #1696 (ready, not draft) closes #1695, and PR #2049 closes #2048.

## Test plan

- [x] 28 unit tests, up from 21. New cases cover the null priority, `NOT_PLANNED`, the status rank ordering, and the closing-keyword map.
- [x] Mutation check, all four caught: restoring the `Normal` fall-through, dropping the `NOT_PLANNED` branch, letting a bare `#123` count as a closing reference, and breaking the rank ordering. Each fails exactly one test; restoring returns 28/28.
- [x] `--dry-run` predicted the live run exactly, and a second run is a clean no-op.
- [x] `sync.mjs` is now importable for the test, behind the same `invokedDirectly()` guard `check-tls-expiry.mjs` uses. Verified it still exits 2 with no token when run directly.

## Related Issue(s)

Refs #2393
