### PR TITLE
fix(frontend): split Settings by who a change affects, not by topic

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/PreferenceGroup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/PreferenceGroup.test.tsx
@@ -10,13 +10,51 @@ import {
 describe('PreferenceGroup', () => {
   it('renders the group title and its children', () => {
     render(
-      <PreferenceGroup title="Workspace preferences">
+      <PreferenceGroup title="Your preferences">
         <div>child content</div>
       </PreferenceGroup>
     );
 
-    expect(screen.getByRole('heading', { name: 'Workspace preferences' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Your preferences' })).toBeInTheDocument();
     expect(screen.getByText('child content')).toBeInTheDocument();
+  });
+
+  // A clinic-wide group must SAY it is clinic-wide. Without this the page looks
+  // correct while telling the reader nothing about who a change affects, which
+  // is the exact failure the scope split exists to prevent.
+  it('names the audience and warns when the scope is the whole clinic', () => {
+    render(
+      <PreferenceGroup title="Scheduling & messaging" scope="organisation">
+        <span>x</span>
+      </PreferenceGroup>
+    );
+
+    expect(screen.getByText('Whole clinic')).toBeInTheDocument();
+    expect(
+      screen.getByText('These apply to everyone at this clinic, not just you.')
+    ).toBeInTheDocument();
+  });
+
+  it('names the audience as the signed-in user for a personal scope', () => {
+    render(
+      <PreferenceGroup title="Your preferences" scope="personal">
+        <span>x</span>
+      </PreferenceGroup>
+    );
+
+    expect(screen.getByText('Only you')).toBeInTheDocument();
+    expect(screen.getByText('These apply to your account on this clinic.')).toBeInTheDocument();
+  });
+
+  it('renders no scope chip or hint when the scope is not declared', () => {
+    render(
+      <PreferenceGroup title="Group">
+        <span>x</span>
+      </PreferenceGroup>
+    );
+
+    expect(screen.queryByText('Whole clinic')).not.toBeInTheDocument();
+    expect(screen.queryByText('Only you')).not.toBeInTheDocument();
   });
 
   it('appends an extra className when provided', () => {

--- a/apps/frontend/src/app/__tests__/pages/Settings/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/index.test.tsx
@@ -124,7 +124,9 @@ describe('Settings page', () => {
     render(<Settings />);
 
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
-    expect(screen.getByText('Personal and workspace preferences')).toBeInTheDocument();
+    expect(
+      screen.getByText('Your preferences, and the clinic settings you administer')
+    ).toBeInTheDocument();
     expect(screen.getByText('Changes save automatically')).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
@@ -1,28 +1,75 @@
 'use client';
 import React from 'react';
 
+/**
+ * Who a group of settings actually affects.
+ *
+ * This is not decoration. Settings mixes per-user preferences with controls that
+ * change behaviour for every colleague at the clinic, and the two used to sit in
+ * undifferentiated cards - so an owner could change the whole clinic believing it
+ * was their own preference. Groups declare their scope and say so on screen.
+ */
+export type PreferenceScope = 'personal' | 'organisation';
+
+const SCOPE_COPY: Record<PreferenceScope, { label: string; hint: string }> = {
+  personal: { label: 'Only you', hint: 'These apply to your account on this clinic.' },
+  organisation: {
+    label: 'Whole clinic',
+    hint: 'These apply to everyone at this clinic, not just you.',
+  },
+};
+
 type PreferenceGroupProps = {
   title: string;
   children: React.ReactNode;
   className?: string;
+  /** Who the group's controls affect. Renders a scope chip and a one-line hint. */
+  scope?: PreferenceScope;
 };
 
 /**
  * Grouped-preferences card from the Settings design: a `--screen` surface with a
  * hairline border, the soft two-layer shadow and a bold group title, stacking one
- * or more preference rows/blocks. Replaces the previous one-card-per-preference
- * pattern (each with its own header band) so the page matches the design's
- * "Workspace preferences" / "Scheduling & messaging" consolidated cards.
+ * or more preference rows/blocks.
+ *
+ * When `scope` is given the title row also carries a chip naming who the settings
+ * affect, plus a faint hint line beneath it.
  */
-export const PreferenceGroup = ({ title, children, className }: PreferenceGroupProps) => (
-  <section
-    className={`flex flex-col gap-[14px] rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[18px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${
-      className ?? ''
-    }`.trim()}
+export const PreferenceGroup = ({ title, children, className, scope }: PreferenceGroupProps) => {
+  const copy = scope ? SCOPE_COPY[scope] : null;
+
+  return (
+    <section
+      className={`flex flex-col gap-[14px] rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[18px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${
+        className ?? ''
+      }`.trim()}
+    >
+      <div className="flex flex-col gap-[3px]">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-[14.5px] font-bold text-[var(--ink)]">{title}</h3>
+          {copy && <ScopeChip scope={scope!} label={copy.label} />}
+        </div>
+        {copy && <p className="m-0! text-[11.5px] text-[var(--ink-faint)]">{copy.hint}</p>}
+      </div>
+      {children}
+    </section>
+  );
+};
+
+/**
+ * The scope chip. Deliberately not a StatusPill: this labels audience, not state,
+ * and must not compete with the status colours used for live/verified/error.
+ */
+const ScopeChip = ({ scope, label }: { scope: PreferenceScope; label: string }) => (
+  <span
+    className={`flex-none rounded-full border px-2 py-[2px] text-[10.5px] font-semibold tracking-[0.02em] whitespace-nowrap ${
+      scope === 'organisation'
+        ? 'border-[var(--blue)] text-[var(--blue)]'
+        : 'border-[var(--hairline)] text-[var(--ink-faint)]'
+    }`}
   >
-    <h3 className="text-[14.5px] font-bold text-[var(--ink)]">{title}</h3>
-    {children}
-  </section>
+    {label}
+  </span>
 );
 
 type PreferenceRowProps = {

--- a/apps/frontend/src/app/features/settings/pages/Settings/index.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/index.tsx
@@ -67,6 +67,34 @@ const FederationSection = dynamic(
   { loading: () => <CardSkeleton /> }
 );
 
+/**
+ * A scope band: the labelled region that separates personal settings from
+ * clinic-wide ones. The heading is what tells a reader, before they touch
+ * anything, whether a change is theirs alone or everyone's.
+ */
+const SettingsBand = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) => (
+  <section className="flex flex-col gap-3.5" aria-labelledby={`settings-band-${title}`}>
+    <div className="flex flex-col gap-[2px]">
+      <h2
+        id={`settings-band-${title}`}
+        className="m-0! text-[15px] font-bold tracking-[-0.01em] text-[var(--ink)]"
+      >
+        {title}
+      </h2>
+      <p className="m-0! text-[12px] text-[var(--ink-faint)]">{description}</p>
+    </div>
+    {children}
+  </section>
+);
+
 const Settings = () => {
   const [profileOpen, setProfileOpen] = useState(false);
   const [hoursOpen, setHoursOpen] = useState(false);
@@ -87,7 +115,9 @@ const Settings = () => {
               className="flex-none"
             />
           </h1>
-          <span className="yc-settings-subtitle">Personal and workspace preferences</span>
+          <span className="yc-settings-subtitle">
+            Your preferences, and the clinic settings you administer
+          </span>
         </div>
         <span className="yc-settings-autosave">
           <span className="yc-settings-autosave-dot" aria-hidden="true" />
@@ -95,40 +125,55 @@ const Settings = () => {
         </span>
       </div>
 
-      {/* Compact control panel — the design's 2-column Settings grid:
-          [Personal | Workspace preferences] / [Scheduling & messaging | Organizations + Delete]. */}
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-3.5 items-start">
-        <Personal
-          onEditProfile={() => setProfileOpen(true)}
-          onEditHours={() => setHoursOpen(true)}
-        />
+      {/* The page is split by WHO a setting affects, not by topic. Grouping by
+          topic previously put per-user controls under a card called "Workspace
+          preferences" and clinic-wide controls beside a device theme toggle, so
+          the labels pointed away from the truth. Scope is the axis that changes
+          whether a click is safe, so it is the axis the page is built on. */}
+      <SettingsBand
+        title="Personal"
+        description="Yours alone. Colleagues are unaffected by anything in this section."
+      >
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3.5 items-start">
+          <Personal
+            onEditProfile={() => setProfileOpen(true)}
+            onEditHours={() => setHoursOpen(true)}
+          />
 
-        <PreferenceGroup title="Workspace preferences">
-          <DefaultOpenScreenPreference />
-          <TimezonePreference />
-          <CompanionTerminologyPreference />
-        </PreferenceGroup>
+          {/* Every control here writes the per-user profile (patchUserProfile) or
+              device-local theme storage — none of it is workspace-wide, which is
+              what the old "Workspace preferences" title wrongly implied. */}
+          <PreferenceGroup title="Your preferences" scope="personal">
+            <DefaultOpenScreenPreference />
+            <TimezonePreference />
+            <CompanionTerminologyPreference />
+            <AppearancePreference />
+          </PreferenceGroup>
 
-        <PreferenceGroup title="Scheduling & messaging">
-          <AppointmentLockWindowPreference />
-          <CrossClinicMessagingPreference />
-          <AppearancePreference />
-        </PreferenceGroup>
-
-        <div className="flex flex-col gap-3.5">
           <YourOrganizations />
           <DeleteProfile />
         </div>
+      </SettingsBand>
 
-        {/* Federation is institution-to-institution: clinical referrals, directory
-            presence and trust between practices. It is deliberately separate from
-            the cross-clinic messaging toggle above, which only governs colleague
-            chat. A clinic can federate without opening its staff to chat, and the
-            reverse, so the two switches are not merged. */}
-        <div className="xl:col-span-2">
+      <SettingsBand
+        title="Organisation"
+        description="Shared clinic settings. Changes here apply to every colleague."
+      >
+        <div className="flex flex-col gap-3.5">
+          {/* Both write the organisation record via updateOrg. */}
+          <PreferenceGroup title="Scheduling & messaging" scope="organisation">
+            <AppointmentLockWindowPreference />
+            <CrossClinicMessagingPreference />
+          </PreferenceGroup>
+
+          {/* Federation is institution-to-institution: clinical referrals, directory
+              presence and trust between practices. It is deliberately separate from
+              the cross-clinic messaging toggle above, which only governs colleague
+              chat. A clinic can federate without opening its staff to chat, and the
+              reverse, so the two switches are not merged. */}
           <FederationSection />
         </div>
-      </div>
+      </SettingsBand>
 
       {/* Detailed editors are reached from the Personal card's "Edit profile" /
           "Edit hours" affordances as centered modals, so the page itself stays


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`/settings` is subtitled "Personal and workspace preferences" and interleaves per-user settings with clinic-wide ones, under group labels that point the wrong way. Scope below is taken from what each control writes:

| Group | Contains | Actually writes |
| --- | --- | --- |
| "Workspace preferences" | Default open screen, Timezone, Companion terminology | `patchUserProfile` - **all three are per-user** |
| "Scheduling & messaging" | Appointment lock window, Cross-clinic messaging, Appearance | first two `updateOrg` (**clinic-wide**), third is a device theme |

So the one group named after the workspace was the one group containing nothing workspace-wide, and the group that did hold clinic-wide controls sat them next to a theme toggle. Nothing on screen told a reader which was which, so an owner could change behaviour for every colleague believing it was their own preference.

## What is the new behavior?

The page is organised by **who a change affects**, because that is what decides whether a click is safe.

- **Personal** band: the profile card, the per-user preferences (default screen, timezone, terminology, appearance), your organisations, delete profile.
- **Organisation** band: the two `updateOrg` controls, and federation.

`PreferenceGroup` now takes a `scope` and renders a chip naming the audience ("Only you" / "Whole clinic") plus a one-line hint, so a clinic-wide group says so before it is touched. The chip is deliberately **not** a `StatusPill` - it labels audience, not state, and must not compete with the verified/live status colours that appear in the same view.

Federation stays on this page and is correctly org-scoped already in the data model: `APActor.organisationId` is `@unique`, and the save route is guarded by `withOrgPermissions()` plus `requirePermission("integrations:edit:any")`. The problem was never the scoping, only that the page never said so.

**Considered and rejected for this PR:** moving the org-scoped controls to `/organization`. That is arguably the purer home, but `/organization` renders a separate phone shell (`PhoneOrganization`, an accordion-based experience) that would not receive them, so the move would introduce a mobile parity gap. `/settings` has no phone variant and is responsive, so scoping it in place fixes the reported confusion without that cost. Worth revisiting as its own change.

## Impact area

`apps/frontend` only - the Settings page composition and the shared `PreferenceGroup`. No API, schema, or behaviour change to any individual control; each one still writes exactly what it wrote before.

## Validation performed

- `apps/frontend` targeted suites: **12 tests passing** across `PreferenceGroup` and the Settings page.
- **Mutation checked**: disabling the scope rendering (`const copy = null`) fails 2 of the new tests; restoring it returns the suite to green. The guards bite rather than passing vacuously.
- `npx tsc --noemit` clean (0 errors). `pnpm --filter frontend run lint` exit 0 - the single reported warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, which this branch does not touch.
- Dev server boots and serves `/settings` 200 under Turbopack.

**Verification gap, stated plainly:** I have not viewed the rendered page. `/settings` requires an authenticated session and the automated browser has none, so this was verified at the code, token and test level rather than visually. The change reuses the existing `PreferenceGroup` surface, token layer (`--ink`, `--ink-faint`, `--hairline`, `--blue`) and type scale rather than introducing new visual primitives, which bounds the risk - but a human should eyeball both themes before merge.

## Related Issue(s)

Fixes #2512
