### PR TITLE
fix(backend): reuse one PDF browser and stop leaking Chromium on render failure

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -2,10 +2,21 @@ import "dotenv/config";
 import { createApp } from "./app";
 import { initQueues } from "./queues";
 import { configureStreamUploadPolicy } from "./config/stream-upload-policy";
+import { closePdfBrowser } from "./services/formPDF.service";
 import logger from "./utils/logger";
 import "./workers";
 
 const PORT = process.env.PORT || 3000;
+
+// The PDF renderer keeps one shared Chromium alive; close it before exiting so
+// a pm2 restart never orphans the browser process. `once` keeps a second
+// signal on its default terminate behaviour.
+const shutdown = (signal: NodeJS.Signals) => {
+  logger.info(`Received ${signal}, shutting down`);
+  void closePdfBrowser().finally(() => process.exit(0));
+};
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);
 
 // NOSONAR – top-level await not supported in this runtime
 async function startServer() {

--- a/apps/backend/src/services/formPDF.service.ts
+++ b/apps/backend/src/services/formPDF.service.ts
@@ -1,10 +1,15 @@
 import { FormField } from "@yosemite-crew/types";
 import fs from "node:fs";
-import { chromium } from "playwright";
+import { chromium, type Browser } from "playwright";
+import {
+  addCachedPromise,
+  type CachedPromise,
+} from "src/utils/cached-promise-cache";
 import {
   resolveDocumentPdfTemplate,
   type DocumentPdfTemplateKind,
 } from "src/services/document-pdf-template-registry.service";
+import logger from "src/utils/logger";
 
 export interface PdfField {
   label: string;
@@ -232,31 +237,108 @@ function applyTemplate(
   return html;
 }
 
+// Templates are static files on disk — cache their contents so repeated renders
+// do not re-read them, and read asynchronously so the event loop is never blocked.
+const TEMPLATE_CACHE_TTL_MS = 60 * 60 * 1000;
+const TEMPLATE_CACHE_MAX_ENTRIES = 16;
+const templateCache = new Map<string, CachedPromise<string>>();
+
+const readTemplate = (templatePath: string): Promise<string> =>
+  addCachedPromise(
+    templateCache,
+    templatePath,
+    TEMPLATE_CACHE_TTL_MS,
+    () => fs.promises.readFile(templatePath, "utf8"),
+    {
+      maxEntries: TEMPLATE_CACHE_MAX_ENTRIES,
+      pruneIntervalMs: TEMPLATE_CACHE_TTL_MS,
+    },
+  );
+
+export const clearPdfTemplateCache = (): void => {
+  templateCache.clear();
+};
+
+// Launching Chromium costs hundreds of milliseconds and hundreds of MB of RSS,
+// so one browser is shared across renders; each render gets its own context,
+// which gives the same isolation as a fresh browser at a fraction of the cost.
+let sharedBrowserPromise: Promise<Browser> | null = null;
+
+const launchSharedBrowser = (): Promise<Browser> => {
+  const launched: Promise<Browser> = chromium
+    .launch()
+    .catch((error: unknown) => {
+      // Do not cache a failed launch — the next render should retry.
+      if (sharedBrowserPromise === launched) {
+        sharedBrowserPromise = null;
+      }
+      throw error;
+    });
+  return launched;
+};
+
+const getSharedBrowser = async (): Promise<Browser> => {
+  const existing = sharedBrowserPromise;
+  if (existing) {
+    const browser = await existing;
+    if (browser.isConnected()) {
+      return browser;
+    }
+    // The browser crashed or was closed externally — replace it, unless a
+    // concurrent caller already has.
+    if (sharedBrowserPromise === existing) {
+      sharedBrowserPromise = null;
+    }
+  }
+  sharedBrowserPromise ??= launchSharedBrowser();
+  return sharedBrowserPromise;
+};
+
+export const closePdfBrowser = async (): Promise<void> => {
+  const existing = sharedBrowserPromise;
+  sharedBrowserPromise = null;
+  if (!existing) return;
+  try {
+    const browser = await existing;
+    await browser.close();
+  } catch (error) {
+    logger.warn("PDF browser was not closed cleanly", { error });
+  }
+};
+
 export async function renderPdf(
   vm: PdfViewModel,
   options?: PdfRenderOptions,
 ): Promise<Buffer> {
   const templateKind = options?.templateKind ?? "FORM";
   const template = resolveDocumentPdfTemplate(templateKind);
-  const templateHtml = fs.readFileSync(template.path, "utf8");
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+  const templateHtml = await readTemplate(template.path);
+  const browser = await getSharedBrowser();
+  const context = await browser.newContext();
 
-  await page.setContent(
-    applyTemplate(vm, templateHtml, template.label, options),
-    {
-      waitUntil: "load",
-    },
-  );
+  try {
+    const page = await context.newPage();
 
-  const pdf = await page.pdf({
-    format: "A4",
-    printBackground: true,
-  });
+    await page.setContent(
+      applyTemplate(vm, templateHtml, template.label, options),
+      {
+        waitUntil: "load",
+      },
+    );
 
-  await browser.close();
-
-  return pdf;
+    return await page.pdf({
+      format: "A4",
+      printBackground: true,
+    });
+  } finally {
+    // Teardown must run even when rendering throws, or the Chromium resources
+    // leak; a close failure must not mask the render error.
+    try {
+      await context.close();
+    } catch (error) {
+      logger.warn("PDF browser context was not closed cleanly", { error });
+    }
+  }
 }
 
 export async function generateFormSubmissionPdf({

--- a/apps/backend/test/services/formPDF.service.test.ts
+++ b/apps/backend/test/services/formPDF.service.test.ts
@@ -5,6 +5,8 @@ import {
   buildPdfViewModel,
   renderPdf,
   generateFormSubmissionPdf,
+  closePdfBrowser,
+  clearPdfTemplateCache,
   PdfViewModel,
 } from "../../src/services/formPDF.service";
 import { FormField } from "@yosemite-crew/types";
@@ -12,16 +14,27 @@ import { FormField } from "@yosemite-crew/types";
 // ----------------------------------------------------------------------
 // 1. MOCKS
 // ----------------------------------------------------------------------
-jest.mock("node:fs");
-jest.mock("playwright");
+jest.mock("node:fs", () => {
+  const mockFs = { promises: { readFile: jest.fn() } };
+  return { __esModule: true, ...mockFs, default: mockFs };
+});
+jest.mock("playwright", () => ({
+  chromium: { launch: jest.fn() },
+}));
 
 const mockPage = {
   setContent: jest.fn(),
   pdf: jest.fn(),
 };
 
-const mockBrowser = {
+const mockContext = {
   newPage: jest.fn(),
+  close: jest.fn(),
+};
+
+const mockBrowser = {
+  newContext: jest.fn(),
+  isConnected: jest.fn(),
   close: jest.fn(),
 };
 
@@ -31,11 +44,16 @@ const mockBrowser = {
 describe("FormPDFService", () => {
   const mockDate = new Date("2023-01-01T12:00:00.000Z");
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Reset the module-level browser singleton and template cache so every
+    // test starts from a cold renderer.
+    await closePdfBrowser();
+    clearPdfTemplateCache();
     jest.clearAllMocks();
-    // Default mock implementation for fs.readFileSync
+
+    // Default mock implementation for fs.promises.readFile
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (fs.readFileSync as any).mockReturnValue(
+    (fs.promises.readFile as any).mockResolvedValue(
       "<html>{{brandSection}}{{title}} {{submittedAt}} {{sections}} {{templateLabel}}</html>",
     );
 
@@ -45,7 +63,13 @@ describe("FormPDFService", () => {
 
     // FIX: Cast the mock function itself to any to avoid 'never' inference
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (mockBrowser.newPage as any).mockResolvedValue(mockPage);
+    (mockBrowser.newContext as any).mockResolvedValue(mockContext);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockBrowser.isConnected as any).mockReturnValue(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockContext.newPage as any).mockResolvedValue(mockPage);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockPage.pdf as any).mockResolvedValue(Buffer.from("mock-pdf-buffer"));
@@ -332,8 +356,9 @@ describe("FormPDFService", () => {
       const result = await renderPdf(mockVm);
 
       expect(chromium.launch).toHaveBeenCalled();
-      expect(mockBrowser.newPage).toHaveBeenCalled();
-      expect(fs.readFileSync).toHaveBeenCalledWith(
+      expect(mockBrowser.newContext).toHaveBeenCalled();
+      expect(mockContext.newPage).toHaveBeenCalled();
+      expect(fs.promises.readFile).toHaveBeenCalledWith(
         expect.stringContaining("pdf-templates/form.html"),
         "utf8",
       );
@@ -352,7 +377,9 @@ describe("FormPDFService", () => {
         format: "A4",
         printBackground: true,
       });
-      expect(mockBrowser.close).toHaveBeenCalled();
+      // The per-render context is torn down; the shared browser stays open.
+      expect(mockContext.close).toHaveBeenCalled();
+      expect(mockBrowser.close).not.toHaveBeenCalled();
       expect(result).toBeInstanceOf(Buffer);
     });
 
@@ -368,7 +395,7 @@ describe("FormPDFService", () => {
         },
       });
 
-      expect(fs.readFileSync).toHaveBeenCalledWith(
+      expect(fs.promises.readFile).toHaveBeenCalledWith(
         expect.stringContaining("pdf-templates/soap-note.html"),
         "utf8",
       );
@@ -384,6 +411,111 @@ describe("FormPDFService", () => {
         expect.stringContaining("SOAP note"),
         { waitUntil: "load" },
       );
+    });
+  });
+
+  /* ========================================================================
+   * BROWSER LIFECYCLE & TEARDOWN
+   * ======================================================================*/
+  describe("browser lifecycle and teardown", () => {
+    const mockVm: PdfViewModel = {
+      title: "Lifecycle",
+      submittedAt: "2023-01-01",
+      sections: [{ title: "S1", fields: [{ label: "L1", value: "V1" }] }],
+    };
+
+    it("reuses one shared browser across renders", async () => {
+      await renderPdf(mockVm);
+      await renderPdf(mockVm);
+
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+      expect(mockBrowser.newContext).toHaveBeenCalledTimes(2);
+      expect(mockBrowser.close).not.toHaveBeenCalled();
+    });
+
+    it("caches the template read across renders of the same kind", async () => {
+      await renderPdf(mockVm);
+      await renderPdf(mockVm);
+
+      expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("relaunches when the shared browser has disconnected", async () => {
+      await renderPdf(mockVm);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockBrowser.isConnected as any).mockReturnValue(false);
+      await renderPdf(mockVm);
+
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache a failed launch", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (chromium.launch as any).mockRejectedValueOnce(new Error("no chromium"));
+
+      await expect(renderPdf(mockVm)).rejects.toThrow("no chromium");
+
+      const result = await renderPdf(mockVm);
+      expect(result).toBeInstanceOf(Buffer);
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+    });
+
+    it("closes the context when setContent throws, leaving the browser open", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockPage.setContent as any).mockRejectedValueOnce(
+        new Error("bad template"),
+      );
+
+      await expect(renderPdf(mockVm)).rejects.toThrow("bad template");
+
+      expect(mockContext.close).toHaveBeenCalledTimes(1);
+      expect(mockBrowser.close).not.toHaveBeenCalled();
+    });
+
+    it("closes the context when pdf generation throws", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockPage.pdf as any).mockRejectedValueOnce(new Error("render timeout"));
+
+      await expect(renderPdf(mockVm)).rejects.toThrow("render timeout");
+
+      expect(mockContext.close).toHaveBeenCalledTimes(1);
+      expect(mockBrowser.close).not.toHaveBeenCalled();
+    });
+
+    it("keeps the render error when context teardown also fails", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockPage.pdf as any).mockRejectedValueOnce(new Error("render timeout"));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockContext.close as any).mockRejectedValueOnce(
+        new Error("close failed"),
+      );
+
+      await expect(renderPdf(mockVm)).rejects.toThrow("render timeout");
+    });
+
+    it("closePdfBrowser closes the shared browser", async () => {
+      await renderPdf(mockVm);
+
+      await closePdfBrowser();
+
+      expect(mockBrowser.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("closePdfBrowser is a no-op when no browser was launched", async () => {
+      await closePdfBrowser();
+
+      expect(mockBrowser.close).not.toHaveBeenCalled();
+    });
+
+    it("closePdfBrowser tolerates a browser that fails to close", async () => {
+      await renderPdf(mockVm);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockBrowser.close as any).mockRejectedValueOnce(
+        new Error("already gone"),
+      );
+
+      await expect(closePdfBrowser()).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Every PDF render in `apps/backend/src/services/formPDF.service.ts` launches a fresh Chromium process (`chromium.launch()` per call, roughly 300-800 ms and 150-300 MB RSS per document), and `browser.close()` is not inside a `finally`. If `page.setContent()` or `page.pdf()` throws (bad template HTML, a load timeout), the Chromium process is orphaned permanently. On the 1.9 GB dev API box with no swap, repeated failures accumulate orphaned processes until the API is OOM-killed instead of returning a 500. The HTML template is also read with `fs.readFileSync` on every render, blocking the event loop.

## What is the new behavior?

**What changed**

- `renderPdf` now runs inside `try/finally`, so teardown always executes; a teardown failure is caught and logged so it can never mask the original render error.
- One shared browser is lazily launched and reused; each render gets a fresh `browser.newContext()` (same isolation as a new browser at a fraction of the cost). A failed launch is never cached (the next render retries), a disconnected or crashed browser is relaunched, and two concurrent callers racing a dead browser cannot double-launch.
- `main.ts` closes the shared browser on SIGTERM/SIGINT via `process.once`, so a pm2 restart cannot orphan it; a second signal still force-kills.
- Template reads moved to `fs.promises.readFile` behind the existing `addCachedPromise` helper (1 h TTL), so the five static templates are read once, not per render.

**Why**

A burst of failed renders could take the whole API down with it (memory exhaustion rather than a 500), and the per-render launch cost dominated PDF latency.

**Impact area**

Backend only: PDF generation for form submissions and rendered clinical documents (`renderPdf`, `generateFormSubmissionPdf`, and their callers in `form.service.ts` and `rendered-document-renderer.service.ts` - call sites unchanged), plus process shutdown in `main.ts`.

**Validation performed**

- 153 tests pass: the rewritten `formPDF.service.test.ts` suite (26 tests, including 9 new lifecycle/throw-path cases: context closed when `setContent`/`pdf` throw with the browser left open, failed-launch retry, disconnect relaunch, template caching, close-failure tolerance) plus both consumer suites (`form.service`, `rendered-document-renderer.service`).
- Coverage on the touched service rose on every metric: 98.18 -> 98.6 statements, 87.5 -> 90.47 branch, 100 functions (baseline measured by stashing).
- `npx tsc` clean (0 errors) and `pnpm --filter backend run lint` exit 0.
- Aikido SAST/secrets scan on the three changed files: one path-traversal pattern match on the template `readFile`, verified false positive - the path comes from a hardcoded registry keyed by a closed 5-literal union type, no request data reaches it.

## Related Issue(s)

Fixes #2486
