### PR TITLE
fix(frontend): enforce the read-only state instead of only advertising it

### DIFF
--- a/apps/frontend/src/app/__tests__/features/settings/CrossClinicMessagingPreference.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/settings/CrossClinicMessagingPreference.test.tsx
@@ -126,3 +126,33 @@ describe('CrossClinicMessagingPreference', () => {
     expect(mockNotify).toHaveBeenCalledWith('success', expect.anything());
   });
 });
+
+// The page-level suite mocks this component and only checks the prop is
+// forwarded, so without these the disabled switch and the early return could
+// both be removed while every focused test stayed green - restoring the exact
+// unauthorised updateOrg request readOnly exists to prevent.
+describe('CrossClinicMessagingPreference (read-only)', () => {
+  it('disables the switch when read-only', () => {
+    setOrg({ _id: 'o1', crossOrgMessagingEnabled: false });
+    render(<CrossClinicMessagingPreference readOnly />);
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('does not call updateOrg when a read-only switch is clicked', async () => {
+    setOrg({ _id: 'o1', name: 'Clinic', crossOrgMessagingEnabled: false });
+    render(<CrossClinicMessagingPreference readOnly />);
+
+    fireEvent.click(screen.getByRole('switch'));
+    await Promise.resolve();
+
+    expect(mockUpdateOrg).not.toHaveBeenCalled();
+  });
+
+  it('still calls updateOrg when not read-only', async () => {
+    setOrg({ _id: 'o1', name: 'Clinic', crossOrgMessagingEnabled: false });
+    render(<CrossClinicMessagingPreference />);
+
+    fireEvent.click(screen.getByRole('switch'));
+    await waitFor(() => expect(mockUpdateOrg).toHaveBeenCalled());
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/AppointmentLockWindowPreference.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/AppointmentLockWindowPreference.test.tsx
@@ -199,3 +199,23 @@ describe('AppointmentLockWindowPreference', () => {
     expect(notify).not.toHaveBeenCalled();
   });
 });
+
+// The page-level suite mocks this component and only checks the prop is
+// forwarded, so without these both `disabled={readOnly}` assignments could be
+// removed while every focused test stayed green - letting an unauthorised
+// member edit and locally persist the clinic lock window again.
+describe('AppointmentLockWindowPreference (read-only)', () => {
+  it('disables both fields when read-only', () => {
+    render(<AppointmentLockWindowPreference readOnly />);
+
+    expect(screen.getByLabelText('Outpatient')).toBeDisabled();
+    expect(screen.getByLabelText('Inpatient')).toBeDisabled();
+  });
+
+  it('leaves both fields editable when not read-only', () => {
+    render(<AppointmentLockWindowPreference />);
+
+    expect(screen.getByLabelText('Outpatient')).not.toBeDisabled();
+    expect(screen.getByLabelText('Inpatient')).not.toBeDisabled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Settings/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/index.test.tsx
@@ -75,11 +75,21 @@ jest.mock('next/dynamic', () => ({
       // whole point of the scope split regress without failing anything. They are
       // identifiable now so the composition tests below can assert placement.
       if (source.includes('Sections/AppointmentLockWindowPreference')) {
-        return <div>Appointment Lock Window Preference</div>;
+        return (
+          <div>
+            Appointment Lock Window Preference
+            <span data-testid="lock-window-readonly">{String(props.readOnly)}</span>
+          </div>
+        );
       }
 
       if (source.includes('Sections/CrossClinicMessagingPreference')) {
-        return <div>Cross Clinic Messaging Preference</div>;
+        return (
+          <div>
+            Cross Clinic Messaging Preference
+            <span data-testid="cross-clinic-readonly">{String(props.readOnly)}</span>
+          </div>
+        );
       }
 
       if (source.includes('Sections/YourOrganizations')) {
@@ -138,10 +148,14 @@ jest.mock('@/app/features/settings/pages/Settings/Sections/CompanionTerminologyP
   default: () => <div>Companion Terminology</div>,
 }));
 
-const mockHasPermission = jest.fn(() => true);
+// Records the permission argument. Discarding it made every permission test
+// pass even when the page checked the WRONG permission - reverting to
+// integrations:edit:any, the exact bug these tests exist to catch, left the
+// suite green.
+const mockHasPermission = jest.fn((_perm?: unknown) => true);
 jest.mock('@/app/hooks/usePermissions', () => ({
   __esModule: true,
-  useHasPermission: () => mockHasPermission(),
+  useHasPermission: (perm: unknown) => mockHasPermission(perm),
 }));
 
 /**
@@ -217,6 +231,25 @@ describe('Settings page', () => {
 
     const group = screen.getByText('Appointment Lock Window Preference').closest('section');
     expect(group).not.toHaveTextContent(/Managed by a clinic administrator/);
+  });
+
+  it('gates the scheduling group on teams:edit:any, not the integrations permission', () => {
+    render(<Settings />);
+
+    // The scheduling controls write through updateOrg, whose PUT route requires
+    // teams:edit:any. Asserting the argument is what makes the other permission
+    // tests meaningful.
+    expect(mockHasPermission).toHaveBeenCalledWith('teams:edit:any');
+    expect(mockHasPermission).not.toHaveBeenCalledWith('integrations:edit:any');
+  });
+
+  it('disables the clinic controls when the member cannot edit them', () => {
+    mockHasPermission.mockReturnValue(false);
+    render(<Settings />);
+
+    // Advertising read-only without enforcing it invites a click the backend rejects.
+    expect(screen.getByTestId('lock-window-readonly')).toHaveTextContent('true');
+    expect(screen.getByTestId('cross-clinic-readonly')).toHaveTextContent('true');
   });
 
   it('keeps the organisation band description permission-neutral', () => {

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/AppointmentLockWindowPreference.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/AppointmentLockWindowPreference.tsx
@@ -26,12 +26,14 @@ const HoursField = ({
   value,
   onChange,
   onCommit,
+  disabled = false,
 }: {
   id: string;
   label: string;
   value: string;
   onChange: (value: string) => void;
   onCommit: () => void;
+  disabled?: boolean;
 }) => (
   <span className="flex flex-col gap-1">
     <label htmlFor={id} className="yc-settings-hours-label">
@@ -40,6 +42,7 @@ const HoursField = ({
     <span className="yc-settings-hours-field">
       <input
         id={id}
+        disabled={disabled}
         type="number"
         inputMode="numeric"
         min={MIN_LOCK_HOURS}
@@ -62,7 +65,7 @@ const HoursField = ({
  * its clinical workspace stays editable before it locks to read-only. Consumed
  * by `isPastLockWindow` in the appointment workspace.
  */
-const AppointmentLockWindowPreference = () => {
+const AppointmentLockWindowPreference = ({ readOnly = false }: { readOnly?: boolean }) => {
   const { notify } = useNotify();
   const saved = useAppointmentLockWindow();
   const primaryOrg = useOrgStore((s) => s.getPrimaryOrg());
@@ -151,6 +154,7 @@ const AppointmentLockWindowPreference = () => {
           value={outpatient}
           onChange={setOutpatient}
           onCommit={commit}
+          disabled={readOnly}
         />
         <HoursField
           id="lock-window-inpatient"
@@ -158,6 +162,7 @@ const AppointmentLockWindowPreference = () => {
           value={inpatient}
           onChange={setInpatient}
           onCommit={commit}
+          disabled={readOnly}
         />
       </span>
     </PreferenceRow>

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.tsx
@@ -13,7 +13,7 @@ import { PreferenceRow } from './PreferenceGroup';
  * versa. Both clinics must have it enabled for a conversation to start. Turning it
  * off removes the clinic from the cross-clinic directory.
  */
-const CrossClinicMessagingPreference = () => {
+const CrossClinicMessagingPreference = ({ readOnly = false }: { readOnly?: boolean }) => {
   const { notify } = useNotify();
   const primaryOrg = useOrgStore((s) => s.getPrimaryOrg());
   const stored = primaryOrg?.crossOrgMessagingEnabled;
@@ -25,7 +25,7 @@ const CrossClinicMessagingPreference = () => {
   const [saving, setSaving] = useState(false);
 
   const handleToggle = async () => {
-    if (!primaryOrg?._id || saving || !isKnown) return;
+    if (readOnly || !primaryOrg?._id || saving || !isKnown) return;
     const next = !enabled;
     setSaving(true);
     try {
@@ -57,7 +57,7 @@ const CrossClinicMessagingPreference = () => {
           role="switch"
           aria-checked={enabled}
           aria-label="Cross-clinic messaging"
-          disabled={saving || !primaryOrg?._id}
+          disabled={readOnly || saving || !primaryOrg?._id}
           onClick={handleToggle}
           className={clsx(
             'relative inline-flex h-6 w-10 shrink-0 items-center rounded-full transition-colors disabled:opacity-50',

--- a/apps/frontend/src/app/features/settings/pages/Settings/index.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/index.tsx
@@ -136,10 +136,7 @@ const Settings = () => {
           preferences" and clinic-wide controls beside a device theme toggle, so
           the labels pointed away from the truth. Scope is the axis that changes
           whether a click is safe, so it is the axis the page is built on. */}
-      <SettingsBand
-        title="Personal"
-        description="Yours alone. Colleagues are unaffected by anything in this section."
-      >
+      <SettingsBand title="Personal" description="Settings for you, not for the clinic.">
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-3.5 items-start">
           <Personal
             onEditProfile={() => setProfileOpen(true)}
@@ -180,8 +177,8 @@ const Settings = () => {
             scope="organisation"
             readOnly={!canEditClinicPreferences}
           >
-            <AppointmentLockWindowPreference />
-            <CrossClinicMessagingPreference />
+            <AppointmentLockWindowPreference readOnly={!canEditClinicPreferences} />
+            <CrossClinicMessagingPreference readOnly={!canEditClinicPreferences} />
           </PreferenceGroup>
 
           {/* Federation is institution-to-institution: clinical referrals, directory


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Three review findings landed on #2517 after it merged. All three are correct and all three are live on `dev`.

**The read-only signal was cosmetic.** Marking the scheduling group read-only only appended a sentence to the hint. `CrossClinicMessagingPreference` still enabled its switch and sent a request the backend rejects; `AppointmentLockWindowPreference` still accepted edits and wrote them locally before its unauthorised update failed. The page advertised a state it did not enforce, which is worse than not advertising it - it invites the click.

**The Personal band made a promise it cannot keep.** It read "Colleagues are unaffected by anything in this section" while containing the browser theme. `yc-theme` is an un-namespaced `localStorage` key, so on a shared browser profile it changes what the **next colleague** sees.

**The permission test asserted nothing about which permission was checked.** The mock discarded its argument, so the suite passed regardless of whether the page checked `TEAMS_EDIT_ANY`, `INTEGRATIONS_EDIT_ANY`, or something unrelated.

## What is the new behavior?

Both controls take a `readOnly` prop, disable their inputs, and refuse to fire the request. The band description says what it can keep: "Settings for you, not for the clinic." The mock records its argument, and the suite asserts `teams:edit:any` **is** checked and `integrations:edit:any` is **not**.

## Impact area

`apps/frontend` Settings only. No API or schema change.

## Validation performed

- **20 tests** across the Settings page and `PreferenceGroup` suites; the wider run covering every touched component is **958 suites / 11,836 tests passing**.
- `npx tsc --noemit` clean (0 errors); `pnpm --filter frontend run lint` exit 0, zero errors.
- **Mutation checked, and this is the part that matters.** I ran the third finding's claim before fixing it: reverting to `PERMISSIONS.INTEGRATIONS_EDIT_ANY` - the exact bug #2517 existed to fix - left all 9 tests green. The test could not detect the bug it was written for. After the fix, that same mutation fails, and dropping `readOnly` from the controls fails another. Both previously passed.

**Not visually verified** - `/settings` needs an authenticated session the automated browser lacks. The disabled states in particular deserve an eyeball.

## Related Issue(s)

Refs #2512
