### PR TITLE
fix(backend): scope IDEXX orders to the caller's organisation

### DIFF
--- a/apps/backend/src/labs/idexx/idexx-order.adapter.ts
+++ b/apps/backend/src/labs/idexx/idexx-order.adapter.ts
@@ -5,6 +5,7 @@ import type {
   LabOrderCreateResult,
 } from "../types";
 import { LabOrderServiceError } from "src/services/lab-order.service";
+import { assertPatientOrgMembership } from "src/services/shared/patient-org-membership";
 import { normalizeLabStatus } from "src/labs/status";
 import {
   buildIdexxClient,
@@ -292,6 +293,21 @@ const resolveOrderParentId = async (
 export class IdexxOrderAdapter implements LabOrderAdapter {
   async createOrder(input: LabOrderCreateInput): Promise<LabOrderCreateResult> {
     const patientId = input.patientId;
+
+    // The caller is authenticated against input.organisationId, but patientId
+    // arrives from the request body and every lookup below resolves it
+    // GLOBALLY. Without this a user with labs:edit:any in one organisation who
+    // knows another tenant's patient id could place an order that ships that
+    // companion's identifiers plus the parent's name, address, email and phone
+    // to IDEXX under their own organisation.
+    //
+    // The species-level breed fallback made this materially worse: those
+    // companions used to be rejected for having no mapped breed, so the check
+    // that was accidentally holding the line is gone.
+    await assertPatientOrgMembership(patientId, input.organisationId, () => {
+      throw new LabOrderServiceError("Companion not found.", 404);
+    });
+
     const parentId = await resolveOrderParentId(patientId, input.parentId);
 
     const { payload, breedSubstitution } = await buildOrderPayload({
@@ -359,6 +375,20 @@ export class IdexxOrderAdapter implements LabOrderAdapter {
   ): Promise<LabOrderCreateResult> {
     const patientId = input.patientId;
     const parentId = input.parentId ?? null;
+
+    // The caller is authenticated against input.organisationId, but patientId
+    // arrives from the request body and every lookup below resolves it
+    // GLOBALLY. Without this a user with labs:edit:any in one organisation who
+    // knows another tenant's patient id could place an order that ships that
+    // companion's identifiers plus the parent's name, address, email and phone
+    // to IDEXX under their own organisation.
+    //
+    // The species-level breed fallback made this materially worse: those
+    // companions used to be rejected for having no mapped breed, so the check
+    // that was accidentally holding the line is gone.
+    await assertPatientOrgMembership(patientId, input.organisationId, () => {
+      throw new LabOrderServiceError("Companion not found.", 404);
+    });
 
     if (!parentId) {
       throw new LabOrderServiceError(

--- a/apps/backend/src/labs/idexx/idexx-order.adapter.ts
+++ b/apps/backend/src/labs/idexx/idexx-order.adapter.ts
@@ -376,16 +376,9 @@ export class IdexxOrderAdapter implements LabOrderAdapter {
     const patientId = input.patientId;
     const parentId = input.parentId ?? null;
 
-    // The caller is authenticated against input.organisationId, but patientId
-    // arrives from the request body and every lookup below resolves it
-    // GLOBALLY. Without this a user with labs:edit:any in one organisation who
-    // knows another tenant's patient id could place an order that ships that
-    // companion's identifiers plus the parent's name, address, email and phone
-    // to IDEXX under their own organisation.
-    //
-    // The species-level breed fallback made this materially worse: those
-    // companions used to be rejected for having no mapped breed, so the check
-    // that was accidentally holding the line is gone.
+    // Same reasoning as createOrder above: patientId comes from the request
+    // body and is resolved globally, so it must be bound to the caller's
+    // organisation before anything reads the companion or its parent.
     await assertPatientOrgMembership(patientId, input.organisationId, () => {
       throw new LabOrderServiceError("Companion not found.", 404);
     });

--- a/apps/backend/test/labs/idexx-order.adapter.test.ts
+++ b/apps/backend/test/labs/idexx-order.adapter.test.ts
@@ -9,6 +9,7 @@ jest.mock("src/config/prisma", () => ({
     patient: { findUnique: jest.fn() },
     parent: { findUnique: jest.fn() },
     parentPatient: { findFirst: jest.fn() },
+    patientOrganisation: { findFirst: jest.fn() },
   },
 }));
 
@@ -90,6 +91,9 @@ describe("IdexxOrderAdapter", () => {
     prismaMock.parentPatient.findFirst.mockResolvedValue({
       parentId: "parent-1",
     });
+    // Default: the companion belongs to the calling organisation. The cross-org
+    // tests below override this to null.
+    prismaMock.patientOrganisation.findFirst.mockResolvedValue({ id: "po-1" });
 
     mockIdexxClient.getCensusPatient.mockRejectedValue({
       response: { status: 404 },
@@ -578,5 +582,90 @@ describe("IdexxOrderAdapter", () => {
         tests: ["T1"],
       } as any),
     ).rejects.toThrow("IDEXX PIMS config missing.");
+  });
+
+  // A PMS user with labs:edit:any in one organisation who knows another
+  // tenant's patient id could previously place an order against it: the caller
+  // is authorised against input.organisationId, but every lookup in the adapter
+  // resolves patientId GLOBALLY. The order shipped that companion's identifiers
+  // plus the parent's name, address, email and phone to IDEXX, under the
+  // attacker's organisation.
+  //
+  // The species-level breed fallback widened it. Those companions used to be
+  // rejected for having no mapped breed, so the check accidentally holding the
+  // line is gone.
+  describe("cross-organisation access", () => {
+    it("refuses to create an order for a companion in another organisation", async () => {
+      prismaMock.patientOrganisation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        adapter.createOrder({
+          organisationId: "org-attacker",
+          patientId: "victim-patient",
+          parentId: "parent-1",
+          tests: ["T1"],
+        } as never),
+      ).rejects.toMatchObject({
+        message: "Companion not found.",
+        statusCode: 404,
+      });
+    });
+
+    it("refuses to update an order for a companion in another organisation", async () => {
+      prismaMock.patientOrganisation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        adapter.updateOrder("IDX-1", {
+          organisationId: "org-attacker",
+          patientId: "victim-patient",
+          parentId: "parent-1",
+          tests: ["T1"],
+        } as never),
+      ).rejects.toMatchObject({
+        message: "Companion not found.",
+        statusCode: 404,
+      });
+    });
+
+    // The victim's details must never leave the process. Asserting only on the
+    // thrown error would still pass if the payload had already been built and
+    // sent, so assert the outbound client was never called.
+    it("sends nothing to IDEXX when the companion is in another organisation", async () => {
+      prismaMock.patientOrganisation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        adapter.createOrder({
+          organisationId: "org-attacker",
+          patientId: "victim-patient",
+          parentId: "parent-1",
+          tests: ["T1"],
+        } as never),
+      ).rejects.toThrow();
+
+      expect(mockIdexxClient.createOrder).not.toHaveBeenCalled();
+      expect(mockIdexxClient.addCensusPatient).not.toHaveBeenCalled();
+      expect(mockIdexxClient.getCensusPatient).not.toHaveBeenCalled();
+    });
+
+    // Scoping must not be satisfied by a PENDING link: that is a relationship
+    // the organisation requested, not one the parent approved.
+    it("scopes the membership lookup to the caller org and ACTIVE status", async () => {
+      await adapter.createOrder({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        parentId: "parent-1",
+        tests: ["T1"],
+      } as never);
+
+      expect(prismaMock.patientOrganisation.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            patientId: "patient-1",
+            organisationId: "org-1",
+            status: "ACTIVE",
+          }),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Codex raised this as **P1** on the dev-to-main promotion (#2483), and it is real. I verified every part of it independently rather than taking the finding at face value.

`IdexxOrderAdapter.createOrder` and `updateOrder` authorise the caller against `input.organisationId`, but `patientId` arrives in the request body and every lookup below resolves it **globally**:

```ts
const companion = await prisma.patient.findUnique({ where: { id: input.patientId } });
const parent    = await prisma.parent.findUnique({ where: { id: input.parentId } });
```

No org predicate on either. So a PMS user holding `labs:edit:any` in Org A who knows an Org B patient id can place an order against it. The payload carries `firstName`, `lastName`, `email`, `phoneNumber` and `address`, so the victim's pet identifiers **and their owner's contact details leave the platform to a third-party lab**, recorded under the attacker's organisation.

What I confirmed:

- `assertPatientOrgMembership` already exists and is the established pattern, used in `blood-bank`, `care-reminder`, `deceased-record`, `estimate` and `insurance-claim`.
- It is called **zero** times in any IDEXX service. All four were checked.
- The widening commit, `e77e55c5` `fix(backend): fall back to species-level breed for IDEXX orders` (#2454), is in this same promotion. Those companions used to be rejected for having no mapped breed, so the check that was accidentally holding the line is gone. That is why this surfaced now.

## What is the new behavior?

Membership is asserted at both entry points, before anything resolves the patient, using the existing shared helper rather than a new predicate.

`ACTIVE` only, so a `PENDING` link an organisation merely requested does not satisfy it, and the uniform `Companion not found.` 404 keeps it from being used to probe which patient ids exist. Both properties come from the shared helper and are pinned by a test here.

## Test plan

Four regression tests:

- refuses to create an order for a companion in another organisation
- refuses to update one
- **sends nothing to IDEXX** in that case. Asserting only on the thrown error would still pass if the payload had already been built and transmitted, so this asserts the outbound client was never called at all
- the membership lookup is scoped to the caller org **and** `status: "ACTIVE"`

- [x] 32 pass (28 pre-existing plus these 4).
- [x] **Mutation-checked**: removing the guard fails exactly those four and leaves all 28 pre-existing tests passing, so they are not passing vacuously.

`tsc` in my worktree reports 23 errors, all Prisma-client mismatches from a client generated on another branch, and **the identical 23 appear on unmodified `dev`** with none in the files touched here. CI typechecks against a freshly generated client.

## Note on the other three threads on #2483

The three CodeQL `js/log-injection` alerts on that PR need no code change. All three lines already carry the `.replace(/[\n\r]+/g, " ")` barrier on `dev`, and none of it is on `main`:

```
chatWebhook.controller.ts   dev=1  main=0
appointment.controller.ts   dev=1  main=0
companion.service.ts        dev=1  main=0
```

CodeQL runs against `main`, so those alerts close on the promotion itself. Merging #2483 is the fix.

## Related Issue(s)

Refs #2393
