### PR TITLE
fix(backend): stop the unauthenticated nearby search publishing internal fields

### DIFF
--- a/apps/backend/src/services/organization.service.ts
+++ b/apps/backend/src/services/organization.service.ts
@@ -1081,9 +1081,19 @@ export const OrganizationService = {
       );
     });
 
+    // The widen-the-net fallback is deliberate and covered by a test, so it
+    // stays. What was NOT deliberate is that it carried neither `isVerified`
+    // nor `isActive`, unlike the primary query above - so on an UNAUTHENTICATED
+    // endpoint it surfaced unverified and deactivated practices that the
+    // primary query is careful to exclude. Apply the same guards.
+    //
+    // Worth revisiting separately: whether "nothing within the radius" should
+    // widen to every organisation at all, since a caller in Berlin currently
+    // gets clinics on other continents. That is a product call, not a fix.
     if (organisations.length === 0) {
       logger.warn("No nearby organisations found, returning all organisations");
       organisations = await prisma.organization.findMany({
+        where: { isVerified: true, isActive: true },
         include: { address: true },
       });
     }
@@ -1093,18 +1103,45 @@ export const OrganizationService = {
     const results = [];
 
     for (const org of pageOrgs) {
+      // Select explicitly rather than spreading the rows. This response is
+      // UNAUTHENTICATED, and the `org` object below is already hand-projected
+      // for exactly that reason; the speciality and service rows were not, so
+      // `...spec` and the raw service rows published every column.
+      //
+      // What that exposed: `maxDiscount`, a practice's internal discount
+      // ceiling, and `cost`, alongside `headName`, `headProfilePicUrl`,
+      // `headUserId` and `memberUserIds` - naming department heads, showing
+      // their photograph, and handing staff user ids to anyone who could guess
+      // a latitude and longitude.
+      //
+      // Listing fields rather than removing them means anything added to these
+      // models in future is excluded by default. That is the point.
       const [specialities, services] = await Promise.all([
         prisma.speciality.findMany({
-          where: { organisationId: org.id },
+          where: { organisationId: org.id, isActive: true },
+          select: { id: true, name: true, description: true },
         }),
         prisma.service.findMany({
-          where: { organisationId: org.id },
+          where: { organisationId: org.id, isActive: true },
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            durationMinutes: true,
+            serviceType: true,
+            // Groups services under their speciality below; not emitted.
+            specialityId: true,
+          },
         }),
       ]);
 
       const specialitiesWithServices = specialities.map((spec) => ({
-        ...spec,
-        services: services.filter((srv) => srv.specialityId === spec.id),
+        id: spec.id,
+        name: spec.name,
+        description: spec.description ?? undefined,
+        services: services
+          .filter((srv) => srv.specialityId === spec.id)
+          .map(({ specialityId: _specialityId, ...srv }) => srv),
       }));
 
       const distanceInMeters =

--- a/apps/backend/test/services/organization.service.test.ts
+++ b/apps/backend/test/services/organization.service.test.ts
@@ -1150,5 +1150,97 @@ describe("OrganizationService", () => {
       expect(result.meta.total).toBe(1);
       expect(result.data[0].specialitiesWithServices).toHaveLength(1);
     });
+
+    // /getNearby is UNAUTHENTICATED - organization.router.ts mounts it behind
+    // attachSessionIfPresent, which never rejects. The speciality and service
+    // rows used to be spread whole into the response, publishing a practice's
+    // internal discount ceiling and naming its department heads to anyone who
+    // could guess a latitude and longitude.
+    it("publishes no internal commercial or staff fields to an anonymous caller", async () => {
+      (prisma.organization.findMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: "org-1",
+          name: "Clinic",
+          address: { latitude: 10, longitude: 20, city: "City" },
+        },
+      ]);
+      (prisma.speciality.findMany as jest.Mock).mockResolvedValueOnce([
+        { id: "spec-1", name: "Dentistry", description: "Teeth" },
+      ]);
+      (prisma.service.findMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: "svc-1",
+          name: "Scale and polish",
+          description: null,
+          durationMinutes: 30,
+          serviceType: "PROCEDURE",
+          specialityId: "spec-1",
+        },
+      ]);
+
+      const result =
+        await OrganizationService.listNearbyForAppointmentsPaginated(
+          10,
+          20,
+          500,
+          1,
+          10,
+        );
+
+      // Assert on the SELECT, not only the output. A future `include` would
+      // reintroduce the leak while the shaped output still looked clean.
+      const specArgs = (prisma.speciality.findMany as jest.Mock).mock
+        .calls[0][0];
+      expect(specArgs.select).toBeDefined();
+      for (const field of [
+        "headUserId",
+        "memberUserIds",
+        "headName",
+        "headProfilePicUrl",
+      ]) {
+        expect(specArgs.select).not.toHaveProperty(field);
+      }
+
+      const svcArgs = (prisma.service.findMany as jest.Mock).mock.calls[0][0];
+      expect(svcArgs.select).toBeDefined();
+      expect(svcArgs.select).not.toHaveProperty("cost");
+      expect(svcArgs.select).not.toHaveProperty("maxDiscount");
+
+      const payload = JSON.stringify(result);
+      for (const leak of [
+        "maxDiscount",
+        "headUserId",
+        "memberUserIds",
+        "headProfilePicUrl",
+        "specialityId",
+      ]) {
+        expect(payload).not.toContain(leak);
+      }
+    });
+
+    // The widen-the-net fallback is intentional, but it used to carry neither
+    // isVerified nor isActive, so it surfaced practices the primary query
+    // deliberately excludes.
+    it("keeps the verified and active guards on the widen-the-net fallback", async () => {
+      (prisma.organization.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.speciality.findMany as jest.Mock).mockResolvedValueOnce([]);
+      (prisma.service.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+      await OrganizationService.listNearbyForAppointmentsPaginated(
+        0,
+        0,
+        500,
+        1,
+        10,
+      );
+
+      const fallbackArgs = (prisma.organization.findMany as jest.Mock).mock
+        .calls[1][0];
+      expect(fallbackArgs.where).toEqual(
+        expect.objectContaining({ isVerified: true, isActive: true }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`GET /fhir/v1/organization/getNearby` is unauthenticated. `organization.router.ts:25-29` mounts it behind `attachSessionIfPresent`, which never rejects, and that is deliberate - it is public discovery.

I confirmed the exposure against dev with no token at all:

```
GET https://devapi.yosemitecrew.com/fhir/v1/organization/getNearby?lat=52.52&lng=13.405
-> 200, 10 organisations
```

The `org` object in that response is already carefully hand-projected (`organization.service.ts:1122-1146`), which shows the intent. The speciality and service rows were not - they were spread whole:

```ts
const specialitiesWithServices = specialities.map((spec) => ({
  ...spec,
  services: services.filter((srv) => srv.specialityId === spec.id),
}));
```

Neither `findMany` carried a `select`, so every column reached an anonymous caller. Observed field lists from the live response:

| Object | Fields published |
|---|---|
| service | `cost`, **`maxDiscount`**, durationMinutes, serviceType, observationToolId, organisationId, specialityId, ... |
| speciality | **`headName`**, **`headProfilePicUrl`**, **`headUserId`**, **`memberUserIds`**, departmentMasterId, fhirId, ... |

`maxDiscount` is a practice's internal discount ceiling - its negotiating floor. The speciality fields name department heads, show their photograph, and hand out staff user ids. All of it to anyone able to guess a latitude and longitude.

Separately, the widen-the-net fallback at `:1084-1089` carried neither `isVerified` nor `isActive`, unlike the primary query directly above it, so it surfaced unverified and deactivated practices that the primary query deliberately excludes.

## What is the new behavior?

Select explicitly instead of spreading, so anything added to these models later is excluded by default rather than published by default. `specialityId` is read to group services under their speciality and is not emitted.

The fallback keeps its behaviour but gains the same `isVerified` / `isActive` guards as the primary query.

**Deliberately not changed:** the fallback itself. It is intentional and has a test asserting it (`falls back to all organisations when none are nearby`), so removing it is a product decision rather than a fix. My first attempt did remove it, and that test correctly failed - worth flagging that whether "nothing within the radius" should widen to *every* organisation is worth deciding, since a caller in Berlin currently gets clinics on other continents.

## Test plan

- [x] Two regression tests. They assert on the prisma **SELECT** as well as on the serialised payload, because a future `include` would reintroduce the leak while the shaped output still looked clean.
- [x] **Mutation-checked**: removing the speciality `select` fails one test; removing the fallback guards fails the other. Restoring gives 51/51.
- [x] 51 tests pass in `organization.service.test.ts`, including the two pre-existing nearby tests.
- [x] `tsc --noEmit` on the backend: **0 errors**.

## Blast radius

None. Nothing in `apps/` or `packages/` calls this endpoint - mobile uses the separate authenticated `/mobile/getNearby`. It is referenced only in the router, controller, service and dev-docs. No client reads the removed fields from this endpoint; the PIMS UI reads `maxDiscount` and `headUserId` from other, authenticated endpoints.

## Related Issue(s)

Refs #2393
