### PR TITLE
fix(frontend): drop the unreachable readOnly clause from the toggle handler

### DIFF
--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.tsx
@@ -25,7 +25,7 @@ const CrossClinicMessagingPreference = ({ readOnly = false }: { readOnly?: boole
   const [saving, setSaving] = useState(false);
 
   const handleToggle = async () => {
-    if (readOnly || !primaryOrg?._id || saving || !isKnown) return;
+    if (!primaryOrg?._id || saving || !isKnown) return;
     const next = !enabled;
     setSaving(true);
     try {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`CrossClinicMessagingPreference.handleToggle` opens with:

```ts
if (readOnly || !primaryOrg?._id || saving || !isKnown) return;
```

The `readOnly` clause **cannot execute**. React dispatches no click to a disabled button, and `disabled` already contains `readOnly`, so the branch is unreachable while the component is rendered read-only. Branch coverage put it at **0 hits**, confirmed by reading the `branchMap` out of `coverage-final.json` rather than inferring it from the line number.

I tried to reach it two ways before concluding that. `removeAttribute('disabled')` left it at 0 hits; setting the DOM property (`toggle.disabled = false`) also left it at 0.

## What is the new behavior?

The clause is removed rather than suppressed with a `v8 ignore`, because CLAUDE.md says not to add error handling for scenarios that cannot happen. The guard becomes byte-identical to what `dev` carried before #2522, and `!isKnown` - which is in the guard but **not** in `disabled` - stays genuinely reachable.

Enforcement remains the `disabled` attribute, and that is the thing under test.

## Why this is a separate PR

This re-lands `ba6995a57`, which **missed its merge**. #2522 merged at `45332fc79` while that commit was pushed minutes afterwards, so it never reached `dev`. I found it by checking `mergeCommit`/`headRefOid` against the branch tip rather than trusting the MERGED status, and my reply on that review thread was inaccurate against `dev` until this lands.

## Impact area

`apps/frontend`, one line, one file. No behaviour change for any user: the removed clause could not run.

## Validation performed

All run from `apps/frontend` on this branch, after rebasing onto current `dev`:

- `npx jest --testPathPatterns="CrossClinic"` -> **13 tests passing**
- `npx tsc --noEmit` -> **exit=0**, 0 lines of output (a clean `tsc` prints nothing, so the exit code is the whole result)
- `pnpm --filter frontend run lint` -> **exit=0**
- **Mutation checked:** removing `readOnly` from the `disabled` expression fails **3 tests**, so the enforcement that replaced the clause is genuinely covered.

**Not run:** the full frontend suite. **Not verified visually** - `/settings` needs an authenticated session the automated browser does not have.

## Related Issue(s)

Refs #2512
