### PR TITLE
chore(repo): add SonarQube secret scanning hooks for Claude Code

### DIFF
--- a/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-pre-tool-use

--- a/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-prompt-submit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,30 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh'",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh'",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. No issue: this came out of setting SonarQube up across both dev machines, and is being raised directly.
- [x] All existing tests and lints pass.

## What is the current behavior?

The repo already commits its security tooling: `.secretlintrc.cjs`, `scripts/check-staged-secrets.js` and `secret-scan.yml` are all tracked, and `.claude/settings.json` is tracked with the `react-doctor.sh` hook in it.

SonarQube secret scanning was not part of that set. It had to be installed per machine with `sonar integrate claude`, so it protected only the machine that ran it.

## What is the new behavior?

Adds two hooks to `.claude/settings.json`, generated by `sonar integrate claude --non-interactive`:

| Hook | Trigger | Effect |
| --- | --- | --- |
| `PreToolUse` | matcher `Read` | scans a file for hardcoded secrets before Claude can read it |
| `UserPromptSubmit` | matcher `*` | scans a submitted prompt for secrets before it reaches the model |

Both call the `sonar-secrets` analyzer through the SonarQube CLI, with a 60s timeout.

The two hook scripts are 5 lines each and both begin:

```bash
if ! command -v sonar &> /dev/null; then
  exit 0
fi
```

So a contributor without SonarQube CLI installed is unaffected, and the hooks degrade to a no-op rather than breaking their session.

### Why commit rather than gitignore

`.claude/settings.json` is tracked, and `.gitignore` does not apply to tracked files. The repo's escape hatch for machine local Claude config is `.claude/settings.local.json`, but these hooks do not belong there: gitignored security tooling protects only the machine that configured it, and external contributors, who benefit most, are the least likely to set it up themselves. Committing matches how every other secret scanning control in this repo is already handled.

### Not included

`sonar integrate` also writes a `.mcp.json` pinning the MCP server to `yosemitecrew_Yosemite-Crew_MobileApp`. That is deliberately left out:

1. That project key is not accessible on SonarCloud. The real key is `yosemitecrew_Yosemite-Crew_MobileAppYC`. The stale value is inherited from `.sonarlint/connectedMode.json` and is already being corrected in #2524.
2. It would bind this four project monorepo to the mobile app alone from the repo root.
3. A user scoped `sonar run mcp` server already covers this without pinning a project.

## Related Issue(s)

Relates to #2524, which fixes the stale project key referenced above.
