### PR TITLE
fix(frontend): stop the developer portal signing valid sessions out

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -232,7 +232,13 @@ jobs:
       - name: Run authenticated Playwright flow
         env:
           E2E_WEB_SERVER_COMMAND: pnpm exec next start -p 3001 -H 127.0.0.1
-        run: pnpm --filter frontend exec playwright test e2e/auth-flow.spec.ts
+        # Specs are named rather than globbed: everything in this job runs with
+        # YC_E2E_* in scope, so adding one is a deliberate act, not something a
+        # new file in e2e/ does by existing.
+        run: |
+          pnpm --filter frontend exec playwright test \
+            e2e/auth-flow.spec.ts \
+            e2e/developer-portal.spec.ts
 
       # This job's artifacts are deliberately NOT uploaded.
       #
@@ -250,8 +256,8 @@ jobs:
       #
       # The job log still carries the assertion, the stack and the step output,
       # which is what a CI failure is normally triaged from. Reproduce locally
-      # with `pnpm --filter frontend exec playwright test e2e/auth-flow.spec.ts`
-      # to get a trace, using your own credentials.
+      # with `pnpm --filter frontend exec playwright test e2e/auth-flow.spec.ts
+      # e2e/developer-portal.spec.ts` to get a trace, using your own credentials.
       #
       # Only restore uploads here if the spec stops handling a real secret (for
       # example a provider-mocked sign-in). The public smoke job keeps its

--- a/apps/frontend/e2e/auth-flow.spec.ts
+++ b/apps/frontend/e2e/auth-flow.spec.ts
@@ -1,4 +1,12 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import {
+  APP_ROUTE_PATTERN,
+  LOGIN_PATH,
+  getRequiredEnv,
+  skipUnlessAuthSurfaceDeployed,
+  submitSignIn,
+  waitForRouteAwayFrom,
+} from './support/auth';
 
 // This spec types a real credential into the sign-in form, and Playwright
 // records input values verbatim. Force trace, screenshot and video off for this
@@ -9,50 +17,6 @@ import { expect, test, type Page } from '@playwright/test';
 // the runner's disk. Defence in depth: the job also uploads no artifacts.
 // Scoped to this file so other specs keep their debugging artefacts.
 test.use({ trace: 'off', screenshot: 'off', video: 'off' });
-
-const LOGIN_PATH = '/signin';
-const APP_ROUTE_PATTERN =
-  /^\/(dashboard|appointments|organization|organizations|create-org|team-onboarding)(\/|$|\?)/;
-
-const getRequiredEnv = (name: 'YC_E2E_EMAIL' | 'YC_E2E_PASSWORD') => {
-  const value = process.env[name]?.trim();
-  test.skip(!value, `${name} is required to run auth-flow.spec.ts`);
-  return value ?? '';
-};
-
-// The sign-in flow talks to the SuperTokens auth surface on the target API
-// (#1672). Until that environment is cut over from the legacy provider, the
-// routes this spec exercises do not exist there - skip instead of failing on
-// an environment that has not been migrated yet.
-const skipUnlessAuthSurfaceDeployed = async () => {
-  const base = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '');
-  if (!base) return;
-  // Only a 404 means "this environment has not cut over yet" and justifies a
-  // skip. A 5xx means the auth surface IS deployed and broken, and a failed
-  // probe means we do not know - treating either as "not deployed" silently
-  // skipped the core sign-in test through exactly the outages it exists to
-  // catch.
-  const response = await fetch(`${base}/auth/signinup/code`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', rid: 'passwordless' },
-    body: JSON.stringify({}),
-  });
-
-  test.skip(
-    response.status === 404,
-    'Target API does not serve the SuperTokens auth surface yet (pre-cutover environment)'
-  );
-
-  if (response.status >= 500) {
-    throw new Error(
-      `Auth surface is deployed but failing: ${base}/auth/signinup/code returned ${response.status}`
-    );
-  }
-};
-
-const waitForAppRoute = async (page: Page) => {
-  await expect.poll(() => new URL(page.url()).pathname, { timeout: 60_000 }).not.toBe(LOGIN_PATH);
-};
 
 test('sign in lands on an app route and survives a reload', async ({ page }) => {
   test.setTimeout(90_000);
@@ -66,21 +30,14 @@ test('sign in lands on an app route and survives a reload', async ({ page }) => 
   await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('load', { timeout: 30_000 });
 
-  const emailInput = page.locator('input[name="email"]');
-  const passwordInput = page.locator('input[name="password"]');
+  await submitSignIn(page, email, password);
 
-  await expect(emailInput).toBeVisible();
-  await emailInput.fill(email);
-  await passwordInput.fill(password);
-
-  await page.getByRole('button', { name: /^sign in$/i }).click();
-
-  await waitForAppRoute(page);
+  await waitForRouteAwayFrom(page, LOGIN_PATH);
 
   const firstPath = new URL(page.url()).pathname;
   expect(firstPath).toMatch(APP_ROUTE_PATTERN);
-  await expect(emailInput).toHaveCount(0);
-  await expect(passwordInput).toHaveCount(0);
+  await expect(page.locator('input[name="email"]')).toHaveCount(0);
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
 
   await page.reload({ waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});

--- a/apps/frontend/e2e/developer-portal.spec.ts
+++ b/apps/frontend/e2e/developer-portal.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import {
+  APP_ROUTE_PATTERN,
+  DEVELOPER_LOGIN_PATH,
+  LOGIN_PATH,
+  getRequiredEnv,
+  skipUnlessAuthSurfaceDeployed,
+  submitSignIn,
+  waitForRouteAwayFrom,
+} from './support/auth';
+
+/**
+ * Regression cover for the developer portal locking out valid sessions.
+ *
+ * Both tests here rest on one fact: the YC_E2E_* account is an ordinary app
+ * account, not a developer one. `auth-flow.spec.ts` is what establishes that -
+ * it asserts sign-in lands on APP_ROUTE_PATTERN, which excludes
+ * `/developers/*`. So this is exactly the account that used to be bounced.
+ *
+ * If that account is ever converted to a developer account, these tests stop
+ * testing anything and start passing for the wrong reason. The first assertion
+ * in each guards against that by failing if the portal lets it in.
+ */
+
+// Same reasoning as auth-flow.spec.ts: a real credential is typed here, and
+// Playwright records input values verbatim. The config default of
+// trace: 'on-first-retry' would capture the filled field.
+test.use({ trace: 'off', screenshot: 'off', video: 'off' });
+
+test('a non-developer keeps their session after visiting a developer route', async ({ page }) => {
+  test.setTimeout(90_000);
+
+  const email = getRequiredEnv('YC_E2E_EMAIL');
+  const password = getRequiredEnv('YC_E2E_PASSWORD');
+  if (!email || !password) return;
+
+  await skipUnlessAuthSurfaceDeployed();
+
+  // Sign in through the ORDINARY form, so the session under test is the one a
+  // user would already have when they wander into the portal.
+  await page.goto(LOGIN_PATH, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('load', { timeout: 30_000 });
+  await submitSignIn(page, email, password);
+  await waitForRouteAwayFrom(page, LOGIN_PATH);
+
+  const signedInPath = new URL(page.url()).pathname;
+  expect(signedInPath).toMatch(APP_ROUTE_PATTERN);
+
+  await page.goto('/developers/api-keys', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
+
+  // Blocked, and told why. The guard used to call signout() here instead.
+  await expect(page.getByText(/isn'?t a developer account/i)).toBeVisible({ timeout: 30_000 });
+
+  /* The point of the test: the session for the REST of the app is untouched.
+     Being signed out of everything for opening a /developers/* URL is what made
+     this look like broken credentials. */
+  await page.goto(signedInPath, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
+
+  expect(new URL(page.url()).pathname).not.toBe(LOGIN_PATH);
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
+});
+
+test('developer sign-in with a non-developer account does not loop', async ({ page }) => {
+  test.setTimeout(90_000);
+
+  const email = getRequiredEnv('YC_E2E_EMAIL');
+  const password = getRequiredEnv('YC_E2E_PASSWORD');
+  if (!email || !password) return;
+
+  await skipUnlessAuthSurfaceDeployed();
+
+  await page.goto(DEVELOPER_LOGIN_PATH, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('load', { timeout: 30_000 });
+
+  await submitSignIn(page, email, password);
+
+  /* The failure this replaces: sign-in succeeded, the redirect sent the user to
+     /developers/home because the developer FORM was used, the guard rejected
+     them and signed them out, and the resulting redirect landed back here - so
+     the form appeared to reject a valid password, silently and forever. */
+  await waitForRouteAwayFrom(page, DEVELOPER_LOGIN_PATH);
+
+  const landed = new URL(page.url()).pathname;
+  expect(landed).not.toBe(DEVELOPER_LOGIN_PATH);
+  expect(landed).toMatch(APP_ROUTE_PATTERN);
+
+  // Signed in, not bounced: the credentials were always fine.
+  await expect(page.locator('input[name="password"]')).toHaveCount(0);
+});

--- a/apps/frontend/e2e/support/auth.ts
+++ b/apps/frontend/e2e/support/auth.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Shared plumbing for the specs that sign in with a real credential.
+ *
+ * Extracted so the credential handling and the pre-cutover skip live in one
+ * place: both are security-relevant enough that two drifting copies would be a
+ * liability. Callers still have to set `trace`/`screenshot`/`video` off
+ * themselves - that is a per-file `test.use`, which cannot be applied from here.
+ */
+
+export const LOGIN_PATH = '/signin';
+export const DEVELOPER_LOGIN_PATH = '/developers/signin';
+
+/**
+ * Routes the main app can legitimately land on after sign-in.
+ *
+ * Deliberately excludes `/developers/*`: the account behind YC_E2E_* is an
+ * ordinary app account, and this pattern is part of how we know that.
+ */
+export const APP_ROUTE_PATTERN =
+  /^\/(dashboard|appointments|organization|organizations|create-org|team-onboarding)(\/|$|\?)/;
+
+export const getRequiredEnv = (name: 'YC_E2E_EMAIL' | 'YC_E2E_PASSWORD') => {
+  const value = process.env[name]?.trim();
+  test.skip(!value, `${name} is required to run this spec`);
+  return value ?? '';
+};
+
+/**
+ * The sign-in flow talks to the SuperTokens auth surface on the target API
+ * (#1672). Until that environment is cut over from the legacy provider, the
+ * routes these specs exercise do not exist there - skip instead of failing on
+ * an environment that has not been migrated yet.
+ */
+export const skipUnlessAuthSurfaceDeployed = async () => {
+  const base = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '');
+  if (!base) return;
+  // Only a 404 means "this environment has not cut over yet" and justifies a
+  // skip. A 5xx means the auth surface IS deployed and broken, and a failed
+  // probe means we do not know - treating either as "not deployed" silently
+  // skipped the core sign-in test through exactly the outages it exists to
+  // catch.
+  const response = await fetch(`${base}/auth/signinup/code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', rid: 'passwordless' },
+    body: JSON.stringify({}),
+  });
+
+  test.skip(
+    response.status === 404,
+    'Target API does not serve the SuperTokens auth surface yet (pre-cutover environment)'
+  );
+
+  if (response.status >= 500) {
+    throw new Error(
+      `Auth surface is deployed but failing: ${base}/auth/signinup/code returned ${response.status}`
+    );
+  }
+};
+
+/** Fills and submits whichever sign-in form is currently on screen. */
+export const submitSignIn = async (page: Page, email: string, password: string) => {
+  const emailInput = page.locator('input[name="email"]');
+  const passwordInput = page.locator('input[name="password"]');
+
+  await expect(emailInput).toBeVisible();
+  await emailInput.fill(email);
+  await passwordInput.fill(password);
+
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+};
+
+/** Waits until the router has moved off `fromPath`. */
+export const waitForRouteAwayFrom = async (page: Page, fromPath: string) => {
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 60_000 }).not.toBe(fromPath);
+};

--- a/apps/frontend/src/app/__tests__/components/DevRouteGuard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DevRouteGuard.test.tsx
@@ -65,7 +65,7 @@ describe('DevRouteGuard', () => {
     expect(mockRedirect).toHaveBeenCalledWith('/developers/signin');
   });
 
-  it('signs out first (without redirecting) when authenticated without developer role', () => {
+  it('keeps the session and explains itself when authenticated without developer role', () => {
     const signout = jest.fn();
     mockUseAuthStore.mockImplementation(() => ({
       status: 'authenticated',
@@ -73,30 +73,20 @@ describe('DevRouteGuard', () => {
       signout,
     }));
 
-    const { queryByText, rerender } = render(
+    const { queryByText, getByText } = render(
       <DevRouteGuard>
         <div>child</div>
       </DevRouteGuard>
     );
 
-    // signout is triggered, but we must not redirect while still authenticated —
-    // doing so would throw before the signout effect commits and strand the session.
-    expect(signout).toHaveBeenCalled();
+    /* The session survives. Signing the user out here used to destroy a valid
+       session for the whole app just because a `/developers/*` URL was opened,
+       and the redirect that followed sent them to a sign-in that could only
+       fail the same way - which read as "valid credentials rejected". */
+    expect(signout).not.toHaveBeenCalled();
     expect(mockRedirect).not.toHaveBeenCalled();
     expect(queryByText('child')).not.toBeInTheDocument();
-
-    // Once signout clears the session, the guard redirects on the next render.
-    mockUseAuthStore.mockImplementation(() => ({
-      status: 'unauthenticated',
-      role: null,
-      signout,
-    }));
-    rerender(
-      <DevRouteGuard>
-        <div>child</div>
-      </DevRouteGuard>
-    );
-    expect(mockRedirect).toHaveBeenCalledWith('/developers/signin');
+    expect(getByText(/isn.t a developer account/i)).toBeInTheDocument();
   });
 
   it('only trusts devAuth on localhost when the local bypass flag is enabled', () => {
@@ -128,25 +118,17 @@ describe('DevRouteGuard', () => {
       signout,
     }));
 
-    const { rerender } = render(
+    const { getByText, queryByText } = render(
       <DevRouteGuard>
         <div>child</div>
       </DevRouteGuard>
     );
 
-    expect(signout).toHaveBeenCalled();
+    // The bypass flag is inert off localhost, so this is an ordinary
+    // non-developer: blocked, told why, session intact.
+    expect(queryByText('child')).not.toBeInTheDocument();
+    expect(getByText(/isn.t a developer account/i)).toBeInTheDocument();
+    expect(signout).not.toHaveBeenCalled();
     expect(mockRedirect).not.toHaveBeenCalled();
-
-    mockUseAuthStore.mockImplementation(() => ({
-      status: 'unauthenticated',
-      role: null,
-      signout,
-    }));
-    rerender(
-      <DevRouteGuard>
-        <div>child</div>
-      </DevRouteGuard>
-    );
-    expect(mockRedirect).toHaveBeenCalledWith('/developers/signin');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
@@ -33,6 +33,15 @@ jest.mock('@/app/lib/postAuthRedirect', () => ({
     if (!value.startsWith('/')) return undefined;
     return value;
   }),
+  /* Real behaviour rather than a jest.fn: the component asks this whether the
+     signed-in account is a developer, and a stub returning undefined would make
+     every account look like a non-developer - passing the mismatch tests for
+     the wrong reason. Not requireActual, which would pull the org/profile
+     services this module imports into a suite that has no use for them. */
+  isDeveloperRole: (role?: string | null) =>
+    String(role ?? '')
+      .trim()
+      .toLowerCase() === 'developer',
 }));
 
 // Mock the shared marketing foundation (AuthShell / AuthBrandContent) so its

--- a/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
@@ -113,6 +113,14 @@ describe('SignIn Page', () => {
     (resolvePostAuthRedirect as jest.Mock).mockResolvedValue('/create-org');
   });
 
+  /* The store mock is a bare jest.fn() with no getState. Tests that need one
+     assign it, and it would otherwise persist onto the shared mock for every
+     later test - changing the fallbackRole they observe. clearAllMocks does not
+     remove an added property, so remove it here. */
+  afterEach(() => {
+    delete (useAuthStore as unknown as { getState?: unknown }).getState;
+  });
+
   // --- 1. Rendering ---
 
   it('renders the sign-in form correctly (default mode)', () => {
@@ -180,9 +188,57 @@ describe('SignIn Page', () => {
       fireEvent.click(getSubmitBtn());
     });
 
+    /* The developer form no longer forces a developer destination - the role
+       does. Passing the form flag routed non-developers to /developers/home,
+       where the guard rejected them. */
     expect(resolvePostAuthRedirect).toHaveBeenCalledWith(
-      expect.objectContaining({ isDeveloper: true })
+      expect.not.objectContaining({ isDeveloper: expect.anything() })
     );
+  });
+
+  it('tells a non-developer why the developer portal is not opening', async () => {
+    mockSignIn.mockResolvedValue({});
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({
+      signIn: mockSignIn,
+      resendCode: mockResendCode,
+      role: 'user',
+    });
+    (useAuthStore as unknown as { getState: unknown }).getState = () => ({ role: 'user' });
+
+    render(<SignIn isDeveloper />);
+    fireEvent.change(getEmailInput(), { target: { value: 'clinic@example.com' } });
+    fireEvent.change(getPasswordInput(), { target: { value: 'pass123' } });
+
+    await act(async () => {
+      fireEvent.click(getSubmitBtn());
+    });
+
+    /* The sign-in itself succeeded - the account just is not a developer one.
+       Saying nothing here is what made this read as a rejected password. */
+    expect(mockSignIn).toHaveBeenCalled();
+    expect(mockShowErrorTost).toHaveBeenCalledWith(
+      expect.objectContaining({ errortext: 'Not a developer account' })
+    );
+  });
+
+  it('stays quiet when the signed-in account really is a developer', async () => {
+    mockSignIn.mockResolvedValue({});
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({
+      signIn: mockSignIn,
+      resendCode: mockResendCode,
+      role: 'developer',
+    });
+    (useAuthStore as unknown as { getState: unknown }).getState = () => ({ role: 'developer' });
+
+    render(<SignIn isDeveloper />);
+    fireEvent.change(getEmailInput(), { target: { value: 'dev@example.com' } });
+    fireEvent.change(getPasswordInput(), { target: { value: 'pass123' } });
+
+    await act(async () => {
+      fireEvent.click(getSubmitBtn());
+    });
+
+    expect(mockShowErrorTost).not.toHaveBeenCalled();
   });
 
   it('toggles password visibility with the show-password button', () => {
@@ -270,7 +326,6 @@ describe('SignIn Page', () => {
     expect(resolvePostAuthRedirect).toHaveBeenCalledWith({
       fallbackRole: undefined,
       redirectPath: undefined,
-      isDeveloper: false,
     });
     expect(mockRouterReplace).toHaveBeenCalledWith('/create-org');
     expect(mockSessionStorage.setItem).toHaveBeenCalledWith('devAuth', 'false');
@@ -296,7 +351,6 @@ describe('SignIn Page', () => {
     expect(resolvePostAuthRedirect).toHaveBeenCalledWith({
       fallbackRole: undefined,
       redirectPath: undefined,
-      isDeveloper: true,
     });
   });
 

--- a/apps/frontend/src/app/__tests__/ui/layout/guards/NotADeveloperState.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/guards/NotADeveloperState.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+}));
+
+import NotADeveloperState from '@/app/ui/layout/guards/DevRouteGuard/NotADeveloperState';
+
+describe('NotADeveloperState', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('names the account type as the problem rather than the credentials', () => {
+    render(<NotADeveloperState onSignOut={jest.fn()} />);
+
+    expect(screen.getByText(/isn't a developer account/i)).toBeInTheDocument();
+    // The distinction that matters: they ARE signed in.
+    expect(screen.getByText(/You're signed in/i)).toBeInTheDocument();
+  });
+
+  it('signs out before sending the user to sign up', () => {
+    const onSignOut = jest.fn();
+    render(<NotADeveloperState onSignOut={onSignOut} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create a developer account/i }));
+
+    /* Order matters: the sign-up form opening on top of a live session for a
+       different account type is how you end up with two identities in play. */
+    expect(onSignOut).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/developers/signup');
+  });
+
+  it('leaves the session alone when the user just goes back', () => {
+    const onSignOut = jest.fn();
+    render(<NotADeveloperState onSignOut={onSignOut} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /back to yosemite crew/i }));
+
+    expect(onSignOut).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
@@ -14,7 +14,11 @@ import OtpModal from '@/app/ui/overlays/OtpModal/OtpModal';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { getEmailValidationError, normalizeEmail } from '@/app/lib/validators';
 import { YosemiteLoader } from '@/app/ui/overlays/Loader';
-import { resolvePostAuthRedirect, sanitizeNextPath } from '@/app/lib/postAuthRedirect';
+import {
+  isDeveloperRole,
+  resolvePostAuthRedirect,
+  sanitizeNextPath,
+} from '@/app/lib/postAuthRedirect';
 import { setStorageItem } from '@/app/lib/browserStorage';
 import { resetSidebarPreference } from '@/app/lib/sidebarPreference';
 import { AuthShell, AuthBrandContent } from '@/app/features/marketing/site';
@@ -203,11 +207,7 @@ const SignInForm = ({
          letting DevRouteGuard bounce them - from the outside that was
          indistinguishable from a rejected password. The session stays valid;
          the account simply belongs elsewhere. */
-      const signedInAsDeveloper =
-        String(signedInRole ?? '')
-          .trim()
-          .toLowerCase() === 'developer';
-      if (isDeveloper && !signedInAsDeveloper) {
+      if (isDeveloper && !isDeveloperRole(signedInRole)) {
         showErrorTost({
           message:
             'That account is not registered as a developer account. Create a developer account to use the portal.',

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
@@ -197,10 +197,36 @@ const SignInForm = ({
       setStorageItem('session', 'devAuth', isDeveloper ? 'true' : 'false');
       const signedInRole =
         typeof useAuthStore.getState === 'function' ? useAuthStore.getState().role : role;
+
+      /* Signing in through the developer form does not make an account a
+         developer account. Say so, rather than routing on into the portal and
+         letting DevRouteGuard bounce them - from the outside that was
+         indistinguishable from a rejected password. The session stays valid;
+         the account simply belongs elsewhere. */
+      const signedInAsDeveloper =
+        String(signedInRole ?? '')
+          .trim()
+          .toLowerCase() === 'developer';
+      if (isDeveloper && !signedInAsDeveloper) {
+        showErrorTost({
+          message:
+            'That account is not registered as a developer account. Create a developer account to use the portal.',
+          errortext: 'Not a developer account',
+          iconElement: (
+            <Icon
+              icon="solar:danger-triangle-bold"
+              width="20"
+              height="20"
+              color="var(--color-danger-600)"
+            />
+          ),
+          className: 'errofoundbg',
+        });
+      }
+
       const nextRoute = await resolvePostAuthRedirect({
         fallbackRole: signedInRole,
         redirectPath: effectiveRedirectPath,
-        isDeveloper,
       });
       router.replace(nextRoute);
     } catch (error: any) {

--- a/apps/frontend/src/app/lib/postAuthRedirect.ts
+++ b/apps/frontend/src/app/lib/postAuthRedirect.ts
@@ -17,7 +17,14 @@ const normalizeRole = (role?: string | null) =>
     .trim()
     .toLowerCase();
 
-const isDeveloperRole = (role?: string | null) => normalizeRole(role) === 'developer';
+/**
+ * The one definition of "this role is a developer role".
+ *
+ * Exported so callers that need the same question answered - SignIn, deciding
+ * whether the developer form matched the account - cannot drift into a second,
+ * subtly different normalization.
+ */
+export const isDeveloperRole = (role?: string | null) => normalizeRole(role) === 'developer';
 const isOwnerRole = (role?: string | null) => normalizeRole(role) === 'owner';
 
 // Only same-origin, absolute-path destinations are safe post-auth targets;

--- a/apps/frontend/src/app/lib/postAuthRedirect.ts
+++ b/apps/frontend/src/app/lib/postAuthRedirect.ts
@@ -54,7 +54,6 @@ export const sanitizeNextPath = (value: string | null): string | undefined => {
 type ResolvePostAuthRedirectOptions = {
   fallbackRole?: string | null;
   redirectPath?: string;
-  isDeveloper?: boolean;
 };
 
 type ResolveOrgScopedRedirectOptions = {
@@ -115,13 +114,17 @@ export const resolveOrgScopedRedirect = async ({
 export const resolvePostAuthRedirect = async ({
   fallbackRole,
   redirectPath,
-  isDeveloper = false,
 }: ResolvePostAuthRedirectOptions): Promise<string> => {
   if (redirectPath) {
     return redirectPath;
   }
 
-  if (isDeveloper || isDeveloperRole(fallbackRole)) {
+  /* The role decides this, and only the role. This used to also accept an
+     `isDeveloper` flag meaning "submitted the developer sign-in form", which is
+     true even for an account with no developer role - so it routed those users
+     to a page DevRouteGuard immediately rejects. Callers that care about the
+     mismatch check the role themselves; see SignIn. */
+  if (isDeveloperRole(fallbackRole)) {
     return '/developers/home';
   }
 

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
@@ -62,9 +62,11 @@ const meta = {
           'Route wrapper for the developer portal: under `/developers` it renders its children only ' +
           'for an authenticated session carrying the developer role, and renders nothing while auth ' +
           'is still resolving. Any other path passes straight through, so it is safe to mount high in ' +
-          'the tree. There is no denial view — an authenticated non-developer is signed out and an ' +
-          'unauthenticated visitor is redirected to `/developers/signin` — which is why the states ' +
-          'worth looking at are "children" and "nothing".',
+          'the tree.\n\n' +
+          'An authenticated non-developer gets a denial view and keeps their session. Signing them ' +
+          'out instead — as this did — threw away a valid session for the whole app because a ' +
+          '`/developers/*` URL was opened, and the redirect that followed landed on a sign-in that ' +
+          'could only fail the same way, which read as valid credentials being rejected.',
       },
     },
   },
@@ -121,10 +123,27 @@ export const NonDeveloperRoute: Story = {
       description: {
         story:
           'On any path outside `/developers` the guard is a pass-through: no role is required and ' +
-          'nothing is redirected, even for a signed-out visitor. The redirect and forced sign-out ' +
-          'paths are not storied — they navigate rather than render, which throws inside a story.',
+          'nothing is redirected, even for a signed-out visitor. The unauthenticated redirect is not ' +
+          'storied — it navigates rather than renders, which throws inside a story.',
       },
     },
   },
   beforeEach: withSession('unauthenticated', null),
+};
+
+export const NotADeveloper: Story = {
+  name: 'Signed in, not a developer',
+  beforeEach: withSession('authenticated', 'user'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A valid session for an account that is not a developer one. The distinction the copy has ' +
+          'to carry is that nothing is wrong with the credentials — the portal is a separate account ' +
+          'type — so the way forward is a developer account, not another sign-in attempt.\n\n' +
+          'The session is left intact. It is only cleared if the reader chooses to go and register, ' +
+          'so that the sign-up form does not open on top of a live session for a different account.',
+      },
+    },
+  },
 };

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
@@ -1,8 +1,9 @@
 'use client';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { redirect, usePathname } from 'next/navigation';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { useAuthStore } from '@/app/stores/authStore';
+import NotADeveloperState from './NotADeveloperState';
 
 const isLocalDeveloperFallbackEnabled = () => {
   if (process.env.NEXT_PUBLIC_DISABLE_AUTH_GUARD !== 'true') return false;
@@ -14,6 +15,14 @@ const isLocalDeveloperFallbackEnabled = () => {
 
 /**
  * Blocks access to developer routes unless authenticated with developer role.
+ *
+ * A signed-in non-developer is shown NotADeveloperState rather than being signed
+ * out. Signing them out was worse in both directions: it destroyed a perfectly
+ * good session for the rest of the app just because the user opened a
+ * `/developers/*` URL, and because the redirect that followed landed on the
+ * developer sign-in page, a successful sign-in with the same account looped
+ * straight back here. The visible result was a sign-in form that appeared to
+ * reject valid credentials without ever saying why.
  */
 const DevRouteGuard = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
@@ -25,32 +34,19 @@ const DevRouteGuard = ({ children }: { children: React.ReactNode }) => {
     isLocalDeveloperFallbackEnabled() && getStorageItem('session', 'devAuth') === 'true';
   const isDevRole = role === 'developer' || devFlag;
   const isAuthenticated = status === 'authenticated' || status === 'signin-authenticated';
-  // Derived during render: non-dev paths always pass; dev paths need an
-  // authenticated developer. While auth status is pending nothing renders.
-  const allowed = !isPending && (!isDevPath || (isAuthenticated && isDevRole));
 
-  useEffect(() => {
-    // Wait for auth status to be determined
-    if (isPending) return;
+  // Nothing renders until auth status is known - neither the children nor the
+  // rejection, since both would be a guess.
+  if (isPending) return null;
 
-    // Authenticated but not a developer - sign out and redirect
-    if (isDevPath && isAuthenticated && !isDevRole) {
-      authStore.signout();
-    }
-  }, [isPending, isDevPath, isAuthenticated, isDevRole, authStore]);
+  // Non-developer routes are none of this guard's business.
+  if (!isDevPath) return <>{children}</>;
 
-  // Only redirect once the session is actually cleared. For an authenticated
-  // non-developer the effect above calls signout() first, which flips status to
-  // 'unauthenticated' and lands us here on the next render — redirecting eagerly
-  // during this render would throw before that signout effect ever commits,
-  // leaving the user logged in while bounced to the developer sign-in page.
-  if (!isPending && isDevPath && status === 'unauthenticated') {
-    redirect('/developers/signin');
+  if (isAuthenticated) {
+    return isDevRole ? <>{children}</> : <NotADeveloperState onSignOut={authStore.signout} />;
   }
 
-  if (!allowed) return null;
-
-  return <>{children}</>;
+  redirect('/developers/signin');
 };
 
 export default DevRouteGuard;

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/NotADeveloperState.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/NotADeveloperState.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { IoCodeSlashOutline } from 'react-icons/io5';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import '@/app/ui/layout/states/states.css';
+
+/**
+ * Shown when a signed-in user reaches a developer route without the developer
+ * role.
+ *
+ * Deliberately not `PermissionDeniedState`: that one explains an org-membership
+ * problem an owner can fix in Organization → Team, which is the wrong advice
+ * here. The developer portal is a separate account type, so the way out is a
+ * developer account, not a role change.
+ *
+ * This is a terminal state rather than a redirect. Bouncing back to
+ * `/developers/signin` while the session is still valid just invites the same
+ * sign-in to fail the same way - the account is the problem, not the attempt.
+ */
+const NotADeveloperState = ({ onSignOut }: { onSignOut: () => void }) => {
+  const router = useRouter();
+
+  return (
+    <div className="yc-state-wrap">
+      <div className="yc-state-card">
+        <span className="yc-state-icon yc-state-icon--warn" aria-hidden>
+          <IoCodeSlashOutline size={25} />
+        </span>
+        <div className="yc-state-title">This isn&apos;t a developer account</div>
+        <p className="yc-state-text">
+          You&apos;re signed in, but the developer portal needs an account registered as a
+          developer. Your existing account still works everywhere else — you can create a separate
+          developer account to build on the API.
+        </p>
+        <div className="yc-state-actions">
+          <Primary
+            text="Create a developer account"
+            onClick={() => {
+              // Sign out first: the sign-up form would otherwise open on top of a
+              // live session for a different account type.
+              onSignOut();
+              router.push('/developers/signup');
+            }}
+          />
+          <Secondary text="Back to Yosemite Crew" onClick={() => router.push('/')} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotADeveloperState;

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
@@ -107,10 +107,13 @@ const OtpModal = ({
 
     const signedInRole =
       typeof useAuthStore.getState === 'function' ? useAuthStore.getState().role : role;
+    /* No `isDeveloper` here: a developer sign-up carries role 'developer' through
+       pendingSignUp, so the role already says where to land. Passing the form
+       flag instead used to route a non-developer to /developers/home, which the
+       route guard then rejected. */
     const nextRoute = await resolvePostAuthRedirect({
       fallbackRole: signedInRole,
       redirectPath,
-      isDeveloper,
     });
     router.push(nextRoute);
   };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Signing in at `/developers/signin` with an account that is not a developer account looks exactly like a rejected password: the form takes the credentials, then returns to itself having said nothing. Reported against `dev.yosemitecrew.com` using credentials that work on the main app.

The credentials were never the problem. The session was being created and then destroyed:

1. `signIn()` succeeds.
2. `resolvePostAuthRedirect` returns `/developers/home` — because the **developer form** was used. It branched on an `isDeveloper` flag meaning "submitted the developer sign-in", not on the account's role.
3. `DevRouteGuard` sees an authenticated non-developer and calls `signout()`.
4. `status` flips to `unauthenticated`, so the guard redirects to `/developers/signin`.
5. Back to 1.

Two things made this hard to recognise from the outside. Nothing was ever said — no error, no explanation — so a valid password was indistinguishable from a wrong one. And the sign-out was not scoped to the attempt: opening any `/developers/*` URL while already signed in threw away a valid session for the whole app.

The role itself is set at sign-up (`/developers/signup` registers `role: 'developer'`), so a main-app account can never satisfy the guard. That part is by design; being silently logged out over it is not.

## What is the new behavior?

Either fix below breaks the loop on its own. Both are worth making, because they are separate defects.

**`resolvePostAuthRedirect` routes on the role alone.** The `isDeveloper` option is removed rather than ignored — it could only ever send someone to a page the guard would reject. `OtpModal`'s developer sign-up still lands correctly, because a developer sign-up carries `role: 'developer'` through `pendingSignUp`.

**`DevRouteGuard` no longer signs anyone out.** A signed-in non-developer gets `NotADeveloperState`, which names the account type as the problem and offers to register a developer account — clearing the session only if they take that offer, so the sign-up form does not open over a live session for a different account. Deliberately not `PermissionDeniedState`: that one explains an org-membership problem an owner fixes in Organization → Team, which is the wrong advice here.

**`SignIn` names the mismatch** instead of redirecting in silence.

Two existing guard tests failed against this change because they asserted the sign-out and the bounce — they encoded the bug. They now assert that the session survives and the reason is shown.

## Validation performed

- **Full frontend suite green: 963 suites, 11,887 tests.** Typecheck and lint clean.
- `NotADeveloperState` at 100% coverage; `DevRouteGuard` at 100% statements.
- Storybook gains the denial state — it renders rather than navigates, so unlike the redirect path it can be storied, and Chromatic now covers it. The component doc no longer claims there is no denial view.
- Rendered headless at 1440×900 and checked with axe (WCAG 2.1 A/AA): **0 violations** across the three guard states, plus the 11 developer-portal stories still clean.

Impact area: `apps/frontend` — the developer route guard, the post-auth redirect helper, sign-in, and the OTP modal. No backend or database changes.

## Related Issue(s)

Follows #2514, which merged the developer portal. This defect predates it — `DevRouteGuard` was untouched by that PR (`git log 5f674a70c..dbbdee307 -- .../DevRouteGuard/` is empty) — but it blocks anyone trying to use the portal now that it has shipped.
