### PR TITLE
fix(frontend): make a disabled federation service visible instead of silent

### DIFF
--- a/apps/frontend/src/app/__tests__/features/federation/FederationSection.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/federation/FederationSection.test.tsx
@@ -144,11 +144,30 @@ describe('FederationSection', () => {
     expect(screen.getByText('Federation identity')).toBeInTheDocument();
   });
 
-  it('renders nothing when getActorSettings rejects', async () => {
+  it('explains the failure instead of disappearing when getActorSettings rejects', async () => {
+    // It used to return null, so on an instance with federation switched off the
+    // entire section vanished from Settings and the only signal was a toast that
+    // had already faded. That reads as "the feature does not exist".
     (getActorSettings as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
     render(<FederationSection />);
     await waitFor(() => expect(getActorSettings).toHaveBeenCalled());
+
+    expect(await screen.findByText('Federation')).toBeInTheDocument();
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    // The working cards are still absent, so this is the failure state.
     expect(screen.queryByText('Federation identity')).not.toBeInTheDocument();
+  });
+
+  it('retries loading when Try again is clicked', async () => {
+    (getActorSettings as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    render(<FederationSection />);
+    const retry = await screen.findByRole('button', { name: 'Try again' });
+
+    (getActorSettings as jest.Mock).mockResolvedValueOnce(mockActor);
+    fireEvent.click(retry);
+
+    expect(await screen.findByText('Federation identity')).toBeInTheDocument();
   });
 
   describe('LicenseTokenCard', () => {

--- a/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
@@ -99,7 +99,21 @@ describe('NetworkDirectory', () => {
         text: 'Could not load the clinic directory.',
       })
     );
-    expect(screen.getByText('No clinics are listed in the directory yet.')).toBeInTheDocument();
+    // Previously this fell through to the empty state, so an unreachable or
+    // switched-off federation service read as "nobody has listed yet".
+    expect(screen.getByText(/directory is unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText('No clinics are listed in the directory yet.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state, not the error state, when the directory is genuinely empty', async () => {
+    (listDirectory as jest.Mock).mockResolvedValueOnce([]);
+    render(<NetworkDirectory />);
+    expect(
+      await screen.findByText('No clinics are listed in the directory yet.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/directory is unavailable/i)).not.toBeInTheDocument();
   });
 
   it('follows a clinic and notifies success', async () => {

--- a/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
+++ b/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
@@ -58,6 +58,10 @@ const NetworkDirectory = () => {
   const [clinics, setClinics] = useState<APDirectoryClinic[]>([]);
   const [loading, setLoading] = useState(true);
   const [followingUri, setFollowingUri] = useState<string | null>(null);
+  // Distinct from "no clinics": a failed load used to fall through to the empty
+  // state, so an unreachable or disabled federation service read as "nobody has
+  // listed yet" and looked like the feature was simply doing nothing.
+  const [unavailable, setUnavailable] = useState(false);
 
   const load = useCallback(async () => {
     // No setLoading(true) here: this runs once from the mount effect and
@@ -66,7 +70,9 @@ const NetworkDirectory = () => {
     try {
       const data = await listDirectory();
       setClinics(data);
+      setUnavailable(false);
     } catch {
+      setUnavailable(true);
       notify('error', {
         title: 'Directory unavailable',
         text: 'Could not load the clinic directory.',
@@ -113,7 +119,13 @@ const NetworkDirectory = () => {
         and messaging with them.
       </div>
       {renderState === 'loading' && <div className={TEXT_MUTED}>Loading...</div>}
-      {renderState === 'empty' && (
+      {renderState === 'empty' && unavailable && (
+        <div className={TEXT_MUTED}>
+          The clinic directory is unavailable. Federation may be switched off on this instance, or
+          the directory service cannot be reached.
+        </div>
+      )}
+      {renderState === 'empty' && !unavailable && (
         <div className={TEXT_MUTED}>No clinics are listed in the directory yet.</div>
       )}
       {renderState === 'ready' && (

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
@@ -805,7 +805,30 @@ const FederationSection = () => {
     return <div className="min-h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />;
   }
 
-  if (!actor) return null;
+  // Never render nothing. Returning null meant that when federation is switched
+  // off on the instance, or the API cannot be reached, the whole section
+  // silently disappeared from Settings and the only signal was a toast that had
+  // already faded - indistinguishable from the feature not existing, which is
+  // exactly how it was reported.
+  if (!actor) {
+    return (
+      <SectionCard title="Federation">
+        <div className={TEXT_MUTED}>
+          Federation settings could not be loaded. Federation may be switched off on this instance,
+          or the API cannot be reached.
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={loadActor}
+            className="text-body-4 text-text-primary underline underline-offset-2"
+          >
+            Try again
+          </button>
+        </div>
+      </SectionCard>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

Federation looks broken on dev, and the UI actively hides why.

Testing `dev.yosemitecrew.com` end to end after #1762 landed:

1. `/settings` renders no Federation section at all. `FederationSection` returns `null` when the actor fetch fails, so the whole section disappears and the only signal is an error toast that fades after a few seconds.
2. `/network` renders "No clinics are listed in the directory yet." on a failed load, because the catch falls through to the empty state. An unreachable or switched-off service is indistinguishable from a genuinely empty directory.

The underlying cause is configuration, not code (details below), but in both cases the UI reports the wrong thing, so the feature reads as missing or silently doing nothing.

## What is the new behavior?

- `FederationSection` renders an explanatory card instead of nothing: it states that federation may be switched off on this instance or the API cannot be reached, and offers a Try again action that re-runs the load.
- `NetworkDirectory` tracks the failure separately from emptiness and renders a distinct message for each.

Both existing tests asserted the old behaviour by name (`renders nothing when getActorSettings rejects`, and an assertion that the failure path shows the empty message). Both are rewritten, and cases are added for the retry path and for a genuinely empty directory.

## Related Issue(s)

Follows YosemiteCrew/Yosemite-Crew#1762.

## Validation performed

- `pnpm --filter frontend run test "federation"` - 61 tests, 3 suites, passing.
- Type-check clean. Lint clean at `--max-warnings=0` on the changed files.
- Full frontend suite: 951 of 953 suites pass. The two failures (`IdexxWorkspace`, `AddCompanionCentralModal`) are 30s-timeout flakes under parallel load in files this branch does not touch; both pass in isolation, 171 tests.

## Deployment findings (no code change, needs infra)

Testing against the live environments turned up three configuration gaps that keep federation switched off end to end. All three are the intended fail-closed defaults, so nothing here is a defect - the feature has simply never been provisioned.

1. **`devapi.yosemitecrew.com` has no `AP_ENABLED=true`.** Every `/ap` route returns `{"error":"Federation is disabled on this instance"}`. Confirmed at `GET /ap/organizations/<orgId>`. `AP_BASE_URL` and `AP_LICENSE_AUTHORITY_URL` will also be needed.
2. **SuperAdmin has no `AP_SIGNING_KEY`.** `GET https://admin.yosemitecrew.com/api/directory` returns `{"error":"AP signing not configured"}` - the 503 branch added in SuperAdmin#183, doing exactly the job it was written for. Without the key SuperAdmin cannot sign licence tokens.
3. **No licence tokens have ever been issued.** The SuperAdmin AP Federation page reports 0 issued, 0 active, 0 revoked. Since every outbound federation action requires a valid licence, nothing can federate and the directory is necessarily empty.

Order to bring it up: set `AP_SIGNING_KEY` on SuperAdmin, issue a licence token for the org and its instance domain, set `AP_ENABLED=true` plus the two URLs on the API, then paste the token into the clinic's Federation settings.
