### PR TITLE
fix(desktop): make DEA compliance logs survivable and fail loudly

### DIFF
--- a/apps/desktop/src/compliance/audit-log.ts
+++ b/apps/desktop/src/compliance/audit-log.ts
@@ -1,10 +1,14 @@
 'use strict';
 
 import fs from 'node:fs';
-import path from 'node:path';
 import crypto from 'node:crypto';
 import { Buffer } from 'node:buffer';
-import { createJsonlStore, type DurableLogFs, type JsonlHealth } from './durable-log';
+import {
+  containedPath,
+  createJsonlStore,
+  type DurableLogFs,
+  type JsonlHealth,
+} from './durable-log';
 
 export interface AuditEntry {
   id: string;
@@ -130,7 +134,10 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
   const mkdirSync = deps.mkdirSync || fs.mkdirSync;
   const existsSync = deps.existsSync || fs.existsSync;
   const now = deps.now || (() => Date.now());
-  const keyPath = path.join(dirPath, AUDIT_KEY_FILENAME);
+  // The signing key was the one compliance path still built with a bare join,
+  // so it never went through the containment check every other path in these
+  // stores uses. It reads a secret, which makes it the worst one to leave out.
+  const keyPath = containedPath(dirPath, AUDIT_KEY_FILENAME);
 
   const secureStore = await resolveSecureStore(deps);
 

--- a/apps/desktop/src/compliance/audit-log.ts
+++ b/apps/desktop/src/compliance/audit-log.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { Buffer } from 'node:buffer';
+import { createJsonlStore, type DurableLogFs, type JsonlHealth } from './durable-log';
 
 export interface AuditEntry {
   id: string;
@@ -17,6 +18,17 @@ export interface AuditEntry {
   // chain (empty string for the genesis entry).
   prevSignature: string;
   signature: string;
+}
+
+/**
+ * Thrown when an audit entry could not be written to disk. An audit entry that
+ * only exists in memory is not an audit entry, so this must reach the caller.
+ */
+export class AuditWriteError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'AuditWriteError';
+  }
 }
 
 export interface AuditLog {
@@ -37,7 +49,24 @@ export interface AuditLog {
   verifyAll: () => { valid: number; tampered: number };
   // Verifies the full hash chain: each entry's stored prevSignature must match
   // the actual prior entry, catching deletion, insertion and reordering.
+  //
+  // A walk over the surviving entries alone cannot detect a log that was
+  // shortened from the front, so this also compares the loaded entries against
+  // the persisted watermark. Without that, a one-entry log left behind by a
+  // truncating crash walks cleanly and certifies a wiped history as intact.
   verifyChain: () => boolean;
+  /** Whether the log on disk can be trusted, and why not when it cannot. */
+  getIntegrity: () => AuditIntegrity;
+}
+
+export interface AuditIntegrity extends JsonlHealth {
+  /**
+   * `session-only` means the stored HMAC key could not be read, so this session
+   * signs with a temporary key. Historical entries then fail verify() because
+   * they were signed with a different key, which is NOT evidence of tampering
+   * and must not be reported as such.
+   */
+  signingKey: 'persisted' | 'session-only';
 }
 
 // OS-backed encryption (Electron safeStorage). Injectable for tests.
@@ -47,11 +76,8 @@ export interface SecureStore {
   decryptString: (encrypted: Buffer) => string;
 }
 
-interface AuditDeps {
-  readFileSync?: typeof fs.readFileSync;
+interface AuditDeps extends Partial<DurableLogFs> {
   writeFileSync?: typeof fs.writeFileSync;
-  mkdirSync?: typeof fs.mkdirSync;
-  existsSync?: typeof fs.existsSync;
   now?: () => number;
   // HMAC key. If omitted, a random per-install key is created and persisted
   // alongside the log (encrypted at rest via secureStore when available).
@@ -78,8 +104,15 @@ const resolveSecureStore = async (deps: AuditDeps): Promise<SecureStore | null> 
   return null;
 };
 
-const AUDIT_FILENAME = 'audit-log.json';
+const AUDIT_LEGACY_FILENAME = 'audit-log.json';
+const AUDIT_FILENAME = 'audit-log.jsonl';
 const AUDIT_KEY_FILENAME = 'audit-key';
+
+const isAuditEntry = (value: unknown): value is AuditEntry => {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && typeof v.action === 'string';
+};
 
 let idCounter = 0;
 const generateId = (): string => `audit-${Date.now()}-${++idCounter}`;
@@ -97,92 +130,135 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
   const mkdirSync = deps.mkdirSync || fs.mkdirSync;
   const existsSync = deps.existsSync || fs.existsSync;
   const now = deps.now || (() => Date.now());
-  const filePath = path.join(dirPath, AUDIT_FILENAME);
   const keyPath = path.join(dirPath, AUDIT_KEY_FILENAME);
 
   const secureStore = await resolveSecureStore(deps);
 
-  // Parse a stored key file wrapper. Returns the recovered key, or null when the
-  // wrapper is present but unusable (caller then generates a fresh key).
-  const decodeStoredKey = (stored: string): string | null => {
+  /**
+   * Reading the stored key has three outcomes, and conflating the last two is
+   * what destroys an installation's audit history: "there is no key yet" means
+   * mint one, but "the key is there and cannot be read right now" (no keyring
+   * session, locked or reset login keychain) must never be answered by writing a
+   * new key over it.
+   */
+  type KeyRead =
+    | { status: 'found'; key: string }
+    | { status: 'absent' }
+    | { status: 'unreadable'; reason: string };
+
+  const isLegacyHexKey = (stored: string): boolean => /^[0-9a-f]{32,}$/i.test(stored);
+
+  const decodeStoredKey = (stored: string): KeyRead => {
+    let parsed: { enc?: boolean; data?: string; key?: string } | null = null;
     try {
-      const parsed = JSON.parse(stored) as {
-        enc?: boolean;
-        data?: string;
-        key?: string;
-      };
-      if (parsed.enc && parsed.data && secureStore) {
-        return secureStore.decryptString(Buffer.from(parsed.data, 'base64'));
+      const value: unknown = JSON.parse(stored);
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        parsed = value as { enc?: boolean; data?: string; key?: string };
       }
-      if (!parsed.enc && typeof parsed.key === 'string') return parsed.key;
-      return null;
     } catch {
-      // legacy plaintext-hex key file
-      return stored;
+      // not JSON: may be a legacy plaintext-hex key file
     }
+
+    if (parsed === null) {
+      if (isLegacyHexKey(stored)) return { status: 'found', key: stored };
+      return { status: 'unreadable', reason: 'the key file is not in a recognised format' };
+    }
+
+    if (parsed.enc) {
+      if (!parsed.data) {
+        return { status: 'unreadable', reason: 'the encrypted key file contains no key data' };
+      }
+      if (!secureStore) {
+        return {
+          status: 'unreadable',
+          reason: 'the key is encrypted but the OS keychain is unavailable',
+        };
+      }
+      try {
+        return {
+          status: 'found',
+          key: secureStore.decryptString(Buffer.from(parsed.data, 'base64')),
+        };
+      } catch (error) {
+        return {
+          status: 'unreadable',
+          reason: `the OS keychain could not decrypt the key: ${(error as Error).message}`,
+        };
+      }
+    }
+
+    if (typeof parsed.key === 'string' && parsed.key !== '') {
+      return { status: 'found', key: parsed.key };
+    }
+    return { status: 'unreadable', reason: 'the key file contains no usable key' };
   };
 
-  const readExistingKey = (): string | null => {
+  const readExistingKey = (): KeyRead => {
+    if (!existsSync(keyPath)) return { status: 'absent' };
+    let stored: string;
     try {
-      if (!existsSync(keyPath)) return null;
-      const stored = readFileSync(keyPath, 'utf8').trim();
-      return stored ? decodeStoredKey(stored) : null;
-    } catch {
-      // fall through and create a new key
-      return null;
+      stored = String(readFileSync(keyPath, 'utf8')).trim();
+    } catch (error) {
+      return {
+        status: 'unreadable',
+        reason: `the key file could not be read: ${(error as Error).message}`,
+      };
     }
+    if (stored === '') return { status: 'unreadable', reason: 'the key file is empty' };
+    return decodeStoredKey(stored);
   };
 
-  const loadOrCreateKey = (): string => {
+  interface KeyState {
+    key: string;
+    persisted: boolean;
+    reason: string | null;
+  }
+
+  const loadOrCreateKey = (): KeyState => {
     const existing = readExistingKey();
-    if (existing !== null) return existing;
+    if (existing.status === 'found') return { key: existing.key, persisted: true, reason: null };
+
     const key = crypto.randomBytes(32).toString('hex');
+    if (existing.status === 'unreadable') {
+      // Overwriting here would destroy the only means of ever verifying the
+      // existing history, permanently, in response to a condition that is
+      // usually temporary. Run on a session key and leave the stored one intact
+      // so it still works once the keychain is available again.
+      return { key, persisted: false, reason: existing.reason };
+    }
+
     try {
       mkdirSync(dirPath, { recursive: true });
       const wrapper = secureStore
         ? { enc: true, data: secureStore.encryptString(key).toString('base64') }
         : { enc: false, key };
       writeFileSync(keyPath, JSON.stringify(wrapper), { mode: 0o600 });
-    } catch {
-      // if persistence fails the key still works for this session
-    }
-    return key;
-  };
-
-  const key = deps.hmacKey || loadOrCreateKey();
-
-  let cached: AuditEntry[] | null = null;
-
-  const load = (): AuditEntry[] => {
-    if (cached) return cached;
-    try {
-      if (!existsSync(filePath)) {
-        cached = [];
-        return cached;
-      }
-      const raw = readFileSync(filePath, 'utf8');
-      const entries: AuditEntry[] = JSON.parse(raw);
-      if (!Array.isArray(entries)) {
-        cached = [];
-        return cached;
-      }
-      cached = entries.filter((e) => typeof e.id === 'string' && typeof e.action === 'string');
-      return cached;
-    } catch {
-      cached = [];
-      return cached;
+      return { key, persisted: true, reason: null };
+    } catch (error) {
+      return {
+        key,
+        persisted: false,
+        reason: `the new signing key could not be saved: ${(error as Error).message}`,
+      };
     }
   };
 
-  const save = (entries: AuditEntry[]): void => {
-    cached = entries;
-    try {
-      mkdirSync(dirPath, { recursive: true });
-      writeFileSync(filePath, JSON.stringify(entries), 'utf8');
-    } catch {
-      // persist must never break the app
-    }
-  };
+  const keyState: KeyState = deps.hmacKey
+    ? { key: deps.hmacKey, persisted: true, reason: null }
+    : loadOrCreateKey();
+  const key = keyState.key;
+
+  const store = createJsonlStore<AuditEntry>({
+    dirPath,
+    fileName: AUDIT_FILENAME,
+    legacyFileName: AUDIT_LEGACY_FILENAME,
+    isRecord: isAuditEntry,
+    watermarkOf: (entry) => entry.signature,
+    fsq: deps,
+    now,
+  });
+
+  const load = (): AuditEntry[] => store.readAll();
 
   const append = (
     input: Omit<AuditEntry, 'id' | 'timestamp' | 'signature' | 'prevSignature'>
@@ -199,8 +275,17 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
       ...unsigned,
       signature: computeSignature(unsigned, key),
     };
-    entries.push(entry);
-    save(entries);
+    try {
+      // The store only advances its in-memory view once the bytes are durable,
+      // so a failed write cannot leave the session showing a signed entry that
+      // is on no disk anywhere.
+      store.append(entry);
+    } catch (error) {
+      throw new AuditWriteError(
+        `failed to persist audit entry ${entry.id}: ${(error as Error).message}`,
+        error
+      );
+    }
     return entry;
   };
 
@@ -268,7 +353,29 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
       if (!verify(entry)) return false;
       prev = entry.signature;
     }
+
+    // Walking the surviving entries proves they are internally consistent, not
+    // that they are all of them. A log truncated back to its first entry walks
+    // perfectly: prevSignature is '' and the HMAC is genuine. The watermark is
+    // what makes that case distinguishable from a genuinely new install.
+    if (!getIntegrity().ok) return false;
+    const watermark = store.watermarkValue();
+    if (watermark !== '' && !entries.some((e) => e.signature === watermark)) return false;
     return true;
+  };
+
+  const getIntegrity = (): AuditIntegrity => {
+    const health = store.health();
+    if (keyState.persisted) return { ...health, signingKey: 'persisted' };
+    const keyReason =
+      `the audit signing key could not be read (${keyState.reason}), so this session signs with a ` +
+      `temporary key; earlier entries cannot be verified until the stored key is readable again`;
+    return {
+      ...health,
+      ok: false,
+      reason: health.reason ? `${health.reason}; ${keyReason}` : keyReason,
+      signingKey: 'session-only',
+    };
   };
 
   return {
@@ -281,6 +388,7 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
     verify,
     verifyAll,
     verifyChain,
+    getIntegrity,
   };
 };
 

--- a/apps/desktop/src/compliance/controlled-substance.ts
+++ b/apps/desktop/src/compliance/controlled-substance.ts
@@ -1,8 +1,9 @@
 'use strict';
 
-import fs from 'node:fs';
+import type fs from 'node:fs';
 import path from 'node:path';
 import type { AuditLog } from './audit-log';
+import { createJsonlStore, type DurableLogFs, type JsonlHealth } from './durable-log';
 
 export type CsAction = 'dispense' | 'administer' | 'receive' | 'waste' | 'transfer' | 'inventory';
 
@@ -25,6 +26,18 @@ export interface CsTransaction {
   auditEntryId: string;
 }
 
+/**
+ * Thrown when a controlled-substance transaction could not be persisted. The
+ * caller must surface the failure: a dispense that is not on disk has not been
+ * recorded, whatever the UI said.
+ */
+export class CsWriteError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'CsWriteError';
+  }
+}
+
 export interface ControlledSubstanceLogbook {
   record: (tx: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>) => CsTransaction;
   getTransactions: (opts?: {
@@ -44,67 +57,73 @@ export interface ControlledSubstanceLogbook {
   getDailyLog: (date: Date) => CsTransaction[];
   getAuditTrail: () => ReturnType<AuditLog['query']>;
   size: () => number;
+  /** Whether the register on disk can be trusted, and why not when it cannot. */
+  getIntegrity: () => JsonlHealth;
 }
 
-interface CsDeps {
+interface CsDeps extends Partial<DurableLogFs> {
   auditLog: AuditLog;
-  readFileSync?: typeof fs.readFileSync;
   writeFileSync?: typeof fs.writeFileSync;
-  mkdirSync?: typeof fs.mkdirSync;
-  existsSync?: typeof fs.existsSync;
   now?: () => number;
 }
 
-const CS_FILENAME = 'controlled-substance-log.json';
+const CS_LEGACY_FILENAME = 'controlled-substance-log.json';
+const CS_FILENAME = 'controlled-substance-log.jsonl';
 
 let txCounter = 0;
 const generateTxId = (): string => `cs-${Date.now()}-${++txCounter}`;
+
+const isCsTransaction = (value: unknown): value is CsTransaction => {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && typeof v.drugName === 'string';
+};
 
 export const createControlledSubstanceLogbook = (
   dirPath: string,
   deps: CsDeps
 ): ControlledSubstanceLogbook => {
-  const readFileSync = deps.readFileSync || fs.readFileSync;
-  const writeFileSync = deps.writeFileSync || fs.writeFileSync;
-  const mkdirSync = deps.mkdirSync || fs.mkdirSync;
-  const existsSync = deps.existsSync || fs.existsSync;
   const now = deps.now || (() => Date.now());
-  const filePath = path.join(dirPath, CS_FILENAME);
 
   // Path-traversal guard: reject any ".." segment that would let dirPath escape
   // its intended location, while still allowing legitimate absolute data dirs.
-  const hasPathTraversal = (): boolean =>
-    path
-      .normalize(filePath)
-      .split(/[\\/]+/)
-      .includes('..');
+  const blockedPath = path
+    .normalize(path.join(dirPath, CS_FILENAME))
+    .split(/[\\/]+/)
+    .includes('..');
 
-  const load = (): CsTransaction[] => {
-    try {
-      if (hasPathTraversal()) return [];
-      if (!existsSync(filePath)) return [];
-      const raw = readFileSync(filePath, 'utf8');
-      const entries: CsTransaction[] = JSON.parse(raw);
-      if (!Array.isArray(entries)) return [];
-      return entries.filter((e) => typeof e.id === 'string' && typeof e.drugName === 'string');
-    } catch {
-      return [];
-    }
+  const store = blockedPath
+    ? null
+    : createJsonlStore<CsTransaction>({
+        dirPath,
+        fileName: CS_FILENAME,
+        legacyFileName: CS_LEGACY_FILENAME,
+        isRecord: isCsTransaction,
+        watermarkOf: (tx) => tx.id,
+        fsq: deps,
+        now,
+      });
+
+  const blockedHealth: JsonlHealth = {
+    ok: false,
+    reason: 'the log directory is not a permitted location, so no register is readable',
+    quarantinePath: null,
+    recordsLoaded: 0,
+    watermarkCount: 0,
+    tornTail: false,
   };
 
-  const save = (entries: CsTransaction[]): void => {
-    try {
-      if (hasPathTraversal()) return;
-      mkdirSync(dirPath, { recursive: true });
-      writeFileSync(filePath, JSON.stringify(entries), 'utf8');
-    } catch {
-      // persist must never break the app
-    }
-  };
+  const load = (): CsTransaction[] => (store ? store.readAll() : []);
 
   const record = (
     input: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>
   ): CsTransaction => {
+    if (!store) {
+      throw new CsWriteError(
+        'refusing to record a controlled substance: the log directory is not a permitted location'
+      );
+    }
+
     // Generate the transaction id up front so it can be signed into the audit
     // entry's details. Mutating details after append() would invalidate the HMAC
     // signature and make the record read as tampered.
@@ -134,9 +153,17 @@ export const createControlledSubstanceLogbook = (
       auditEntryId: auditEntry.id,
     };
 
-    const entries = load();
-    entries.push(tx);
-    save(entries);
+    try {
+      store.append(tx);
+    } catch (error) {
+      // The audit entry above is already signed and on disk, so the two
+      // regulatory records would otherwise disagree forever. Surface the
+      // failure instead of returning a transaction that exists nowhere.
+      throw new CsWriteError(
+        `failed to persist controlled-substance transaction ${txId}: ${(error as Error).message}`,
+        error
+      );
+    }
     return tx;
   };
 
@@ -145,7 +172,7 @@ export const createControlledSubstanceLogbook = (
     since?: number;
     limit?: number;
   }): CsTransaction[] => {
-    let entries = load();
+    let entries = [...load()];
     if (opts?.drugName) {
       entries = entries.filter((e) => e.drugName === opts.drugName);
     }
@@ -208,6 +235,8 @@ export const createControlledSubstanceLogbook = (
 
   const size = (): number => load().length;
 
+  const getIntegrity = (): JsonlHealth => (store ? store.health() : blockedHealth);
+
   return {
     record,
     getTransactions,
@@ -217,5 +246,6 @@ export const createControlledSubstanceLogbook = (
     getDailyLog,
     getAuditTrail,
     size,
+    getIntegrity,
   };
 };

--- a/apps/desktop/src/compliance/controlled-substance.ts
+++ b/apps/desktop/src/compliance/controlled-substance.ts
@@ -156,15 +156,49 @@ export const createControlledSubstanceLogbook = (
     try {
       store.append(tx);
     } catch (error) {
-      // The audit entry above is already signed and on disk, so the two
-      // regulatory records would otherwise disagree forever. Surface the
-      // failure instead of returning a transaction that exists nowhere.
+      // The audit entry above is already signed and on disk. Surfacing the
+      // failure is necessary but not sufficient: left alone, the audit trail
+      // would assert that a dispense occurred while the register holds no such
+      // transaction, and a retry would add a second such claim. Write an
+      // explicit compensation entry so the two regulatory histories cannot
+      // disagree about whether the event completed.
+      const compensated = appendCompensation(input, txId, auditEntry.id, error as Error);
       throw new CsWriteError(
-        `failed to persist controlled-substance transaction ${txId}: ${(error as Error).message}`,
+        `failed to persist controlled-substance transaction ${txId}: ${(error as Error).message}` +
+          (compensated ? '' : ' (the compensating audit entry could not be written either)'),
         error
       );
     }
     return tx;
+  };
+
+  /**
+   * Records that a transaction announced in the audit log never reached the
+   * register. Returns false when the audit log is unwritable too, which the
+   * caller reports rather than hides.
+   */
+  const appendCompensation = (
+    input: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>,
+    txId: string,
+    voidedAuditEntryId: string,
+    cause: Error
+  ): boolean => {
+    try {
+      deps.auditLog.append({
+        action: `cs:${input.action}:not-recorded`,
+        actor: input.veterinarianId,
+        resourceType: 'controlled-substance',
+        resourceId: `${input.drugName}:${input.lotNumber}`,
+        details: {
+          csTransactionId: txId,
+          voidsAuditEntryId: voidedAuditEntryId,
+          reason: cause.message,
+        },
+      });
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   const getTransactions = (opts?: {

--- a/apps/desktop/src/compliance/controlled-substance.ts
+++ b/apps/desktop/src/compliance/controlled-substance.ts
@@ -38,8 +38,11 @@ export class CsWriteError extends Error {
   }
 }
 
+/** A transaction as the caller supplies it, before the store stamps identity. */
+export type CsTransactionInput = Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>;
+
 export interface ControlledSubstanceLogbook {
-  record: (tx: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>) => CsTransaction;
+  record: (tx: CsTransactionInput) => CsTransaction;
   getTransactions: (opts?: {
     drugName?: string;
     since?: number;
@@ -116,7 +119,7 @@ export const createControlledSubstanceLogbook = (
   const load = (): CsTransaction[] => (store ? store.readAll() : []);
 
   const record = (
-    input: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>
+    input: CsTransactionInput
   ): CsTransaction => {
     if (!store) {
       throw new CsWriteError(
@@ -178,7 +181,7 @@ export const createControlledSubstanceLogbook = (
    * caller reports rather than hides.
    */
   const appendCompensation = (
-    input: Omit<CsTransaction, 'id' | 'timestamp' | 'auditEntryId'>,
+    input: CsTransactionInput,
     txId: string,
     voidedAuditEntryId: string,
     cause: Error

--- a/apps/desktop/src/compliance/durable-log.ts
+++ b/apps/desktop/src/compliance/durable-log.ts
@@ -1,0 +1,379 @@
+'use strict';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { Buffer } from 'node:buffer';
+
+/**
+ * Append-only, crash-durable record store shared by the DEA compliance logs.
+ *
+ * Rewriting a whole JSON array on every append is not survivable: a crash or a
+ * short write between truncate and completion leaves truncated JSON, the next
+ * launch parses it as "empty", and the following append overwrites every
+ * surviving record. That is silent, total loss of a federally required record.
+ *
+ * This store instead writes one JSON object per line with O_APPEND + fsync, so
+ * an interrupted write can only ever damage the final line. It also persists a
+ * watermark (record count + a caller-chosen last-record marker) next to the log
+ * so that a log which has been shortened, replaced or deleted is *detectable*
+ * rather than indistinguishable from a fresh install.
+ */
+
+export interface DurableLogFs {
+  readFileSync: typeof fs.readFileSync;
+  mkdirSync: typeof fs.mkdirSync;
+  existsSync: typeof fs.existsSync;
+  openSync: (filePath: string, flags: string, mode?: number) => number;
+  writeSync: (fd: number, data: string) => number;
+  fsyncSync: (fd: number) => void;
+  closeSync: (fd: number) => void;
+  renameSync: (from: string, to: string) => void;
+  truncateSync: (filePath: string, length: number) => void;
+}
+
+/**
+ * Why a log is not trustworthy. `null` reason means the log is intact as far as
+ * this store can tell.
+ */
+export interface JsonlHealth {
+  ok: boolean;
+  reason: string | null;
+  /** Where a damaged file was moved to, so an operator can recover it. */
+  quarantinePath: string | null;
+  /** Records successfully parsed out of the live log file. */
+  recordsLoaded: number;
+  /** Highest record count ever persisted. A larger value means records were lost. */
+  watermarkCount: number;
+  /** True when the final line was incomplete (interrupted write) and was skipped. */
+  tornTail: boolean;
+}
+
+export interface JsonlStore<T> {
+  readAll: () => T[];
+  /** Durably appends one record. Throws if the record did not reach the disk. */
+  append: (record: T) => void;
+  health: () => JsonlHealth;
+  /** The last-record marker persisted alongside the log ('' when never written). */
+  watermarkValue: () => string;
+}
+
+export interface JsonlStoreOptions<T> {
+  dirPath: string;
+  /** Base name of the append-only log, e.g. `audit-log.jsonl`. */
+  fileName: string;
+  /** Legacy whole-array JSON file to migrate from, if one is present. */
+  legacyFileName?: string;
+  isRecord: (value: unknown) => value is T;
+  /** Stable marker for a record (a signature or id) stored in the watermark. */
+  watermarkOf: (record: T) => string;
+  fsq?: Partial<DurableLogFs>;
+  now?: () => number;
+  /** Called when the store detects damage. Never throws into the caller. */
+  onDamage?: (health: JsonlHealth) => void;
+}
+
+interface WatermarkFile {
+  count?: number;
+  last?: string;
+  brokenAt?: number;
+  reason?: string;
+  quarantined?: string[];
+}
+
+const defaultFs = (): DurableLogFs => ({
+  readFileSync: fs.readFileSync,
+  mkdirSync: fs.mkdirSync,
+  existsSync: fs.existsSync,
+  openSync: fs.openSync,
+  writeSync: (fd, data) => fs.writeSync(fd, data),
+  fsyncSync: fs.fsyncSync,
+  closeSync: fs.closeSync,
+  renameSync: fs.renameSync,
+  truncateSync: fs.truncateSync,
+});
+
+const resolveFs = (partial?: Partial<DurableLogFs>): DurableLogFs => ({
+  ...defaultFs(),
+  ...(partial || {}),
+});
+
+/**
+ * Writes `data` to `filePath` and returns only once the bytes are on the
+ * platter. A short write is an error: silently persisting half a record is the
+ * failure mode this module exists to remove.
+ */
+const writeDurably = (fsq: DurableLogFs, filePath: string, data: string, flags: string): void => {
+  const fd = fsq.openSync(filePath, flags, 0o600);
+  try {
+    const written = fsq.writeSync(fd, data);
+    const expected = Buffer.byteLength(data, 'utf8');
+    if (typeof written === 'number' && written < expected) {
+      throw new Error(`short write: ${written}/${expected} bytes to ${filePath}`);
+    }
+    fsq.fsyncSync(fd);
+  } finally {
+    fsq.closeSync(fd);
+  }
+};
+
+/** Replaces a small sidecar file atomically (write temp, fsync, rename). */
+const replaceAtomically = (fsq: DurableLogFs, filePath: string, data: string): void => {
+  const tmpPath = `${filePath}.tmp`;
+  writeDurably(fsq, tmpPath, data, 'w');
+  fsq.renameSync(tmpPath, filePath);
+};
+
+export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> => {
+  const fsq = resolveFs(opts.fsq);
+  const now = opts.now || (() => Date.now());
+  const filePath = path.join(opts.dirPath, opts.fileName);
+  const statePath = path.join(opts.dirPath, `${opts.fileName}.state.json`);
+  const legacyPath = opts.legacyFileName ? path.join(opts.dirPath, opts.legacyFileName) : null;
+
+  let records: T[] | null = null;
+  let endsWithNewline = true;
+  let health: JsonlHealth = {
+    ok: true,
+    reason: null,
+    quarantinePath: null,
+    recordsLoaded: 0,
+    watermarkCount: 0,
+    tornTail: false,
+  };
+
+  const readState = (): WatermarkFile => {
+    try {
+      if (!fsq.existsSync(statePath)) return {};
+      const parsed: unknown = JSON.parse(String(fsq.readFileSync(statePath, 'utf8')));
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+      return parsed as WatermarkFile;
+    } catch {
+      // An unreadable watermark weakens loss detection but must not, by itself,
+      // make the log look damaged. The chain/HMAC checks still apply.
+      return {};
+    }
+  };
+
+  const writeState = (state: WatermarkFile): void => {
+    replaceAtomically(fsq, statePath, JSON.stringify(state));
+  };
+
+  /**
+   * Moves a damaged log aside instead of appending onto it. The replacement log
+   * is NOT presented as an intact genesis chain: `brokenAt` is persisted in the
+   * watermark so health() keeps reporting the break after restart.
+   */
+  const quarantine = (reason: string, priorState: WatermarkFile): string | null => {
+    const quarantinePath = `${filePath}.corrupt-${now()}`;
+    try {
+      fsq.renameSync(filePath, quarantinePath);
+    } catch {
+      return null;
+    }
+    try {
+      writeState({
+        count: priorState.count ?? 0,
+        last: priorState.last ?? '',
+        brokenAt: now(),
+        reason,
+        quarantined: [...(priorState.quarantined || []), quarantinePath],
+      });
+    } catch {
+      // The rename already preserved the evidence; a failed watermark update
+      // must not throw away the in-memory damage report.
+    }
+    return quarantinePath;
+  };
+
+  /**
+   * Converts a legacy whole-array log into the append-only format. Written to a
+   * temp file and renamed, so an interrupted migration leaves the legacy file
+   * untouched and is simply retried on the next launch.
+   */
+  const migrateLegacy = (): string | null => {
+    if (!legacyPath || fsq.existsSync(filePath) || !fsq.existsSync(legacyPath)) return null;
+    const raw = String(fsq.readFileSync(legacyPath, 'utf8'));
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) throw new Error('legacy log is not an array');
+    const valid = parsed.filter(opts.isRecord);
+    const body = valid.map((r) => `${JSON.stringify(r)}\n`).join('');
+    fsq.mkdirSync(opts.dirPath, { recursive: true });
+    const tmpPath = `${filePath}.migrating`;
+    writeDurably(fsq, tmpPath, body, 'w');
+    fsq.renameSync(tmpPath, filePath);
+    const lastValid = valid.length > 0 ? valid[valid.length - 1]! : null;
+    writeState({ count: valid.length, last: lastValid ? opts.watermarkOf(lastValid) : '' });
+    return raw;
+  };
+
+  const parseLines = (
+    raw: string
+  ): { parsed: T[]; tornTail: string | null; midFileCorruption: boolean } => {
+    const lines = raw.split('\n');
+    const trailing = lines.pop() ?? '';
+    const parsed: T[] = [];
+    let midFileCorruption = false;
+
+    for (const line of lines) {
+      if (line.trim() === '') continue;
+      try {
+        const value: unknown = JSON.parse(line);
+        if (opts.isRecord(value)) parsed.push(value);
+        else midFileCorruption = true;
+      } catch {
+        midFileCorruption = true;
+      }
+    }
+
+    // The trailing fragment has no terminating newline, so an interrupted append
+    // can only have damaged this one. Keep it if it happens to be complete.
+    let tornTail: string | null = null;
+    if (trailing.trim() !== '') {
+      try {
+        const value: unknown = JSON.parse(trailing);
+        if (opts.isRecord(value)) parsed.push(value);
+        else tornTail = trailing;
+      } catch {
+        tornTail = trailing;
+      }
+    }
+
+    return { parsed, tornTail, midFileCorruption };
+  };
+
+  /**
+   * Drops an incomplete final record, after copying it aside for forensics.
+   *
+   * The fragment cannot simply be left in place: once a further record is
+   * appended after it, it stops being the *last* line and would then read as
+   * mid-file corruption, quarantining an otherwise healthy log. The fragment was
+   * never acknowledged to any caller, so discarding it loses nothing.
+   */
+  const dropTornTail = (raw: string, fragment: string): boolean => {
+    const keepBytes = Buffer.byteLength(raw, 'utf8') - Buffer.byteLength(fragment, 'utf8');
+    try {
+      writeDurably(fsq, `${filePath}.torn-${now()}`, fragment, 'w');
+      fsq.truncateSync(filePath, keepBytes);
+      return true;
+    } catch {
+      // Leaving the fragment is survivable: the next load sees it as mid-file
+      // damage and quarantines loudly rather than losing records silently.
+      return false;
+    }
+  };
+
+  const load = (): T[] => {
+    if (records) return records;
+    const state = readState();
+    const watermarkCount = state.count ?? 0;
+
+    let raw = '';
+    try {
+      const migrated = migrateLegacy();
+      if (migrated !== null) {
+        raw = fsq.existsSync(filePath) ? String(fsq.readFileSync(filePath, 'utf8')) : '';
+      } else if (fsq.existsSync(filePath)) {
+        raw = String(fsq.readFileSync(filePath, 'utf8'));
+      }
+    } catch (error) {
+      // The file exists but cannot be read or migrated. Reporting "no records"
+      // here is what lets a wiped register look like a clean install, so the log
+      // is marked unreadable and callers must treat it as untrustworthy.
+      records = [];
+      health = {
+        ok: false,
+        reason: `log unreadable: ${(error as Error).message}`,
+        quarantinePath: null,
+        recordsLoaded: 0,
+        watermarkCount,
+        tornTail: false,
+      };
+      opts.onDamage?.(health);
+      return records;
+    }
+
+    const { parsed, tornTail, midFileCorruption } = parseLines(raw);
+    endsWithNewline = raw === '' || raw.endsWith('\n');
+    records = parsed;
+
+    if (tornTail !== null && dropTornTail(raw, tornTail)) endsWithNewline = true;
+
+    let quarantinePath: string | null = null;
+    const reasons: string[] = [];
+    if (midFileCorruption) {
+      quarantinePath = quarantine('unparseable record inside the log', state);
+      reasons.push(
+        quarantinePath
+          ? `unparseable records found; damaged log moved to ${quarantinePath}`
+          : 'unparseable records found and the damaged log could not be quarantined'
+      );
+      // The damaged file was moved aside; the live log restarts empty but is
+      // never reported as an intact history.
+      if (quarantinePath) {
+        records = [];
+        endsWithNewline = true;
+      }
+    }
+    if (state.brokenAt) {
+      reasons.push(state.reason || 'log was previously found damaged');
+    }
+    if (records.length < watermarkCount) {
+      reasons.push(
+        `${watermarkCount - records.length} record(s) missing (expected ${watermarkCount}, found ${records.length})`
+      );
+    }
+    if (tornTail !== null) {
+      reasons.push('the final record was written incompletely and was discarded');
+    }
+
+    const priorQuarantine = state.quarantined || [];
+    health = {
+      ok: reasons.length === 0,
+      reason: reasons.length ? reasons.join('; ') : null,
+      quarantinePath:
+        quarantinePath ?? (priorQuarantine.length ? priorQuarantine[priorQuarantine.length - 1]! : null),
+      recordsLoaded: records.length,
+      watermarkCount,
+      tornTail: tornTail !== null,
+    };
+    if (!health.ok) opts.onDamage?.(health);
+    return records;
+  };
+
+  const append = (record: T): void => {
+    const current = load();
+    fsq.mkdirSync(opts.dirPath, { recursive: true });
+    // A torn tail has no newline of its own; without this separator the new
+    // record would be concatenated onto the fragment and lost as well.
+    const payload = `${endsWithNewline ? '' : '\n'}${JSON.stringify(record)}\n`;
+    writeDurably(fsq, filePath, payload, 'a');
+    // Only after the bytes are durable does the in-memory view advance. Doing
+    // this first is how a failed write ends up reported to the user as a
+    // successful, signed record.
+    endsWithNewline = true;
+    current.push(record);
+    health = { ...health, recordsLoaded: current.length };
+    try {
+      const state = readState();
+      writeState({
+        ...state,
+        count: Math.max(current.length, state.count ?? 0),
+        last: opts.watermarkOf(record),
+      });
+      health = { ...health, watermarkCount: Math.max(current.length, state.count ?? 0) };
+    } catch {
+      // The record itself is durable. A stale watermark can only under-report
+      // the expected count, which never turns loss into a clean bill of health.
+    }
+  };
+
+  return {
+    readAll: load,
+    append,
+    health: () => {
+      load();
+      return health;
+    },
+    watermarkValue: () => readState().last ?? '',
+  };
+};

--- a/apps/desktop/src/compliance/durable-log.ts
+++ b/apps/desktop/src/compliance/durable-log.ts
@@ -106,7 +106,19 @@ const resolveFs = (partial?: Partial<DurableLogFs>): DurableLogFs => ({
  * keeps the caller's shape (relative stays relative) so injected filesystems
  * still see the paths they expect.
  */
+const assertSafeDirectory = (dirPath: string): void => {
+  // The controlled-substance logbook already refused a traversing directory;
+  // the audit log had no such guard, so this applies the same rule to every
+  // store. A ".." segment means the configured data directory is not the one
+  // being written to.
+  const segments = path.normalize(dirPath).split(/[\\/]+/);
+  if (segments.includes('..')) {
+    throw new Error(`refusing to use "${dirPath}": the log directory escapes its parent`);
+  }
+};
+
 const containedPath = (dirPath: string, name: string): string => {
+  assertSafeDirectory(dirPath);
   const base = path.resolve(dirPath);
   const target = path.resolve(base, name);
   const relative = path.relative(base, target);
@@ -143,6 +155,7 @@ const writeDurably = (fsq: DurableLogFs, filePath: string, data: string, flags: 
  */
 const syncDirectory = (fsq: DurableLogFs, dirPath: string): void => {
   try {
+    assertSafeDirectory(dirPath);
     const fd = fsq.openSync(dirPath, 'r');
     try {
       fsq.fsyncSync(fd);

--- a/apps/desktop/src/compliance/durable-log.ts
+++ b/apps/desktop/src/compliance/durable-log.ts
@@ -78,7 +78,11 @@ interface WatermarkFile {
   brokenAt?: number;
   reason?: string;
   quarantined?: string[];
+  /** Set once the legacy array log has been converted. Never migrate twice. */
+  migratedAt?: number;
 }
+
+const CORRUPTION_REASON = 'unparseable record inside the log';
 
 const defaultFs = (): DurableLogFs => ({
   readFileSync: fs.readFileSync,
@@ -117,7 +121,7 @@ const assertSafeDirectory = (dirPath: string): void => {
   }
 };
 
-const containedPath = (dirPath: string, name: string): string => {
+export const containedPath = (dirPath: string, name: string): string => {
   assertSafeDirectory(dirPath);
   const base = path.resolve(dirPath);
   const target = path.resolve(base, name);
@@ -204,18 +208,14 @@ const parseLines = <T>(raw: string, isRecord: (v: unknown) => v is T): ParsedLog
     }
   }
 
-  // The trailing fragment has no terminating newline, so an interrupted append
-  // can only have damaged this one. Keep it if it happens to be complete.
-  let tornTail: string | null = null;
-  if (trailing.trim() !== '') {
-    try {
-      const value: unknown = JSON.parse(trailing);
-      if (isRecord(value)) parsed.push(value);
-      else tornTail = trailing;
-    } catch {
-      tornTail = trailing;
-    }
-  }
+  // The terminating newline IS the commit marker. A record is written as
+  // `json + "\n"` in one write followed by fsync, so a complete record always
+  // carries its newline; a trailing fragment without one means the write did
+  // not finish, whether or not the JSON happens to parse. Accepting a
+  // parseable-but-unterminated tail would commit a record whose caller was
+  // explicitly told the append failed - resurrecting a controlled-substance
+  // transaction after its `:not-recorded` compensation was already written.
+  const tornTail = trailing.trim() === '' ? null : trailing;
 
   return { parsed, tornTail, midFileCorruption };
 };
@@ -241,6 +241,8 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
   };
   /** Set when a record reached the log but its watermark update did not. */
   let watermarkStale: string | null = null;
+  /** Set when the existing history could not be read. Blocks all appends. */
+  let unreadableReason: string | null = null;
 
   const readState = (): WatermarkFile => {
     try {
@@ -270,6 +272,14 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
    * presented as an intact history again.
    */
   const preserveDamaged = (raw: string, reason: string, priorState: WatermarkFile): string | null => {
+    // The damaged line is deliberately left in the live log, so every launch
+    // re-detects it. Copying the whole compliance log each time would grow
+    // without bound and eventually fill the volume, which would itself start
+    // failing compliance writes. One copy per break is enough; the sidecar
+    // already carries the break and the path to the copy.
+    const alreadyPreserved = priorState.quarantined?.[priorState.quarantined.length - 1];
+    if (priorState.brokenAt && alreadyPreserved) return alreadyPreserved;
+
     const quarantinePath = `${filePath}.corrupt-${now()}`;
     try {
       writeDurably(fsq, quarantinePath, raw, 'w');
@@ -298,8 +308,16 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
    * temp file and renamed, so an interrupted migration leaves the legacy file
    * untouched and is simply retried on the next launch.
    */
-  const migrateLegacy = (): boolean => {
+  const migrateLegacy = (state: WatermarkFile): boolean => {
     if (!legacyPath || fsq.existsSync(filePath) || !fsq.existsSync(legacyPath)) return false;
+    // The legacy array is kept after migration rather than deleted. If the live
+    // log is later lost - the very loss the watermark exists to detect -
+    // re-running the migration would rebuild an old snapshot and overwrite the
+    // newer count and marker with the legacy ones, so every record added since
+    // the original migration would vanish while the store reported itself
+    // healthy. A watermark proving a newer log existed means this is loss, not
+    // a first run.
+    if (state.migratedAt !== undefined || state.count !== undefined) return false;
     const parsed: unknown = JSON.parse(String(fsq.readFileSync(legacyPath, 'utf8')));
     if (!Array.isArray(parsed)) throw new Error('legacy log is not an array');
     const valid = parsed.filter(opts.isRecord);
@@ -310,7 +328,11 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     fsq.renameSync(tmpPath, filePath);
     syncDirectory(fsq, opts.dirPath);
     const lastValid = valid.length > 0 ? valid[valid.length - 1]! : null;
-    writeState({ count: valid.length, last: lastValid ? opts.watermarkOf(lastValid) : '' });
+    writeState({
+      count: valid.length,
+      last: lastValid ? opts.watermarkOf(lastValid) : '',
+      migratedAt: now(),
+    });
     return true;
   };
 
@@ -336,8 +358,8 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
   };
 
   /** Reads the live log, migrating a legacy array file first if one is present. */
-  const readRaw = (): string => {
-    const migrated = migrateLegacy();
+  const readRaw = (state: WatermarkFile): string => {
+    const migrated = migrateLegacy(state);
     if (!migrated && !fsq.existsSync(filePath)) return '';
     return String(fsq.readFileSync(filePath, 'utf8'));
   };
@@ -364,10 +386,13 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     quarantineFailed: boolean
   ): string[] => {
     const reasons: string[] = [];
-    if (quarantinePath)
-      reasons.push(`unparseable records found; a copy of the damaged log is at ${quarantinePath}`);
+    // Kept short and stable so it matches what gets persisted: the freshly
+    // detected reason and the one replayed from the sidecar must collapse to
+    // one line rather than stacking on every launch. The path to the copy is
+    // reported separately as health.quarantinePath.
+    if (quarantinePath) reasons.push(CORRUPTION_REASON);
     else if (quarantineFailed)
-      reasons.push('unparseable records found and the damaged log could not be copied aside');
+      reasons.push('unparseable record inside the log, which could not be copied aside');
     if (state.brokenAt) reasons.push(state.reason || 'log was previously found damaged');
 
     const expected = state.count ?? 0;
@@ -385,7 +410,7 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     }
     if (tornTail !== null) reasons.push('the final record was written incompletely and was discarded');
     if (watermarkStale) reasons.push(watermarkStale);
-    return reasons;
+    return [...new Set(reasons)];
   };
 
   const load = (): T[] => {
@@ -395,13 +420,14 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
 
     let raw: string;
     try {
-      raw = readRaw();
+      raw = readRaw(state);
     } catch (error) {
       // The file exists but cannot be read or migrated. Reporting "no records"
       // here is what lets a wiped register look like a clean install, so the log
       // is marked unreadable and callers must treat it as untrustworthy.
       records = [];
-      health = unreadable((error as Error).message, watermarkCount);
+      unreadableReason = (error as Error).message;
+      health = unreadable(unreadableReason, watermarkCount);
       opts.onDamage?.(health);
       return records;
     }
@@ -413,7 +439,7 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
 
     // The parseable records stay live and appendable; only a copy is set aside.
     const quarantinePath = midFileCorruption
-      ? preserveDamaged(raw, 'unparseable record inside the log', state)
+      ? preserveDamaged(raw, CORRUPTION_REASON, state)
       : null;
 
     const reasons = damageReasons(
@@ -434,7 +460,24 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
       watermarkCount,
       tornTail: tornTail !== null,
     };
-    if (!health.ok) opts.onDamage?.(health);
+    if (!health.ok) {
+      // A detected loss that lives only in memory is erased by ordinary use:
+      // once enough new records replace the missing ones the count matches
+      // again, the marker is present, and the shortened log certifies as
+      // intact. Persist the break so it outlives the session that saw it.
+      // Re-read rather than reusing the snapshot taken at the top of load():
+      // preserveDamaged may have written brokenAt and the quarantine path since
+      // then, and writing a stale copy back would erase them.
+      const current = readState();
+      if (!current.brokenAt && health.reason) {
+        try {
+          writeState({ ...current, brokenAt: now(), reason: health.reason });
+        } catch {
+          // Best effort: the in-memory report still stands for this session.
+        }
+      }
+      opts.onDamage?.(health);
+    }
     return records;
   };
 
@@ -456,6 +499,15 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
 
   const append = (record: T): void => {
     const current = load();
+    if (unreadableReason !== null) {
+      // The cache is empty because the history could not be READ, not because
+      // there is none. Appending here would sign an audit entry with a genesis
+      // prevSignature over a log that still exists, and would report a
+      // controlled-substance register that omits every prior transaction.
+      throw new Error(
+        `refusing to append: the existing log could not be read (${unreadableReason})`
+      );
+    }
     fsq.mkdirSync(opts.dirPath, { recursive: true });
     const isNewFile = !fsq.existsSync(filePath);
     // A torn tail has no newline of its own; without this separator the new

--- a/apps/desktop/src/compliance/durable-log.ts
+++ b/apps/desktop/src/compliance/durable-log.ts
@@ -38,7 +38,7 @@ export interface DurableLogFs {
 export interface JsonlHealth {
   ok: boolean;
   reason: string | null;
-  /** Where a damaged file was moved to, so an operator can recover it. */
+  /** Where a copy of a damaged file was placed, so an operator can recover it. */
   quarantinePath: string | null;
   /** Records successfully parsed out of the live log file. */
   recordsLoaded: number;
@@ -94,8 +94,27 @@ const defaultFs = (): DurableLogFs => ({
 
 const resolveFs = (partial?: Partial<DurableLogFs>): DurableLogFs => ({
   ...defaultFs(),
-  ...(partial || {}),
+  ...partial,
 });
+
+/**
+ * Builds a path inside `dirPath` and refuses any name that would escape it.
+ *
+ * Every filename this module touches is derived from a caller-supplied base
+ * name, so a name containing traversal segments would let the store read or
+ * overwrite a file outside the compliance data directory. The returned path
+ * keeps the caller's shape (relative stays relative) so injected filesystems
+ * still see the paths they expect.
+ */
+const containedPath = (dirPath: string, name: string): string => {
+  const base = path.resolve(dirPath);
+  const target = path.resolve(base, name);
+  const relative = path.relative(base, target);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`refusing to use "${name}": it resolves outside the log directory`);
+  }
+  return path.join(dirPath, name);
+};
 
 /**
  * Writes `data` to `filePath` and returns only once the bytes are on the
@@ -116,19 +135,86 @@ const writeDurably = (fsq: DurableLogFs, filePath: string, data: string, flags: 
   }
 };
 
-/** Replaces a small sidecar file atomically (write temp, fsync, rename). */
-const replaceAtomically = (fsq: DurableLogFs, filePath: string, data: string): void => {
+/**
+ * fsyncs the directory itself. Syncing a file does not make its *directory
+ * entry* durable on POSIX filesystems, so a create or rename can still vanish
+ * after power loss even though the write returned. Best effort: Windows has no
+ * equivalent and rejects the open, which is not an error worth propagating.
+ */
+const syncDirectory = (fsq: DurableLogFs, dirPath: string): void => {
+  try {
+    const fd = fsq.openSync(dirPath, 'r');
+    try {
+      fsq.fsyncSync(fd);
+    } finally {
+      fsq.closeSync(fd);
+    }
+  } catch {
+    // Not supported on this platform; the file data itself is already synced.
+  }
+};
+
+/** Replaces a small sidecar file atomically (write temp, fsync, rename, sync dir). */
+const replaceAtomically = (
+  fsq: DurableLogFs,
+  dirPath: string,
+  filePath: string,
+  data: string
+): void => {
   const tmpPath = `${filePath}.tmp`;
   writeDurably(fsq, tmpPath, data, 'w');
   fsq.renameSync(tmpPath, filePath);
+  syncDirectory(fsq, dirPath);
+};
+
+interface ParsedLog<T> {
+  parsed: T[];
+  /** The incomplete final line, or null when the file ends cleanly. */
+  tornTail: string | null;
+  midFileCorruption: boolean;
+}
+
+const parseLines = <T>(raw: string, isRecord: (v: unknown) => v is T): ParsedLog<T> => {
+  const lines = raw.split('\n');
+  const trailing = lines.pop() ?? '';
+  const parsed: T[] = [];
+  let midFileCorruption = false;
+
+  for (const line of lines) {
+    if (line.trim() === '') continue;
+    try {
+      const value: unknown = JSON.parse(line);
+      if (isRecord(value)) parsed.push(value);
+      else midFileCorruption = true;
+    } catch {
+      midFileCorruption = true;
+    }
+  }
+
+  // The trailing fragment has no terminating newline, so an interrupted append
+  // can only have damaged this one. Keep it if it happens to be complete.
+  let tornTail: string | null = null;
+  if (trailing.trim() !== '') {
+    try {
+      const value: unknown = JSON.parse(trailing);
+      if (isRecord(value)) parsed.push(value);
+      else tornTail = trailing;
+    } catch {
+      tornTail = trailing;
+    }
+  }
+
+  return { parsed, tornTail, midFileCorruption };
 };
 
 export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> => {
   const fsq = resolveFs(opts.fsq);
   const now = opts.now || (() => Date.now());
-  const filePath = path.join(opts.dirPath, opts.fileName);
-  const statePath = path.join(opts.dirPath, `${opts.fileName}.state.json`);
-  const legacyPath = opts.legacyFileName ? path.join(opts.dirPath, opts.legacyFileName) : null;
+  const filePath = containedPath(opts.dirPath, opts.fileName);
+  const statePath = containedPath(opts.dirPath, `${opts.fileName}.state.json`);
+  const legacyPath = opts.legacyFileName
+    ? containedPath(opts.dirPath, opts.legacyFileName)
+    : null;
 
   let records: T[] | null = null;
   let endsWithNewline = true;
@@ -140,6 +226,8 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     watermarkCount: 0,
     tornTail: false,
   };
+  /** Set when a record reached the log but its watermark update did not. */
+  let watermarkStale: string | null = null;
 
   const readState = (): WatermarkFile => {
     try {
@@ -155,23 +243,30 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
   };
 
   const writeState = (state: WatermarkFile): void => {
-    replaceAtomically(fsq, statePath, JSON.stringify(state));
+    replaceAtomically(fsq, opts.dirPath, statePath, JSON.stringify(state));
   };
 
   /**
-   * Moves a damaged log aside instead of appending onto it. The replacement log
-   * is NOT presented as an intact genesis chain: `brokenAt` is persisted in the
-   * watermark so health() keeps reporting the break after restart.
+   * Copies a damaged log aside and records the break in the watermark.
+   *
+   * The damaged file is copied, not moved: the records that did survive are
+   * still a legally required register and must stay readable and appendable.
+   * Moving the file would preserve the evidence at the cost of the surviving
+   * data, which is the wrong trade for a DEA log. `brokenAt` is persisted so
+   * health() keeps reporting the break after a restart, and the log is never
+   * presented as an intact history again.
    */
-  const quarantine = (reason: string, priorState: WatermarkFile): string | null => {
+  const preserveDamaged = (raw: string, reason: string, priorState: WatermarkFile): string | null => {
     const quarantinePath = `${filePath}.corrupt-${now()}`;
     try {
-      fsq.renameSync(filePath, quarantinePath);
+      writeDurably(fsq, quarantinePath, raw, 'w');
+      syncDirectory(fsq, opts.dirPath);
     } catch {
       return null;
     }
     try {
       writeState({
+        ...priorState,
         count: priorState.count ?? 0,
         last: priorState.last ?? '',
         brokenAt: now(),
@@ -179,8 +274,8 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
         quarantined: [...(priorState.quarantined || []), quarantinePath],
       });
     } catch {
-      // The rename already preserved the evidence; a failed watermark update
-      // must not throw away the in-memory damage report.
+      // The copy already preserved the evidence; a failed watermark update must
+      // not throw away the in-memory damage report.
     }
     return quarantinePath;
   };
@@ -190,10 +285,9 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
    * temp file and renamed, so an interrupted migration leaves the legacy file
    * untouched and is simply retried on the next launch.
    */
-  const migrateLegacy = (): string | null => {
-    if (!legacyPath || fsq.existsSync(filePath) || !fsq.existsSync(legacyPath)) return null;
-    const raw = String(fsq.readFileSync(legacyPath, 'utf8'));
-    const parsed: unknown = JSON.parse(raw);
+  const migrateLegacy = (): boolean => {
+    if (!legacyPath || fsq.existsSync(filePath) || !fsq.existsSync(legacyPath)) return false;
+    const parsed: unknown = JSON.parse(String(fsq.readFileSync(legacyPath, 'utf8')));
     if (!Array.isArray(parsed)) throw new Error('legacy log is not an array');
     const valid = parsed.filter(opts.isRecord);
     const body = valid.map((r) => `${JSON.stringify(r)}\n`).join('');
@@ -201,44 +295,10 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     const tmpPath = `${filePath}.migrating`;
     writeDurably(fsq, tmpPath, body, 'w');
     fsq.renameSync(tmpPath, filePath);
+    syncDirectory(fsq, opts.dirPath);
     const lastValid = valid.length > 0 ? valid[valid.length - 1]! : null;
     writeState({ count: valid.length, last: lastValid ? opts.watermarkOf(lastValid) : '' });
-    return raw;
-  };
-
-  const parseLines = (
-    raw: string
-  ): { parsed: T[]; tornTail: string | null; midFileCorruption: boolean } => {
-    const lines = raw.split('\n');
-    const trailing = lines.pop() ?? '';
-    const parsed: T[] = [];
-    let midFileCorruption = false;
-
-    for (const line of lines) {
-      if (line.trim() === '') continue;
-      try {
-        const value: unknown = JSON.parse(line);
-        if (opts.isRecord(value)) parsed.push(value);
-        else midFileCorruption = true;
-      } catch {
-        midFileCorruption = true;
-      }
-    }
-
-    // The trailing fragment has no terminating newline, so an interrupted append
-    // can only have damaged this one. Keep it if it happens to be complete.
-    let tornTail: string | null = null;
-    if (trailing.trim() !== '') {
-      try {
-        const value: unknown = JSON.parse(trailing);
-        if (opts.isRecord(value)) parsed.push(value);
-        else tornTail = trailing;
-      } catch {
-        tornTail = trailing;
-      }
-    }
-
-    return { parsed, tornTail, midFileCorruption };
+    return true;
   };
 
   /**
@@ -262,76 +322,101 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     }
   };
 
+  /** Reads the live log, migrating a legacy array file first if one is present. */
+  const readRaw = (): string => {
+    const migrated = migrateLegacy();
+    if (!migrated && !fsq.existsSync(filePath)) return '';
+    return String(fsq.readFileSync(filePath, 'utf8'));
+  };
+
+  const unreadable = (message: string, watermarkCount: number): JsonlHealth => ({
+    ok: false,
+    reason: `log unreadable: ${message}`,
+    quarantinePath: null,
+    recordsLoaded: 0,
+    watermarkCount,
+    tornTail: false,
+  });
+
+  /**
+   * Everything that makes a successfully parsed log untrustworthy: damage found
+   * now, damage recorded on an earlier run, and records the watermark says
+   * should be here but are not.
+   */
+  const damageReasons = (
+    state: WatermarkFile,
+    loaded: T[],
+    tornTail: string | null,
+    quarantinePath: string | null,
+    quarantineFailed: boolean
+  ): string[] => {
+    const reasons: string[] = [];
+    if (quarantinePath)
+      reasons.push(`unparseable records found; a copy of the damaged log is at ${quarantinePath}`);
+    else if (quarantineFailed)
+      reasons.push('unparseable records found and the damaged log could not be copied aside');
+    if (state.brokenAt) reasons.push(state.reason || 'log was previously found damaged');
+
+    const expected = state.count ?? 0;
+    if (loaded.length < expected) {
+      reasons.push(
+        `${expected - loaded.length} record(s) missing (expected ${expected}, found ${loaded.length})`
+      );
+    }
+    // Count alone cannot catch a same-length replacement (a restored backup, a
+    // rolled-back file). The marker of the last acknowledged record must still
+    // be present somewhere in the log.
+    const marker = state.last ?? '';
+    if (marker !== '' && !loaded.some((r) => opts.watermarkOf(r) === marker)) {
+      reasons.push('the last recorded entry is missing: the log has been replaced');
+    }
+    if (tornTail !== null) reasons.push('the final record was written incompletely and was discarded');
+    if (watermarkStale) reasons.push(watermarkStale);
+    return reasons;
+  };
+
   const load = (): T[] => {
     if (records) return records;
     const state = readState();
     const watermarkCount = state.count ?? 0;
 
-    let raw = '';
+    let raw: string;
     try {
-      const migrated = migrateLegacy();
-      if (migrated !== null) {
-        raw = fsq.existsSync(filePath) ? String(fsq.readFileSync(filePath, 'utf8')) : '';
-      } else if (fsq.existsSync(filePath)) {
-        raw = String(fsq.readFileSync(filePath, 'utf8'));
-      }
+      raw = readRaw();
     } catch (error) {
       // The file exists but cannot be read or migrated. Reporting "no records"
       // here is what lets a wiped register look like a clean install, so the log
       // is marked unreadable and callers must treat it as untrustworthy.
       records = [];
-      health = {
-        ok: false,
-        reason: `log unreadable: ${(error as Error).message}`,
-        quarantinePath: null,
-        recordsLoaded: 0,
-        watermarkCount,
-        tornTail: false,
-      };
+      health = unreadable((error as Error).message, watermarkCount);
       opts.onDamage?.(health);
       return records;
     }
 
-    const { parsed, tornTail, midFileCorruption } = parseLines(raw);
+    const { parsed, tornTail, midFileCorruption } = parseLines(raw, opts.isRecord);
     endsWithNewline = raw === '' || raw.endsWith('\n');
     records = parsed;
-
     if (tornTail !== null && dropTornTail(raw, tornTail)) endsWithNewline = true;
 
-    let quarantinePath: string | null = null;
-    const reasons: string[] = [];
-    if (midFileCorruption) {
-      quarantinePath = quarantine('unparseable record inside the log', state);
-      reasons.push(
-        quarantinePath
-          ? `unparseable records found; damaged log moved to ${quarantinePath}`
-          : 'unparseable records found and the damaged log could not be quarantined'
-      );
-      // The damaged file was moved aside; the live log restarts empty but is
-      // never reported as an intact history.
-      if (quarantinePath) {
-        records = [];
-        endsWithNewline = true;
-      }
-    }
-    if (state.brokenAt) {
-      reasons.push(state.reason || 'log was previously found damaged');
-    }
-    if (records.length < watermarkCount) {
-      reasons.push(
-        `${watermarkCount - records.length} record(s) missing (expected ${watermarkCount}, found ${records.length})`
-      );
-    }
-    if (tornTail !== null) {
-      reasons.push('the final record was written incompletely and was discarded');
-    }
+    // The parseable records stay live and appendable; only a copy is set aside.
+    const quarantinePath = midFileCorruption
+      ? preserveDamaged(raw, 'unparseable record inside the log', state)
+      : null;
 
+    const reasons = damageReasons(
+      state,
+      records,
+      tornTail,
+      quarantinePath,
+      midFileCorruption && quarantinePath === null
+    );
     const priorQuarantine = state.quarantined || [];
     health = {
       ok: reasons.length === 0,
       reason: reasons.length ? reasons.join('; ') : null,
       quarantinePath:
-        quarantinePath ?? (priorQuarantine.length ? priorQuarantine[priorQuarantine.length - 1]! : null),
+        quarantinePath ??
+        (priorQuarantine.length ? priorQuarantine[priorQuarantine.length - 1]! : null),
       recordsLoaded: records.length,
       watermarkCount,
       tornTail: tornTail !== null,
@@ -340,31 +425,46 @@ export const createJsonlStore = <T>(opts: JsonlStoreOptions<T>): JsonlStore<T> =
     return records;
   };
 
+  /** Advances the sidecar watermark. Flags the store degraded if it cannot. */
+  const advanceWatermark = (record: T, count: number): void => {
+    try {
+      const state = readState();
+      const nextCount = Math.max(count, state.count ?? 0);
+      writeState({ ...state, count: nextCount, last: opts.watermarkOf(record) });
+      health = { ...health, watermarkCount: nextCount };
+    } catch (error) {
+      // The record itself is durable, but a stale watermark cannot prove a
+      // *later* loss of it, so the store must stop claiming to be healthy.
+      watermarkStale = `the loss-detection watermark could not be updated (${(error as Error).message}), so missing records may go undetected`;
+      health = { ...health, ok: false, reason: watermarkStale };
+      opts.onDamage?.(health);
+    }
+  };
+
   const append = (record: T): void => {
     const current = load();
     fsq.mkdirSync(opts.dirPath, { recursive: true });
+    const isNewFile = !fsq.existsSync(filePath);
     // A torn tail has no newline of its own; without this separator the new
     // record would be concatenated onto the fragment and lost as well.
     const payload = `${endsWithNewline ? '' : '\n'}${JSON.stringify(record)}\n`;
-    writeDurably(fsq, filePath, payload, 'a');
+    try {
+      writeDurably(fsq, filePath, payload, 'a');
+    } catch (error) {
+      // A short write leaves a partial line behind. Assume the worst so that a
+      // retry starts on a fresh line instead of being spliced onto the
+      // fragment, which would corrupt the retry as well as the original.
+      endsWithNewline = false;
+      throw error;
+    }
+    if (isNewFile) syncDirectory(fsq, opts.dirPath);
     // Only after the bytes are durable does the in-memory view advance. Doing
     // this first is how a failed write ends up reported to the user as a
     // successful, signed record.
     endsWithNewline = true;
     current.push(record);
     health = { ...health, recordsLoaded: current.length };
-    try {
-      const state = readState();
-      writeState({
-        ...state,
-        count: Math.max(current.length, state.count ?? 0),
-        last: opts.watermarkOf(record),
-      });
-      health = { ...health, watermarkCount: Math.max(current.length, state.count ?? 0) };
-    } catch {
-      // The record itself is durable. A stale watermark can only under-report
-      // the expected count, which never turns loss into a clean bill of health.
-    }
+    advanceWatermark(record, current.length);
   };
 
   return {

--- a/apps/desktop/src/core/ipc-handlers.ts
+++ b/apps/desktop/src/core/ipc-handlers.ts
@@ -19,7 +19,10 @@ import {
   type SettingsStore,
 } from '../utils/settings-store';
 import type { AuditLog } from '../compliance/audit-log';
-import type { ControlledSubstanceLogbook } from '../compliance/controlled-substance';
+import type {
+  ControlledSubstanceLogbook,
+  CsTransaction,
+} from '../compliance/controlled-substance';
 import type { DeaRegistrationTracker } from '../compliance/dea-registration';
 import type { IpcMain as IpcMainType } from 'electron';
 import type { DesktopLogger } from '../utils/logger';
@@ -391,9 +394,18 @@ export const registerIpc = (services: IpcServices, ipc: IpcMainType = ipcMain): 
       return { ok: false, error: 'invalid-quantity' };
     if (action !== 'transfer' && action !== 'inventory' && quantity <= 0)
       return { ok: false, error: 'invalid-quantity' };
-    const tx = services.controlledSubstanceLog.record(
-      data as Parameters<ControlledSubstanceLogbook['record']>[0]
-    );
+    // record() throws when the transaction did not reach the disk. Reporting
+    // ok:true there is how a full disk or a locked file produced a green
+    // confirmation for a dispense that was never written down.
+    let tx: CsTransaction;
+    try {
+      tx = services.controlledSubstanceLog.record(
+        data as Parameters<ControlledSubstanceLogbook['record']>[0]
+      );
+    } catch (error) {
+      services.logger.error('cs_record_failed', { error });
+      return { ok: false, error: 'cs-write-failed' };
+    }
     services.logger.info('cs_recorded', { id: tx.id, drugName: tx.drugName });
     return { ok: true, transaction: tx };
   });

--- a/apps/desktop/src/core/ipc-handlers.ts
+++ b/apps/desktop/src/core/ipc-handlers.ts
@@ -424,7 +424,16 @@ export const registerIpc = (services: IpcServices, ipc: IpcMainType = ipcMain): 
     const entry = args[0];
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry))
       return { ok: false, error: 'invalid-entry' };
-    const created = services.auditLog.append(entry as Parameters<AuditLog['append']>[0]);
+    // append() throws when the entry did not reach the disk. An audit entry that
+    // exists only in this process is not an audit entry, so the caller has to be
+    // told rather than shown a generic handler failure.
+    let created: ReturnType<AuditLog['append']>;
+    try {
+      created = services.auditLog.append(entry as Parameters<AuditLog['append']>[0]);
+    } catch (error) {
+      services.logger.error('audit_append_failed', { error });
+      return { ok: false, error: 'audit-write-failed' };
+    }
     services.logger.info('audit_appended', {
       id: created.id,
       action: created.action,

--- a/apps/desktop/src/ui/status-dialogs.ts
+++ b/apps/desktop/src/ui/status-dialogs.ts
@@ -69,6 +69,18 @@ export interface StatusDialogService {
 export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogService => {
   const { dialog } = deps;
 
+  // A daily log or biennial report built from a register that lost records is
+  // an understated compliance document with nothing on its face to say so. Any
+  // output derived from the register carries the warning.
+  const registerWarning = (): string => {
+    const integrity = deps.controlledSubstanceLog?.getIntegrity();
+    if (!integrity || integrity.ok) return '';
+    const preserved = integrity.quarantinePath
+      ? `\nDamaged register preserved at: ${integrity.quarantinePath}`
+      : '';
+    return `\n\nWARNING: the controlled-substance register is not intact, so this output may be incomplete.\n${integrity.reason}${preserved}`;
+  };
+
   const infoDialog = (message: string, detail: string): void => {
     void dialog.showMessageBox({
       type: 'info',
@@ -115,13 +127,13 @@ export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogS
       if (!result) {
         infoDialog(
           'Controlled-Substance Export',
-          'No controlled-substance transactions to export for today.'
+          `No controlled-substance transactions to export for today.${registerWarning()}`
         );
         return;
       }
       infoDialog(
         'Controlled-Substance Export',
-        `Exported ${result.rowCount} row(s) to:\n${result.filePath}`
+        `Exported ${result.rowCount} row(s) to:\n${result.filePath}${registerWarning()}`
       );
     },
 
@@ -200,6 +212,8 @@ export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogS
           path: result,
           format: selectedFormat.name,
         });
+        const warning = registerWarning();
+        if (warning) infoDialog('DEA Report', `Saved to:\n${result}${warning}`);
       } catch (error) {
         deps.logger.error('dea_report_save_failed', { error });
         dialog.showErrorBox('DEA Report', 'Failed to save the report.');

--- a/apps/desktop/src/ui/status-dialogs.ts
+++ b/apps/desktop/src/ui/status-dialogs.ts
@@ -86,9 +86,23 @@ export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogS
       }
       const { valid, tampered } = deps.auditLog.verifyAll();
       const chainIntact = deps.auditLog.verifyChain();
+      const integrity = deps.auditLog.getIntegrity();
+      // Without the stored key every historical entry fails its signature check.
+      // Reporting that as "Tampered" is indistinguishable from real tampering
+      // and sends the practice looking for a breach that did not happen.
+      const signatureLines =
+        integrity.signingKey === 'session-only'
+          ? 'Signatures: CANNOT BE CHECKED (signing key unreadable)'
+          : `Valid signatures: ${valid}\nTampered: ${tampered}`;
+      // "Hash chain intact: yes" over a log that lost records is an affirmative
+      // false compliance statement, so say what is wrong when anything is.
+      const problem = integrity.ok ? '' : `\n\nProblem detected: ${integrity.reason}`;
+      const quarantine = integrity.quarantinePath
+        ? `\nDamaged log preserved at: ${integrity.quarantinePath}`
+        : '';
       infoDialog(
         'Audit Trail Integrity',
-        `Total entries: ${deps.auditLog.size()}\nValid signatures: ${valid}\nTampered: ${tampered}\nHash chain intact: ${chainIntact ? 'yes' : 'NO'}`
+        `Total entries: ${deps.auditLog.size()}\n${signatureLines}\nHash chain intact: ${chainIntact ? 'yes' : 'NO'}${problem}${quarantine}`
       );
     },
 

--- a/apps/desktop/tests/audit-key-preservation.test.ts
+++ b/apps/desktop/tests/audit-key-preservation.test.ts
@@ -121,6 +121,24 @@ describe('audit signing key preservation', () => {
     expect(log.getIntegrity().reason).toContain('no usable key');
   });
 
+  test.each(['../../../etc', 'data/../../secrets'])(
+    'refuses to read a signing key from a directory that escapes its parent: %s',
+    async (badDir) => {
+      // The key path was the last compliance path built with a bare join, so it
+      // never went through the containment check the log paths use - and it is
+      // the one that reads a secret. Seed a key at the traversed location so an
+      // unguarded join would demonstrably read it.
+      const escaped = `${badDir}/audit-key`;
+      mem.dirs.add(badDir);
+      mem.files.set(escaped, JSON.stringify({ enc: false, key: 'b'.repeat(64) }));
+
+      await expect(createAuditLog(badDir, deps())).rejects.toThrow(/escapes its parent/);
+      expect(mem.readFileSync.mock.calls.map(([f]) => f)).not.toContain(escaped);
+      // ...and the file at the traversed path is untouched.
+      expect(JSON.parse(mem.files.get(escaped)!).key).toBe('b'.repeat(64));
+    }
+  );
+
   test('a genuinely absent key is still created on first run', async () => {
     const log = await createAuditLog(DIR, deps());
     expect(mem.files.has(KEY_PATH)).toBe(true);

--- a/apps/desktop/tests/audit-key-preservation.test.ts
+++ b/apps/desktop/tests/audit-key-preservation.test.ts
@@ -1,0 +1,188 @@
+import path from 'node:path';
+import os from 'node:os';
+import { Buffer } from 'node:buffer';
+import { createAuditLog, type AuditEntry } from '../src/compliance/audit-log';
+import { createMemoryFs, asDeps, type MemoryFs } from './helpers/memory-fs';
+
+/**
+ * Regression tests for blocker 4: when safeStorage was unavailable at startup
+ * (no keyring session on Linux, a locked or reset login keychain) or
+ * decryptString threw, the audit log minted a fresh HMAC key and wrote it over
+ * the existing one. The original was then gone even after the keyring recovered,
+ * every historical entry failed verify(), and Help > Verify Audit Trail reported
+ * the whole history as "Tampered" - indistinguishable from real tampering.
+ */
+
+const DIR = path.join(os.tmpdir(), 'audit-key-test');
+const KEY_PATH = path.join(DIR, 'audit-key');
+
+const ENTRY = {
+  action: 'patient:update',
+  actor: 'dr-smith',
+  resourceType: 'patient',
+  resourceId: 'p1',
+  details: {},
+};
+
+const workingKeychain = {
+  isEncryptionAvailable: () => true,
+  encryptString: (s: string) => Buffer.from(`enc:${s}`, 'utf8'),
+  decryptString: (b: Buffer) => b.toString('utf8').replace(/^enc:/, ''),
+};
+
+describe('audit signing key preservation', () => {
+  let mem: MemoryFs;
+  const deps = () => asDeps(mem, () => 1000);
+
+  beforeEach(() => {
+    mem = createMemoryFs();
+  });
+
+  test('an unreadable key is never overwritten and recovers when the keychain returns', async () => {
+    const first = await createAuditLog(DIR, { ...deps(), secureStore: workingKeychain });
+    const entry = first.append(ENTRY);
+    const originalKeyFile = mem.files.get(KEY_PATH)!;
+    expect(first.verify(entry)).toBe(true);
+
+    // Next launch with no keyring session: safeStorage is unavailable.
+    const degraded = await createAuditLog(DIR, { ...deps(), secureStore: null });
+    expect(mem.files.get(KEY_PATH)).toBe(originalKeyFile);
+    expect(degraded.getIntegrity().signingKey).toBe('session-only');
+    expect(degraded.getIntegrity().ok).toBe(false);
+    expect(degraded.getIntegrity().reason).toContain('OS keychain is unavailable');
+    expect(degraded.verifyChain()).toBe(false);
+
+    // Keyring recovers on a later launch: the original key still decrypts and
+    // the historical entry verifies again.
+    const recovered = await createAuditLog(DIR, { ...deps(), secureStore: workingKeychain });
+    expect(recovered.getIntegrity().signingKey).toBe('persisted');
+    expect(recovered.verify(entry)).toBe(true);
+    expect(recovered.verifyChain()).toBe(true);
+  });
+
+  test('a key the keychain cannot decrypt is left in place, not replaced', async () => {
+    await createAuditLog(DIR, { ...deps(), secureStore: workingKeychain });
+    const originalKeyFile = mem.files.get(KEY_PATH)!;
+
+    const brokenKeychain = {
+      isEncryptionAvailable: () => true,
+      encryptString: (s: string) => Buffer.from(`enc:${s}`, 'utf8'),
+      decryptString: () => {
+        throw new Error('keychain item not found');
+      },
+    };
+    const log = await createAuditLog(DIR, { ...deps(), secureStore: brokenKeychain });
+
+    expect(mem.files.get(KEY_PATH)).toBe(originalKeyFile);
+    expect(log.getIntegrity().signingKey).toBe('session-only');
+    expect(log.getIntegrity().reason).toContain('could not decrypt the key');
+  });
+
+  test('a key file that cannot be read at all is left in place', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, JSON.stringify({ enc: false, key: 'a'.repeat(64) }));
+    mem.readFileSync.mockImplementation((p: string) => {
+      if (p === KEY_PATH) throw new Error('EACCES: permission denied');
+      throw new Error('ENOENT');
+    });
+
+    const log = await createAuditLog(DIR, deps());
+    expect(JSON.parse(mem.files.get(KEY_PATH)!)).toMatchObject({ key: 'a'.repeat(64) });
+    expect(log.getIntegrity().signingKey).toBe('session-only');
+    expect(log.getIntegrity().reason).toContain('could not be read');
+  });
+
+  test('an empty or unrecognised key file is not silently replaced', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, '   ');
+    const emptyKeyLog = await createAuditLog(DIR, deps());
+    expect(mem.files.get(KEY_PATH)).toBe('   ');
+    expect(emptyKeyLog.getIntegrity().reason).toContain('empty');
+
+    mem.files.set(KEY_PATH, 'this is not a key');
+    const garbageKeyLog = await createAuditLog(DIR, deps());
+    expect(mem.files.get(KEY_PATH)).toBe('this is not a key');
+    expect(garbageKeyLog.getIntegrity().reason).toContain('not in a recognised format');
+  });
+
+  test('an encrypted key file with no key data is not replaced', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, JSON.stringify({ enc: true }));
+    const log = await createAuditLog(DIR, { ...deps(), secureStore: workingKeychain });
+    expect(JSON.parse(mem.files.get(KEY_PATH)!)).toEqual({ enc: true });
+    expect(log.getIntegrity().reason).toContain('no key data');
+  });
+
+  test('a plaintext wrapper with an empty key is not replaced', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, JSON.stringify({ enc: false, key: '' }));
+    const log = await createAuditLog(DIR, deps());
+    expect(JSON.parse(mem.files.get(KEY_PATH)!)).toEqual({ enc: false, key: '' });
+    expect(log.getIntegrity().reason).toContain('no usable key');
+  });
+
+  test('a genuinely absent key is still created on first run', async () => {
+    const log = await createAuditLog(DIR, deps());
+    expect(mem.files.has(KEY_PATH)).toBe(true);
+    expect(log.getIntegrity().signingKey).toBe('persisted');
+    const entry = log.append(ENTRY);
+    expect(log.verify(entry)).toBe(true);
+    expect(log.verifyChain()).toBe(true);
+  });
+
+  test('a key that cannot be saved runs session-only rather than claiming to be stored', async () => {
+    mem.writeFileSync.mockImplementation(() => {
+      throw new Error('EROFS: read-only file system');
+    });
+    const log = await createAuditLog(DIR, deps());
+    expect(log.getIntegrity().signingKey).toBe('session-only');
+    expect(log.getIntegrity().reason).toContain('could not be saved');
+  });
+
+  test('a session-only key still allows recording, so the events are not lost', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, JSON.stringify({ enc: true, data: 'xx' }));
+    const log = await createAuditLog(DIR, { ...deps(), secureStore: null });
+
+    const entry = log.append(ENTRY);
+    expect(log.size()).toBe(1);
+    // Signed with the temporary key, so it verifies within this session.
+    expect(log.verify(entry)).toBe(true);
+  });
+
+  test('the key problem is combined with, not hidden by, a log problem', async () => {
+    mem.dirs.add(DIR);
+    mem.files.set(KEY_PATH, JSON.stringify({ enc: true, data: 'xx' }));
+    mem.files.set(path.join(DIR, 'audit-log.jsonl'), 'corrupt line\n{"id":"a","action":"x"}\n');
+
+    const log = await createAuditLog(DIR, { ...deps(), secureStore: null });
+    const reason = log.getIntegrity().reason!;
+    expect(reason).toContain('unparseable');
+    expect(reason).toContain('signing key could not be read');
+  });
+
+  test('an explicitly injected key is treated as persisted', async () => {
+    const log = await createAuditLog(DIR, { ...deps(), hmacKey: 'k'.repeat(64) });
+    expect(log.getIntegrity().signingKey).toBe('persisted');
+  });
+});
+
+describe('audit trail dialog with an unreadable key', () => {
+  test('historical entries are reported as uncheckable, not as tampered', async () => {
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+
+    const first = await createAuditLog(DIR, { ...deps, secureStore: workingKeychain });
+    first.append(ENTRY);
+    first.append({ ...ENTRY, resourceId: 'p2' });
+
+    const degraded = await createAuditLog(DIR, { ...deps, secureStore: null });
+    // Every entry fails its signature check under the temporary key...
+    expect(degraded.verifyAll()).toEqual({ valid: 0, tampered: 2 });
+    // ...which is exactly why the integrity report must say the key is the
+    // problem rather than letting the dialog print "Tampered: 2".
+    expect(degraded.getIntegrity().signingKey).toBe('session-only');
+    const entries: AuditEntry[] = degraded.query();
+    expect(entries).toHaveLength(2);
+  });
+});

--- a/apps/desktop/tests/audit-log.test.ts
+++ b/apps/desktop/tests/audit-log.test.ts
@@ -1,31 +1,23 @@
 import { createAuditLog, type AuditEntry } from '../src/compliance/audit-log';
-import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { createMemoryFs, asDeps, readJsonl, type MemoryFs } from './helpers/memory-fs';
 
 describe('createAuditLog', () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-log-test-'));
-  let mockFs: Record<string, string> = {};
+  const tmpDir = path.join(os.tmpdir(), 'audit-log-test');
+  const logPath = path.join(tmpDir, 'audit-log.jsonl');
+  let mem: MemoryFs;
 
-  const makeDeps = (nowVal?: number | (() => number)) => ({
-    readFileSync: jest.fn((filePath: string) => {
-      if (mockFs[filePath] !== undefined) return mockFs[filePath];
-      throw new Error('ENOENT');
-    }),
-    writeFileSync: jest.fn((filePath: string, data: string) => {
-      mockFs[filePath] = data;
-    }),
-    mkdirSync: jest.fn(),
-    existsSync: jest.fn((filePath: string) => mockFs[filePath] !== undefined),
-    now: typeof nowVal === 'function' ? nowVal : jest.fn(() => nowVal ?? 1000),
-  });
+  const makeDeps = (nowVal?: number | (() => number)) =>
+    asDeps(mem, typeof nowVal === 'function' ? nowVal : () => nowVal ?? 1000);
+
+  /** Overwrites the append-only log with an attacker-supplied set of entries. */
+  const rewriteLog = (entries: AuditEntry[]): void => {
+    mem.files.set(logPath, entries.map((e) => `${JSON.stringify(e)}\n`).join(''));
+  };
 
   beforeEach(() => {
-    mockFs = {};
-  });
-
-  afterAll(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    mem = createMemoryFs();
   });
 
   test('append creates an entry with id, timestamp, and signature', async () => {
@@ -315,13 +307,10 @@ describe('createAuditLog', () => {
       details: {},
     });
 
-    // read raw file, tamper with it, write back to mockFs
-    const writeCalls = (deps.writeFileSync as jest.Mock).mock.calls;
-    const filePath = writeCalls[writeCalls.length - 1][0] as string;
-    const raw = writeCalls[writeCalls.length - 1][1] as string;
-    const entries: AuditEntry[] = JSON.parse(raw);
+    // read the persisted log, tamper with it, write it back
+    const entries = readJsonl<AuditEntry>(mem, logPath);
     entries[0].details = { breed: 'Poodle' };
-    mockFs[filePath] = JSON.stringify(entries);
+    rewriteLog(entries);
     const tamperedLog = await createAuditLog(tmpDir, deps);
 
     const tampered = tamperedLog.query({ resourceType: 'patient' });
@@ -348,12 +337,9 @@ describe('createAuditLog', () => {
       details: {},
     });
 
-    const writeCalls = (deps.writeFileSync as jest.Mock).mock.calls;
-    const filePath = writeCalls[writeCalls.length - 1][0] as string;
-    const raw = writeCalls[writeCalls.length - 1][1] as string;
-    const entries: AuditEntry[] = JSON.parse(raw);
+    const entries = readJsonl<AuditEntry>(mem, logPath);
     entries[0].resourceId = 'p999';
-    mockFs[filePath] = JSON.stringify(entries);
+    rewriteLog(entries);
     const tamperedLog = await createAuditLog(tmpDir, deps);
 
     const after = tamperedLog.verifyAll();
@@ -407,13 +393,8 @@ describe('createAuditLog', () => {
     });
     expect(log.verifyChain()).toBe(true);
 
-    const auditWrites = (deps.writeFileSync as jest.Mock).mock.calls.filter((c) =>
-      String(c[0]).endsWith('audit-log.json')
-    );
-    const filePath = auditWrites[auditWrites.length - 1][0] as string;
-    const raw = auditWrites[auditWrites.length - 1][1] as string;
-    const entries: AuditEntry[] = JSON.parse(raw);
-    mockFs[filePath] = JSON.stringify([entries[1], entries[0]]); // reordered
+    const entries = readJsonl<AuditEntry>(mem, logPath);
+    rewriteLog([entries[1], entries[0]]); // reordered
     expect((await createAuditLog(tmpDir, deps)).verifyChain()).toBe(false);
   });
 
@@ -469,8 +450,9 @@ describe('createAuditLog', () => {
     // manually write a key file in legacy { enc: false, key: '...' } format
     const keyPath = path.join(tmpDir, 'audit-key');
     const legacyKey = 'abcdef1234567890';
-    mockFs[keyPath] = JSON.stringify({ enc: false, key: legacyKey });
-    mockFs[path.join(tmpDir, 'audit-log.json')] = '[]';
+    mem.files.set(keyPath, JSON.stringify({ enc: false, key: legacyKey }));
+    mem.files.set(path.join(tmpDir, 'audit-log.json'), '[]');
+    mem.dirs.add(tmpDir);
 
     const log = await createAuditLog(tmpDir, deps);
     log.append({
@@ -486,8 +468,9 @@ describe('createAuditLog', () => {
   test('loads key from legacy hex-only key file', async () => {
     const deps = makeDeps(1000);
     const keyPath = path.join(tmpDir, 'audit-key');
-    mockFs[keyPath] = '00'.repeat(32);
-    mockFs[path.join(tmpDir, 'audit-log.json')] = '[]';
+    mem.files.set(keyPath, '00'.repeat(32));
+    mem.files.set(path.join(tmpDir, 'audit-log.json'), '[]');
+    mem.dirs.add(tmpDir);
 
     const log = await createAuditLog(tmpDir, deps);
     log.append({

--- a/apps/desktop/tests/compliance-durability.test.ts
+++ b/apps/desktop/tests/compliance-durability.test.ts
@@ -239,4 +239,94 @@ describe('compliance write failures (blocker 2: failures reported as success)', 
     expect(() => log.append(AUDIT_INPUT)).toThrow(AuditWriteError);
     expect(log.size()).toBe(0);
   });
+
+  test('a retry after a partial write starts on a new line instead of splicing', async () => {
+    const log = await createAuditLog(CS_DIR, deps());
+    log.append(AUDIT_INPUT);
+
+    // Half a record reaches the disk, then the caller retries.
+    mem.truncateWrite((p) => p === AUDIT_LOG, 12);
+    expect(() => log.append({ ...AUDIT_INPUT, resourceId: 'p2' })).toThrow(AuditWriteError);
+    mem.clearFaults();
+    log.append({ ...AUDIT_INPUT, resourceId: 'p3' });
+
+    // The retry must be its own line. Concatenating it onto the fragment would
+    // corrupt the retry too, and the acknowledged entry would be lost.
+    const reopened = await createAuditLog(CS_DIR, deps());
+    expect(reopened.query().map((e) => e.resourceId).sort()).toEqual(['p1', 'p3']);
+  });
+
+  test('a dispense that fails to persist is voided in the audit trail', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+
+    mem.failWrite((p) => p === CS_LOG, 'ENOSPC');
+    expect(() => logbook.record(DISPENSE)).toThrow(CsWriteError);
+
+    // The audit log already carried a signed cs:dispense entry. Without a
+    // compensation record it would assert forever that a dispense happened.
+    const entries = readJsonl<AuditEntry>(mem, AUDIT_LOG);
+    expect(entries.map((e) => e.action)).toEqual(['cs:dispense', 'cs:dispense:not-recorded']);
+    expect(entries[1]!.details.voidsAuditEntryId).toBe(entries[0]!.id);
+    expect(entries[1]!.details.csTransactionId).toBe(entries[0]!.details.csTransactionId);
+    // The compensation entry is part of the signed chain, not a loose note.
+    expect(auditLog.verify(entries[1]!)).toBe(true);
+  });
+
+  test('an unwritable audit log is reported when the compensation also fails', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+
+    // The disk fills after the cs:dispense entry is written: the register write
+    // fails, and so does the compensation that would have voided it.
+    let auditWrites = 0;
+    mem.failWrite((p) => {
+      if (p === CS_LOG) return true;
+      if (p !== AUDIT_LOG) return false;
+      auditWrites += 1;
+      return auditWrites > 1;
+    }, 'ENOSPC');
+
+    expect(() => logbook.record(DISPENSE)).toThrow(/compensating audit entry could not be written/);
+  });
+
+  test('a same-length replacement of the register is detected', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+    logbook.record(DISPENSE);
+    logbook.record({ ...DISPENSE, lotNumber: 'LOT-002' });
+    expect(logbook.getIntegrity().ok).toBe(true);
+
+    // A restored backup or rolled-back file: same record count, different
+    // records. A count-only watermark check would call this healthy.
+    const swapped = readJsonl<CsTransaction>(mem, CS_LOG).map((tx, i) => ({
+      ...tx,
+      id: `cs-other-${i}`,
+    }));
+    mem.files.set(CS_LOG, swapped.map((tx) => `${JSON.stringify(tx)}\n`).join(''));
+
+    const reopened = createControlledSubstanceLogbook(CS_DIR, {
+      auditLog: await createAuditLog(CS_DIR, deps()),
+      ...deps(),
+    });
+    expect(reopened.size()).toBe(2);
+    expect(reopened.getIntegrity().ok).toBe(false);
+    expect(reopened.getIntegrity().reason).toContain('has been replaced');
+  });
+
+  test('a record whose watermark cannot be advanced leaves the store degraded', async () => {
+    const log = await createAuditLog(CS_DIR, deps());
+    log.append(AUDIT_INPUT);
+    expect(log.getIntegrity().ok).toBe(true);
+
+    mem.failOpen((p) => p.includes('.state.json'), 'ENOSPC');
+    log.append({ ...AUDIT_INPUT, resourceId: 'p2' });
+
+    // The entry is durable, but a stale watermark cannot prove a later loss of
+    // it, so the store must stop claiming to be healthy.
+    expect(readJsonl<AuditEntry>(mem, AUDIT_LOG)).toHaveLength(2);
+    expect(log.getIntegrity().ok).toBe(false);
+    expect(log.getIntegrity().reason).toContain('watermark could not be updated');
+    expect(log.verifyChain()).toBe(false);
+  });
 });

--- a/apps/desktop/tests/compliance-durability.test.ts
+++ b/apps/desktop/tests/compliance-durability.test.ts
@@ -1,0 +1,242 @@
+import path from 'node:path';
+import os from 'node:os';
+import { createAuditLog, AuditWriteError, type AuditEntry } from '../src/compliance/audit-log';
+import {
+  createControlledSubstanceLogbook,
+  CsWriteError,
+  type CsTransaction,
+} from '../src/compliance/controlled-substance';
+import { createMemoryFs, asDeps, readJsonl, type MemoryFs } from './helpers/memory-fs';
+
+/**
+ * Regression tests for the two release-blocking persistence defects found by the
+ * DEA compliance audit:
+ *
+ *  - Blocker 1: both stores rewrote the entire JSON array on every append with a
+ *    bare writeFileSync. A crash mid-write truncated the file, the next launch
+ *    parsed it as empty, and the following append overwrote every survivor.
+ *    verifyChain() then walked the one surviving entry and certified the wiped
+ *    log as intact.
+ *  - Blocker 2: save() swallowed every write error, so a dispense that never
+ *    reached the disk was reported to the user as recorded, while the audit log
+ *    kept a signed entry pointing at a transaction in no logbook.
+ */
+
+const CS_DIR = path.join(os.tmpdir(), 'cs-durability-test');
+const CS_LOG = path.join(CS_DIR, 'controlled-substance-log.jsonl');
+const AUDIT_LOG = path.join(CS_DIR, 'audit-log.jsonl');
+const AUDIT_STATE = path.join(CS_DIR, 'audit-log.jsonl.state.json');
+
+const DISPENSE = {
+  action: 'dispense' as const,
+  drugName: 'Ketamine',
+  drugClass: 'CIII',
+  lotNumber: 'LOT-001',
+  quantity: 10,
+  unit: 'mL',
+  veterinarianId: 'vet-1',
+  veterinarianName: 'Dr. Smith',
+};
+
+const AUDIT_INPUT = {
+  action: 'patient:update',
+  actor: 'dr-smith',
+  resourceType: 'patient',
+  resourceId: 'p1',
+  details: {},
+};
+
+describe('compliance log durability (blocker 1: non-atomic writes)', () => {
+  let mem: MemoryFs;
+  let clock: number;
+  const deps = () => asDeps(mem, () => (clock += 1000));
+
+  beforeEach(() => {
+    mem = createMemoryFs();
+    clock = 1000;
+  });
+
+  test('records are appended, never rewritten, and are fsynced', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+
+    logbook.record(DISPENSE);
+    const afterFirst = mem.files.get(CS_LOG)!;
+    logbook.record({ ...DISPENSE, lotNumber: 'LOT-002' });
+    const afterSecond = mem.files.get(CS_LOG)!;
+
+    // The whole-array rewrite is what allowed a partial write to destroy prior
+    // records. The second append must leave the first record's bytes untouched.
+    expect(afterSecond.startsWith(afterFirst)).toBe(true);
+    expect(readJsonl<CsTransaction>(mem, CS_LOG)).toHaveLength(2);
+
+    const appendFlags = mem.openSync.mock.calls
+      .filter((c) => c[0] === CS_LOG)
+      .map((c) => c[1] as string);
+    expect(appendFlags.length).toBeGreaterThan(0);
+    expect(appendFlags.every((f) => f.includes('a'))).toBe(true);
+    expect(mem.fsyncCalls).toContain(CS_LOG);
+  });
+
+  test('an interrupted append cannot destroy the records already written', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+    logbook.record(DISPENSE);
+    logbook.record({ ...DISPENSE, lotNumber: 'LOT-002' });
+    const survivors = readJsonl<CsTransaction>(mem, CS_LOG).map((tx) => tx.id);
+
+    // Simulate a crash part-way through writing a third record.
+    mem.truncateWrite((p) => p === CS_LOG, 20);
+    expect(() => logbook.record({ ...DISPENSE, lotNumber: 'LOT-003' })).toThrow(CsWriteError);
+    mem.clearFaults();
+
+    // Reopen: the torn fragment is discarded, both complete records survive, and
+    // the next append does not overwrite them.
+    const reopened = createControlledSubstanceLogbook(CS_DIR, {
+      auditLog: await createAuditLog(CS_DIR, deps()),
+      ...deps(),
+    });
+    expect(reopened.getTransactions().map((tx) => tx.id).sort()).toEqual(survivors.sort());
+    expect(reopened.getIntegrity().ok).toBe(false);
+    expect(reopened.getIntegrity().tornTail).toBe(true);
+
+    reopened.record({ ...DISPENSE, lotNumber: 'LOT-004' });
+    const finalIds = readJsonl<CsTransaction>(mem, CS_LOG).map((tx) => tx.id);
+    expect(finalIds).toEqual(expect.arrayContaining(survivors));
+    expect(finalIds).toHaveLength(3);
+  });
+
+  test('a shortened audit log is reported as broken, not as an intact chain', async () => {
+    const first = await createAuditLog(CS_DIR, deps());
+    for (let i = 0; i < 5; i++) first.append({ ...AUDIT_INPUT, resourceId: `p${i}` });
+    expect(first.verifyChain()).toBe(true);
+
+    // Exactly the state a truncating crash used to leave behind: one genuine,
+    // correctly signed genesis entry and nothing else.
+    const entries = readJsonl<AuditEntry>(mem, AUDIT_LOG);
+    mem.files.set(AUDIT_LOG, `${JSON.stringify(entries[0])}\n`);
+
+    const reopened = await createAuditLog(CS_DIR, deps());
+    expect(reopened.size()).toBe(1);
+    // The surviving entry is individually valid, which is why walking the chain
+    // alone declared the wiped log healthy.
+    expect(reopened.verify(reopened.query()[0]!)).toBe(true);
+    expect(reopened.verifyChain()).toBe(false);
+    expect(reopened.getIntegrity().ok).toBe(false);
+    expect(reopened.getIntegrity().reason).toContain('missing');
+  });
+
+  test('an unparseable audit log is quarantined instead of starting a new genesis chain', async () => {
+    const first = await createAuditLog(CS_DIR, deps());
+    first.append(AUDIT_INPUT);
+    first.append({ ...AUDIT_INPUT, resourceId: 'p2' });
+
+    // Damage a line in the middle of the file, not the tail.
+    const lines = mem.files.get(AUDIT_LOG)!.split('\n');
+    lines[0] = '{"id":"audit-1","action":"pat';
+    mem.files.set(AUDIT_LOG, lines.join('\n'));
+
+    const reopened = await createAuditLog(CS_DIR, deps());
+    const integrity = reopened.getIntegrity();
+    expect(integrity.ok).toBe(false);
+    expect(integrity.quarantinePath).toBeTruthy();
+    // The damaged bytes are preserved for an investigator, not deleted.
+    expect(mem.files.get(integrity.quarantinePath!)).toContain('{"id":"audit-1","action":"pat');
+    expect(reopened.verifyChain()).toBe(false);
+
+    // The break is remembered across restarts: appending afterwards must not
+    // make the replacement log look like a clean, intact history.
+    reopened.append({ ...AUDIT_INPUT, resourceId: 'p3' });
+    const later = await createAuditLog(CS_DIR, deps());
+    expect(later.verifyChain()).toBe(false);
+    expect(later.getIntegrity().reason).toContain('unparseable record inside the log');
+    expect(
+      (JSON.parse(mem.files.get(AUDIT_STATE)!) as { brokenAt?: number }).brokenAt
+    ).toBeGreaterThan(0);
+  });
+
+  test('a legacy whole-array log is migrated into the append-only format', async () => {
+    const legacyEntries = [
+      { id: 'cs-legacy-1', drugName: 'Ketamine', action: 'receive', timestamp: 500, quantity: 5 },
+      { id: 'cs-legacy-2', drugName: 'Ketamine', action: 'dispense', timestamp: 600, quantity: 2 },
+    ];
+    mem.dirs.add(CS_DIR);
+    mem.files.set(path.join(CS_DIR, 'controlled-substance-log.json'), JSON.stringify(legacyEntries));
+
+    const logbook = createControlledSubstanceLogbook(CS_DIR, {
+      auditLog: await createAuditLog(CS_DIR, deps()),
+      ...deps(),
+    });
+
+    expect(logbook.size()).toBe(2);
+    expect(logbook.getIntegrity().ok).toBe(true);
+    expect(readJsonl<CsTransaction>(mem, CS_LOG).map((tx) => tx.id)).toEqual([
+      'cs-legacy-1',
+      'cs-legacy-2',
+    ]);
+  });
+
+  test('the watermark records how many entries should exist', async () => {
+    const log = await createAuditLog(CS_DIR, deps());
+    log.append(AUDIT_INPUT);
+    log.append({ ...AUDIT_INPUT, resourceId: 'p2' });
+
+    const state = JSON.parse(mem.files.get(AUDIT_STATE)!) as { count: number; last: string };
+    expect(state.count).toBe(2);
+    expect(state.last).toBe(readJsonl<AuditEntry>(mem, AUDIT_LOG)[1]!.signature);
+  });
+});
+
+describe('compliance write failures (blocker 2: failures reported as success)', () => {
+  let mem: MemoryFs;
+  let clock: number;
+  const deps = () => asDeps(mem, () => (clock += 1000));
+
+  beforeEach(() => {
+    mem = createMemoryFs();
+    clock = 1000;
+  });
+
+  test('a dispense whose write fails throws instead of returning a transaction', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+
+    // A full disk. No crash required.
+    mem.failWrite((p) => p === CS_LOG, 'ENOSPC');
+
+    expect(() => logbook.record(DISPENSE)).toThrow(CsWriteError);
+    expect(readJsonl<CsTransaction>(mem, CS_LOG)).toHaveLength(0);
+    expect(logbook.size()).toBe(0);
+  });
+
+  test('a locked file (antivirus, read-only dir) is reported, not swallowed', async () => {
+    const auditLog = await createAuditLog(CS_DIR, deps());
+    const logbook = createControlledSubstanceLogbook(CS_DIR, { auditLog, ...deps() });
+
+    mem.failOpen((p) => p === CS_LOG, 'EPERM');
+    expect(() => logbook.record(DISPENSE)).toThrow(CsWriteError);
+  });
+
+  test('a failed audit append does not leave a phantom entry in the session view', async () => {
+    const log = await createAuditLog(CS_DIR, deps());
+    log.append(AUDIT_INPUT);
+    expect(log.size()).toBe(1);
+
+    mem.failWrite((p) => p === AUDIT_LOG, 'ENOSPC');
+    expect(() => log.append({ ...AUDIT_INPUT, resourceId: 'p2' })).toThrow(AuditWriteError);
+
+    // The in-memory cache used to be assigned before the write was attempted, so
+    // the session went on showing a signed entry that reached no disk.
+    expect(log.size()).toBe(1);
+    expect(log.query().map((e) => e.resourceId)).toEqual(['p1']);
+    expect(readJsonl<AuditEntry>(mem, AUDIT_LOG)).toHaveLength(1);
+  });
+
+  test('a partially written record is rejected rather than silently accepted', async () => {
+    const log = await createAuditLog(CS_DIR, deps());
+    mem.truncateWrite((p) => p === AUDIT_LOG, 10);
+
+    expect(() => log.append(AUDIT_INPUT)).toThrow(AuditWriteError);
+    expect(log.size()).toBe(0);
+  });
+});

--- a/apps/desktop/tests/controlled-substance-security.test.ts
+++ b/apps/desktop/tests/controlled-substance-security.test.ts
@@ -21,72 +21,50 @@ describe('Controlled Substance Logbook - Path Traversal Security', () => {
     mem = createMemoryFs();
   });
 
-  test('blocks path traversal with .. in directory path', async () => {
+  // One shape, many malicious inputs: the logbook must never touch the disk and
+  // must never present a blocked directory as an empty-but-healthy register.
+  test.each([
+    ['.. in the directory path', '../../../etc'],
+    ['multiple .. sequences', '../../../../../../root'],
+    ['traversal hidden mid-path', 'data/../../../etc'],
+    ['a traversal pointing at a seeded file', '../../../etc/passwd'],
+  ])('blocks path traversal: %s', async (_label, maliciousPath) => {
     const deps = makeFsDeps(1000);
     const auditLog = await createAuditLog('safe-dir', deps);
+    // Seed a file at the target so a successful traversal would be observable.
+    mem.files.set(
+      `${maliciousPath}/controlled-substance-log.jsonl`,
+      `${JSON.stringify({ id: 'malicious-1', drugName: 'SensitiveData', timestamp: 1000 })}\n`
+    );
 
-    // Attacker tries to traverse to sensitive directory
-    const maliciousPath = '../../../etc';
-    const logbook = createControlledSubstanceLogbook(maliciousPath, {
-      auditLog,
-      ...deps,
-    });
+    const logbook = createControlledSubstanceLogbook(maliciousPath, { auditLog, ...deps });
 
-    // Security check prevents reading from traversed path
-    expect(logbook.getTransactions()).toEqual([]);
-    expect(logbook.size()).toBe(0);
-
-    // Verify no file system access occurred with the malicious path
-    expect(deps.readFileSync).not.toHaveBeenCalled();
-  });
-
-  test('blocks path traversal with multiple .. sequences', async () => {
-    const deps = makeFsDeps(1000);
-    const auditLog = await createAuditLog('safe-dir', deps);
-
-    // Multiple traversal attempts
-    const maliciousPath = '../../../../../../root';
-    const logbook = createControlledSubstanceLogbook(maliciousPath, {
-      auditLog,
-      ...deps,
-    });
-
-    // Should reject and return empty results
     expect(logbook.getTransactions()).toEqual([]);
     expect(logbook.size()).toBe(0);
     expect(logbook.getInventory()).toEqual([]);
+    // A blocked register is not a healthy empty one.
+    expect(logbook.getIntegrity().ok).toBe(false);
+    expect(deps.readFileSync).not.toHaveBeenCalled();
   });
 
-  test('blocks path traversal in mixed paths', async () => {
+  test('a percent-encoded sequence is a literal directory name, not a traversal', async () => {
     const deps = makeFsDeps(1000);
     const auditLog = await createAuditLog('safe-dir', deps);
+    // The filesystem never decodes %2F, so "..%2F..%2Fetc" names one directory
+    // and cannot escape anywhere. The guard correctly leaves it alone; the
+    // security property is that it stays put, not that it is rejected.
+    const encodedPath = '..%2F..%2Fetc';
+    mem.files.set(
+      `${encodedPath}/controlled-substance-log.jsonl`,
+      `${JSON.stringify({ id: 'local-1', drugName: 'Ketamine', timestamp: 1000 })}\n`
+    );
 
-    // Traversal hidden in seemingly safe path
-    const maliciousPath = 'data/../../../etc';
-    const logbook = createControlledSubstanceLogbook(maliciousPath, {
-      auditLog,
-      ...deps,
-    });
-
-    // Should be blocked due to .. in path
-    expect(logbook.getTransactions()).toEqual([]);
-    expect(logbook.size()).toBe(0);
-  });
-
-  test('blocks path traversal with encoded sequences', async () => {
-    const deps = makeFsDeps(1000);
-    const auditLog = await createAuditLog('safe-dir', deps);
-
-    // Path with encoded .. (though Node.js path.join normalizes this)
-    const maliciousPath = '..%2F..%2Fetc';
-    const logbook = createControlledSubstanceLogbook(maliciousPath, {
-      auditLog,
-      ...deps,
-    });
-
-    // The path contains '..' so should be rejected
-    expect(logbook.getTransactions()).toEqual([]);
-    expect(logbook.size()).toBe(0);
+    const logbook = createControlledSubstanceLogbook(encodedPath, { auditLog, ...deps });
+    expect(logbook.getTransactions()).toHaveLength(1);
+    // Reads stayed inside the named directory; nothing above it was touched.
+    expect(deps.readFileSync.mock.calls.every(([f]) => String(f).startsWith(encodedPath))).toBe(
+      true
+    );
   });
 
   test('allows safe relative paths without traversal', async () => {
@@ -120,30 +98,6 @@ describe('Controlled Substance Logbook - Path Traversal Security', () => {
     const transactions = logbook.getTransactions();
     expect(transactions).toHaveLength(1);
     expect(transactions[0].drugName).toBe('Ketamine');
-  });
-
-  test('prevents reading sensitive files via path traversal', async () => {
-    const deps = makeFsDeps(1000);
-    const auditLog = await createAuditLog('safe-dir', deps);
-
-    // Simulate attacker trying to read /etc/passwd
-    mem.files.set(
-      '../../../etc/passwd/controlled-substance-log.jsonl',
-      `${JSON.stringify({ id: 'malicious-1', drugName: 'SensitiveData', timestamp: 1000 })}\n`
-    );
-
-    const maliciousPath = '../../../etc/passwd';
-    const logbook = createControlledSubstanceLogbook(maliciousPath, {
-      auditLog,
-      ...deps,
-    });
-
-    // Should not be able to read the sensitive file
-    expect(logbook.getTransactions()).toEqual([]);
-    expect(logbook.size()).toBe(0);
-
-    // Verify readFileSync was not called (security check prevented it)
-    expect(deps.readFileSync).not.toHaveBeenCalled();
   });
 
   test('record on a blocked path throws instead of returning an unpersisted transaction', async () => {

--- a/apps/desktop/tests/controlled-substance-security.test.ts
+++ b/apps/desktop/tests/controlled-substance-security.test.ts
@@ -1,5 +1,9 @@
-import { createControlledSubstanceLogbook } from '../src/compliance/controlled-substance';
+import {
+  createControlledSubstanceLogbook,
+  CsWriteError,
+} from '../src/compliance/controlled-substance';
 import { createAuditLog } from '../src/compliance/audit-log';
+import { createMemoryFs, asDeps, type MemoryFs } from './helpers/memory-fs';
 
 /**
  * Security tests for path traversal vulnerability mitigation in controlled substance logbook.
@@ -9,23 +13,12 @@ import { createAuditLog } from '../src/compliance/audit-log';
  * intended directory.
  */
 describe('Controlled Substance Logbook - Path Traversal Security', () => {
-  let mockFs: Record<string, string> = {};
+  let mem: MemoryFs;
 
-  const makeFsDeps = (nowVal = 1000) => ({
-    readFileSync: jest.fn((filePath: string) => {
-      if (mockFs[filePath] !== undefined) return mockFs[filePath];
-      throw new Error('ENOENT');
-    }),
-    writeFileSync: jest.fn((filePath: string, data: string) => {
-      mockFs[filePath] = data;
-    }),
-    mkdirSync: jest.fn(),
-    existsSync: jest.fn((filePath: string) => mockFs[filePath] !== undefined),
-    now: jest.fn(() => nowVal),
-  });
+  const makeFsDeps = (nowVal = 1000) => asDeps(mem, () => nowVal);
 
   beforeEach(() => {
-    mockFs = {};
+    mem = createMemoryFs();
   });
 
   test('blocks path traversal with .. in directory path', async () => {
@@ -134,13 +127,10 @@ describe('Controlled Substance Logbook - Path Traversal Security', () => {
     const auditLog = await createAuditLog('safe-dir', deps);
 
     // Simulate attacker trying to read /etc/passwd
-    mockFs['../../../etc/passwd/controlled-substance-log.json'] = JSON.stringify([
-      {
-        id: 'malicious-1',
-        drugName: 'SensitiveData',
-        timestamp: 1000,
-      },
-    ]);
+    mem.files.set(
+      '../../../etc/passwd/controlled-substance-log.jsonl',
+      `${JSON.stringify({ id: 'malicious-1', drugName: 'SensitiveData', timestamp: 1000 })}\n`
+    );
 
     const maliciousPath = '../../../etc/passwd';
     const logbook = createControlledSubstanceLogbook(maliciousPath, {
@@ -156,7 +146,7 @@ describe('Controlled Substance Logbook - Path Traversal Security', () => {
     expect(deps.readFileSync).not.toHaveBeenCalled();
   });
 
-  test('record operation fails silently with malicious path', async () => {
+  test('record on a blocked path throws instead of returning an unpersisted transaction', async () => {
     const deps = makeFsDeps(1000);
     const auditLog = await createAuditLog('safe-dir', deps);
 
@@ -166,24 +156,25 @@ describe('Controlled Substance Logbook - Path Traversal Security', () => {
       ...deps,
     });
 
-    // Attempt to record a transaction
-    const tx = logbook.record({
-      action: 'receive',
-      drugName: 'Ketamine',
-      drugClass: 'CIII',
-      lotNumber: 'LOT-001',
-      quantity: 100,
-      unit: 'mL',
-      veterinarianId: 'vet-456',
-      veterinarianName: 'Dr. Smith',
-    });
+    // Returning a transaction here is what let the UI confirm a dispense that
+    // was never written. The caller must be told the record does not exist.
+    expect(() =>
+      logbook.record({
+        action: 'receive',
+        drugName: 'Ketamine',
+        drugClass: 'CIII',
+        lotNumber: 'LOT-001',
+        quantity: 100,
+        unit: 'mL',
+        veterinarianId: 'vet-456',
+        veterinarianName: 'Dr. Smith',
+      })
+    ).toThrow(CsWriteError);
 
-    // Transaction is created but not persisted
-    expect(tx.id).toMatch(/^cs-/);
-
-    // But reading back should return empty due to security check
     expect(logbook.getTransactions()).toEqual([]);
     expect(logbook.size()).toBe(0);
+    // ...and the store says so, rather than reporting a healthy empty register.
+    expect(logbook.getIntegrity().ok).toBe(false);
   });
 
   test('blocks absolute paths on Unix-like systems', async () => {

--- a/apps/desktop/tests/controlled-substance.test.ts
+++ b/apps/desktop/tests/controlled-substance.test.ts
@@ -1,32 +1,17 @@
 import { createControlledSubstanceLogbook } from '../src/compliance/controlled-substance';
 import { createAuditLog } from '../src/compliance/audit-log';
-import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { createMemoryFs, asDeps, type MemoryFs } from './helpers/memory-fs';
 
 describe('createControlledSubstanceLogbook', () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-logbook-test-'));
-  let mockFs: Record<string, string> = {};
+  const tmpDir = path.join(os.tmpdir(), 'cs-logbook-test');
+  let mem: MemoryFs;
 
-  const makeFsDeps = (nowVal = 1000) => ({
-    readFileSync: jest.fn((filePath: string) => {
-      if (mockFs[filePath] !== undefined) return mockFs[filePath];
-      throw new Error('ENOENT');
-    }),
-    writeFileSync: jest.fn((filePath: string, data: string) => {
-      mockFs[filePath] = data;
-    }),
-    mkdirSync: jest.fn(),
-    existsSync: jest.fn((filePath: string) => mockFs[filePath] !== undefined),
-    now: jest.fn(() => nowVal),
-  });
+  const makeFsDeps = (nowVal = 1000) => asDeps(mem, () => nowVal);
 
   beforeEach(() => {
-    mockFs = {};
-  });
-
-  afterAll(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    mem = createMemoryFs();
   });
 
   test('record adds a controlled substance transaction and audit entry', async () => {

--- a/apps/desktop/tests/durable-log.test.ts
+++ b/apps/desktop/tests/durable-log.test.ts
@@ -1,0 +1,229 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createJsonlStore } from '../src/compliance/durable-log';
+import { createMemoryFs, type MemoryFs } from './helpers/memory-fs';
+
+interface Rec {
+  id: string;
+  value: number;
+}
+
+const isRec = (v: unknown): v is Rec =>
+  typeof v === 'object' && v !== null && typeof (v as Rec).id === 'string';
+
+const DIR = path.join(os.tmpdir(), 'durable-log-test');
+const LOG = path.join(DIR, 'log.jsonl');
+const STATE = path.join(DIR, 'log.jsonl.state.json');
+const LEGACY = path.join(DIR, 'log.json');
+
+describe('createJsonlStore', () => {
+  let mem: MemoryFs;
+  let clock: number;
+
+  const makeStore = (overrides: Partial<Parameters<typeof createJsonlStore<Rec>>[0]> = {}) =>
+    createJsonlStore<Rec>({
+      dirPath: DIR,
+      fileName: 'log.jsonl',
+      legacyFileName: 'log.json',
+      isRecord: isRec,
+      watermarkOf: (r) => r.id,
+      fsq: mem,
+      now: () => (clock += 1000),
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    mem = createMemoryFs();
+    clock = 1000;
+    mem.dirs.add(DIR);
+  });
+
+  test('round-trips records through a real filesystem', () => {
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), 'durable-log-real-'));
+    try {
+      // No fs injection: this exercises the real openSync/writeSync/fsyncSync path.
+      const store = createJsonlStore<Rec>({
+        dirPath: realDir,
+        fileName: 'log.jsonl',
+        isRecord: isRec,
+        watermarkOf: (r) => r.id,
+      });
+      store.append({ id: 'a', value: 1 });
+      store.append({ id: 'b', value: 2 });
+
+      const raw = fs.readFileSync(path.join(realDir, 'log.jsonl'), 'utf8');
+      expect(raw).toBe('{"id":"a","value":1}\n{"id":"b","value":2}\n');
+      expect(store.health().ok).toBe(true);
+      expect(store.watermarkValue()).toBe('b');
+    } finally {
+      fs.rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+
+  test('an unreadable watermark does not by itself condemn the log', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    mem.files.set(STATE, 'not json at all');
+
+    const store = makeStore();
+    expect(store.readAll()).toHaveLength(1);
+    expect(store.health().ok).toBe(true);
+    expect(store.watermarkValue()).toBe('');
+  });
+
+  test('a watermark that is not an object is ignored', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    mem.files.set(STATE, '["not", "an", "object"]');
+    expect(makeStore().health().watermarkCount).toBe(0);
+  });
+
+  test('a log that cannot be read is reported unreadable, never as empty', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    mem.readFileSync.mockImplementation((p: string) => {
+      if (p === LOG) throw new Error('EACCES: permission denied');
+      throw new Error('ENOENT');
+    });
+
+    const damage = jest.fn();
+    const store = makeStore({ onDamage: damage });
+    expect(store.readAll()).toEqual([]);
+    const health = store.health();
+    expect(health.ok).toBe(false);
+    expect(health.reason).toContain('log unreadable');
+    expect(damage).toHaveBeenCalled();
+  });
+
+  test('a legacy file that is not an array is treated as unreadable', () => {
+    mem.files.set(LEGACY, '{"not":"an array"}');
+    const store = makeStore();
+    expect(store.readAll()).toEqual([]);
+    expect(store.health().reason).toContain('legacy log is not an array');
+  });
+
+  test('legacy migration drops entries that are not records', () => {
+    mem.files.set(LEGACY, JSON.stringify([{ id: 'a', value: 1 }, { nope: true }, null]));
+    const store = makeStore();
+    expect(store.readAll()).toEqual([{ id: 'a', value: 1 }]);
+    expect(JSON.parse(mem.files.get(STATE)!)).toMatchObject({ count: 1, last: 'a' });
+  });
+
+  test('an empty legacy log migrates to an empty watermark', () => {
+    mem.files.set(LEGACY, '[]');
+    const store = makeStore();
+    expect(store.readAll()).toEqual([]);
+    expect(JSON.parse(mem.files.get(STATE)!)).toMatchObject({ count: 0, last: '' });
+  });
+
+  test('a store with no legacy file configured skips migration entirely', () => {
+    mem.files.set(LEGACY, JSON.stringify([{ id: 'ignored', value: 9 }]));
+    const store = makeStore({ legacyFileName: undefined });
+    expect(store.readAll()).toEqual([]);
+  });
+
+  test('well-formed JSON that is not a record counts as corruption', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n{"wrong":"shape"}\n');
+    const store = makeStore();
+    expect(store.health().ok).toBe(false);
+    expect(store.health().quarantinePath).toBeTruthy();
+  });
+
+  test('a trailing fragment that parses but is not a record is a torn tail', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n{"wrong":"shape"}');
+    const store = makeStore();
+    expect(store.readAll()).toEqual([{ id: 'a', value: 1 }]);
+    expect(store.health().tornTail).toBe(true);
+    // The fragment is preserved for inspection and removed from the live log.
+    expect(mem.files.get(LOG)).toBe('{"id":"a","value":1}\n');
+    expect([...mem.files.keys()].some((k) => k.includes('.torn-'))).toBe(true);
+  });
+
+  test('blank lines in the log are skipped without being called corruption', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n\n{"id":"b","value":2}\n');
+    const store = makeStore();
+    expect(store.readAll()).toHaveLength(2);
+    expect(store.health().ok).toBe(true);
+  });
+
+  test('a torn tail that cannot be truncated is left for the next load to catch', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n{"id":"b"');
+    mem.truncateSync.mockImplementation(() => {
+      throw new Error('EPERM');
+    });
+
+    const store = makeStore();
+    expect(store.readAll()).toEqual([{ id: 'a', value: 1 }]);
+    expect(store.health().tornTail).toBe(true);
+
+    // Appending still works, and the fragment survives as its own line so the
+    // next load reports damage loudly rather than losing records.
+    store.append({ id: 'c', value: 3 });
+    expect(mem.files.get(LOG)).toContain('{"id":"b"\n{"id":"c","value":3}\n');
+  });
+
+  test('a damaged log that cannot be quarantined still reports the damage', () => {
+    mem.files.set(LOG, 'garbage line\n{"id":"a","value":1}\n');
+    mem.renameSync.mockImplementation(() => {
+      throw new Error('EBUSY');
+    });
+
+    const health = makeStore().health();
+    expect(health.ok).toBe(false);
+    expect(health.reason).toContain('could not be quarantined');
+    expect(health.quarantinePath).toBeNull();
+  });
+
+  test('quarantine survives a failed watermark update', () => {
+    mem.files.set(LOG, 'garbage line\n{"id":"a","value":1}\n');
+    const realOpen = mem.openSync.getMockImplementation()!;
+    mem.openSync.mockImplementation((p: string, flags: string) => {
+      if (p.includes('.state.json')) throw new Error('ENOSPC');
+      return realOpen(p, flags);
+    });
+
+    const health = makeStore().health();
+    expect(health.ok).toBe(false);
+    expect(health.quarantinePath).toBeTruthy();
+  });
+
+  test('a previously recorded break is remembered and reported', () => {
+    mem.files.set(STATE, JSON.stringify({ count: 0, last: '', brokenAt: 42 }));
+    expect(makeStore().health().reason).toBe('log was previously found damaged');
+  });
+
+  test('an earlier quarantine path is surfaced on later loads', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    mem.files.set(
+      STATE,
+      JSON.stringify({ count: 1, last: 'a', brokenAt: 42, quarantined: ['/old/corrupt-1'] })
+    );
+    expect(makeStore().health().quarantinePath).toBe('/old/corrupt-1');
+  });
+
+  test('a record stays durable even when the watermark cannot be updated', () => {
+    const store = makeStore();
+    store.append({ id: 'a', value: 1 });
+
+    const realOpen = mem.openSync.getMockImplementation()!;
+    mem.openSync.mockImplementation((p: string, flags: string) => {
+      if (p.includes('.state.json')) throw new Error('ENOSPC');
+      return realOpen(p, flags);
+    });
+
+    expect(() => store.append({ id: 'b', value: 2 })).not.toThrow();
+    expect(mem.files.get(LOG)).toContain('{"id":"b","value":2}');
+    expect(store.readAll()).toHaveLength(2);
+  });
+
+  test('the default clock is used when none is injected', () => {
+    mem.files.set(LOG, 'garbage\n{"id":"a","value":1}\n');
+    const store = createJsonlStore<Rec>({
+      dirPath: DIR,
+      fileName: 'log.jsonl',
+      isRecord: isRec,
+      watermarkOf: (r) => r.id,
+      fsq: mem,
+    });
+    const quarantined = store.health().quarantinePath!;
+    expect(Number(quarantined.split('.corrupt-')[1])).toBeGreaterThan(1_600_000_000_000);
+  });
+});

--- a/apps/desktop/tests/durable-log.test.ts
+++ b/apps/desktop/tests/durable-log.test.ts
@@ -90,6 +90,89 @@ describe('createJsonlStore', () => {
     ).toThrow(/resolves outside the log directory/);
   });
 
+  test('a complete but unterminated tail is NOT committed', () => {
+    // A short write can persist the whole JSON object and lose only the
+    // newline. The caller was told the append failed, so accepting this record
+    // would resurrect a transaction the caller believes does not exist.
+    mem.files.set(LOG, '{"id":"a","value":1}\n{"id":"b","value":2}');
+    const store = makeStore();
+
+    expect(store.readAll()).toEqual([{ id: 'a', value: 1 }]);
+    expect(store.health().tornTail).toBe(true);
+    expect(mem.files.get(LOG)).toBe('{"id":"a","value":1}\n');
+    // The rejected bytes are kept for inspection rather than destroyed.
+    const torn = [...mem.files.keys()].find((k) => k.includes('.torn-'))!;
+    expect(mem.files.get(torn)).toBe('{"id":"b","value":2}');
+  });
+
+  test('refuses to append when the existing history could not be read', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    mem.readFileSync.mockImplementation((p: string) => {
+      if (p === LOG) throw new Error('EACCES: permission denied');
+      throw new Error('ENOENT');
+    });
+
+    const store = makeStore();
+    expect(store.readAll()).toEqual([]);
+    // The cache is empty because the log is unreadable, not because it is
+    // empty. Appending would start a fresh history over an existing one.
+    expect(() => store.append({ id: 'b', value: 2 })).toThrow(/could not be read/);
+  });
+
+  test('does not re-migrate a legacy log after the live log is lost', () => {
+    mem.files.set(LEGACY, JSON.stringify([{ id: 'old-1', value: 1 }]));
+    const first = makeStore();
+    expect(first.readAll()).toEqual([{ id: 'old-1', value: 1 }]);
+    first.append({ id: 'new-1', value: 2 });
+    expect(JSON.parse(mem.files.get(STATE)!)).toMatchObject({ count: 2, last: 'new-1' });
+
+    // The live log is lost. Re-running the migration would rebuild the stale
+    // snapshot and overwrite the newer watermark, hiding the loss entirely.
+    mem.files.delete(LOG);
+    const reopened = makeStore();
+
+    expect(reopened.readAll()).toEqual([]);
+    expect(reopened.health().ok).toBe(false);
+    expect(reopened.health().reason).toContain('2 record(s) missing');
+    expect(JSON.parse(mem.files.get(STATE)!).last).toBe('new-1');
+  });
+
+  test('persists a detected loss so ordinary use cannot erase it', () => {
+    const store = makeStore();
+    for (const id of ['a', 'b', 'c']) store.append({ id, value: 1 });
+
+    // Truncate to one record, then record enough new ones to restore the count.
+    mem.files.set(LOG, '{"id":"a","value":1}\n');
+    const shortened = makeStore();
+    expect(shortened.health().reason).toContain('2 record(s) missing');
+    // The break reached the sidecar, not just this session's memory.
+    expect(JSON.parse(mem.files.get(STATE)!).brokenAt).toBeGreaterThan(0);
+
+    shortened.append({ id: 'd', value: 1 });
+    shortened.append({ id: 'e', value: 1 });
+
+    const later = makeStore();
+    expect(later.readAll()).toHaveLength(3);
+    // Counts line up again and the marker is present, so without the persisted
+    // break this would now certify as intact.
+    expect(later.health().ok).toBe(false);
+  });
+
+  test('copies a persistent corruption once, not on every launch', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\ngarbage\n{"id":"b","value":2}\n');
+    const first = makeStore();
+    const path1 = first.health().quarantinePath!;
+    expect(path1).toBeTruthy();
+
+    // The damaged line stays in the live log by design, so every launch
+    // re-detects it. Copying the whole log each time would fill the volume.
+    const second = makeStore();
+    const third = makeStore();
+    expect(second.health().quarantinePath).toBe(path1);
+    expect(third.health().quarantinePath).toBe(path1);
+    expect([...mem.files.keys()].filter((k) => k.includes('.corrupt-'))).toHaveLength(1);
+  });
+
   test('an unreadable watermark does not by itself condemn the log', () => {
     mem.files.set(LOG, '{"id":"a","value":1}\n');
     mem.files.set(STATE, 'not json at all');

--- a/apps/desktop/tests/durable-log.test.ts
+++ b/apps/desktop/tests/durable-log.test.ts
@@ -61,6 +61,35 @@ describe('createJsonlStore', () => {
     }
   });
 
+  test.each(['../../../etc', 'data/../../secrets', '..'])(
+    'refuses a log directory that escapes its parent: %s',
+    (badDir) => {
+      // The audit log used to pass its directory straight through with no
+      // traversal guard at all, unlike the controlled-substance logbook.
+      expect(() =>
+        createJsonlStore<Rec>({
+          dirPath: badDir,
+          fileName: 'log.jsonl',
+          isRecord: isRec,
+          watermarkOf: (r) => r.id,
+          fsq: mem,
+        })
+      ).toThrow(/escapes its parent/);
+    }
+  );
+
+  test('refuses a filename that escapes the log directory', () => {
+    expect(() =>
+      createJsonlStore<Rec>({
+        dirPath: DIR,
+        fileName: '../../etc/passwd',
+        isRecord: isRec,
+        watermarkOf: (r) => r.id,
+        fsq: mem,
+      })
+    ).toThrow(/resolves outside the log directory/);
+  });
+
   test('an unreadable watermark does not by itself condemn the log', () => {
     mem.files.set(LOG, '{"id":"a","value":1}\n');
     mem.files.set(STATE, 'not json at all');

--- a/apps/desktop/tests/durable-log.test.ts
+++ b/apps/desktop/tests/durable-log.test.ts
@@ -160,19 +160,40 @@ describe('createJsonlStore', () => {
     expect(mem.files.get(LOG)).toContain('{"id":"b"\n{"id":"c","value":3}\n');
   });
 
-  test('a damaged log that cannot be quarantined still reports the damage', () => {
+  test('a damaged log that cannot be copied aside still reports the damage', () => {
     mem.files.set(LOG, 'garbage line\n{"id":"a","value":1}\n');
-    mem.renameSync.mockImplementation(() => {
-      throw new Error('EBUSY');
-    });
+    mem.failOpen((p) => p.includes('.corrupt-'), 'EROFS');
 
-    const health = makeStore().health();
+    const store = makeStore();
+    const health = store.health();
     expect(health.ok).toBe(false);
-    expect(health.reason).toContain('could not be quarantined');
+    expect(health.reason).toContain('could not be copied aside');
     expect(health.quarantinePath).toBeNull();
+    // The surviving record stays readable either way: preserving evidence must
+    // not cost the records that are still a required register.
+    expect(store.readAll()).toEqual([{ id: 'a', value: 1 }]);
   });
 
-  test('quarantine survives a failed watermark update', () => {
+  test('a damaged log keeps its surviving records live and appendable', () => {
+    mem.files.set(LOG, '{"id":"a","value":1}\ngarbage line\n{"id":"b","value":2}\n');
+    const store = makeStore();
+
+    expect(store.readAll()).toEqual([
+      { id: 'a', value: 1 },
+      { id: 'b', value: 2 },
+    ]);
+    const quarantined = store.health().quarantinePath!;
+    // A copy, not a move: the live log is intact on disk.
+    expect(mem.files.get(quarantined)).toContain('garbage line');
+    expect(mem.files.get(LOG)).toContain('garbage line');
+
+    store.append({ id: 'c', value: 3 });
+    expect(store.readAll()).toHaveLength(3);
+    // ...and it never goes back to claiming to be healthy.
+    expect(store.health().ok).toBe(false);
+  });
+
+  test('the damage report survives a failed watermark update', () => {
     mem.files.set(LOG, 'garbage line\n{"id":"a","value":1}\n');
     const realOpen = mem.openSync.getMockImplementation()!;
     mem.openSync.mockImplementation((p: string, flags: string) => {

--- a/apps/desktop/tests/helpers/memory-fs.ts
+++ b/apps/desktop/tests/helpers/memory-fs.ts
@@ -1,0 +1,195 @@
+import path from 'node:path';
+import { Buffer } from 'node:buffer';
+
+/**
+ * In-memory filesystem covering the whole surface the compliance logs use,
+ * including the append/fsync path. The previous mocks stubbed only
+ * read/write/exists/mkdir, so any code reaching for openSync fell through to the
+ * real disk and made the tests non-hermetic.
+ *
+ * Faults can be armed per path so that write failures (ENOSPC, EACCES, an
+ * antivirus lock) are testable without touching a real filesystem.
+ */
+export interface MemoryFs {
+  files: Map<string, string>;
+  dirs: Set<string>;
+  fsyncCalls: string[];
+  /** Fail the next open of any path matching this predicate. */
+  failOpen: (match: (filePath: string, flags: string) => boolean, code?: string) => void;
+  /** Fail writes to any path matching this predicate. */
+  failWrite: (match: (filePath: string) => boolean, code?: string) => void;
+  /** Make writes to matching paths silently persist fewer bytes than asked. */
+  truncateWrite: (match: (filePath: string) => boolean, keepBytes: number) => void;
+  clearFaults: () => void;
+  readFileSync: jest.Mock;
+  writeFileSync: jest.Mock;
+  mkdirSync: jest.Mock;
+  existsSync: jest.Mock;
+  openSync: jest.Mock;
+  writeSync: jest.Mock;
+  fsyncSync: jest.Mock;
+  closeSync: jest.Mock;
+  renameSync: jest.Mock;
+  truncateSync: jest.Mock;
+}
+
+const enoent = (filePath: string, op: string): Error => {
+  const err = new Error(`ENOENT: no such file or directory, ${op} '${filePath}'`) as Error & {
+    code?: string;
+  };
+  err.code = 'ENOENT';
+  return err;
+};
+
+const failure = (code: string, filePath: string, op: string): Error => {
+  const err = new Error(`${code}: simulated failure, ${op} '${filePath}'`) as Error & {
+    code?: string;
+  };
+  err.code = code;
+  return err;
+};
+
+export const createMemoryFs = (seed: Record<string, string> = {}): MemoryFs => {
+  const files = new Map<string, string>(Object.entries(seed));
+  const dirs = new Set<string>();
+  const fsyncCalls: string[] = [];
+  const handles = new Map<number, string>();
+  let nextFd = 10;
+
+  let openFault: { match: (p: string, f: string) => boolean; code: string } | null = null;
+  let writeFault: { match: (p: string) => boolean; code: string } | null = null;
+  let shortWrite: { match: (p: string) => boolean; keepBytes: number } | null = null;
+
+  // Seeded files imply their directories exist.
+  for (const filePath of files.keys()) dirs.add(path.dirname(filePath));
+
+  const addDir = (dirPath: string): void => {
+    let current = dirPath;
+    while (current && current !== path.dirname(current)) {
+      dirs.add(current);
+      current = path.dirname(current);
+    }
+    dirs.add(current);
+  };
+
+  const fs: MemoryFs = {
+    files,
+    dirs,
+    fsyncCalls,
+    failOpen: (match, code = 'EACCES') => {
+      openFault = { match, code };
+    },
+    failWrite: (match, code = 'ENOSPC') => {
+      writeFault = { match, code };
+    },
+    truncateWrite: (match, keepBytes) => {
+      shortWrite = { match, keepBytes };
+    },
+    clearFaults: () => {
+      openFault = null;
+      writeFault = null;
+      shortWrite = null;
+    },
+
+    readFileSync: jest.fn((filePath: string) => {
+      const content = files.get(filePath);
+      if (content === undefined) throw enoent(filePath, 'open');
+      return content;
+    }),
+
+    writeFileSync: jest.fn((filePath: string, data: string) => {
+      files.set(filePath, String(data));
+      addDir(path.dirname(filePath));
+    }),
+
+    mkdirSync: jest.fn((dirPath: string) => {
+      addDir(dirPath);
+    }),
+
+    existsSync: jest.fn((target: string) => files.has(target) || dirs.has(target)),
+
+    openSync: jest.fn((filePath: string, flags: string) => {
+      if (openFault?.match(filePath, flags)) throw failure(openFault.code, filePath, 'open');
+      if (!dirs.has(path.dirname(filePath))) throw enoent(filePath, 'open');
+      if (flags.includes('w') || !files.has(filePath)) files.set(filePath, '');
+      const fd = nextFd++;
+      handles.set(fd, filePath);
+      return fd;
+    }),
+
+    writeSync: jest.fn((fd: number, data: string) => {
+      const filePath = handles.get(fd);
+      if (filePath === undefined) throw new Error(`EBADF: bad file descriptor ${fd}`);
+      if (writeFault?.match(filePath)) throw failure(writeFault.code, filePath, 'write');
+      const payload =
+        shortWrite?.match(filePath) === true
+          ? Buffer.from(data, 'utf8').subarray(0, shortWrite.keepBytes).toString('utf8')
+          : data;
+      files.set(filePath, (files.get(filePath) ?? '') + payload);
+      return Buffer.byteLength(payload, 'utf8');
+    }),
+
+    fsyncSync: jest.fn((fd: number) => {
+      const filePath = handles.get(fd);
+      if (filePath === undefined) throw new Error(`EBADF: bad file descriptor ${fd}`);
+      fsyncCalls.push(filePath);
+    }),
+
+    closeSync: jest.fn((fd: number) => {
+      handles.delete(fd);
+    }),
+
+    renameSync: jest.fn((from: string, to: string) => {
+      const content = files.get(from);
+      if (content === undefined) throw enoent(from, 'rename');
+      files.delete(from);
+      files.set(to, content);
+      addDir(path.dirname(to));
+    }),
+
+    truncateSync: jest.fn((filePath: string, length: number) => {
+      const content = files.get(filePath);
+      if (content === undefined) throw enoent(filePath, 'truncate');
+      files.set(filePath, Buffer.from(content, 'utf8').subarray(0, length).toString('utf8'));
+    }),
+  };
+
+  return fs;
+};
+
+/** The dependency subset the compliance stores accept. */
+export const asDeps = (
+  mem: MemoryFs,
+  now: () => number = () => 1000
+): {
+  readFileSync: jest.Mock;
+  writeFileSync: jest.Mock;
+  mkdirSync: jest.Mock;
+  existsSync: jest.Mock;
+  openSync: jest.Mock;
+  writeSync: jest.Mock;
+  fsyncSync: jest.Mock;
+  closeSync: jest.Mock;
+  renameSync: jest.Mock;
+  truncateSync: jest.Mock;
+  now: () => number;
+} => ({
+  readFileSync: mem.readFileSync,
+  writeFileSync: mem.writeFileSync,
+  mkdirSync: mem.mkdirSync,
+  existsSync: mem.existsSync,
+  openSync: mem.openSync,
+  writeSync: mem.writeSync,
+  fsyncSync: mem.fsyncSync,
+  closeSync: mem.closeSync,
+  renameSync: mem.renameSync,
+  truncateSync: mem.truncateSync,
+  now,
+});
+
+/** Reads a JSONL log back out of the memory filesystem. */
+export const readJsonl = <T>(mem: MemoryFs, filePath: string): T[] =>
+  (mem.files.get(filePath) ?? '')
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => JSON.parse(line) as T);

--- a/apps/desktop/tests/helpers/memory-fs.ts
+++ b/apps/desktop/tests/helpers/memory-fs.ts
@@ -54,6 +54,7 @@ export const createMemoryFs = (seed: Record<string, string> = {}): MemoryFs => {
   const dirs = new Set<string>();
   const fsyncCalls: string[] = [];
   const handles = new Map<number, string>();
+  const dirHandles = new Set<number>();
   let nextFd = 10;
 
   let openFault: { match: (p: string, f: string) => boolean; code: string } | null = null;
@@ -110,6 +111,14 @@ export const createMemoryFs = (seed: Record<string, string> = {}): MemoryFs => {
 
     openSync: jest.fn((filePath: string, flags: string) => {
       if (openFault?.match(filePath, flags)) throw failure(openFault.code, filePath, 'open');
+      // Opening a directory is how the code fsyncs a directory entry. It must
+      // not conjure a file at that path.
+      if (dirs.has(filePath) && !files.has(filePath)) {
+        const dirFd = nextFd++;
+        dirHandles.add(dirFd);
+        handles.set(dirFd, filePath);
+        return dirFd;
+      }
       if (!dirs.has(path.dirname(filePath))) throw enoent(filePath, 'open');
       if (flags.includes('w') || !files.has(filePath)) files.set(filePath, '');
       const fd = nextFd++;
@@ -120,6 +129,7 @@ export const createMemoryFs = (seed: Record<string, string> = {}): MemoryFs => {
     writeSync: jest.fn((fd: number, data: string) => {
       const filePath = handles.get(fd);
       if (filePath === undefined) throw new Error(`EBADF: bad file descriptor ${fd}`);
+      if (dirHandles.has(fd)) throw failure('EISDIR', filePath, 'write');
       if (writeFault?.match(filePath)) throw failure(writeFault.code, filePath, 'write');
       const payload =
         shortWrite?.match(filePath) === true
@@ -137,6 +147,7 @@ export const createMemoryFs = (seed: Record<string, string> = {}): MemoryFs => {
 
     closeSync: jest.fn((fd: number) => {
       handles.delete(fd);
+      dirHandles.delete(fd);
     }),
 
     renameSync: jest.fn((from: string, to: string) => {

--- a/apps/desktop/tests/ipc-handlers.test.ts
+++ b/apps/desktop/tests/ipc-handlers.test.ts
@@ -41,6 +41,7 @@ jest.mock('../src/ui/theming', () => ({
 }));
 
 import { registerIpc, type IpcServices } from '../src/core/ipc-handlers';
+import { CsWriteError } from '../src/compliance/controlled-substance';
 import { getDesktopConfig } from '../src/core/navigation-policy';
 import { BUILTIN_ACTIONS } from '../src/ui/command-palette';
 
@@ -411,6 +412,33 @@ describe('ipc-handlers — happy paths', () => {
       ok: false,
       error: 'invalid-quantity',
     });
+  });
+
+  test('cs-record reports a failed write instead of confirming the dispense', async () => {
+    const services = makeServices();
+    services.controlledSubstanceLog = {
+      record: () => {
+        throw new CsWriteError('ENOSPC: no space left on device');
+      },
+    } as never;
+    const call = register(services);
+
+    // A dispense that never reached the disk must not come back as ok:true with
+    // a transaction the caller can show as confirmation.
+    expect(
+      await call('yc:cs-record', {
+        action: 'dispense',
+        drugName: 'Ketamine',
+        drugClass: 'CIII',
+        lotNumber: 'L1',
+        quantity: 5,
+        unit: 'mL',
+        veterinarianId: 'v1',
+        veterinarianName: 'Dr. X',
+      })
+    ).toEqual({ ok: false, error: 'cs-write-failed' });
+    expect(services.logger.error).toHaveBeenCalledWith('cs_record_failed', expect.anything());
+    expect(services.logger.info).not.toHaveBeenCalledWith('cs_recorded', expect.anything());
   });
 
   test('tab + window + misc handlers', async () => {

--- a/apps/desktop/tests/ipc-handlers.test.ts
+++ b/apps/desktop/tests/ipc-handlers.test.ts
@@ -42,6 +42,7 @@ jest.mock('../src/ui/theming', () => ({
 
 import { registerIpc, type IpcServices } from '../src/core/ipc-handlers';
 import { CsWriteError } from '../src/compliance/controlled-substance';
+import { AuditWriteError } from '../src/compliance/audit-log';
 import { getDesktopConfig } from '../src/core/navigation-policy';
 import { BUILTIN_ACTIONS } from '../src/ui/command-palette';
 
@@ -412,6 +413,25 @@ describe('ipc-handlers — happy paths', () => {
       ok: false,
       error: 'invalid-quantity',
     });
+  });
+
+  test('audit-append reports a failed write instead of confirming the entry', async () => {
+    const services = makeServices();
+    services.auditLog = {
+      append: () => {
+        throw new AuditWriteError('ENOSPC: no space left on device');
+      },
+    } as never;
+    const call = register(services);
+
+    // An audit entry that reached no disk is not an audit entry; the caller has
+    // to be told, and with a specific reason rather than a generic failure.
+    expect(await call('yc:audit-append', { action: 'patient:update' })).toEqual({
+      ok: false,
+      error: 'audit-write-failed',
+    });
+    expect(services.logger.error).toHaveBeenCalledWith('audit_append_failed', expect.anything());
+    expect(services.logger.info).not.toHaveBeenCalledWith('audit_appended', expect.anything());
   });
 
   test('cs-record reports a failed write instead of confirming the dispense', async () => {

--- a/apps/desktop/tests/status-dialogs.test.ts
+++ b/apps/desktop/tests/status-dialogs.test.ts
@@ -51,6 +51,15 @@ const makeDeps = (overrides: Partial<StatusDialogDeps> = {}): StatusDialogDeps =
     verifyAll: () => ({ valid: 3, tampered: 0 }),
     verifyChain: () => true,
     size: () => 3,
+    getIntegrity: () => ({
+      ok: true,
+      reason: null,
+      quarantinePath: null,
+      recordsLoaded: 3,
+      watermarkCount: 3,
+      tornTail: false,
+      signingKey: 'persisted' as const,
+    }),
   } as never,
   csExport: {
     exportDailyLog: () => ({ rowCount: 2, filePath: '/tmp/cs.csv' }),
@@ -105,6 +114,56 @@ describe('status dialogs — happy paths', () => {
     expect((deps.dialog.showMessageBox as jest.Mock).mock.calls.length).toBeGreaterThan(5);
     expect(deps.secondaryDisplays!.openDisplay).toHaveBeenCalled();
     expect(deps.runBackup).toHaveBeenCalled();
+  });
+
+  test('verifyAuditTrail names the problem when the log is not intact', () => {
+    const deps = makeDeps({
+      auditLog: {
+        verifyAll: () => ({ valid: 1, tampered: 0 }),
+        verifyChain: () => false,
+        size: () => 1,
+        getIntegrity: () => ({
+          ok: false,
+          reason: '4 record(s) missing (expected 5, found 1)',
+          quarantinePath: '/data/audit-log.jsonl.corrupt-1700000000',
+          recordsLoaded: 1,
+          watermarkCount: 5,
+          tornTail: false,
+        }),
+      } as never,
+    });
+    createStatusDialogService(deps).verifyAuditTrail();
+
+    const detail = (deps.dialog.showMessageBox as jest.Mock).mock.calls[0][0].detail as string;
+    expect(detail).toContain('Hash chain intact: NO');
+    expect(detail).toContain('4 record(s) missing');
+    expect(detail).toContain('/data/audit-log.jsonl.corrupt-1700000000');
+  });
+
+  test('verifyAuditTrail does not call unverifiable entries tampered', () => {
+    const deps = makeDeps({
+      auditLog: {
+        // With a session-only key every historical entry fails its check.
+        verifyAll: () => ({ valid: 0, tampered: 12 }),
+        verifyChain: () => false,
+        size: () => 12,
+        getIntegrity: () => ({
+          ok: false,
+          reason: 'the audit signing key could not be read (the OS keychain is unavailable)',
+          quarantinePath: null,
+          recordsLoaded: 12,
+          watermarkCount: 12,
+          tornTail: false,
+          signingKey: 'session-only' as const,
+        }),
+      } as never,
+    });
+    createStatusDialogService(deps).verifyAuditTrail();
+
+    const detail = (deps.dialog.showMessageBox as jest.Mock).mock.calls[0][0].detail as string;
+    expect(detail).toContain('CANNOT BE CHECKED');
+    expect(detail).not.toContain('Tampered: 12');
+    expect(detail).toContain('signing key could not be read');
   });
 
   test('generateDeaReportAction writes the chosen format', () => {

--- a/apps/desktop/tests/status-dialogs.test.ts
+++ b/apps/desktop/tests/status-dialogs.test.ts
@@ -69,7 +69,16 @@ const makeDeps = (overrides: Partial<StatusDialogDeps> = {}): StatusDialogDeps =
     getExpiringSoon: () => [],
     getAllRegistrations: () => [{ deaNumber: 'AB123' }],
   } as never,
-  controlledSubstanceLog: {} as never,
+  controlledSubstanceLog: {
+    getIntegrity: () => ({
+      ok: true,
+      reason: null,
+      quarantinePath: null,
+      recordsLoaded: 0,
+      watermarkCount: 0,
+      tornTail: false,
+    }),
+  } as never,
   pmpService: {
     getPending: () => [],
     getSubmitted: () => [1],
@@ -164,6 +173,56 @@ describe('status dialogs — happy paths', () => {
     expect(detail).toContain('CANNOT BE CHECKED');
     expect(detail).not.toContain('Tampered: 12');
     expect(detail).toContain('signing key could not be read');
+  });
+
+  test('a compliance export from a damaged register carries a warning', () => {
+    const damaged = {
+      getIntegrity: () => ({
+        ok: false,
+        reason: '2 record(s) missing (expected 9, found 7)',
+        quarantinePath: '/data/cs.jsonl.corrupt-1700000000',
+        recordsLoaded: 7,
+        watermarkCount: 9,
+        tornTail: false,
+      }),
+    } as never;
+
+    const deps = makeDeps({ controlledSubstanceLog: damaged });
+    const svc = createStatusDialogService(deps);
+    svc.exportCsDailyLog();
+    const exported = (deps.dialog.showMessageBox as jest.Mock).mock.calls[0][0].detail as string;
+    // A daily log built from an incomplete register must not look authoritative.
+    expect(exported).toContain('WARNING: the controlled-substance register is not intact');
+    expect(exported).toContain('2 record(s) missing');
+    expect(exported).toContain('/data/cs.jsonl.corrupt-1700000000');
+
+    // ...and so must the biennial report.
+    const reportDeps = makeDeps({ controlledSubstanceLog: damaged });
+    createStatusDialogService(reportDeps).generateDeaReportAction();
+    const reported = (reportDeps.dialog.showMessageBox as jest.Mock).mock.calls
+      .map((c) => c[0].detail as string)
+      .join('\n');
+    expect(reported).toContain('WARNING: the controlled-substance register is not intact');
+  });
+
+  test('an empty daily export from a damaged register still warns', () => {
+    const deps = makeDeps({
+      csExport: { exportDailyLog: () => null } as never,
+      controlledSubstanceLog: {
+        getIntegrity: () => ({
+          ok: false,
+          reason: 'the final record was written incompletely and was discarded',
+          quarantinePath: null,
+          recordsLoaded: 0,
+          watermarkCount: 1,
+          tornTail: true,
+        }),
+      } as never,
+    });
+    createStatusDialogService(deps).exportCsDailyLog();
+    const detail = (deps.dialog.showMessageBox as jest.Mock).mock.calls[0][0].detail as string;
+    expect(detail).toContain('No controlled-substance transactions to export');
+    expect(detail).toContain('WARNING: the controlled-substance register is not intact');
   });
 
   test('generateDeaReportAction writes the chosen format', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

Found by an adversarial DEA compliance audit of `apps/desktop` (37 candidates, 16 survived two independent refuters, collapsing to 8 distinct defects). This PR covers blockers 1, 2 and 4. Blocker 3 (witnessless waste) is a separate PR.

## What is the current behavior?

**1. Non-atomic writes destroy the register and the audit chain.**

`controlled-substance.ts` and `audit-log.ts` both rewrote the entire JSON array on every append with a bare `writeFileSync`: no temp file, no rename, no fsync. Both mapped an unparseable file to `[]`.

A crash mid-write leaves truncated JSON. The next launch reads it as empty, and the next `record()` / `append()` does `load() -> [] -> push one -> save()`, overwriting every survivor. `verifyChain()` then walks the one-entry array, sees `prevSignature === ''` and a genuine HMAC, and returns true, so Help > Verify Audit Trail prints "Hash chain intact: yes" over a wiped log. Nothing in `src/sync` replicates controlled substances, so there is no second copy.

**2. A dispense whose write failed is reported as recorded.**

`save()` swallowed every error and returned void; `record()` returned the transaction unconditionally; the `yc:cs-record` handler returned `{ ok: true, transaction }` and logged `cs_recorded`. ENOSPC, a read-only data directory, or an antivirus file lock produced a green UI confirmation with nothing on disk. Worse, the audit entry was already appended, and `audit-log.ts` assigned `cached = entries` before the write was attempted, so the session kept showing a signed `cs:dispense` entry pointing at a `csTransactionId` that exists in no logbook. No crash required: a full disk was enough.

**3. The audit HMAC key is silently regenerated and the old one destroyed.**

If `safeStorage` was unavailable at startup (no keyring session on Linux, a locked or reset login keychain) or `decryptString` threw, `readExistingKey()` returned null and a fresh key was minted and written over `audit-key`. The original was then gone even after the keyring recovered, every historical entry failed `verify()`, and the dialog reported the entire history as "Tampered", indistinguishable from real tampering. (`decryptString` throwing actually fell through to the legacy-plaintext branch and used the raw wrapper JSON as the key, which is worse than the audit described.)

## What is the new behavior?

**Append-only, crash-durable persistence.** Both stores now go through a shared `src/compliance/durable-log.ts`: one JSON record per line, written with `O_APPEND` + `fsync`, short writes rejected. An interrupted write can only damage the final line, and prior records are never rewritten.

**Damage is loud, never silent.** An incomplete final record is copied to a `.torn-<ts>` sidecar and dropped (it was never acknowledged to any caller, and leaving it in place would make it read as mid-file corruption after the next append). A corrupt record *inside* the file is copied to `.corrupt-<ts>` and the break is recorded in the watermark, so the log is never presented as intact again, across restarts. The damaged file is **copied, not moved**: the records that did survive are still a legally required register and stay live and appendable.

**A failed write cannot poison the retry.** A short write leaves a partial line behind, so any failed append assumes the file no longer ends cleanly and the retry starts on a fresh line rather than being spliced onto the fragment.

**The two regulatory records cannot disagree.** When the audit entry is written but the register write then fails, a `cs:<action>:not-recorded` compensation entry is appended naming the audit entry it voids, so the audit trail never asserts a dispense that exists in no logbook.

**A shortened chain is detectable.** The watermark persists the record count and last signature. `verifyChain()` now returns false when the loaded log has fewer records than the watermark, or when the recorded last signature is absent, which is exactly the truncated-crash case that previously certified as intact. The dialog names the problem and points at the quarantined file.

**Write failures reach the caller.** `append()` and `record()` throw `AuditWriteError` / `CsWriteError`; `yc:cs-record` returns `{ ok: false, error: 'cs-write-failed' }` and logs `cs_record_failed`. The in-memory view only advances after the bytes are durable, so a failed write can no longer leave a phantom entry in the session.

**The signing key is never minted over an unreadable one.** Key reads are now tri-state: found / absent / unreadable. Absent still mints and persists. Unreadable leaves the stored key untouched, runs the session on a temporary key, and reports `signingKey: 'session-only'`, so the dialog prints "Signatures: CANNOT BE CHECKED (signing key unreadable)" instead of calling the history tampered. Once the keychain recovers, the original key decrypts and the history verifies again.

**Migration.** Existing `audit-log.json` / `controlled-substance-log.json` array files are migrated to the new `.jsonl` format on first read, via temp file plus rename, so an interrupted migration leaves the legacy file untouched and simply retries. The legacy file is not deleted.

**Durability and containment.** The containing directory is fsynced after a create or rename, since syncing a file does not make its directory entry durable on POSIX. Every path the store derives goes through a containment check that refuses a filename resolving outside the log directory, and a directory path containing a `..` segment: the controlled-substance logbook already refused a traversing directory, `createAuditLog` did not.

**Compliance output is gated on register integrity.** The daily controlled-substance export and the DEA biennial report both carry an explicit warning naming the problem and the preserved copy when `getIntegrity()` is not ok, so an export from a truncated register cannot go out looking authoritative.

## Impact area

`apps/desktop` compliance only: the controlled-substance register, the audit log, the `yc:cs-record` IPC handler, and the Audit Trail dialog. No backend, frontend or mobile changes.

Two behaviour changes worth calling out for review:

- `record()` now throws on a blocked (path-traversal) directory instead of returning an unpersisted transaction. The existing test that asserted the old silent behaviour was rewritten, since it was asserting the defect.
- `AuditLog` and `ControlledSubstanceLogbook` gained `getIntegrity()`. Test doubles for `auditLog` need it.

## Validation performed

- `npx jest`: 1006 tests, 69 suites, all pass.
- Coverage: 98.31% statements, 90.64% branches, 97.63% functions (thresholds 95/88/95/95). Every touched file finished at or above where it started.
- `npx tsc --noemit -p tsconfig.test.json` and `npx eslint src tests --max-warnings=0` clean.
- Pre-push monorepo lint + type-check passed.
- **Mutation checked.** Each new test was validated by reintroducing the specific defect and confirming the matching test fails, then restoring and confirming green. 18 mutations exercised: append reopened with `'w'` instead of `'a'`; `verifyChain()` with the watermark check removed; write errors swallowed again; the in-memory cache advanced before the write; the short-write guard removed; the copy-aside disabled; legacy migration disabled; the watermark never persisted; the watermark marker check removed; a failed watermark update leaving health OK; the retry newline guard removed; the compensation entry removed; the audit-append IPC error swallowed; the register-integrity warning suppressed; an unreadable key minted over; `decryptString` failure falling back to the raw file contents; the dialog printing "Tampered" regardless of key state; the directory traversal guard removed. No test passed both with and without its fix.

## Related Issue(s)

Fixes #

