### PR TITLE
fix(frontend): let Safari load the hero video by dropping the source media gate

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -475,6 +475,20 @@ describe('motion primitives', () => {
     expect(container.querySelector('video')).not.toBeInTheDocument();
   });
 
+  it('HeroVideo leaves the source ungated so WebKit can select it', () => {
+    // A media attribute here is not a safe optimisation. WebKit evaluates it during
+    // the initial resource selection, before a render-blocking stylesheet has resolved
+    // styles, reads it as not matching and rejects the only candidate source. The
+    // element then sits in NETWORK_NO_SOURCE, which is terminal, so the loop never
+    // loads in Safari on any landing page. Reduced motion is guarded by the unmount
+    // above and by the prefers-reduced-motion rule in marketing.css instead.
+    const { container } = render(<HeroVideo src="https://x/v.mp4" />);
+    const source = container.querySelector('video > source') as HTMLSourceElement;
+    expect(source).toBeInTheDocument();
+    expect(source.getAttribute('src')).toBe('https://x/v.mp4');
+    expect(source.hasAttribute('media')).toBe(false);
+  });
+
   it('Tilt flattens when the cursor leaves the card', () => {
     render(
       <Tilt max={6}>

--- a/apps/frontend/src/app/features/marketing/site/marketing.css
+++ b/apps/frontend/src/app/features/marketing/site/marketing.css
@@ -246,8 +246,14 @@
    cannot know prefers-reduced-motion, so the markup ships either way and a reader
    who asked for less motion would otherwise watch it paint before it disappears.
    Hiding it here means it never paints for them; the component still removes it,
-   which is what stops the playback (display alone does not), and the media
-   attribute on the <source> is what stops the download when scripting never runs.
+   which is what stops the playback (display alone does not).
+
+   This rule and that unmount are the whole guard. The <source> deliberately
+   carries no media attribute: gating it on (prefers-reduced-motion: no-preference)
+   also stopped the download for everyone on Safari, because WebKit evaluates that
+   query during the initial resource selection and lands the element in a terminal
+   NETWORK_NO_SOURCE it never retries. When scripting never runs, a reduced-motion
+   reader now fetches the file and never sees it, which is the cheaper failure.
 
    The scrim selector is scoped to the one HeroVideo renders beside its video.
    The attribute is not exclusive: PetParents places its own standalone

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -330,12 +330,17 @@ export function HeroVideo({ src, poster, position = 'center 42%' }: Readonly<Her
         onError={() => setFailed(true)}
         style={{ ...HERO_VIDEO_STYLE, objectPosition: position }}
       >
-        {/* The media gate stops the FETCH for reduced-motion readers even when
-            hydration never runs (scripting off, a blocked bundle): a source whose
-            media query does not match is never selected. Browsers without media
-            support on video sources ignore it and fall back to the CSS guard
-            plus the unmount above. */}
-        <source src={src} type="video/mp4" media="(prefers-reduced-motion: no-preference)" />
+        {/* No `media` gate on this source. It used to carry
+            media="(prefers-reduced-motion: no-preference)" so the fetch never started
+            for reduced-motion readers, but WebKit evaluates a source's media query
+            during the initial resource selection - before a render-blocking stylesheet
+            has resolved styles - decides it does not match, and rejects the only
+            candidate. That leaves the element in NETWORK_NO_SOURCE, which is terminal:
+            Safari never re-selects, so the loop never loaded on any landing page while
+            matchMedia reported the very same query as matching a moment later.
+            Reduced motion is still honoured twice over - the CSS guard hides this pair
+            from first paint, and the unmount above is what stops playback. */}
+        <source src={src} type="video/mp4" />
       </video>
       <div data-hero-scrim="" style={HERO_SCRIM_STYLE} />
     </div>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The ambient hero loop does not play in Safari on any marketing landing page. Every Safari visitor sees the static poster where the video should be, on /, /pet-parents and /pet-businesses, on every fresh load. Chrome is unaffected, which is why this was invisible in review.

It is not an autoplay refusal. The element never gets a source at all - `networkState` 3 (`NETWORK_NO_SOURCE`), `currentSrc` empty, `readyState` 0 - so there is nothing for the autoplay policy to allow or block:

```
{"net":3,"ready":0,"src":"NONE","paused":true,"t":0,"mediaMatches":true}
```

The cause is the `media="(prefers-reduced-motion: no-preference)"` attribute added to the `<source>` in #2476. WebKit evaluates a source's media query during the initial resource selection, before a render blocking stylesheet has resolved styles, reads it as not matching, and rejects the only candidate. `NETWORK_NO_SOURCE` is terminal, so Safari never re-selects - even though `matchMedia` reports that exact query as matching moments later, and a manual `video.load()` selects and plays it:

```
{"phase":"load() WITH media attr","currentSrc":"SELECTED","netState":1,"ready":4,"paused":false,"t":3.73}
```

Isolated with two videos parsed into the same document, behind the same render blocking stylesheet, same file, same Safari:

| `<source>` | networkState | source selected | playing |
| --- | --- | --- | --- |
| with `media="(prefers-reduced-motion: no-preference)"` | 3, NETWORK_NO_SOURCE | none | no |
| without it | 1, idle | selected | yes, t=3.97 |

## What is the new behavior?

The `<source>` carries no `media` attribute, so WebKit selects it and the loop plays in Safari again.

Reduced motion is still honoured twice over, so nothing regresses for those readers:

- the `prefers-reduced-motion` rule in `marketing.css` hides the video and its scrim from first paint
- `HeroVideo` unmounting the element is what actually stops playback

What is given up is the narrow case the attribute bought - not fetching the file when scripting never runs. That is deliberate: it was costing every Safari visitor the video. If the fetch gate is wanted back later it has to be done by mounting the `<source>` client side after reading the preference, not by an attribute the parser evaluates too early. Both the component and the CSS comment now record why, so it is not reintroduced as an optimisation.

**Impact area:** apps/frontend, marketing landing pages only. No API, schema, or shared package changes.

**Validation performed:**

- `npx tsc --noEmit` from apps/frontend - exit 0, no output
- `pnpm --filter frontend run lint` - exit 0, no output
- `pnpm --filter frontend run test -- --testPathPatterns="marketing/site/motion"` - 48 passed, 2 suites
- New regression test asserts the source carries no `media` attribute. Mutation checked: re-adding the attribute makes it fail, so it is not a green-by-absence test
- Aikido SAST and secrets scan on the changed component - no issues
- Reproduced and verified against the deployed dev site in Safari 26.5.2

Ruled out by direct test in the same Safari before landing on this cause, all of which autoplay correctly: the CDN asset and its H.264 profile, `opacity: 0.3` and `0.16`, the `blur(1px) saturate() brightness()` filter, the scrim layered over the video, and six DOM insertion patterns including React style creation and remount. Also ruled out: CSP (`media-src` allows the CloudFront host), service workers (none), Safari content blockers and extensions (none installed), Low Power Mode and macOS Reduce Motion (both off).

One note for anyone verifying this in CI or a headless run: Playwright's WebKit ships with the autoplay policy disabled - it will autoplay an unmuted video - so it does not reproduce the failure and is not a valid check for this.

## Related Issue(s)

Fixes #2488
