### PR TITLE
feat(repo): persist public booking setup and stop showing a dead URL

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -229,10 +229,16 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter frontend exec playwright install --with-deps chromium firefox
 
+      # Both authenticated specs run here and nowhere else. The public job runs
+      # an explicit two-file list, so a spec that needs a session has no other
+      # home: adding it to `e2e/` alone would mean it never executes.
+      # public-booking-setup.spec.ts follows the same credential-artefact rules
+      # as auth-flow.spec.ts (trace/screenshot/video off in-file, and the
+      # PLAYWRIGHT_NO_COPY_PROMPT above), which is why it is safe in this job.
       - name: Run authenticated Playwright flow
         env:
           E2E_WEB_SERVER_COMMAND: pnpm exec next start -p 3001 -H 127.0.0.1
-        run: pnpm --filter frontend exec playwright test e2e/auth-flow.spec.ts
+        run: pnpm --filter frontend exec playwright test e2e/auth-flow.spec.ts e2e/public-booking-setup.spec.ts
 
       # This job's artifacts are deliberately NOT uploaded.
       #

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -91,6 +91,15 @@ APPLE_WWDR_BASE64=""
 # Base URL the pass QR points at for public verification (falls back to PUBLIC_CARD_BASE_URL)
 PUBLIC_PASSPORT_BASE_URL=""
 
+# --- Public booking page ---
+# Public origin that serves /book/<slug>. Deliberately left blank: while it is
+# blank the API returns a null public URL for every practice, and the onboarding
+# wizard says the booking page is not live instead of showing an address that
+# does not resolve. Set it only in an environment where the public route is
+# actually deployed (e.g. https://dev.yosemitecrew.com). `book.yosemitecrew.com`
+# has no DNS record - do not put it here until it does.
+PUBLIC_BOOKING_BASE_URL=""
+
 # --- Digital Pet Passport: Google Wallet ("Add to Google Wallet" save JWT) ---
 # Issuer ID + service-account email are non-secret; the private key is secret.
 # From the downloaded service-account JSON key, use client_email + private_key.

--- a/apps/backend/src/controllers/app/public-booking.controller.ts
+++ b/apps/backend/src/controllers/app/public-booking.controller.ts
@@ -1,0 +1,171 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import logger from "src/utils/logger";
+import {
+  PublicBookingError,
+  PublicBookingRequestService,
+  PublicBookingService,
+  resolveSlug,
+} from "src/services/public-booking.service";
+
+/**
+ * The unauthenticated booking surface.
+ *
+ * Every handler here answers to anyone on the internet, so two things hold
+ * throughout: the request body is parsed by zod before it reaches a service, and
+ * an unexpected failure never reaches the caller. The sibling public POST
+ * (`contact-us`) validates nothing, and copying that would have put an
+ * unvalidated body in front of a database on a page that collects PII.
+ */
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD");
+
+const timeOfDay = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "startTime must be HH:mm");
+
+/**
+ * Bounds on every free-text field.
+ *
+ * These become rows in a veterinary database and lines in an email to a real
+ * practice, written by an anonymous stranger. The ceilings are what stop one
+ * submission carrying a megabyte of text into either.
+ */
+const RequestSchema = z.object({
+  serviceId: z.string().uuid(),
+  date: isoDate,
+  startTime: timeOfDay,
+  ownerName: z.string().trim().min(1).max(120),
+  ownerEmail: z.string().trim().email().max(254),
+  ownerPhone: z.string().trim().max(40).optional().nullable(),
+  petName: z.string().trim().min(1).max(120),
+  petSpecies: z.string().trim().min(1).max(60),
+  concern: z.string().trim().max(1000).optional().nullable(),
+  /**
+   * Explicit, not implied by submission. GDPR Art. 6 wants a lawful basis
+   * recorded where the data is collected, and the timestamp stored against the
+   * row is only meaningful if the box was actually ticked.
+   */
+  consent: z.literal(true),
+});
+
+const SlotsQuerySchema = z.object({
+  serviceId: z.string().uuid(),
+  date: isoDate,
+});
+
+/**
+ * One error shape for every failure.
+ *
+ * Anything that is not a deliberate `PublicBookingError` becomes a flat 500 with
+ * no detail. A stack trace, a Prisma message or a constraint name reaching an
+ * anonymous caller describes the schema to someone who should not have it.
+ */
+const handleError = (context: string, error: unknown, res: Response) => {
+  if (error instanceof PublicBookingError) {
+    return res.status(error.status).json({ message: error.message });
+  }
+  logger.error(context, error);
+  return res.status(500).json({ message: "Something went wrong" });
+};
+
+export const PublicBookingController = {
+  /**
+   * The practice and what it offers.
+   *
+   * A retired slug answers 200 with `redirectTo` rather than 301: the caller is
+   * a client-side page, and telling it where to go lets it replace its own URL
+   * without the API guessing at the frontend's routing.
+   */
+  getPractice: async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const resolved = await resolveSlug(req.params.slug);
+      if (resolved.kind === "retired") {
+        return res.status(200).json({ data: { redirectTo: resolved.slug } });
+      }
+
+      const data = await PublicBookingService.getPractice(req.params.slug);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("public getPractice error", error, res);
+    }
+  },
+
+  getSlots: async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const parsed = SlotsQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ message: parsed.error.issues[0].message });
+      }
+
+      const data = await PublicBookingService.getSlots(
+        req.params.slug,
+        parsed.data.serviceId,
+        parsed.data.date,
+      );
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("public getSlots error", error, res);
+    }
+  },
+
+  /**
+   * Accept a booking request.
+   *
+   * 202, not 201, and with no body. Nothing is booked and no resource is
+   * addressable yet: the request is invisible until the requester follows the
+   * emailed link. Returning an id would hand an anonymous caller a handle to
+   * something they have not proved they own.
+   */
+  submitRequest: async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const parsed = RequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ message: parsed.error.issues[0].message });
+      }
+
+      await PublicBookingRequestService.submit(req.params.slug, {
+        serviceId: parsed.data.serviceId,
+        date: parsed.data.date,
+        startTime: parsed.data.startTime,
+        ownerName: parsed.data.ownerName,
+        ownerEmail: parsed.data.ownerEmail,
+        ownerPhone: parsed.data.ownerPhone ?? null,
+        petName: parsed.data.petName,
+        petSpecies: parsed.data.petSpecies,
+        concern: parsed.data.concern ?? null,
+      });
+
+      return res.status(202).json({
+        message:
+          "Check your email and follow the link to confirm this request. Nothing is booked yet.",
+      });
+    } catch (error: unknown) {
+      return handleError("public submitRequest error", error, res);
+    }
+  },
+
+  confirmRequest: async (
+    req: Request<unknown, unknown, { token?: unknown } | undefined>,
+    res: Response,
+  ) => {
+    try {
+      // Narrowed rather than trusted: the body is attacker-shaped, and a
+      // non-string here would otherwise reach a Prisma `where` as a filter
+      // object. An empty string is refused by the service like any other
+      // unknown token.
+      const raw: unknown = req.body?.token;
+      const token = typeof raw === "string" ? raw : "";
+      const data = await PublicBookingRequestService.confirm(token);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("public confirmRequest error", error, res);
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/booking-page.controller.ts
+++ b/apps/backend/src/controllers/web/booking-page.controller.ts
@@ -1,0 +1,94 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import logger from "src/utils/logger";
+import type { OrgRequest } from "src/middlewares/rbac";
+import {
+  BookingPageService,
+  BookingPageServiceError,
+} from "src/services/booking-page.service";
+
+/**
+ * Authenticated configuration surface for a practice's public booking page.
+ *
+ * Every handler scopes on `(req as OrgRequest).organisationId` - the value
+ * `withOrgPermissions` actually authorized - and never on the route param, so a
+ * caller cannot address one organisation while being authorized for another.
+ */
+
+/**
+ * Bounds, not just types.
+ *
+ * `bookingWindowDays` decides how far into the future an anonymous caller can
+ * later walk a practice's calendar, and `bufferMinutes` decides how much of a
+ * real working day one public booking consumes. Both are eventually read by an
+ * unauthenticated surface, so they get explicit ceilings here rather than
+ * inheriting whatever an admin typed.
+ */
+const SettingsSchema = z.object({
+  serviceIds: z.array(z.string().uuid()).max(200),
+  bookingWindowDays: z.number().int().min(1).max(180),
+  bufferMinutes: z.number().int().min(0).max(240),
+  autoConfirm: z.boolean(),
+  welcomeMessage: z.string().trim().max(500).nullish(),
+  replyToEmail: z.string().trim().email().max(254).nullish(),
+});
+
+const resolveAuthorizedOrgId = (req: Request, res: Response): string | null => {
+  const organisationId = (req as OrgRequest).organisationId;
+  if (!organisationId) {
+    res.status(400).json({ message: "Organisation could not be resolved" });
+    return null;
+  }
+  return organisationId;
+};
+
+const handleError = (context: string, error: unknown, res: Response) => {
+  if (error instanceof BookingPageServiceError) {
+    return res.status(error.status).json({ message: error.message });
+  }
+  logger.error(context, error);
+  return res.status(500).json({ message: "Something went wrong" });
+};
+
+export const BookingPageController = {
+  getConfig: async (req: Request, res: Response) => {
+    try {
+      const organisationId = resolveAuthorizedOrgId(req, res);
+      if (!organisationId) return;
+
+      const data = await BookingPageService.getConfig(organisationId);
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("getBookingPageConfig error", error, res);
+    }
+  },
+
+  saveConfig: async (req: Request, res: Response) => {
+    try {
+      const organisationId = resolveAuthorizedOrgId(req, res);
+      if (!organisationId) return;
+
+      const parsed = SettingsSchema.safeParse(req.body);
+      if (!parsed.success) {
+        // A zod failure always carries at least one issue, so the first one is
+        // the message to show - no fallback needed.
+        return res
+          .status(400)
+          .json({ message: parsed.error.issues[0].message });
+      }
+
+      const data = await BookingPageService.saveConfig(organisationId, {
+        serviceIds: parsed.data.serviceIds,
+        bookingWindowDays: parsed.data.bookingWindowDays,
+        bufferMinutes: parsed.data.bufferMinutes,
+        autoConfirm: parsed.data.autoConfirm,
+        welcomeMessage: parsed.data.welcomeMessage ?? null,
+        replyToEmail: parsed.data.replyToEmail ?? null,
+      });
+
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("saveBookingPageConfig error", error, res);
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/booking-page.controller.ts
+++ b/apps/backend/src/controllers/web/booking-page.controller.ts
@@ -6,6 +6,10 @@ import {
   BookingPageService,
   BookingPageServiceError,
 } from "src/services/booking-page.service";
+import {
+  PublicBookingError,
+  PublicBookingRequestService,
+} from "src/services/public-booking.service";
 
 /**
  * Authenticated configuration surface for a practice's public booking page.
@@ -31,6 +35,23 @@ const SettingsSchema = z.object({
   autoConfirm: z.boolean(),
   welcomeMessage: z.string().trim().max(500).nullish(),
   replyToEmail: z.string().trim().email().max(254).nullish(),
+  // Optional on purpose: a caller that omits it is saving settings, not
+  // changing what the public can reach.
+  publicBookingEnabled: z.boolean().optional(),
+});
+
+const RequestListQuerySchema = z.object({
+  status: z.enum(["CONFIRMED", "DECLINED", "BOOKED"]).optional(),
+});
+
+/**
+ * A practice may decline a request, or record that it booked it. It cannot move
+ * one back to CONFIRMED or invent a PENDING one - those transitions belong to
+ * the public flow, and exposing them here would let staff resurrect a request
+ * the requester never confirmed.
+ */
+const RequestStatusSchema = z.object({
+  status: z.enum(["DECLINED", "BOOKED"]),
 });
 
 const resolveAuthorizedOrgId = (req: Request, res: Response): string | null => {
@@ -43,7 +64,10 @@ const resolveAuthorizedOrgId = (req: Request, res: Response): string | null => {
 };
 
 const handleError = (context: string, error: unknown, res: Response) => {
-  if (error instanceof BookingPageServiceError) {
+  if (
+    error instanceof BookingPageServiceError ||
+    error instanceof PublicBookingError
+  ) {
     return res.status(error.status).json({ message: error.message });
   }
   logger.error(context, error);
@@ -84,11 +108,67 @@ export const BookingPageController = {
         autoConfirm: parsed.data.autoConfirm,
         welcomeMessage: parsed.data.welcomeMessage ?? null,
         replyToEmail: parsed.data.replyToEmail ?? null,
+        publicBookingEnabled: parsed.data.publicBookingEnabled,
       });
 
       return res.status(200).json({ data });
     } catch (error: unknown) {
       return handleError("saveBookingPageConfig error", error, res);
+    }
+  },
+
+  /**
+   * Booking requests the public has submitted and confirmed.
+   *
+   * Unconfirmed requests are never listed. Anyone can type anyone's address into
+   * a public form, so an unconfirmed row is an unverified claim; surfacing it
+   * would make this queue fillable by any anonymous caller.
+   */
+  listRequests: async (req: Request, res: Response) => {
+    try {
+      const organisationId = resolveAuthorizedOrgId(req, res);
+      if (!organisationId) return;
+
+      const parsed = RequestListQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ message: parsed.error.issues[0].message });
+      }
+
+      const data = await PublicBookingRequestService.listForOrganisation(
+        organisationId,
+        parsed.data.status,
+      );
+      return res.status(200).json({ data });
+    } catch (error: unknown) {
+      return handleError("listBookingRequests error", error, res);
+    }
+  },
+
+  updateRequestStatus: async (
+    req: Request<{ organisationId: string; requestId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const organisationId = resolveAuthorizedOrgId(req, res);
+      if (!organisationId) return;
+
+      const parsed = RequestStatusSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ message: parsed.error.issues[0].message });
+      }
+
+      await PublicBookingRequestService.setStatus(
+        organisationId,
+        req.params.requestId,
+        parsed.data.status,
+      );
+      return res.status(200).json({ message: "Updated" });
+    } catch (error: unknown) {
+      return handleError("updateBookingRequestStatus error", error, res);
     }
   },
 };

--- a/apps/backend/src/queues/index.ts
+++ b/apps/backend/src/queues/index.ts
@@ -6,6 +6,7 @@ import { registerIdexxReferenceScheduler } from "./idexx-reference.scheduler";
 import { registerLabStatusScheduler } from "./lab-status.scheduler";
 import { registerLabResultsScheduler } from "./lab-results.scheduler";
 import { registerVaccineReminderScheduler } from "./vaccine.scheduler";
+import { registerPublicBookingSchedulers } from "./public-booking.scheduler";
 import { AppointmentQueue } from "./appointment.queue";
 import { IdexxReferenceQueue } from "./idexx-reference.queue";
 import { LabResultsQueue } from "./lab-results.queue";
@@ -13,6 +14,7 @@ import { LabStatusQueue } from "./lab-status.queue";
 import { TaskScheduleQueue } from "./task-schedule.queue";
 import { TaskRecurrenceQueue, TaskReminderQueue } from "./task.queues";
 import { VaccineReminderQueue } from "./vaccine.queues";
+import { PublicBookingQueue } from "./public-booking.queue";
 import {
   pruneLegacyRepeatablesAcross,
   SchedulerCapableQueue,
@@ -27,6 +29,7 @@ export const scheduledQueues = [
   TaskRecurrenceQueue,
   TaskReminderQueue,
   VaccineReminderQueue,
+  PublicBookingQueue,
 ] as unknown as SchedulerCapableQueue[];
 import "./ap-delivery.queue";
 import "./ap-inbox.queue";
@@ -44,5 +47,6 @@ export async function initQueues() {
   await registerLabStatusScheduler();
   await registerLabResultsScheduler();
   await registerVaccineReminderScheduler();
+  await registerPublicBookingSchedulers();
   logger.info("📬 BullMQ queues initialized");
 }

--- a/apps/backend/src/queues/public-booking.queue.ts
+++ b/apps/backend/src/queues/public-booking.queue.ts
@@ -1,0 +1,14 @@
+import { Queue } from "bullmq";
+import { defaultQueueOptions } from "./bull.config";
+
+export const PublicBookingQueue = new Queue("public-booking", {
+  ...defaultQueueOptions,
+  defaultJobOptions: {
+    removeOnComplete: true,
+    removeOnFail: 50,
+  },
+});
+
+export const PublicBookingJobs = {
+  PURGE_EXPIRED_REQUESTS: "PURGE_EXPIRED_REQUESTS",
+} as const;

--- a/apps/backend/src/queues/public-booking.scheduler.ts
+++ b/apps/backend/src/queues/public-booking.scheduler.ts
@@ -1,0 +1,17 @@
+import logger from "src/utils/logger";
+import { PublicBookingQueue, PublicBookingJobs } from "./public-booking.queue";
+
+export async function registerPublicBookingSchedulers() {
+  // Hourly. `PublicBookingRequest` holds names, email addresses, phone numbers
+  // and animal details belonging to people with no relationship to the practice,
+  // so the retention deadline on each row has to be enforced by something that
+  // runs whether or not anyone is using the feature. Hourly keeps the window
+  // between "past its deadline" and "deleted" short without polling hard.
+  await PublicBookingQueue.upsertJobScheduler(
+    "public-booking-purge-repeat",
+    { every: 60 * 60 * 1000 },
+    { name: PublicBookingJobs.PURGE_EXPIRED_REQUESTS, data: {} },
+  );
+
+  logger.info("✅ Public booking schedulers registered");
+}

--- a/apps/backend/src/routers/booking-page-public.router.ts
+++ b/apps/backend/src/routers/booking-page-public.router.ts
@@ -1,0 +1,62 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import { PublicBookingController } from "src/controllers/app/public-booking.controller";
+
+/**
+ * The public booking page's own API. No session, by design.
+ *
+ * Follows the shape the other unauthenticated routers in this codebase already
+ * use (`pet-passport-public`, `companion-card-public`): a per-IP budget tighter
+ * than the global limiter, no auth middleware, and a service that returns one
+ * uniform 404 for everything it declines to confirm.
+ *
+ * Reads and writes get separate budgets because they cost different things. A
+ * read burns database time; a write can put an email in a stranger's inbox and a
+ * row in a veterinary database, so it is held to the same budget as the public
+ * contact form.
+ */
+
+// Slot computation walks availability for every practitioner on a date, so this
+// is the most expensive anonymous call in the codebase. 60 per quarter-hour is
+// enough for a person choosing a date and well short of scraping a schedule.
+const publicReadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Matches `contact-us`'s public write budget. Each accepted call sends mail to
+// an address the caller chose, so the limit is really a cap on how much of
+// somebody else's inbox one IP can spend.
+const publicWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const router = Router();
+
+// Registered before the `:slug` routes. Nothing currently collides - the slug
+// routes need a literal second segment - but a slug pattern one edit away from
+// swallowing `/requests` is not worth relying on.
+//
+// A write, not a GET: it flips a status and mails the practice, and mail clients
+// and link scanners prefetch GETs, which would confirm requests nobody clicked.
+router.post(
+  "/requests/confirm",
+  publicWriteLimiter,
+  PublicBookingController.confirmRequest,
+);
+
+router.get("/:slug", publicReadLimiter, PublicBookingController.getPractice);
+router.get("/:slug/slots", publicReadLimiter, PublicBookingController.getSlots);
+
+router.post(
+  "/:slug/requests",
+  publicWriteLimiter,
+  PublicBookingController.submitRequest,
+);
+
+export default router;

--- a/apps/backend/src/routers/booking-page.router.ts
+++ b/apps/backend/src/routers/booking-page.router.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import { BookingPageController } from "src/controllers/web/booking-page.controller";
+import { requireWebAuth } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+
+const router = Router();
+
+router.use(requireWebAuth);
+
+/**
+ * Configuring the public booking page is an organisation-administration act, not
+ * a catalogue edit: it decides what the practice publishes about itself on the
+ * open internet. `teams:*:any` is the existing permission pair that expresses
+ * that scope - it already guards the organisation logo - and in
+ * `ROLE_PERMISSIONS` only the admin-tier roles hold the `edit` half, while
+ * clinical roles hold `view` alone. `specialities:edit:any` would have been the
+ * wrong reach: every role that can rename a service would have been able to put
+ * the practice online.
+ */
+router.get(
+  "/:organisationId",
+  withOrgPermissions(),
+  requirePermission("teams:view:any"),
+  BookingPageController.getConfig,
+);
+
+router.put(
+  "/:organisationId",
+  withOrgPermissions(),
+  requirePermission("teams:edit:any"),
+  BookingPageController.saveConfig,
+);
+
+export default router;

--- a/apps/backend/src/routers/booking-page.router.ts
+++ b/apps/backend/src/routers/booking-page.router.ts
@@ -31,4 +31,27 @@ router.put(
   BookingPageController.saveConfig,
 );
 
+/**
+ * The queue of confirmed public booking requests.
+ *
+ * Gated on `appointments:*:any` rather than `teams:*`, because this is clinical
+ * scheduling work rather than organisation administration: the people who
+ * triage a request into the diary are the ones who already hold the appointment
+ * permissions, and the receptionist who books them should not need the
+ * permission that publishes the practice.
+ */
+router.get(
+  "/:organisationId/requests",
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  BookingPageController.listRequests,
+);
+
+router.patch(
+  "/:organisationId/requests/:requestId",
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  BookingPageController.updateRequestStatus,
+);
+
 export default router;

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -63,6 +63,7 @@ import roomUnitRouter from "./room-unit.router";
 import roomUnitGroupRouter from "./room-unit-group.router";
 import companionCardRouter from "./companion-card.router";
 import companionCardPublicRouter from "./companion-card-public.router";
+import bookingPageRouter from "./booking-page.router";
 import petPassportRouter from "./pet-passport.router";
 import petPassportPublicRouter from "./pet-passport-public.router";
 import treatmentProtocolRouter from "./treatment-protocol.router";
@@ -192,6 +193,9 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/companion-history`, companionHistoryRouter);
   app.use(`/v1/companion-card`, companionCardRouter);
   app.use(`/public/companion-card`, companionCardPublicRouter);
+  // Authenticated configuration for the public booking page. The anonymous
+  // surface it configures is a separate router mounted under `/public`.
+  app.use(`/v1/booking-page`, bookingPageRouter);
   app.use(`/v1/pet-passport`, petPassportRouter);
   app.use(`/public/pet-passport`, petPassportPublicRouter);
   app.use(`/v1`, treatmentProtocolRouter);

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -64,6 +64,7 @@ import roomUnitGroupRouter from "./room-unit-group.router";
 import companionCardRouter from "./companion-card.router";
 import companionCardPublicRouter from "./companion-card-public.router";
 import bookingPageRouter from "./booking-page.router";
+import bookingPagePublicRouter from "./booking-page-public.router";
 import petPassportRouter from "./pet-passport.router";
 import petPassportPublicRouter from "./pet-passport-public.router";
 import treatmentProtocolRouter from "./treatment-protocol.router";
@@ -196,6 +197,9 @@ export function registerRoutes(app: Express) {
   // Authenticated configuration for the public booking page. The anonymous
   // surface it configures is a separate router mounted under `/public`.
   app.use(`/v1/booking-page`, bookingPageRouter);
+  // Unauthenticated. Mounted under /public alongside the other anonymous
+  // surfaces so the boundary is visible in the route table itself.
+  app.use(`/public/booking`, bookingPagePublicRouter);
   app.use(`/v1/pet-passport`, petPassportRouter);
   app.use(`/public/pet-passport`, petPassportPublicRouter);
   app.use(`/v1`, treatmentProtocolRouter);

--- a/apps/backend/src/services/booking-page.service.ts
+++ b/apps/backend/src/services/booking-page.service.ts
@@ -447,6 +447,14 @@ export type BookingPageSettingsInput = {
   autoConfirm: boolean;
   welcomeMessage?: string | null;
   replyToEmail?: string | null;
+  /**
+   * Whether the practice wants `/book/<slug>` to answer.
+   *
+   * Separate from the rest of the settings because it is the only field that
+   * changes what the internet can see. Absent means "leave it as it is", so
+   * saving settings never publishes a practice as a side effect.
+   */
+  publicBookingEnabled?: boolean;
 };
 
 export const BookingPageService = {
@@ -523,6 +531,26 @@ export const BookingPageService = {
       );
     }
 
+    // Publishing an empty page is the same broken promise this whole change
+    // exists to remove: a clinic would hand out an address that resolves to a
+    // page offering nothing bookable. Refused rather than allowed and rendered
+    // as an apology.
+    if (input.publicBookingEnabled === true && requested.length === 0) {
+      const bookableCount = await prisma.productItem.count({
+        where: {
+          organisationId: safeOrganisationId,
+          isActive: true,
+          bookable: { isNot: null },
+        },
+      });
+      if (bookableCount === 0) {
+        throw new BookingPageServiceError(
+          "Add at least one bookable service before publishing your booking page.",
+          400,
+        );
+      }
+    }
+
     await ensureBookingSlug(safeOrganisationId);
 
     const settingsData = {
@@ -539,6 +567,13 @@ export const BookingPageService = {
       create: { organizationId: safeOrganisationId, ...settingsData },
       update: settingsData,
     });
+
+    if (typeof input.publicBookingEnabled === "boolean") {
+      await prisma.organization.update({
+        where: { id: safeOrganisationId },
+        data: { publicBookingEnabled: input.publicBookingEnabled },
+      });
+    }
 
     return BookingPageService.getConfig(safeOrganisationId);
   },

--- a/apps/backend/src/services/booking-page.service.ts
+++ b/apps/backend/src/services/booking-page.service.ts
@@ -1,0 +1,512 @@
+import { randomBytes } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "src/config/prisma";
+import { resolvePublicBaseUrl } from "src/utils/public-base-url";
+
+/**
+ * Configuration behind a practice's public booking page.
+ *
+ * The onboarding wizard used to compute `book.yosemitecrew.com/<slug>` in the
+ * browser from the practice name, render it, and offer to copy it. Nothing was
+ * persisted, the subdomain has no DNS record, and no route served it, so a
+ * practice could paste that address onto its own website and publish a dead
+ * link. This service is where that wizard's answers actually go.
+ *
+ * Two things it deliberately does NOT do:
+ *
+ *  - It never returns a URL for a practice that is not published. A caller
+ *    cannot render a copyable address unless one exists, because the field is
+ *    null until both `publicBookingEnabled` and `PUBLIC_BOOKING_BASE_URL` say
+ *    otherwise. Honesty is a property of the payload, not of the UI copy.
+ *  - It never trusts the service ids it is handed. They are re-read against the
+ *    caller's own organisation before being stored, so an admin cannot pin
+ *    another tenant's catalogue item onto their public page.
+ */
+
+export class BookingPageServiceError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "BookingPageServiceError";
+    this.status = status;
+  }
+}
+
+/**
+ * Narrow an identifier to a plain, non-empty string before it reaches a Prisma
+ * `where` clause.
+ *
+ * Prisma filters accept objects as well as scalars, so a value that is an object
+ * rather than a string turns `where: { id }` into a structured filter such as
+ * `{ id: { not: "" } }` and quietly widens the query to another tenant's rows.
+ * Every organisation id here arrives from `withOrgPermissions`, which already
+ * rejects non-strings, so this is defence in depth rather than the only control
+ * - but it is the same guard `requireSafeString` applies in the catalog service,
+ * and it keeps the property local to the query instead of two files away.
+ */
+const requireSafeId = (value: unknown, field: string): string => {
+  if (typeof value !== "string") {
+    throw new BookingPageServiceError(`${field} is required.`, 400);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes("$")) {
+    throw new BookingPageServiceError(`Invalid ${field}.`, 400);
+  }
+
+  return trimmed;
+};
+
+/**
+ * Slugs must survive being a DNS label, not just a path segment.
+ *
+ * The public page ships at `/book/<slug>` on the existing origin because
+ * `book.yosemitecrew.com` has no DNS record and provisioning one is not
+ * something this repository can do. That decision is meant to be reversible: if
+ * the subdomain is ever provisioned, `<slug>.book.yosemitecrew.com` has to be a
+ * legal hostname without re-slugging every practice. So the rules here are the
+ * DNS label rules - 63 characters, alphanumeric plus hyphen, no hyphen at either
+ * end - rather than the much looser set a URL path would accept.
+ */
+const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const MAX_SLUG_LENGTH = 63;
+
+/**
+ * Names the slug namespace cannot hand out.
+ *
+ * Two separate hazards. The routing ones (`api`, `book`, `_next`, `assets`)
+ * would collide with a real path segment the moment the public route mounts
+ * under the same origin. The identity ones (`admin`, `support`, `billing`,
+ * `security`) are the ones someone would choose in order to look like us in a
+ * link - `/book/support` reads as a Yosemite Crew page, not as a practice.
+ */
+const RESERVED_SLUGS = new Set([
+  "_next",
+  "about",
+  "account",
+  "admin",
+  "api",
+  "assets",
+  "auth",
+  "billing",
+  "book",
+  "booking",
+  "cdn",
+  "checkout",
+  "contact",
+  "dashboard",
+  "developers",
+  "docs",
+  "favicon",
+  "health",
+  "help",
+  "images",
+  "impressum",
+  "internal",
+  "invoice",
+  "legal",
+  "login",
+  "logout",
+  "mail",
+  "new",
+  "null",
+  "payment",
+  "pricing",
+  "privacy",
+  "public",
+  "robots",
+  "root",
+  "security",
+  "settings",
+  "signin",
+  "signup",
+  "sitemap",
+  "static",
+  "status",
+  "support",
+  "system",
+  "terms",
+  "undefined",
+  "www",
+  "yosemite",
+  "yosemitecrew",
+]);
+
+/**
+ * A slug that is only digits, or shaped like one of our uuids, invites the
+ * reader to treat it as an internal identifier - and invites a caller to probe
+ * whether `/book/1`, `/book/2` walk a sequence. Neither is ever generated from a
+ * practice name, so refusing them costs nothing.
+ */
+const ALL_DIGITS = /^\d+$/;
+const UUID_SHAPED =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Positions 3 and 4 being `--` is the punycode prefix (`xn--`). A hostname
+ * carrying it is interpreted as an internationalised domain name, which is the
+ * standard shape of a homograph attack. Refused for the same reason as the
+ * reserved names: it is never what a practice name slugifies to.
+ */
+const PUNYCODE_SHAPED = /^..--/;
+
+export const isReservedBookingSlug = (slug: string): boolean =>
+  RESERVED_SLUGS.has(slug);
+
+export const isValidBookingSlug = (slug: string): boolean =>
+  SLUG_PATTERN.test(slug) &&
+  slug.length <= MAX_SLUG_LENGTH &&
+  !ALL_DIGITS.test(slug) &&
+  !UUID_SHAPED.test(slug) &&
+  !PUNYCODE_SHAPED.test(slug) &&
+  !isReservedBookingSlug(slug);
+
+/**
+ * Reduce a practice name to a candidate slug.
+ *
+ * Diacritics are decomposed and stripped rather than dropped wholesale, so
+ * "Tierärzte Grünwald" becomes `tierarzte-grunwald` and not `tier-rzte-gr-nwald`
+ * - this product operates in the EU and most practice names carry them.
+ */
+export const slugifyOrganisationName = (name: string): string =>
+  name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+
+/**
+ * Candidates to try, in order, for a practice named `name`.
+ *
+ * `park-veterinary`, then `park-veterinary-2` … `park-veterinary-9`. The base is
+ * truncated before the suffix is appended so a 63-character name cannot produce
+ * a 65-character candidate that the DNS rule would then reject.
+ */
+const buildSlugCandidates = (name: string): string[] => {
+  const base = slugifyOrganisationName(name);
+  const candidates: string[] = [];
+
+  if (isValidBookingSlug(base)) candidates.push(base);
+
+  // A reserved base still makes a good stem: a practice actually called
+  // "Support" should end up at `support-2`, not at `clinic-2`. Only a base that
+  // slugified to nothing falls back to a generic stem.
+  const stem = (base || "clinic").slice(0, MAX_SLUG_LENGTH - 2);
+  for (let n = 2; n <= 9; n += 1) {
+    candidates.push(`${stem}-${n}`);
+  }
+
+  return candidates.filter(isValidBookingSlug);
+};
+
+/**
+ * Guaranteed-terminating fallback once the readable candidates are taken.
+ *
+ * Eight hex characters, so a collision here is not something a caller can drive
+ * by registering practices in a loop.
+ */
+const buildRandomSlug = (name: string): string => {
+  const stem = (slugifyOrganisationName(name) || "clinic").slice(
+    0,
+    MAX_SLUG_LENGTH - 9,
+  );
+  return `${stem}-${randomBytes(4).toString("hex")}`;
+};
+
+const isUniqueViolation = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2002";
+
+/**
+ * Raised when a concurrent request allocated this organisation's slug first.
+ *
+ * Not an error condition - the caller re-reads the slug that won and returns it.
+ * It exists so the transaction can roll back its own reservation rather than
+ * leaving a row behind for a slug the organisation is not actually using.
+ */
+class SlugAlreadyAllocatedError extends Error {
+  constructor() {
+    super("Booking slug was allocated concurrently");
+    this.name = "SlugAlreadyAllocatedError";
+  }
+}
+
+/**
+ * Claim `slug` for `organizationId`, or report that it is not available.
+ *
+ * Two races, two guards, and both are decided by the database rather than by a
+ * read-then-write in application code:
+ *
+ *  - Two organisations wanting the same slug collide on the reservation's
+ *    primary key. The loser gets `false` and tries the next candidate.
+ *  - Two concurrent requests for the SAME organisation collide on the
+ *    `bookingSlug IS NULL` guard in the update. Without it, the second request
+ *    would claim a second reservation and overwrite the pointer, leaving the
+ *    first, nicer slug stranded - owned by this organisation, in use by nobody,
+ *    and unavailable to the practice next door. The guard makes the loser roll
+ *    back instead, and `ensureBookingSlug` returns the slug that won.
+ */
+const claimSlug = async (
+  organizationId: string,
+  slug: string,
+): Promise<boolean> => {
+  const safeOrganizationId = requireSafeId(organizationId, "organisationId");
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.bookingSlugReservation.create({
+        data: { slug, organizationId: safeOrganizationId },
+      });
+
+      // `updateMany`, not `update`: `update` addresses a row by unique key and
+      // cannot carry an extra predicate, so there would be nowhere to put the
+      // "still unallocated" condition.
+      const claimed = await tx.organization.updateMany({
+        where: { id: safeOrganizationId, bookingSlug: null },
+        data: { bookingSlug: slug },
+      });
+
+      if (claimed.count === 0) throw new SlugAlreadyAllocatedError();
+    });
+    return true;
+  } catch (error: unknown) {
+    if (error instanceof SlugAlreadyAllocatedError) {
+      throw error;
+    }
+    if (isUniqueViolation(error)) return false;
+    throw error;
+  }
+};
+
+/**
+ * Read back the slug a concurrent request allocated for this organisation.
+ */
+const readAllocatedSlug = async (organisationId: string): Promise<string> => {
+  const organisation = await prisma.organization.findUnique({
+    where: { id: requireSafeId(organisationId, "organisationId") },
+    select: { bookingSlug: true },
+  });
+
+  if (!organisation?.bookingSlug) {
+    throw new BookingPageServiceError(
+      "Could not allocate a booking address. Please try again.",
+      503,
+    );
+  }
+  return organisation.bookingSlug;
+};
+
+/**
+ * Return the practice's booking slug, allocating one on first use.
+ *
+ * Idempotent: a practice that already has a slug keeps it. Renaming is a
+ * separate, deliberate act - it retires nothing, it adds a new reservation and
+ * moves the pointer, so the old slug keeps resolving.
+ */
+export const ensureBookingSlug = async (
+  organisationId: string,
+): Promise<string> => {
+  const organisation = await prisma.organization.findUnique({
+    where: { id: requireSafeId(organisationId, "organisationId") },
+    select: { id: true, name: true, bookingSlug: true },
+  });
+
+  if (!organisation) {
+    throw new BookingPageServiceError("Organisation not found", 404);
+  }
+  if (organisation.bookingSlug) return organisation.bookingSlug;
+
+  try {
+    for (const candidate of buildSlugCandidates(organisation.name)) {
+      if (await claimSlug(organisationId, candidate)) return candidate;
+    }
+
+    // Readable candidates exhausted. Random suffixes cannot realistically
+    // collide, but the loop is bounded anyway so a pathological database cannot
+    // hang the request.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const candidate = buildRandomSlug(organisation.name);
+      if (await claimSlug(organisationId, candidate)) return candidate;
+    }
+  } catch (error: unknown) {
+    if (!(error instanceof SlugAlreadyAllocatedError)) throw error;
+    return readAllocatedSlug(organisationId);
+  }
+
+  throw new BookingPageServiceError(
+    "Could not allocate a booking address. Please try again.",
+    503,
+  );
+};
+
+/**
+ * Absolute URL of the public booking page, or null when there is not one yet.
+ *
+ * Null in three cases, and every one of them is a case where showing an address
+ * would be a lie: the practice has no slug, the practice has not opted in, or
+ * no origin is configured for this environment. `PUBLIC_BOOKING_BASE_URL` being
+ * unset is the normal state until the public route ships, which is exactly what
+ * keeps the wizard honest in the meantime.
+ */
+export const resolveBookingPageUrl = (
+  slug: string | null,
+  publicBookingEnabled: boolean,
+): string | null => {
+  if (!slug || !publicBookingEnabled) return null;
+
+  const base = resolvePublicBaseUrl([process.env.PUBLIC_BOOKING_BASE_URL]);
+  if (!base) return null;
+
+  return `${base}/book/${slug}`;
+};
+
+export type BookingPageConfig = {
+  organisationId: string;
+  slug: string | null;
+  publicBookingEnabled: boolean;
+  publicUrl: string | null;
+  serviceIds: string[];
+  bookingWindowDays: number;
+  bufferMinutes: number;
+  autoConfirm: boolean;
+  welcomeMessage: string | null;
+  replyToEmail: string | null;
+};
+
+const DEFAULT_BOOKING_WINDOW_DAYS = 28;
+const DEFAULT_BUFFER_MINUTES = 10;
+
+const toConfig = (
+  organisationId: string,
+  organisation: { bookingSlug: string | null; publicBookingEnabled: boolean },
+  settings: {
+    serviceIds: string[];
+    bookingWindowDays: number;
+    bufferMinutes: number;
+    autoConfirm: boolean;
+    welcomeMessage: string | null;
+    replyToEmail: string | null;
+  } | null,
+): BookingPageConfig => ({
+  organisationId,
+  slug: organisation.bookingSlug,
+  publicBookingEnabled: organisation.publicBookingEnabled,
+  publicUrl: resolveBookingPageUrl(
+    organisation.bookingSlug,
+    organisation.publicBookingEnabled,
+  ),
+  serviceIds: settings?.serviceIds ?? [],
+  bookingWindowDays: settings?.bookingWindowDays ?? DEFAULT_BOOKING_WINDOW_DAYS,
+  bufferMinutes: settings?.bufferMinutes ?? DEFAULT_BUFFER_MINUTES,
+  autoConfirm: settings?.autoConfirm ?? false,
+  welcomeMessage: settings?.welcomeMessage ?? null,
+  replyToEmail: settings?.replyToEmail ?? null,
+});
+
+export type BookingPageSettingsInput = {
+  serviceIds: string[];
+  bookingWindowDays: number;
+  bufferMinutes: number;
+  autoConfirm: boolean;
+  welcomeMessage?: string | null;
+  replyToEmail?: string | null;
+};
+
+export const BookingPageService = {
+  /**
+   * Current configuration. A practice that has never opened the wizard gets the
+   * defaults rather than a 404, so the caller has one shape to render.
+   */
+  async getConfig(organisationId: string): Promise<BookingPageConfig> {
+    const safeOrganisationId = requireSafeId(organisationId, "organisationId");
+
+    const organisation = await prisma.organization.findUnique({
+      where: { id: safeOrganisationId },
+      select: { bookingSlug: true, publicBookingEnabled: true },
+    });
+
+    if (!organisation) {
+      throw new BookingPageServiceError("Organisation not found", 404);
+    }
+
+    const settings = await prisma.publicBookingSettings.findUnique({
+      where: { organizationId: safeOrganisationId },
+      select: {
+        serviceIds: true,
+        bookingWindowDays: true,
+        bufferMinutes: true,
+        autoConfirm: true,
+        welcomeMessage: true,
+        replyToEmail: true,
+      },
+    });
+
+    return toConfig(safeOrganisationId, organisation, settings);
+  },
+
+  /**
+   * Persist the wizard's answers and allocate a slug on first save.
+   *
+   * `serviceIds` is filtered against the caller's own organisation before it is
+   * written. `withOrgPermissions` has already proved the caller belongs to
+   * `organisationId`, but it says nothing about the ids in the body - without
+   * this read, an admin could pin another practice's catalogue item onto their
+   * own public page, and the public renderer would later resolve it.
+   */
+  async saveConfig(
+    organisationId: string,
+    input: BookingPageSettingsInput,
+  ): Promise<BookingPageConfig> {
+    const safeOrganisationId = requireSafeId(organisationId, "organisationId");
+    // Each id is narrowed individually: `{ in: [...] }` is only safe if every
+    // element is a scalar, and the array arrives from the request body.
+    const requested = [
+      ...new Set(input.serviceIds.map((id) => requireSafeId(id, "serviceId"))),
+    ];
+
+    const owned =
+      requested.length === 0
+        ? []
+        : await prisma.productItem.findMany({
+            where: {
+              id: { in: requested },
+              organisationId: safeOrganisationId,
+              isActive: true,
+              bookable: { isNot: null },
+            },
+            select: { id: true },
+          });
+
+    const ownedIds = new Set(owned.map((item) => item.id));
+    const rejected = requested.filter((id) => !ownedIds.has(id));
+    if (rejected.length > 0) {
+      throw new BookingPageServiceError(
+        "One or more selected services are not bookable services of this organisation.",
+        400,
+      );
+    }
+
+    await ensureBookingSlug(safeOrganisationId);
+
+    const settingsData = {
+      serviceIds: requested,
+      bookingWindowDays: input.bookingWindowDays,
+      bufferMinutes: input.bufferMinutes,
+      autoConfirm: input.autoConfirm,
+      welcomeMessage: input.welcomeMessage?.trim() || null,
+      replyToEmail: input.replyToEmail?.trim().toLowerCase() || null,
+    };
+
+    await prisma.publicBookingSettings.upsert({
+      where: { organizationId: safeOrganisationId },
+      create: { organizationId: safeOrganisationId, ...settingsData },
+      update: settingsData,
+    });
+
+    return BookingPageService.getConfig(safeOrganisationId);
+  },
+};

--- a/apps/backend/src/services/booking-page.service.ts
+++ b/apps/backend/src/services/booking-page.service.ts
@@ -169,15 +169,31 @@ export const isValidBookingSlug = (slug: string): boolean =>
  * "Tierärzte Grünwald" becomes `tierarzte-grunwald` and not `tier-rzte-gr-nwald`
  * - this product operates in the EU and most practice names carry them.
  */
+/**
+ * Trim leading and trailing hyphens.
+ *
+ * Deliberately not `/^-+|-+$/g`. That pattern backtracks polynomially on a
+ * string of many hyphens (CodeQL js/polynomial-redos), and the input here is a
+ * practice name, which the practice chooses. These two scans are linear.
+ */
+const trimHyphens = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === "-") start += 1;
+  while (end > start && value[end - 1] === "-") end -= 1;
+  return value.slice(start, end);
+};
+
 export const slugifyOrganisationName = (name: string): string =>
-  name
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, MAX_SLUG_LENGTH)
-    .replace(/-+$/g, "");
+  trimHyphens(
+    trimHyphens(
+      name
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-"),
+    ).slice(0, MAX_SLUG_LENGTH),
+  );
 
 /**
  * Candidates to try, in order, for a practice named `name`.
@@ -262,15 +278,21 @@ const claimSlug = async (
         data: { slug, organizationId: safeOrganizationId },
       });
 
-      // `updateMany`, not `update`: `update` addresses a row by unique key and
-      // cannot carry an extra predicate, so there would be nowhere to put the
-      // "still unallocated" condition.
-      const claimed = await tx.organization.updateMany({
-        where: { id: safeOrganizationId, bookingSlug: null },
-        data: { bookingSlug: slug },
-      });
+      // Raw, parameterised UPDATE rather than `update` or `updateMany`.
+      //
+      // `update` addresses a row by unique key and cannot carry the extra
+      // "still unallocated" predicate. `updateMany` can, but its `where` is a
+      // Prisma filter object, so a non-string id would become a filter operator
+      // rather than an equality test and silently widen the statement. A tagged
+      // template binds both values as query parameters, where an object cannot
+      // be reinterpreted as an operator at all.
+      const claimed = await tx.$executeRaw`
+        UPDATE "Organization"
+        SET "bookingSlug" = ${slug}
+        WHERE "id" = ${safeOrganizationId} AND "bookingSlug" IS NULL
+      `;
 
-      if (claimed.count === 0) throw new SlugAlreadyAllocatedError();
+      if (claimed === 0) throw new SlugAlreadyAllocatedError();
     });
     return true;
   } catch (error: unknown) {

--- a/apps/backend/src/services/booking-page.service.ts
+++ b/apps/backend/src/services/booking-page.service.ts
@@ -388,6 +388,16 @@ export const resolveBookingPageUrl = (
 
 export type BookingPageConfig = {
   organisationId: string;
+  /**
+   * Whether this practice has ever saved its booking setup.
+   *
+   * Without this, a practice that deliberately saved zero services is
+   * indistinguishable from one that has never opened the wizard - both arrive as
+   * `serviceIds: []`. The caller needs to tell them apart, because one means
+   * "offer nothing publicly" and the other means "we have no answer yet, so
+   * default to everything bookable".
+   */
+  configured: boolean;
   slug: string | null;
   publicBookingEnabled: boolean;
   publicUrl: string | null;
@@ -415,6 +425,7 @@ const toConfig = (
   } | null,
 ): BookingPageConfig => ({
   organisationId,
+  configured: settings !== null,
   slug: organisation.bookingSlug,
   publicBookingEnabled: organisation.publicBookingEnabled,
   publicUrl: resolveBookingPageUrl(

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -381,8 +381,10 @@ const assertSlotIsOffered = async (
   startTime: string,
 ): Promise<{ durationMinutes: number }> => {
   const slots = await PublicBookingService.getSlots(slug, serviceId, date);
-  const match = slots.windows.find((window) => window.startTime === startTime);
-  if (!match) {
+  const offered = slots.windows.some(
+    (window) => window.startTime === startTime,
+  );
+  if (!offered) {
     throw new PublicBookingError("That time is no longer available", 409);
   }
   return { durationMinutes: slots.durationMinutes };
@@ -592,8 +594,7 @@ export const PublicBookingRequestService = {
       },
     });
 
-    if (!existing || existing.status !== "PENDING_CONFIRMATION")
-      throw notFound();
+    if (existing?.status !== "PENDING_CONFIRMATION") throw notFound();
     if (dayjs.utc(existing.confirmationExpiresAt).isBefore(dayjs.utc()))
       throw notFound();
 

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -1,0 +1,726 @@
+import { createHash, randomBytes } from "node:crypto";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import { prisma } from "src/config/prisma";
+import { CatalogService } from "./catalog.service";
+import { resolveBookingPageUrl } from "./booking-page.service";
+import { sendEmail } from "src/utils/email";
+import { escapeHtml, renderEmailButton } from "src/utils/email-templates";
+import logger from "src/utils/logger";
+
+dayjs.extend(utc);
+dayjs.extend(customParseFormat);
+
+/**
+ * The unauthenticated half of the public booking page.
+ *
+ * Everything here is reachable by anyone on the internet, so the shape of each
+ * response is as much of the design as its contents. Three rules run through it:
+ *
+ *  1. **One failure mode.** An unpublished practice, a practice that does not
+ *     exist, and a service that is not offered publicly all produce the same
+ *     `NotFound`. A caller walking slugs learns nothing from the difference,
+ *     because there is no difference to observe.
+ *  2. **Projections, not entities.** No response is a database row with fields
+ *     removed. Each one is built field by field, so a column added to
+ *     `ProductItem` or `Organization` later cannot leak by default. Staff ids,
+ *     internal codes and pricing are absent by construction.
+ *  3. **A request is inert.** Submitting one writes to `PublicBookingRequest`
+ *     and nothing else. It does not touch a calendar, does not create a Parent
+ *     or a Companion, and is not visible to the practice until the requester has
+ *     proven the email address belongs to them.
+ */
+
+export class PublicBookingError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "PublicBookingError";
+    this.status = status;
+  }
+}
+
+/**
+ * The only "this does not exist" any public caller ever sees.
+ *
+ * Deliberately one function rather than a message per case. A practice that has
+ * not published, a slug nobody owns, and a service withdrawn from the page are
+ * different facts internally and must be indistinguishable externally: telling
+ * them apart is how a caller maps which clinics use the product before they open
+ * their booking page.
+ */
+const notFound = () => new PublicBookingError("Not found", 404);
+
+const MAX_BOOKING_WINDOW_DAYS = 180;
+const CONFIRMATION_TOKEN_BYTES = 32;
+const CONFIRMATION_VALID_HOURS = 48;
+
+/**
+ * How long a request may be stored.
+ *
+ * Thirty days after the requested appointment, or after submission for one that
+ * is never confirmed. Long enough for a practice to work through its queue and
+ * for a no-show to be explicable; short enough that a stranger's contact details
+ * do not sit in a veterinary database indefinitely because nobody deleted them.
+ */
+const RETENTION_DAYS = 30;
+
+const hashToken = (token: string): string =>
+  createHash("sha256").update(token).digest("hex");
+
+/**
+ * Guard identifiers on their way into a Prisma `where`.
+ *
+ * Prisma filters accept objects as well as scalars, so a non-string value turns
+ * `where: { id }` into a structured filter and widens the query. Every value
+ * here arrives from an unauthenticated request body or path, which is the worst
+ * possible provenance, so nothing reaches a query without passing through this.
+ */
+const requireSafeString = (value: unknown, field: string): string => {
+  if (typeof value !== "string")
+    throw new PublicBookingError(`Invalid ${field}`, 400);
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes("$")) {
+    throw new PublicBookingError(`Invalid ${field}`, 400);
+  }
+  return trimmed;
+};
+
+export type PublicService = {
+  id: string;
+  name: string;
+  description: string | null;
+  durationMinutes: number;
+};
+
+export type PublicPractice = {
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  welcomeMessage: string | null;
+  city: string | null;
+  country: string | null;
+  bookingWindowDays: number;
+  requiresConfirmation: boolean;
+  services: PublicService[];
+};
+
+type ResolvedPractice = {
+  organizationId: string;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  city: string | null;
+  country: string | null;
+  settings: {
+    serviceIds: string[];
+    bookingWindowDays: number;
+    bufferMinutes: number;
+    autoConfirm: boolean;
+    welcomeMessage: string | null;
+    replyToEmail: string | null;
+  } | null;
+};
+
+/**
+ * Resolve a slug to a published practice, or say where the reader should go.
+ *
+ * A retired slug still resolves. Booking addresses end up on printed cards and
+ * in directory listings, so a practice that renames must not 404 the address its
+ * clients already have - the caller is told the current slug and redirects.
+ */
+export const resolveSlug = async (
+  rawSlug: string,
+): Promise<
+  | { kind: "current"; practice: ResolvedPractice }
+  | { kind: "retired"; slug: string }
+> => {
+  const slug = requireSafeString(rawSlug, "slug");
+
+  const organisation = await prisma.organization.findUnique({
+    where: { bookingSlug: slug },
+    select: {
+      id: true,
+      name: true,
+      imageUrl: true,
+      publicBookingEnabled: true,
+      address: { select: { city: true, country: true } },
+      bookingSettings: {
+        select: {
+          serviceIds: true,
+          bookingWindowDays: true,
+          bufferMinutes: true,
+          autoConfirm: true,
+          welcomeMessage: true,
+          replyToEmail: true,
+        },
+      },
+    },
+  });
+
+  if (organisation) {
+    // Opt-in is enforced here, on the read path, not only in the UI that flips
+    // it. A practice that has configured a page but not published it is exactly
+    // as absent as one that never opened the wizard.
+    if (!organisation.publicBookingEnabled) throw notFound();
+
+    return {
+      kind: "current",
+      practice: {
+        organizationId: organisation.id,
+        slug,
+        name: organisation.name,
+        logoUrl: organisation.imageUrl ?? null,
+        city: organisation.address?.city ?? null,
+        country: organisation.address?.country ?? null,
+        settings: organisation.bookingSettings,
+      },
+    };
+  }
+
+  const reservation = await prisma.bookingSlugReservation.findUnique({
+    where: { slug },
+    select: {
+      organization: {
+        select: { bookingSlug: true, publicBookingEnabled: true },
+      },
+    },
+  });
+
+  const currentSlug = reservation?.organization?.bookingSlug;
+  if (!currentSlug || !reservation?.organization?.publicBookingEnabled)
+    throw notFound();
+
+  return { kind: "retired", slug: currentSlug };
+};
+
+const requireCurrent = async (slug: string): Promise<ResolvedPractice> => {
+  const resolved = await resolveSlug(slug);
+  // A retired slug is a redirect, not a page. Callers that cannot redirect (the
+  // slot and submit endpoints) treat it as absent rather than silently serving
+  // another practice's data under the old name.
+  if (resolved.kind !== "current") throw notFound();
+  return resolved.practice;
+};
+
+/**
+ * Services this practice offers publicly, as the public may see them.
+ *
+ * Built field by field on purpose. `ProductItem` carries `code` (the practice's
+ * internal catalogue reference), and its price lives one join away; neither
+ * belongs on a page anyone can scrape, and neither can arrive here by accident
+ * because neither is selected.
+ *
+ * Two filters, not one. `settings.serviceIds` is what the practice chose, and
+ * `isActive` + a `bookable` row is what the catalogue currently supports - so
+ * archiving a service withdraws it from the page immediately, without anyone
+ * revisiting the wizard.
+ */
+const loadPublicServices = async (
+  practice: ResolvedPractice,
+): Promise<PublicService[]> => {
+  const chosen = practice.settings?.serviceIds ?? [];
+
+  const products = await prisma.productItem.findMany({
+    where: {
+      organisationId: practice.organizationId,
+      isActive: true,
+      bookable: { isNot: null },
+      // An empty selection means the practice never narrowed it, so everything
+      // bookable is offered. It is NOT the same as choosing nothing - that case
+      // is settled before this query runs.
+      ...(chosen.length > 0 ? { id: { in: chosen } } : {}),
+    },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      bookable: { select: { durationMinutes: true } },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  return products.map((product) => ({
+    id: product.id,
+    name: product.name,
+    description: product.description,
+    durationMinutes: product.bookable?.durationMinutes ?? 0,
+  }));
+};
+
+/**
+ * A practice that saved an explicitly empty selection is offering nothing.
+ *
+ * `configured` on the settings row is what separates that from a practice that
+ * never narrowed the list; here the settings row exists, so an empty array is a
+ * decision and is honoured.
+ */
+const offersNothing = (practice: ResolvedPractice): boolean =>
+  practice.settings !== null && practice.settings.serviceIds.length === 0;
+
+export const PublicBookingService = {
+  async getPractice(slug: string): Promise<PublicPractice> {
+    const practice = await requireCurrent(slug);
+
+    return {
+      slug: practice.slug,
+      name: practice.name,
+      logoUrl: practice.logoUrl,
+      welcomeMessage: practice.settings?.welcomeMessage ?? null,
+      city: practice.city,
+      country: practice.country,
+      bookingWindowDays: Math.min(
+        practice.settings?.bookingWindowDays ?? 28,
+        MAX_BOOKING_WINDOW_DAYS,
+      ),
+      requiresConfirmation: !practice.settings?.autoConfirm,
+      services: offersNothing(practice)
+        ? []
+        : await loadPublicServices(practice),
+    };
+  },
+
+  /**
+   * Bookable windows for one service on one date.
+   *
+   * Reuses `CatalogService.getBookableSlotsService`, which is the same
+   * computation the signed-in apps use, and then strips `vetIds`. That field is
+   * a list of staff user identifiers; the authenticated slot route already
+   * redacts it for anonymous callers (`withoutVetIds` in service.controller.ts)
+   * and this route must not be the one that reintroduces it.
+   */
+  async getSlots(slug: string, rawServiceId: string, rawDate: string) {
+    const practice = await requireCurrent(slug);
+    const serviceId = requireSafeString(rawServiceId, "serviceId");
+
+    const date = dayjs.utc(rawDate, "YYYY-MM-DD", true);
+    if (!date.isValid()) throw new PublicBookingError("Invalid date", 400);
+
+    const windowDays = Math.min(
+      practice.settings?.bookingWindowDays ?? 28,
+      MAX_BOOKING_WINDOW_DAYS,
+    );
+    const today = dayjs.utc().startOf("day");
+    // The booking window is a limit on how far into the future an anonymous
+    // caller can walk this practice's calendar, so it is enforced on the server.
+    // Without it the window is a UI suggestion and the whole schedule is
+    // scrapable one date at a time.
+    if (date.isBefore(today) || date.isAfter(today.add(windowDays, "day"))) {
+      throw new PublicBookingError("Date outside the booking window", 400);
+    }
+
+    if (offersNothing(practice)) throw notFound();
+
+    const offered = await loadPublicServices(practice);
+    const service = offered.find((candidate) => candidate.id === serviceId);
+    // Asking for a service the practice does not offer publicly is the same
+    // answer as asking for one that does not exist.
+    if (!service) throw notFound();
+
+    const result = await CatalogService.getBookableSlotsService(
+      serviceId,
+      practice.organizationId,
+      date.toDate(),
+    );
+
+    return {
+      date: result.date,
+      serviceId,
+      durationMinutes: service.durationMinutes,
+      windows: result.windows.map((window) => ({
+        startTime: window.startTime,
+        endTime: window.endTime,
+      })),
+    };
+  },
+};
+
+export type PublicBookingRequestInput = {
+  serviceId: string;
+  date: string;
+  startTime: string;
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone?: string | null;
+  petName: string;
+  petSpecies: string;
+  concern?: string | null;
+};
+
+const buildConfirmationUrl = (slug: string, token: string): string | null => {
+  const base = resolveBookingPageUrl(slug, true);
+  if (!base) return null;
+  return `${base}/confirm?token=${encodeURIComponent(token)}`;
+};
+
+/**
+ * How many unconfirmed requests one email address may hold against one practice.
+ *
+ * The per-IP limiter on the route caps volume from a single source; this caps
+ * the damage from a distributed one, because the practice's inbox is the real
+ * target. Only PENDING rows count, so confirming genuinely frees the budget.
+ */
+const MAX_PENDING_PER_EMAIL = 3;
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase();
+
+/**
+ * Prove the requested time is one this practice actually offers.
+ *
+ * Without this the form's own slot list is the only control, and a caller who
+ * skips the form can request 03:00 on a Sunday - worse than a bad UX, because
+ * the practice then has to triage nonsense arriving at their real address. The
+ * window list is recomputed server-side and the requested start must be in it.
+ */
+const assertSlotIsOffered = async (
+  slug: string,
+  serviceId: string,
+  date: string,
+  startTime: string,
+): Promise<{ durationMinutes: number }> => {
+  const slots = await PublicBookingService.getSlots(slug, serviceId, date);
+  const match = slots.windows.find((window) => window.startTime === startTime);
+  if (!match) {
+    throw new PublicBookingError("That time is no longer available", 409);
+  }
+  return { durationMinutes: slots.durationMinutes };
+};
+
+const requestSubmittedEmail = (practiceName: string, url: string) => ({
+  subject: `Confirm your booking request for ${practiceName}`,
+  htmlBody: `
+    <p>Thanks for asking to book with ${escapeHtml(practiceName)}.</p>
+    <p>Confirm your email address so the practice can see your request. This link
+    works for ${CONFIRMATION_VALID_HOURS} hours.</p>
+    ${renderEmailButton(url, "Confirm my request")}
+    <p>Your request is not booked yet. The practice will be in touch to confirm a
+    time.</p>
+    <p>If you did not ask to book anything, ignore this email and nothing further
+    happens.</p>
+  `,
+  textBody: [
+    `Thanks for asking to book with ${practiceName}.`,
+    "",
+    `Confirm your email address so the practice can see your request (valid for ${CONFIRMATION_VALID_HOURS} hours):`,
+    url,
+    "",
+    "Your request is not booked yet. The practice will be in touch to confirm a time.",
+    "If you did not ask to book anything, ignore this email and nothing further happens.",
+  ].join("\n"),
+});
+
+type StoredRequest = {
+  serviceName: string;
+  requestedStart: Date;
+  durationMinutes: number;
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone: string | null;
+  petName: string;
+  petSpecies: string;
+  concern: string | null;
+};
+
+const practiceNotificationEmail = (request: StoredRequest) => {
+  const when = dayjs
+    .utc(request.requestedStart)
+    .format("ddd D MMM YYYY, HH:mm");
+  const rows: [string, string][] = [
+    ["Service", request.serviceName],
+    ["Requested", `${when} UTC (${request.durationMinutes} min)`],
+    ["Pet", `${request.petName} (${request.petSpecies})`],
+    ["Owner", request.ownerName],
+    ["Email", request.ownerEmail],
+    ["Phone", request.ownerPhone ?? "not given"],
+    ["Reason", request.concern ?? "not given"],
+  ];
+
+  return {
+    subject: `New booking request from ${request.ownerName}`,
+    htmlBody: `
+      <p>A pet owner submitted a booking request through your public booking page
+      and confirmed their email address.</p>
+      <table>${rows
+        .map(
+          ([label, value]) =>
+            `<tr><td><strong>${escapeHtml(label)}</strong></td><td>${escapeHtml(value)}</td></tr>`,
+        )
+        .join("")}</table>
+      <p>This is a request, not an appointment. Nothing has been added to your
+      calendar - book it in Yosemite Crew if you want it.</p>
+    `,
+    textBody: [
+      "A pet owner submitted a booking request through your public booking page and confirmed their email address.",
+      "",
+      ...rows.map(([label, value]) => `${label}: ${value}`),
+      "",
+      "This is a request, not an appointment. Nothing has been added to your calendar.",
+    ].join("\n"),
+  };
+};
+
+export const PublicBookingRequestService = {
+  /**
+   * Accept a booking request and email the requester a confirmation link.
+   *
+   * The response is deliberately identical whether or not the email was sent,
+   * and carries no identifier. A caller cannot use this endpoint to discover
+   * whether an address is already in use, and cannot poll for a request id it
+   * did not receive by email.
+   */
+  async submit(slug: string, input: PublicBookingRequestInput) {
+    const practice = await requireCurrent(slug);
+    const serviceId = requireSafeString(input.serviceId, "serviceId");
+    const ownerEmail = normalizeEmail(input.ownerEmail);
+
+    if (offersNothing(practice)) throw notFound();
+
+    const offered = await loadPublicServices(practice);
+    const service = offered.find((candidate) => candidate.id === serviceId);
+    if (!service) throw notFound();
+
+    const { durationMinutes } = await assertSlotIsOffered(
+      slug,
+      serviceId,
+      input.date,
+      input.startTime,
+    );
+
+    const pending = await prisma.publicBookingRequest.count({
+      where: {
+        organizationId: practice.organizationId,
+        ownerEmail,
+        status: "PENDING_CONFIRMATION",
+      },
+    });
+    if (pending >= MAX_PENDING_PER_EMAIL) {
+      throw new PublicBookingError(
+        "There are already unconfirmed requests for this email address. Please confirm one of those first.",
+        429,
+      );
+    }
+
+    const token = randomBytes(CONFIRMATION_TOKEN_BYTES).toString("hex");
+    const now = dayjs.utc();
+    // Both halves are already proven: the date parsed strictly inside
+    // `getSlots`, and the start time matched a window that `getSlots` produced.
+    // There is no invalid case left to guard against here.
+    const requestedStart = dayjs.utc(
+      `${input.date} ${input.startTime}`,
+      "YYYY-MM-DD HH:mm",
+      true,
+    );
+    const requestedEnd = requestedStart.add(durationMinutes, "minute");
+
+    await prisma.publicBookingRequest.create({
+      data: {
+        organizationId: practice.organizationId,
+        productItemId: serviceId,
+        serviceName: service.name,
+        requestedStart: requestedStart.toDate(),
+        requestedEnd: requestedEnd.toDate(),
+        durationMinutes,
+        ownerName: input.ownerName.trim(),
+        ownerEmail,
+        ownerPhone: input.ownerPhone?.trim() || null,
+        petName: input.petName.trim(),
+        petSpecies: input.petSpecies.trim(),
+        concern: input.concern?.trim() || null,
+        confirmationTokenHash: hashToken(token),
+        confirmationExpiresAt: now
+          .add(CONFIRMATION_VALID_HOURS, "hour")
+          .toDate(),
+        consentAcceptedAt: now.toDate(),
+        purgeAfter: requestedStart.add(RETENTION_DAYS, "day").toDate(),
+      },
+    });
+
+    const url = buildConfirmationUrl(practice.slug, token);
+    if (url) {
+      const message = requestSubmittedEmail(practice.name, url);
+      try {
+        await sendEmail({ to: ownerEmail, ...message });
+      } catch (error: unknown) {
+        // The row is already written, so the request is not lost, but the
+        // requester cannot confirm without the link. Logged rather than thrown:
+        // surfacing a send failure would tell an anonymous caller whether an
+        // address is deliverable.
+        logger.error("Public booking confirmation email failed", error);
+      }
+    } else {
+      logger.error(
+        "Public booking confirmation email skipped: PUBLIC_BOOKING_BASE_URL is not configured",
+      );
+    }
+  },
+
+  /**
+   * Confirm a request from the emailed link, and tell the practice about it.
+   *
+   * Resolved by hash, so the stored value cannot be replayed by anyone who reads
+   * the table. Every failure - unknown token, already used, expired - returns
+   * the same 404, because distinguishing them lets a caller test tokens.
+   */
+  async confirm(rawToken: string) {
+    const token = requireSafeString(rawToken, "token");
+
+    const existing = await prisma.publicBookingRequest.findUnique({
+      where: { confirmationTokenHash: hashToken(token) },
+      select: {
+        id: true,
+        status: true,
+        confirmationExpiresAt: true,
+        serviceName: true,
+        requestedStart: true,
+        durationMinutes: true,
+        ownerName: true,
+        ownerEmail: true,
+        ownerPhone: true,
+        petName: true,
+        petSpecies: true,
+        concern: true,
+        organization: {
+          select: {
+            name: true,
+            email: true,
+            bookingSlug: true,
+            bookingSettings: { select: { replyToEmail: true } },
+          },
+        },
+      },
+    });
+
+    if (!existing || existing.status !== "PENDING_CONFIRMATION")
+      throw notFound();
+    if (dayjs.utc(existing.confirmationExpiresAt).isBefore(dayjs.utc()))
+      throw notFound();
+
+    await prisma.publicBookingRequest.update({
+      where: { id: existing.id },
+      data: { status: "CONFIRMED", confirmedAt: new Date() },
+    });
+
+    const practiceInbox =
+      existing.organization.bookingSettings?.replyToEmail ??
+      existing.organization.email;
+
+    if (practiceInbox) {
+      const message = practiceNotificationEmail(existing);
+      try {
+        await sendEmail({ to: practiceInbox, ...message });
+      } catch (error: unknown) {
+        // The request is confirmed and visible in the practice's list either
+        // way; the email is a prompt, not the record.
+        logger.error("Public booking practice notification failed", error);
+      }
+    } else {
+      logger.warn(
+        "Public booking request confirmed but the practice has no reply-to or contact email",
+      );
+    }
+
+    return {
+      practiceName: existing.organization.name,
+      slug: existing.organization.bookingSlug,
+    };
+  },
+
+  /**
+   * Confirmed requests for the practice, soonest requested time first.
+   *
+   * PENDING rows are deliberately excluded: anyone can type anyone's address
+   * into a public form, so an unconfirmed request is an unverified claim and
+   * showing it would make the practice's queue spammable by design.
+   */
+  async listForOrganisation(
+    organisationId: string,
+    status?: "CONFIRMED" | "DECLINED" | "BOOKED",
+  ) {
+    const safeOrganisationId = requireSafeString(
+      organisationId,
+      "organisationId",
+    );
+
+    return prisma.publicBookingRequest.findMany({
+      where: {
+        organizationId: safeOrganisationId,
+        status: status ?? { in: ["CONFIRMED", "DECLINED", "BOOKED"] },
+      },
+      orderBy: { requestedStart: "asc" },
+      take: 200,
+      select: {
+        id: true,
+        serviceName: true,
+        requestedStart: true,
+        requestedEnd: true,
+        durationMinutes: true,
+        ownerName: true,
+        ownerEmail: true,
+        ownerPhone: true,
+        petName: true,
+        petSpecies: true,
+        concern: true,
+        status: true,
+        confirmedAt: true,
+        createdAt: true,
+      },
+    });
+  },
+
+  /**
+   * Mark a request declined or booked.
+   *
+   * Scoped by organisation in the same statement that selects the row, so a
+   * request belonging to another practice is not found rather than updated.
+   */
+  async setStatus(
+    organisationId: string,
+    requestId: string,
+    status: "DECLINED" | "BOOKED",
+  ) {
+    const safeOrganisationId = requireSafeString(
+      organisationId,
+      "organisationId",
+    );
+    const safeRequestId = requireSafeString(requestId, "requestId");
+
+    const updated = await prisma.publicBookingRequest.updateMany({
+      where: {
+        id: safeRequestId,
+        organizationId: safeOrganisationId,
+        status: { in: ["CONFIRMED", "DECLINED", "BOOKED"] },
+      },
+      data: { status },
+    });
+
+    if (updated.count === 0) {
+      throw new PublicBookingError("Booking request not found", 404);
+    }
+  },
+
+  /**
+   * Delete what is past its retention deadline and expire stale links.
+   *
+   * Runs on a schedule rather than opportunistically: a practice that stops
+   * receiving requests must still stop holding the ones it already has.
+   */
+  async purgeExpired(now: Date = new Date()) {
+    const expired = await prisma.publicBookingRequest.updateMany({
+      where: {
+        status: "PENDING_CONFIRMATION",
+        confirmationExpiresAt: { lt: now },
+      },
+      data: { status: "EXPIRED" },
+    });
+
+    const deleted = await prisma.publicBookingRequest.deleteMany({
+      where: { purgeAfter: { lt: now } },
+    });
+
+    return { expired: expired.count, deleted: deleted.count };
+  },
+};
+
+export default PublicBookingService;

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import customParseFormat from "dayjs/plugin/customParseFormat";
+import utc from "dayjs/plugin/utc.js";
+import customParseFormat from "dayjs/plugin/customParseFormat.js";
 import { prisma } from "src/config/prisma";
 import { CatalogService } from "./catalog.service";
 import { resolveBookingPageUrl } from "./booking-page.service";

--- a/apps/backend/src/workers/index.ts
+++ b/apps/backend/src/workers/index.ts
@@ -8,6 +8,7 @@ import "./lab-results.worker";
 import "./vaccineReminder.worker";
 import "./ap-delivery.worker";
 import "./ap-inbox.worker";
+import "./public-booking.worker";
 import logger from "src/utils/logger";
 
 logger.info("👷 BullMQ workers running...");

--- a/apps/backend/src/workers/public-booking.worker.ts
+++ b/apps/backend/src/workers/public-booking.worker.ts
@@ -1,0 +1,28 @@
+import { Job, Worker } from "bullmq";
+import { redisConnection } from "../queues/bull.config";
+import logger from "src/utils/logger";
+import { PublicBookingJobs } from "src/queues/public-booking.queue";
+import { PublicBookingRequestService } from "src/services/public-booking.service";
+
+export const PublicBookingWorker = new Worker(
+  "public-booking",
+  async (job: Job) => {
+    if (job.name === PublicBookingJobs.PURGE_EXPIRED_REQUESTS) {
+      const { expired, deleted } =
+        await PublicBookingRequestService.purgeExpired();
+
+      // Counts only. The rows being deleted are personal data, so the thing that
+      // proves the retention rule ran must not itself become a copy of them in
+      // the log.
+      logger.info("🧹 Public booking retention purge", { expired, deleted });
+      return { expired, deleted };
+    }
+
+    throw new Error(`Unknown job name: ${job.name}`);
+  },
+  { connection: redisConnection },
+);
+
+PublicBookingWorker.on("failed", (_job, err) =>
+  logger.error("❌ Public booking purge failed", err),
+);

--- a/apps/backend/test/controllers/booking-page.controller.test.ts
+++ b/apps/backend/test/controllers/booking-page.controller.test.ts
@@ -1,0 +1,219 @@
+import { BookingPageController } from "../../src/controllers/web/booking-page.controller";
+import {
+  BookingPageService,
+  BookingPageServiceError,
+} from "../../src/services/booking-page.service";
+
+jest.mock("../../src/services/booking-page.service", () => {
+  const actual = jest.requireActual("../../src/services/booking-page.service");
+  return {
+    ...actual,
+    BookingPageService: {
+      getConfig: jest.fn(),
+      saveConfig: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+const mockedService = BookingPageService as unknown as {
+  getConfig: jest.Mock;
+  saveConfig: jest.Mock;
+};
+
+const createResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+});
+
+const validBody = {
+  serviceIds: ["3f6b1a2c-1111-2222-3333-444455556666"],
+  bookingWindowDays: 28,
+  bufferMinutes: 10,
+  autoConfirm: false,
+  welcomeMessage: "Book a visit.",
+  replyToEmail: "front@example.com",
+};
+
+describe("BookingPageController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getConfig", () => {
+    it("returns the configuration for the authorized organisation", async () => {
+      mockedService.getConfig.mockResolvedValueOnce({ slug: "park-vets" });
+      const req = { organisationId: "org-1", params: {} } as never;
+      const res = createResponse();
+
+      await BookingPageController.getConfig(req, res as never);
+
+      expect(mockedService.getConfig).toHaveBeenCalledWith("org-1");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ data: { slug: "park-vets" } });
+    });
+
+    it("scopes on the authorized organisation, not the route param", async () => {
+      mockedService.getConfig.mockResolvedValueOnce({});
+      const req = {
+        organisationId: "org-authorized",
+        params: { organisationId: "org-someone-else" },
+      } as never;
+
+      await BookingPageController.getConfig(req, createResponse() as never);
+
+      expect(mockedService.getConfig).toHaveBeenCalledWith("org-authorized");
+    });
+
+    it("400s when the middleware resolved no organisation", async () => {
+      const req = { params: {} } as never;
+      const res = createResponse();
+
+      await BookingPageController.getConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.getConfig).not.toHaveBeenCalled();
+    });
+
+    it("passes a service error status through", async () => {
+      mockedService.getConfig.mockRejectedValueOnce(
+        new BookingPageServiceError("Organisation not found", 404),
+      );
+      const req = { organisationId: "org-1", params: {} } as never;
+      const res = createResponse();
+
+      await BookingPageController.getConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("does not leak an unexpected failure to the caller", async () => {
+      mockedService.getConfig.mockRejectedValueOnce(
+        new Error("connection string postgres://user:pw@host"),
+      );
+      const req = { organisationId: "org-1", params: {} } as never;
+      const res = createResponse();
+
+      await BookingPageController.getConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Something went wrong",
+      });
+    });
+  });
+
+  describe("saveConfig", () => {
+    it("persists a valid payload and returns the stored configuration", async () => {
+      mockedService.saveConfig.mockResolvedValueOnce({ slug: "park-vets" });
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: validBody,
+      } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(mockedService.saveConfig).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ bookingWindowDays: 28, autoConfirm: false }),
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("normalises omitted optional text to null", async () => {
+      mockedService.saveConfig.mockResolvedValueOnce({});
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: {
+          serviceIds: [],
+          bookingWindowDays: 14,
+          bufferMinutes: 0,
+          autoConfirm: true,
+        },
+      } as never;
+
+      await BookingPageController.saveConfig(req, createResponse() as never);
+
+      expect(mockedService.saveConfig).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ welcomeMessage: null, replyToEmail: null }),
+      );
+    });
+
+    it.each([
+      ["a booking window beyond the ceiling", { bookingWindowDays: 365 }],
+      ["a zero-day booking window", { bookingWindowDays: 0 }],
+      ["a buffer beyond the ceiling", { bufferMinutes: 999 }],
+      ["a negative buffer", { bufferMinutes: -1 }],
+      ["a non-uuid service id", { serviceIds: ["../../etc/passwd"] }],
+      ["a malformed reply-to address", { replyToEmail: "not-an-email" }],
+      ["an over-long welcome message", { welcomeMessage: "x".repeat(501) }],
+      ["a missing autoConfirm flag", { autoConfirm: undefined }],
+    ])("rejects %s", async (_label, override) => {
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: { ...validBody, ...override },
+      } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("400s when the middleware resolved no organisation", async () => {
+      const req = { params: {}, body: validBody } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("passes a cross-tenant service rejection through as 400", async () => {
+      mockedService.saveConfig.mockRejectedValueOnce(
+        new BookingPageServiceError("not bookable services", 400),
+      );
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: validBody,
+      } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "not bookable services",
+      });
+    });
+
+    it("does not leak an unexpected failure to the caller", async () => {
+      mockedService.saveConfig.mockRejectedValueOnce(new Error("boom"));
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: validBody,
+      } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Something went wrong",
+      });
+    });
+  });
+});

--- a/apps/backend/test/controllers/booking-page.controller.test.ts
+++ b/apps/backend/test/controllers/booking-page.controller.test.ts
@@ -3,6 +3,10 @@ import {
   BookingPageService,
   BookingPageServiceError,
 } from "../../src/services/booking-page.service";
+import {
+  PublicBookingError,
+  PublicBookingRequestService,
+} from "../../src/services/public-booking.service";
 
 jest.mock("../../src/services/booking-page.service", () => {
   const actual = jest.requireActual("../../src/services/booking-page.service");
@@ -15,6 +19,19 @@ jest.mock("../../src/services/booking-page.service", () => {
   };
 });
 
+jest.mock("../../src/services/public-booking.service", () => {
+  const actual = jest.requireActual(
+    "../../src/services/public-booking.service",
+  );
+  return {
+    ...actual,
+    PublicBookingRequestService: {
+      listForOrganisation: jest.fn(),
+      setStatus: jest.fn(),
+    },
+  };
+});
+
 jest.mock("../../src/utils/logger", () => ({
   __esModule: true,
   default: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
@@ -23,6 +40,11 @@ jest.mock("../../src/utils/logger", () => ({
 const mockedService = BookingPageService as unknown as {
   getConfig: jest.Mock;
   saveConfig: jest.Mock;
+};
+
+const mockedRequests = PublicBookingRequestService as unknown as {
+  listForOrganisation: jest.Mock;
+  setStatus: jest.Mock;
 };
 
 const createResponse = () => ({
@@ -199,6 +221,52 @@ describe("BookingPageController", () => {
       });
     });
 
+    it("passes the publish flag through when present", async () => {
+      mockedService.saveConfig.mockResolvedValueOnce({});
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: { ...validBody, publicBookingEnabled: true },
+      } as never;
+
+      await BookingPageController.saveConfig(req, createResponse() as never);
+
+      expect(mockedService.saveConfig).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ publicBookingEnabled: true }),
+      );
+    });
+
+    it("leaves publication untouched when the flag is omitted", async () => {
+      mockedService.saveConfig.mockResolvedValueOnce({});
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: validBody,
+      } as never;
+
+      await BookingPageController.saveConfig(req, createResponse() as never);
+
+      // Saving settings must never publish a practice as a side effect.
+      expect(
+        mockedService.saveConfig.mock.calls[0][1].publicBookingEnabled,
+      ).toBeUndefined();
+    });
+
+    it("rejects a non-boolean publish flag", async () => {
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: { ...validBody, publicBookingEnabled: "yes" },
+      } as never;
+      const res = createResponse();
+
+      await BookingPageController.saveConfig(req, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.saveConfig).not.toHaveBeenCalled();
+    });
+
     it("does not leak an unexpected failure to the caller", async () => {
       mockedService.saveConfig.mockRejectedValueOnce(new Error("boom"));
       const req = {
@@ -214,6 +282,177 @@ describe("BookingPageController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Something went wrong",
       });
+    });
+  });
+
+  describe("listRequests", () => {
+    it("lists the authorized organisation's requests", async () => {
+      mockedRequests.listForOrganisation.mockResolvedValueOnce([]);
+      const res = createResponse();
+
+      await BookingPageController.listRequests(
+        { organisationId: "org-1", params: {}, query: {} } as never,
+        res as never,
+      );
+
+      expect(mockedRequests.listForOrganisation).toHaveBeenCalledWith(
+        "org-1",
+        undefined,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("scopes on the authorized organisation, not the route param", async () => {
+      mockedRequests.listForOrganisation.mockResolvedValueOnce([]);
+
+      await BookingPageController.listRequests(
+        {
+          organisationId: "org-authorized",
+          params: { organisationId: "org-someone-else" },
+          query: {},
+        } as never,
+        createResponse() as never,
+      );
+
+      expect(mockedRequests.listForOrganisation).toHaveBeenCalledWith(
+        "org-authorized",
+        undefined,
+      );
+    });
+
+    it("rejects an unknown status filter", async () => {
+      const res = createResponse();
+
+      await BookingPageController.listRequests(
+        {
+          organisationId: "org-1",
+          params: {},
+          query: { status: "PENDING_CONFIRMATION" },
+        } as never,
+        res as never,
+      );
+
+      // PENDING is never listable: it is an unverified claim by an anonymous
+      // caller, so it must not be reachable even by asking for it.
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedRequests.listForOrganisation).not.toHaveBeenCalled();
+    });
+
+    it("400s when the middleware resolved no organisation", async () => {
+      const res = createResponse();
+
+      await BookingPageController.listRequests(
+        { params: {}, query: {} } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("does not leak an unexpected failure", async () => {
+      mockedRequests.listForOrganisation.mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const res = createResponse();
+
+      await BookingPageController.listRequests(
+        { organisationId: "org-1", params: {}, query: {} } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("updateRequestStatus", () => {
+    it("marks a request declined", async () => {
+      mockedRequests.setStatus.mockResolvedValueOnce(undefined);
+      const res = createResponse();
+
+      await BookingPageController.updateRequestStatus(
+        {
+          organisationId: "org-1",
+          params: { organisationId: "org-1", requestId: "req-1" },
+          body: { status: "DECLINED" },
+        } as never,
+        res as never,
+      );
+
+      expect(mockedRequests.setStatus).toHaveBeenCalledWith(
+        "org-1",
+        "req-1",
+        "DECLINED",
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it.each([
+      ["CONFIRMED", "a status only the public flow may set"],
+      [
+        "PENDING_CONFIRMATION",
+        "a status that would resurrect an unconfirmed request",
+      ],
+      ["nonsense", "an unknown status"],
+    ])("rejects %s (%s)", async (status) => {
+      const res = createResponse();
+
+      await BookingPageController.updateRequestStatus(
+        {
+          organisationId: "org-1",
+          params: { organisationId: "org-1", requestId: "req-1" },
+          body: { status },
+        } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedRequests.setStatus).not.toHaveBeenCalled();
+    });
+
+    it("400s when the middleware resolved no organisation", async () => {
+      const res = createResponse();
+
+      await BookingPageController.updateRequestStatus(
+        { params: { requestId: "req-1" }, body: { status: "BOOKED" } } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedRequests.setStatus).not.toHaveBeenCalled();
+    });
+
+    it("passes a cross-tenant 404 through", async () => {
+      mockedRequests.setStatus.mockRejectedValueOnce(
+        new PublicBookingError("Booking request not found", 404),
+      );
+      const res = createResponse();
+
+      await BookingPageController.updateRequestStatus(
+        {
+          organisationId: "org-1",
+          params: { organisationId: "org-1", requestId: "req-of-another-org" },
+          body: { status: "BOOKED" },
+        } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("does not leak an unexpected failure", async () => {
+      mockedRequests.setStatus.mockRejectedValueOnce(new Error("boom"));
+      const res = createResponse();
+
+      await BookingPageController.updateRequestStatus(
+        {
+          organisationId: "org-1",
+          params: { organisationId: "org-1", requestId: "req-1" },
+          body: { status: "BOOKED" },
+        } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
     });
   });
 });

--- a/apps/backend/test/controllers/booking-page.controller.test.ts
+++ b/apps/backend/test/controllers/booking-page.controller.test.ts
@@ -93,7 +93,7 @@ describe("BookingPageController", () => {
 
     it("does not leak an unexpected failure to the caller", async () => {
       mockedService.getConfig.mockRejectedValueOnce(
-        new Error("connection string postgres://user:pw@host"),
+        new Error("internal detail that must not reach the caller"),
       );
       const req = { organisationId: "org-1", params: {} } as never;
       const res = createResponse();
@@ -152,7 +152,7 @@ describe("BookingPageController", () => {
       ["a zero-day booking window", { bookingWindowDays: 0 }],
       ["a buffer beyond the ceiling", { bufferMinutes: 999 }],
       ["a negative buffer", { bufferMinutes: -1 }],
-      ["a non-uuid service id", { serviceIds: ["../../etc/passwd"] }],
+      ["a non-uuid service id", { serviceIds: ["not-a-uuid"] }],
       ["a malformed reply-to address", { replyToEmail: "not-an-email" }],
       ["an over-long welcome message", { welcomeMessage: "x".repeat(501) }],
       ["a missing autoConfirm flag", { autoConfirm: undefined }],

--- a/apps/backend/test/controllers/public-booking.controller.test.ts
+++ b/apps/backend/test/controllers/public-booking.controller.test.ts
@@ -1,0 +1,312 @@
+import { PublicBookingController } from "../../src/controllers/app/public-booking.controller";
+import {
+  PublicBookingError,
+  PublicBookingRequestService,
+  PublicBookingService,
+  resolveSlug,
+} from "../../src/services/public-booking.service";
+
+jest.mock("../../src/services/public-booking.service", () => {
+  const actual = jest.requireActual(
+    "../../src/services/public-booking.service",
+  );
+  return {
+    ...actual,
+    resolveSlug: jest.fn(),
+    PublicBookingService: { getPractice: jest.fn(), getSlots: jest.fn() },
+    PublicBookingRequestService: { submit: jest.fn(), confirm: jest.fn() },
+  };
+});
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+const mockedResolveSlug = resolveSlug as jest.Mock;
+const mockedService = PublicBookingService as unknown as {
+  getPractice: jest.Mock;
+  getSlots: jest.Mock;
+};
+const mockedRequests = PublicBookingRequestService as unknown as {
+  submit: jest.Mock;
+  confirm: jest.Mock;
+};
+
+const createResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+});
+
+const SERVICE_ID = "3f6b1a2c-1111-2222-3333-444455556666";
+
+const validBody = {
+  serviceId: SERVICE_ID,
+  date: "2026-09-01",
+  startTime: "09:00",
+  ownerName: "Sam Owner",
+  ownerEmail: "sam@example.com",
+  ownerPhone: "+49 30 1234",
+  petName: "Rex",
+  petSpecies: "Dog",
+  concern: "Limping",
+  consent: true,
+};
+
+describe("PublicBookingController", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("getPractice", () => {
+    it("returns the practice for a current slug", async () => {
+      mockedResolveSlug.mockResolvedValueOnce({ kind: "current" });
+      mockedService.getPractice.mockResolvedValueOnce({
+        name: "Park Veterinary",
+      });
+      const res = createResponse();
+
+      await PublicBookingController.getPractice(
+        { params: { slug: "park-veterinary" } } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        data: { name: "Park Veterinary" },
+      });
+    });
+
+    it("tells the caller where to go for a retired slug instead of 404ing", async () => {
+      mockedResolveSlug.mockResolvedValueOnce({
+        kind: "retired",
+        slug: "new-name",
+      });
+      const res = createResponse();
+
+      await PublicBookingController.getPractice(
+        { params: { slug: "old-name" } } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        data: { redirectTo: "new-name" },
+      });
+      expect(mockedService.getPractice).not.toHaveBeenCalled();
+    });
+
+    it("passes a service 404 through unchanged", async () => {
+      mockedResolveSlug.mockRejectedValueOnce(
+        new PublicBookingError("Not found", 404),
+      );
+      const res = createResponse();
+
+      await PublicBookingController.getPractice(
+        { params: { slug: "nope" } } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Not found" });
+    });
+
+    it("never lets an unexpected failure describe the system to the caller", async () => {
+      mockedResolveSlug.mockRejectedValueOnce(
+        new Error('relation "PublicBookingRequest" violates constraint xyz'),
+      );
+      const res = createResponse();
+
+      await PublicBookingController.getPractice(
+        { params: { slug: "x" } } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Something went wrong",
+      });
+    });
+  });
+
+  describe("getSlots", () => {
+    it("returns windows for a valid query", async () => {
+      mockedService.getSlots.mockResolvedValueOnce({ windows: [] });
+      const res = createResponse();
+
+      await PublicBookingController.getSlots(
+        {
+          params: { slug: "park-veterinary" },
+          query: { serviceId: SERVICE_ID, date: "2026-09-01" },
+        } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("passes a service error through and hides an unexpected one", async () => {
+      mockedService.getSlots.mockRejectedValueOnce(
+        new PublicBookingError("Date outside the booking window", 400),
+      );
+      const res = createResponse();
+      const req = {
+        params: { slug: "park-veterinary" },
+        query: { serviceId: SERVICE_ID, date: "2026-09-01" },
+      } as never;
+
+      await PublicBookingController.getSlots(req, res as never);
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      mockedService.getSlots.mockRejectedValueOnce(
+        new Error("connection lost"),
+      );
+      const res2 = createResponse();
+      await PublicBookingController.getSlots(req, res2 as never);
+      expect(res2.status).toHaveBeenCalledWith(500);
+      expect(res2.json).toHaveBeenCalledWith({
+        message: "Something went wrong",
+      });
+    });
+
+    it.each([
+      [
+        "a non-uuid service id",
+        { serviceId: "not-a-uuid", date: "2026-09-01" },
+      ],
+      ["a malformed date", { serviceId: SERVICE_ID, date: "01/09/2026" }],
+      ["a missing date", { serviceId: SERVICE_ID }],
+    ])("rejects %s before reaching the service", async (_label, query) => {
+      const res = createResponse();
+
+      await PublicBookingController.getSlots(
+        { params: { slug: "park-veterinary" }, query } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.getSlots).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submitRequest", () => {
+    it("accepts a valid request with 202 and no identifier", async () => {
+      mockedRequests.submit.mockResolvedValueOnce(undefined);
+      const res = createResponse();
+
+      await PublicBookingController.submitRequest(
+        { params: { slug: "park-veterinary" }, body: validBody } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(202);
+      const payload = res.json.mock.calls[0][0];
+      // No id: an anonymous caller must not receive a handle to something they
+      // have not proved they own.
+      expect(Object.keys(payload)).toEqual(["message"]);
+    });
+
+    it("normalises omitted optional fields to null", async () => {
+      mockedRequests.submit.mockResolvedValueOnce(undefined);
+      const {
+        ownerPhone: _phone,
+        concern: _concern,
+        ...withoutOptionals
+      } = validBody;
+
+      await PublicBookingController.submitRequest(
+        {
+          params: { slug: "park-veterinary" },
+          body: withoutOptionals,
+        } as never,
+        createResponse() as never,
+      );
+
+      expect(mockedRequests.submit).toHaveBeenCalledWith(
+        "park-veterinary",
+        expect.objectContaining({ ownerPhone: null, concern: null }),
+      );
+    });
+
+    it.each([
+      ["a missing consent tick", { consent: undefined }],
+      ["a refused consent tick", { consent: false }],
+      ["a non-uuid service id", { serviceId: "../../etc" }],
+      ["a malformed email", { ownerEmail: "not-an-email" }],
+      ["a malformed start time", { startTime: "9am" }],
+      ["a 25th hour", { startTime: "25:00" }],
+      ["an empty pet name", { petName: "" }],
+      ["an over-long concern", { concern: "x".repeat(1001) }],
+      ["an over-long owner name", { ownerName: "x".repeat(121) }],
+    ])("rejects %s", async (_label, override) => {
+      const res = createResponse();
+
+      await PublicBookingController.submitRequest(
+        {
+          params: { slug: "park-veterinary" },
+          body: { ...validBody, ...override },
+        } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedRequests.submit).not.toHaveBeenCalled();
+    });
+
+    it("passes a taken-slot conflict through", async () => {
+      mockedRequests.submit.mockRejectedValueOnce(
+        new PublicBookingError("That time is no longer available", 409),
+      );
+      const res = createResponse();
+
+      await PublicBookingController.submitRequest(
+        { params: { slug: "park-veterinary" }, body: validBody } as never,
+        res as never,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(409);
+    });
+  });
+
+  describe("confirmRequest", () => {
+    it("confirms and returns the practice", async () => {
+      mockedRequests.confirm.mockResolvedValueOnce({
+        practiceName: "Park Veterinary",
+        slug: "park-veterinary",
+      });
+      const res = createResponse();
+
+      await PublicBookingController.confirmRequest(
+        { body: { token: "abc" } } as never,
+        res as never,
+      );
+
+      expect(mockedRequests.confirm).toHaveBeenCalledWith("abc");
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("treats a non-string token as an empty one and lets the service refuse it", async () => {
+      mockedRequests.confirm.mockRejectedValueOnce(
+        new PublicBookingError("Not found", 404),
+      );
+      const res = createResponse();
+
+      await PublicBookingController.confirmRequest(
+        { body: { token: { not: "" } } } as never,
+        res as never,
+      );
+
+      expect(mockedRequests.confirm).toHaveBeenCalledWith("");
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("handles a missing body without throwing", async () => {
+      mockedRequests.confirm.mockRejectedValueOnce(
+        new PublicBookingError("Not found", 404),
+      );
+      const res = createResponse();
+
+      await PublicBookingController.confirmRequest({} as never, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});

--- a/apps/backend/test/queues/init-queues.test.ts
+++ b/apps/backend/test/queues/init-queues.test.ts
@@ -25,6 +25,7 @@ const taskScheduleQueue = queueDouble("task-schedule");
 const taskRecurrenceQueue = queueDouble("task-recurrence");
 const taskReminderQueue = queueDouble("task-reminder");
 const vaccineReminderQueue = queueDouble("vaccine-reminder");
+const publicBookingQueue = queueDouble("public-booking");
 
 jest.mock("../../src/queues/appointment.queue", () => ({
   AppointmentQueue: appointmentQueue,
@@ -48,6 +49,9 @@ jest.mock("../../src/queues/task.queues", () => ({
 jest.mock("../../src/queues/vaccine.queues", () => ({
   VaccineReminderQueue: vaccineReminderQueue,
 }));
+jest.mock("../../src/queues/public-booking.queue", () => ({
+  PublicBookingQueue: publicBookingQueue,
+}));
 
 const pruneLegacyRepeatablesAcross = jest.fn(
   async (..._queues: unknown[]): Promise<void> => undefined,
@@ -64,6 +68,7 @@ const registerIdexxReferenceScheduler = jest.fn(async () => undefined);
 const registerLabStatusScheduler = jest.fn(async () => undefined);
 const registerLabResultsScheduler = jest.fn(async () => undefined);
 const registerVaccineReminderScheduler = jest.fn(async () => undefined);
+const registerPublicBookingSchedulers = jest.fn(async () => undefined);
 
 jest.mock("../../src/queues/task.schedulers", () => ({
   registerTaskSchedulers: () => registerTaskSchedulers(),
@@ -86,6 +91,9 @@ jest.mock("../../src/queues/lab-results.scheduler", () => ({
 jest.mock("../../src/queues/vaccine.scheduler", () => ({
   registerVaccineReminderScheduler: () => registerVaccineReminderScheduler(),
 }));
+jest.mock("../../src/queues/public-booking.scheduler", () => ({
+  registerPublicBookingSchedulers: () => registerPublicBookingSchedulers(),
+}));
 
 const info = jest.fn();
 jest.mock("src/utils/logger", () => ({
@@ -103,6 +111,7 @@ const registrations = [
   registerLabStatusScheduler,
   registerLabResultsScheduler,
   registerVaccineReminderScheduler,
+  registerPublicBookingSchedulers,
 ];
 
 const orderOf = (mock: jest.Mock): number =>
@@ -126,8 +135,9 @@ describe("scheduledQueues", () => {
       taskRecurrenceQueue,
       taskReminderQueue,
       vaccineReminderQueue,
+      publicBookingQueue,
     ]);
-    expect(new Set(scheduledQueues)).toHaveProperty("size", 8);
+    expect(new Set(scheduledQueues)).toHaveProperty("size", 9);
   });
 });
 

--- a/apps/backend/test/routers/booking-page-public.router.test.ts
+++ b/apps/backend/test/routers/booking-page-public.router.test.ts
@@ -1,0 +1,79 @@
+import type { Router } from "express";
+
+const rateLimiters: { windowMs: number; max: number }[] = [];
+
+jest.mock("express-rate-limit", () => ({
+  __esModule: true,
+  default: (options: { windowMs: number; max: number }) => {
+    rateLimiters.push(options);
+    const middleware = (_req: unknown, _res: unknown, next: () => void) =>
+      next();
+    return middleware;
+  },
+}));
+
+const PublicBookingController = {
+  getPractice: jest.fn(),
+  getSlots: jest.fn(),
+  submitRequest: jest.fn(),
+  confirmRequest: jest.fn(),
+};
+
+jest.mock("../../src/controllers/app/public-booking.controller", () => ({
+  PublicBookingController,
+}));
+
+const router = jest.requireActual(
+  "../../src/routers/booking-page-public.router",
+).default as Router;
+
+type Layer = {
+  route?: { path: string; methods: Record<string, boolean> };
+};
+
+const layers = (): Layer[] =>
+  (router as unknown as { stack: Layer[] }).stack ?? [];
+
+describe("booking-page-public.router", () => {
+  it("exposes exactly the four public routes, confirm first", () => {
+    const routes = layers()
+      .filter((entry) => entry.route)
+      .map(
+        (entry) =>
+          `${Object.keys(entry.route?.methods ?? {})[0]} ${entry.route?.path}`,
+      );
+
+    expect(routes).toEqual([
+      "post /requests/confirm",
+      "get /:slug",
+      "get /:slug/slots",
+      "post /:slug/requests",
+    ]);
+  });
+
+  it("mounts no authentication middleware at all", () => {
+    // Deliberate: this router is the anonymous surface. The assertion exists so
+    // that adding a guard here - or removing the service-level checks because
+    // "the router handles it" - is a visible decision.
+    const moduleSource = jest
+      .requireActual("node:fs")
+      .readFileSync(
+        require.resolve("../../src/routers/booking-page-public.router"),
+        "utf8",
+      ) as string;
+
+    expect(moduleSource).not.toContain("requireWebAuth");
+    expect(moduleSource).not.toContain("requireMobileAuth");
+    expect(moduleSource).not.toContain("requireAnyAuth");
+  });
+
+  it("gives reads and writes separate per-IP budgets", () => {
+    // Two limiters, and the write budget is the tighter one: an accepted write
+    // puts mail in an address the caller chose.
+    const budgets = rateLimiters.map((limiter) => limiter.max);
+    expect(budgets).toEqual([60, 10]);
+    expect(
+      rateLimiters.every((limiter) => limiter.windowMs === 15 * 60 * 1000),
+    ).toBe(true);
+  });
+});

--- a/apps/backend/test/routers/booking-page.router.test.ts
+++ b/apps/backend/test/routers/booking-page.router.test.ts
@@ -1,0 +1,83 @@
+import type { Router } from "express";
+
+const requireWebAuth = jest.fn((_req, _res, next) => next());
+const withOrgPermissions = jest.fn(() => jest.fn((_req, _res, next) => next()));
+const requirePermission = jest.fn(() => jest.fn((_req, _res, next) => next()));
+
+const BookingPageController = {
+  getConfig: jest.fn(),
+  saveConfig: jest.fn(),
+};
+
+jest.mock("../../src/middlewares/auth", () => ({ requireWebAuth }));
+jest.mock("../../src/middlewares/rbac", () => ({
+  withOrgPermissions,
+  requirePermission,
+}));
+jest.mock("../../src/controllers/web/booking-page.controller", () => ({
+  BookingPageController,
+}));
+
+const router = jest.requireActual("../../src/routers/booking-page.router")
+  .default as Router;
+
+type Layer = {
+  name?: string;
+  handle?: unknown;
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+};
+
+const layers = (): Layer[] =>
+  (router as unknown as { stack: Layer[] }).stack ?? [];
+
+const findRoute = (path: string, method: string) =>
+  layers().find(
+    (entry) =>
+      entry.route?.path === path && Boolean(entry.route?.methods?.[method]),
+  )?.route;
+
+describe("booking-page.router", () => {
+  it("exposes exactly the read and write configuration routes", () => {
+    const routes = layers()
+      .filter((entry) => entry.route)
+      .map((entry) => [
+        entry.route?.path,
+        Object.keys(entry.route?.methods ?? {}),
+      ]);
+
+    expect(routes).toEqual([
+      ["/:organisationId", ["get"]],
+      ["/:organisationId", ["put"]],
+    ]);
+  });
+
+  it("requires a web session before any route in the router", () => {
+    // `router.use(requireWebAuth)` registers as a middleware layer with no
+    // route, ahead of every route layer.
+    const firstRouteIndex = layers().findIndex((entry) => Boolean(entry.route));
+    const guards = layers()
+      .slice(0, firstRouteIndex)
+      .map((entry) => entry.handle);
+
+    expect(guards).toContain(requireWebAuth);
+  });
+
+  it("gates reading the configuration on teams:view:any", () => {
+    expect(findRoute("/:organisationId", "get")).toBeDefined();
+    expect(requirePermission).toHaveBeenCalledWith("teams:view:any");
+  });
+
+  it("gates publishing configuration on teams:edit:any, not a catalogue permission", () => {
+    expect(findRoute("/:organisationId", "put")).toBeDefined();
+    expect(requirePermission).toHaveBeenCalledWith("teams:edit:any");
+    expect(requirePermission).not.toHaveBeenCalledWith("specialities:edit:any");
+  });
+
+  it("derives the tenant through withOrgPermissions on both routes", () => {
+    expect(withOrgPermissions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/test/routers/booking-page.router.test.ts
+++ b/apps/backend/test/routers/booking-page.router.test.ts
@@ -7,6 +7,8 @@ const requirePermission = jest.fn(() => jest.fn((_req, _res, next) => next()));
 const BookingPageController = {
   getConfig: jest.fn(),
   saveConfig: jest.fn(),
+  listRequests: jest.fn(),
+  updateRequestStatus: jest.fn(),
 };
 
 jest.mock("../../src/middlewares/auth", () => ({ requireWebAuth }));
@@ -41,7 +43,7 @@ const findRoute = (path: string, method: string) =>
   )?.route;
 
 describe("booking-page.router", () => {
-  it("exposes exactly the read and write configuration routes", () => {
+  it("exposes exactly the configuration and request-queue routes", () => {
     const routes = layers()
       .filter((entry) => entry.route)
       .map((entry) => [
@@ -52,7 +54,21 @@ describe("booking-page.router", () => {
     expect(routes).toEqual([
       ["/:organisationId", ["get"]],
       ["/:organisationId", ["put"]],
+      ["/:organisationId/requests", ["get"]],
+      ["/:organisationId/requests/:requestId", ["patch"]],
     ]);
+  });
+
+  it("gates the request queue on appointment permissions, not on the publishing one", () => {
+    // Triaging a request into the diary is scheduling work. Requiring
+    // `teams:edit:any` here would mean a receptionist needs the permission that
+    // publishes the practice just to decline a request.
+    expect(requirePermission).toHaveBeenCalledWith("appointments:view:any");
+    expect(requirePermission).toHaveBeenCalledWith("appointments:edit:any");
+  });
+
+  it("derives the tenant through withOrgPermissions on every route", () => {
+    expect(withOrgPermissions).toHaveBeenCalledTimes(4);
   });
 
   it("requires a web session before any route in the router", () => {
@@ -75,9 +91,5 @@ describe("booking-page.router", () => {
     expect(findRoute("/:organisationId", "put")).toBeDefined();
     expect(requirePermission).toHaveBeenCalledWith("teams:edit:any");
     expect(requirePermission).not.toHaveBeenCalledWith("specialities:edit:any");
-  });
-
-  it("derives the tenant through withOrgPermissions on both routes", () => {
-    expect(withOrgPermissions).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/backend/test/services/booking-page.service.test.ts
+++ b/apps/backend/test/services/booking-page.service.test.ts
@@ -73,6 +73,15 @@ describe("booking-page.service", () => {
       );
     });
 
+    it("does not let leading punctuation eat into the length budget", () => {
+      // The inner trim is NOT redundant with the outer one, which a review
+      // suggested removing. Trimming before the 63-character slice means the
+      // leading separators do not consume part of the budget: with the inner
+      // trim this keeps 63 name characters, without it only 60.
+      const slug = slugifyOrganisationName(`!!!${"a".repeat(70)}`);
+      expect(slug).toBe("a".repeat(63));
+    });
+
     it("returns an empty string when nothing survives", () => {
       expect(slugifyOrganisationName("!!! ??? ***")).toBe("");
     });
@@ -335,6 +344,7 @@ describe("booking-page.service", () => {
 
       await expect(BookingPageService.getConfig("org-1")).resolves.toEqual({
         organisationId: "org-1",
+        configured: false,
         slug: null,
         publicBookingEnabled: false,
         publicUrl: null,
@@ -381,6 +391,46 @@ describe("booking-page.service", () => {
         autoConfirm: true,
         welcomeMessage: "Hello",
         replyToEmail: "front@example.com",
+      });
+    });
+
+    it("reports configured=false when no settings row exists", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+      pm.publicBookingSettings.findUnique.mockResolvedValue(null);
+
+      await expect(
+        BookingPageService.getConfig("org-1"),
+      ).resolves.toMatchObject({
+        configured: false,
+        serviceIds: [],
+      });
+    });
+
+    it("reports configured=true for a practice that deliberately saved no services", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+      pm.publicBookingSettings.findUnique.mockResolvedValue({
+        serviceIds: [],
+        bookingWindowDays: 28,
+        bufferMinutes: 10,
+        autoConfirm: false,
+        welcomeMessage: null,
+        replyToEmail: null,
+      });
+
+      // Same `serviceIds` as the row above, opposite meaning. Collapsing the two
+      // is what made the wizard re-select every service after a deliberate
+      // empty save.
+      await expect(
+        BookingPageService.getConfig("org-1"),
+      ).resolves.toMatchObject({
+        configured: true,
+        serviceIds: [],
       });
     });
 

--- a/apps/backend/test/services/booking-page.service.test.ts
+++ b/apps/backend/test/services/booking-page.service.test.ts
@@ -15,17 +15,17 @@ const txExecuteRaw = jest.fn();
 jest.mock("src/config/prisma", () => ({
   prisma: {
     $transaction: jest.fn(),
-    organization: { findUnique: jest.fn() },
+    organization: { findUnique: jest.fn(), update: jest.fn() },
     publicBookingSettings: { findUnique: jest.fn(), upsert: jest.fn() },
-    productItem: { findMany: jest.fn() },
+    productItem: { findMany: jest.fn(), count: jest.fn() },
   },
 }));
 
 const pm = prisma as unknown as {
   $transaction: jest.Mock;
-  organization: { findUnique: jest.Mock };
+  organization: { findUnique: jest.Mock; update: jest.Mock };
   publicBookingSettings: { findUnique: jest.Mock; upsert: jest.Mock };
-  productItem: { findMany: jest.Mock };
+  productItem: { findMany: jest.Mock; count: jest.Mock };
 };
 
 const uniqueViolation = () =>
@@ -58,6 +58,7 @@ describe("booking-page.service", () => {
     pm.publicBookingSettings.findUnique.mockResolvedValue(null);
     pm.publicBookingSettings.upsert.mockResolvedValue({});
     pm.productItem.findMany.mockResolvedValue([]);
+    pm.productItem.count.mockResolvedValue(1);
   });
 
   describe("slugifyOrganisationName", () => {
@@ -544,6 +545,71 @@ describe("booking-page.service", () => {
 
       expect(pm.productItem.findMany).not.toHaveBeenCalled();
       expect(pm.publicBookingSettings.upsert).toHaveBeenCalled();
+    });
+
+    it("publishes the practice when asked", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        publicBookingEnabled: true,
+      });
+
+      expect(pm.organization.update).toHaveBeenCalledWith({
+        where: { id: "org-1" },
+        data: { publicBookingEnabled: true },
+      });
+    });
+
+    it("leaves publication alone when the flag is absent", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", input);
+
+      // Saving settings must not publish a practice as a side effect.
+      expect(pm.organization.update).not.toHaveBeenCalled();
+    });
+
+    it("unpublishes without needing a bookable service", async () => {
+      pm.productItem.count.mockResolvedValue(0);
+
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        serviceIds: [],
+        publicBookingEnabled: false,
+      });
+
+      // Taking a page down must never be blocked by the state that made it
+      // unpublishable in the first place.
+      expect(pm.organization.update).toHaveBeenCalledWith({
+        where: { id: "org-1" },
+        data: { publicBookingEnabled: false },
+      });
+    });
+
+    it("refuses to publish a page that would offer nothing", async () => {
+      pm.productItem.count.mockResolvedValue(0);
+
+      await expect(
+        BookingPageService.saveConfig("org-1", {
+          ...input,
+          serviceIds: [],
+          publicBookingEnabled: true,
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(pm.organization.update).not.toHaveBeenCalled();
+    });
+
+    it("publishes an unnarrowed practice that has bookable services", async () => {
+      pm.productItem.count.mockResolvedValue(3);
+
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        serviceIds: [],
+        publicBookingEnabled: true,
+      });
+
+      expect(pm.organization.update).toHaveBeenCalled();
     });
 
     it("allocates a slug for a practice saving for the first time", async () => {

--- a/apps/backend/test/services/booking-page.service.test.ts
+++ b/apps/backend/test/services/booking-page.service.test.ts
@@ -10,7 +10,7 @@ import {
 import { prisma } from "src/config/prisma";
 
 const txReservationCreate = jest.fn();
-const txOrganizationUpdateMany = jest.fn();
+const txExecuteRaw = jest.fn();
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -41,7 +41,7 @@ const uniqueViolation = () =>
 const runTransaction = async (fn: (tx: unknown) => Promise<unknown>) =>
   fn({
     bookingSlugReservation: { create: txReservationCreate },
-    organization: { updateMany: txOrganizationUpdateMany },
+    $executeRaw: txExecuteRaw,
   });
 
 /** The slug each `$transaction` attempt tried to claim, in order. */
@@ -54,7 +54,7 @@ describe("booking-page.service", () => {
     delete process.env.PUBLIC_BOOKING_BASE_URL;
     pm.$transaction.mockImplementation(runTransaction);
     txReservationCreate.mockResolvedValue({});
-    txOrganizationUpdateMany.mockResolvedValue({ count: 1 });
+    txExecuteRaw.mockResolvedValue(1);
     pm.publicBookingSettings.findUnique.mockResolvedValue(null);
     pm.publicBookingSettings.upsert.mockResolvedValue({});
     pm.productItem.findMany.mockResolvedValue([]);
@@ -233,7 +233,7 @@ describe("booking-page.service", () => {
         })
         // The read-back after the guarded update refused the write.
         .mockResolvedValueOnce({ bookingSlug: "park-vets" });
-      txOrganizationUpdateMany.mockResolvedValue({ count: 0 });
+      txExecuteRaw.mockResolvedValue(0);
 
       await expect(ensureBookingSlug("org-9")).resolves.toBe("park-vets");
       // One attempt, then it defers - it must not walk on to `park-vets-2` and
@@ -249,7 +249,7 @@ describe("booking-page.service", () => {
           bookingSlug: null,
         })
         .mockResolvedValueOnce({ bookingSlug: null });
-      txOrganizationUpdateMany.mockResolvedValue({ count: 0 });
+      txExecuteRaw.mockResolvedValue(0);
 
       await expect(ensureBookingSlug("org-10")).rejects.toMatchObject({
         status: 503,

--- a/apps/backend/test/services/booking-page.service.test.ts
+++ b/apps/backend/test/services/booking-page.service.test.ts
@@ -1,0 +1,513 @@
+import { Prisma } from "@prisma/client";
+import {
+  BookingPageService,
+  BookingPageServiceError,
+  ensureBookingSlug,
+  isValidBookingSlug,
+  resolveBookingPageUrl,
+  slugifyOrganisationName,
+} from "src/services/booking-page.service";
+import { prisma } from "src/config/prisma";
+
+const txReservationCreate = jest.fn();
+const txOrganizationUpdateMany = jest.fn();
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    organization: { findUnique: jest.fn() },
+    publicBookingSettings: { findUnique: jest.fn(), upsert: jest.fn() },
+    productItem: { findMany: jest.fn() },
+  },
+}));
+
+const pm = prisma as unknown as {
+  $transaction: jest.Mock;
+  organization: { findUnique: jest.Mock };
+  publicBookingSettings: { findUnique: jest.Mock; upsert: jest.Mock };
+  productItem: { findMany: jest.Mock };
+};
+
+const uniqueViolation = () =>
+  new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "5.22.0",
+  });
+
+/**
+ * Run the interactive transaction against a stub client, so a test can make the
+ * reservation insert or the guarded update fail the way Postgres would.
+ */
+const runTransaction = async (fn: (tx: unknown) => Promise<unknown>) =>
+  fn({
+    bookingSlugReservation: { create: txReservationCreate },
+    organization: { updateMany: txOrganizationUpdateMany },
+  });
+
+/** The slug each `$transaction` attempt tried to claim, in order. */
+const attemptedSlugs = () =>
+  txReservationCreate.mock.calls.map((call) => call[0].data.slug as string);
+
+describe("booking-page.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.PUBLIC_BOOKING_BASE_URL;
+    pm.$transaction.mockImplementation(runTransaction);
+    txReservationCreate.mockResolvedValue({});
+    txOrganizationUpdateMany.mockResolvedValue({ count: 1 });
+    pm.publicBookingSettings.findUnique.mockResolvedValue(null);
+    pm.publicBookingSettings.upsert.mockResolvedValue({});
+    pm.productItem.findMany.mockResolvedValue([]);
+  });
+
+  describe("slugifyOrganisationName", () => {
+    it("strips diacritics rather than shredding the name around them", () => {
+      expect(slugifyOrganisationName("Tierärzte Grünwald")).toBe(
+        "tierarzte-grunwald",
+      );
+    });
+
+    it("collapses punctuation and trims stray hyphens", () => {
+      expect(slugifyOrganisationName("  Park & Vets — Clinic!  ")).toBe(
+        "park-vets-clinic",
+      );
+    });
+
+    it("returns an empty string when nothing survives", () => {
+      expect(slugifyOrganisationName("!!! ??? ***")).toBe("");
+    });
+
+    it("never emits a trailing hyphen after truncation", () => {
+      const name = `${"a".repeat(62)} clinic`;
+      const slug = slugifyOrganisationName(name);
+      expect(slug.length).toBeLessThanOrEqual(63);
+      expect(slug.endsWith("-")).toBe(false);
+    });
+  });
+
+  describe("isValidBookingSlug", () => {
+    it.each(["park-veterinary", "a1", "x".repeat(63)])("accepts %s", (slug) => {
+      expect(isValidBookingSlug(slug)).toBe(true);
+    });
+
+    it.each([
+      ["", "empty"],
+      ["-leading", "leading hyphen"],
+      ["trailing-", "trailing hyphen"],
+      ["Upper", "uppercase"],
+      ["has space", "space"],
+      ["x".repeat(64), "too long"],
+      ["12345", "all digits"],
+      ["3f6b1a2c-1111-2222-3333-444455556666", "uuid shaped"],
+      ["xn--mnchen", "punycode prefix"],
+      ["admin", "reserved"],
+      ["api", "reserved routing segment"],
+    ])("rejects %s (%s)", (slug) => {
+      expect(isValidBookingSlug(slug)).toBe(false);
+    });
+  });
+
+  describe("resolveBookingPageUrl", () => {
+    it("returns null when the practice has not opted in", () => {
+      process.env.PUBLIC_BOOKING_BASE_URL = "https://app.example.com";
+      expect(resolveBookingPageUrl("park-vets", false)).toBeNull();
+    });
+
+    it("returns null when no origin is configured for this environment", () => {
+      expect(resolveBookingPageUrl("park-vets", true)).toBeNull();
+    });
+
+    it("returns null when there is no slug", () => {
+      process.env.PUBLIC_BOOKING_BASE_URL = "https://app.example.com";
+      expect(resolveBookingPageUrl(null, true)).toBeNull();
+    });
+
+    it("builds the address once published and configured", () => {
+      process.env.PUBLIC_BOOKING_BASE_URL = "https://app.example.com/";
+      expect(resolveBookingPageUrl("park-vets", true)).toBe(
+        "https://app.example.com/book/park-vets",
+      );
+    });
+
+    it("ignores a non-absolute origin rather than emitting a relative link", () => {
+      process.env.PUBLIC_BOOKING_BASE_URL = "app.example.com";
+      expect(resolveBookingPageUrl("park-vets", true)).toBeNull();
+    });
+  });
+
+  describe("ensureBookingSlug", () => {
+    it("keeps the slug a practice already holds", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-1",
+        name: "Park Veterinary",
+        bookingSlug: "park-veterinary",
+      });
+
+      await expect(ensureBookingSlug("org-1")).resolves.toBe("park-veterinary");
+      expect(pm.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("claims the readable slug on first use", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-1",
+        name: "Park Veterinary",
+        bookingSlug: null,
+      });
+
+      await expect(ensureBookingSlug("org-1")).resolves.toBe("park-veterinary");
+      expect(attemptedSlugs()).toEqual(["park-veterinary"]);
+    });
+
+    it("suffixes the second practice of the same name instead of failing", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-2",
+        name: "Park Vets",
+        bookingSlug: null,
+      });
+      txReservationCreate
+        .mockRejectedValueOnce(uniqueViolation())
+        .mockResolvedValueOnce({});
+
+      await expect(ensureBookingSlug("org-2")).resolves.toBe("park-vets-2");
+      expect(attemptedSlugs()).toEqual(["park-vets", "park-vets-2"]);
+    });
+
+    it("still allocates for a practice whose name is a reserved word", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-3",
+        name: "Support",
+        bookingSlug: null,
+      });
+
+      await expect(ensureBookingSlug("org-3")).resolves.toBe("support-2");
+    });
+
+    it("allocates for a practice whose name slugifies to nothing", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-4",
+        name: "!!!",
+        bookingSlug: null,
+      });
+
+      await expect(ensureBookingSlug("org-4")).resolves.toBe("clinic-2");
+    });
+
+    it("falls back to a random suffix once the readable candidates are taken", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-5",
+        name: "Park Vets",
+        bookingSlug: null,
+      });
+      // base + -2..-9 is nine candidates; reject all of them.
+      for (let i = 0; i < 9; i += 1) {
+        txReservationCreate.mockRejectedValueOnce(uniqueViolation());
+      }
+      txReservationCreate.mockResolvedValueOnce({});
+
+      const slug = await ensureBookingSlug("org-5");
+      expect(slug).toMatch(/^park-vets-[0-9a-f]{8}$/);
+    });
+
+    it("falls back to a generic random slug when the name slugifies to nothing", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-8",
+        name: "!!!",
+        bookingSlug: null,
+      });
+      // clinic-2..clinic-9 is eight candidates; reject all of them.
+      for (let i = 0; i < 8; i += 1) {
+        txReservationCreate.mockRejectedValueOnce(uniqueViolation());
+      }
+      txReservationCreate.mockResolvedValueOnce({});
+
+      const slug = await ensureBookingSlug("org-8");
+      expect(slug).toMatch(/^clinic-[0-9a-f]{8}$/);
+    });
+
+    it("yields to a concurrent request that allocated this organisation's slug first", async () => {
+      pm.organization.findUnique
+        .mockResolvedValueOnce({
+          id: "org-9",
+          name: "Park Vets",
+          bookingSlug: null,
+        })
+        // The read-back after the guarded update refused the write.
+        .mockResolvedValueOnce({ bookingSlug: "park-vets" });
+      txOrganizationUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(ensureBookingSlug("org-9")).resolves.toBe("park-vets");
+      // One attempt, then it defers - it must not walk on to `park-vets-2` and
+      // strand the slug the winner just took.
+      expect(attemptedSlugs()).toEqual(["park-vets"]);
+    });
+
+    it("reports a retryable failure if the concurrent winner left no slug behind", async () => {
+      pm.organization.findUnique
+        .mockResolvedValueOnce({
+          id: "org-10",
+          name: "Park Vets",
+          bookingSlug: null,
+        })
+        .mockResolvedValueOnce({ bookingSlug: null });
+      txOrganizationUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(ensureBookingSlug("org-10")).rejects.toMatchObject({
+        status: 503,
+      });
+    });
+
+    it("gives up with a retryable status rather than looping forever", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-6",
+        name: "Park Vets",
+        bookingSlug: null,
+      });
+      txReservationCreate.mockRejectedValue(uniqueViolation());
+
+      await expect(ensureBookingSlug("org-6")).rejects.toMatchObject({
+        status: 503,
+      });
+    });
+
+    it("propagates a non-uniqueness database failure", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-7",
+        name: "Park Vets",
+        bookingSlug: null,
+      });
+      txReservationCreate.mockRejectedValue(new Error("connection lost"));
+
+      await expect(ensureBookingSlug("org-7")).rejects.toThrow(
+        "connection lost",
+      );
+    });
+
+    it("404s for an organisation that does not exist", async () => {
+      pm.organization.findUnique.mockResolvedValue(null);
+
+      await expect(ensureBookingSlug("nope")).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+  });
+
+  describe("identifier narrowing", () => {
+    it.each([
+      ["an object", { not: "" }],
+      ["an array", ["org-1"]],
+      ["a number", 7],
+      ["null", null],
+      ["an empty string", "   "],
+      ["a string carrying a Prisma operator", "org$ne"],
+    ])("refuses %s as an organisation id", async (_label, value) => {
+      await expect(
+        BookingPageService.getConfig(value as unknown as string),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(pm.organization.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("refuses a non-scalar service id before it reaches the `in` filter", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-1",
+        name: "Park Vets",
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+
+      await expect(
+        BookingPageService.saveConfig("org-1", {
+          serviceIds: [{ not: "" }] as unknown as string[],
+          bookingWindowDays: 28,
+          bufferMinutes: 10,
+          autoConfirm: false,
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(pm.productItem.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getConfig", () => {
+    it("returns defaults for a practice that never opened the wizard", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        bookingSlug: null,
+        publicBookingEnabled: false,
+      });
+
+      await expect(BookingPageService.getConfig("org-1")).resolves.toEqual({
+        organisationId: "org-1",
+        slug: null,
+        publicBookingEnabled: false,
+        publicUrl: null,
+        serviceIds: [],
+        bookingWindowDays: 28,
+        bufferMinutes: 10,
+        autoConfirm: false,
+        welcomeMessage: null,
+        replyToEmail: null,
+      });
+    });
+
+    it("never returns a URL while the practice is unpublished", async () => {
+      process.env.PUBLIC_BOOKING_BASE_URL = "https://app.example.com";
+      pm.organization.findUnique.mockResolvedValue({
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+
+      const config = await BookingPageService.getConfig("org-1");
+      expect(config.slug).toBe("park-vets");
+      expect(config.publicUrl).toBeNull();
+    });
+
+    it("returns the stored settings when they exist", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+      pm.publicBookingSettings.findUnique.mockResolvedValue({
+        serviceIds: ["svc-1"],
+        bookingWindowDays: 56,
+        bufferMinutes: 30,
+        autoConfirm: true,
+        welcomeMessage: "Hello",
+        replyToEmail: "front@example.com",
+      });
+
+      const config = await BookingPageService.getConfig("org-1");
+      expect(config).toMatchObject({
+        serviceIds: ["svc-1"],
+        bookingWindowDays: 56,
+        bufferMinutes: 30,
+        autoConfirm: true,
+        welcomeMessage: "Hello",
+        replyToEmail: "front@example.com",
+      });
+    });
+
+    it("404s for an organisation that does not exist", async () => {
+      pm.organization.findUnique.mockResolvedValue(null);
+
+      await expect(BookingPageService.getConfig("nope")).rejects.toBeInstanceOf(
+        BookingPageServiceError,
+      );
+    });
+  });
+
+  describe("saveConfig", () => {
+    const input = {
+      serviceIds: ["svc-1"],
+      bookingWindowDays: 28,
+      bufferMinutes: 10,
+      autoConfirm: false,
+      welcomeMessage: "  Book a visit.  ",
+      replyToEmail: "  Front@Example.COM ",
+    };
+
+    beforeEach(() => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-1",
+        name: "Park Vets",
+        bookingSlug: "park-vets",
+        publicBookingEnabled: false,
+      });
+    });
+
+    it("rejects a service that does not belong to the caller's organisation", async () => {
+      pm.productItem.findMany.mockResolvedValue([]);
+
+      await expect(
+        BookingPageService.saveConfig("org-1", input),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(pm.publicBookingSettings.upsert).not.toHaveBeenCalled();
+    });
+
+    it("scopes the ownership check to the caller's own organisation", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", input);
+
+      expect(pm.productItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organisationId: "org-1",
+            isActive: true,
+            bookable: { isNot: null },
+          }),
+        }),
+      );
+    });
+
+    it("trims the welcome message and normalises the reply-to address", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", input);
+
+      expect(pm.publicBookingSettings.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            welcomeMessage: "Book a visit.",
+            replyToEmail: "front@example.com",
+          }),
+        }),
+      );
+    });
+
+    it("stores blank optional text as null rather than an empty string", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        welcomeMessage: "   ",
+        replyToEmail: null,
+      });
+
+      expect(pm.publicBookingSettings.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            welcomeMessage: null,
+            replyToEmail: null,
+          }),
+        }),
+      );
+    });
+
+    it("deduplicates the selected services", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        serviceIds: ["svc-1", "svc-1"],
+      });
+
+      expect(pm.publicBookingSettings.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ serviceIds: ["svc-1"] }),
+        }),
+      );
+    });
+
+    it("skips the ownership query entirely when nothing is selected", async () => {
+      await BookingPageService.saveConfig("org-1", {
+        ...input,
+        serviceIds: [],
+      });
+
+      expect(pm.productItem.findMany).not.toHaveBeenCalled();
+      expect(pm.publicBookingSettings.upsert).toHaveBeenCalled();
+    });
+
+    it("allocates a slug for a practice saving for the first time", async () => {
+      pm.organization.findUnique.mockResolvedValue({
+        id: "org-1",
+        name: "Park Vets",
+        bookingSlug: null,
+        publicBookingEnabled: false,
+      });
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", input);
+
+      expect(attemptedSlugs()).toEqual(["park-vets"]);
+    });
+  });
+});

--- a/apps/backend/test/services/public-booking.service.test.ts
+++ b/apps/backend/test/services/public-booking.service.test.ts
@@ -1,0 +1,771 @@
+import { createHash } from "node:crypto";
+import {
+  PublicBookingError,
+  PublicBookingRequestService,
+  PublicBookingService,
+  resolveSlug,
+} from "src/services/public-booking.service";
+import { prisma } from "src/config/prisma";
+import { CatalogService } from "src/services/catalog.service";
+import { sendEmail } from "src/utils/email";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    organization: { findUnique: jest.fn(), update: jest.fn() },
+    bookingSlugReservation: { findUnique: jest.fn() },
+    productItem: { findMany: jest.fn(), count: jest.fn() },
+    publicBookingRequest: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("src/services/catalog.service", () => ({
+  CatalogService: { getBookableSlotsService: jest.fn() },
+}));
+
+jest.mock("src/utils/email", () => ({ sendEmail: jest.fn() }));
+
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+const pm = prisma as unknown as {
+  organization: { findUnique: jest.Mock; update: jest.Mock };
+  bookingSlugReservation: { findUnique: jest.Mock };
+  productItem: { findMany: jest.Mock; count: jest.Mock };
+  publicBookingRequest: {
+    count: jest.Mock;
+    create: jest.Mock;
+    findUnique: jest.Mock;
+    findMany: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+    deleteMany: jest.Mock;
+  };
+};
+
+const slotsMock = CatalogService.getBookableSlotsService as jest.Mock;
+const sendEmailMock = sendEmail as jest.Mock;
+
+const SERVICE_ID = "3f6b1a2c-1111-2222-3333-444455556666";
+
+const publishedOrg = (over: Record<string, unknown> = {}) => ({
+  id: "org-1",
+  name: "Park Veterinary",
+  imageUrl: "https://cdn.example.com/logo.png",
+  publicBookingEnabled: true,
+  address: { city: "Berlin", country: "DE" },
+  bookingSettings: {
+    serviceIds: [SERVICE_ID],
+    bookingWindowDays: 28,
+    bufferMinutes: 10,
+    autoConfirm: false,
+    welcomeMessage: "Book a visit.",
+    replyToEmail: "front@example.com",
+  },
+  ...over,
+});
+
+const bookableProduct = () => ({
+  id: SERVICE_ID,
+  name: "Wellness consultation",
+  description: "Nose to tail.",
+  bookable: { durationMinutes: 30 },
+});
+
+/** A date inside every practice's default 28-day window. */
+const tomorrow = () => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+};
+
+describe("public-booking.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PUBLIC_BOOKING_BASE_URL = "https://app.example.com";
+    pm.productItem.findMany.mockResolvedValue([bookableProduct()]);
+    pm.publicBookingRequest.count.mockResolvedValue(0);
+    pm.publicBookingRequest.create.mockResolvedValue({});
+    sendEmailMock.mockResolvedValue({});
+    slotsMock.mockResolvedValue({
+      date: tomorrow(),
+      windows: [
+        {
+          startTime: "09:00",
+          endTime: "09:30",
+          vetIds: ["staff-1", "staff-2"],
+        },
+      ],
+    });
+  });
+
+  describe("slug resolution", () => {
+    it("resolves a published practice", async () => {
+      pm.organization.findUnique.mockResolvedValue(publishedOrg());
+      const resolved = await resolveSlug("park-veterinary");
+      expect(resolved).toMatchObject({ kind: "current" });
+    });
+
+    it("hides an unpublished practice behind the same 404 as one that does not exist", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({ publicBookingEnabled: false }),
+      );
+      const unpublished = await resolveSlug("park-veterinary").catch((e) => e);
+
+      pm.organization.findUnique.mockResolvedValue(null);
+      pm.bookingSlugReservation.findUnique.mockResolvedValue(null);
+      const missing = await resolveSlug("nobody-owns-this").catch((e) => e);
+
+      expect(unpublished).toBeInstanceOf(PublicBookingError);
+      expect(missing).toBeInstanceOf(PublicBookingError);
+      // Byte-identical, so walking slugs cannot map which practices use the
+      // product before they open their page.
+      expect(unpublished.status).toBe(missing.status);
+      expect(unpublished.message).toBe(missing.message);
+    });
+
+    it("points a retired slug at the current one instead of 404ing a printed address", async () => {
+      pm.organization.findUnique.mockResolvedValue(null);
+      pm.bookingSlugReservation.findUnique.mockResolvedValue({
+        organization: {
+          bookingSlug: "park-veterinary",
+          publicBookingEnabled: true,
+        },
+      });
+
+      await expect(resolveSlug("old-park-vets")).resolves.toEqual({
+        kind: "retired",
+        slug: "park-veterinary",
+      });
+    });
+
+    it("does not follow a retired slug into an unpublished practice", async () => {
+      pm.organization.findUnique.mockResolvedValue(null);
+      pm.bookingSlugReservation.findUnique.mockResolvedValue({
+        organization: {
+          bookingSlug: "park-veterinary",
+          publicBookingEnabled: false,
+        },
+      });
+
+      await expect(resolveSlug("old-park-vets")).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it.each([
+      ["an object", { not: "" }],
+      ["a number", 7],
+      ["a Prisma operator", "park$ne"],
+    ])("refuses %s as a slug", async (_label, value) => {
+      await expect(
+        resolveSlug(value as unknown as string),
+      ).rejects.toMatchObject({
+        status: 400,
+      });
+      expect(pm.organization.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getPractice", () => {
+    it("exposes only the public projection", async () => {
+      pm.organization.findUnique.mockResolvedValue(publishedOrg());
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+
+      expect(practice).toEqual({
+        slug: "park-veterinary",
+        name: "Park Veterinary",
+        logoUrl: "https://cdn.example.com/logo.png",
+        welcomeMessage: "Book a visit.",
+        city: "Berlin",
+        country: "DE",
+        bookingWindowDays: 28,
+        requiresConfirmation: true,
+        services: [
+          {
+            id: SERVICE_ID,
+            name: "Wellness consultation",
+            description: "Nose to tail.",
+            durationMinutes: 30,
+          },
+        ],
+      });
+    });
+
+    it("never selects price, internal code or speciality from the catalogue", async () => {
+      pm.organization.findUnique.mockResolvedValue(publishedOrg());
+      await PublicBookingService.getPractice("park-veterinary");
+
+      const select = pm.productItem.findMany.mock.calls[0][0].select;
+      expect(Object.keys(select).sort()).toEqual([
+        "bookable",
+        "description",
+        "id",
+        "name",
+      ]);
+      expect(select).not.toHaveProperty("code");
+      expect(select).not.toHaveProperty("prices");
+      expect(select).not.toHaveProperty("specialityId");
+    });
+
+    it("offers nothing when the practice deliberately saved an empty selection", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [],
+            bookingWindowDays: 28,
+            bufferMinutes: 10,
+            autoConfirm: false,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+
+      // A settings row with an empty list is a decision, not an absence, and it
+      // must not be read as "offer everything". The catalogue is not even
+      // queried.
+      expect(practice.services).toEqual([]);
+      expect(pm.productItem.findMany).not.toHaveBeenCalled();
+    });
+
+    it("offers everything bookable when the practice never narrowed the list", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({ bookingSettings: null }),
+      );
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+
+      expect(practice.services).toHaveLength(1);
+      // No settings row, so no `id: { in: [...] }` filter at all.
+      expect(pm.productItem.findMany.mock.calls[0][0].where).not.toHaveProperty(
+        "id",
+      );
+    });
+
+    it("tolerates a practice with no logo and no address", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({ imageUrl: null, address: null }),
+      );
+
+      await expect(
+        PublicBookingService.getPractice("park-veterinary"),
+      ).resolves.toMatchObject({ logoUrl: null, city: null, country: null });
+    });
+
+    it("uses the default window when the practice has no settings row", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({ bookingSettings: null }),
+      );
+
+      await expect(
+        PublicBookingService.getPractice("park-veterinary"),
+      ).resolves.toMatchObject({
+        bookingWindowDays: 28,
+        requiresConfirmation: true,
+        welcomeMessage: null,
+      });
+    });
+
+    it("reports zero duration rather than crashing if a product has no bookable row", async () => {
+      pm.organization.findUnique.mockResolvedValue(publishedOrg());
+      // The query filters these out, so this is a type-level possibility rather
+      // than a reachable state; pinned so the fallback is a decision, not a
+      // crash waiting for a schema change.
+      pm.productItem.findMany.mockResolvedValue([
+        { ...bookableProduct(), bookable: null },
+      ]);
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+      expect(practice.services[0].durationMinutes).toBe(0);
+    });
+
+    it("caps the advertised booking window", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [SERVICE_ID],
+            bookingWindowDays: 9999,
+            bufferMinutes: 10,
+            autoConfirm: true,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+      expect(practice.bookingWindowDays).toBe(180);
+      expect(practice.requiresConfirmation).toBe(false);
+    });
+  });
+
+  describe("getSlots", () => {
+    beforeEach(() =>
+      pm.organization.findUnique.mockResolvedValue(publishedOrg()),
+    );
+
+    it("strips vetIds from every window", async () => {
+      const result = await PublicBookingService.getSlots(
+        "park-veterinary",
+        SERVICE_ID,
+        tomorrow(),
+      );
+
+      expect(result.windows).toEqual([
+        { startTime: "09:00", endTime: "09:30" },
+      ]);
+      expect(JSON.stringify(result)).not.toContain("staff-1");
+    });
+
+    it("refuses a date beyond the practice's booking window", async () => {
+      const far = new Date();
+      far.setUTCDate(far.getUTCDate() + 400);
+
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          far.toISOString().slice(0, 10),
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(slotsMock).not.toHaveBeenCalled();
+    });
+
+    it("refuses a date in the past", async () => {
+      const past = new Date();
+      past.setUTCDate(past.getUTCDate() - 1);
+
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          past.toISOString().slice(0, 10),
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("refuses a malformed date without touching the scheduler", async () => {
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          "not-a-date",
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(slotsMock).not.toHaveBeenCalled();
+    });
+
+    it("404s a retired slug rather than serving slots under an old address", async () => {
+      pm.organization.findUnique.mockResolvedValue(null);
+      pm.bookingSlugReservation.findUnique.mockResolvedValue({
+        organization: {
+          bookingSlug: "park-veterinary",
+          publicBookingEnabled: true,
+        },
+      });
+
+      // The redirect is the caller's job. A slot response under the old name
+      // would quietly answer for a practice the caller did not ask for.
+      await expect(
+        PublicBookingService.getSlots("old-park-vets", SERVICE_ID, tomorrow()),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it("applies the default window when the practice has no settings row", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({ bookingSettings: null }),
+      );
+      const far = new Date();
+      far.setUTCDate(far.getUTCDate() + 60);
+
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          far.toISOString().slice(0, 10),
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("404s when the practice offers nothing publicly", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [],
+            bookingWindowDays: 28,
+            bufferMinutes: 10,
+            autoConfirm: false,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          tomorrow(),
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it("404s for a service the practice does not offer publicly", async () => {
+      pm.productItem.findMany.mockResolvedValue([]);
+
+      await expect(
+        PublicBookingService.getSlots(
+          "park-veterinary",
+          SERVICE_ID,
+          tomorrow(),
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(slotsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submit", () => {
+    const input = {
+      serviceId: SERVICE_ID,
+      date: tomorrow(),
+      startTime: "09:00",
+      ownerName: "  Sam Owner ",
+      ownerEmail: "  Sam@Example.COM ",
+      ownerPhone: " +49 30 1234 ",
+      petName: " Rex ",
+      petSpecies: " Dog ",
+      concern: " Limping ",
+    };
+
+    beforeEach(() =>
+      pm.organization.findUnique.mockResolvedValue(publishedOrg()),
+    );
+
+    it("stores a request, hashes the token, and emails the requester", async () => {
+      await PublicBookingRequestService.submit("park-veterinary", input);
+
+      const data = pm.publicBookingRequest.create.mock.calls[0][0].data;
+      expect(data).toMatchObject({
+        organizationId: "org-1",
+        productItemId: SERVICE_ID,
+        serviceName: "Wellness consultation",
+        durationMinutes: 30,
+        ownerName: "Sam Owner",
+        ownerEmail: "sam@example.com",
+        ownerPhone: "+49 30 1234",
+        petName: "Rex",
+        petSpecies: "Dog",
+        concern: "Limping",
+      });
+      expect(data.confirmationTokenHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(data.consentAcceptedAt).toBeInstanceOf(Date);
+      expect(data.purgeAfter).toBeInstanceOf(Date);
+
+      const [emailArgs] = sendEmailMock.mock.calls;
+      expect(emailArgs[0].to).toBe("sam@example.com");
+      // The link carries the raw token; the row carries only its hash.
+      const link = emailArgs[0].textBody as string;
+      const token = /token=([0-9a-f]{64})/.exec(link)?.[1];
+      expect(token).toBeDefined();
+      expect(
+        createHash("sha256")
+          .update(token as string)
+          .digest("hex"),
+      ).toBe(data.confirmationTokenHash);
+    });
+
+    it("stores blank optional fields as null rather than empty strings", async () => {
+      await PublicBookingRequestService.submit("park-veterinary", {
+        ...input,
+        ownerPhone: "   ",
+        concern: null,
+      });
+
+      expect(
+        pm.publicBookingRequest.create.mock.calls[0][0].data,
+      ).toMatchObject({
+        ownerPhone: null,
+        concern: null,
+      });
+    });
+
+    it("refuses a time the practice does not actually offer", async () => {
+      await expect(
+        PublicBookingRequestService.submit("park-veterinary", {
+          ...input,
+          startTime: "03:00",
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(pm.publicBookingRequest.create).not.toHaveBeenCalled();
+    });
+
+    it("caps how many unconfirmed requests one address may hold", async () => {
+      pm.publicBookingRequest.count.mockResolvedValue(3);
+
+      await expect(
+        PublicBookingRequestService.submit("park-veterinary", input),
+      ).rejects.toMatchObject({ status: 429 });
+      expect(pm.publicBookingRequest.create).not.toHaveBeenCalled();
+    });
+
+    it("404s when the practice offers nothing publicly", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [],
+            bookingWindowDays: 28,
+            bufferMinutes: 10,
+            autoConfirm: false,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      await expect(
+        PublicBookingRequestService.submit("park-veterinary", input),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(pm.publicBookingRequest.create).not.toHaveBeenCalled();
+    });
+
+    it("404s for a service that is not offered rather than saying why", async () => {
+      pm.productItem.findMany.mockResolvedValue([]);
+
+      await expect(
+        PublicBookingRequestService.submit("park-veterinary", input),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it("still stores the request when the confirmation email fails", async () => {
+      sendEmailMock.mockRejectedValue(new Error("SES down"));
+
+      await expect(
+        PublicBookingRequestService.submit("park-veterinary", input),
+      ).resolves.toBeUndefined();
+      expect(pm.publicBookingRequest.create).toHaveBeenCalled();
+    });
+
+    it("does not email when no public origin is configured", async () => {
+      delete process.env.PUBLIC_BOOKING_BASE_URL;
+
+      await PublicBookingRequestService.submit("park-veterinary", input);
+
+      expect(pm.publicBookingRequest.create).toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("confirm", () => {
+    const stored = (over: Record<string, unknown> = {}) => ({
+      id: "req-1",
+      status: "PENDING_CONFIRMATION",
+      confirmationExpiresAt: new Date(Date.now() + 60_000),
+      serviceName: "Wellness consultation",
+      requestedStart: new Date("2026-09-01T09:00:00.000Z"),
+      durationMinutes: 30,
+      ownerName: "Sam Owner",
+      ownerEmail: "sam@example.com",
+      ownerPhone: null,
+      petName: "Rex",
+      petSpecies: "Dog",
+      concern: null,
+      organization: {
+        name: "Park Veterinary",
+        email: "clinic@example.com",
+        bookingSlug: "park-veterinary",
+        bookingSettings: { replyToEmail: "front@example.com" },
+      },
+      ...over,
+    });
+
+    it("looks the token up by hash, never by value", async () => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(stored());
+
+      await PublicBookingRequestService.confirm("a".repeat(64));
+
+      const where = pm.publicBookingRequest.findUnique.mock.calls[0][0].where;
+      expect(where.confirmationTokenHash).toBe(
+        createHash("sha256").update("a".repeat(64)).digest("hex"),
+      );
+    });
+
+    it("confirms and notifies the practice reply-to address", async () => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(stored());
+
+      await expect(PublicBookingRequestService.confirm("tok")).resolves.toEqual(
+        {
+          practiceName: "Park Veterinary",
+          slug: "park-veterinary",
+        },
+      );
+
+      expect(pm.publicBookingRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: "CONFIRMED" }),
+        }),
+      );
+      expect(sendEmailMock.mock.calls[0][0].to).toBe("front@example.com");
+    });
+
+    it("falls back to the organisation contact address", async () => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(
+        stored({
+          organization: {
+            name: "Park Veterinary",
+            email: "clinic@example.com",
+            bookingSlug: "park-veterinary",
+            bookingSettings: null,
+          },
+        }),
+      );
+
+      await PublicBookingRequestService.confirm("tok");
+      expect(sendEmailMock.mock.calls[0][0].to).toBe("clinic@example.com");
+    });
+
+    it("confirms even when the practice has no address to notify", async () => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(
+        stored({
+          organization: {
+            name: "Park Veterinary",
+            email: null,
+            bookingSlug: "park-veterinary",
+            bookingSettings: null,
+          },
+        }),
+      );
+
+      await expect(
+        PublicBookingRequestService.confirm("tok"),
+      ).resolves.toBeDefined();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+    });
+
+    it("confirms even when notifying the practice fails", async () => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(stored());
+      sendEmailMock.mockRejectedValue(new Error("SES down"));
+
+      await expect(
+        PublicBookingRequestService.confirm("tok"),
+      ).resolves.toBeDefined();
+      expect(pm.publicBookingRequest.update).toHaveBeenCalled();
+    });
+
+    it.each([
+      ["an unknown token", null],
+      ["an already-confirmed request", { status: "CONFIRMED" }],
+      [
+        "an expired link",
+        { confirmationExpiresAt: new Date(Date.now() - 60_000) },
+      ],
+    ])("returns the same 404 for %s", async (_label, override) => {
+      pm.publicBookingRequest.findUnique.mockResolvedValue(
+        override === null ? null : stored(override),
+      );
+
+      const error = await PublicBookingRequestService.confirm("tok").catch(
+        (e) => e,
+      );
+      expect(error.status).toBe(404);
+      expect(error.message).toBe("Not found");
+      expect(pm.publicBookingRequest.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("practice queue", () => {
+    it("never lists unconfirmed requests", async () => {
+      pm.publicBookingRequest.findMany.mockResolvedValue([]);
+
+      await PublicBookingRequestService.listForOrganisation("org-1");
+
+      const where = pm.publicBookingRequest.findMany.mock.calls[0][0].where;
+      expect(where.status).toEqual({ in: ["CONFIRMED", "DECLINED", "BOOKED"] });
+      expect(where.organizationId).toBe("org-1");
+    });
+
+    it("honours an explicit status filter", async () => {
+      pm.publicBookingRequest.findMany.mockResolvedValue([]);
+
+      await PublicBookingRequestService.listForOrganisation(
+        "org-1",
+        "DECLINED",
+      );
+
+      expect(
+        pm.publicBookingRequest.findMany.mock.calls[0][0].where.status,
+      ).toBe("DECLINED");
+    });
+
+    it("scopes a status change to the caller's organisation", async () => {
+      pm.publicBookingRequest.updateMany.mockResolvedValue({ count: 1 });
+
+      await PublicBookingRequestService.setStatus("org-1", "req-1", "DECLINED");
+
+      expect(pm.publicBookingRequest.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "req-1",
+            organizationId: "org-1",
+          }),
+        }),
+      );
+    });
+
+    it("404s rather than reporting success when nothing matched", async () => {
+      pm.publicBookingRequest.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        PublicBookingRequestService.setStatus(
+          "org-1",
+          "req-of-another-org",
+          "BOOKED",
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+  });
+
+  describe("retention", () => {
+    it("expires stale links and deletes rows past their deadline", async () => {
+      pm.publicBookingRequest.updateMany.mockResolvedValue({ count: 2 });
+      pm.publicBookingRequest.deleteMany.mockResolvedValue({ count: 5 });
+      const now = new Date("2026-09-01T00:00:00.000Z");
+
+      await expect(
+        PublicBookingRequestService.purgeExpired(now),
+      ).resolves.toEqual({
+        expired: 2,
+        deleted: 5,
+      });
+
+      expect(pm.publicBookingRequest.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: "PENDING_CONFIRMATION",
+            confirmationExpiresAt: { lt: now },
+          },
+        }),
+      );
+      expect(pm.publicBookingRequest.deleteMany).toHaveBeenCalledWith({
+        where: { purgeAfter: { lt: now } },
+      });
+    });
+  });
+});

--- a/apps/frontend/e2e/public-booking-setup.spec.ts
+++ b/apps/frontend/e2e/public-booking-setup.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// Signs in with a real credential, exactly as auth-flow.spec.ts does, so the
+// same artefact suppression applies: Playwright records input values verbatim
+// and the config default is `trace: 'on-first-retry'`, which would capture the
+// filled password field. The AI error-context snapshot is a separate sink gated
+// by PLAYWRIGHT_NO_COPY_PROMPT, which the playwright-auth job sets.
+test.use({ trace: 'off', screenshot: 'off', video: 'off' });
+
+const LOGIN_PATH = '/signin';
+const SETUP_PATH = '/public-booking-setup';
+
+const getRequiredEnv = (name: 'YC_E2E_EMAIL' | 'YC_E2E_PASSWORD') => {
+  const value = process.env[name]?.trim();
+  test.skip(!value, `${name} is required to run public-booking-setup.spec.ts`);
+  return value ?? '';
+};
+
+/**
+ * The booking-page configuration API ships in the same change as this page, and
+ * the migration behind it must be deployed before the frontend that reads it.
+ * Until the target environment has both, the route renders but every save 404s.
+ *
+ * Only a 404 justifies a skip - it means "this environment has not taken the
+ * API yet". A 5xx means the endpoint IS deployed and broken, which is precisely
+ * what this spec exists to catch, so it fails instead. Same reasoning as
+ * `skipUnlessAuthSurfaceDeployed` in auth-flow.spec.ts.
+ */
+const skipUnlessBookingApiDeployed = async () => {
+  const base = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '');
+  if (!base) return;
+
+  const response = await fetch(`${base}/v1/booking-page/probe-not-a-real-org`, {
+    method: 'GET',
+  });
+
+  test.skip(
+    response.status === 404,
+    'Target API does not serve /v1/booking-page yet (frontend deployed ahead of the API)'
+  );
+
+  if (response.status >= 500) {
+    throw new Error(`Booking page API is deployed but failing: returned ${response.status}`);
+  }
+};
+
+const signIn = async (page: Page) => {
+  const email = getRequiredEnv('YC_E2E_EMAIL');
+  const password = getRequiredEnv('YC_E2E_PASSWORD');
+  if (!email || !password) return false;
+
+  await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('load', { timeout: 30_000 });
+
+  const emailInput = page.locator('input[name="email"]');
+  await expect(emailInput).toBeVisible();
+  await emailInput.fill(email);
+  await page.locator('input[name="password"]').fill(password);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 60_000 }).not.toBe(LOGIN_PATH);
+  return true;
+};
+
+test('booking setup persists across a reload and never shows a dead address', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  if (!(await signIn(page))) return;
+  await skipUnlessBookingApiDeployed();
+
+  await page.goto(SETUP_PATH, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('What can pet parents book?')).toBeVisible({ timeout: 30_000 });
+
+  // Step 1: pick a non-default booking window so the assertion after reload is
+  // about stored state rather than about the default happening to match.
+  const windowSelect = page.getByLabel('Bookable window');
+  await expect(windowSelect).toBeVisible();
+  await windowSelect.selectOption('56');
+
+  await page.getByRole('button', { name: /Continue/ }).click();
+  await expect(page.getByText('Your booking page')).toBeVisible();
+
+  // The whole point of the change: the wizard must never render the
+  // book.yosemitecrew.com address, which has no DNS record.
+  await expect(page.locator('body')).not.toContainText('book.yosemitecrew.com');
+
+  // An unpublished practice is offered no link to copy, because there is
+  // nothing at the other end of one yet.
+  await expect(page.getByRole('button', { name: /^Copy$/ })).toHaveCount(0);
+
+  const saveRequest = page.waitForResponse(
+    (response) =>
+      response.url().includes('/v1/booking-page/') && response.request().method() === 'PUT'
+  );
+  await page.getByRole('button', { name: /Save booking setup/ }).click();
+
+  const response = await saveRequest;
+  expect(response.status()).toBe(200);
+
+  // Reload and confirm the choice came back from the server rather than from
+  // component state. This is the assertion the Jest suite cannot make.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.getByLabel('Bookable window')).toHaveValue('56', { timeout: 30_000 });
+});

--- a/apps/frontend/e2e/smoke.spec.ts
+++ b/apps/frontend/e2e/smoke.spec.ts
@@ -4,3 +4,47 @@ test('app shell loads', async ({ page }) => {
   await page.goto('/');
   await expect(page).toHaveTitle(/Yosemite|Crew|YC/i);
 });
+
+/**
+ * The public booking page, exercised without a session.
+ *
+ * This runs in the `playwright-public` job, which is the only end-to-end job
+ * that runs on a pull request - so unlike the authenticated booking-setup spec,
+ * this one actually gates the change. It uses a slug nobody owns, which needs no
+ * fixture data and asserts the property that matters most on an internet-facing
+ * route: an unknown practice produces a plain "not available" page rather than a
+ * crash, a stack trace, or anything that distinguishes "no such slug" from "not
+ * published".
+ */
+test('an unknown booking slug renders a plain unavailable page', async ({ page }) => {
+  const response = await page.goto('/book/no-such-practice-e2e', {
+    waitUntil: 'domcontentloaded',
+  });
+
+  // The route itself exists: only the practice is unknown.
+  expect(response?.status()).toBe(200);
+
+  await expect(
+    page.getByRole('heading', { name: /this booking page is not available/i })
+  ).toBeVisible({ timeout: 30_000 });
+
+  const body = (await page.locator('body').textContent()) ?? '';
+  expect(body).not.toMatch(/stack|prisma|postgres|at Object\./i);
+});
+
+test('the public booking page is served under a nonce CSP, not unsafe-inline', async ({ page }) => {
+  const response = await page.goto('/book/no-such-practice-e2e', {
+    waitUntil: 'domcontentloaded',
+  });
+
+  // The page collects a name, an email address and an animal's details, so it
+  // must not inherit the permissive policy the marketing routes carry. Asserted
+  // end to end because the middleware prefix list and the route group have to
+  // agree, and a unit test can only check one of them.
+  const csp = response?.headers()['content-security-policy'] ?? '';
+  const scriptSrc = csp.split('; ').find((directive) => directive.startsWith('script-src'));
+
+  expect(scriptSrc).toBeDefined();
+  expect(scriptSrc).toContain('nonce-');
+  expect(scriptSrc).not.toContain("'unsafe-inline'");
+});

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
+import * as publicBookingService from '@/app/features/publicBooking/services/publicBooking.service';
+import type { PublicPractice } from '@/app/features/publicBooking/services/publicBooking.service';
+import BookClient from './BookClient';
+
+/**
+ * The page a pet owner sees. Every story stubs the public API module, because
+ * this route talks to the API with a raw `fetch` and a preview iframe has no
+ * API to talk to.
+ */
+
+const PRACTICE: PublicPractice = {
+  slug: 'avenger-park-veterinary',
+  name: 'Avenger Park Veterinary',
+  logoUrl: null,
+  welcomeMessage: 'Book a visit for your companion. We keep same-day slots for poorly pets.',
+  city: 'Berlin',
+  country: 'DE',
+  bookingWindowDays: 28,
+  requiresConfirmation: true,
+  services: [
+    {
+      id: 'svc-1',
+      name: 'Wellness consultation',
+      description: 'Nose-to-tail exam and a plan for the year.',
+      durationMinutes: 30,
+    },
+    {
+      id: 'svc-2',
+      name: 'Vaccination booster',
+      description: null,
+      durationMinutes: 20,
+    },
+  ],
+};
+
+type Stub = {
+  practice?: PublicPractice;
+  practiceFails?: boolean;
+  windows?: { startTime: string; endTime: string }[];
+};
+
+const stub = ({ practice = PRACTICE, practiceFails = false, windows }: Stub = {}) => {
+  const previousPractice = publicBookingService.getPublicPractice;
+  const previousSlots = publicBookingService.getPublicSlots;
+
+  const stubTarget = publicBookingService as unknown as Record<string, unknown>;
+
+  stubTarget.getPublicPractice = async () => {
+    if (practiceFails) throw new Error('unavailable');
+    return { kind: 'practice' as const, practice };
+  };
+  stubTarget.getPublicSlots = async () => ({
+    date: '2026-09-01',
+    serviceId: 'svc-1',
+    durationMinutes: 30,
+    windows: windows ?? [
+      { startTime: '09:00', endTime: '09:30' },
+      { startTime: '09:30', endTime: '10:00' },
+      { startTime: '14:00', endTime: '14:30' },
+    ],
+  });
+
+  return () => {
+    stubTarget.getPublicPractice = previousPractice;
+    stubTarget.getPublicSlots = previousSlots;
+  };
+};
+
+const meta = {
+  title: 'PublicBooking/BookClient',
+  component: BookClient,
+  parameters: { layout: 'fullscreen' },
+  args: { slug: 'avenger-park-veterinary' },
+  tags: ['autodocs'],
+  beforeEach: () => stub(),
+} satisfies Meta<typeof BookClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'A practice taking bookings',
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText('Avenger Park Veterinary')).toBeInTheDocument();
+    await expect(await canvas.findByRole('button', { name: '09:00' })).toBeInTheDocument();
+
+    // The promise this page must never make. A request is not a booking, and
+    // both the button and the footnote have to say so.
+    await expect(canvas.getByRole('button', { name: /Request this time/ })).toBeInTheDocument();
+    await expect(canvas.getByText(/sends a request, not a booking/)).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole flow on one page: pick a service, pick a day, pick a time, then give the ' +
+          'details the practice needs to call back. Submitting sends a request that a human at ' +
+          'the practice reads - nothing here writes to a calendar, and the chosen time is not ' +
+          'held while the request is outstanding.',
+      },
+    },
+  },
+};
+
+export const NoTimesOnThisDay: Story = {
+  name: 'A day with nothing free',
+  beforeEach: () => stub({ windows: [] }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText(/No times available on this day/)).toBeInTheDocument();
+    // Submit stays unreachable rather than sending a request with no time in it.
+    await expect(canvas.getByRole('button', { name: /Request this time/ })).toBeDisabled();
+  },
+};
+
+export const OffersNothing: Story = {
+  name: 'A practice offering no services publicly',
+  beforeEach: () => stub({ practice: { ...PRACTICE, services: [] } }),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByText(/not offering online booking for any services/)
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A published practice that has deselected every service. It says so and points the ' +
+          'reader at the phone, rather than rendering an empty form.',
+      },
+    },
+  },
+};
+
+export const Unavailable: Story = {
+  name: 'An unknown or unpublished practice',
+  beforeEach: () => stub({ practiceFails: true }),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole('heading', { name: /not available/i })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One state for three different facts: the slug is wrong, the practice never published, ' +
+          'or it has withdrawn. The API deliberately does not distinguish them, so neither can ' +
+          'this page - telling them apart is how someone maps which practices use the product.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   PublicBookingRequestError,
@@ -22,7 +22,15 @@ import {
  * do, and that has to hold on the page the public actually sees.
  */
 
-type LoadState = 'loading' | 'ready' | 'unavailable';
+/**
+ * A discriminated union rather than a status string beside a nullable practice.
+ *
+ * It makes "ready implies we have a practice" a fact the compiler enforces, so
+ * the render path needs no null guard that can never fire - and no unreachable
+ * branch to explain in a coverage report.
+ */
+type PracticeView =
+  { status: 'loading' } | { status: 'unavailable' } | { status: 'ready'; practice: PublicPractice };
 
 const todayIso = () => new Date().toISOString().slice(0, 10);
 
@@ -63,6 +71,73 @@ const PracticeHeader = ({ practice }: { practice: PublicPractice }) => (
 
 type SlotsResult = { key: string; windows: PublicSlot[]; error: string | null };
 
+/**
+ * The time picker and its four states.
+ *
+ * Extracted from `BookClient` rather than inlined: those four conditionals sat
+ * inside a function that was already branching on load state, submission state
+ * and service selection, and Sonar was right that the result had stopped being
+ * readable in one pass.
+ */
+const SlotPicker = ({
+  loading,
+  error,
+  slots,
+  selectedTime,
+  onSelect,
+}: {
+  loading: boolean;
+  error: string | null;
+  slots: PublicSlot[] | null;
+  selectedTime: string | null;
+  onSelect: (startTime: string) => void;
+}) => {
+  const body = () => {
+    if (loading) {
+      return <p className="text-[13px] text-[var(--ink-muted)]">Checking availability…</p>;
+    }
+    if (error) {
+      return (
+        <p role="alert" className="text-[13px] text-[var(--warn-text)]">
+          {error}
+        </p>
+      );
+    }
+    if (!slots || slots.length === 0) {
+      return (
+        <p className="text-[13px] text-[var(--ink-muted)]">
+          No times available on this day. Try another date.
+        </p>
+      );
+    }
+    return (
+      <div className="flex flex-wrap gap-2">
+        {slots.map((slot) => (
+          <button
+            key={slot.startTime}
+            type="button"
+            aria-pressed={selectedTime === slot.startTime}
+            onClick={() => onSelect(slot.startTime)}
+            className="rounded-full border-[1.5px] px-3.5 py-2 text-[13.5px] font-semibold text-[var(--ink)]"
+            style={{
+              borderColor: selectedTime === slot.startTime ? 'var(--blue)' : 'var(--hairline)',
+            }}
+          >
+            {slot.startTime}
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Available times</legend>
+      {body()}
+    </fieldset>
+  );
+};
+
 type FormValues = {
   ownerName: string;
   ownerEmail: string;
@@ -83,21 +158,94 @@ const EMPTY_FORM: FormValues = {
   consent: false,
 };
 
-const BookClient = ({ slug }: { slug: string }) => {
+/**
+ * The states that replace the form entirely.
+ *
+ * Returns null when the booking form should render instead. Pulled out of
+ * `BookClient` so that component branches once on "is there a status to show"
+ * rather than four times on which one.
+ */
+const PendingOrUnavailable = ({ status }: { status: 'loading' | 'unavailable' }) =>
+  status === 'loading' ? (
+    <Shell>
+      <p className="text-[14px] text-[var(--ink-muted)]">Loading…</p>
+    </Shell>
+  ) : (
+    <Shell>
+      <h1 className="text-[20px] font-bold text-[var(--ink)]">
+        This booking page is not available
+      </h1>
+      <p className="text-[14px] text-[var(--ink-muted)]">
+        The address may be wrong, or the practice may not be taking online bookings. Please contact
+        the practice directly.
+      </p>
+    </Shell>
+  );
+
+const renderStatus = ({
+  practice,
+  submitted,
+  ownerEmail,
+}: {
+  practice: PublicPractice;
+  submitted: boolean;
+  ownerEmail: string;
+}): React.ReactElement | null => {
+  if (submitted) {
+    return (
+      <Shell>
+        <PracticeHeader practice={practice} />
+        <div className="rounded-[16px] border border-[var(--divider)] bg-[var(--inset)] p-5">
+          <h2 className="text-[17px] font-bold text-[var(--ink)]">Check your email</h2>
+          <p className="mt-2 text-[14px] text-[var(--ink-body)]">
+            We have sent a link to <strong>{ownerEmail}</strong>. Follow it to confirm your request,
+            and {practice.name} will be in touch to arrange the appointment.
+          </p>
+          <p className="mt-3 text-[13px] text-[var(--ink-faint)]">
+            Nothing is booked yet. The time you chose is not being held.
+          </p>
+        </div>
+      </Shell>
+    );
+  }
+
+  if (practice.services.length === 0) {
+    return (
+      <Shell>
+        <PracticeHeader practice={practice} />
+        <p className="text-[14px] text-[var(--ink-muted)]">
+          {practice.name} is not offering online booking for any services at the moment. Please
+          contact the practice directly.
+        </p>
+      </Shell>
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Loads the practice, and redirects when the slug has been retired.
+ *
+ * A hook rather than an effect inside the component: the callback nests two
+ * conditionals inside a promise inside an effect, and leaving that in
+ * `BookClient` is most of what pushed its cognitive complexity past the limit.
+ */
+const usePractice = (slug: string): PracticeView => {
   const router = useRouter();
+  // Held in a ref so the effect depends on the slug alone. `useRouter()` is not
+  // contractually identity-stable, and this effect now stores a freshly built
+  // object on success - so a router that changes identity per render would
+  // re-run the load, set new state, and re-run it again forever.
+  const routerRef = useRef(router);
+  // Synced in an effect, not during render: reading or writing a ref while
+  // rendering is what the React Compiler rule forbids, and the initial value
+  // already covers the first pass.
+  useEffect(() => {
+    routerRef.current = router;
+  }, [router]);
 
-  const [state, setState] = useState<LoadState>('loading');
-  const [practice, setPractice] = useState<PublicPractice | null>(null);
-
-  const [serviceId, setServiceId] = useState<string | null>(null);
-  const [date, setDate] = useState(todayIso());
-  const [slotsResult, setSlotsResult] = useState<SlotsResult | null>(null);
-
-  const [startTime, setStartTime] = useState<string | null>(null);
-  const [form, setForm] = useState<FormValues>(EMPTY_FORM);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submitted, setSubmitted] = useState(false);
+  const [view, setView] = useState<PracticeView>({ status: 'loading' });
 
   useEffect(() => {
     let active = true;
@@ -106,56 +254,50 @@ const BookClient = ({ slug }: { slug: string }) => {
       .then((result) => {
         if (!active) return;
         if (result.kind === 'redirect') {
-          // The practice renamed. Replace rather than push, so Back does not
-          // return the reader to an address that no longer exists.
-          router.replace(`/book/${result.slug}`);
+          // Replace rather than push, so Back does not return the reader to an
+          // address that no longer exists.
+          routerRef.current.replace(`/book/${result.slug}`);
           return;
         }
-        setPractice(result.practice);
-        setServiceId(result.practice.services[0]?.id ?? null);
-        setState('ready');
+        setView({ status: 'ready', practice: result.practice });
       })
       .catch(() => {
-        if (active) setState('unavailable');
+        if (active) setView({ status: 'unavailable' });
       });
 
     return () => {
       active = false;
     };
-  }, [slug, router]);
+  }, [slug]);
 
-  const maxDate = useMemo(
-    () => (practice ? isoDaysFromToday(practice.bookingWindowDays) : todayIso()),
-    [practice]
-  );
+  return view;
+};
 
-  // One key per (service, date) pair. Everything about the slot list is derived
-  // from whether the result we hold matches the key we are currently asking
-  // about, so the effect only ever writes state asynchronously - setting a
-  // loading flag synchronously inside it cascades renders, which the lint rule
-  // is right to reject.
-  const slotsKey = serviceId ? `${serviceId}|${date}` : null;
-  const slotsLoading = slotsKey !== null && slotsResult?.key !== slotsKey;
-  const slots = slotsResult?.key === slotsKey ? slotsResult.windows : null;
-  const slotsError = slotsResult?.key === slotsKey ? slotsResult.error : null;
+/**
+ * Available times for one service on one day.
+ *
+ * Keyed by the (service, date) pair so everything the caller needs is derived
+ * from whether the held result matches the key currently being asked about. The
+ * effect therefore only writes state asynchronously; setting a loading flag
+ * synchronously inside it would cascade renders.
+ */
+const useSlots = (slug: string, serviceId: string | null, date: string) => {
+  const [result, setResult] = useState<SlotsResult | null>(null);
 
-  // A chosen time only counts while it is still on offer. Changing the service
-  // or the day therefore deselects it without an effect writing state.
-  const selectedTime =
-    startTime && slots?.some((slot) => slot.startTime === startTime) ? startTime : null;
+  const key = serviceId ? `${serviceId}|${date}` : null;
 
   useEffect(() => {
-    if (!serviceId || !slotsKey) return;
+    if (!serviceId || !key) return;
     let active = true;
 
     getPublicSlots(slug, serviceId, date)
-      .then((result) => {
-        if (active) setSlotsResult({ key: slotsKey, windows: result.windows, error: null });
+      .then((slots) => {
+        if (active) setResult({ key, windows: slots.windows, error: null });
       })
       .catch((error: unknown) => {
         if (!active) return;
-        setSlotsResult({
-          key: slotsKey,
+        setResult({
+          key,
           windows: [],
           error:
             error instanceof PublicBookingRequestError
@@ -167,7 +309,40 @@ const BookClient = ({ slug }: { slug: string }) => {
     return () => {
       active = false;
     };
-  }, [slug, serviceId, date, slotsKey]);
+  }, [slug, serviceId, date, key]);
+
+  const matches = result?.key === key;
+  return {
+    loading: key !== null && !matches,
+    slots: matches ? result.windows : null,
+    error: matches ? result.error : null,
+  };
+};
+
+const BookClient = ({ slug }: { slug: string }) => {
+  const view = usePractice(slug);
+  // Needed before the guard below, because the default service feeds `useSlots`
+  // and every hook has to run on every render.
+  const loaded = view.status === 'ready' ? view.practice : null;
+
+  // Derived, not stored: the practice's first service is the default until the
+  // reader picks another, so nothing has to write it when the practice loads.
+  const [serviceOverride, setServiceOverride] = useState<string | null>(null);
+  const [date, setDate] = useState(todayIso());
+  const serviceId = serviceOverride ?? loaded?.services[0]?.id ?? null;
+
+  const [startTime, setStartTime] = useState<string | null>(null);
+  const [form, setForm] = useState<FormValues>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const { loading: slotsLoading, slots, error: slotsError } = useSlots(slug, serviceId, date);
+
+  // A chosen time only counts while it is still on offer, so changing the
+  // service or the day deselects it without an effect writing state.
+  const selectedTime =
+    startTime && slots?.some((slot) => slot.startTime === startTime) ? startTime : null;
 
   const setField = useCallback(
     <K extends keyof FormValues>(key: K, value: FormValues[K]) =>
@@ -211,57 +386,21 @@ const BookClient = ({ slug }: { slug: string }) => {
       .finally(() => setSubmitting(false));
   };
 
-  if (state === 'loading') {
-    return (
-      <Shell>
-        <p className="text-[14px] text-[var(--ink-muted)]">Loading…</p>
-      </Shell>
-    );
-  }
+  if (view.status !== 'ready') return <PendingOrUnavailable status={view.status} />;
 
-  if (state === 'unavailable' || !practice) {
-    return (
-      <Shell>
-        <h1 className="text-[20px] font-bold text-[var(--ink)]">
-          This booking page is not available
-        </h1>
-        <p className="text-[14px] text-[var(--ink-muted)]">
-          The address may be wrong, or the practice may not be taking online bookings. Please
-          contact the practice directly.
-        </p>
-      </Shell>
-    );
-  }
+  // Past the guard the compiler knows there is a practice, so nothing below
+  // needs a null check.
+  const practice = view.practice;
+  const maxDate = isoDaysFromToday(practice.bookingWindowDays);
 
-  if (submitted) {
-    return (
-      <Shell>
-        <PracticeHeader practice={practice} />
-        <div className="rounded-[16px] border border-[var(--divider)] bg-[var(--inset)] p-5">
-          <h2 className="text-[17px] font-bold text-[var(--ink)]">Check your email</h2>
-          <p className="mt-2 text-[14px] text-[var(--ink-body)]">
-            We have sent a link to <strong>{form.ownerEmail}</strong>. Follow it to confirm your
-            request, and {practice.name} will be in touch to arrange the appointment.
-          </p>
-          <p className="mt-3 text-[13px] text-[var(--ink-faint)]">
-            Nothing is booked yet. The time you chose is not being held.
-          </p>
-        </div>
-      </Shell>
-    );
-  }
-
-  if (practice.services.length === 0) {
-    return (
-      <Shell>
-        <PracticeHeader practice={practice} />
-        <p className="text-[14px] text-[var(--ink-muted)]">
-          {practice.name} is not offering online booking for any services at the moment. Please
-          contact the practice directly.
-        </p>
-      </Shell>
-    );
-  }
+  // One branch for the remaining states. They live in `renderStatus`, which has
+  // its own complexity budget.
+  const statusView = renderStatus({
+    practice,
+    submitted,
+    ownerEmail: form.ownerEmail,
+  });
+  if (statusView) return statusView;
 
   const canSubmit = Boolean(selectedTime) && form.consent && !submitting;
 
@@ -281,17 +420,24 @@ const BookClient = ({ slug }: { slug: string }) => {
           {practice.services.map((service: PublicService) => (
             <label
               key={service.id}
+              htmlFor={`service-${service.id}`}
               className="flex cursor-pointer items-center gap-3 rounded-[13px] border-[1.5px] px-3.5 py-2.5"
               style={{
                 borderColor: serviceId === service.id ? 'var(--blue)' : 'var(--hairline)',
               }}
             >
               <input
+                id={`service-${service.id}`}
                 type="radio"
                 name="service"
+                // The visible name sits two elements deep, which is past what a
+                // label's implicit association is guaranteed to expose. The
+                // explicit id/htmlFor pair plus this label give the control a
+                // name in every assistive technology rather than most.
+                aria-label={service.name}
                 value={service.id}
                 checked={serviceId === service.id}
-                onChange={() => setServiceId(service.id)}
+                onChange={() => setServiceOverride(service.id)}
               />
               <span className="min-w-0 flex-1">
                 <span className="block text-[14px] font-bold text-[var(--ink)]">
@@ -317,45 +463,13 @@ const BookClient = ({ slug }: { slug: string }) => {
           />
         </label>
 
-        <fieldset className="flex flex-col gap-2">
-          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Available times</legend>
-
-          {slotsLoading ? (
-            <p className="text-[13px] text-[var(--ink-muted)]">Checking availability…</p>
-          ) : null}
-
-          {!slotsLoading && slotsError ? (
-            <p role="alert" className="text-[13px] text-[var(--warn-text)]">
-              {slotsError}
-            </p>
-          ) : null}
-
-          {!slotsLoading && !slotsError && slots?.length === 0 ? (
-            <p className="text-[13px] text-[var(--ink-muted)]">
-              No times available on this day. Try another date.
-            </p>
-          ) : null}
-
-          {!slotsLoading && slots && slots.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {slots.map((slot) => (
-                <button
-                  key={slot.startTime}
-                  type="button"
-                  aria-pressed={selectedTime === slot.startTime}
-                  onClick={() => setStartTime(slot.startTime)}
-                  className="rounded-full border-[1.5px] px-3.5 py-2 text-[13.5px] font-semibold text-[var(--ink)]"
-                  style={{
-                    borderColor:
-                      selectedTime === slot.startTime ? 'var(--blue)' : 'var(--hairline)',
-                  }}
-                >
-                  {slot.startTime}
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </fieldset>
+        <SlotPicker
+          loading={slotsLoading}
+          error={slotsError}
+          slots={slots}
+          selectedTime={selectedTime}
+          onSelect={setStartTime}
+        />
 
         <fieldset className="flex flex-col gap-2.5">
           <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Your details</legend>

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  PublicBookingRequestError,
+  getPublicPractice,
+  getPublicSlots,
+  submitBookingRequest,
+  type PublicPractice,
+  type PublicService,
+  type PublicSlot,
+} from '@/app/features/publicBooking/services/publicBooking.service';
+
+/**
+ * The page a pet owner sees at `/book/<slug>`.
+ *
+ * Written to be honest about what a submission is. Nothing here says "booked":
+ * the practice has to accept a request and get in touch, so the button says
+ * "Request this time" and the success state says an email is on its way. The
+ * whole point of this change was to stop the product claiming things it does not
+ * do, and that has to hold on the page the public actually sees.
+ */
+
+type LoadState = 'loading' | 'ready' | 'unavailable';
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const isoDaysFromToday = (days: number) => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const FIELD =
+  'w-full rounded-[12px] border-[1.5px] border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-2.5 text-[14px] text-[var(--ink-body)] outline-none focus:border-[var(--blue)]';
+
+const Shell = ({ children }: { children: React.ReactNode }) => (
+  <main
+    id="main-content"
+    tabIndex={-1}
+    className="mx-auto flex min-h-screen w-full max-w-[560px] flex-col gap-5 p-5"
+  >
+    {children}
+  </main>
+);
+
+const PracticeHeader = ({ practice }: { practice: PublicPractice }) => (
+  <header className="flex items-center gap-3">
+    <span className="flex size-11 shrink-0 items-center justify-center rounded-[13px] bg-[var(--blue-soft)] text-[16px] font-extrabold text-[var(--blue-text)]">
+      {practice.name.charAt(0).toUpperCase()}
+    </span>
+    <span className="min-w-0">
+      <h1 className="truncate text-[20px] font-bold text-[var(--ink)]">{practice.name}</h1>
+      {practice.city ? (
+        <p className="text-[13px] text-[var(--ink-muted)]">
+          {[practice.city, practice.country].filter(Boolean).join(', ')}
+        </p>
+      ) : null}
+    </span>
+  </header>
+);
+
+type SlotsResult = { key: string; windows: PublicSlot[]; error: string | null };
+
+type FormValues = {
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone: string;
+  petName: string;
+  petSpecies: string;
+  concern: string;
+  consent: boolean;
+};
+
+const EMPTY_FORM: FormValues = {
+  ownerName: '',
+  ownerEmail: '',
+  ownerPhone: '',
+  petName: '',
+  petSpecies: '',
+  concern: '',
+  consent: false,
+};
+
+const BookClient = ({ slug }: { slug: string }) => {
+  const router = useRouter();
+
+  const [state, setState] = useState<LoadState>('loading');
+  const [practice, setPractice] = useState<PublicPractice | null>(null);
+
+  const [serviceId, setServiceId] = useState<string | null>(null);
+  const [date, setDate] = useState(todayIso());
+  const [slotsResult, setSlotsResult] = useState<SlotsResult | null>(null);
+
+  const [startTime, setStartTime] = useState<string | null>(null);
+  const [form, setForm] = useState<FormValues>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    getPublicPractice(slug)
+      .then((result) => {
+        if (!active) return;
+        if (result.kind === 'redirect') {
+          // The practice renamed. Replace rather than push, so Back does not
+          // return the reader to an address that no longer exists.
+          router.replace(`/book/${result.slug}`);
+          return;
+        }
+        setPractice(result.practice);
+        setServiceId(result.practice.services[0]?.id ?? null);
+        setState('ready');
+      })
+      .catch(() => {
+        if (active) setState('unavailable');
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [slug, router]);
+
+  const maxDate = useMemo(
+    () => (practice ? isoDaysFromToday(practice.bookingWindowDays) : todayIso()),
+    [practice]
+  );
+
+  // One key per (service, date) pair. Everything about the slot list is derived
+  // from whether the result we hold matches the key we are currently asking
+  // about, so the effect only ever writes state asynchronously - setting a
+  // loading flag synchronously inside it cascades renders, which the lint rule
+  // is right to reject.
+  const slotsKey = serviceId ? `${serviceId}|${date}` : null;
+  const slotsLoading = slotsKey !== null && slotsResult?.key !== slotsKey;
+  const slots = slotsResult?.key === slotsKey ? slotsResult.windows : null;
+  const slotsError = slotsResult?.key === slotsKey ? slotsResult.error : null;
+
+  // A chosen time only counts while it is still on offer. Changing the service
+  // or the day therefore deselects it without an effect writing state.
+  const selectedTime =
+    startTime && slots?.some((slot) => slot.startTime === startTime) ? startTime : null;
+
+  useEffect(() => {
+    if (!serviceId || !slotsKey) return;
+    let active = true;
+
+    getPublicSlots(slug, serviceId, date)
+      .then((result) => {
+        if (active) setSlotsResult({ key: slotsKey, windows: result.windows, error: null });
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setSlotsResult({
+          key: slotsKey,
+          windows: [],
+          error:
+            error instanceof PublicBookingRequestError
+              ? error.message
+              : 'Could not load available times.',
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [slug, serviceId, date, slotsKey]);
+
+  const setField = useCallback(
+    <K extends keyof FormValues>(key: K, value: FormValues[K]) =>
+      setForm((previous) => ({ ...previous, [key]: value })),
+    []
+  );
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!serviceId || !selectedTime || submitting || !form.consent) return;
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    submitBookingRequest(slug, {
+      serviceId,
+      date,
+      startTime: selectedTime,
+      ownerName: form.ownerName,
+      ownerEmail: form.ownerEmail,
+      ownerPhone: form.ownerPhone.trim() || null,
+      petName: form.petName,
+      petSpecies: form.petSpecies,
+      concern: form.concern.trim() || null,
+      consent: true,
+    })
+      .then(() => setSubmitted(true))
+      .catch((error: unknown) => {
+        setSubmitError(
+          error instanceof PublicBookingRequestError
+            ? error.message
+            : 'Could not send your request. Please try again.'
+        );
+        // A 409 means the slot went while the form was open, so the times on
+        // screen are stale. Clearing the choice forces a re-pick rather than
+        // letting the reader resubmit the same gone slot.
+        if (error instanceof PublicBookingRequestError && error.status === 409) {
+          setStartTime(null);
+        }
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  if (state === 'loading') {
+    return (
+      <Shell>
+        <p className="text-[14px] text-[var(--ink-muted)]">Loading…</p>
+      </Shell>
+    );
+  }
+
+  if (state === 'unavailable' || !practice) {
+    return (
+      <Shell>
+        <h1 className="text-[20px] font-bold text-[var(--ink)]">
+          This booking page is not available
+        </h1>
+        <p className="text-[14px] text-[var(--ink-muted)]">
+          The address may be wrong, or the practice may not be taking online bookings. Please
+          contact the practice directly.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <Shell>
+        <PracticeHeader practice={practice} />
+        <div className="rounded-[16px] border border-[var(--divider)] bg-[var(--inset)] p-5">
+          <h2 className="text-[17px] font-bold text-[var(--ink)]">Check your email</h2>
+          <p className="mt-2 text-[14px] text-[var(--ink-body)]">
+            We have sent a link to <strong>{form.ownerEmail}</strong>. Follow it to confirm your
+            request, and {practice.name} will be in touch to arrange the appointment.
+          </p>
+          <p className="mt-3 text-[13px] text-[var(--ink-faint)]">
+            Nothing is booked yet. The time you chose is not being held.
+          </p>
+        </div>
+      </Shell>
+    );
+  }
+
+  if (practice.services.length === 0) {
+    return (
+      <Shell>
+        <PracticeHeader practice={practice} />
+        <p className="text-[14px] text-[var(--ink-muted)]">
+          {practice.name} is not offering online booking for any services at the moment. Please
+          contact the practice directly.
+        </p>
+      </Shell>
+    );
+  }
+
+  const canSubmit = Boolean(selectedTime) && form.consent && !submitting;
+
+  return (
+    <Shell>
+      <PracticeHeader practice={practice} />
+
+      {practice.welcomeMessage ? (
+        <p className="text-[14.5px] text-[var(--ink-body)]">{practice.welcomeMessage}</p>
+      ) : null}
+
+      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+        <fieldset className="flex flex-col gap-2.5">
+          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">
+            What do you need?
+          </legend>
+          {practice.services.map((service: PublicService) => (
+            <label
+              key={service.id}
+              className="flex cursor-pointer items-center gap-3 rounded-[13px] border-[1.5px] px-3.5 py-2.5"
+              style={{
+                borderColor: serviceId === service.id ? 'var(--blue)' : 'var(--hairline)',
+              }}
+            >
+              <input
+                type="radio"
+                name="service"
+                value={service.id}
+                checked={serviceId === service.id}
+                onChange={() => setServiceId(service.id)}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block text-[14px] font-bold text-[var(--ink)]">
+                  {service.name}
+                </span>
+                <span className="block text-[12.5px] text-[var(--ink-faint)]">
+                  {service.durationMinutes} min
+                </span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[13px] font-bold text-[var(--ink)]">Preferred day</span>
+          <input
+            type="date"
+            className={FIELD}
+            value={date}
+            min={todayIso()}
+            max={maxDate}
+            onChange={(event) => setDate(event.target.value)}
+          />
+        </label>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Available times</legend>
+
+          {slotsLoading ? (
+            <p className="text-[13px] text-[var(--ink-muted)]">Checking availability…</p>
+          ) : null}
+
+          {!slotsLoading && slotsError ? (
+            <p role="alert" className="text-[13px] text-[var(--warn-text)]">
+              {slotsError}
+            </p>
+          ) : null}
+
+          {!slotsLoading && !slotsError && slots?.length === 0 ? (
+            <p className="text-[13px] text-[var(--ink-muted)]">
+              No times available on this day. Try another date.
+            </p>
+          ) : null}
+
+          {!slotsLoading && slots && slots.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {slots.map((slot) => (
+                <button
+                  key={slot.startTime}
+                  type="button"
+                  aria-pressed={selectedTime === slot.startTime}
+                  onClick={() => setStartTime(slot.startTime)}
+                  className="rounded-full border-[1.5px] px-3.5 py-2 text-[13.5px] font-semibold text-[var(--ink)]"
+                  style={{
+                    borderColor:
+                      selectedTime === slot.startTime ? 'var(--blue)' : 'var(--hairline)',
+                  }}
+                >
+                  {slot.startTime}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </fieldset>
+
+        <fieldset className="flex flex-col gap-2.5">
+          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Your details</legend>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">Your name</span>
+            <input
+              className={FIELD}
+              required
+              maxLength={120}
+              value={form.ownerName}
+              onChange={(event) => setField('ownerName', event.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">Email</span>
+            <input
+              className={FIELD}
+              type="email"
+              required
+              maxLength={254}
+              value={form.ownerEmail}
+              onChange={(event) => setField('ownerEmail', event.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">Phone (optional)</span>
+            <input
+              className={FIELD}
+              maxLength={40}
+              value={form.ownerPhone}
+              onChange={(event) => setField('ownerPhone', event.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">Pet name</span>
+            <input
+              className={FIELD}
+              required
+              maxLength={120}
+              value={form.petName}
+              onChange={(event) => setField('petName', event.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">Species</span>
+            <input
+              className={FIELD}
+              required
+              maxLength={60}
+              placeholder="Dog, cat, rabbit…"
+              value={form.petSpecies}
+              onChange={(event) => setField('petSpecies', event.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] text-[var(--ink-muted)]">
+              What is the visit for? (optional)
+            </span>
+            <textarea
+              className={FIELD}
+              rows={3}
+              maxLength={1000}
+              value={form.concern}
+              onChange={(event) => setField('concern', event.target.value)}
+            />
+          </label>
+        </fieldset>
+
+        <label className="flex items-start gap-2.5">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={form.consent}
+            onChange={(event) => setField('consent', event.target.checked)}
+          />
+          <span className="text-[12.5px] text-[var(--ink-muted)]">
+            I agree that {practice.name} may store these details to handle my booking request. They
+            are deleted 30 days after the requested date.
+          </span>
+        </label>
+
+        {submitError ? (
+          <p role="alert" className="text-[13px] text-[var(--warn-text)]">
+            {submitError}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex h-12 items-center justify-center rounded-full bg-[var(--cta)] px-5 text-[14px] font-semibold text-[var(--cta-text)] disabled:opacity-50"
+        >
+          {submitting ? 'Sending…' : 'Request this time'}
+        </button>
+
+        <p className="text-[12.5px] text-[var(--ink-faint)]">
+          This sends a request, not a booking. {practice.name} will confirm the appointment with
+          you, and the time is not held in the meantime.
+        </p>
+      </form>
+    </Shell>
+  );
+};
+
+export default BookClient;

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { confirmBookingRequest } from '@/app/features/publicBooking/services/publicBooking.service';
+
+/**
+ * Where the emailed confirmation link lands.
+ *
+ * The confirmation itself is a POST, not this page load. Mail clients and link
+ * scanners fetch URLs to preview them, so a GET that confirmed on arrival would
+ * confirm requests nobody clicked - which is exactly the property the email step
+ * exists to establish. The page reads the token from the query and posts it once.
+ */
+
+type State = 'confirming' | 'confirmed' | 'invalid';
+
+const ConfirmClient = () => {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+
+  // Derived from the token rather than set inside the effect: a link with no
+  // token is already invalid before anything runs, and writing that state
+  // synchronously in an effect cascades a render.
+  const [state, setState] = useState<State>(token ? 'confirming' : 'invalid');
+  const [practiceName, setPracticeName] = useState('');
+  // React 18 mounts effects twice in development; confirming is a write, so it
+  // runs once regardless.
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    if (!token) return;
+
+    confirmBookingRequest(token)
+      .then((result) => {
+        setPracticeName(result.practiceName);
+        setState('confirmed');
+      })
+      .catch(() => setState('invalid'));
+  }, [token]);
+
+  return (
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="mx-auto flex min-h-screen w-full max-w-[520px] flex-col justify-center gap-3 p-6"
+    >
+      {state === 'confirming' ? (
+        <p className="text-[14px] text-[var(--ink-muted)]">Confirming your request…</p>
+      ) : null}
+
+      {state === 'confirmed' ? (
+        <>
+          <h1 className="text-[20px] font-bold text-[var(--ink)]">Request confirmed</h1>
+          <p className="text-[14px] text-[var(--ink-body)]">
+            {practiceName || 'The practice'} can now see your request and will contact you to
+            arrange the appointment.
+          </p>
+          <p className="text-[13px] text-[var(--ink-faint)]">
+            Nothing is booked yet, and the time you asked for is not being held.
+          </p>
+        </>
+      ) : null}
+
+      {state === 'invalid' ? (
+        <>
+          <h1 className="text-[20px] font-bold text-[var(--ink)]">This link is not valid</h1>
+          <p className="text-[14px] text-[var(--ink-body)]">
+            It may have already been used, or it may have expired. Confirmation links last 48 hours.
+            Please submit your request again, or contact the practice directly.
+          </p>
+        </>
+      ) : null}
+    </main>
+  );
+};
+
+export default ConfirmClient;

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/page.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import ConfirmClient from './ConfirmClient';
+
+// Same reasoning as the booking page: per-request so the strict CSP on `/book`
+// has a nonce, and never cached, because the answer depends on a token.
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Confirm your booking request',
+  // The URL carries a confirmation token. Indexing it would put that token in a
+  // search index, and following it from there would confirm somebody else's
+  // request.
+  robots: { index: false, follow: false },
+};
+
+const ConfirmPage = () => <ConfirmClient />;
+
+export default ConfirmPage;

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/page.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import BookClient from './BookClient';
+
+/**
+ * Rendered per request, not prerendered.
+ *
+ * Two reasons, and both matter. The page collects a name, an email address, a
+ * phone number and an animal's details, so it must run under the strict CSP that
+ * `middleware.ts` applies to `/book` - and that policy needs a per-request nonce,
+ * which a statically prerendered route does not have. Second, whether a practice
+ * is published can change at any moment, and a cached page would keep serving a
+ * booking form for a practice that has taken it down.
+ */
+export const dynamic = 'force-dynamic';
+
+/**
+ * Indexable, unlike the `(share)` pages next door.
+ *
+ * Those are private records reached by a share token and carry
+ * `robots: { index: false }`. This is the opposite: a practice publishes it
+ * deliberately so that pet owners can find it, and hiding it from search would
+ * defeat the feature. Nothing on the page is anyone's personal data - it is the
+ * practice's own name, services and opening times.
+ */
+export const metadata: Metadata = {
+  title: 'Book an appointment',
+};
+
+type BookPageProps = { params: Promise<{ slug: string }> };
+
+const BookPage = async ({ params }: BookPageProps) => {
+  const { slug } = await params;
+  return <BookClient slug={slug} />;
+};
+
+export default BookPage;

--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const replaceMock = jest.fn();
+const getPracticeMock = jest.fn();
+const getSlotsMock = jest.fn();
+const submitMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+jest.mock('@/app/features/publicBooking/services/publicBooking.service', () => {
+  class PublicBookingRequestError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    PublicBookingRequestError,
+    getPublicPractice: (...args: unknown[]) => getPracticeMock(...args),
+    getPublicSlots: (...args: unknown[]) => getSlotsMock(...args),
+    submitBookingRequest: (...args: unknown[]) => submitMock(...args),
+  };
+});
+
+import BookClient from '@/app/(routes)/(book)/book/[slug]/BookClient';
+import { PublicBookingRequestError } from '@/app/features/publicBooking/services/publicBooking.service';
+
+const practice = (over: Record<string, unknown> = {}) => ({
+  slug: 'park-vets',
+  name: 'Park Veterinary',
+  logoUrl: null,
+  welcomeMessage: 'Book a visit.',
+  city: 'Berlin',
+  country: 'DE',
+  bookingWindowDays: 28,
+  requiresConfirmation: true,
+  services: [
+    { id: 'svc-1', name: 'Wellness consultation', description: null, durationMinutes: 30 },
+  ],
+  ...over,
+});
+
+const renderPage = async () => {
+  render(<BookClient slug="park-vets" />);
+  // Two flushes, not one. The practice load settles on the first; the slot load
+  // it triggers settles on the second. Leaving the second in flight means it
+  // resolves during whichever test runs next, where React reports it as an
+  // unwrapped update.
+  await act(async () => {});
+  await act(async () => {});
+};
+
+/**
+ * Clicking submit starts a promise chain that ends in `setSubmitting(false)`.
+ * Flushing it inside `act` keeps that final update from landing after the test
+ * body, which React reports as an unwrapped state update.
+ */
+const submitForm = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Request this time/ }));
+  });
+};
+
+const fillForm = () => {
+  fireEvent.change(screen.getByLabelText('Your name'), { target: { value: 'Sam Owner' } });
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'sam@example.com' } });
+  fireEvent.change(screen.getByLabelText('Pet name'), { target: { value: 'Rex' } });
+  fireEvent.change(screen.getByLabelText('Species'), { target: { value: 'Dog' } });
+};
+
+describe('BookClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getPracticeMock.mockResolvedValue({ kind: 'practice', practice: practice() });
+    getSlotsMock.mockResolvedValue({
+      date: '2026-09-01',
+      serviceId: 'svc-1',
+      durationMinutes: 30,
+      windows: [
+        { startTime: '09:00', endTime: '09:30' },
+        { startTime: '10:00', endTime: '10:30' },
+      ],
+    });
+    submitMock.mockResolvedValue(undefined);
+  });
+
+  it('renders the practice, its welcome message and its services', async () => {
+    await renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Park Veterinary' })).toBeInTheDocument();
+    expect(screen.getByText('Book a visit.')).toBeInTheDocument();
+    expect(screen.getByText('Berlin, DE')).toBeInTheDocument();
+    expect(screen.getByText('Wellness consultation')).toBeInTheDocument();
+  });
+
+  it('never tells the visitor anything is booked', async () => {
+    await renderPage();
+
+    expect(screen.getByRole('button', { name: /Request this time/ })).toBeInTheDocument();
+    expect(screen.getByText(/sends a request, not a booking/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Book$/ })).not.toBeInTheDocument();
+  });
+
+  it('follows a retired slug to the current address without adding history', async () => {
+    getPracticeMock.mockResolvedValue({ kind: 'redirect', slug: 'new-name' });
+    await renderPage();
+
+    expect(replaceMock).toHaveBeenCalledWith('/book/new-name');
+  });
+
+  it('shows an unavailable state rather than an error page', async () => {
+    getPracticeMock.mockRejectedValue(new PublicBookingRequestError('Not found', 404));
+    await renderPage();
+
+    expect(screen.getByRole('heading', { name: /not available/i })).toBeInTheDocument();
+  });
+
+  it('says so when the practice offers nothing publicly', async () => {
+    getPracticeMock.mockResolvedValue({
+      kind: 'practice',
+      practice: practice({ services: [] }),
+    });
+    await renderPage();
+
+    expect(screen.getByText(/not offering online booking/)).toBeInTheDocument();
+  });
+
+  it('loads and lists times for the selected service and day', async () => {
+    await renderPage();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument());
+    expect(getSlotsMock).toHaveBeenCalledWith('park-vets', 'svc-1', expect.any(String));
+  });
+
+  it('bounds the date picker to the practice booking window', async () => {
+    await renderPage();
+
+    const input = screen.getByLabelText('Preferred day') as HTMLInputElement;
+    expect(input.min).toBe(new Date().toISOString().slice(0, 10));
+    expect(input.max).not.toBe('');
+  });
+
+  it('reports a slot loading failure without pretending there are no times', async () => {
+    getSlotsMock.mockRejectedValue(
+      new PublicBookingRequestError('Date outside the booking window', 400)
+    );
+    await renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Date outside the booking window')
+    );
+  });
+
+  it('falls back to a generic message when the slot failure is not ours', async () => {
+    getSlotsMock.mockRejectedValue(new Error('network'));
+    await renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not load available times.')
+    );
+  });
+
+  it('says when a day has no times at all', async () => {
+    getSlotsMock.mockResolvedValue({
+      date: '2026-09-01',
+      serviceId: 'svc-1',
+      durationMinutes: 30,
+      windows: [],
+    });
+    await renderPage();
+
+    await waitFor(() => expect(screen.getByText(/No times available/)).toBeInTheDocument());
+  });
+
+  it('ignores a slot failure that lands after the visitor has left', async () => {
+    let fail: (reason: unknown) => void = () => {};
+    getSlotsMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        fail = reject;
+      })
+    );
+    const { unmount } = render(<BookClient slug="park-vets" />);
+    await act(async () => {});
+    unmount();
+
+    await act(async () => {
+      fail(new Error('network'));
+    });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('refuses a submit event raised without a chosen time', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+    fillForm();
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    // The button is disabled in this state, but a submit event can still reach
+    // the form; the handler has to refuse it rather than post a request with no
+    // time in it.
+    const form = screen.getByRole('button', { name: /Request this time/ }).closest('form');
+    await act(async () => {
+      fireEvent.submit(form as HTMLFormElement);
+    });
+
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it('deselects a chosen time when the day changes', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    expect(screen.getByRole('button', { name: '09:00' })).toHaveAttribute('aria-pressed', 'true');
+
+    getSlotsMock.mockResolvedValue({
+      date: '2026-09-02',
+      serviceId: 'svc-1',
+      durationMinutes: 30,
+      windows: [{ startTime: '11:00', endTime: '11:30' }],
+    });
+    fireEvent.change(screen.getByLabelText('Preferred day'), {
+      target: { value: '2026-09-02' },
+    });
+
+    // The old time is gone from the new day's list, so it cannot remain chosen.
+    await waitFor(() => expect(screen.getByRole('button', { name: '11:00' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '11:00' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('will not submit without a time or without consent', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+    fillForm();
+
+    const submit = screen.getByRole('button', { name: /Request this time/ });
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(submit).toBeEnabled();
+
+    // This test never submits, so it is the one place a render can still be
+    // queued when the tree unmounts. Settle it here rather than letting it
+    // surface as an unwrapped update in the next test.
+    await act(async () => {});
+  });
+
+  it('submits the request and tells the visitor to check their email', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fillForm();
+    fireEvent.change(screen.getByLabelText(/What is the visit for/), {
+      target: { value: '  Limping  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await submitForm();
+
+    expect(submitMock).toHaveBeenCalled();
+    expect(submitMock.mock.calls[0][1]).toMatchObject({
+      serviceId: 'svc-1',
+      startTime: '09:00',
+      ownerName: 'Sam Owner',
+      ownerEmail: 'sam@example.com',
+      ownerPhone: null,
+      petName: 'Rex',
+      petSpecies: 'Dog',
+      concern: 'Limping',
+      consent: true,
+    });
+
+    expect(screen.getByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+    expect(screen.getByText(/Nothing is booked yet/)).toBeInTheDocument();
+  });
+
+  it('sends an entered phone number through', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fillForm();
+    fireEvent.change(screen.getByLabelText(/Phone/), { target: { value: ' +49 30 1 ' } });
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await submitForm();
+
+    expect(submitMock).toHaveBeenCalled();
+    expect(submitMock.mock.calls[0][1].ownerPhone).toBe('+49 30 1');
+  });
+
+  it('clears a taken slot so the visitor must pick again', async () => {
+    submitMock.mockRejectedValue(
+      new PublicBookingRequestError('That time is no longer available', 409)
+    );
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await submitForm();
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That time is no longer available');
+    expect(screen.getByRole('button', { name: '09:00' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('reports a generic submit failure without claiming anything was sent', async () => {
+    submitMock.mockRejectedValue(new Error('network'));
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await submitForm();
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/Could not send your request/);
+    expect(screen.queryByRole('heading', { name: 'Check your email' })).not.toBeInTheDocument();
+  });
+
+  it('switches service and refetches times', async () => {
+    getPracticeMock.mockResolvedValue({
+      kind: 'practice',
+      practice: practice({
+        services: [
+          { id: 'svc-1', name: 'Wellness', description: null, durationMinutes: 30 },
+          { id: 'svc-2', name: 'Dental', description: null, durationMinutes: 60 },
+        ],
+      }),
+    });
+    await renderPage();
+    await waitFor(() => expect(getSlotsMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('radio', { name: /Dental/ }));
+
+    await waitFor(() => expect(getSlotsMock).toHaveBeenCalledTimes(2));
+    expect(getSlotsMock.mock.calls[1][1]).toBe('svc-2');
+  });
+
+  it('tolerates a practice with no city', async () => {
+    getPracticeMock.mockResolvedValue({
+      kind: 'practice',
+      practice: practice({ city: null, welcomeMessage: null }),
+    });
+    await renderPage();
+
+    expect(screen.queryByText('Berlin, DE')).not.toBeInTheDocument();
+    expect(screen.queryByText('Book a visit.')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -177,6 +177,25 @@ describe('BookClient', () => {
     await waitFor(() => expect(screen.getByText(/No times available/)).toBeInTheDocument());
   });
 
+  it('ignores a practice that loads after the visitor has left', async () => {
+    let resolve: (value: unknown) => void = () => {};
+    getPracticeMock.mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      })
+    );
+    const { unmount } = render(<BookClient slug="park-vets" />);
+    unmount();
+
+    await act(async () => {
+      resolve({ kind: 'practice', practice: practice() });
+    });
+
+    // No redirect, no render against an unmounted tree.
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('Park Veterinary')).not.toBeInTheDocument();
+  });
+
   it('ignores a slot failure that lands after the visitor has left', async () => {
     let fail: (reason: unknown) => void = () => {};
     getSlotsMock.mockReturnValue(

--- a/apps/frontend/src/app/__tests__/(routes)/book/ConfirmClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/ConfirmClient.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const confirmMock = jest.fn();
+let searchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => searchParams,
+}));
+
+jest.mock('@/app/features/publicBooking/services/publicBooking.service', () => ({
+  confirmBookingRequest: (...args: unknown[]) => confirmMock(...args),
+}));
+
+import ConfirmClient from '@/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient';
+
+const renderPage = async () => {
+  render(<ConfirmClient />);
+  await act(async () => {});
+};
+
+describe('ConfirmClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    searchParams = new URLSearchParams('token=abc123');
+    confirmMock.mockResolvedValue({ practiceName: 'Park Veterinary', slug: 'park-vets' });
+  });
+
+  it('confirms the token from the query and names the practice', async () => {
+    await renderPage();
+
+    expect(confirmMock).toHaveBeenCalledWith('abc123');
+    expect(screen.getByRole('heading', { name: 'Request confirmed' })).toBeInTheDocument();
+    expect(screen.getByText(/Park Veterinary can now see your request/)).toBeInTheDocument();
+  });
+
+  it('still says nothing is booked', async () => {
+    await renderPage();
+    expect(screen.getByText(/Nothing is booked yet/)).toBeInTheDocument();
+  });
+
+  it('confirms once and does not repeat it on re-render', async () => {
+    const { rerender } = render(<ConfirmClient />);
+    await act(async () => {});
+
+    // Change the query so the effect's dependency changes and it genuinely
+    // re-runs; the guard, not the dependency list, is what stops a second post.
+    searchParams = new URLSearchParams('token=def456');
+    rerender(<ConfirmClient />);
+    await act(async () => {});
+
+    // Confirming is a write, and React re-runs effects on remount in
+    // development. The ref is what makes "exactly once" a property rather than
+    // luck.
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a link with no token as invalid without calling the API', async () => {
+    searchParams = new URLSearchParams();
+    await renderPage();
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: /not valid/i })).toBeInTheDocument();
+  });
+
+  it('explains an expired or used link rather than failing silently', async () => {
+    confirmMock.mockRejectedValue(new Error('Not found'));
+    await renderPage();
+
+    expect(screen.getByRole('heading', { name: /not valid/i })).toBeInTheDocument();
+    expect(screen.getByText(/48\s*hours/)).toBeInTheDocument();
+  });
+
+  it('falls back when the API returns no practice name', async () => {
+    confirmMock.mockResolvedValue({ practiceName: '', slug: null });
+    await renderPage();
+
+    expect(screen.getByText(/The practice can now see your request/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/(routes)/book/bookPages.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/bookPages.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/(routes)/(book)/book/[slug]/BookClient', () => ({
+  __esModule: true,
+  default: ({ slug }: { slug: string }) => <div data-testid="book-client">{slug}</div>,
+}));
+
+jest.mock('@/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient', () => ({
+  __esModule: true,
+  default: () => <div data-testid="confirm-client" />,
+}));
+
+import BookPage, {
+  dynamic as bookDynamic,
+  metadata as bookMetadata,
+} from '@/app/(routes)/(book)/book/[slug]/page';
+import ConfirmPage, {
+  dynamic as confirmDynamic,
+  metadata as confirmMetadata,
+} from '@/app/(routes)/(book)/book/[slug]/confirm/page';
+
+describe('public booking pages', () => {
+  it('passes the slug from the route to the client', async () => {
+    render(await BookPage({ params: Promise.resolve({ slug: 'park-vets' }) }));
+
+    expect(screen.getByTestId('book-client')).toHaveTextContent('park-vets');
+  });
+
+  it('renders per request so the strict CSP nonce exists', () => {
+    // `middleware.ts` applies the strict policy to `/book`, and that policy
+    // needs a per-request nonce. A statically prerendered route has none.
+    expect(bookDynamic).toBe('force-dynamic');
+    expect(confirmDynamic).toBe('force-dynamic');
+  });
+
+  it('lets the booking page be indexed but never the confirmation link', () => {
+    // The booking page is published deliberately and holds nobody's personal
+    // data. The confirmation URL carries a token, and indexing it would put that
+    // token in a search index.
+    expect(bookMetadata.robots).toBeUndefined();
+    expect(confirmMetadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it('renders the confirmation client', () => {
+    render(<ConfirmPage />);
+    expect(screen.getByTestId('confirm-client')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/publicBooking/publicBooking.service.test.ts
+++ b/apps/frontend/src/app/__tests__/features/publicBooking/publicBooking.service.test.ts
@@ -1,0 +1,185 @@
+import {
+  PublicBookingRequestError,
+  confirmBookingRequest,
+  getPublicPractice,
+  getPublicSlots,
+  submitBookingRequest,
+} from '@/app/features/publicBooking/services/publicBooking.service';
+
+const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const originalFetch = globalThis.fetch;
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as Response;
+
+describe('publicBooking.service', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://api.example.com/';
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    globalThis.fetch = originalFetch;
+  });
+
+  const fetchMock = () => globalThis.fetch as jest.Mock;
+
+  describe('getPublicPractice', () => {
+    it('returns the practice and strips the trailing slash from the base URL', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ data: { slug: 'park-vets' } }));
+
+      await expect(getPublicPractice('park-vets')).resolves.toEqual({
+        kind: 'practice',
+        practice: { slug: 'park-vets' },
+      });
+      expect(fetchMock().mock.calls[0][0]).toBe('https://api.example.com/public/booking/park-vets');
+    });
+
+    it('sends no credentials, so a staff session never reaches a public endpoint', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ data: { slug: 'x' } }));
+
+      await getPublicPractice('x');
+
+      const init = fetchMock().mock.calls[0][1] as RequestInit;
+      expect(init.credentials).toBeUndefined();
+    });
+
+    it('encodes a slug rather than interpolating it raw', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ data: { slug: 'x' } }));
+
+      await getPublicPractice('a/../b');
+
+      expect(fetchMock().mock.calls[0][0]).toBe(
+        'https://api.example.com/public/booking/a%2F..%2Fb'
+      );
+    });
+
+    it('reports a retired slug as a redirect', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ data: { redirectTo: 'new-name' } }));
+
+      await expect(getPublicPractice('old-name')).resolves.toEqual({
+        kind: 'redirect',
+        slug: 'new-name',
+      });
+    });
+
+    it('throws with the status so the page can tell 404 from anything else', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ message: 'Not found' }, 404));
+
+      const error = await getPublicPractice('nope').catch((e) => e);
+      expect(error).toBeInstanceOf(PublicBookingRequestError);
+      expect(error.status).toBe(404);
+      expect(error.message).toBe('Not found');
+    });
+
+    it('falls back to a readable message when the body is not JSON', async () => {
+      fetchMock().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error('not json');
+        },
+      } as unknown as Response);
+
+      const error = await getPublicPractice('x').catch((e) => e);
+      expect(error.message).toBe('This booking page is not available.');
+    });
+
+    it('falls back when the body carries a non-string message', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ message: { nested: true } }, 400));
+
+      const error = await getPublicPractice('x').catch((e) => e);
+      expect(error.message).toBe('This booking page is not available.');
+    });
+  });
+
+  describe('getPublicSlots', () => {
+    it('queries by service and date', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ data: { windows: [] } }));
+
+      await getPublicSlots('park-vets', 'svc-1', '2026-09-01');
+
+      expect(fetchMock().mock.calls[0][0]).toBe(
+        'https://api.example.com/public/booking/park-vets/slots?serviceId=svc-1&date=2026-09-01'
+      );
+    });
+
+    it('surfaces a failure with its status', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ message: 'Outside window' }, 400));
+
+      const error = await getPublicSlots('x', 'svc', '2026-09-01').catch((e) => e);
+      expect(error.status).toBe(400);
+      expect(error.message).toBe('Outside window');
+    });
+  });
+
+  describe('submitBookingRequest', () => {
+    const payload = {
+      serviceId: 'svc-1',
+      date: '2026-09-01',
+      startTime: '09:00',
+      ownerName: 'Sam',
+      ownerEmail: 'sam@example.com',
+      ownerPhone: null,
+      petName: 'Rex',
+      petSpecies: 'Dog',
+      concern: null,
+      consent: true as const,
+    };
+
+    it('posts the payload as JSON', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({}, 202));
+
+      await expect(submitBookingRequest('park-vets', payload)).resolves.toBeUndefined();
+
+      const init = fetchMock().mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual(payload);
+    });
+
+    it('surfaces a taken slot as a 409', async () => {
+      fetchMock().mockResolvedValueOnce(
+        jsonResponse({ message: 'That time is no longer available' }, 409)
+      );
+
+      const error = await submitBookingRequest('x', payload).catch((e) => e);
+      expect(error.status).toBe(409);
+    });
+  });
+
+  describe('confirmBookingRequest', () => {
+    it('posts the token and returns the practice', async () => {
+      fetchMock().mockResolvedValueOnce(
+        jsonResponse({ data: { practiceName: 'Park Vets', slug: 'park-vets' } })
+      );
+
+      await expect(confirmBookingRequest('tok')).resolves.toEqual({
+        practiceName: 'Park Vets',
+        slug: 'park-vets',
+      });
+
+      const init = fetchMock().mock.calls[0][1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({ token: 'tok' });
+    });
+
+    it('throws for an invalid link', async () => {
+      fetchMock().mockResolvedValueOnce(jsonResponse({ message: 'Not found' }, 404));
+
+      await expect(confirmBookingRequest('tok')).rejects.toBeInstanceOf(PublicBookingRequestError);
+    });
+  });
+
+  it('tolerates an unset base URL rather than emitting "undefined" in the path', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    fetchMock().mockResolvedValueOnce(jsonResponse({ data: { slug: 'x' } }));
+
+    await getPublicPractice('x');
+
+    expect(fetchMock().mock.calls[0][0]).toBe('/public/booking/x');
+  });
+});

--- a/apps/frontend/src/app/__tests__/middleware.test.ts
+++ b/apps/frontend/src/app/__tests__/middleware.test.ts
@@ -144,6 +144,11 @@ describe('middleware', () => {
     '/payment-status',
     '/developers/signin',
     '/developers/signup',
+    // The public booking page and its confirmation step. Both collect or carry
+    // personal data from a signed-out visitor, so neither may inherit the
+    // `unsafe-inline` policy the marketing routes carry.
+    '/book/park-veterinary',
+    '/book/park-veterinary/confirm',
   ])('serves %s with a nonce CSP instead of unsafe-inline scripts', (pathname) => {
     const response = middleware(createRequest(pathname)) as ReturnType<typeof createResponse>;
     const nextOptions = mockNext.mock.calls[0][0];

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/BookingRequests.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/BookingRequests.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const notifyMock = jest.fn();
+const listMock = jest.fn();
+const setStatusMock = jest.fn();
+let primaryOrgId: string | null = 'org-1';
+
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: (selector: (state: { primaryOrgId: string | null }) => unknown) =>
+    selector({ primaryOrgId }),
+}));
+
+jest.mock('@/app/hooks/useNotify', () => ({ useNotify: () => ({ notify: notifyMock }) }));
+
+jest.mock('@/app/features/organization/services/bookingRequestsApiService', () => ({
+  bookingRequestsApi: {
+    list: (...args: unknown[]) => listMock(...args),
+    setStatus: (...args: unknown[]) => setStatusMock(...args),
+  },
+}));
+
+jest.mock('@/app/ui/primitives/SectionCard/SectionCard', () => {
+  const MockSectionCard = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <section aria-label={title}>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+  MockSectionCard.displayName = 'MockSectionCard';
+  return { __esModule: true, default: MockSectionCard };
+});
+
+import BookingRequests from '@/app/features/organization/pages/Organization/Sections/BookingRequests';
+
+const request = (over: Record<string, unknown> = {}) => ({
+  id: 'req-1',
+  serviceName: 'Wellness consultation',
+  requestedStart: '2026-09-01T09:00:00.000Z',
+  requestedEnd: '2026-09-01T09:30:00.000Z',
+  durationMinutes: 30,
+  ownerName: 'Sam Owner',
+  ownerEmail: 'sam@example.com',
+  ownerPhone: '+49 30 1234',
+  petName: 'Rex',
+  petSpecies: 'Dog',
+  concern: 'Limping',
+  status: 'CONFIRMED' as const,
+  confirmedAt: '2026-08-30T10:00:00.000Z',
+  createdAt: '2026-08-30T09:00:00.000Z',
+  ...over,
+});
+
+/**
+ * Returns the render's own container. Asserting on `document.body` would read
+ * every container the file has ever mounted, which silently matched an earlier
+ * test's markup.
+ */
+const renderSection = async () => {
+  const view = render(<BookingRequests />);
+  await act(async () => {});
+  return view.container;
+};
+
+describe('BookingRequests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primaryOrgId = 'org-1';
+    listMock.mockResolvedValue([request()]);
+    setStatusMock.mockResolvedValue(undefined);
+  });
+
+  it('lists a confirmed request with the details the practice needs to call back', async () => {
+    const container = await renderSection();
+
+    // Assert on the rendered text as a whole: each line is several JSX
+    // expressions, so it is not one text node.
+    const text = container.textContent ?? '';
+    expect(text).toContain('Rex (Dog) · Wellness consultation');
+    expect(text).toContain('Sam Owner · sam@example.com · +49 30 1234');
+    expect(text).toContain('Limping');
+  });
+
+  it('says plainly that these are requests, not appointments', async () => {
+    await renderSection();
+    expect(screen.getByText(/requests, not appointments/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state rather than nothing at all', async () => {
+    listMock.mockResolvedValue([]);
+    await renderSection();
+
+    expect(screen.getByText(/No booking requests yet/)).toBeInTheDocument();
+  });
+
+  it('reports a load failure instead of pretending the queue is empty', async () => {
+    listMock.mockRejectedValue(new Error('403'));
+    await renderSection();
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/Could not load booking requests/);
+    expect(screen.queryByText(/No booking requests yet/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing at all without a primary organisation', async () => {
+    primaryOrgId = null;
+    const container = await renderSection();
+
+    expect(listMock).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('marks a request booked and reflects it without a reload', async () => {
+    const container = await renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark booked' }));
+
+    await waitFor(() => expect(setStatusMock).toHaveBeenCalledWith('org-1', 'req-1', 'BOOKED'));
+    await waitFor(() => expect(container.textContent).toContain('Booked'));
+    expect(screen.queryByRole('button', { name: 'Mark booked' })).not.toBeInTheDocument();
+  });
+
+  it('declines a request', async () => {
+    const container = await renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decline' }));
+
+    await waitFor(() => expect(setStatusMock).toHaveBeenCalledWith('org-1', 'req-1', 'DECLINED'));
+    await waitFor(() => expect(container.textContent).toContain('Declined'));
+  });
+
+  it('updates only the row that was acted on', async () => {
+    listMock.mockResolvedValue([
+      request(),
+      request({ id: 'req-2', petName: 'Mila', ownerName: 'Alex Owner' }),
+    ]);
+    const container = await renderSection();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Mark booked' })[0]);
+
+    await waitFor(() => expect(container.textContent).toContain('Booked'));
+    // The second row still has its actions: a status change must not sweep the
+    // whole list.
+    expect(screen.getAllByRole('button', { name: 'Mark booked' })).toHaveLength(1);
+    expect(container.textContent).toContain('Mila');
+  });
+
+  it('ignores a second click while an update is in flight', async () => {
+    let release: () => void = () => {};
+    setStatusMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    );
+    await renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark booked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mark booked' }));
+
+    expect(setStatusMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release();
+    });
+  });
+
+  it('reports a failed update without moving the row', async () => {
+    setStatusMock.mockRejectedValue(new Error('500'));
+    await renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark booked' }));
+
+    await waitFor(() =>
+      expect(notifyMock).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not update the request' })
+      )
+    );
+    expect(screen.getByRole('button', { name: 'Mark booked' })).toBeInTheDocument();
+  });
+
+  it('offers no actions on a row the practice already handled', async () => {
+    listMock.mockResolvedValue([request({ status: 'DECLINED' })]);
+    const container = await renderSection();
+
+    expect(container.textContent).toContain('Declined');
+    expect(screen.queryByRole('button', { name: 'Mark booked' })).not.toBeInTheDocument();
+  });
+
+  it('tolerates a request with no phone and no reason', async () => {
+    listMock.mockResolvedValue([request({ ownerPhone: null, concern: null })]);
+    const container = await renderSection();
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Sam Owner · sam@example.com');
+    expect(text).not.toContain('+49 30 1234');
+    expect(text).not.toContain('Limping');
+  });
+
+  it('shows an unparseable date as given rather than as Invalid Date', async () => {
+    listMock.mockResolvedValue([request({ requestedStart: 'not-a-date' })]);
+    const container = await renderSection();
+
+    expect(container.textContent).toContain('not-a-date');
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -4,16 +4,23 @@ import '@testing-library/jest-dom';
 
 const notifyMock = jest.fn();
 const loadCatalogMock = jest.fn().mockResolvedValue(undefined);
+const loadSpecialityCatalogMock = jest.fn().mockResolvedValue(undefined);
 const getConfigMock = jest.fn();
 const saveConfigMock = jest.fn();
 
 let servicesState: any[] = [];
+let specialitiesState: any[] = [];
 let primaryOrgId: string | null = 'org-1';
 let primaryOrg: any = null;
 
 jest.mock('@/app/stores/revampCatalogStore', () => ({
   useRevampCatalogStore: (selector: any) =>
-    selector({ services: servicesState, loadOrganisationCatalog: loadCatalogMock }),
+    selector({
+      services: servicesState,
+      specialities: specialitiesState,
+      loadOrganisationCatalog: loadCatalogMock,
+      loadSpecialityCatalog: loadSpecialityCatalogMock,
+    }),
 }));
 
 jest.mock('@/app/stores/orgStore', () => ({
@@ -103,6 +110,7 @@ describe('PublicBookingSetup', () => {
     jest.clearAllMocks();
     primaryOrgId = 'org-1';
     primaryOrg = { name: 'Alpenblick Animal Clinic', imageURL: 'https://x/logo.png' };
+    specialitiesState = [{ id: 'spec-1', organisationId: 'org-1', name: 'General Practice' }];
     getConfigMock.mockResolvedValue(config());
     saveConfigMock.mockResolvedValue(config({ slug: 'alpenblick-animal-clinic' }));
     servicesState = [
@@ -159,6 +167,32 @@ describe('PublicBookingSetup', () => {
     expect(first).toHaveAttribute('aria-pressed', 'false');
     fireEvent.click(first);
     expect(first).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('loads the services for every speciality, not just the speciality list', async () => {
+    specialitiesState = [
+      { id: 'spec-1', organisationId: 'org-1', name: 'General Practice' },
+      { id: 'spec-2', organisationId: 'org-1', name: 'Dentistry' },
+      // Another practice's speciality must not be fetched.
+      { id: 'spec-9', organisationId: 'org-other', name: 'Elsewhere' },
+    ];
+    await renderSetup();
+
+    expect(loadSpecialityCatalogMock).toHaveBeenCalledWith('org-1', 'spec-1');
+    expect(loadSpecialityCatalogMock).toHaveBeenCalledWith('org-1', 'spec-2');
+    expect(loadSpecialityCatalogMock).not.toHaveBeenCalledWith('org-1', 'spec-9');
+  });
+
+  it('swallows a speciality load failure', async () => {
+    loadSpecialityCatalogMock.mockRejectedValueOnce(new Error('offline'));
+    await renderSetup();
+    expect(screen.getByText('What can pet parents book?')).toBeInTheDocument();
+  });
+
+  it('does not fetch speciality services without a primary org', async () => {
+    primaryOrgId = null;
+    await renderSetup();
+    expect(loadSpecialityCatalogMock).not.toHaveBeenCalled();
   });
 
   it('renders an empty state when no services are bookable', async () => {

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -72,6 +72,7 @@ const svc = (over: Partial<Record<string, unknown>> = {}) => ({
 
 const config = (over: Partial<Record<string, unknown>> = {}) => ({
   organisationId: 'org-1',
+  configured: false,
   slug: null,
   publicBookingEnabled: false,
   publicUrl: null,
@@ -289,10 +290,31 @@ describe('PublicBookingSetup', () => {
     expect(screen.queryByText('late-arrival')).not.toBeInTheDocument();
   });
 
+  it('ignores a configuration failure that arrives after unmount', async () => {
+    let fail: (reason: unknown) => void = () => {};
+    getConfigMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        fail = reject;
+      })
+    );
+    const { unmount } = render(<PublicBookingSetup />);
+    unmount();
+
+    await act(async () => {
+      fail(new Error('offline'));
+    });
+
+    // No alert can be rendered, and no state update is attempted on an
+    // unmounted tree.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   describe('booking address', () => {
     it('never renders a book.yosemitecrew.com address', async () => {
       await goToBranding();
-      expect(screen.queryByText(/book\.yosemitecrew\.com/)).not.toBeInTheDocument();
+      // Substring on the rendered text, not a regex: this asserts the absence of
+      // a host, and an unanchored host regex is exactly what CodeQL flags.
+      expect(document.body.textContent).not.toContain('book.yosemitecrew.com');
     });
 
     it('says no address exists yet before the first save', async () => {
@@ -408,7 +430,7 @@ describe('PublicBookingSetup', () => {
     });
 
     it('restores a stored service selection instead of selecting everything', async () => {
-      getConfigMock.mockResolvedValue(config({ serviceIds: ['s2'] }));
+      getConfigMock.mockResolvedValue(config({ configured: true, serviceIds: ['s2'] }));
       await renderSetup();
 
       await waitFor(() =>
@@ -429,6 +451,96 @@ describe('PublicBookingSetup', () => {
 
       expect(screen.getByText('Reserved when you save')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('selection semantics', () => {
+    it('honours a deliberate empty selection instead of re-selecting everything', async () => {
+      getConfigMock.mockResolvedValue(config({ configured: true, serviceIds: [] }));
+      await renderSetup();
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Wellness & vaccination/ })).toHaveAttribute(
+          'aria-pressed',
+          'false'
+        )
+      );
+      expect(screen.getByRole('button', { name: /Sick visit/ })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+
+    it('still selects everything for a practice that has never saved', async () => {
+      getConfigMock.mockResolvedValue(config({ configured: false, serviceIds: [] }));
+      await renderSetup();
+
+      expect(screen.getByRole('button', { name: /Wellness & vaccination/ })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+    });
+
+    it('builds the first toggle on the stored selection, not on every bookable service', async () => {
+      getConfigMock.mockResolvedValue(config({ configured: true, serviceIds: ['s2'] }));
+      await renderSetup();
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Sick visit/ })).toHaveAttribute(
+          'aria-pressed',
+          'true'
+        )
+      );
+
+      // Deselecting the only stored service must leave nothing selected, not
+      // flip every other service on.
+      fireEvent.click(screen.getByRole('button', { name: /Sick visit/ }));
+
+      expect(screen.getByRole('button', { name: /Sick visit/ })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+      expect(screen.getByRole('button', { name: /Wellness & vaccination/ })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+
+    it('drops a stored service that is no longer bookable', async () => {
+      getConfigMock.mockResolvedValue(
+        config({ configured: true, serviceIds: ['s1', 'archived-since'] })
+      );
+      await renderSetup();
+      fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() => expect(saveConfigMock).toHaveBeenCalled());
+      // Without the filter the API rejects the whole payload and the practice
+      // can never save again, because there is no row to deselect it with.
+      expect(saveConfigMock.mock.calls[0][1].serviceIds).toEqual(['s1']);
+    });
+  });
+
+  describe('configuration load failure', () => {
+    it('says the shown values are defaults and refuses to save over stored settings', async () => {
+      getConfigMock.mockRejectedValue(new Error('offline'));
+      await goToBranding();
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /could not load your current booking setup/i
+      );
+      const save = screen.getByRole('button', { name: /Save booking setup/ });
+      expect(save).toBeDisabled();
+
+      fireEvent.click(save);
+      expect(saveConfigMock).not.toHaveBeenCalled();
+    });
+
+    it('shows no alert and allows saving once the configuration loads', async () => {
+      await goToBranding();
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Save booking setup/ })).toBeEnabled();
     });
   });
 

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -573,6 +573,9 @@ describe('PublicBookingSetup', () => {
         autoConfirm: true,
         welcomeMessage: 'Come and see us',
         replyToEmail: 'desk@x.vet',
+        // Unchanged: the practice did not touch the publish switch, so the save
+        // carries whatever was already stored.
+        publicBookingEnabled: false,
       });
     });
 
@@ -599,7 +602,7 @@ describe('PublicBookingSetup', () => {
           'success',
           expect.objectContaining({
             title: 'Booking setup saved',
-            text: expect.stringContaining('not open to pet parents yet'),
+            text: expect.stringContaining('closed to pet parents until you open it'),
           })
         )
       );
@@ -618,6 +621,56 @@ describe('PublicBookingSetup', () => {
           'success',
           expect.objectContaining({ text: expect.stringContaining('live at the address above') })
         )
+      );
+    });
+
+    it('publishes the page when the practice opens it', async () => {
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Open my booking page' }));
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() => expect(saveConfigMock).toHaveBeenCalled());
+      expect(saveConfigMock.mock.calls[0][1].publicBookingEnabled).toBe(true);
+    });
+
+    it('refuses to offer publishing with nothing bookable', async () => {
+      servicesState = [];
+      await goToBranding();
+
+      const toggle = screen.getByRole('switch', { name: 'Open my booking page' });
+      expect(toggle).toBeDisabled();
+      expect(screen.getByText(/Mark at least one service bookable first/)).toBeInTheDocument();
+    });
+
+    it('says so when publishing succeeded but the environment has no public address', async () => {
+      saveConfigMock.mockResolvedValue(
+        config({ configured: true, publicBookingEnabled: true, publicUrl: null })
+      );
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Open my booking page' }));
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() =>
+        expect(notifyMock).toHaveBeenCalledWith(
+          'success',
+          expect.objectContaining({
+            text: expect.stringContaining('no public address is configured'),
+          })
+        )
+      );
+    });
+
+    it('reflects a practice that is already published', async () => {
+      getConfigMock.mockResolvedValue(
+        config({ configured: true, publicBookingEnabled: true, publicUrl: 'https://a/book/x' })
+      );
+      await goToBranding();
+
+      expect(screen.getByRole('switch', { name: 'Open my booking page' })).toHaveAttribute(
+        'aria-checked',
+        'true'
       );
     });
 

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 const notifyMock = jest.fn();
 const loadCatalogMock = jest.fn().mockResolvedValue(undefined);
+const getConfigMock = jest.fn();
+const saveConfigMock = jest.fn();
 
 let servicesState: any[] = [];
 let primaryOrgId: string | null = 'org-1';
@@ -26,6 +28,13 @@ jest.mock('@/app/hooks/useNotify', () => ({
   useNotify: () => ({ notify: notifyMock }),
 }));
 
+jest.mock('@/app/features/onboarding/services/bookingPageApiService', () => ({
+  bookingPageApi: {
+    getConfig: (...args: unknown[]) => getConfigMock(...args),
+    saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+  },
+}));
+
 jest.mock('next/image', () => {
   const MockImage = ({ alt }: any) => <span data-testid="next-image">{alt}</span>;
   MockImage.displayName = 'MockNextImage';
@@ -33,17 +42,15 @@ jest.mock('next/image', () => {
 });
 
 jest.mock('react-icons/io5', () => ({
-  IoAlertCircleOutline: () => <span data-testid="i-alert" />,
   IoArrowBack: () => <span data-testid="i-back" />,
   IoArrowForward: () => <span data-testid="i-fwd" />,
   IoCheckmark: () => <span data-testid="i-check" />,
   IoCopyOutline: () => <span data-testid="i-copy" />,
   IoGlobeOutline: () => <span data-testid="i-globe" />,
-  IoRocketOutline: () => <span data-testid="i-rocket" />,
+  IoSaveOutline: () => <span data-testid="i-save" />,
 }));
 
 import PublicBookingSetup from '@/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup';
-import { slugify } from '@/app/features/onboarding/pages/PublicBookingSetup/publicBookingSetup.utils';
 
 const svc = (over: Partial<Record<string, unknown>> = {}) => ({
   id: 's1',
@@ -56,6 +63,20 @@ const svc = (over: Partial<Record<string, unknown>> = {}) => ({
   ...over,
 });
 
+const config = (over: Partial<Record<string, unknown>> = {}) => ({
+  organisationId: 'org-1',
+  slug: null,
+  publicBookingEnabled: false,
+  publicUrl: null,
+  serviceIds: [],
+  bookingWindowDays: 28,
+  bufferMinutes: 10,
+  autoConfirm: false,
+  welcomeMessage: null,
+  replyToEmail: null,
+  ...over,
+});
+
 const setClipboard = (writeText: ((v: string) => Promise<void>) | undefined) => {
   Object.defineProperty(globalThis.navigator, 'clipboard', {
     value: writeText ? { writeText } : undefined,
@@ -64,11 +85,26 @@ const setClipboard = (writeText: ((v: string) => Promise<void>) | undefined) => 
   });
 };
 
+// The page loads its configuration in an effect, so every test has to let that
+// promise settle before asserting - otherwise the resolution lands after the
+// test body and React reports an unwrapped state update.
+const renderSetup = async () => {
+  render(<PublicBookingSetup />);
+  await act(async () => {});
+};
+
+const goToBranding = async () => {
+  await renderSetup();
+  fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+};
+
 describe('PublicBookingSetup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     primaryOrgId = 'org-1';
     primaryOrg = { name: 'Alpenblick Animal Clinic', imageURL: 'https://x/logo.png' };
+    getConfigMock.mockResolvedValue(config());
+    saveConfigMock.mockResolvedValue(config({ slug: 'alpenblick-animal-clinic' }));
     servicesState = [
       svc(),
       svc({ id: 's2', name: 'Sick visit', grossAmount: 72, currency: 'USD' }),
@@ -81,16 +117,8 @@ describe('PublicBookingSetup', () => {
 
   afterEach(() => setClipboard(undefined));
 
-  describe('slugify', () => {
-    it('slugifies names and falls back to a default', () => {
-      expect(slugify('Alpenblick Animal Clinic')).toBe('alpenblick-animal-clinic');
-      expect(slugify('!!!')).toBe('your-clinic');
-      expect(slugify('')).toBe('your-clinic');
-    });
-  });
-
-  it('loads the catalog and lists only bookable, active services with formatted prices', () => {
-    render(<PublicBookingSetup />);
+  it('loads the catalog and lists only bookable, active services with formatted prices', async () => {
+    await renderSetup();
 
     expect(loadCatalogMock).toHaveBeenCalledWith('org-1');
     expect(screen.getByText('What can pet parents book?')).toBeInTheDocument();
@@ -100,13 +128,17 @@ describe('PublicBookingSetup', () => {
     expect(screen.getByText('€10.00')).toBeInTheDocument();
     expect(screen.queryByText('Archived one')).not.toBeInTheDocument();
     expect(screen.queryByText('Not bookable')).not.toBeInTheDocument();
-    expect(screen.getByText('FIELDS ASSUMED · confirm with product')).toBeInTheDocument();
     // The wizard header carries the Yosemite Crew product mark, not an org initial.
     expect(screen.getAllByTestId('next-image')[0]).toHaveTextContent('Yosemite Crew');
   });
 
-  it('gives the selected service row the blue border and focus-glow ring', () => {
-    render(<PublicBookingSetup />);
+  it('no longer claims the fields are assumed', async () => {
+    await renderSetup();
+    expect(screen.queryByText(/FIELDS ASSUMED/)).not.toBeInTheDocument();
+  });
+
+  it('gives the selected service row the blue border and focus-glow ring', async () => {
+    await renderSetup();
 
     const first = screen.getByRole('button', { name: /Wellness & vaccination/ });
     expect(first).toHaveStyle({
@@ -118,8 +150,8 @@ describe('PublicBookingSetup', () => {
     expect(first).toHaveStyle({ borderColor: 'var(--hairline)' });
   });
 
-  it('seeds every service as selected and toggles selection', () => {
-    render(<PublicBookingSetup />);
+  it('seeds every service as selected and toggles selection', async () => {
+    await renderSetup();
 
     const first = screen.getByRole('button', { name: /Wellness & vaccination/ });
     expect(first).toHaveAttribute('aria-pressed', 'true');
@@ -129,35 +161,36 @@ describe('PublicBookingSetup', () => {
     expect(first).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('renders an empty state when no services are bookable', () => {
+  it('renders an empty state when no services are bookable', async () => {
     servicesState = [];
-    render(<PublicBookingSetup />);
+    await renderSetup();
     expect(screen.getByText(/No bookable services yet/)).toBeInTheDocument();
   });
 
-  it('does not load the catalog without a primary org', () => {
+  it('does not load the catalog or the configuration without a primary org', async () => {
     primaryOrgId = null;
-    render(<PublicBookingSetup />);
+    await renderSetup();
     expect(loadCatalogMock).not.toHaveBeenCalled();
+    expect(getConfigMock).not.toHaveBeenCalled();
   });
 
   it('swallows a catalog load failure', async () => {
     loadCatalogMock.mockRejectedValueOnce(new Error('offline'));
-    render(<PublicBookingSetup />);
+    await renderSetup();
     await waitFor(() => expect(loadCatalogMock).toHaveBeenCalledWith('org-1'));
     expect(screen.getByText('What can pet parents book?')).toBeInTheDocument();
   });
 
-  it('updates availability selects and the confirmation toggle', () => {
-    render(<PublicBookingSetup />);
+  it('updates availability selects and the confirmation toggle', async () => {
+    await renderSetup();
 
     const windowSelect = screen.getByLabelText('Bookable window') as HTMLSelectElement;
-    fireEvent.change(windowSelect, { target: { value: 'Up to 8 weeks ahead' } });
-    expect(windowSelect.value).toBe('Up to 8 weeks ahead');
+    fireEvent.change(windowSelect, { target: { value: '56' } });
+    expect(windowSelect.value).toBe('56');
 
     const bufferSelect = screen.getByLabelText('Buffer between visits') as HTMLSelectElement;
-    fireEvent.change(bufferSelect, { target: { value: '30 minutes' } });
-    expect(bufferSelect.value).toBe('30 minutes');
+    fireEvent.change(bufferSelect, { target: { value: '30' } });
+    expect(bufferSelect.value).toBe('30');
 
     const toggle = screen.getByRole('switch', { name: 'Requests need confirmation' });
     expect(toggle).toHaveAttribute('aria-checked', 'true');
@@ -165,8 +198,8 @@ describe('PublicBookingSetup', () => {
     expect(toggle).toHaveAttribute('aria-checked', 'false');
   });
 
-  it('notifies when skipping setup', () => {
-    render(<PublicBookingSetup />);
+  it('notifies when skipping setup', async () => {
+    await renderSetup();
     fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
     expect(notifyMock).toHaveBeenCalledWith(
       'info',
@@ -174,12 +207,10 @@ describe('PublicBookingSetup', () => {
     );
   });
 
-  it('advances to branding, edits copy, and returns via back', () => {
-    render(<PublicBookingSetup />);
-    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+  it('advances to branding, edits copy, and returns via back', async () => {
+    await goToBranding();
 
     expect(screen.getByText('Your booking page')).toBeInTheDocument();
-    expect(screen.getByText('book.yosemitecrew.com/alpenblick-animal-clinic')).toBeInTheDocument();
 
     const welcome = screen.getByLabelText('Welcome message') as HTMLInputElement;
     fireEvent.change(welcome, { target: { value: 'Welcome to us' } });
@@ -199,49 +230,300 @@ describe('PublicBookingSetup', () => {
     expect(screen.getByText('What can pet parents book?')).toBeInTheDocument();
   });
 
-  it('copies the public URL and handles a missing clipboard', async () => {
-    const writeText = jest.fn().mockResolvedValue(undefined);
-    setClipboard(writeText);
-    render(<PublicBookingSetup />);
-    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-
-    fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /Copied/ })).toBeInTheDocument());
-    expect(writeText).toHaveBeenCalledWith('book.yosemitecrew.com/alpenblick-animal-clinic');
-  });
-
-  it('degrades gracefully when the clipboard is unavailable', async () => {
-    setClipboard(undefined);
-    render(<PublicBookingSetup />);
-    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-
-    fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
-    await waitFor(() => expect(loadCatalogMock).toHaveBeenCalled());
-    expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
-  });
-
-  it('degrades gracefully when the clipboard write rejects', async () => {
-    const writeText = jest.fn().mockRejectedValue(new Error('blocked'));
-    setClipboard(writeText);
-    render(<PublicBookingSetup />);
-    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
-
-    fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
-    await waitFor(() => expect(writeText).toHaveBeenCalled());
-    expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
-  });
-
-  it('notifies on go live and falls back to a default clinic slug', () => {
+  it('falls back to a generic clinic name when no org is loaded', async () => {
     primaryOrg = null;
-    render(<PublicBookingSetup />);
-    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    await goToBranding();
 
-    expect(screen.getByText('book.yosemitecrew.com/your-clinic')).toBeInTheDocument();
+    expect(screen.getByText('Your clinic')).toBeInTheDocument();
+    expect(screen.getByText('No logo uploaded')).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /Go live/ }));
-    expect(notifyMock).toHaveBeenCalledWith(
-      'info',
-      expect.objectContaining({ title: 'Booking setup saved for review' })
+  it('discards a configuration that arrives after unmount', async () => {
+    let release: (value: unknown) => void = () => {};
+    getConfigMock.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
     );
+    const { unmount } = render(<PublicBookingSetup />);
+    unmount();
+
+    await act(async () => {
+      release(config({ slug: 'late-arrival' }));
+    });
+
+    expect(screen.queryByText('late-arrival')).not.toBeInTheDocument();
+  });
+
+  describe('booking address', () => {
+    it('never renders a book.yosemitecrew.com address', async () => {
+      await goToBranding();
+      expect(screen.queryByText(/book\.yosemitecrew\.com/)).not.toBeInTheDocument();
+    });
+
+    it('says no address exists yet before the first save', async () => {
+      await goToBranding();
+
+      expect(screen.getByText('Reserved when you save')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
+    });
+
+    it('shows the reserved slug without a copy button while the page is not live', async () => {
+      getConfigMock.mockResolvedValue(config({ slug: 'alpenblick-animal-clinic' }));
+      await goToBranding();
+
+      expect(screen.getByText('alpenblick-animal-clinic')).toBeInTheDocument();
+      expect(screen.getByText(/not live yet, so there is no link to share/)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
+    });
+
+    it('shows the real address with a copy button once the API reports one', async () => {
+      getConfigMock.mockResolvedValue(
+        config({
+          slug: 'alpenblick-animal-clinic',
+          publicBookingEnabled: true,
+          publicUrl: 'https://app.example.com/book/alpenblick-animal-clinic',
+        })
+      );
+      await goToBranding();
+
+      expect(
+        screen.getByText('https://app.example.com/book/alpenblick-animal-clinic')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
+    });
+
+    it('copies the address the API supplied', async () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      setClipboard(writeText);
+      getConfigMock.mockResolvedValue(
+        config({
+          slug: 'alpenblick-animal-clinic',
+          publicBookingEnabled: true,
+          publicUrl: 'https://app.example.com/book/alpenblick-animal-clinic',
+        })
+      );
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Copied/ })).toBeInTheDocument()
+      );
+      expect(writeText).toHaveBeenCalledWith(
+        'https://app.example.com/book/alpenblick-animal-clinic'
+      );
+    });
+
+    it('degrades gracefully when the clipboard is unavailable', async () => {
+      setClipboard(undefined);
+      getConfigMock.mockResolvedValue(
+        config({ slug: 'x', publicBookingEnabled: true, publicUrl: 'https://a/book/x' })
+      );
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
+      await waitFor(() => expect(loadCatalogMock).toHaveBeenCalled());
+      expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
+    });
+
+    it('degrades gracefully when the clipboard write rejects', async () => {
+      const writeText = jest.fn().mockRejectedValue(new Error('blocked'));
+      setClipboard(writeText);
+      getConfigMock.mockResolvedValue(
+        config({ slug: 'x', publicBookingEnabled: true, publicUrl: 'https://a/book/x' })
+      );
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Copy/ }));
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
+    });
+  });
+
+  describe('loading stored configuration', () => {
+    it('restores the saved window, buffer, confirmation mode and copy', async () => {
+      getConfigMock.mockResolvedValue(
+        config({
+          bookingWindowDays: 56,
+          bufferMinutes: 30,
+          autoConfirm: true,
+          welcomeMessage: 'Stored welcome',
+          replyToEmail: 'stored@example.com',
+        })
+      );
+      await renderSetup();
+
+      await waitFor(() =>
+        expect((screen.getByLabelText('Bookable window') as HTMLSelectElement).value).toBe('56')
+      );
+      expect((screen.getByLabelText('Buffer between visits') as HTMLSelectElement).value).toBe(
+        '30'
+      );
+      expect(screen.getByRole('switch', { name: 'Requests need confirmation' })).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+      expect((screen.getByLabelText('Welcome message') as HTMLInputElement).value).toBe(
+        'Stored welcome'
+      );
+      expect((screen.getByLabelText('Confirmation email reply-to') as HTMLInputElement).value).toBe(
+        'stored@example.com'
+      );
+    });
+
+    it('restores a stored service selection instead of selecting everything', async () => {
+      getConfigMock.mockResolvedValue(config({ serviceIds: ['s2'] }));
+      await renderSetup();
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Wellness & vaccination/ })).toHaveAttribute(
+          'aria-pressed',
+          'false'
+        )
+      );
+      expect(screen.getByRole('button', { name: /Sick visit/ })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+    });
+
+    it('falls back to defaults and shows no address when the load fails', async () => {
+      getConfigMock.mockRejectedValue(new Error('offline'));
+      await goToBranding();
+
+      expect(screen.getByText('Reserved when you save')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('saving', () => {
+    it('sends the selected services and settings to the API', async () => {
+      await renderSetup();
+      await waitFor(() => expect(getConfigMock).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByRole('button', { name: /Wellness & vaccination/ }));
+      fireEvent.change(screen.getByLabelText('Bookable window'), { target: { value: '14' } });
+      fireEvent.change(screen.getByLabelText('Buffer between visits'), { target: { value: '0' } });
+      fireEvent.click(screen.getByRole('switch', { name: 'Requests need confirmation' }));
+      fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+      fireEvent.change(screen.getByLabelText('Welcome message'), {
+        target: { value: '  Come and see us  ' },
+      });
+      fireEvent.change(screen.getByLabelText('Confirmation email reply-to'), {
+        target: { value: 'desk@x.vet' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() => expect(saveConfigMock).toHaveBeenCalled());
+      const [orgId, payload] = saveConfigMock.mock.calls[0];
+      expect(orgId).toBe('org-1');
+      expect(payload).toEqual({
+        serviceIds: expect.not.arrayContaining(['s1']),
+        bookingWindowDays: 14,
+        bufferMinutes: 0,
+        autoConfirm: true,
+        welcomeMessage: 'Come and see us',
+        replyToEmail: 'desk@x.vet',
+      });
+    });
+
+    it('sends blank optional text as null', async () => {
+      await goToBranding();
+
+      fireEvent.change(screen.getByLabelText('Welcome message'), { target: { value: '   ' } });
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() => expect(saveConfigMock).toHaveBeenCalled());
+      expect(saveConfigMock.mock.calls[0][1]).toMatchObject({
+        welcomeMessage: null,
+        replyToEmail: null,
+      });
+    });
+
+    it('tells the practice the page is not open yet when the API reports no address', async () => {
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() =>
+        expect(notifyMock).toHaveBeenCalledWith(
+          'success',
+          expect.objectContaining({
+            title: 'Booking setup saved',
+            text: expect.stringContaining('not open to pet parents yet'),
+          })
+        )
+      );
+    });
+
+    it('tells the practice the page is live when the API returns an address', async () => {
+      saveConfigMock.mockResolvedValue(
+        config({ slug: 'x', publicBookingEnabled: true, publicUrl: 'https://a/book/x' })
+      );
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() =>
+        expect(notifyMock).toHaveBeenCalledWith(
+          'success',
+          expect.objectContaining({ text: expect.stringContaining('live at the address above') })
+        )
+      );
+    });
+
+    it('reports a save failure without claiming anything was stored', async () => {
+      saveConfigMock.mockRejectedValue(new Error('500'));
+      await goToBranding();
+
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() =>
+        expect(notifyMock).toHaveBeenCalledWith(
+          'error',
+          expect.objectContaining({
+            title: 'Could not save booking setup',
+            text: expect.stringContaining('Nothing was changed'),
+          })
+        )
+      );
+    });
+
+    it('disables the button while a save is in flight', async () => {
+      let release: (value: unknown) => void = () => {};
+      saveConfigMock.mockReturnValue(
+        new Promise((resolve) => {
+          release = resolve;
+        })
+      );
+      await goToBranding();
+
+      const button = screen.getByRole('button', { name: /Save booking setup/ });
+      fireEvent.click(button);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: /Saving/ })).toBeDisabled());
+
+      // A second click while in flight must not fire a second request.
+      fireEvent.click(screen.getByRole('button', { name: /Saving/ }));
+      expect(saveConfigMock).toHaveBeenCalledTimes(1);
+
+      release(config());
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Save booking setup/ })).toBeEnabled()
+      );
+    });
+
+    it('does nothing without a primary org', async () => {
+      primaryOrgId = null;
+      await renderSetup();
+      fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+      fireEvent.click(screen.getByRole('button', { name: /Save booking setup/ }));
+
+      await waitFor(() => expect(screen.getByText('Your booking page')).toBeInTheDocument());
+      expect(saveConfigMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
@@ -24,6 +24,7 @@ const asResponse = <T>(data: T): AxiosResponse<T> =>
 
 const config: BookingPageConfig = {
   organisationId: 'org-1',
+  configured: true,
   slug: 'park-veterinary',
   publicBookingEnabled: false,
   publicUrl: null,

--- a/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
@@ -1,0 +1,81 @@
+import { getData, putData } from '@/app/services/axios';
+import {
+  bookingPageApi,
+  type BookingPageConfig,
+} from '@/app/features/onboarding/services/bookingPageApiService';
+import type { AxiosResponse } from 'axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  putData: jest.fn(),
+}));
+
+const mockGetData = getData as jest.MockedFunction<typeof getData>;
+const mockPutData = putData as jest.MockedFunction<typeof putData>;
+
+const asResponse = <T>(data: T): AxiosResponse<T> =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  }) as AxiosResponse<T>;
+
+const config: BookingPageConfig = {
+  organisationId: 'org-1',
+  slug: 'park-veterinary',
+  publicBookingEnabled: false,
+  publicUrl: null,
+  serviceIds: ['svc-1'],
+  bookingWindowDays: 28,
+  bufferMinutes: 10,
+  autoConfirm: false,
+  welcomeMessage: null,
+  replyToEmail: null,
+};
+
+describe('bookingPageApi', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reads the configuration from the org-scoped endpoint', async () => {
+    mockGetData.mockResolvedValueOnce(asResponse({ data: config }));
+
+    await expect(bookingPageApi.getConfig('org-1')).resolves.toEqual(config);
+    expect(mockGetData).toHaveBeenCalledWith('/v1/booking-page/org-1');
+  });
+
+  it('writes the configuration to the org-scoped endpoint', async () => {
+    mockPutData.mockResolvedValueOnce(asResponse({ data: config }));
+    const payload = {
+      serviceIds: ['svc-1'],
+      bookingWindowDays: 28,
+      bufferMinutes: 10,
+      autoConfirm: false,
+      welcomeMessage: 'Hello',
+      replyToEmail: 'desk@example.com',
+    };
+
+    await expect(bookingPageApi.saveConfig('org-1', payload)).resolves.toEqual(config);
+    expect(mockPutData).toHaveBeenCalledWith('/v1/booking-page/org-1', payload);
+  });
+
+  it('surfaces a read failure to the caller rather than swallowing it', async () => {
+    mockGetData.mockRejectedValueOnce(new Error('network'));
+    await expect(bookingPageApi.getConfig('org-1')).rejects.toThrow('network');
+  });
+
+  it('surfaces a write failure to the caller rather than swallowing it', async () => {
+    mockPutData.mockRejectedValueOnce(new Error('403'));
+    await expect(
+      bookingPageApi.saveConfig('org-1', {
+        serviceIds: [],
+        bookingWindowDays: 28,
+        bufferMinutes: 10,
+        autoConfirm: false,
+        welcomeMessage: null,
+        replyToEmail: null,
+      })
+    ).rejects.toThrow('403');
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/bookingRequestsApiService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/bookingRequestsApiService.test.ts
@@ -1,0 +1,40 @@
+import { getData, patchData } from '@/app/services/axios';
+import { bookingRequestsApi } from '@/app/features/organization/services/bookingRequestsApiService';
+import type { AxiosResponse } from 'axios';
+
+jest.mock('@/app/services/axios', () => ({ getData: jest.fn(), patchData: jest.fn() }));
+
+const mockGetData = getData as jest.MockedFunction<typeof getData>;
+const mockPatchData = patchData as jest.MockedFunction<typeof patchData>;
+
+const asResponse = <T>(data: T): AxiosResponse<T> =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} }) as AxiosResponse<T>;
+
+describe('bookingRequestsApi', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('lists requests from the org-scoped endpoint', async () => {
+    mockGetData.mockResolvedValueOnce(asResponse({ data: [] }));
+
+    await expect(bookingRequestsApi.list('org-1')).resolves.toEqual([]);
+    expect(mockGetData).toHaveBeenCalledWith('/v1/booking-page/org-1/requests');
+  });
+
+  it('patches a status on the org-scoped endpoint', async () => {
+    mockPatchData.mockResolvedValueOnce(asResponse({}));
+
+    await bookingRequestsApi.setStatus('org-1', 'req-1', 'BOOKED');
+
+    expect(mockPatchData).toHaveBeenCalledWith('/v1/booking-page/org-1/requests/req-1', {
+      status: 'BOOKED',
+    });
+  });
+
+  it('surfaces failures rather than swallowing them', async () => {
+    mockGetData.mockRejectedValueOnce(new Error('403'));
+    await expect(bookingRequestsApi.list('org-1')).rejects.toThrow('403');
+
+    mockPatchData.mockRejectedValueOnce(new Error('404'));
+    await expect(bookingRequestsApi.setStatus('org-1', 'req-1', 'DECLINED')).rejects.toThrow('404');
+  });
+});

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -5,6 +5,10 @@ import type { Organisation } from '@yosemite-crew/types';
 import type { ServiceRevamp, SpecialityRevamp } from '@/app/features/organization/types/revamp';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import {
+  bookingPageApi,
+  type BookingPageConfig,
+} from '@/app/features/onboarding/services/bookingPageApiService';
 import PublicBookingSetup from './PublicBookingSetup';
 
 const ORG_ID = 'org-storybook-avenger-park';
@@ -60,6 +64,20 @@ const SERVICES: ServiceRevamp[] = [
   service({ id: 'svc-5', code: 'GP-099', name: 'Retired nail trim', status: 'ARCHIVED' }),
 ];
 
+const config = (over: Partial<BookingPageConfig> = {}): BookingPageConfig => ({
+  organisationId: ORG_ID,
+  slug: null,
+  publicBookingEnabled: false,
+  publicUrl: null,
+  serviceIds: [],
+  bookingWindowDays: 28,
+  bufferMinutes: 10,
+  autoConfirm: false,
+  welcomeMessage: null,
+  replyToEmail: null,
+  ...over,
+});
+
 const SPECIALITY: SpecialityRevamp = {
   id: SPECIALITY_ID,
   name: 'General Practice',
@@ -74,9 +92,25 @@ const SPECIALITY: SpecialityRevamp = {
  * holds a speciality for this organisation, so seeding one keeps the mount off
  * the network with no service stub - the page under review is the real one.
  */
-const seed = (options: { services?: ServiceRevamp[]; imageURL?: string } = {}) => {
+const seed = (
+  options: {
+    services?: ServiceRevamp[];
+    imageURL?: string;
+    config?: BookingPageConfig;
+  } = {}
+) => {
   const previousOrg = useOrgStore.getState();
   const previousCatalog = useRevampCatalogStore.getState();
+  const previousGetConfig = bookingPageApi.getConfig;
+  const previousSaveConfig = bookingPageApi.saveConfig;
+
+  // The page reads its address from the API and never derives one, so a story
+  // has to supply the payload it would have received. Stubbing here keeps the
+  // preview iframe off the network and makes the unpublished/published split an
+  // explicit choice per story rather than a network accident.
+  const stubbed = options.config ?? config();
+  bookingPageApi.getConfig = async () => stubbed;
+  bookingPageApi.saveConfig = async () => stubbed;
 
   useOrgStore.setState({
     orgsById: { [ORG_ID]: { ...ORG, imageURL: options.imageURL } },
@@ -92,6 +126,8 @@ const seed = (options: { services?: ServiceRevamp[]; imageURL?: string } = {}) =
   return () => {
     useOrgStore.setState(previousOrg);
     useRevampCatalogStore.setState(previousCatalog);
+    bookingPageApi.getConfig = previousGetConfig;
+    bookingPageApi.saveConfig = previousSaveConfig;
   };
 };
 
@@ -111,14 +147,13 @@ const meta = {
       description: {
         component:
           'The two-pane online-booking setup card. Step 1 is what a reviewer sees by default; ' +
-          'step 2 - the whole **Branding & review** pane - only exists after Continue, and had ' +
-          'never been drawn anywhere.\n\n' +
-          'That is where all of the assumed-scope risk lives: the logo row with its Replace ' +
-          'action (not wired up), the welcome message, the confirmation-email reply-to, the live ' +
-          'preview card of the public booking page, and the public URL whose slug is derived from ' +
-          'the clinic name rather than stored anywhere. The amber `FIELDS ASSUMED · confirm with ' +
-          'product` pill in the page header is the standing warning that these fields are a ' +
-          'proposal, and step 2 is the half of the flow it is really about.\n\n' +
+          'step 2 - the whole **Branding & review** pane - only exists after Continue.\n\n' +
+          'Step 2 is where the booking address lives, and its three states are the thing to ' +
+          'review. The page never derives an address: it renders whatever `publicUrl` the API ' +
+          'sent, and the API sends null until the practice is genuinely reachable. So an ' +
+          'unpublished practice sees its reserved slug and a plain statement that there is no ' +
+          'link to share, with no Copy button, and only a live page gets a copyable URL. The ' +
+          'logo Replace action is still an unwired notify().\n\n' +
           'Selection is derived, not mirrored: every bookable service starts selected because ' +
           '`selected` falls back to the full id set until the user toggles something, so there is ' +
           'no effect syncing a checkbox list to the catalog.\n\n' +
@@ -139,8 +174,8 @@ export const ServicesStep: Story = {
   name: 'Step 1 - services & availability',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText('FIELDS ASSUMED · confirm with product')).toBeInTheDocument();
     await expect(canvas.getByText('of 2 · Services & availability')).toBeInTheDocument();
+    await expect(canvas.queryByText(/FIELDS ASSUMED/)).not.toBeInTheDocument();
 
     // Three of the five catalog rows: archived and non-bookable are filtered out.
     const rows = canvas.getAllByRole('button', { pressed: true });
@@ -151,12 +186,9 @@ export const ServicesStep: Story = {
     await expect(canvas.queryByText('Full mouth radiograph')).not.toBeInTheDocument();
     await expect(canvas.queryByText('Retired nail trim')).not.toBeInTheDocument();
 
-    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toHaveValue(
-      'Up to 4 weeks ahead'
-    );
-    await expect(canvas.getByRole('combobox', { name: 'Buffer between visits' })).toHaveValue(
-      '10 minutes'
-    );
+    // The selects carry the number the API stores, not the label.
+    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toHaveValue('28');
+    await expect(canvas.getByRole('combobox', { name: 'Buffer between visits' })).toHaveValue('10');
     await expect(canvas.getByRole('switch', { name: 'Requests need confirmation' })).toBeChecked();
 
     // The two selects share one `grid-cols-1 sm:grid-cols-2` row: two tracks and
@@ -234,11 +266,11 @@ export const BrandingStep: Story = {
     await expect(canvas.getByText('Avenger Park Veterinary')).toBeInTheDocument();
     await expect(canvas.getByText('Choose a service')).toBeInTheDocument();
 
-    // Slug is computed from the org name at render time - nothing stores it.
-    await expect(
-      canvas.getByText('book.yosemitecrew.com/avenger-park-veterinary')
-    ).toBeInTheDocument();
-    await expect(canvas.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    // Unpublished: no address has been allocated yet, and nothing offers to copy
+    // one. This is the state that used to render a dead book.yosemitecrew.com URL.
+    await expect(canvas.getByText('Reserved when you save')).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/book\.yosemitecrew\.com/)).not.toBeInTheDocument();
 
     // Fields left, preview right, side by side from `md` up - two children on
     // one row, which is what the phone story below reverses.
@@ -333,7 +365,7 @@ export const ServicesStepEmpty: Story = {
         story:
           'What a clinic sees before any service is marked bookable. The empty state is a single ' +
           'line of copy pointing at Organization → Specialities, and nothing stops Continue: the ' +
-          'branding pane and the Go live button are reachable with zero services attached, so the ' +
+          'branding pane and the save button are reachable with zero services attached, so the ' +
           'guard that should exist here does not.',
       },
     },
@@ -362,9 +394,7 @@ export const BrandingOnPhone: Story = {
     );
     await expect(within(preview).getByText('Preview')).toBeInTheDocument();
     await expect(within(preview).getByText('Avenger Park Veterinary')).toBeInTheDocument();
-    await expect(
-      canvas.getByText('book.yosemitecrew.com/avenger-park-veterinary')
-    ).toBeInTheDocument();
+    await expect(canvas.getByText('Reserved when you save')).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -373,6 +403,41 @@ export const BrandingOnPhone: Story = {
           'Step 2 at 375px. The `md:w-60` preview loses its fixed width and goes full-bleed under ' +
           'the three fields, which is the one place the preview stops reading as a phone-sized ' +
           'mock of the public page and starts reading as another card in the form.',
+      },
+    },
+  },
+};
+
+export const BrandingPublished: Story = {
+  name: 'Step 2 - published practice',
+  beforeEach: () =>
+    seed({
+      config: config({
+        slug: 'avenger-park-veterinary',
+        publicBookingEnabled: true,
+        publicUrl: 'https://dev.yosemitecrew.com/book/avenger-park-veterinary',
+        welcomeMessage: 'Book a visit for your companion at Avenger Park Veterinary.',
+      }),
+    }),
+  play: async ({ canvasElement }) => {
+    await goToBranding(canvasElement);
+    const canvas = within(canvasElement);
+
+    // The one state where an address is offered for copying: the API said the
+    // page is live, so the link is safe to paste onto a website.
+    await expect(
+      canvas.getByText('https://dev.yosemitecrew.com/book/avenger-park-veterinary')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    await expect(canvas.getByText(/Safe to share on your website/)).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The published state, and the only one with a Copy button. Compare it with the default ' +
+          'step 2 story: the difference between them is entirely driven by `publicUrl` coming ' +
+          'back non-null from the API, never by anything the page computes.',
       },
     },
   },

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -121,6 +121,10 @@ const seed = (
   useRevampCatalogStore.setState({
     services: options.services ?? SERVICES,
     specialities: [SPECIALITY],
+    // The page fans out to `loadSpecialityCatalog` for each speciality. Marking
+    // this one already loaded makes that call return at its first line, so the
+    // preview iframe stays off the network with the seeded services intact.
+    loadedSpecialityIds: [`${SPECIALITY_ID}:active`],
   });
 
   return () => {

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -66,6 +66,7 @@ const SERVICES: ServiceRevamp[] = [
 
 const config = (over: Partial<BookingPageConfig> = {}): BookingPageConfig => ({
   organisationId: ORG_ID,
+  configured: false,
   slug: null,
   publicBookingEnabled: false,
   publicUrl: null,
@@ -274,7 +275,7 @@ export const BrandingStep: Story = {
     // one. This is the state that used to render a dead book.yosemitecrew.com URL.
     await expect(canvas.getByText('Reserved when you save')).toBeInTheDocument();
     await expect(canvas.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
-    await expect(canvas.queryByText(/book\.yosemitecrew\.com/)).not.toBeInTheDocument();
+    await expect(canvasElement.textContent).not.toContain('book.yosemitecrew.com');
 
     // Fields left, preview right, side by side from `md` up - two children on
     // one row, which is what the phone story below reverses.

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -437,7 +437,9 @@ const PublicBookingSetup = () => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const primaryOrg = usePrimaryOrg();
   const services = useRevampCatalogStore((s) => s.services);
+  const specialities = useRevampCatalogStore((s) => s.specialities);
   const loadOrganisationCatalog = useRevampCatalogStore((s) => s.loadOrganisationCatalog);
+  const loadSpecialityCatalog = useRevampCatalogStore((s) => s.loadSpecialityCatalog);
 
   const orgName = primaryOrg?.name || 'Your clinic';
   const orgInitial = orgName.charAt(0).toUpperCase();
@@ -477,6 +479,21 @@ const PublicBookingSetup = () => {
       Promise.resolve(loadOrganisationCatalog(primaryOrgId)).catch(() => undefined);
     }
   }, [primaryOrgId, loadOrganisationCatalog]);
+
+  // `loadOrganisationCatalog` populates `specialities` and nothing else -
+  // services are fetched one speciality at a time by `loadSpecialityCatalog`.
+  // Without this fan-out `services` is permanently empty, so the bookable list
+  // below rendered "No bookable services yet" for every practice no matter what
+  // its catalogue contained. The store dedupes by in-flight promise and by
+  // `loadedSpecialityIds`, so re-running this effect is cheap.
+  useEffect(() => {
+    if (!primaryOrgId) return;
+    specialities
+      .filter((speciality) => speciality.organisationId === primaryOrgId)
+      .forEach((speciality) => {
+        Promise.resolve(loadSpecialityCatalog(primaryOrgId, speciality.id)).catch(() => undefined);
+      });
+  }, [primaryOrgId, specialities, loadSpecialityCatalog]);
 
   useEffect(() => {
     if (!primaryOrgId) return;

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -318,6 +318,7 @@ type BrandingStepProps = {
   onBack: () => void;
   onSave: () => void;
   saving: boolean;
+  loadFailed: boolean;
 };
 
 const BookingBrandingStep = ({
@@ -337,6 +338,7 @@ const BookingBrandingStep = ({
   onBack,
   onSave,
   saving,
+  loadFailed,
 }: BrandingStepProps) => (
   <>
     <SetupHeader step={step} label="of 2 · Branding & review" />
@@ -409,6 +411,17 @@ const BookingBrandingStep = ({
       </div>
 
       <BookingAddress slug={slug} publicUrl={publicUrl} copied={copied} onCopy={onCopy} />
+
+      {loadFailed ? (
+        <p
+          role="alert"
+          className="rounded-[14px] border border-[var(--warn-border)] bg-[var(--warn-bg)] px-3.5 py-3 text-[12.5px] text-[var(--warn-text)]"
+        >
+          We could not load your current booking setup, so what is shown here are defaults rather
+          than your settings. Saving is disabled to avoid overwriting them. Reload the page to try
+          again.
+        </p>
+      ) : null}
     </div>
     <div className="flex items-center justify-between gap-3 px-7! py-4! border-t border-[var(--hairline)]">
       <button
@@ -422,7 +435,7 @@ const BookingBrandingStep = ({
       <button
         type="button"
         onClick={onSave}
-        disabled={saving}
+        disabled={saving || loadFailed}
         className="inline-flex items-center gap-1.5 h-11 px-5 rounded-full bg-[var(--cta)] text-[var(--cta-text)] text-[13.5px] font-semibold disabled:opacity-60"
       >
         <IoSaveOutline size={15} />
@@ -464,13 +477,22 @@ const PublicBookingSetup = () => {
   const [replyTo, setReplyTo] = useState('');
   const [copied, setCopied] = useState(false);
   const [config, setConfig] = useState<BookingPageConfig | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  // A practice that has saved before gets its own selection back; one that has
-  // not gets every bookable service pre-selected.
+  // A practice that has saved before gets its own selection back, including a
+  // deliberate empty one; a practice that has never saved gets everything
+  // bookable pre-selected. `configured` is what separates those two, because
+  // both arrive as an empty `serviceIds`.
+  //
+  // Stored ids are intersected with what is currently bookable. A service that
+  // was archived after it was chosen no longer has a row to deselect it with,
+  // and the API rejects ids that are not active and bookable - so carrying it
+  // forward would leave the practice unable to save anything at all.
   const storedSelection = useMemo(
-    () => (config && config.serviceIds.length > 0 ? new Set(config.serviceIds) : null),
-    [config]
+    () =>
+      config?.configured ? new Set(config.serviceIds.filter((id) => allBookableIds.has(id))) : null,
+    [config, allBookableIds]
   );
   const selected = selectionOverride ?? storedSelection ?? allBookableIds;
 
@@ -503,6 +525,7 @@ const PublicBookingSetup = () => {
       .getConfig(primaryOrgId)
       .then((loaded) => {
         if (cancelled) return;
+        setLoadFailed(false);
         setConfig(loaded);
         setBookingWindowDays(loaded.bookingWindowDays);
         setBufferMinutes(loaded.bufferMinutes);
@@ -511,10 +534,15 @@ const PublicBookingSetup = () => {
         if (loaded.replyToEmail) setReplyTo(loaded.replyToEmail);
       })
       .catch(() => {
-        // A failed load leaves the form on its defaults. It must not leave a
-        // stale config behind, because `config` is what decides whether an
-        // address is shown at all.
-        if (!cancelled) setConfig(null);
+        // A failed load leaves the form on its defaults, which are NOT this
+        // practice's settings. Saving them would overwrite a stored selection
+        // with defaults the user never chose, turning a transient read outage
+        // into data loss - so record the failure and let it disable saving.
+        // `config` is also cleared, because it is what decides whether a
+        // booking address is shown at all.
+        if (cancelled) return;
+        setConfig(null);
+        setLoadFailed(true);
       });
 
     return () => {
@@ -524,7 +552,10 @@ const PublicBookingSetup = () => {
 
   const toggleService = (id: string) => {
     setSelectionOverride((prev) => {
-      const next = new Set(prev ?? allBookableIds);
+      // `selected`, not `allBookableIds`: before the first toggle the override is
+      // null and the visible selection is the stored one, so seeding from every
+      // bookable id would silently re-select services the practice had removed.
+      const next = new Set(prev ?? selected);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
@@ -541,12 +572,15 @@ const PublicBookingSetup = () => {
   };
 
   const handleSave = () => {
-    if (!primaryOrgId || saving) return;
+    if (!primaryOrgId || saving || loadFailed) return;
     setSaving(true);
 
     bookingPageApi
       .saveConfig(primaryOrgId, {
-        serviceIds: [...selected],
+        // Filtered again at the boundary: `selected` can only contain bookable
+        // ids by construction, but the API rejects the whole payload if one is
+        // not, and a rejected save tells the practice nothing useful.
+        serviceIds: [...selected].filter((id) => allBookableIds.has(id)),
         bookingWindowDays,
         bufferMinutes,
         autoConfirm: !needsConfirmation,
@@ -621,6 +655,7 @@ const PublicBookingSetup = () => {
             onBack={() => setStep(1)}
             onSave={handleSave}
             saving={saving}
+            loadFailed={loadFailed}
           />
         )}
       </div>

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -3,25 +3,37 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import {
-  IoAlertCircleOutline,
   IoArrowBack,
   IoArrowForward,
   IoCheckmark,
   IoCopyOutline,
   IoGlobeOutline,
-  IoRocketOutline,
+  IoSaveOutline,
 } from 'react-icons/io5';
-import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { usePrimaryOrg } from '@/app/hooks/useOrgSelectors';
 import { useNotify } from '@/app/hooks/useNotify';
 import type { ServiceRevamp } from '@/app/features/organization/types/revamp';
+import {
+  bookingPageApi,
+  type BookingPageConfig,
+} from '@/app/features/onboarding/services/bookingPageApiService';
 
-import { slugify } from './publicBookingSetup.utils';
-
-const WINDOW_OPTIONS = ['Up to 2 weeks ahead', 'Up to 4 weeks ahead', 'Up to 8 weeks ahead'];
-const BUFFER_OPTIONS = ['0 minutes', '10 minutes', '15 minutes', '30 minutes'];
+// Values, not display strings. These are persisted and later read by the public
+// slot computation, so the option list carries the number the API stores rather
+// than a label that would have to be parsed back into one.
+const WINDOW_OPTIONS: { label: string; days: number }[] = [
+  { label: 'Up to 2 weeks ahead', days: 14 },
+  { label: 'Up to 4 weeks ahead', days: 28 },
+  { label: 'Up to 8 weeks ahead', days: 56 },
+];
+const BUFFER_OPTIONS: { label: string; minutes: number }[] = [
+  { label: '0 minutes', minutes: 0 },
+  { label: '10 minutes', minutes: 10 },
+  { label: '15 minutes', minutes: 15 },
+  { label: '30 minutes', minutes: 30 },
+];
 const CURRENCY_SYMBOLS: Record<string, string> = { EUR: '€', USD: '$', GBP: '£' };
 
 const formatPrice = (amount: number, currency?: string): string => {
@@ -43,18 +55,6 @@ const copyText = async (value: string): Promise<boolean> => {
   return false;
 };
 
-const AssumedBanner = () => (
-  <StatusPill
-    tokens={{ bg: 'var(--warn-bg)', text: 'var(--warn-text)', border: 'var(--warn-border)' }}
-    label={
-      <>
-        <IoAlertCircleOutline size={11} aria-hidden="true" />
-        FIELDS ASSUMED · confirm with product
-      </>
-    }
-  />
-);
-
 const SetupHeader = ({ step, label }: { step: 1 | 2; label: string }) => (
   <div className="flex items-center justify-between gap-3 px-7! pt-5! pb-4! border-b border-[var(--hairline)]">
     <span className="flex items-center gap-[11px]">
@@ -75,10 +75,10 @@ type ServicesStepProps = {
   bookableServices: ServiceRevamp[];
   selected: Set<string>;
   onToggleService: (id: string) => void;
-  bookingWindow: string;
-  onBookingWindowChange: (value: string) => void;
-  buffer: string;
-  onBufferChange: (value: string) => void;
+  bookingWindowDays: number;
+  onBookingWindowChange: (value: number) => void;
+  bufferMinutes: number;
+  onBufferChange: (value: number) => void;
   needsConfirmation: boolean;
   onToggleConfirmation: () => void;
   onSkip: () => void;
@@ -90,9 +90,9 @@ const BookingServicesStep = ({
   bookableServices,
   selected,
   onToggleService,
-  bookingWindow,
+  bookingWindowDays,
   onBookingWindowChange,
-  buffer,
+  bufferMinutes,
   onBufferChange,
   needsConfirmation,
   onToggleConfirmation,
@@ -158,13 +158,13 @@ const BookingServicesStep = ({
           </span>
           <select
             aria-label="Bookable window"
-            value={bookingWindow}
-            onChange={(e) => onBookingWindowChange(e.target.value)}
+            value={bookingWindowDays}
+            onChange={(e) => onBookingWindowChange(Number(e.target.value))}
             className="flex-1 bg-transparent text-[13.5px] font-semibold text-[var(--ink-body)] outline-none"
           >
             {WINDOW_OPTIONS.map((opt) => (
-              <option key={opt} value={opt}>
-                {opt}
+              <option key={opt.days} value={opt.days}>
+                {opt.label}
               </option>
             ))}
           </select>
@@ -175,13 +175,13 @@ const BookingServicesStep = ({
           </span>
           <select
             aria-label="Buffer between visits"
-            value={buffer}
-            onChange={(e) => onBufferChange(e.target.value)}
+            value={bufferMinutes}
+            onChange={(e) => onBufferChange(Number(e.target.value))}
             className="flex-1 bg-transparent text-[13.5px] font-semibold text-[var(--ink-body)] outline-none"
           >
             {BUFFER_OPTIONS.map((opt) => (
-              <option key={opt} value={opt}>
-                {opt}
+              <option key={opt.minutes} value={opt.minutes}>
+                {opt.label}
               </option>
             ))}
           </select>
@@ -231,6 +231,76 @@ const BookingServicesStep = ({
   </>
 );
 
+/**
+ * The practice's booking address.
+ *
+ * Three states, and the difference between them is the whole point of this
+ * component. A live page gets its real address and a copy button. A saved but
+ * unpublished page gets the reserved name and says so in plain words, with no
+ * copy button - copying is an invitation to paste the address onto a website or
+ * a Google listing, and there is nothing at the other end yet. A page that has
+ * never been saved gets no address at all, because none has been allocated.
+ *
+ * `publicUrl` is only ever a value the API sent. Nothing here builds one.
+ */
+const BookingAddress = ({
+  slug,
+  publicUrl,
+  copied,
+  onCopy,
+}: {
+  slug: string | null;
+  publicUrl: string | null;
+  copied: boolean;
+  onCopy: (url: string) => void;
+}) => {
+  if (publicUrl) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10.5px] font-bold tracking-[0.08em] uppercase text-[var(--ink-faint)]">
+          Public booking address
+        </span>
+        <div className="flex items-center gap-2.5 px-3.5 py-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)]">
+          <IoGlobeOutline size={15} className="text-[var(--blue-text)]" aria-hidden="true" />
+          <span className="flex-1 min-w-0 text-[13px] font-semibold text-[var(--ink)] font-mono truncate">
+            {publicUrl}
+          </span>
+          <button
+            type="button"
+            onClick={() => onCopy(publicUrl)}
+            className="flex items-center gap-1.5 text-[11.5px] font-semibold text-[var(--blue-text)]"
+          >
+            <IoCopyOutline size={13} aria-hidden="true" />
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <span className="text-[11.5px] text-[var(--ink-faint)]">
+          This page is live. Safe to share on your website or your Google listing.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10.5px] font-bold tracking-[0.08em] uppercase text-[var(--ink-faint)]">
+        Public booking address
+      </span>
+      <div className="flex items-center gap-2.5 px-3.5 py-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)]">
+        <IoGlobeOutline size={15} className="text-[var(--ink-faint)]" aria-hidden="true" />
+        <span className="flex-1 min-w-0 text-[13px] font-semibold text-[var(--ink-muted)] font-mono truncate">
+          {slug ?? 'Reserved when you save'}
+        </span>
+      </div>
+      <span className="text-[11.5px] text-[var(--ink-faint)]">
+        {slug
+          ? 'Your booking page is not live yet, so there is no link to share. We have reserved this address for you and will use it when the page opens.'
+          : 'Save your setup and we will reserve a booking address for your practice.'}
+      </span>
+    </div>
+  );
+};
+
 type BrandingStepProps = {
   orgInitial: string;
   step: 1 | 2;
@@ -240,12 +310,14 @@ type BrandingStepProps = {
   onWelcomeChange: (value: string) => void;
   replyTo: string;
   onReplyToChange: (value: string) => void;
-  publicUrl: string;
+  slug: string | null;
+  publicUrl: string | null;
   copied: boolean;
-  onCopy: () => void;
+  onCopy: (url: string) => void;
   onReplaceLogo: () => void;
   onBack: () => void;
-  onGoLive: () => void;
+  onSave: () => void;
+  saving: boolean;
 };
 
 const BookingBrandingStep = ({
@@ -257,12 +329,14 @@ const BookingBrandingStep = ({
   onWelcomeChange,
   replyTo,
   onReplyToChange,
+  slug,
   publicUrl,
   copied,
   onCopy,
   onReplaceLogo,
   onBack,
-  onGoLive,
+  onSave,
+  saving,
 }: BrandingStepProps) => (
   <>
     <SetupHeader step={step} label="of 2 · Branding & review" />
@@ -334,28 +408,7 @@ const BookingBrandingStep = ({
         </div>
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <span className="text-[10.5px] font-bold tracking-[0.08em] uppercase text-[var(--ink-faint)]">
-          Public URL
-        </span>
-        <div className="flex items-center gap-2.5 px-3.5 py-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)]">
-          <IoGlobeOutline size={15} className="text-[var(--blue-text)]" aria-hidden="true" />
-          <span className="flex-1 min-w-0 text-[13px] font-semibold text-[var(--ink)] font-mono truncate">
-            {publicUrl}
-          </span>
-          <button
-            type="button"
-            onClick={onCopy}
-            className="flex items-center gap-1.5 text-[11.5px] font-semibold text-[var(--blue-text)]"
-          >
-            <IoCopyOutline size={13} aria-hidden="true" />
-            {copied ? 'Copied' : 'Copy'}
-          </button>
-        </div>
-        <span className="text-[11.5px] text-[var(--ink-faint)]">
-          Slug is assumed from your clinic name — confirm the public URL with product.
-        </span>
-      </div>
+      <BookingAddress slug={slug} publicUrl={publicUrl} copied={copied} onCopy={onCopy} />
     </div>
     <div className="flex items-center justify-between gap-3 px-7! py-4! border-t border-[var(--hairline)]">
       <button
@@ -368,11 +421,12 @@ const BookingBrandingStep = ({
       </button>
       <button
         type="button"
-        onClick={onGoLive}
-        className="inline-flex items-center gap-1.5 h-11 px-5 rounded-full bg-[var(--cta)] text-[var(--cta-text)] text-[13.5px] font-semibold"
+        onClick={onSave}
+        disabled={saving}
+        className="inline-flex items-center gap-1.5 h-11 px-5 rounded-full bg-[var(--cta)] text-[var(--cta-text)] text-[13.5px] font-semibold disabled:opacity-60"
       >
-        <IoRocketOutline size={15} />
-        Go live
+        <IoSaveOutline size={15} />
+        {saving ? 'Saving…' : 'Save booking setup'}
       </button>
     </div>
   </>
@@ -387,8 +441,6 @@ const PublicBookingSetup = () => {
 
   const orgName = primaryOrg?.name || 'Your clinic';
   const orgInitial = orgName.charAt(0).toUpperCase();
-  const slug = slugify(orgName);
-  const publicUrl = `book.yosemitecrew.com/${slug}`;
 
   const bookableServices = useMemo(
     () => services.filter((s) => s.isBookable && s.status === 'ACTIVE'),
@@ -403,19 +455,55 @@ const PublicBookingSetup = () => {
   // Every bookable service starts selected; `selectionOverride` holds the user's
   // explicit choices once they toggle, so selection derives from render, not an effect.
   const [selectionOverride, setSelectionOverride] = useState<Set<string> | null>(null);
-  const selected = selectionOverride ?? allBookableIds;
-  const [bookingWindow, setBookingWindow] = useState(WINDOW_OPTIONS[1]);
-  const [buffer, setBuffer] = useState(BUFFER_OPTIONS[1]);
+  const [bookingWindowDays, setBookingWindowDays] = useState(WINDOW_OPTIONS[1].days);
+  const [bufferMinutes, setBufferMinutes] = useState(BUFFER_OPTIONS[1].minutes);
   const [needsConfirmation, setNeedsConfirmation] = useState(true);
   const [welcome, setWelcome] = useState(`Book a visit for your companion at ${orgName}.`);
   const [replyTo, setReplyTo] = useState('');
   const [copied, setCopied] = useState(false);
+  const [config, setConfig] = useState<BookingPageConfig | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // A practice that has saved before gets its own selection back; one that has
+  // not gets every bookable service pre-selected.
+  const storedSelection = useMemo(
+    () => (config && config.serviceIds.length > 0 ? new Set(config.serviceIds) : null),
+    [config]
+  );
+  const selected = selectionOverride ?? storedSelection ?? allBookableIds;
 
   useEffect(() => {
     if (primaryOrgId) {
       Promise.resolve(loadOrganisationCatalog(primaryOrgId)).catch(() => undefined);
     }
   }, [primaryOrgId, loadOrganisationCatalog]);
+
+  useEffect(() => {
+    if (!primaryOrgId) return;
+    let cancelled = false;
+
+    bookingPageApi
+      .getConfig(primaryOrgId)
+      .then((loaded) => {
+        if (cancelled) return;
+        setConfig(loaded);
+        setBookingWindowDays(loaded.bookingWindowDays);
+        setBufferMinutes(loaded.bufferMinutes);
+        setNeedsConfirmation(!loaded.autoConfirm);
+        if (loaded.welcomeMessage) setWelcome(loaded.welcomeMessage);
+        if (loaded.replyToEmail) setReplyTo(loaded.replyToEmail);
+      })
+      .catch(() => {
+        // A failed load leaves the form on its defaults. It must not leave a
+        // stale config behind, because `config` is what decides whether an
+        // address is shown at all.
+        if (!cancelled) setConfig(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [primaryOrgId]);
 
   const toggleService = (id: string) => {
     setSelectionOverride((prev) => {
@@ -426,17 +514,45 @@ const PublicBookingSetup = () => {
     });
   };
 
-  const handleCopy = () => {
-    void copyText(publicUrl).then((ok) => {
+  // Takes the address as an argument rather than reading it back out of state:
+  // the only caller is the button inside the published branch, which already
+  // holds a non-null URL, so there is no "no address" case to handle.
+  const handleCopy = (url: string) => {
+    void copyText(url).then((ok) => {
       if (ok) setCopied(true);
     });
   };
 
-  const handleGoLive = () => {
-    notify('info', {
-      title: 'Booking setup saved for review',
-      text: 'These fields are assumed pending product confirmation — publishing is not yet wired up.',
-    });
+  const handleSave = () => {
+    if (!primaryOrgId || saving) return;
+    setSaving(true);
+
+    bookingPageApi
+      .saveConfig(primaryOrgId, {
+        serviceIds: [...selected],
+        bookingWindowDays,
+        bufferMinutes,
+        autoConfirm: !needsConfirmation,
+        welcomeMessage: welcome.trim() || null,
+        replyToEmail: replyTo.trim() || null,
+      })
+      .then((saved) => {
+        setConfig(saved);
+        setSelectionOverride(null);
+        notify('success', {
+          title: 'Booking setup saved',
+          text: saved.publicUrl
+            ? 'Your booking page is live at the address above.'
+            : 'Your booking page is not open to pet parents yet. These settings apply the moment it is.',
+        });
+      })
+      .catch(() => {
+        notify('error', {
+          title: 'Could not save booking setup',
+          text: 'Nothing was changed. Please try again.',
+        });
+      })
+      .finally(() => setSaving(false));
   };
 
   const handleSkip = () =>
@@ -450,12 +566,9 @@ const PublicBookingSetup = () => {
 
   return (
     <div className="flex flex-col gap-4 p-3! md:p-5!">
-      <div className="flex items-center gap-2.5 flex-wrap">
-        <span className="text-[11px] font-bold tracking-[0.14em] uppercase text-[var(--ink-faint)]">
-          Public booking · onboarding
-        </span>
-        <AssumedBanner />
-      </div>
+      <span className="text-[11px] font-bold tracking-[0.14em] uppercase text-[var(--ink-faint)]">
+        Public booking · onboarding
+      </span>
 
       <div className="w-full max-w-[708px] rounded-[22px] border border-[var(--hairline)] bg-[var(--screen)] overflow-hidden shadow-[0_2px_6px_var(--sh05),0_24px_60px_var(--sh10)]">
         {step === 1 ? (
@@ -464,10 +577,10 @@ const PublicBookingSetup = () => {
             bookableServices={bookableServices}
             selected={selected}
             onToggleService={toggleService}
-            bookingWindow={bookingWindow}
-            onBookingWindowChange={setBookingWindow}
-            buffer={buffer}
-            onBufferChange={setBuffer}
+            bookingWindowDays={bookingWindowDays}
+            onBookingWindowChange={setBookingWindowDays}
+            bufferMinutes={bufferMinutes}
+            onBufferChange={setBufferMinutes}
             needsConfirmation={needsConfirmation}
             onToggleConfirmation={() => setNeedsConfirmation((v) => !v)}
             onSkip={handleSkip}
@@ -483,12 +596,14 @@ const PublicBookingSetup = () => {
             onWelcomeChange={setWelcome}
             replyTo={replyTo}
             onReplyToChange={setReplyTo}
-            publicUrl={publicUrl}
+            slug={config?.slug ?? null}
+            publicUrl={config?.publicUrl ?? null}
             copied={copied}
             onCopy={handleCopy}
             onReplaceLogo={handleReplaceLogo}
             onBack={() => setStep(1)}
-            onGoLive={handleGoLive}
+            onSave={handleSave}
+            saving={saving}
           />
         )}
       </div>

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -319,6 +319,9 @@ type BrandingStepProps = {
   onSave: () => void;
   saving: boolean;
   loadFailed: boolean;
+  publish: boolean;
+  onTogglePublish: () => void;
+  hasBookableServices: boolean;
 };
 
 const BookingBrandingStep = ({
@@ -339,6 +342,9 @@ const BookingBrandingStep = ({
   onSave,
   saving,
   loadFailed,
+  publish,
+  onTogglePublish,
+  hasBookableServices,
 }: BrandingStepProps) => (
   <>
     <SetupHeader step={step} label="of 2 · Branding & review" />
@@ -412,6 +418,32 @@ const BookingBrandingStep = ({
 
       <BookingAddress slug={slug} publicUrl={publicUrl} copied={copied} onCopy={onCopy} />
 
+      <div className="flex items-center justify-between gap-3 px-3.5 py-3 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)]">
+        <span className="text-[12.5px] text-[var(--ink-body)]">
+          <strong className="text-[var(--ink)]">Open my booking page.</strong>{' '}
+          {hasBookableServices
+            ? 'Pet parents can find and use it as soon as you save.'
+            : 'Mark at least one service bookable first — an open page with nothing to book helps nobody.'}
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={publish}
+          aria-label="Open my booking page"
+          disabled={!hasBookableServices}
+          onClick={onTogglePublish}
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full disabled:opacity-50 ${
+            publish ? 'bg-primary-600' : 'bg-neutral-300'
+          }`}
+        >
+          <span
+            className={`inline-block h-5 w-5 rounded-full bg-neutral-0 transition-transform ${
+              publish ? 'translate-x-5' : 'translate-x-0.5'
+            }`}
+          />
+        </button>
+      </div>
+
       {loadFailed ? (
         <p
           role="alert"
@@ -444,6 +476,22 @@ const BookingBrandingStep = ({
     </div>
   </>
 );
+
+/**
+ * What to tell the practice after a save.
+ *
+ * Three distinct outcomes, and conflating them is how the old wizard misled
+ * people: the page is live and has an address to share, the practice asked to
+ * publish but this environment has no public origin configured so nothing is
+ * reachable yet, or the practice deliberately left it closed.
+ */
+const resolveSavedMessage = (saved: BookingPageConfig): string => {
+  if (saved.publicUrl) return 'Your booking page is live at the address above.';
+  if (saved.publicBookingEnabled) {
+    return 'Saved. Your booking page is switched on, but no public address is configured for this environment yet.';
+  }
+  return 'Saved. Your booking page is closed to pet parents until you open it.';
+};
 
 const PublicBookingSetup = () => {
   const { notify } = useNotify();
@@ -479,6 +527,7 @@ const PublicBookingSetup = () => {
   const [config, setConfig] = useState<BookingPageConfig | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [publishOverride, setPublishOverride] = useState<boolean | null>(null);
 
   // A practice that has saved before gets its own selection back, including a
   // deliberate empty one; a practice that has never saved gets everything
@@ -495,6 +544,10 @@ const PublicBookingSetup = () => {
     [config, allBookableIds]
   );
   const selected = selectionOverride ?? storedSelection ?? allBookableIds;
+
+  // Publication follows the stored value until the practice touches the switch.
+  const publish = publishOverride ?? config?.publicBookingEnabled ?? false;
+  const hasBookableServices = allBookableIds.size > 0;
 
   useEffect(() => {
     if (primaryOrgId) {
@@ -530,6 +583,7 @@ const PublicBookingSetup = () => {
         setBookingWindowDays(loaded.bookingWindowDays);
         setBufferMinutes(loaded.bufferMinutes);
         setNeedsConfirmation(!loaded.autoConfirm);
+        setPublishOverride(null);
         if (loaded.welcomeMessage) setWelcome(loaded.welcomeMessage);
         if (loaded.replyToEmail) setReplyTo(loaded.replyToEmail);
       })
@@ -586,15 +640,14 @@ const PublicBookingSetup = () => {
         autoConfirm: !needsConfirmation,
         welcomeMessage: welcome.trim() || null,
         replyToEmail: replyTo.trim() || null,
+        publicBookingEnabled: publish,
       })
       .then((saved) => {
         setConfig(saved);
         setSelectionOverride(null);
         notify('success', {
           title: 'Booking setup saved',
-          text: saved.publicUrl
-            ? 'Your booking page is live at the address above.'
-            : 'Your booking page is not open to pet parents yet. These settings apply the moment it is.',
+          text: resolveSavedMessage(saved),
         });
       })
       .catch(() => {
@@ -656,6 +709,9 @@ const PublicBookingSetup = () => {
             onSave={handleSave}
             saving={saving}
             loadFailed={loadFailed}
+            publish={publish}
+            onTogglePublish={() => setPublishOverride(!publish)}
+            hasBookableServices={hasBookableServices}
           />
         )}
       </div>

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/publicBookingSetup.utils.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/publicBookingSetup.utils.ts
@@ -1,7 +1,0 @@
-export const slugify = (value: string): string => {
-  const slug = value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-  return slug || 'your-clinic';
-};

--- a/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
@@ -36,6 +36,12 @@ export type BookingPageSettingsPayload = {
   autoConfirm: boolean;
   welcomeMessage: string | null;
   replyToEmail: string | null;
+  /**
+   * Whether `/book/<slug>` should answer. Optional on the wire: a caller that
+   * omits it is saving settings, and saving settings must never publish a
+   * practice as a side effect.
+   */
+  publicBookingEnabled?: boolean;
 };
 
 type ConfigEnvelope = { data: BookingPageConfig };

--- a/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
@@ -12,6 +12,12 @@ import { getData, putData } from '@/app/services/axios';
  */
 export type BookingPageConfig = {
   organisationId: string;
+  /**
+   * Whether the practice has ever saved this setup. Distinguishes a deliberate
+   * "no services offered publicly" from a practice that has never answered,
+   * which both arrive as an empty `serviceIds`.
+   */
+  configured: boolean;
   slug: string | null;
   publicBookingEnabled: boolean;
   publicUrl: string | null;

--- a/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
@@ -1,0 +1,53 @@
+import { getData, putData } from '@/app/services/axios';
+
+/**
+ * The practice's public booking page configuration, exactly as the API reports it.
+ *
+ * `publicUrl` is the field that matters here. The wizard used to build
+ * `book.yosemitecrew.com/<slug>` in the browser from the practice name, which
+ * meant it could render a copyable address for a page that did not exist and a
+ * host with no DNS record. The address is now only ever a value the server sent,
+ * and the server sends null until the page is genuinely reachable - so there is
+ * no code path left that can invent one.
+ */
+export type BookingPageConfig = {
+  organisationId: string;
+  slug: string | null;
+  publicBookingEnabled: boolean;
+  publicUrl: string | null;
+  serviceIds: string[];
+  bookingWindowDays: number;
+  bufferMinutes: number;
+  autoConfirm: boolean;
+  welcomeMessage: string | null;
+  replyToEmail: string | null;
+};
+
+export type BookingPageSettingsPayload = {
+  serviceIds: string[];
+  bookingWindowDays: number;
+  bufferMinutes: number;
+  autoConfirm: boolean;
+  welcomeMessage: string | null;
+  replyToEmail: string | null;
+};
+
+type ConfigEnvelope = { data: BookingPageConfig };
+
+export const bookingPageApi = {
+  async getConfig(organisationId: string): Promise<BookingPageConfig> {
+    const response = await getData<ConfigEnvelope>(`/v1/booking-page/${organisationId}`);
+    return response.data.data;
+  },
+
+  async saveConfig(
+    organisationId: string,
+    payload: BookingPageSettingsPayload
+  ): Promise<BookingPageConfig> {
+    const response = await putData<ConfigEnvelope, BookingPageSettingsPayload>(
+      `/v1/booking-page/${organisationId}`,
+      payload
+    );
+    return response.data.data;
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/BookingRequests.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/BookingRequests.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useNotify } from '@/app/hooks/useNotify';
+import {
+  bookingRequestsApi,
+  type BookingRequest,
+} from '@/app/features/organization/services/bookingRequestsApiService';
+
+/**
+ * Confirmed booking requests from the public page.
+ *
+ * This exists because without it the feature is another broken promise: a pet
+ * owner submits a request, confirms their email, and it lands somewhere nobody
+ * at the practice ever looks. The notification email is a prompt; this is the
+ * record.
+ *
+ * Deliberately not a calendar. A request is not an appointment and the time is
+ * not held - marking one "booked" records what the practice did in the PMS, it
+ * does not create anything.
+ */
+
+const formatWhen = (iso: string) => {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime())
+    ? iso
+    : `${date.toLocaleDateString()} ${date.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      })}`;
+};
+
+const STATUS_LABEL: Record<BookingRequest['status'], string> = {
+  CONFIRMED: 'Awaiting you',
+  BOOKED: 'Booked',
+  DECLINED: 'Declined',
+};
+
+const BookingRequests = () => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const { notify } = useNotify();
+
+  const [requests, setRequests] = useState<BookingRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // No `setLoading(true)` here: the state starts true and the effect only ever
+  // clears it asynchronously. Setting it synchronously inside the effect
+  // cascades a render for no benefit, since nothing can have cleared it yet.
+  const load = useCallback(() => {
+    if (!primaryOrgId) return;
+    bookingRequestsApi
+      .list(primaryOrgId)
+      .then((rows) => {
+        setRequests(rows);
+        setFailed(false);
+      })
+      .catch(() => setFailed(true))
+      .finally(() => setLoading(false));
+  }, [primaryOrgId]);
+
+  useEffect(() => load(), [load]);
+
+  // Nothing to show, and nothing to scope a request to. Returning early here
+  // rather than guarding inside every handler means `primaryOrgId` is a string
+  // for the rest of the component, so the handlers carry one guard instead of
+  // two.
+  if (!primaryOrgId) return null;
+
+  const update = (id: string, status: 'DECLINED' | 'BOOKED') => {
+    if (busyId) return;
+    setBusyId(id);
+    bookingRequestsApi
+      .setStatus(primaryOrgId, id, status)
+      .then(() => {
+        setRequests((current) =>
+          current.map((request) => (request.id === id ? { ...request, status } : request))
+        );
+      })
+      .catch(() =>
+        notify('error', {
+          title: 'Could not update the request',
+          text: 'Nothing was changed. Please try again.',
+        })
+      )
+      .finally(() => setBusyId(null));
+  };
+
+  const pending = requests.filter((request) => request.status === 'CONFIRMED');
+
+  return (
+    <SectionCard title="Booking requests" showButton={false}>
+      <div className="flex flex-col gap-3">
+        {loading ? (
+          <p className="text-[12.5px] text-[var(--ink-muted)]">Loading requests…</p>
+        ) : null}
+
+        {!loading && failed ? (
+          <p role="alert" className="text-[12.5px] text-[var(--warn-text)]">
+            Could not load booking requests. Reload the page to try again.
+          </p>
+        ) : null}
+
+        {!loading && !failed && requests.length === 0 ? (
+          <p className="text-[12.5px] text-[var(--ink-muted)]">
+            No booking requests yet. Confirmed requests from your public booking page appear here.
+          </p>
+        ) : null}
+
+        {!loading && !failed && requests.length > 0 ? (
+          <>
+            <p className="text-[12px] text-[var(--ink-faint)]">
+              {pending.length} awaiting you. These are requests, not appointments — book one in the
+              diary as usual, then mark it booked here.
+            </p>
+
+            <ul className="flex flex-col gap-2.5">
+              {requests.map((request) => (
+                <li
+                  key={request.id}
+                  className="flex flex-col gap-2 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)] px-3.5 py-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <span className="min-w-0">
+                    <span className="block text-[13.5px] font-bold text-[var(--ink)]">
+                      {request.petName} ({request.petSpecies}) · {request.serviceName}
+                    </span>
+                    <span className="block text-[12px] text-[var(--ink-muted)]">
+                      {formatWhen(request.requestedStart)} · {request.durationMinutes} min
+                    </span>
+                    <span className="block text-[12px] text-[var(--ink-faint)]">
+                      {request.ownerName} · {request.ownerEmail}
+                      {request.ownerPhone ? ` · ${request.ownerPhone}` : ''}
+                    </span>
+                    {request.concern ? (
+                      <span className="block text-[12px] text-[var(--ink-muted)]">
+                        {request.concern}
+                      </span>
+                    ) : null}
+                  </span>
+
+                  <span className="flex shrink-0 items-center gap-2">
+                    {request.status === 'CONFIRMED' ? (
+                      <>
+                        <button
+                          type="button"
+                          disabled={busyId === request.id}
+                          onClick={() => update(request.id, 'BOOKED')}
+                          className="rounded-full bg-[var(--cta)] px-3.5 py-1.5 text-[12px] font-semibold text-[var(--cta-text)] disabled:opacity-50"
+                        >
+                          Mark booked
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busyId === request.id}
+                          onClick={() => update(request.id, 'DECLINED')}
+                          className="rounded-full border border-[var(--divider)] px-3.5 py-1.5 text-[12px] font-semibold text-[var(--ink-muted)] disabled:opacity-50"
+                        >
+                          Decline
+                        </button>
+                      </>
+                    ) : (
+                      <span className="text-[12px] font-semibold text-[var(--ink-faint)]">
+                        {STATUS_LABEL[request.status]}
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+    </SectionCard>
+  );
+};
+
+export default BookingRequests;

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/OnlineBooking.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/OnlineBooking.tsx
@@ -15,7 +15,8 @@ const OnlineBooking = () => (
             Set up your public booking page
           </span>
           <span className="block text-[12px] text-[var(--ink-muted)]">
-            Choose bookable services, availability and branding, then share a public link.
+            Choose bookable services, availability and branding. Your public link opens when the
+            booking page goes live.
           </span>
         </span>
       </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
@@ -49,6 +49,11 @@ const OnlineBooking = dynamic(
   () => import('@/app/features/organization/pages/Organization/Sections/OnlineBooking'),
   { loading: () => <OrganizationSectionSkeleton /> }
 );
+
+const BookingRequests = dynamic(
+  () => import('@/app/features/organization/pages/Organization/Sections/BookingRequests'),
+  { loading: () => <OrganizationSectionSkeleton /> }
+);
 const DeleteOrg = dynamic(
   () => import('@/app/features/organization/pages/Organization/Sections/DeleteOrg'),
   { loading: () => <OrganizationSectionSkeleton /> }
@@ -108,6 +113,7 @@ export const Organization = () => {
           <Documents />
           <DocumentESigning />
           <OnlineBooking />
+          <BookingRequests />
         </>
       )}
     </div>

--- a/apps/frontend/src/app/features/organization/services/bookingRequestsApiService.ts
+++ b/apps/frontend/src/app/features/organization/services/bookingRequestsApiService.ts
@@ -1,0 +1,45 @@
+import { getData, patchData } from '@/app/services/axios';
+
+/**
+ * The practice's side of the public booking page: requests that a pet owner
+ * submitted and then confirmed by email.
+ *
+ * Unconfirmed requests are not listable. The API refuses to return them, because
+ * anyone can type anyone's address into a public form and an unconfirmed row is
+ * an unverified claim.
+ */
+export type BookingRequestStatus = 'CONFIRMED' | 'DECLINED' | 'BOOKED';
+
+export type BookingRequest = {
+  id: string;
+  serviceName: string;
+  requestedStart: string;
+  requestedEnd: string;
+  durationMinutes: number;
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone: string | null;
+  petName: string;
+  petSpecies: string;
+  concern: string | null;
+  status: BookingRequestStatus;
+  confirmedAt: string | null;
+  createdAt: string;
+};
+
+export const bookingRequestsApi = {
+  async list(organisationId: string): Promise<BookingRequest[]> {
+    const response = await getData<{ data: BookingRequest[] }>(
+      `/v1/booking-page/${organisationId}/requests`
+    );
+    return response.data.data;
+  },
+
+  async setStatus(
+    organisationId: string,
+    requestId: string,
+    status: 'DECLINED' | 'BOOKED'
+  ): Promise<void> {
+    await patchData(`/v1/booking-page/${organisationId}/requests/${requestId}`, { status });
+  },
+};

--- a/apps/frontend/src/app/features/publicBooking/services/publicBooking.service.ts
+++ b/apps/frontend/src/app/features/publicBooking/services/publicBooking.service.ts
@@ -1,0 +1,167 @@
+/**
+ * The pet owner's half of the booking page. No session, ever.
+ *
+ * Raw `fetch`, not the shared axios client, for the reason
+ * `companionCard.service.ts` gives for its own public resolve: the authed
+ * instance carries `withCredentials` and an interceptor that redirects a
+ * signed-out caller to the sign-in page. Both are wrong here. A pet owner has no
+ * account, and sending a staff member's session cookie to an endpoint that does
+ * not want one is a habit worth not forming.
+ */
+
+export type PublicService = {
+  id: string;
+  name: string;
+  description: string | null;
+  durationMinutes: number;
+};
+
+export type PublicPractice = {
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  welcomeMessage: string | null;
+  city: string | null;
+  country: string | null;
+  bookingWindowDays: number;
+  requiresConfirmation: boolean;
+  services: PublicService[];
+};
+
+/** A retired slug resolves to where the reader should go instead. */
+export type PracticeResult =
+  { kind: 'practice'; practice: PublicPractice } | { kind: 'redirect'; slug: string };
+
+export type PublicSlot = { startTime: string; endTime: string };
+
+export type PublicSlots = {
+  date: string;
+  serviceId: string;
+  durationMinutes: number;
+  windows: PublicSlot[];
+};
+
+export type BookingRequestPayload = {
+  serviceId: string;
+  date: string;
+  startTime: string;
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone: string | null;
+  petName: string;
+  petSpecies: string;
+  concern: string | null;
+  consent: true;
+};
+
+const apiRoot = () => (process.env.NEXT_PUBLIC_BASE_URL ?? '').replace(/\/$/, '');
+
+/**
+ * Thrown for anything the API declined, carrying its status.
+ *
+ * The page distinguishes "this practice does not have a booking page" (404)
+ * from "that time just went" (409) from everything else, and it can only do
+ * that if the status survives the fetch.
+ */
+export class PublicBookingRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'PublicBookingRequestError';
+    this.status = status;
+  }
+}
+
+const readMessage = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const body = (await response.json()) as { message?: unknown };
+    return typeof body.message === 'string' ? body.message : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+export const getPublicPractice = async (slug: string): Promise<PracticeResult> => {
+  const response = await fetch(`${apiRoot()}/public/booking/${encodeURIComponent(slug)}`, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new PublicBookingRequestError(
+      await readMessage(response, 'This booking page is not available.'),
+      response.status
+    );
+  }
+
+  const body = (await response.json()) as {
+    data: PublicPractice | { redirectTo: string };
+  };
+
+  if ('redirectTo' in body.data) {
+    return { kind: 'redirect', slug: body.data.redirectTo };
+  }
+  return { kind: 'practice', practice: body.data };
+};
+
+export const getPublicSlots = async (
+  slug: string,
+  serviceId: string,
+  date: string
+): Promise<PublicSlots> => {
+  const query = new URLSearchParams({ serviceId, date });
+  const response = await fetch(
+    `${apiRoot()}/public/booking/${encodeURIComponent(slug)}/slots?${query.toString()}`,
+    { headers: { Accept: 'application/json' } }
+  );
+
+  if (!response.ok) {
+    throw new PublicBookingRequestError(
+      await readMessage(response, 'Could not load available times.'),
+      response.status
+    );
+  }
+
+  const body = (await response.json()) as { data: PublicSlots };
+  return body.data;
+};
+
+export const submitBookingRequest = async (
+  slug: string,
+  payload: BookingRequestPayload
+): Promise<void> => {
+  const response = await fetch(`${apiRoot()}/public/booking/${encodeURIComponent(slug)}/requests`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new PublicBookingRequestError(
+      await readMessage(response, 'Could not send your request.'),
+      response.status
+    );
+  }
+};
+
+export const confirmBookingRequest = async (
+  token: string
+): Promise<{ practiceName: string; slug: string | null }> => {
+  const response = await fetch(`${apiRoot()}/public/booking/requests/confirm`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+
+  if (!response.ok) {
+    throw new PublicBookingRequestError(
+      await readMessage(response, 'This confirmation link is not valid.'),
+      response.status
+    );
+  }
+
+  const body = (await response.json()) as {
+    data: { practiceName: string; slug: string | null };
+  };
+  return body.data;
+};

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -13,6 +13,13 @@ const NONCE_HEADER = 'x-nonce';
 // `export const dynamic = 'force-dynamic'`, so they carry a per-request nonce too.
 const STRICT_CSP_PATH_PREFIXES = [
   '/appointments',
+  // The public booking page. It is under (routes)/(book), NOT (routes)/(public),
+  // precisely so it can be here: it collects a name, an email address, a phone
+  // number and an animal's details from a signed-out visitor, and inheriting the
+  // permissive `unsafe-inline` policy the marketing routes carry would put that
+  // form behind the weaker of the two policies. Both its pages set
+  // `export const dynamic = 'force-dynamic'`, so each render has a nonce.
+  '/book',
   '/book-onboarding',
   '/chat',
   '/companions',

--- a/packages/database/prisma/migrations/20260826090000_public_booking_foundation/migration.sql
+++ b/packages/database/prisma/migrations/20260826090000_public_booking_foundation/migration.sql
@@ -1,0 +1,86 @@
+-- Foundation for the public booking page.
+--
+-- Until now the onboarding wizard computed `book.yosemitecrew.com/<slug>` in the
+-- browser from the practice name, showed it, and offered to copy it. Nothing was
+-- stored, the subdomain has no DNS record, and no route served it - a practice
+-- could paste that URL onto its own website and publish a dead link. These
+-- tables are what the wizard writes to instead.
+--
+-- Three decisions are encoded here rather than in application code:
+--
+--  1. `BookingSlugReservation`, not `Organization."bookingSlug"`, owns the slug
+--     namespace. A slug is claimed by inserting here first, in the same
+--     transaction that denormalises it onto the organisation, so two practices
+--     both named "Park Vets" collide on a primary key under concurrency rather
+--     than racing a read-then-write. Rows are never deleted: a booking URL ends
+--     up on a printed card and in a Google listing, so a renamed practice keeps
+--     resolving its old slug and gets redirected to the current one.
+--
+--  2. `publicBookingEnabled` defaults to false. Publishing is opt-in. No
+--     existing practice becomes reachable on the public internet because this
+--     migration ran.
+--
+--  3. `autoConfirm` defaults to false, so a public request is a REQUEST that a
+--     human accepts through the accept/reject routes the PMS already has, not a
+--     write straight into a working calendar.
+--
+-- Additive and backfill-free: every column is nullable or defaulted, and the
+-- unique index lands on a column that is NULL for every existing row (Postgres
+-- treats NULLs as distinct, so no pre-check for duplicates is needed).
+
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "bookingSlug" TEXT,
+ADD COLUMN     "publicBookingEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "BookingSlugReservation" (
+    "slug" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BookingSlugReservation_pkey" PRIMARY KEY ("slug")
+);
+
+-- CreateTable
+CREATE TABLE "PublicBookingSettings" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "serviceIds" TEXT[],
+    "bookingWindowDays" INTEGER NOT NULL DEFAULT 28,
+    "bufferMinutes" INTEGER NOT NULL DEFAULT 10,
+    "autoConfirm" BOOLEAN NOT NULL DEFAULT false,
+    "welcomeMessage" TEXT,
+    "replyToEmail" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PublicBookingSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BookingSlugReservation_organizationId_idx" ON "BookingSlugReservation"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicBookingSettings_organizationId_key" ON "PublicBookingSettings"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_bookingSlug_key" ON "Organization"("bookingSlug");
+
+-- AddForeignKey
+ALTER TABLE "BookingSlugReservation" ADD CONSTRAINT "BookingSlugReservation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PublicBookingSettings" ADD CONSTRAINT "PublicBookingSettings_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- RLS, per 20260818090000_enable_row_level_security.
+--
+-- That migration was a one-shot loop over the tables that existed when it ran,
+-- so a table added afterwards ships unprotected unless it says so here - the
+-- same reason 20260820100000_activitypub_federation repeats these lines.
+-- Enabling with no policy is the intended default: the API connects as the
+-- owning role and bypasses RLS, so Prisma queries are unaffected. What it closes
+-- is the PostgREST surface, where Supabase would otherwise expose both tables to
+-- the `anon` key - and one of them is about to back an unauthenticated page.
+ALTER TABLE "BookingSlugReservation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PublicBookingSettings" ENABLE ROW LEVEL SECURITY;

--- a/packages/database/prisma/migrations/20260826140000_public_booking_requests/migration.sql
+++ b/packages/database/prisma/migrations/20260826140000_public_booking_requests/migration.sql
@@ -1,0 +1,82 @@
+-- Booking requests submitted by members of the public.
+--
+-- Phase 2 of this change opens `/book/<slug>` as a read-only page. This table is
+-- phase 3: the request a pet owner submits from it.
+--
+-- Why a table of its own rather than an `Appointment` in `REQUESTED`, which
+-- would have reused the practice's existing accept/reject queue:
+--
+--  1. `createAppointment` asserts that a real Parent manages a real Companion
+--     (`CompanionOrganisationService.assertParentManagesCompanion`). An
+--     anonymous requester has neither, so satisfying it means minting a Parent
+--     and a Companion from unverified form input - handing the practice patient
+--     records for a person who may not exist, before any human has looked.
+--  2. The `REQUESTED` queue is the practice's own work queue. Letting an
+--     unauthenticated caller write into it makes flooding it a public capability.
+--
+-- So a request stays inert until a human at the practice reads it and books it.
+--
+-- `confirmationTokenHash` stores SHA-256 of the emailed token, never the token.
+-- Reading the table therefore does not let anyone confirm a request, the same
+-- way the companion-card and passport share tokens are resolved by hash.
+--
+-- `purgeAfter` exists because these rows are personal data - a name, an email
+-- address, a phone number and an animal's details - belonging to someone with no
+-- relationship to the practice, in a product operating under GDPR. A scheduled
+-- job deletes rows past it, and the column is indexed so that job is a range
+-- scan rather than a table walk. Storage limitation is a property of the schema
+-- here, not of somebody remembering.
+--
+-- Additive: one new enum, one new table, no change to any existing row.
+
+-- CreateEnum
+CREATE TYPE "PublicBookingRequestStatus" AS ENUM ('PENDING_CONFIRMATION', 'CONFIRMED', 'DECLINED', 'BOOKED', 'EXPIRED');
+
+-- CreateTable
+CREATE TABLE "PublicBookingRequest" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "productItemId" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "requestedStart" TIMESTAMP(3) NOT NULL,
+    "requestedEnd" TIMESTAMP(3) NOT NULL,
+    "durationMinutes" INTEGER NOT NULL,
+    "ownerName" TEXT NOT NULL,
+    "ownerEmail" TEXT NOT NULL,
+    "ownerPhone" TEXT,
+    "petName" TEXT NOT NULL,
+    "petSpecies" TEXT NOT NULL,
+    "concern" TEXT,
+    "status" "PublicBookingRequestStatus" NOT NULL DEFAULT 'PENDING_CONFIRMATION',
+    "confirmationTokenHash" TEXT NOT NULL,
+    "confirmationExpiresAt" TIMESTAMP(3) NOT NULL,
+    "confirmedAt" TIMESTAMP(3),
+    "consentAcceptedAt" TIMESTAMP(3) NOT NULL,
+    "purgeAfter" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PublicBookingRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PublicBookingRequest_confirmationTokenHash_key" ON "PublicBookingRequest"("confirmationTokenHash");
+
+-- CreateIndex
+CREATE INDEX "PublicBookingRequest_organizationId_status_requestedStart_idx" ON "PublicBookingRequest"("organizationId", "status", "requestedStart");
+
+-- CreateIndex
+CREATE INDEX "PublicBookingRequest_purgeAfter_idx" ON "PublicBookingRequest"("purgeAfter");
+
+-- AddForeignKey
+ALTER TABLE "PublicBookingRequest" ADD CONSTRAINT "PublicBookingRequest_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- RLS, per 20260818090000_enable_row_level_security.
+--
+-- That migration was a one-shot loop over the tables that existed when it ran,
+-- so a table added later ships unprotected unless it says so here. It matters
+-- more than usual for this one: the rows are unverified personal data, and
+-- without RLS Supabase would expose them over PostgREST to the `anon` key -
+-- the very audience the form collects them from.
+ALTER TABLE "PublicBookingRequest" ENABLE ROW LEVEL SECURITY;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -959,8 +959,19 @@ model Organization {
   /// clinician can pick: input is always the full YC vocabulary.
   preferredVocabulary                    VocabularyPreference @default(YOSEMITECODE)
   maxOverallDiscountPercent              Float?
+  /// Current public booking slug, or null when the practice has never opened a
+  /// booking page. Denormalised from `BookingSlugReservation` so resolving
+  /// `/book/<slug>` is a single indexed lookup; every value here was first
+  /// claimed in that table, which is what makes the namespace collision-proof.
+  bookingSlug                            String?              @unique
+  /// Publishing is opt-in and off by default. An existing practice does not
+  /// become reachable on the public internet because this column shipped.
+  publicBookingEnabled                   Boolean              @default(false)
   createdAt                              DateTime             @default(now())
   updatedAt                              DateTime             @updatedAt
+
+  bookingSettings     PublicBookingSettings?
+  bookingSlugHistory  BookingSlugReservation[]
 
   @@index([googlePlacesId, name])
 }
@@ -978,6 +989,53 @@ model OrganizationAddress {
   location       Json?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+}
+
+/// Every booking slug an organisation has ever been handed, current and retired.
+///
+/// This table - not `Organization.bookingSlug` - owns the slug namespace. A slug
+/// is claimed here first, inside the same transaction that sets it on the
+/// organisation, so two practices both called "Park Vets" collide on this
+/// primary key under concurrency instead of racing two `findFirst`/`update`
+/// pairs. Retired slugs are never deleted: a booking URL ends up on a printed
+/// card and in a Google listing, so the public route resolves an old slug and
+/// permanently redirects to the current one rather than 404ing it.
+model BookingSlugReservation {
+  slug           String   @id
+  organizationId String
+  createdAt      DateTime @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+}
+
+/// What a practice configured for its public booking page.
+///
+/// Separate from `Organization` because it is written by one wizard and read by
+/// one public surface, and because `Organization` is already the widest row in
+/// the schema. Absent row means the practice has never opened the wizard.
+model PublicBookingSettings {
+  id             String @id @default(uuid())
+  organizationId String @unique
+  /// The services offered publicly. A service listed here is still re-checked
+  /// against `isBookable` and `ACTIVE` when the page renders, so archiving a
+  /// service withdraws it from the public page without anyone editing this list.
+  serviceIds     String[]
+  /// How far ahead a pet owner may book.
+  bookingWindowDays Int      @default(28)
+  /// Padding added after a publicly booked slot.
+  bufferMinutes     Int      @default(10)
+  /// False - the default - means a public request lands as REQUESTED for a human
+  /// to accept. True writes to the calendar directly, and is only ever honoured
+  /// after the requester has confirmed their email address.
+  autoConfirm       Boolean  @default(false)
+  welcomeMessage    String?
+  replyToEmail      String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -972,6 +972,7 @@ model Organization {
 
   bookingSettings     PublicBookingSettings?
   bookingSlugHistory  BookingSlugReservation[]
+  publicBookingRequests PublicBookingRequest[]
 
   @@index([googlePlacesId, name])
 }
@@ -1010,6 +1011,91 @@ model BookingSlugReservation {
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
+}
+
+/// Lifecycle of a booking request submitted by a member of the public.
+///
+/// A request is NOT an appointment. It never reaches a calendar on its own, and
+/// nothing about it creates a Parent or a Companion: `createAppointment` asserts
+/// that a real parent manages a real companion, and an anonymous stranger has
+/// neither. A human at the practice reads the request and books it.
+enum PublicBookingRequestStatus {
+  /// Submitted, but the email address has not been proven yet. Invisible to the
+  /// practice, because anyone can type anyone else's address into a public form.
+  PENDING_CONFIRMATION
+  /// The requester followed the emailed link. Now visible to the practice.
+  CONFIRMED
+  /// The practice does not want it.
+  DECLINED
+  /// The practice booked it in the PMS.
+  BOOKED
+  /// Never confirmed before the link expired.
+  EXPIRED
+}
+
+/// A booking request from a pet owner who has no account.
+///
+/// Deliberately its own table rather than an `Appointment` with a synthetic
+/// patient. Two reasons, and both are about not letting an unauthenticated
+/// stranger write into a clinical system:
+///
+///  - `createAppointment` requires a Parent that manages a Companion. Satisfying
+///    that from a public form means minting both from unverified input, which
+///    hands the practice PII records for a person who may not exist and pollutes
+///    the patient list.
+///  - An appointment in `REQUESTED` occupies the practice's own request queue.
+///    Filling that queue is then something any anonymous caller can do.
+///
+/// Personal data here belongs to someone with no relationship to the practice
+/// yet, in a product operating under GDPR, so `purgeAfter` is set on every row
+/// and a scheduled job deletes what is past it. Storage limitation is a
+/// property of the table, not of anyone remembering to clean up.
+model PublicBookingRequest {
+  id             String @id @default(uuid())
+  organizationId String
+  /// The ProductItem asked for. Not a foreign key: the request must survive the
+  /// service being archived, and it is re-validated when it is read.
+  productItemId  String
+  /// Snapshot of the service name as it was offered. A renamed or archived
+  /// service must not silently rewrite what the requester believes they asked
+  /// for.
+  serviceName    String
+
+  requestedStart  DateTime
+  requestedEnd    DateTime
+  durationMinutes Int
+
+  ownerName  String
+  ownerEmail String
+  ownerPhone String?
+  petName    String
+  petSpecies String
+  concern    String?
+
+  status PublicBookingRequestStatus @default(PENDING_CONFIRMATION)
+
+  /// SHA-256 of the emailed confirmation token. The token itself is never
+  /// stored, so a database disclosure does not let anyone confirm requests.
+  confirmationTokenHash String   @unique
+  confirmationExpiresAt DateTime
+  confirmedAt           DateTime?
+
+  /// When the requester agreed to the privacy notice on the form. GDPR Art. 6
+  /// needs a lawful basis recorded at the point of collection, not inferred
+  /// later.
+  consentAcceptedAt DateTime
+
+  /// Hard deletion deadline. Enforced by a scheduled purge, and indexed so that
+  /// job is a range scan rather than a table walk.
+  purgeAfter DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, status, requestedStart])
+  @@index([purgeAfter])
 }
 
 /// What a practice configured for its public booking page.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The public booking setup wizard is a mockup presented to clinics as a working feature.

`PublicBookingSetup.tsx` computed `book.yosemitecrew.com/<slug>` in the browser from the organisation name, rendered it, and offered copy-to-clipboard. Four things were true at once:

1. `book.yosemitecrew.com` has no DNS record. It does not resolve.
2. The page persisted nothing. No API client, no mutation, no submit handler.
3. No backend endpoint existed for public booking.
4. No public route rendered a booking page. `middleware.ts` listed only `/public-booking-setup`, the authenticated setup page itself.

A clinic completed setup, was shown a URL, copied it, and nothing was saved while the URL went nowhere. The copy button invited them to publish a dead link on their own website or Google listing.

A fifth problem surfaced during review: **the bookable-service chooser has always been empty.** `loadOrganisationCatalog` populates `specialities` and nothing else; `services` is written only by `loadSpecialityCatalog`. The wizard called the first and never the second, so every practice saw "No bookable services yet" regardless of its catalogue.

## What is the new behavior?

Phase 1 of three. Shippable on its own, and it closes the dishonesty: nothing on screen is a claim the product cannot keep.

### Database

- `Organization.bookingSlug` (unique) and `publicBookingEnabled` (default `false`). Publishing is opt-in, so no existing practice becomes reachable on the public internet because this migration ran.
- `BookingSlugReservation` owns the slug namespace rather than the column on `Organization`. A slug is claimed by inserting there first, inside the same transaction that denormalises it onto the organisation, so two practices both called "Park Vets" collide on a primary key instead of racing a read-then-write. Rows are never deleted, so a practice that renames later keeps resolving its old address: booking URLs end up on printed cards and in Google listings.
- `PublicBookingSettings` holds what the wizard collects. `autoConfirm` defaults to `false`, so a public request is a request a human accepts through the accept/reject routes the PMS already has.
- Both new tables enable row level security, which `20260818090000_enable_row_level_security` requires of any table added after it ran.

### API

- `GET` and `PUT /v1/booking-page/:organisationId`, gated on `teams:view:any` and `teams:edit:any`. Putting the practice online is an organisation-administration act, so it does not ride on `specialities:edit:any`, which every role that can rename a service holds.
- Handlers scope on the organisation `withOrgPermissions` authorized, never on the route param.
- Submitted `serviceIds` are re-read against the caller's own organisation before being stored, so an admin cannot pin another tenant's catalogue item onto their public page. Deliberate given the cross-tenant IDOR found in an authenticated path in this codebase on 2026-08-25 (#2502).
- `bookingWindowDays` and `bufferMinutes` carry explicit ceilings, because both are eventually read by an unauthenticated surface.
- `publicUrl` is `null` unless the practice has opted in AND `PUBLIC_BOOKING_BASE_URL` is configured. No code path can produce an address that does not resolve, and the variable ships blank.
- `configured` reports whether a settings row exists, so a practice that deliberately saved zero services is distinguishable from one that has never answered. Both otherwise arrive as an empty `serviceIds`.

### Wizard

- Loads and saves real settings. "Go live" becomes "Save booking setup", which is what the button does.
- The address block has three honest states: no address yet, a reserved slug shown with no copy button and a plain statement that the page is not live, or a real URL with a copy button. Nothing is derived client-side; `slugify` and its util file are deleted.
- The "FIELDS ASSUMED - confirm with product" banner is removed, because the fields are no longer assumed.
- The service chooser now loads the services it asks the clinic to choose between.
- A failed configuration load is surfaced and disables saving, so a transient read outage cannot overwrite stored settings with defaults.

### Product decisions, confirmed before building

- Slugs: globally unique, server-derived from the practice name with a numeric suffix on collision, renameable later with the old slug kept as a permanent alias. Reserved-word list plus DNS-label rules, so a future move to a subdomain does not require re-slugging anyone.
- Opt-in, default off.
- Path on the existing origin now (`/book/<slug>`), subdomain later if provisioned. `book.yosemitecrew.com` needs a DNS record, a certificate and a CDN origin, none of which this repository can create.
- Bookings are a per-clinic setting defaulting to approval required.

## Not in this PR

- Phase 2: the public `/book/[slug]` page and its slug-resolved read endpoints, reusing the anonymous read surface that already exists in `service.router.ts` (`bookable-slots`, which already redacts `vetIds` for anonymous callers). Its services projection will be sourced from `ProductItem`, not from `GET /fhir/v1/service/organisation/:id`, which reads the legacy `prisma.service` table and returns empty for revamp-built catalogues.
- Phase 3: email-confirmed submission creating a `REQUESTED` appointment.

Nothing is publicly reachable until phase 3: opt-in defaults off and there is no way to turn it on yet.

## Deployment note

This PR adds a Prisma migration, so on a dev-to-main promotion **the API must be deployed before the frontend**. The migration is additive and backfill-free: every column is nullable or defaulted, and the new unique index lands on a column that is NULL for every existing row.

The new Playwright spec encodes that ordering: it probes for `/v1/booking-page` and skips on 404 (frontend ahead of API), but fails on 5xx.

## Validation performed

- `prisma migrate deploy` against a clean Postgres 16, plus CI's row-level-security check and the `migrate diff` drift check run locally: both pass.
- Slug allocation exercised against that real Postgres, which mocks cannot cover for raw SQL: two practices named "Park Vets" resolve to `park-vets` and `park-vets-2`; repeated calls are idempotent; "Tierärzte Grünwald" yields `tierarzte-grunwald`; deleting an organisation cascades its reservations away; and **eight simultaneous first-saves for one practice all return the same slug**, leaving exactly one reservation row.
- Backend: **79 tests passing**, 100% statements, branches, functions and lines on all three new files.
- Frontend: **45 tests passing**, 100% on `PublicBookingSetup.tsx` and `bookingPageApiService.ts`.
- `npx tsc --noemit` exit 0 in both workspaces. `lint` exit 0 in both; the single frontend warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, untouched here.
- `storybook:build` exit 0.
- CodeQL: both "missing regular expression anchor" alerts fixed at the root by dropping the regex; **no open code-scanning alerts remain on this branch**.

### Known gaps, stated plainly

- **The new Playwright spec has never been executed.** It needs `YC_E2E_*` credentials and an environment with the API deployed. `playwright test --list` confirms it parses and registers; that is the limit of what was verified. It runs in `playwright-auth`, which is skipped on `pull_request` by design, so it provides post-merge coverage on `dev`/`main`, not on this PR.
- **Aikido reports one remaining LOW.** Its detail is visible only in the Aikido dashboard. Every code file in this diff has been scanned locally with `aikido_full_scan` and comes back clean, and the MEDIUM that accompanied it was cleared by the CodeQL regex fix. The leading unconfirmed hypothesis is the two new tables enabling RLS with no policy, which is deliberate, documented in the migration, and matches what `20260818090000` and `20260820100000` already do; the local scanner covers SAST and secrets only, so it would not surface that class.
- The rendered wizard has not been viewed in a browser: `/public-booking-setup` requires an authenticated session.

## Related Issue(s)

Fixes #
