### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -44,7 +44,14 @@ jobs:
 
       - name: Open or update the back-merge pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BACKMERGE_TOKEN first when it exists. The built-in GITHUB_TOKEN is
+          # refused outright by "GitHub Actions is not permitted to create or
+          # approve pull requests" whenever the repository or organisation has
+          # `can_approve_pull_request_reviews` off, which is the case here and
+          # SHOULD stay that way - the same switch also lets a workflow approve
+          # pull requests, which is a larger hole than the one this closes.
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          USING_PAT: ${{ secrets.BACKMERGE_TOKEN && 'true' || 'false' }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -60,6 +67,7 @@ jobs:
 
           BEHIND="$(git rev-list --count origin/dev..origin/main)"
           echo "main has ${BEHIND} commit(s) that dev does not contain."
+          echo "credential: $([ "${USING_PAT}" = "true" ] && echo BACKMERGE_TOKEN || echo GITHUB_TOKEN)"
 
           EXISTING="$(gh pr list --repo "${REPO}" --base dev --head main --state open --json number --jq '.[0].number // empty')"
           if [ -n "${EXISTING}" ]; then
@@ -72,9 +80,8 @@ jobs:
           # restore ancestry, and it is the safety net for the rare case where the
           # diff is NOT empty - something landed on main without passing through
           # dev, and that content would otherwise be stranded.
-          gh pr create --repo "${REPO}" --base dev --head main \
-            --title "chore(repo): back-merge main into dev" \
-            --body "$(cat <<'BODY'
+          BODY_FILE="$(mktemp)"
+          cat > "${BODY_FILE}" <<'BODY'
           Opened automatically so that `dev` continues to contain `main`.
 
           `main` currently holds commits `dev` does not. Usually these are only the merge commits created by each `dev` to `main` promotion, and the file diff is empty - merging this restores ancestry and nothing else.
@@ -83,4 +90,38 @@ jobs:
 
           Merge with a merge commit. Do not squash: squashing creates a new commit and leaves the ancestry broken, which is the problem this exists to fix.
           BODY
-          )"
+
+          if gh pr create --repo "${REPO}" --base dev --head main \
+               --title "chore(repo): back-merge main into dev" \
+               --body-file "${BODY_FILE}" 2>"${BODY_FILE}.err"; then
+            exit 0
+          fi
+
+          # Distinguish "this repository forbids Actions opening pull requests"
+          # from any other failure. Only the former has a settings-level answer,
+          # and reporting the raw GraphQL string sends people to the workflow
+          # looking for a bug that is not there.
+          if grep -q "not permitted to create or approve pull requests" "${BODY_FILE}.err"; then
+            {
+              echo "::error::dev no longer contains main, and this workflow cannot open the back-merge pull request itself."
+              echo
+              echo "GITHUB_TOKEN is refused because 'Allow GitHub Actions to create and approve"
+              echo "pull requests' is off for this repository and organisation."
+              echo
+              echo "Do NOT turn that setting on to fix this. It also lets a workflow APPROVE pull"
+              echo "requests, which is a bigger hole than the one this job closes."
+              echo
+              echo "Either:"
+              echo "  - add a BACKMERGE_TOKEN secret (a PAT with pull-requests: write on this repo),"
+              echo "    which this job prefers automatically when present; or"
+              echo "  - open it by hand:"
+              echo "      gh pr create --repo ${REPO} --base dev --head main \\"
+              echo "        --title 'chore(repo): back-merge main into dev'"
+              echo "    and merge it with a MERGE COMMIT, never a squash."
+            } >&2
+            exit 1
+          fi
+
+          echo "::error::Failed to open the back-merge pull request." >&2
+          cat "${BODY_FILE}.err" >&2
+          exit 1

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -54,12 +54,19 @@ jobs:
     # Release sync PRs replay already-merged dev history into main. Keep title
     # validation active, but do not re-lint historical commits in that path.
     #
+    # The back-merge is the same situation in the opposite direction: a main to
+    # dev pull request replays already-merged MAIN history into dev, so it
+    # re-lints commits that shipped long ago and cannot be rewritten. #2503 failed
+    # exactly that way, on `chore(deps): bump json (#2131)` - scope `deps` is not
+    # in scope-enum. That is the Dependabot commit merged straight into main on
+    # 2026-08-13, the incident that made back-merges necessary in the first place.
+    #
     # Dependabot writes long changelog and release-note lines into its commit
     # bodies, which trip config-conventional's body/footer-max-line-length and
     # fail this job on every bot PR. The PR-title gate above still runs, so the
     # conventional type(scope) contract is enforced on the squash-merge subject;
     # only the generated body lines are exempt.
-    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') && !(github.event.pull_request.base.ref == 'dev' && github.event.pull_request.head.ref == 'main') && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` is 2 commits behind `dev`, and both are workflow fixes that only take effect once they are ON `main`.

```
c11cf1645  Merge pull request #2503 from YosemiteCrew/main   (the back-merge)
c5549018a  ci(repo): let the back-merge report why it cannot open its own pull request (#2504)
```

`#2504` added two things:

1. `back-merge.yml` now prefers a `BACKMERGE_TOKEN` when present and, when refused, explains that `GITHUB_TOKEN` cannot open pull requests here rather than dying on a raw GraphQL error.
2. `pr-governance.yml` exempts the back-merge direction (`base: dev`, `head: main`) from re-linting commit messages, matching the exemption that already existed for `dev` to `main` promotions.

**The second one does not work until `main` carries it.** For `pull_request` events GitHub reads the workflow definition from the HEAD branch, and a back-merge's head IS `main`. Verified empirically: a fresh run after #2504 merged (32855397093) still executed the job and failed on `chore(deps): bump json (#2131)`, so #2503 had to be merged with an explicit admin bypass.

This promotion is what makes the exemption real, so the next back-merge does not need that bypass.

## What is the new behavior?

Nothing at runtime. The whole diff is:

```
.github/workflows/back-merge.yml
.github/workflows/pr-governance.yml
```

- **0** files under `apps/` or `packages/`
- **0** migrations

## Deploy notes

**No API deploy is needed.** Production is already running `1adfd8064`, and this carries no backend code and no migrations, so the running API is unaffected.

`cd-frontend.yaml` fires on push to `main`, but its `detect-frontend` job gates the deploy on affected paths and nothing frontend changed here, so it should self-skip. Worth a glance at the run afterwards rather than an assumption.

## Related Issue(s)

Refs #2393
