### PR TITLE
fix(repo): point SonarLint at the mobile project key that exists

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,5 +1,5 @@
 {
     "sonarCloudOrganization": "yosemitecrew",
-    "projectKey": "yosemitecrew_Yosemite-Crew_MobileApp",
+    "projectKey": "yosemitecrew_Yosemite-Crew_MobileAppYC",
     "region": "EU"
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [ ] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

`.sonarlint/connectedMode.json` binds the repository to project key
`yosemitecrew_Yosemite-Crew_MobileApp`. That key does not exist in the
`yosemitecrew` organisation, so SonarLint resolves no project and connected-mode
rules are silently unavailable to everyone who opens the repo. It fails quietly —
there is no error, the IDE just offers nothing.

## What is the new behavior?

Points at `yosemitecrew_Yosemite-Crew_MobileAppYC`, which does exist and is the key
`apps/mobileAppYC/sonar-project.properties` already declares via
`sonar.projectKey`. The two are now consistent.

## Verification

- `sonar list projects` confirms `yosemitecrew_Yosemite-Crew_MobileAppYC` exists and
  `..._MobileApp` does not
- Matches `apps/mobileAppYC/sonar-project.properties`, which is what CI analyses
- File still parses as JSON; diff is a single line with formatting untouched

## Note for reviewers

SonarCloud also carries a lower-case `yosemitecrew_Yosemite-Crew_mobileAppYC`. The
capitalised key is the one CI pushes to, so that is the one used here — but the
duplicate pair is worth cleaning up separately.

Separately: this file lives at the repo root yet binds a monorepo of four Sonar
projects (Frontend, Backend, Desktop, MobileAppYC) to the mobile one. Correcting the
key is the minimal fix; whether a root-level binding to a single app is the right
model is a larger question left alone here.