### PR TITLE
fix(frontend): give SectionCard its own surface and fix seven token misuses

### DIFF
--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
@@ -40,7 +40,7 @@ const ToggleRow = ({ title, description, checked, onChange }: ToggleRowProps) =>
           checked ? 'translate-x-[20px]' : 'translate-x-[2px]'
         )}
         style={{
-          backgroundColor: checked ? '#ffffff' : 'var(--screen)',
+          backgroundColor: checked ? 'var(--white-text)' : 'var(--screen)',
           borderColor: checked ? 'transparent' : 'var(--hairline)',
         }}
       />
@@ -68,7 +68,7 @@ const DocumentESigning = () => {
       fallback={<Fallback resource="document e-signing settings" />}
     >
       <SectionCard title="E-signing" showButton={false}>
-        <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] overflow-hidden shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+        <div className="overflow-hidden">
           <div className="px-5! py-3! border-b border-[var(--hairline)] text-[11.5px] text-[var(--ink-faint)]">
             How consent documents get signed
           </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
@@ -73,7 +73,7 @@ const Documents = () => {
         buttonClick={setAddPopup}
         showButton={canEditDocument}
       >
-        <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] overflow-hidden shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+        <div className="overflow-hidden">
           <div className="px-5! py-3! border-b border-[var(--hairline)] text-[11.5px] text-[var(--ink-faint)]">
             Clinic-wide templates and files
           </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
@@ -70,7 +70,7 @@ export const LinkedMedicalDevicesCard = ({
 
   return (
     <SectionCard title="Linked medical devices" showButton={false}>
-      <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] overflow-hidden shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <div className="overflow-hidden">
         <div className="flex items-center justify-between gap-3 px-5! py-3! border-b border-[var(--hairline)]">
           <div className="text-[11.5px] text-[var(--ink-faint)]">
             Last cloud poll {lastPoll} · {buildHealthText(total, onlineCount)}
@@ -128,7 +128,7 @@ export const LinkedMedicalDevicesCard = ({
                   </span>
                 ) : (
                   <span className="flex items-center gap-1.5 text-[11px] font-bold text-[var(--warn-text)]">
-                    <span className="size-[7px] rounded-full bg-[var(--warn-text)]" />
+                    <span className="size-[7px] rounded-full bg-[var(--warn)]" />
                     {'IDLE'}
                     {idleSuffix}
                   </span>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/OnlineBooking.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/OnlineBooking.tsx
@@ -5,7 +5,7 @@ import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
 
 const OnlineBooking = () => (
   <SectionCard title="Online booking" showButton={false}>
-    <div className="flex flex-col gap-3 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-4! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-3 px-5! py-4! sm:flex-row sm:items-center sm:justify-between">
       <div className="flex min-w-0 items-start gap-3">
         <span className="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-[var(--blue-soft)] text-[var(--blue-text)]">
           <IoCalendarOutline size={16} />

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
@@ -194,7 +194,7 @@ export const UnitsSection = ({
             type="button"
             aria-label="Add unit type"
             onClick={onAddUnit}
-            className="flex size-8 items-center justify-center rounded-full bg-text-primary text-[var(--screen)]"
+            className="flex size-8 items-center justify-center rounded-full bg-[var(--ink)] text-[var(--screen)]"
           >
             <FiPlus size={16} aria-hidden="true" />
           </button>
@@ -204,7 +204,7 @@ export const UnitsSection = ({
     {open && (
       <div className="flex flex-col gap-3">
         {formData.units.map((unit) => (
-          <div key={unit.id} className="rounded-2xl border border-blue-text p-3">
+          <div key={unit.id} className="rounded-2xl border border-[var(--blue)] p-3">
             <div className="mb-3 text-caption-1 text-blue-text">Draft unit type</div>
             <RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />
           </div>
@@ -265,7 +265,7 @@ export const EquipmentSection = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-[var(--screen)]"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-[var(--ink)] text-[var(--screen)]"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoContent.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoContent.tsx
@@ -31,7 +31,7 @@ const IconCircleButton = ({
     onClick={onClick}
     className={`flex size-8 items-center justify-center rounded-full border ${
       danger
-        ? 'border-text-error bg-[var(--screen)] text-text-error'
+        ? 'border-[var(--danger-border)] bg-[var(--screen)] text-text-error'
         : 'border-[var(--ink)] bg-[var(--ink)] text-[var(--screen)]'
     }`}
   >

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
@@ -250,7 +250,7 @@ const RoomInfoSections = ({
               type="button"
               aria-label="Add unit type"
               onClick={onAddUnit}
-              className="flex size-8 items-center justify-center rounded-full bg-text-primary text-[var(--screen)]"
+              className="flex size-8 items-center justify-center rounded-full bg-[var(--ink)] text-[var(--screen)]"
             >
               <FiPlus size={16} aria-hidden="true" />
             </button>
@@ -274,7 +274,7 @@ const RoomInfoSections = ({
                 />
               </fieldset>
             ) : (
-              <div key={unit.id} className="rounded-2xl border border-blue-text p-3">
+              <div key={unit.id} className="rounded-2xl border border-[var(--blue)] p-3">
                 <RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />
               </div>
             )
@@ -319,7 +319,7 @@ const RoomInfoSections = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-[var(--screen)]"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-[var(--ink)] text-[var(--screen)]"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -414,7 +414,7 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
                   <div className="w-18 flex justify-center">
                     {viewDisabled ? (
                       /* v8 ignore next -- every PERMISSION_ROWS entry defines a non-empty `view`, so viewDisabled is never true */
-                      <span className="text-muted-400">{'—'}</span>
+                      <span className="text-text-tertiary">{'—'}</span>
                     ) : (
                       <input
                         type="checkbox"
@@ -430,7 +430,7 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
                   </div>
                   <div className="w-18 flex justify-center">
                     {editDisabled ? (
-                      <span className="text-muted-400">{'—'}</span>
+                      <span className="text-text-tertiary">{'—'}</span>
                     ) : (
                       <input
                         type="checkbox"

--- a/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.tsx
+++ b/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.tsx
@@ -41,10 +41,13 @@ const SectionCard: React.FC<SectionCardProps> = ({
   const canEditSubscription = can(PERMISSIONS.SUBSCRIPTION_EDIT_ANY);
   const plan = subscription?.plan;
   const hasCustomerId = Boolean(subscription?.stripeCustomerId);
-  const hasFinanceAction = canEditSubscription && finance && (hasCustomerId || plan === 'free');
   const [loadingPortal, setLoadingPortal] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const paddingYClass = showButton || hasFinanceAction ? 'py-2' : 'py-[20px]';
+  // An action in the header used to collapse the whole card to py-2 (8px) while
+  // an actionless one sat at 20px, so two adjacent sections could differ by 12px
+  // for a reason the reader cannot see. The action button carries its own height;
+  // the card keeps one padding either way.
+  const paddingYClass = 'py-[18px]';
 
   const handleBillingPortal = async () => {
     setError(null);
@@ -72,8 +75,13 @@ const SectionCard: React.FC<SectionCardProps> = ({
   }, [error]);
 
   return (
+    // Carries the same card surface as the Settings PreferenceGroup: --screen
+    // ground, hairline border, 18px radius and the two-layer shadow. Without the
+    // ground and shadow this rendered as a bare frame, which is why four
+    // consumers had each grown their OWN inner card to compensate - stacking two
+    // visible borders. The surface belongs to the primitive, once.
     <div
-      className={`flex flex-col gap-3 rounded-2xl border border-card-border px-6 ${paddingYClass}`}
+      className={`flex flex-col gap-3 rounded-[18px] border border-card-border bg-[var(--screen)] px-6 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${paddingYClass}`}
     >
       <div className="flex items-center gap-x-4 gap-y-2">
         <h2 className="min-w-0 flex-1 text-heading-3 text-text-primary">{title}</h2>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

An audit of the Organization page surfaced a structural defect and seven token misuses. Every finding here was adversarially re-verified against source before being acted on, and findings that did not survive that check were dropped.

**`SectionCard` had a border but no ground and no shadow**, so it rendered as a bare frame rather than a card. Four sections had each independently grown their **own** fully-styled card *inside* it to compensate - `Documents`, `LinkedMedicalDevices`, `DocumentESigning`, `OnlineBooking` - so two bordered surfaces stacked visibly. The fifth consumer, `Specialities`, had no inner card and so stayed a bare frame. The same primitive therefore rendered two different ways depending on which section you looked at.

**Its vertical padding disagreed with itself:** `showButton || hasFinanceAction ? 'py-2' : 'py-[20px]'` - a header action collapsed the card to 8px while an actionless one sat at 20px, so adjacent sections differed by 12px for a reason no reader can see.

**Token misuses**, each one named explicitly in `apps/frontend/AGENTS.md`:

| File | Was | Problem |
| --- | --- | --- |
| `DocumentESigning.tsx:43` | `'#ffffff'` | Hardcoded. The unchecked knob used `--screen`, so **the checked knob stopped following the dark theme** |
| `LinkedMedicalDevices.tsx:131` | `bg-[var(--warn-text)]` | Text token as a fill; the ONLINE dot beside it correctly uses the `--success` fill |
| `Rooms/AddRoomSections.tsx`, `Rooms/RoomInfoSections.tsx` | `bg-text-primary` (4 sites) | Text-semantic token as a background; `RoomInfoContent.tsx:35` builds the identical control correctly with `bg-[var(--ink)]` |
| same two files | `border-blue-text` (2 sites) | `--blue-text` is tuned to carry 4.5:1 **text** duty; borders take the fill |
| `Rooms/RoomInfoContent.tsx:34` | `border-text-error` | `--danger-border` exists for exactly this and `DeleteOrg.tsx:22` already uses it |
| `Team/PermissionsEditor.tsx:417,433` | `text-muted-400` | Raw ramp step as text at **1.61:1** against the row |

## What is the new behavior?

The card surface belongs to the primitive, once: `--screen` ground, 18px radius, and the same two-layer shadow the Settings `PreferenceGroup` uses. The four inner cards keep their layout classes and drop the duplicated surface, so `Specialities` gains a real card and the other four lose their doubled border. Padding is one value either way. Every token above now uses the token its role calls for.

**Deliberately not changed:** the section title stays `text-heading-3`. The audit flagged it as diverging from the Settings group-title (14.5px/700), but a page-level section title is legitimately larger than a settings-group title - that is a design opinion, not a defect, and it is not mine to decide unilaterally.

`hasFinanceAction` became unused once the padding was unified and is removed; lint caught it.

## Impact area

`apps/frontend`. `SectionCard` is a shared primitive with exactly five consumers, all on the Organization page (`FederationSection.tsx:72` and `NetworkDirectory.tsx:21` define separate local components that share the name only). The `PermissionsEditor` change is latent - no `PERMISSION_ROWS` entry currently has an empty `view`/`edit` list, so that em dash does not render today, but it is one data change from being visible.

## Validation performed

- **31 suites / 395 tests passing** across `SectionCard`, `Documents`, `OnlineBooking`, `DocumentESigning`, `LinkedMedicalDevices`, `PermissionsEditor` and `Rooms`.
- `npx tsc --noemit` clean (0 errors). `pnpm --filter frontend run lint` exit 0 - the one warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, untouched here.
- Grep confirms zero residual occurrences of every fixed pattern in the Organization tree.

**Not visually verified.** These are surface and token changes, which is exactly the class that wants an eyeball - `/organization` needs an authenticated session the automated browser does not have. The `#ffffff` fix in particular should be confirmed in **dark** mode, since that is where the bug was.

## Related Issue(s)

Refs #2512
