### PR TITLE
ci(repo): stop bot pull requests reaching main, and keep dev ahead of it

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,0 +1,86 @@
+name: Back-merge main into dev
+
+# dev must always CONTAIN main, so that "is everything promoted?" is answerable
+# with `git merge-base --is-ancestor main dev` instead of forensics.
+#
+# It is not answerable today. Promotion merges dev into main with a merge commit,
+# and that commit lives only on main - dev never receives it. After 32 promotions
+# dev was 40 commits "behind" main while holding identical content, which makes
+# the count useless: a harmless merge commit and a hotfix that never came back
+# look exactly the same.
+#
+# That ambiguity has already cost something real. The json security bump (#2131)
+# was merged straight into main on 2026-08-13, dev stayed on the vulnerable
+# version, and nothing detected it - a person did, later. This job is the part
+# that would have caught it: anything reaching main gets a pull request back into
+# dev, automatically, whether it arrived by promotion or through the main-direct
+# escape hatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: back-merge
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  back-merge:
+    name: Open a back-merge pull request
+    if: github.repository_owner == 'YosemiteCrew'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Open or update the back-merge pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main dev --quiet
+
+          # The invariant itself. When it already holds there is nothing to carry
+          # back, which is the normal state immediately after a back-merge lands.
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "dev already contains main - nothing to back-merge."
+            exit 0
+          fi
+
+          BEHIND="$(git rev-list --count origin/dev..origin/main)"
+          echo "main has ${BEHIND} commit(s) that dev does not contain."
+
+          EXISTING="$(gh pr list --repo "${REPO}" --base dev --head main --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${EXISTING}" ]; then
+            echo "::notice::Back-merge PR #${EXISTING} is already open; it updates itself as main moves."
+            exit 0
+          fi
+
+          # Usually an empty diff: main's tree is dev's tree at the point they
+          # diverged, so only the merge commits differ. The pull request exists to
+          # restore ancestry, and it is the safety net for the rare case where the
+          # diff is NOT empty - something landed on main without passing through
+          # dev, and that content would otherwise be stranded.
+          gh pr create --repo "${REPO}" --base dev --head main \
+            --title "chore(repo): back-merge main into dev" \
+            --body "$(cat <<'BODY'
+          Opened automatically so that `dev` continues to contain `main`.
+
+          `main` currently holds commits `dev` does not. Usually these are only the merge commits created by each `dev` to `main` promotion, and the file diff is empty - merging this restores ancestry and nothing else.
+
+          **If the diff is NOT empty, read it.** That means something reached `main` without passing through `dev`, and this pull request is carrying it back. That is the case the json security bump (#2131) fell into, where `dev` was left on the vulnerable version.
+
+          Merge with a merge commit. Do not squash: squashing creates a new commit and leaves the ancestry broken, which is the problem this exists to fix.
+          BODY
+          )"

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -23,9 +23,11 @@ concurrency:
   cancel-in-progress: true
 
 # pull_request_target runs against the BASE repository, so it must never check
-# out or execute the pull request's code. It only reads branch metadata below.
+# out or execute the pull request's code. It only reads branch metadata and
+# retargets the pull request through the API below.
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   guard:
@@ -33,19 +35,67 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Bots first, and deliberately BEFORE the main-direct escape hatch, so no
+      # label a human applies can wave a bot's pull request into main.
+      #
+      # Dependabot SECURITY updates ignore `target-branch: dev` and always open
+      # against the default branch - that is a GitHub behaviour we cannot
+      # configure away, and it is how #2131 landed on main leaving dev on the
+      # vulnerable version. Blocking those PRs alone would leave the fix
+      # stranded, so retarget them at dev where they can actually be merged.
+      - name: Retarget bot pull requests at dev
+        id: retarget
+        if: github.event.pull_request.user.type == 'Bot'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A fork branch cannot be retargeted usefully, and we will not grant it
+          # a path into main. Leave it for the guard below to reject.
+          if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            echo "retargeted=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "::notice::${AUTHOR} opened this against main. Retargeting at dev."
+          gh pr edit "${PR}" --repo "${BASE_REPO}" --base dev
+
+          gh pr comment "${PR}" --repo "${BASE_REPO}" --body "$(cat <<'BODY'
+          Retargeted from `main` to `dev` automatically.
+
+          `main` only ever takes changes from `dev`. Dependabot security updates ignore the `target-branch: dev` setting and always open against the default branch, so this is corrected here rather than in configuration.
+
+          Nothing is needed from you: review and merge this into `dev`, and the next `dev` to `main` promotion carries it. If the diff no longer applies cleanly against `dev`, close this and let the `dev`-targeted update supersede it.
+          BODY
+          )"
+
+          echo "retargeted=true" >> "${GITHUB_OUTPUT}"
+
       - name: Check the head branch
+        if: steps.retarget.outputs.retargeted != 'true'
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+          IS_BOT: ${{ github.event.pull_request.user.type == 'Bot' }}
           # A deliberate, human-applied escape hatch for the rare direct-to-main
           # change (an emergency hotfix, or a dependabot.yml sync that has to
-          # take effect before the next promotion). Dependabot cannot apply it:
-          # it only sets the labels listed in dependabot.yml, and this is not
-          # one of them.
+          # take effect before the next promotion). Checked AFTER the bot branch
+          # above, so it can only ever release a human's pull request.
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
+
+          if [[ "${IS_BOT}" == "true" ]]; then
+            echo "::error::A bot pull request (${HEAD_REPO}:${HEAD_REF}) cannot merge into main, and the 'main-direct' label does not apply to it. It should have been retargeted at dev automatically; if it was not, retarget it by hand."
+            exit 1
+          fi
 
           if [[ ",${LABELS}," == *",main-direct,"* ]]; then
             echo "::notice::'main-direct' label present - a human has explicitly allowed this direct merge."


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two gaps, found while working out why `dev` read as 40 commits behind `main`.

### 1. A bot pull request could use the human escape hatch

`promotion-guard.yml` checked the `main-direct` label **first**:

```bash
if [[ ",${LABELS}," == *",main-direct,"* ]]; then
  exit 0
fi
```

The comment above it reasoned that Dependabot cannot apply that label itself, which is true. But the check does not care who applied it. Labelling a Dependabot or Aikido pull request was enough to release it into `main`.

Both bots have merged directly into `main` before, six times between June and August 2026: #2131, #1786, #1785, #1784, #1631 (Dependabot) and #1800 (Aikido autofix). All predate the guard, which landed 2026-08-13, three hours after #2131.

### 2. Dependabot security updates cannot be aimed at `dev`

They ignore `target-branch: dev` and always open against the default branch. That is GitHub behaviour, not a configuration mistake. The guard would now block them, which is correct but leaves the security fix stranded on a red pull request nobody can merge.

### 3. Nothing carried `main`'s commits back to `dev`

Every promotion merges `dev` into `main` with a merge commit that exists only on `main`. `dev` never receives it. After 32 promotions:

```
$ git rev-list --left-right --count origin/main...origin/dev
40      13
$ git diff --stat origin/main $(git merge-base origin/main origin/dev)
(empty - identical trees)
```

Identical content, 40 commits "behind". The count is therefore useless: a harmless promotion merge commit and a hotfix that never came back look exactly the same, and telling them apart takes real forensics.

That ambiguity has already cost something. #2131 was merged straight into `main` on 2026-08-13; `dev` stayed on the vulnerable `json` and nothing detected it. A person did, later.

## What is the new behavior?

**Bots are handled before the label is consulted.** A bot-authored pull request against `main` is retargeted at `dev` automatically, with a comment on the pull request explaining why. If it cannot be retargeted, because it comes from a fork, it is refused. The `main-direct` label now explicitly does not apply to bots.

**`back-merge.yml`** opens a pull request from `main` into `dev` whenever `dev` stops containing `main`. Usually the diff is empty and merging it just restores ancestry. When the diff is **not** empty, something reached `main` without passing through `dev` and this carries it back, which is exactly the #2131 case.

This restores `git merge-base --is-ancestor main dev` as a meaningful check, and it is what makes the `main-direct` escape hatch safe to keep.

## Deliberately not changed

The `Main` ruleset still lists bypass actors with `bypass_mode: always`:

```
actor_type=OrganizationAdmin   bypass_mode=always
actor_type=RepositoryRole (5)  bypass_mode=always
```

Those skip the ruleset entirely, required checks included, so an admin can still merge anything into `main` by hand. Removing them is the only way to close that completely; Ankit chose to keep the break-glass path. This PR narrows everything reachable in code, and the back-merge above means an admin override no longer strands anything on `main`.

## Test plan

- [x] Both workflows parse, and both `run:` blocks pass `bash -n`.
- [x] The retarget step was executed locally against a stubbed `gh` with a simulated Dependabot payload: it calls `pr edit --base dev`, posts the intended comment, and sets `retargeted=true`. The heredoc renders correctly through YAML block-scalar indentation stripping, which was the part most likely to break.
- [x] The back-merge step was executed locally against the real repository state: it correctly reports `main has 40 commit(s) that dev does not contain` and renders the pull request body.
- [x] The ancestry fix was verified in a scratch worktree: merging `origin/main` into `dev` produces 0 conflicts, changes no files, and afterwards `git merge-base --is-ancestor origin/main HEAD` passes.
- [x] Failure mode checked: if `gh pr edit` fails, `set -euo pipefail` fails the step and therefore the required check, so a bot pull request is blocked rather than let through.

## Related Issue(s)

Refs #2393
