### PR TITLE
fix(backend): read the revocation list in the shape the authority serves

### DIFF
--- a/apps/backend/src/services/ap-license.service.ts
+++ b/apps/backend/src/services/ap-license.service.ts
@@ -71,11 +71,18 @@ async function getRevokedJtis(): Promise<string[]> {
   ) {
     return revokedCache.value;
   }
-  const data = await fetchJson<{ revokedJtis: string[] }>(
+  // The authority serves a bare JSON array of revoked jti values - see
+  // SuperAdmin's app/api/ap/revoked.json/route.ts, which has shipped that shape
+  // since before this client existed. Reading it as `{ revokedJtis }` produced
+  // undefined, and the `.includes()` below then threw on EVERY verification, so
+  // no instance could ever be verified. The object form is still accepted in
+  // case the authority is changed later.
+  const data = await fetchJson<string[] | { revokedJtis?: string[] }>(
     `${authorityBase()}/api/ap/revoked.json`,
   );
-  revokedCache = { value: data.revokedJtis, fetchedAt: Date.now() };
-  return data.revokedJtis;
+  const jtis = Array.isArray(data) ? data : (data.revokedJtis ?? []);
+  revokedCache = { value: jtis, fetchedAt: Date.now() };
+  return jtis;
 }
 
 function base64urlDecode(str: string): Buffer {

--- a/apps/backend/test/services/ap-license.service.test.ts
+++ b/apps/backend/test/services/ap-license.service.test.ts
@@ -99,7 +99,8 @@ function makeToken(
 
 function mockFetch(opts?: { revoked?: string[]; jwks?: unknown }) {
   const jwks = opts?.jwks ?? { keys: [signingJwk] };
-  const revoked = { revokedJtis: opts?.revoked ?? [] };
+  // The authority serves a BARE ARRAY, which is what broke verification.
+  const revoked = opts?.revoked ?? [];
   (global.fetch as unknown as jest.Mock) = jest.fn((url: string) => {
     const body = url.includes("revoked") ? revoked : jwks;
     return Promise.resolve({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

Licence verification throws on every token, so no instance can ever federate.

SuperAdmin serves the revocation list as a bare JSON array of jti values, and has done since before this client was written:

```
GET https://admin.yosemitecrew.com/api/ap/revoked.json  ->  []
```

`getRevokedJtis` reads that response as `{ revokedJtis: string[] }`, so the value is `undefined`, and the membership test on the next line calls `.includes()` on it:

```ts
const revoked = await getRevokedJtis();   // undefined
if (revoked.includes(claims.jti))         // TypeError
```

`verifyLicenseToken` therefore throws for every token, `isLicenseTokenValid` returns false for every token, and every gate that depends on it - inbound Follow, inbound referral Offer, AgentTask, and each outbound sender - refuses. The federation trust model cannot admit anyone.

This is not reachable today only because `AP_ENABLED` is unset on the API, so the routes 404 before getting here. It would have surfaced as "still doesn't work" immediately after the environment was configured.

## What is the new behavior?

The client reads the array the authority actually serves, and still accepts the object form in case the authority changes later.

## Related Issue(s)

Follows YosemiteCrew/Yosemite-Crew#1762 and YosemiteCrew/SuperAdmin#183.

## Validation performed

- Verified against the live authority: `https://admin.yosemitecrew.com/api/ap/revoked.json` returns `[]`.
- The test mock served `{ revokedJtis: [...] }`, so it encoded the same wrong assumption as the client. The pair agreed with each other while disagreeing with the authority, which is why a fully green suite never caught this. The mock now serves the array.
- Mutation checked: with the corrected mock, reverting this fix fails 6 tests. Restoring it returns the suite to green.
- `pnpm --filter backend run test` - 426 suites, 10163 tests passing. Lint and type-check clean.

## Note for whoever configures the environment

`AP_LICENSE_AUTHORITY_URL` defaults to `https://api.yosemitecrew.com`, which is not where SuperAdmin is served. It must be set explicitly to `https://admin.yosemitecrew.com`, or the signing key and revocation list are fetched from the wrong host.
