### PR TITLE
fix(repo): tell the client when the directory is unavailable, not just empty

### DIFF
--- a/apps/backend/src/services/activitypub.service.ts
+++ b/apps/backend/src/services/activitypub.service.ts
@@ -1079,7 +1079,7 @@ export async function setDirectoryListing(
  */
 export async function listDirectory(
   orgId: string,
-): Promise<{ clinics: DirectoryClinic[] }> {
+): Promise<{ clinics: DirectoryClinic[]; unavailable: boolean }> {
   const actor = await getActorByOrgId(orgId);
   const licenseToken = actor?.licenseToken;
 
@@ -1109,10 +1109,14 @@ export async function listDirectory(
       },
       DIRECTORY_CACHE_OPTIONS,
     );
-    return { clinics };
+    return { clinics, unavailable: false };
   } catch (err) {
+    // Still degrade gracefully - an unreachable authority must not error the
+    // page - but SAY SO. Returning a bare empty list made "the authority is
+    // down or unconfigured" indistinguishable from "nobody has listed yet",
+    // and the UI reported the latter.
     logger.error("[AP] listDirectory error", { err });
-    return { clinics: [] };
+    return { clinics: [], unavailable: true };
   }
 }
 

--- a/apps/backend/test/services/activitypub.service.test.ts
+++ b/apps/backend/test/services/activitypub.service.test.ts
@@ -1483,7 +1483,7 @@ describe("listDirectory", () => {
 
       const result = await fresh.listDirectory("org-1");
 
-      expect(result).toEqual({ clinics });
+      expect(result).toEqual({ clinics, unavailable: false });
       const [url, opts] = fetchMock.mock.calls[0];
       expect(url).toBe("https://authority.example/api/directory");
       expect(opts.headers.Authorization).toBe("Bearer lic-token");
@@ -1521,7 +1521,7 @@ describe("listDirectory", () => {
 
       const result = await fresh.listDirectory("org-1");
 
-      expect(result).toEqual({ clinics: [] });
+      expect(result).toEqual({ clinics: [], unavailable: false });
       expect(fetchMock.mock.calls[0][1].headers.Authorization).toBeUndefined();
     });
   });
@@ -1537,11 +1537,11 @@ describe("listDirectory", () => {
       global.fetch = fetchMock as unknown as typeof fetch;
 
       const result = await fresh.listDirectory("org-1");
-      expect(result).toEqual({ clinics });
+      expect(result).toEqual({ clinics, unavailable: false });
     });
   });
 
-  it("returns { clinics: [] } (resilient) when the authority responds non-ok", async () => {
+  it("reports unavailable, not empty, when the authority responds non-ok", async () => {
     await jest.isolateModulesAsync(async () => {
       const fresh = await import("src/services/activitypub.service");
       prisma.aPActor.findUnique.mockResolvedValue(makeActor());
@@ -1551,11 +1551,11 @@ describe("listDirectory", () => {
       }) as unknown as typeof fetch;
 
       const result = await fresh.listDirectory("org-1");
-      expect(result).toEqual({ clinics: [] });
+      expect(result).toEqual({ clinics: [], unavailable: true });
     });
   });
 
-  it("returns { clinics: [] } (resilient) when fetch rejects (network error)", async () => {
+  it("reports unavailable, not empty, when fetch rejects (network error)", async () => {
     await jest.isolateModulesAsync(async () => {
       const fresh = await import("src/services/activitypub.service");
       prisma.aPActor.findUnique.mockResolvedValue(makeActor());
@@ -1566,7 +1566,7 @@ describe("listDirectory", () => {
         ) as unknown as typeof fetch;
 
       const result = await fresh.listDirectory("org-1");
-      expect(result).toEqual({ clinics: [] });
+      expect(result).toEqual({ clinics: [], unavailable: true });
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
@@ -57,9 +57,9 @@ beforeEach(() => {
 
 describe('NetworkDirectory', () => {
   it('shows the loading state before data resolves', async () => {
-    let resolve: (value: APDirectoryClinic[]) => void = () => {};
+    let resolve: (value: { clinics: APDirectoryClinic[] }) => void = () => {};
     (listDirectory as jest.Mock).mockReturnValue(
-      new Promise<APDirectoryClinic[]>((r) => {
+      new Promise<{ clinics: APDirectoryClinic[] }>((r) => {
         resolve = r;
       })
     );
@@ -68,12 +68,12 @@ describe('NetworkDirectory', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
 
     await act(async () => {
-      resolve([]);
+      resolve({ clinics: [] });
     });
   });
 
   it('shows the empty state when no clinics are listed', async () => {
-    (listDirectory as jest.Mock).mockResolvedValue([]);
+    (listDirectory as jest.Mock).mockResolvedValue({ clinics: [], unavailable: false });
     render(<NetworkDirectory />);
     await waitFor(() =>
       expect(screen.getByText('No clinics are listed in the directory yet.')).toBeInTheDocument()
@@ -81,7 +81,10 @@ describe('NetworkDirectory', () => {
   });
 
   it('renders clinic cards with name, handle, and host', async () => {
-    (listDirectory as jest.Mock).mockResolvedValue([clinicA, clinicB]);
+    (listDirectory as jest.Mock).mockResolvedValue({
+      clinics: [clinicA, clinicB],
+      unavailable: false,
+    });
     render(<NetworkDirectory />);
     await waitFor(() => screen.getByText('Alpha Vet Clinic'));
     expect(screen.getByText('@alpha-vet')).toBeInTheDocument();
@@ -107,8 +110,21 @@ describe('NetworkDirectory', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('reports unavailable when the API answers 200 but flags the authority as unreachable', async () => {
+    // The backend degrades gracefully rather than erroring, so a successful
+    // response can still mean "could not load". Without honouring the flag this
+    // rendered as "no clinics listed yet", which is how the whole feature came
+    // to look like it was simply doing nothing.
+    (listDirectory as jest.Mock).mockResolvedValueOnce({ clinics: [], unavailable: true });
+    render(<NetworkDirectory />);
+    expect(await screen.findByText(/directory is unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText('No clinics are listed in the directory yet.')
+    ).not.toBeInTheDocument();
+  });
+
   it('shows the empty state, not the error state, when the directory is genuinely empty', async () => {
-    (listDirectory as jest.Mock).mockResolvedValueOnce([]);
+    (listDirectory as jest.Mock).mockResolvedValueOnce({ clinics: [], unavailable: false });
     render(<NetworkDirectory />);
     expect(
       await screen.findByText('No clinics are listed in the directory yet.')
@@ -117,7 +133,7 @@ describe('NetworkDirectory', () => {
   });
 
   it('follows a clinic and notifies success', async () => {
-    (listDirectory as jest.Mock).mockResolvedValue([clinicA]);
+    (listDirectory as jest.Mock).mockResolvedValue({ clinics: [clinicA], unavailable: false });
     (followRemoteActor as jest.Mock).mockResolvedValueOnce(undefined);
 
     render(<NetworkDirectory />);
@@ -136,7 +152,7 @@ describe('NetworkDirectory', () => {
   });
 
   it('notifies error when following a clinic fails', async () => {
-    (listDirectory as jest.Mock).mockResolvedValue([clinicA]);
+    (listDirectory as jest.Mock).mockResolvedValue({ clinics: [clinicA], unavailable: false });
     (followRemoteActor as jest.Mock).mockRejectedValueOnce(new Error('fail'));
 
     render(<NetworkDirectory />);

--- a/apps/frontend/src/app/__tests__/features/federation/federationService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/federation/federationService.test.ts
@@ -280,8 +280,23 @@ describe('federationService', () => {
       ];
       mockGetData.mockResolvedValueOnce({ data: { clinics } });
       const result = await listDirectory();
-      expect(result).toEqual(clinics);
+      // Returns the envelope now, so the caller can tell "empty" from
+      // "the authority could not be reached".
+      expect(result).toEqual({ clinics, unavailable: undefined });
       expect(mockGetData).toHaveBeenCalledWith('/ap/manage/directory');
+    });
+
+    it('passes the unavailable flag through', async () => {
+      mockGetData.mockResolvedValueOnce({ data: { clinics: [], unavailable: true } });
+      await expect(listDirectory()).resolves.toEqual({ clinics: [], unavailable: true });
+    });
+
+    it('defaults clinics to an empty array when the field is absent', async () => {
+      mockGetData.mockResolvedValueOnce({ data: {} });
+      await expect(listDirectory()).resolves.toEqual({
+        clinics: [],
+        unavailable: undefined,
+      });
     });
 
     it('throws when getData rejects', async () => {

--- a/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
+++ b/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
@@ -69,8 +69,10 @@ const NetworkDirectory = () => {
     // would be a synchronous state write during the effect body.
     try {
       const data = await listDirectory();
-      setClinics(data);
-      setUnavailable(false);
+      setClinics(data.clinics);
+      // The backend degrades gracefully when the authority is unreachable, so a
+      // successful response can still mean "could not load". Trust its flag.
+      setUnavailable(Boolean(data.unavailable));
     } catch {
       setUnavailable(true);
       notify('error', {

--- a/apps/frontend/src/app/features/federation/services/federationService.ts
+++ b/apps/frontend/src/app/features/federation/services/federationService.ts
@@ -2,7 +2,6 @@ import { getData, postData, putData, patchData } from '@/app/services/axios';
 import type {
   APActorSettings,
   APDirectory,
-  APDirectoryClinic,
   APFollower,
   APFollowing,
   APReferral,
@@ -65,9 +64,9 @@ export const respondToReferral = (referralId: string, action: 'accept' | 'declin
 export const updateActorProfile = (opts: { summary?: string; iconUrl?: string }) =>
   putData(`${BASE}/actor`, opts);
 
-export const listDirectory = async (): Promise<APDirectoryClinic[]> => {
+export const listDirectory = async (): Promise<APDirectory> => {
   const res = await getData<APDirectory>(`${BASE}/directory`);
-  return res.data.clinics;
+  return { clinics: res.data.clinics ?? [], unavailable: res.data.unavailable };
 };
 
 export const setDirectoryListed = (listed: boolean) =>

--- a/apps/frontend/src/app/features/federation/types/federation.ts
+++ b/apps/frontend/src/app/features/federation/types/federation.ts
@@ -31,6 +31,8 @@ export interface APDirectoryClinic {
 
 export interface APDirectory {
   clinics: APDirectoryClinic[];
+  /** True when the authority could not be reached, as opposed to being empty. */
+  unavailable?: boolean;
 }
 
 export interface APFollower {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

`/network` reports "No clinics are listed in the directory yet." while the directory authority is returning an error.

Observed on dev right now:

```
GET https://admin.yosemitecrew.com/api/directory  ->  {"error":"AP signing not configured"}
GET https://dev.yosemitecrew.com/network          ->  "No clinics are listed in the directory yet."
```

`listDirectory` degrades gracefully when the authority cannot be reached, which is the right behaviour - the page should not error - but it returned a bare empty list. The API then answers 200 with no clinics, so the client cannot distinguish "the authority is down or unconfigured" from "nobody has listed yet", and renders the latter.

This is the same masking problem as #2484, one layer lower. That PR made the client honest about *its own* request failing; this path never fails, so it was untouched.

## What is the new behavior?

`listDirectory` returns `{ clinics, unavailable }`. The controller passes it through unchanged, the frontend service carries the flag, and `NetworkDirectory` renders the unavailable and genuinely-empty cases distinctly.

Graceful degradation is unchanged: an unreachable authority still yields an empty list and a rendered page, never an error.

## Related Issue(s)

Follows YosemiteCrew/Yosemite-Crew#1762, #2484 and #2495.

## Validation performed

- Backend: 438 suites, 10548 tests passing. Lint and type-check clean.
- Frontend: federation suites 64 tests passing. Lint clean at `--max-warnings=0`, type-check clean.
- Mutation checked: forcing the flag to false in the component fails the new test; restoring it returns to green.
- The two resilient backend tests were named `returns { clinics: [] } (resilient) when ...` and asserted the old shape. They now state the new contract and assert `unavailable: true`.
