### PR TITLE
fix(repo): resolve the open CodeQL alerts on backend logging and the Sonar CI script

### DIFF
--- a/apps/backend/src/controllers/app/chatWebhook.controller.ts
+++ b/apps/backend/src/controllers/app/chatWebhook.controller.ts
@@ -36,8 +36,10 @@ export const scanMessageAttachments = async (
 
     const result = await scanAttachmentUrl(url);
     if (!result.clean) {
+      // The message id arrives in the webhook payload; strip line breaks so it
+      // cannot forge additional log lines.
       logger.warn(
-        `Unsafe chat attachment on message ${messageId} (${result.threat}); deleting message`,
+        `Unsafe chat attachment on message ${messageId.replace(/[\n\r]+/g, " ")} (${result.threat}); deleting message`,
       );
       try {
         const client = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);

--- a/apps/backend/src/controllers/web/appointment.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.controller.ts
@@ -132,7 +132,12 @@ export const AppointmentController = {
     try {
       const { appointmentId } = req.params;
       logger.info("Request Path: ", req.params);
-      logger.info("Accepting appointment with ID:", appointmentId);
+      // The id is caller-supplied; strip line breaks so it cannot forge
+      // additional log lines.
+      logger.info(
+        "Accepting appointment with ID:",
+        appointmentId.replace(/[\n\r]+/g, " "),
+      );
       const dto = req.body as AppointmentRequestDTO; // partial FHIR update fields
 
       const result = await AppointmentService.approveRequestedFromPms(

--- a/apps/backend/src/services/companion.service.ts
+++ b/apps/backend/src/services/companion.service.ts
@@ -235,7 +235,11 @@ const ensureCodeExists = async (code: string, type: "SPECIES" | "BREED") => {
   });
 
   if (!entry) {
-    logger.warn(`Invalid ${type} code provided: ${code}`);
+    // The code is caller-supplied; strip line breaks so it cannot forge
+    // additional log lines.
+    logger.warn(
+      `Invalid ${type} code provided: ${code.replace(/[\n\r]+/g, " ")}`,
+    );
     throw new CompanionServiceError(`Invalid ${type.toLowerCase()} code.`, 400);
   }
 };

--- a/apps/backend/test/controllers/chatWebhook.controller.test.ts
+++ b/apps/backend/test/controllers/chatWebhook.controller.test.ts
@@ -19,6 +19,7 @@ import {
   scanMessageAttachments,
 } from "src/controllers/app/chatWebhook.controller";
 import { scanAttachmentUrl } from "src/services/attachmentScanner.service";
+import logger from "src/utils/logger";
 import type { Request, Response } from "express";
 
 const mockScan = scanAttachmentUrl as unknown as jest.Mock;
@@ -120,6 +121,19 @@ describe("scanMessageAttachments", () => {
       message: { id: "m1", attachments: [{ image_url: "u" }] },
     });
     expect(mockDeleteMessage).toHaveBeenCalledWith("m1", true);
+  });
+
+  it("strips line breaks from the message id before logging it", async () => {
+    const warn = jest.spyOn(logger, "warn").mockImplementation(() => logger);
+    mockScan.mockResolvedValue({ clean: false, threat: "bad" });
+    await scanMessageAttachments({
+      type: "message.new",
+      message: { id: "m1\nforged line", attachments: [{ asset_url: "u" }] },
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("m1 forged line");
+    expect(warn.mock.calls[0][0]).not.toContain("\n");
+    warn.mockRestore();
   });
 
   it("swallows a delete failure", async () => {

--- a/scripts/ci/sonar-thresholds.mjs
+++ b/scripts/ci/sonar-thresholds.mjs
@@ -63,6 +63,25 @@ export const METRICS = ['coverage', 'duplicated_lines_density', 'violations'];
 // reason not to: the only read in this file has to be visibly constant.
 const REPORT_TASK = '.scannerwork/report-task.txt';
 
+// The one Sonar host this repository scans to. report-task.txt names a server
+// URL too, but honouring it would send SONAR_TOKEN (Basic auth on every poll)
+// to whatever host a tampered .scannerwork names. So the file's value is
+// checked against this pin and then discarded; every request below uses the
+// constant.
+export const SONAR_SERVER = 'https://sonarcloud.io';
+
+/**
+ * Why the report's serverUrl must equal the pin, as a failure message - or
+ * null when it does. Split out so the refusal has a test.
+ */
+export function pinnedServerFailure(serverUrl) {
+  if (serverUrl === SONAR_SERVER) return null;
+  return (
+    `${REPORT_TASK} names server ${serverUrl}, but this repository scans to ` +
+    `${SONAR_SERVER}. Refusing to send SONAR_TOKEN anywhere else.`
+  );
+}
+
 /**
  * Parse the scanner's report-task.txt.
  *
@@ -310,8 +329,14 @@ async function main(argv) {
     }
   }
 
+  const pinFailure = pinnedServerFailure(report.serverUrl);
+  if (pinFailure) {
+    process.stderr.write(`sonar-thresholds: ${pinFailure}\n`);
+    return 1;
+  }
+
   const scope = analysisScope(report.dashboardUrl);
-  const task = await waitForAnalysis(report.serverUrl, report.ceTaskId);
+  const task = await waitForAnalysis(SONAR_SERVER, report.ceTaskId);
 
   // The report file names the project and the task independently, and a stale
   // .scannerwork picked up from the repository root would agree with itself
@@ -326,7 +351,7 @@ async function main(argv) {
   }
 
   const query = measuresQuery(report.projectKey, scope, METRICS);
-  const { component } = await getJson(`${report.serverUrl}/api/measures/component?${query}`);
+  const { component } = await getJson(`${SONAR_SERVER}/api/measures/component?${query}`);
   const measures = component.measures ?? [];
 
   const shown = (metric) =>

--- a/scripts/ci/sonar-thresholds.test.mjs
+++ b/scripts/ci/sonar-thresholds.test.mjs
@@ -14,10 +14,12 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  SONAR_SERVER,
   analysisScope,
   checkMeasures,
   measuresQuery,
   parseReportTask,
+  pinnedServerFailure,
 } from './sonar-thresholds.mjs';
 
 /** The limits the workflow passes, spelled once. */
@@ -51,6 +53,18 @@ describe('reading report-task.txt', () => {
     const report = parseReportTask('#comment\n\n!bang\nceTaskUrl=https\\://x/y?id\\=a=b\n');
     assert.equal(report.ceTaskUrl, 'https://x/y?id=a=b');
     assert.equal(Object.keys(report).length, 1);
+  });
+});
+
+describe('pinning the server', () => {
+  it('accepts the one host this repository scans to', () => {
+    assert.equal(pinnedServerFailure(SONAR_SERVER), null);
+  });
+
+  it('refuses any other host, naming both sides', () => {
+    const failure = pinnedServerFailure('https://sonar.attacker.example');
+    assert.match(failure, /https:\/\/sonar\.attacker\.example/);
+    assert.match(failure, /Refusing to send SONAR_TOKEN/);
   });
 });
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Four open CodeQL alerts on the default branch describe real weaknesses:

- js/log-injection (alerts 1314, 1315, 1316): three log statements interpolate caller-supplied values verbatim. A value containing a line break can forge additional log lines - the Stream webhook message id in `chatWebhook.controller.ts`, the `appointmentId` route param in `appointment.controller.ts`, and the species/breed code in `companion.service.ts`.
- js/file-access-to-http (alert 1306): `scripts/ci/sonar-thresholds.mjs` polls whatever server URL `.scannerwork/report-task.txt` names, attaching `SONAR_TOKEN` as Basic auth to every request. A tampered report file could redirect the token to an arbitrary host.

## What is the new behavior?

- The three log statements strip line breaks (`replace(/[\n\r]+/g, " ")`) from the caller-supplied value before logging, so a crafted value can no longer forge log lines. A new test asserts the chat webhook warning comes out newline-free.
- The Sonar threshold script pins its API host to `https://sonarcloud.io` (`SONAR_SERVER`). The report file's `serverUrl` is checked against the pin and then discarded; every request uses the constant, so the token can no longer be redirected. The refusal path is covered by new tests for `pinnedServerFailure`.

Validation: `pnpm --filter backend run type-check` clean; targeted jest (`chatWebhook.controller|companion.service|appointment.controller`) 175/175 passing; `node --test scripts/ci/sonar-thresholds.test.mjs` 19/19 passing; Aikido opengrep + gitleaks scans of the changed files clean (only the known auto-ignored Prisma NoSQL FP pattern on pre-existing lines).

The remaining 15 open alerts (js/sensitive-get-query) are name-heuristic false positives - opaque resource UUIDs or Zod-parsed enums on authenticated, org-scoped routes, five of them `req.params` path segments the rule mistakes for query strings. They are being dismissed with per-alert verified comments, matching the prior triage of alerts 1319/1321/1008-1011.

## Related Issue(s)

No standalone issue; this resolves the open code scanning alerts:
https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1314
https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1315
https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1316
https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1306
