### PR TITLE
fix(backend): allow-list the roles provisioning may assign

### DIFF
--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -22,6 +22,24 @@ type UpdateUserNameRequest = Request<
 const trimmedString = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim() ? value.trim() : undefined;
 
+/**
+ * The roles a caller is allowed to claim for itself while provisioning.
+ *
+ * `POST /fhir/v1/user` is guarded by `requireWebAuth` alone, and the role is
+ * read from the request body, so whatever passes this check is a role any
+ * signed-up account can hand itself. The previous check was a shape test
+ * (`/^[a-z_-]{1,40}$/i`) that accepted any word - `superadmin` included, which
+ * `requireSuperAdmin` turns into read and write over every business on the
+ * platform. A shape is not a permission; this is an allow-list for that reason.
+ *
+ * These two are what the sign-up form actually sends: `developer` for a
+ * developer sign-up, and `member` for everyone else. Anything else is dropped
+ * rather than refused, which is how an unparseable role has always been
+ * treated - by this point the account already exists in the auth provider, so
+ * failing the request would strand it with no application user behind it.
+ */
+const SELF_ASSIGNABLE_ROLES = new Set(["developer", "member"]);
+
 // Names/role come from the signup form (request body) with the session as
 // fallback; the session token no longer carries profile attributes.
 function resolveProvisioningProfile(req: AuthenticatedRequest): {
@@ -30,11 +48,26 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
   role?: string;
 } {
   const body = (req.body ?? {}) as Record<string, unknown>;
-  const role = trimmedString(body.role);
+  const requestedRole = trimmedString(body.role)?.toLowerCase();
+  const role =
+    requestedRole && SELF_ASSIGNABLE_ROLES.has(requestedRole)
+      ? requestedRole
+      : undefined;
+
+  // Worth a line in the log: a request naming a role it cannot have is either a
+  // client sending something the form never offers, or someone reaching for a
+  // privilege. Bounded and passed as a field, never concatenated into the
+  // message, so a crafted value cannot forge log structure.
+  if (requestedRole && !role) {
+    logger.warn("Provisioning requested a role that is not self-assignable", {
+      requestedRole: requestedRole.slice(0, 40),
+    });
+  }
+
   return {
     firstName: trimmedString(body.firstName) ?? req.firstName,
     lastName: trimmedString(body.lastName) ?? req.lastName,
-    role: role && /^[a-z_-]{1,40}$/i.test(role) ? role : undefined,
+    role,
   };
 }
 

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -161,6 +161,65 @@ describe("UserController", () => {
       expect(mockSetUserRole).not.toHaveBeenCalled();
     });
 
+    /*
+     * The route is behind `requireWebAuth` and nothing else, so a role the body
+     * can name is a role any signed-up account can grant itself. `superadmin`
+     * is the one that matters: `requireSuperAdmin` reads exactly these roles and
+     * opens `/super-admin/businesses` across every tenant. The old shape check
+     * accepted it. Names must still sync, so the request is served - only the
+     * role is dropped.
+     */
+    it.each(["superadmin", "SuperAdmin", "  superadmin  ", "owner", "admin"])(
+      "never grants a role the sign-up form cannot ask for: %s",
+      async (role) => {
+        mockAuthService = {
+          updateUserName: mockUpdateUserName,
+          setUserRole: mockSetUserRole,
+        };
+        (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+        const req = createMockReq({
+          userId: "user-123",
+          email: "test@example.com",
+          firstName: "SessionFirst",
+          lastName: "SessionLast",
+          body: { role },
+        });
+        await UserController.create(req, mockRes as Response);
+
+        expect(mockSetUserRole).not.toHaveBeenCalled();
+        expect(mockUpdateUserName).toHaveBeenCalled();
+        expect(mockRes.status).toHaveBeenCalledWith(201);
+      },
+    );
+
+    // The other half of the allow-list: the two roles sign-up does send still
+    // reach the provider, case- and padding-insensitively, or a developer
+    // sign-up silently produces an account the portal will not admit.
+    it.each([
+      ["developer", "developer"],
+      ["Developer", "developer"],
+      ["  developer  ", "developer"],
+      ["member", "member"],
+    ])("still grants %s as %s", async (role, expected) => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        userId: "user-123",
+        email: "test@example.com",
+        firstName: "SessionFirst",
+        lastName: "SessionLast",
+        body: { role },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockSetUserRole).toHaveBeenCalledWith("user-123", expected);
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`POST /fhir/v1/user` provisions the application user after sign-up. The name and role come from the request body, and the route is guarded by `requireWebAuth` — a valid session, nothing more.

The role was validated by **shape**:

```js
role: role && /^[a-z_-]{1,40}$/i.test(role) ? role : undefined
```

Any single lowercase word satisfies that. It is then passed to `authService.setUserRole`, which writes the role into the auth provider (`UserRoles.addRoleToUser` plus user metadata) for the caller's own account.

A shape is not a permission. The roles this system recognises are not all equal — some are read back for authorisation decisions, so a check that accepts arbitrary words lets a caller name one it was never offered. The sign-up form only ever sends `developer` (developer sign-up) or `member` (everyone else); the gap between what the form sends and what the endpoint accepts is the whole defect.

## What is the new behavior?

The shape test is replaced with an allow-list of the two roles sign-up actually sends, matched case- and padding-insensitively so `Developer` and `"  developer  "` still work:

```js
const SELF_ASSIGNABLE_ROLES = new Set(["developer", "member"]);
```

A role outside the set is **dropped and logged**, not refused. That matches how an unparseable role has always been handled, and it matters: by the time this endpoint is called the account already exists in the auth provider, so failing the request would strand it verified with no application user behind it. Names still sync; only the role is discarded. The log line passes the value as a bounded field rather than concatenating it into the message, so a crafted value cannot forge log structure.

**What this does not change:** a role can still only be set at *first* provisioning. `UserService.create` throws 409 for an existing user and the controller returns before the sync runs, so an existing account's role cannot be corrected through this endpoint. Deliberately left alone — making the role re-settable here would turn a one-shot assignment into a standing one, which is the wrong direction for this route. Correcting an existing account's role belongs behind an admin path.

## Validation performed

- `pnpm --filter backend run test -- user.controller` — **46 passed** (37 before; 9 new cases).
- `pnpm --filter backend run type-check` — clean.
- `pnpm --filter backend run lint` — clean, 0 problems.
- New coverage is table-driven in both directions: privileged and unoffered roles (`superadmin`, `SuperAdmin`, `"  superadmin  "`, `owner`, `admin`) are dropped while the request still succeeds with names synced; the offered roles (`developer`, `Developer`, `"  developer  "`, `member`) still reach the provider normalised.

Impact area: `apps/backend` — the user provisioning controller only. No frontend, schema, or migration changes.

## Related Issue(s)

None open; found while diagnosing why `/developers/*` rejected an account on `dev`.
