### PR TITLE
fix(backend): default the licence authority to SuperAdmin, not this API

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -119,4 +119,4 @@ SUPERADMIN_CONTACT_INTAKE_KEY=""
 AP_BASE_URL=""                  # Full public URL of this instance, e.g. https://api.yosemitecrew.com
 AP_ENABLED="true"               # Set to "false" to disable AP endpoints
 AP_AUTO_APPROVE_FOLLOWS="false" # Set to "true" to auto-accept incoming Follow requests
-AP_LICENSE_AUTHORITY_URL=""     # Base URL for license JWK + revocation endpoints (default: https://api.yosemitecrew.com)
+AP_LICENSE_AUTHORITY_URL=""     # Base URL for license JWK + revocation endpoints, served by SuperAdmin (default: https://admin.yosemitecrew.com)

--- a/apps/backend/src/services/ap-license.service.ts
+++ b/apps/backend/src/services/ap-license.service.ts
@@ -39,8 +39,11 @@ let jwkCache: Cache<JWK[]> | null = null;
 let revokedCache: Cache<string[]> | null = null;
 
 function authorityBase(): string {
+  // The licence authority is SuperAdmin, not this API. Defaulting to the API's
+  // own host meant every deployment had to override this or fetch the signing
+  // key and revocation list from somewhere that does not serve them.
   return (
-    process.env.AP_LICENSE_AUTHORITY_URL ?? "https://api.yosemitecrew.com"
+    process.env.AP_LICENSE_AUTHORITY_URL ?? "https://admin.yosemitecrew.com"
   ).replace(/\/$/, "");
 }
 

--- a/apps/backend/test/services/ap-license.service.test.ts
+++ b/apps/backend/test/services/ap-license.service.test.ts
@@ -221,6 +221,71 @@ describe("ap-license.service", () => {
     });
   });
 
+  describe("authority host", () => {
+    // The signing key and revocation list are served by SuperAdmin, not by this
+    // API. Nothing asserted the host before, so a default pointing at the API's
+    // own origin verified nothing and no test noticed.
+    function captureFetchedUrls(): string[] {
+      const urls: string[] = [];
+      mockFetch();
+      const inner = global.fetch as unknown as jest.Mock;
+      (global.fetch as unknown as jest.Mock) = jest.fn((url: string) => {
+        urls.push(url);
+        return inner(url);
+      });
+      return urls;
+    }
+
+    it("fetches both licence endpoints from SuperAdmin by default", async () => {
+      const previous = process.env.AP_LICENSE_AUTHORITY_URL;
+      delete process.env.AP_LICENSE_AUTHORITY_URL;
+      const urls = captureFetchedUrls();
+      try {
+        await withFreshModule((mod) =>
+          mod.verifyLicenseToken(makeToken(), ACTOR_URI),
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.AP_LICENSE_AUTHORITY_URL;
+        } else {
+          process.env.AP_LICENSE_AUTHORITY_URL = previous;
+        }
+      }
+
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          "https://admin.yosemitecrew.com/api/ap/signing-key.json",
+          "https://admin.yosemitecrew.com/api/ap/revoked.json",
+        ]),
+      );
+    });
+
+    it("prefers an explicitly configured authority over the default", async () => {
+      const previous = process.env.AP_LICENSE_AUTHORITY_URL;
+      process.env.AP_LICENSE_AUTHORITY_URL = "https://authority.example/";
+      const urls = captureFetchedUrls();
+      try {
+        await withFreshModule((mod) =>
+          mod.verifyLicenseToken(makeToken(), ACTOR_URI),
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.AP_LICENSE_AUTHORITY_URL;
+        } else {
+          process.env.AP_LICENSE_AUTHORITY_URL = previous;
+        }
+      }
+
+      // The trailing slash is stripped rather than producing a double slash.
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          "https://authority.example/api/ap/signing-key.json",
+          "https://authority.example/api/ap/revoked.json",
+        ]),
+      );
+    });
+  });
+
   describe("isLicenseTokenValid", () => {
     it("returns false for a null token without fetching", async () => {
       const spy = jest.fn();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`AP_LICENSE_AUTHORITY_URL` falls back to `https://api.yosemitecrew.com`, which is this API rather than the licence authority:

```ts
// apps/backend/src/services/ap-license.service.ts:41-43
return (
  process.env.AP_LICENSE_AUTHORITY_URL ?? "https://api.yosemitecrew.com"
).replace(/\/$/, "");
```

The signing key and revocation list are served by SuperAdmin at `https://admin.yosemitecrew.com`. With the default in force, both fetches go to a host that does not serve those endpoints, so no licence can ever verify and every gate that depends on it (inbound Follow, inbound referral Offer, AgentTask, each outbound sender) refuses. Every deployment had to know to override the default to work at all.

`.env.example:122` documented the same wrong default, so anyone configuring an instance from it inherited the mistake.

Neither API box sets the variable today, so both are running on the wrong default. This is currently masked because `AP_ENABLED` is unset, which makes the federation routes 404 before reaching this code.

## What is the new behavior?

The default is the actual authority, `https://admin.yosemitecrew.com`, and the `.env.example` comment matches. An explicitly configured `AP_LICENSE_AUTHORITY_URL` still wins, so a self-hosted instance pointing at its own authority is unaffected.

**Why the wrong default survived a green suite:** no test asserted the host. The fetch mock matched on `url.includes("revoked")` and ignored the origin entirely, so the endpoint could have been on any host and every test still passed. This is the same shape of blind spot as #2495, where the mock and the client agreed with each other while disagreeing with the authority.

Two tests now pin it:

- the default resolves to SuperAdmin for both licence endpoints
- an explicit override still wins, with its trailing slash stripped rather than producing a double slash

## Impact area

Backend only, ActivityPub licence verification. No schema, no API surface, no frontend.

## Validation performed

- `apps/backend` ap-license suite: 25 tests passing (23 existing plus the 2 new).
- Mutation checked: reverting the default to `https://api.yosemitecrew.com` fails the new default test; restoring it returns the suite to green. The guard actually bites.
- Full backend suite run rather than the targeted file, because the new tests mutate `process.env` and restore it in `finally`: **437 suites, 10,535 tests passing**, no leakage into other suites.
- `npx tsc` clean (0 errors), `pnpm --filter backend run lint` exit 0, full pre-push gate passed.
- Live check: `https://admin.yosemitecrew.com/api/ap/revoked.json` returns `[]`; the same path on `api.yosemitecrew.com` does not serve the endpoint.

## Still outstanding after this merge

This removes the need for the override but does not set it. Per #2497, neither API box declares `AP_LICENSE_AUTHORITY_URL`, and no workflow deploys those boxes. Setting it explicitly is still the belt-and-braces step, and `AP_ENABLED` remains unset, so federation stays off until someone with box access turns it on.

## Related Issue(s)

Refs #2497
