### PR TITLE
feat(repo): project SOAP coded terms into VeNom/SNOMED FHIR codings

### DIFF
--- a/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
@@ -141,19 +141,18 @@ const serializeSoapNote = async (record: SoapNoteRecord) => {
 
 const serializeSoapNoteBundle = async (records: SoapNoteRecord[]) => {
   const bundle = clinicalArtifactFhirMapper.bundles.soapNotes(records);
-  // recordBundle maps records in order, so entries pair up index-for-index.
-  await Promise.all(
-    records.map(async (record, index) => {
-      const coded = await SoapCodedTermsFhirService.codedTermExtensions(
-        record.soapNote.diagnoses,
-      );
-      const resource = bundle.entry?.[index]?.resource as
-        Composition | undefined;
-      if (coded.length > 0 && resource) {
-        resource.extension = [...(resource.extension ?? []), ...coded];
-      }
-    }),
-  );
+  // One projection query set for the whole bundle; recordBundle maps records
+  // in order, so per-record extension lists pair up index-for-index.
+  const codedPerRecord =
+    await SoapCodedTermsFhirService.codedTermExtensionsForMany(
+      records.map((record) => record.soapNote.diagnoses),
+    );
+  codedPerRecord.forEach((coded, index) => {
+    const resource = bundle.entry?.[index]?.resource as Composition | undefined;
+    if (coded.length > 0 && resource) {
+      resource.extension = [...(resource.extension ?? []), ...coded];
+    }
+  });
   return bundle;
 };
 

--- a/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
@@ -10,6 +10,8 @@ import {
   ClinicalArtifactServiceError,
 } from "src/services/clinical-artifact.service";
 import { clinicalArtifactFhirMapper } from "src/services/fhir-clinical-artifact.mapper";
+import { SoapCodedTermsFhirService } from "src/services/soap-coded-terms.service";
+import type { SoapNoteRecord } from "@yosemite-crew/types";
 import { createFhirErrorHandler } from "src/controllers/web/fhir-controller.shared";
 import { resolveVerifiedUserId } from "src/utils/request";
 import type { PrescriptionActor } from "src/services/clinical-artifact.service";
@@ -121,6 +123,40 @@ const readAppointmentId = (value: string | undefined) => value?.trim() || "";
 
 const readEncounterId = (value: string | undefined) => value?.trim() || "";
 
+/**
+ * SOAP notes serialize through these so every response carries the typed
+ * coded-term projection (YC + usable VeNom/SNOMED translations) alongside the
+ * raw diagnoses channel. Derived per read; the stored record is never touched.
+ */
+const serializeSoapNote = async (record: SoapNoteRecord) => {
+  const composition = clinicalArtifactFhirMapper.soapNoteToComposition(record);
+  const coded = await SoapCodedTermsFhirService.codedTermExtensions(
+    record.soapNote.diagnoses,
+  );
+  if (coded.length > 0) {
+    composition.extension = [...(composition.extension ?? []), ...coded];
+  }
+  return composition;
+};
+
+const serializeSoapNoteBundle = async (records: SoapNoteRecord[]) => {
+  const bundle = clinicalArtifactFhirMapper.bundles.soapNotes(records);
+  // recordBundle maps records in order, so entries pair up index-for-index.
+  await Promise.all(
+    records.map(async (record, index) => {
+      const coded = await SoapCodedTermsFhirService.codedTermExtensions(
+        record.soapNote.diagnoses,
+      );
+      const resource = bundle.entry?.[index]?.resource as
+        Composition | undefined;
+      if (coded.length > 0 && resource) {
+        resource.extension = [...(resource.extension ?? []), ...coded];
+      }
+    }),
+  );
+  return bundle;
+};
+
 export const ClinicalArtifactFhirController = {
   async listSoapNotesForAppointment(req: Request, res: Response) {
     try {
@@ -128,9 +164,7 @@ export const ClinicalArtifactFhirController = {
         req.params.organisationId,
         readAppointmentId(req.params.appointmentId),
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.bundles.soapNotes(records));
+      return res.status(200).json(await serializeSoapNoteBundle(records));
     } catch (error) {
       return handleError(error, res);
     }
@@ -142,9 +176,7 @@ export const ClinicalArtifactFhirController = {
         req.params.organisationId,
         readEncounterId(req.params.encounterId),
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.bundles.soapNotes(records));
+      return res.status(200).json(await serializeSoapNoteBundle(records));
     } catch (error) {
       return handleError(error, res);
     }
@@ -163,9 +195,7 @@ export const ClinicalArtifactFhirController = {
           organisationId: req.params.organisationId,
         }),
       );
-      return res
-        .status(201)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(201).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }
@@ -177,9 +207,7 @@ export const ClinicalArtifactFhirController = {
         req.params.soapNoteId,
         req.params.organisationId,
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(200).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }
@@ -200,9 +228,7 @@ export const ClinicalArtifactFhirController = {
         }),
         req.params.organisationId,
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(200).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }
@@ -495,9 +521,7 @@ export const ClinicalArtifactFhirController = {
         req.params.soapNoteId,
         req.params.organisationId,
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(200).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }
@@ -509,9 +533,7 @@ export const ClinicalArtifactFhirController = {
         req.params.soapNoteId,
         req.params.organisationId,
       );
-      return res
-        .status(200)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(200).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }
@@ -524,9 +546,7 @@ export const ClinicalArtifactFhirController = {
         req.params.organisationId,
         resolveVerifiedUserId(req),
       );
-      return res
-        .status(201)
-        .json(clinicalArtifactFhirMapper.soapNoteToComposition(record));
+      return res.status(201).json(await serializeSoapNote(record));
     } catch (error) {
       return handleError(error, res);
     }

--- a/apps/backend/src/services/soap-coded-terms.service.ts
+++ b/apps/backend/src/services/soap-coded-terms.service.ts
@@ -1,0 +1,104 @@
+import type { Coding, Extension } from "@yosemite-crew/fhir";
+import {
+  parseSoapCodedProblems,
+  SOAP_CODED_SECTIONS,
+  SOAP_CODED_TERM_EXTENSION_URL,
+  CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL,
+} from "@yosemite-crew/types";
+import type { MappingEquivalence } from "src/models/code-mapping";
+import {
+  SYSTEM_URI,
+  TerminologyProjectionService,
+  USABLE_EQUIVALENCES,
+  type ProjectionTarget,
+} from "src/services/terminology-projection.service";
+
+/** Our uppercase enum -> the FHIR ConceptMapEquivalence code it came from. */
+const FHIR_EQUIVALENCE: Record<MappingEquivalence, string> = {
+  RELATEDTO: "relatedto",
+  EQUIVALENT: "equivalent",
+  EQUAL: "equal",
+  WIDER: "wider",
+  SUBSUMES: "subsumes",
+  NARROWER: "narrower",
+  SPECIALIZES: "specializes",
+  INEXACT: "inexact",
+  UNMATCHED: "unmatched",
+  DISJOINT: "disjoint",
+};
+
+const EXTERNAL_TARGETS: ProjectionTarget[] = ["VENOM", "SNOMED"];
+
+/**
+ * FHIR projection of a SOAP note's picked coded terms. Derived at read time and
+ * never written back: the stored `diagnoses` channel remains exactly what the
+ * clinician picked (record immutability), while every read serves translations
+ * from the current mapping table. Only mappings with a usable ConceptMap
+ * equivalence are emitted, and each external coding carries its equivalence
+ * explicitly so a NARROWER or INEXACT crosswalk cannot read as an exact match.
+ */
+export const SoapCodedTermsFhirService = {
+  async codedTermExtensions(diagnoses: unknown): Promise<Extension[]> {
+    const parsed = parseSoapCodedProblems(diagnoses);
+    if (!parsed) return [];
+
+    const ycCodes = [
+      ...new Set(
+        SOAP_CODED_SECTIONS.flatMap((section) =>
+          (parsed[section] ?? []).map((term) => term.ycCode),
+        ),
+      ),
+    ];
+
+    const projections = await Promise.all(
+      EXTERNAL_TARGETS.map((target) =>
+        TerminologyProjectionService.projectCodes(ycCodes, target),
+      ),
+    );
+
+    const translations = new Map<string, Coding[]>();
+    for (const list of projections) {
+      for (const projected of list) {
+        if (projected.status !== "mapped") continue;
+        if (!USABLE_EQUIVALENCES.includes(projected.equivalence)) continue;
+        const held = translations.get(projected.ycCode) ?? [];
+        held.push({
+          ...projected.coding,
+          extension: [
+            {
+              url: CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL,
+              valueCode: FHIR_EQUIVALENCE[projected.equivalence],
+            },
+          ],
+        });
+        translations.set(projected.ycCode, held);
+      }
+    }
+
+    return SOAP_CODED_SECTIONS.flatMap((section) =>
+      (parsed[section] ?? []).map((term) => ({
+        url: SOAP_CODED_TERM_EXTENSION_URL,
+        extension: [
+          { url: "section", valueString: section },
+          {
+            url: "concept",
+            valueCodeableConcept: {
+              text: term.label,
+              coding: [
+                // The Yosemite coding keeps the pick-time label deliberately:
+                // a signed note must render what was recorded, not what the
+                // vocabulary calls the concept today.
+                {
+                  system: SYSTEM_URI.YOSEMITECODE,
+                  code: term.ycCode,
+                  display: term.label,
+                },
+                ...(translations.get(term.ycCode) ?? []),
+              ],
+            },
+          },
+        ],
+      })),
+    );
+  },
+};

--- a/apps/backend/src/services/soap-coded-terms.service.ts
+++ b/apps/backend/src/services/soap-coded-terms.service.ts
@@ -37,68 +37,97 @@ const EXTERNAL_TARGETS: ProjectionTarget[] = ["VENOM", "SNOMED"];
  * equivalence are emitted, and each external coding carries its equivalence
  * explicitly so a NARROWER or INEXACT crosswalk cannot read as an exact match.
  */
-export const SoapCodedTermsFhirService = {
-  async codedTermExtensions(diagnoses: unknown): Promise<Extension[]> {
-    const parsed = parseSoapCodedProblems(diagnoses);
-    if (!parsed) return [];
+type ParsedProblems = ReturnType<typeof parseSoapCodedProblems>;
 
-    const ycCodes = [
-      ...new Set(
-        SOAP_CODED_SECTIONS.flatMap((section) =>
-          (parsed[section] ?? []).map((term) => term.ycCode),
-        ),
-      ),
-    ];
+const codesIn = (parsed: NonNullable<ParsedProblems>): string[] =>
+  SOAP_CODED_SECTIONS.flatMap((section) =>
+    (parsed[section] ?? []).map((term) => term.ycCode),
+  );
 
-    const projections = await Promise.all(
-      EXTERNAL_TARGETS.map((target) =>
-        TerminologyProjectionService.projectCodes(ycCodes, target),
-      ),
-    );
-
-    const translations = new Map<string, Coding[]>();
-    for (const list of projections) {
-      for (const projected of list) {
-        if (projected.status !== "mapped") continue;
-        if (!USABLE_EQUIVALENCES.includes(projected.equivalence)) continue;
-        const held = translations.get(projected.ycCode) ?? [];
-        held.push({
-          ...projected.coding,
-          extension: [
-            {
-              url: CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL,
-              valueCode: FHIR_EQUIVALENCE[projected.equivalence],
-            },
-          ],
-        });
-        translations.set(projected.ycCode, held);
-      }
-    }
-
-    return SOAP_CODED_SECTIONS.flatMap((section) =>
-      (parsed[section] ?? []).map((term) => ({
-        url: SOAP_CODED_TERM_EXTENSION_URL,
+/** Usable translations per YC code, each coding carrying its explicit equivalence. */
+const translationsFor = async (
+  ycCodes: string[],
+): Promise<Map<string, Coding[]>> => {
+  const translations = new Map<string, Coding[]>();
+  if (ycCodes.length === 0) return translations;
+  const projections = await Promise.all(
+    EXTERNAL_TARGETS.map((target) =>
+      TerminologyProjectionService.projectCodes(ycCodes, target),
+    ),
+  );
+  for (const list of projections) {
+    for (const projected of list) {
+      if (projected.status !== "mapped") continue;
+      if (!USABLE_EQUIVALENCES.includes(projected.equivalence)) continue;
+      const held = translations.get(projected.ycCode) ?? [];
+      held.push({
+        ...projected.coding,
         extension: [
-          { url: "section", valueString: section },
           {
-            url: "concept",
-            valueCodeableConcept: {
-              text: term.label,
-              coding: [
-                // The Yosemite coding keeps the pick-time label deliberately:
-                // a signed note must render what was recorded, not what the
-                // vocabulary calls the concept today.
-                {
-                  system: SYSTEM_URI.YOSEMITECODE,
-                  code: term.ycCode,
-                  display: term.label,
-                },
-                ...(translations.get(term.ycCode) ?? []),
-              ],
-            },
+            url: CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL,
+            valueCode: FHIR_EQUIVALENCE[projected.equivalence],
           },
         ],
-      })),
+      });
+      translations.set(projected.ycCode, held);
+    }
+  }
+  return translations;
+};
+
+const extensionsFor = (
+  parsed: NonNullable<ParsedProblems>,
+  translations: Map<string, Coding[]>,
+): Extension[] =>
+  SOAP_CODED_SECTIONS.flatMap((section) =>
+    (parsed[section] ?? []).map((term) => ({
+      url: SOAP_CODED_TERM_EXTENSION_URL,
+      extension: [
+        { url: "section", valueString: section },
+        {
+          url: "concept",
+          valueCodeableConcept: {
+            text: term.label,
+            coding: [
+              // The Yosemite coding keeps the pick-time label deliberately:
+              // a signed note must render what was recorded, not what the
+              // vocabulary calls the concept today.
+              {
+                system: SYSTEM_URI.YOSEMITECODE,
+                code: term.ycCode,
+                display: term.label,
+              },
+              ...(translations.get(term.ycCode) ?? []),
+            ],
+          },
+        },
+      ],
+    })),
+  );
+
+export const SoapCodedTermsFhirService = {
+  /**
+   * Batched form for bundles: one projection query set for the union of every
+   * record's codes, with each record keeping only its own terms. Order and
+   * length mirror the input, so entries pair up index-for-index.
+   */
+  async codedTermExtensionsForMany(
+    diagnosesList: unknown[],
+  ): Promise<Extension[][]> {
+    const parsedList = diagnosesList.map(parseSoapCodedProblems);
+    const ycCodes = [
+      ...new Set(
+        parsedList.flatMap((parsed) => (parsed ? codesIn(parsed) : [])),
+      ),
+    ];
+    const translations = await translationsFor(ycCodes);
+    return parsedList.map((parsed) =>
+      parsed ? extensionsFor(parsed, translations) : [],
     );
+  },
+
+  async codedTermExtensions(diagnoses: unknown): Promise<Extension[]> {
+    const [only] = await this.codedTermExtensionsForMany([diagnoses]);
+    return only ?? [];
   },
 };

--- a/apps/backend/src/services/terminology-projection.service.ts
+++ b/apps/backend/src/services/terminology-projection.service.ts
@@ -45,7 +45,7 @@ export type ProjectedCode =
  * overstate what the target vocabulary can express - the opposite of what a coverage
  * disclosure is for.
  */
-const USABLE_EQUIVALENCES: MappingEquivalence[] = [
+export const USABLE_EQUIVALENCES: MappingEquivalence[] = [
   "RELATEDTO",
   "EQUIVALENT",
   "EQUAL",

--- a/apps/backend/test/controllers/clinical-artifact.fhir.controller.test.ts
+++ b/apps/backend/test/controllers/clinical-artifact.fhir.controller.test.ts
@@ -75,6 +75,9 @@ jest.mock("../../src/utils/logger", () => ({
 jest.mock("../../src/services/soap-coded-terms.service", () => ({
   SoapCodedTermsFhirService: {
     codedTermExtensions: jest.fn(async () => []),
+    codedTermExtensionsForMany: jest.fn(async (list: unknown[]) =>
+      list.map(() => []),
+    ),
   },
 }));
 
@@ -1480,8 +1483,8 @@ describe("ClinicalArtifactFhirController", () => {
         resourceType: "Bundle",
         entry: [{ resource: { resourceType: "Composition" } }],
       } as never);
-      mockedCodedTerms.codedTermExtensions.mockResolvedValueOnce([
-        { url: "marker-ext" },
+      mockedCodedTerms.codedTermExtensionsForMany.mockResolvedValueOnce([
+        [{ url: "marker-ext" }],
       ] as never);
       mockedService.listSoapNotesForAppointment.mockResolvedValueOnce([
         { artifact: { id: "artifact-1" }, soapNote: { id: "soap-1" } },

--- a/apps/backend/test/controllers/clinical-artifact.fhir.controller.test.ts
+++ b/apps/backend/test/controllers/clinical-artifact.fhir.controller.test.ts
@@ -6,6 +6,7 @@ import {
   ClinicalArtifactServiceError,
 } from "../../src/services/clinical-artifact.service";
 import { clinicalArtifactFhirMapper } from "../../src/services/fhir-clinical-artifact.mapper";
+import { SoapCodedTermsFhirService } from "../../src/services/soap-coded-terms.service";
 import logger from "../../src/utils/logger";
 
 jest.mock("../../src/services/clinical-artifact.service", () => {
@@ -71,6 +72,12 @@ jest.mock("../../src/utils/logger", () => ({
   },
 }));
 
+jest.mock("../../src/services/soap-coded-terms.service", () => ({
+  SoapCodedTermsFhirService: {
+    codedTermExtensions: jest.fn(async () => []),
+  },
+}));
+
 jest.mock("../../src/services/fhir-clinical-artifact.mapper", () => ({
   clinicalArtifactFhirMapper: {
     soapNoteToComposition: jest.fn(),
@@ -96,6 +103,9 @@ jest.mock("../../src/services/fhir-clinical-artifact.mapper", () => ({
 
 const mockedService = ClinicalArtifactService as jest.Mocked<
   typeof ClinicalArtifactService
+>;
+const mockedCodedTerms = SoapCodedTermsFhirService as jest.Mocked<
+  typeof SoapCodedTermsFhirService
 >;
 const mockedMapper = clinicalArtifactFhirMapper as jest.Mocked<
   typeof clinicalArtifactFhirMapper
@@ -1434,5 +1444,60 @@ describe("ClinicalArtifactFhirController", () => {
         );
       },
     );
+  });
+
+  describe("coded-term projection wiring", () => {
+    it("appends coded-term extensions to single SOAP responses and passes the stored diagnoses", async () => {
+      mockedMapper.soapNoteToComposition.mockReturnValue({
+        resourceType: "Composition",
+      } as never);
+      mockedCodedTerms.codedTermExtensions.mockResolvedValueOnce([
+        { url: "marker-ext" },
+      ] as never);
+      mockedService.getSoapNote.mockResolvedValueOnce({
+        artifact: { id: "artifact-1" },
+        soapNote: {
+          id: "soap-1",
+          diagnoses: { plan: [{ ycCode: "YC-1", label: "L" }] },
+        },
+      } as never);
+
+      await ClinicalArtifactFhirController.getSoapNote(
+        req as Request,
+        res as Response,
+      );
+
+      expect(mockedCodedTerms.codedTermExtensions).toHaveBeenCalledWith({
+        plan: [{ ycCode: "YC-1", label: "L" }],
+      });
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({ extension: [{ url: "marker-ext" }] }),
+      );
+    });
+
+    it("appends coded-term extensions to each bundle entry", async () => {
+      mockedMapper.bundles.soapNotes.mockReturnValue({
+        resourceType: "Bundle",
+        entry: [{ resource: { resourceType: "Composition" } }],
+      } as never);
+      mockedCodedTerms.codedTermExtensions.mockResolvedValueOnce([
+        { url: "marker-ext" },
+      ] as never);
+      mockedService.listSoapNotesForAppointment.mockResolvedValueOnce([
+        { artifact: { id: "artifact-1" }, soapNote: { id: "soap-1" } },
+      ] as never);
+
+      await ClinicalArtifactFhirController.listSoapNotesForAppointment(
+        req as Request,
+        res as Response,
+      );
+
+      const bundle = jsonMock.mock.calls[0][0] as {
+        entry: Array<{ resource: { extension?: unknown } }>;
+      };
+      expect(bundle.entry[0].resource.extension).toEqual([
+        { url: "marker-ext" },
+      ]);
+    });
   });
 });

--- a/apps/backend/test/services/soap-coded-terms.service.test.ts
+++ b/apps/backend/test/services/soap-coded-terms.service.test.ts
@@ -1,0 +1,192 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeMapping: { findMany: jest.fn() },
+    codeEntry: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import { SoapCodedTermsFhirService } from "src/services/soap-coded-terms.service";
+
+const mappingFind = (
+  prisma as unknown as { codeMapping: { findMany: jest.Mock } }
+).codeMapping.findMany;
+const entryFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+
+type Ext = {
+  url: string;
+  valueString?: string;
+  valueCode?: string;
+  valueCodeableConcept?: {
+    text?: string;
+    coding?: Array<{
+      system?: string;
+      code?: string;
+      display?: string;
+      extension?: Ext[];
+    }>;
+  };
+  extension?: Ext[];
+};
+
+const concept = (ext: Ext) =>
+  ext.extension?.find((e) => e.url === "concept")?.valueCodeableConcept;
+const section = (ext: Ext) =>
+  ext.extension?.find((e) => e.url === "section")?.valueString;
+const equivalenceOf = (coding: { extension?: Ext[] }): string | undefined =>
+  coding.extension?.find((e) => e.url.endsWith("concept-map-equivalence"))
+    ?.valueCode;
+
+beforeEach(() => {
+  mappingFind.mockReset();
+  entryFind.mockReset();
+});
+
+describe("SoapCodedTermsFhirService.codedTermExtensions", () => {
+  it("returns no extensions for absent or malformed diagnoses", async () => {
+    expect(await SoapCodedTermsFhirService.codedTermExtensions(null)).toEqual(
+      [],
+    );
+    expect(
+      await SoapCodedTermsFhirService.codedTermExtensions("not-an-object"),
+    ).toEqual([]);
+    expect(mappingFind).not.toHaveBeenCalled();
+  });
+
+  it("projects each picked term into a CodeableConcept with YC plus usable translations", async () => {
+    // Both targets exist as concepts; YC-1 maps to VeNom (EQUIVALENT) and
+    // SNOMED (NARROWER), YC-2 has only an UNMATCHED VeNom row.
+    entryFind.mockResolvedValue([{ code: "YC-1" }, { code: "YC-2" }]);
+    mappingFind.mockImplementation(({ where }) =>
+      Promise.resolve(
+        where.targetSystem === "VENOM"
+          ? [
+              {
+                sourceCode: "YC-1",
+                targetCode: "2062",
+                targetDisplay: "Vomiting",
+                equivalence: "EQUIVALENT",
+              },
+              {
+                sourceCode: "YC-2",
+                targetCode: "999",
+                targetDisplay: "No counterpart",
+                equivalence: "UNMATCHED",
+              },
+            ]
+          : [
+              {
+                sourceCode: "YC-1",
+                targetCode: "422400008",
+                targetDisplay: "Vomiting (disorder)",
+                equivalence: "NARROWER",
+              },
+            ],
+      ),
+    );
+
+    const extensions = (await SoapCodedTermsFhirService.codedTermExtensions({
+      subjective: [{ ycCode: "YC-1", label: "Picked label" }],
+      assessment: [{ ycCode: "YC-2", label: "Gap concept" }],
+    })) as Ext[];
+
+    expect(extensions).toHaveLength(2);
+    expect(section(extensions[0])).toBe("subjective");
+    expect(section(extensions[1])).toBe("assessment");
+
+    const first = concept(extensions[0]);
+    // The pick-time label is the record, even if the vocabulary display differs.
+    expect(first?.text).toBe("Picked label");
+    expect(first?.coding).toEqual([
+      expect.objectContaining({
+        system: "https://yosemitecrew.com/fhir/CodeSystem/yosemite",
+        code: "YC-1",
+        display: "Picked label",
+      }),
+      expect.objectContaining({ system: "urn:venom", code: "2062" }),
+      expect.objectContaining({
+        system: "http://snomed.info/sct",
+        code: "422400008",
+      }),
+    ]);
+    // Equivalence is explicit per external coding, in FHIR's lowercase codes.
+    expect(equivalenceOf(first!.coding![1])).toBe("equivalent");
+    expect(equivalenceOf(first!.coding![2])).toBe("narrower");
+
+    // UNMATCHED never rides along as a translation: YC coding only.
+    const second = concept(extensions[1]);
+    expect(second?.coding).toHaveLength(1);
+    expect(second?.coding?.[0].code).toBe("YC-2");
+  });
+
+  it("emits only the YC coding for a retired or unknown concept", async () => {
+    // Concept absent from CodeEntry: a mapping outliving its concept must not
+    // resurrect it as a translation.
+    entryFind.mockResolvedValue([]);
+    mappingFind.mockResolvedValue([
+      {
+        sourceCode: "YC-GONE",
+        targetCode: "1",
+        targetDisplay: "x",
+        equivalence: "EQUIVALENT",
+      },
+    ]);
+
+    const extensions = (await SoapCodedTermsFhirService.codedTermExtensions({
+      plan: [{ ycCode: "YC-GONE", label: "Retired concept" }],
+    })) as Ext[];
+
+    expect(concept(extensions[0])?.coding).toHaveLength(1);
+    expect(concept(extensions[0])?.coding?.[0].code).toBe("YC-GONE");
+  });
+
+  it("queries each target once with the deduped code set", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockResolvedValue([]);
+
+    await SoapCodedTermsFhirService.codedTermExtensions({
+      subjective: [{ ycCode: "YC-1", label: "A" }],
+      plan: [{ ycCode: "YC-1", label: "A" }],
+    });
+
+    // One VENOM query + one SNOMED query, not one per term or per section.
+    expect(mappingFind).toHaveBeenCalledTimes(2);
+    for (const call of mappingFind.mock.calls) {
+      expect(call[0].where.sourceCode).toEqual({ in: ["YC-1"] });
+    }
+  });
+
+  it("keeps the strongest mapping when a term has several in one system", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }]);
+    mappingFind.mockImplementation(({ where }) =>
+      Promise.resolve(
+        where.targetSystem === "VENOM"
+          ? [
+              {
+                sourceCode: "YC-1",
+                targetCode: "weak",
+                targetDisplay: "w",
+                equivalence: "INEXACT",
+              },
+              {
+                sourceCode: "YC-1",
+                targetCode: "strong",
+                targetDisplay: "s",
+                equivalence: "EQUAL",
+              },
+            ]
+          : [],
+      ),
+    );
+
+    const extensions = (await SoapCodedTermsFhirService.codedTermExtensions({
+      subjective: [{ ycCode: "YC-1", label: "A" }],
+    })) as Ext[];
+
+    const codings = concept(extensions[0])?.coding ?? [];
+    expect(codings).toHaveLength(2);
+    expect(codings[1].code).toBe("strong");
+    expect(equivalenceOf(codings[1])).toBe("equal");
+  });
+});

--- a/apps/backend/test/services/soap-coded-terms.service.test.ts
+++ b/apps/backend/test/services/soap-coded-terms.service.test.ts
@@ -157,6 +157,60 @@ describe("SoapCodedTermsFhirService.codedTermExtensions", () => {
     }
   });
 
+  it("batches a bundle into one query set with per-record attribution", async () => {
+    entryFind.mockResolvedValue([{ code: "YC-1" }, { code: "YC-2" }]);
+    mappingFind.mockImplementation(({ where }) =>
+      Promise.resolve(
+        where.targetSystem === "VENOM"
+          ? [
+              {
+                sourceCode: "YC-1",
+                targetCode: "v1",
+                targetDisplay: "V1",
+                equivalence: "EQUIVALENT",
+              },
+              {
+                sourceCode: "YC-2",
+                targetCode: "v2",
+                targetDisplay: "V2",
+                equivalence: "EQUIVALENT",
+              },
+            ]
+          : [],
+      ),
+    );
+
+    const perRecord =
+      (await SoapCodedTermsFhirService.codedTermExtensionsForMany([
+        { subjective: [{ ycCode: "YC-1", label: "One" }] },
+        "malformed",
+        { assessment: [{ ycCode: "YC-2", label: "Two" }] },
+      ])) as Ext[][];
+
+    // One VENOM + one SNOMED query for the whole bundle, over the union set.
+    expect(mappingFind).toHaveBeenCalledTimes(2);
+    for (const call of mappingFind.mock.calls) {
+      expect(call[0].where.sourceCode).toEqual({ in: ["YC-1", "YC-2"] });
+    }
+
+    // Output mirrors input order; each record keeps only its own terms.
+    expect(perRecord).toHaveLength(3);
+    expect(perRecord[1]).toEqual([]);
+    expect(concept(perRecord[0][0])?.coding?.[0].code).toBe("YC-1");
+    expect(concept(perRecord[0][0])?.coding?.[1].code).toBe("v1");
+    expect(perRecord[0]).toHaveLength(1);
+    expect(concept(perRecord[2][0])?.coding?.[0].code).toBe("YC-2");
+    expect(concept(perRecord[2][0])?.coding?.[1].code).toBe("v2");
+    expect(perRecord[2]).toHaveLength(1);
+  });
+
+  it("makes no queries when no record carries coded terms", async () => {
+    const perRecord =
+      await SoapCodedTermsFhirService.codedTermExtensionsForMany([null, {}]);
+    expect(perRecord).toEqual([[], []]);
+    expect(mappingFind).not.toHaveBeenCalled();
+  });
+
   it("keeps the strongest mapping when a term has several in one system", async () => {
     entryFind.mockResolvedValue([{ code: "YC-1" }]);
     mappingFind.mockImplementation(({ where }) =>

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -344,6 +344,21 @@ const SOAP_ASSESSMENT_EXTENSION_URL =
 const SOAP_PLAN_EXTENSION_URL = 'https://yosemitecrew.com/fhir/StructureDefinition/soap-note-plan';
 export const SOAP_DIAGNOSES_EXTENSION_URL =
   'https://yosemitecrew.com/fhir/StructureDefinition/soap-note-diagnoses';
+/**
+ * Typed FHIR surface for picked coded terms: one complex extension per term,
+ * carrying a `section` discriminator and a `concept` valueCodeableConcept whose
+ * codings hold the Yosemite code plus any usable VeNom/SNOMED translations.
+ * Derived at read time from the raw `soap-note-diagnoses` channel - never stored,
+ * so a signed note's record is immutable while projections stay current.
+ */
+export const SOAP_CODED_TERM_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/soap-note-coded-term';
+/**
+ * Per-coding ConceptMap equivalence (FHIR ConceptMapEquivalence code, lowercase),
+ * so a NARROWER or INEXACT crosswalk is never passed off as an exact translation.
+ */
+export const CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/concept-map-equivalence';
 const SOAP_METADATA_EXTENSION_URL =
   'https://yosemitecrew.com/fhir/StructureDefinition/soap-note-metadata';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -421,6 +421,8 @@ export {
   type SoapNoteRecord,
   SOAP_CODED_SECTIONS,
   SOAP_DIAGNOSES_EXTENSION_URL,
+  SOAP_CODED_TERM_EXTENSION_URL,
+  CONCEPT_MAP_EQUIVALENCE_EXTENSION_URL,
   parseSoapCodedProblems,
   type SoapCodedSection,
   type SoapCodedTerm,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

SOAP coded terms (#2496) export as Yosemite codes only. The mapping layer — 8,529 concepts with VeNom mappings, 5,110 with SNOMED, each graded with a FHIR ConceptMap equivalence — and the terminology-projection service exist but have no consumer, so a FHIR consumer of a SOAP Composition cannot interoperate on standard vocabularies.

## What is the new behavior?

Every SOAP note response (create/patch/get/finalize/amend/reopen + both list bundles) now carries one `soap-note-coded-term` complex extension per picked term: a `section` discriminator plus a `concept` valueCodeableConcept whose codings hold the Yosemite code and the strongest usable VeNom/SNOMED translations under canonical system URIs (`http://snomed.info/sct`, `urn:venom`).

Clinical-compliance rules encoded in the design:

- **Record immutability**: projections are derived at read time and never written back. The stored `diagnoses` channel stays exactly what the clinician picked; the YC coding renders the pick-time label, not today's vocabulary display, so a signed note can never be silently rewritten by a mapping or display update.
- **Honest equivalence**: only mappings with a usable ConceptMap equivalence are emitted (UNMATCHED/DISJOINT never ride along), and every external coding carries its equivalence explicitly as a lowercase FHIR ConceptMapEquivalence code via a `concept-map-equivalence` extension — a NARROWER or INEXACT crosswalk cannot pass as an exact translation.
- **Existence before mapping**: a mapping that outlives its concept does not resurrect it; retired/unknown concepts emit the YC coding only.
- **Typed FHIR**: proper Extension/CodeableConcept/Coding datatypes from the R4 types, not ad-hoc JSON; the raw `soap-note-diagnoses` channel is unchanged for UI round-trip.

`packages/types` gains the two extension URL constants; `USABLE_EQUIVALENCES` is now exported from the projection service (it previously gated only coverage disclosures, not projections).

## Impact area

Backend SOAP note serialization. No frontend or mobile changes; no schema changes; stored data untouched.

## Validation performed

- Backend tsc clean, scoped ESLint clean, `@yosemite-crew/types` builds.
- New service suite (5 tests) + controller wiring tests (83 total in the suite) + the existing terminology-projection suite (20) all green.
- **Mutation-checked (5 mutations, each caught):** usable-equivalence gate removal; pick-time-label removal; equivalence-code mislabel (narrower→equivalent); single-response merge removal; bundle-entry merge removal.
- Secrets scan clean. Local opengrep SAST was unavailable (shared rules cache wiped by a concurrent session) — the Aikido featurebranch scan on this PR is the authoritative SAST/code-quality gate.
- Post-merge: live proof on dev via the deployed API — list the QA note from #2496 and show real VeNom/SNOMED codings with equivalences.

## Related Issue(s)

Closes #2500
