### PR TITLE
ci(repo): let the back-merge report why it cannot open its own pull request

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -44,7 +44,14 @@ jobs:
 
       - name: Open or update the back-merge pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BACKMERGE_TOKEN first when it exists. The built-in GITHUB_TOKEN is
+          # refused outright by "GitHub Actions is not permitted to create or
+          # approve pull requests" whenever the repository or organisation has
+          # `can_approve_pull_request_reviews` off, which is the case here and
+          # SHOULD stay that way - the same switch also lets a workflow approve
+          # pull requests, which is a larger hole than the one this closes.
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          USING_PAT: ${{ secrets.BACKMERGE_TOKEN && 'true' || 'false' }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -60,6 +67,7 @@ jobs:
 
           BEHIND="$(git rev-list --count origin/dev..origin/main)"
           echo "main has ${BEHIND} commit(s) that dev does not contain."
+          echo "credential: $([ "${USING_PAT}" = "true" ] && echo BACKMERGE_TOKEN || echo GITHUB_TOKEN)"
 
           EXISTING="$(gh pr list --repo "${REPO}" --base dev --head main --state open --json number --jq '.[0].number // empty')"
           if [ -n "${EXISTING}" ]; then
@@ -72,9 +80,8 @@ jobs:
           # restore ancestry, and it is the safety net for the rare case where the
           # diff is NOT empty - something landed on main without passing through
           # dev, and that content would otherwise be stranded.
-          gh pr create --repo "${REPO}" --base dev --head main \
-            --title "chore(repo): back-merge main into dev" \
-            --body "$(cat <<'BODY'
+          BODY_FILE="$(mktemp)"
+          cat > "${BODY_FILE}" <<'BODY'
           Opened automatically so that `dev` continues to contain `main`.
 
           `main` currently holds commits `dev` does not. Usually these are only the merge commits created by each `dev` to `main` promotion, and the file diff is empty - merging this restores ancestry and nothing else.
@@ -83,4 +90,38 @@ jobs:
 
           Merge with a merge commit. Do not squash: squashing creates a new commit and leaves the ancestry broken, which is the problem this exists to fix.
           BODY
-          )"
+
+          if gh pr create --repo "${REPO}" --base dev --head main \
+               --title "chore(repo): back-merge main into dev" \
+               --body-file "${BODY_FILE}" 2>"${BODY_FILE}.err"; then
+            exit 0
+          fi
+
+          # Distinguish "this repository forbids Actions opening pull requests"
+          # from any other failure. Only the former has a settings-level answer,
+          # and reporting the raw GraphQL string sends people to the workflow
+          # looking for a bug that is not there.
+          if grep -q "not permitted to create or approve pull requests" "${BODY_FILE}.err"; then
+            {
+              echo "::error::dev no longer contains main, and this workflow cannot open the back-merge pull request itself."
+              echo
+              echo "GITHUB_TOKEN is refused because 'Allow GitHub Actions to create and approve"
+              echo "pull requests' is off for this repository and organisation."
+              echo
+              echo "Do NOT turn that setting on to fix this. It also lets a workflow APPROVE pull"
+              echo "requests, which is a bigger hole than the one this job closes."
+              echo
+              echo "Either:"
+              echo "  - add a BACKMERGE_TOKEN secret (a PAT with pull-requests: write on this repo),"
+              echo "    which this job prefers automatically when present; or"
+              echo "  - open it by hand:"
+              echo "      gh pr create --repo ${REPO} --base dev --head main \\"
+              echo "        --title 'chore(repo): back-merge main into dev'"
+              echo "    and merge it with a MERGE COMMIT, never a squash."
+            } >&2
+            exit 1
+          fi
+
+          echo "::error::Failed to open the back-merge pull request." >&2
+          cat "${BODY_FILE}.err" >&2
+          exit 1

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -54,12 +54,19 @@ jobs:
     # Release sync PRs replay already-merged dev history into main. Keep title
     # validation active, but do not re-lint historical commits in that path.
     #
+    # The back-merge is the same situation in the opposite direction: a main to
+    # dev pull request replays already-merged MAIN history into dev, so it
+    # re-lints commits that shipped long ago and cannot be rewritten. #2503 failed
+    # exactly that way, on `chore(deps): bump json (#2131)` - scope `deps` is not
+    # in scope-enum. That is the Dependabot commit merged straight into main on
+    # 2026-08-13, the incident that made back-merges necessary in the first place.
+    #
     # Dependabot writes long changelog and release-note lines into its commit
     # bodies, which trip config-conventional's body/footer-max-line-length and
     # fail this job on every bot PR. The PR-title gate above still runs, so the
     # conventional type(scope) contract is enforced on the squash-merge subject;
     # only the generated body lines are exempt.
-    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') && !(github.event.pull_request.base.ref == 'dev' && github.event.pull_request.head.ref == 'main') && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The first real run of `back-merge.yml`, on the #2483 promotion, failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

My mistake. The job carries `pull-requests: write`, but that is overridden by **"Allow GitHub Actions to create and approve pull requests"**, which is off at both repository and organisation level:

```
repo: default_workflow_permissions=read  can_approve_pull_request_reviews=false
org:  default_workflow_permissions=read  can_approve_pull_request_reviews=false
```

I verified the workflow's *logic* against the real repository state before shipping it, and never verified the one thing it exists to do: that its token can actually open a pull request.

**That setting should stay off.** The same switch also lets a workflow *approve* pull requests, so turning it on to fix a back-merge opens a larger hole than the one this job closes.

The failure mode compounds it: the raw GraphQL string sends whoever reads it into the workflow file looking for a bug that is not there.

## What is the new behavior?

Take a token if one is offered, and explain the situation when one is not.

- Prefers `BACKMERGE_TOKEN` when the secret exists, falling back to `GITHUB_TOKEN`, and prints which is in use so a silent fallback is visible.
- On the specific refusal: says what is wrong, says why the obvious setting change is the wrong answer, and gives the exact command to open it by hand.
- On any **other** failure: reports the real error and does not blame the setting.

```
::error::dev no longer contains main, and this workflow cannot open the back-merge pull request itself.

GITHUB_TOKEN is refused because 'Allow GitHub Actions to create and approve
pull requests' is off for this repository and organisation.

Do NOT turn that setting on to fix this. It also lets a workflow APPROVE pull
requests, which is a bigger hole than the one this job closes.

Either:
  - add a BACKMERGE_TOKEN secret (a PAT with pull-requests: write on this repo),
    which this job prefers automatically when present; or
  - open it by hand:
      gh pr create --repo YosemiteCrew/Yosemite-Crew --base dev --head main \
        --title 'chore(repo): back-merge main into dev'
    and merge it with a MERGE COMMIT, never a squash.
```

## Test plan

Extracted the `run:` block and exercised every path against a stubbed `gh`, checking exit codes without a pipe in the way (a pipeline reports the last command's status, which is how a failing step reads as green):

| Case | Result |
|---|---|
| creation refused | exits **1**, prints the guidance above |
| unrelated failure | exits **1**, prints the real error, does **not** mention settings |
| success with a PAT | exits **0**, logs `credential: BACKMERGE_TOKEN` |
| invariant already holds | no-op - this is what the live run did before the promotion |

- [x] Workflow parses; `bash -n` clean on the extracted script.

## Note

#2503 carries the back-merge this run should have opened. Its diff is empty - pure ancestry - and it must be merged with a **merge commit, not a squash**, since a squash recreates the exact ancestry break it fixes.

`BACKMERGE_TOKEN` is optional. Without it this job now fails loudly with instructions instead of failing obscurely, which is the important part.

## Related Issue(s)

Refs #2393
