### PR TITLE
fix(mobile): let the breed picker retry a failed lookup

### DIFF
--- a/apps/mobileAppYC/__tests__/components/common/BreedBottomSheet.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/common/BreedBottomSheet.test.tsx
@@ -124,6 +124,85 @@ describe('BreedBottomSheet', () => {
     );
   });
 
+  // The gap this closes: the picker could SAY the lookup failed but offered no
+  // way to run it again, and breed is required, so that state dead-ended
+  // companion creation.
+  it('offers a retry when the lookup failed', () => {
+    const onRetry = jest.fn();
+    render(
+      <BreedBottomSheet
+        breeds={[]}
+        loadFailed
+        onRetry={onRetry}
+        selectedBreed={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    const {emptyAction} = mockGenericSelectBottomSheet.mock.calls.at(-1)[0];
+    expect(emptyAction).toEqual({
+      label: 'common.try_again',
+      onPress: onRetry,
+    });
+
+    emptyAction.onPress();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // A species that genuinely has no breeds is not something a retry can fix,
+  // and offering one there would be a lie.
+  it('offers no retry when the species simply has no breeds', () => {
+    render(
+      <BreedBottomSheet
+        breeds={[]}
+        onRetry={jest.fn()}
+        selectedBreed={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(mockGenericSelectBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({emptyAction: undefined}),
+    );
+  });
+
+  it('offers no retry when no handler is supplied', () => {
+    render(
+      <BreedBottomSheet
+        breeds={[]}
+        loadFailed
+        selectedBreed={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    expect(mockGenericSelectBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({emptyAction: undefined}),
+    );
+  });
+
+  it('reports loading rather than failure while a lookup is in flight', () => {
+    render(
+      <BreedBottomSheet
+        breeds={[]}
+        loadFailed
+        loading
+        onRetry={jest.fn()}
+        selectedBreed={null}
+        onSave={mockOnSave}
+      />,
+    );
+
+    // Loading outranks the stale failure, and the retry is withheld so a slow
+    // lookup cannot be fired twice by an impatient tap.
+    expect(mockGenericSelectBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emptyMessage: 'common.loading',
+        emptyAction: undefined,
+      }),
+    );
+  });
+
   it('transforms the breeds prop into items for the child', () => {
     render(
       <BreedBottomSheet

--- a/apps/mobileAppYC/__tests__/components/common/GenericSelectBottomSheet.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/common/GenericSelectBottomSheet.test.tsx
@@ -406,6 +406,34 @@ describe('GenericSelectBottomSheet', () => {
       expect(screen.getByText(defaultProps.emptyMessage)).toBeTruthy();
     });
 
+    // An empty list can be empty because the LOOKUP FAILED, which in a sheet
+    // whose field is required is otherwise a dead end.
+    it('renders an optional action under the empty message', () => {
+      const onPress = jest.fn();
+      render(
+        <GenericSelectBottomSheet
+          {...defaultProps}
+          items={[]}
+          emptyAction={{label: 'Try Again', onPress}}
+          ref={ref}
+        />,
+      );
+      openSheet();
+
+      expect(screen.getByText('Try Again')).toBeTruthy();
+      fireEvent.press(screen.getByTestId('select-sheet-empty-action'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no action when none is supplied', () => {
+      render(
+        <GenericSelectBottomSheet {...defaultProps} items={[]} ref={ref} />,
+      );
+      openSheet();
+
+      expect(screen.queryByTestId('select-sheet-empty-action')).toBeNull();
+    });
+
     it('uses the default empty message when none is provided', () => {
       render(
         <GenericSelectBottomSheet

--- a/apps/mobileAppYC/__tests__/features/companion/hooks/useBreedOptions.test.ts
+++ b/apps/mobileAppYC/__tests__/features/companion/hooks/useBreedOptions.test.ts
@@ -1,0 +1,189 @@
+import {act, renderHook, waitFor} from '@testing-library/react-native';
+
+import {useBreedOptions} from '@/features/companion/hooks/useBreedOptions';
+import {getFreshStoredTokens} from '@/features/auth/sessionManager';
+import {fetchBreedCodeEntries} from '@/features/companion/services/codeEntriesService';
+
+jest.mock('@/features/auth/sessionManager', () => ({
+  getFreshStoredTokens: jest.fn(),
+}));
+
+jest.mock('@/features/companion/services/codeEntriesService', () => ({
+  fetchBreedCodeEntries: jest.fn(),
+}));
+
+const mockTokens = getFreshStoredTokens as jest.Mock;
+const mockFetch = fetchBreedCodeEntries as jest.Mock;
+
+const params = {
+  category: 'dog' as any,
+  speciesQueryFor: () => 'DOG',
+  speciesLabelFor: () => 'Dog',
+  speciesCodeFor: () => 'SP-DOG',
+};
+
+describe('useBreedOptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockTokens.mockResolvedValue({accessToken: 'token'});
+    mockFetch.mockResolvedValue([
+      {code: 'B1', display: 'Pug', meta: {speciesCode: 'SP-1'}},
+    ]);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('maps entries into breeds on a successful lookup', async () => {
+    const {result} = renderHook(() => useBreedOptions(params));
+
+    await waitFor(() => expect(result.current.breedLoading).toBe(false));
+
+    expect(result.current.breedOptions).toEqual([
+      {
+        speciesId: 1,
+        speciesName: 'Dog',
+        breedId: 1,
+        breedName: 'Pug',
+        speciesCode: 'SP-1',
+        breedCode: 'B1',
+      },
+    ]);
+    expect(result.current.breedLoadFailed).toBe(false);
+  });
+
+  it('falls back to the supplied species code when an entry has none', async () => {
+    mockFetch.mockResolvedValue([{code: 'B2', display: 'Beagle'}]);
+    const {result} = renderHook(() => useBreedOptions(params));
+
+    await waitFor(() => expect(result.current.breedLoading).toBe(false));
+
+    expect(result.current.breedOptions[0].speciesCode).toBe('SP-DOG');
+  });
+
+  // The root cause behind the "no network request at all" report: the token
+  // read early-returns, so the breed request is never sent. It still has to
+  // surface as a retryable failure rather than an empty list.
+  it('reports a failure without sending any request when there is no token', async () => {
+    mockTokens.mockResolvedValue(null);
+    const {result} = renderHook(() => useBreedOptions(params));
+
+    await waitFor(() => expect(result.current.breedLoadFailed).toBe(true));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.breedOptions).toEqual([]);
+  });
+
+  it('reports a failure when the lookup throws', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const {result} = renderHook(() => useBreedOptions(params));
+
+    await waitFor(() => expect(result.current.breedLoadFailed).toBe(true));
+    expect(result.current.breedOptions).toEqual([]);
+  });
+
+  it('does not report failure for a species with genuinely no breeds', async () => {
+    mockFetch.mockResolvedValue([]);
+    const {result} = renderHook(() => useBreedOptions(params));
+
+    await waitFor(() => expect(result.current.breedLoading).toBe(false));
+
+    expect(result.current.breedOptions).toEqual([]);
+    expect(result.current.breedLoadFailed).toBe(false);
+  });
+
+  describe('retry', () => {
+    it('re-runs the lookup and clears the failure when it succeeds', async () => {
+      mockTokens.mockResolvedValueOnce(null);
+      const {result} = renderHook(() => useBreedOptions(params));
+
+      await waitFor(() => expect(result.current.breedLoadFailed).toBe(true));
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      await act(async () => {
+        result.current.retryBreeds();
+      });
+
+      await waitFor(() => expect(result.current.breedLoadFailed).toBe(false));
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.current.breedOptions).toHaveLength(1);
+    });
+
+    it('keeps the failure when the retry fails again', async () => {
+      mockTokens.mockResolvedValue(null);
+      const {result} = renderHook(() => useBreedOptions(params));
+
+      await waitFor(() => expect(result.current.breedLoadFailed).toBe(true));
+
+      await act(async () => {
+        result.current.retryBreeds();
+      });
+
+      await waitFor(() => expect(result.current.breedLoadFailed).toBe(true));
+    });
+
+    it('does nothing without a category', async () => {
+      const {result} = renderHook(() =>
+        useBreedOptions({...params, category: null}),
+      );
+
+      await act(async () => {
+        result.current.retryBreeds();
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('category changes', () => {
+    it('clears state when the category is cleared', async () => {
+      const {result, rerender} = renderHook((p: any) => useBreedOptions(p), {
+        initialProps: params,
+      });
+
+      await waitFor(() => expect(result.current.breedOptions).toHaveLength(1));
+
+      rerender({...params, category: null});
+
+      await waitFor(() => expect(result.current.breedOptions).toEqual([]));
+      expect(result.current.breedLoadFailed).toBe(false);
+      expect(result.current.breedLoading).toBe(false);
+    });
+
+    // A slow response for a category the user has moved away from must not
+    // land on the new one.
+    it('discards a response from a superseded category', async () => {
+      let releaseFirst: (v: any) => void = () => {};
+      mockFetch.mockImplementationOnce(
+        () => new Promise(resolve => (releaseFirst = resolve)),
+      );
+
+      const {result, rerender} = renderHook((p: any) => useBreedOptions(p), {
+        initialProps: params,
+      });
+
+      mockFetch.mockResolvedValue([{code: 'C1', display: 'Siamese'}]);
+      rerender({
+        ...params,
+        category: 'cat' as any,
+        speciesLabelFor: () => 'Cat',
+      });
+
+      await waitFor(() =>
+        expect(result.current.breedOptions[0]?.breedName).toBe('Siamese'),
+      );
+
+      await act(async () => {
+        releaseFirst([{code: 'B1', display: 'Pug'}]);
+        // Let the resolved promise's continuation AND any state update it
+        // schedules actually run, otherwise this asserts before the stale
+        // response has had a chance to land and passes for the wrong reason.
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.breedOptions.map(b => b.breedName)).toEqual([
+        'Siamese',
+      ]);
+    });
+  });
+});

--- a/apps/mobileAppYC/src/features/companion/hooks/useBreedOptions.ts
+++ b/apps/mobileAppYC/src/features/companion/hooks/useBreedOptions.ts
@@ -1,0 +1,139 @@
+// src/features/companion/hooks/useBreedOptions.ts
+//
+// Breed lookup for a companion category, with the three states the picker has
+// to tell apart: loading, failed, and "this species genuinely has no breeds".
+//
+// Extracted from AddCompanionScreen because the failure here is not cosmetic.
+// The lookup reads a token first and returns early when there is none, so a
+// failed token read sends ZERO breed traffic - the request the user is waiting
+// for is never made. Breed is a required field, so before this the picker could
+// only say the lookup failed and the form could not be completed at all. A
+// retry has to exist, and it has to be testable: the screen it came from is
+// over 1300 lines and sits in sonar.coverage.exclusions.
+//
+// The category-to-species maps stay with their screens and are passed in, so
+// this hook does not have an opinion about where they live.
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {getFreshStoredTokens} from '@/features/auth/sessionManager';
+import {
+  fetchBreedCodeEntries,
+  type BreedCodeEntry,
+} from '@/features/companion/services/codeEntriesService';
+import type {Breed, CompanionCategory} from '@/features/companion/types';
+
+export interface UseBreedOptionsParams {
+  category: CompanionCategory | null;
+  /** Species term the breed endpoint expects for this category. */
+  speciesQueryFor: (category: CompanionCategory) => string;
+  /** Human-facing species name stored on each mapped breed. */
+  speciesLabelFor: (category: CompanionCategory) => string;
+  /** Species code to fall back to when an entry carries none. */
+  speciesCodeFor?: (category: CompanionCategory) => string | undefined;
+}
+
+export interface UseBreedOptionsResult {
+  breedOptions: Breed[];
+  /** The lookup failed, as opposed to returning an empty list. */
+  breedLoadFailed: boolean;
+  breedLoading: boolean;
+  /** Re-run the lookup for the current category. */
+  retryBreeds: () => void;
+}
+
+export const useBreedOptions = ({
+  category,
+  speciesQueryFor,
+  speciesLabelFor,
+  speciesCodeFor,
+}: UseBreedOptionsParams): UseBreedOptionsResult => {
+  const [breedOptions, setBreedOptions] = useState<Breed[]>([]);
+  const [breedLoadFailed, setBreedLoadFailed] = useState(false);
+  const [breedLoading, setBreedLoading] = useState(false);
+
+  // Bumped on every lookup. A response only wins while its ticket is still the
+  // current one, so switching category mid-flight cannot land the old
+  // category's breeds on the new one.
+  const requestTicket = useRef(0);
+
+  // Held in a ref so changing callback identities cannot restart the effect and
+  // refetch on every render.
+  const resolvers = useRef({speciesQueryFor, speciesLabelFor, speciesCodeFor});
+  resolvers.current = {speciesQueryFor, speciesLabelFor, speciesCodeFor};
+
+  const load = useCallback(async (targetCategory: CompanionCategory) => {
+    const ticket = ++requestTicket.current;
+    const isCurrent = () => requestTicket.current === ticket;
+
+    setBreedLoading(true);
+    try {
+      const tokens = await getFreshStoredTokens();
+      if (!tokens?.accessToken) {
+        // The zero-traffic path: no request is sent at all. It still has to be
+        // reported as a retryable failure, not as an empty list.
+        if (isCurrent()) {
+          setBreedOptions([]);
+          setBreedLoadFailed(true);
+        }
+        return;
+      }
+
+      const entries = await fetchBreedCodeEntries(
+        resolvers.current.speciesQueryFor(targetCategory),
+        tokens.accessToken,
+      );
+      if (!isCurrent()) {
+        return;
+      }
+
+      setBreedOptions(
+        entries.map((entry: BreedCodeEntry, index: number) => ({
+          speciesId: index + 1,
+          speciesName: resolvers.current.speciesLabelFor(targetCategory),
+          breedId: index + 1,
+          breedName: entry.display,
+          speciesCode:
+            entry.meta?.speciesCode ??
+            resolvers.current.speciesCodeFor?.(targetCategory),
+          breedCode: entry.code,
+        })),
+      );
+      setBreedLoadFailed(false);
+    } catch (error) {
+      if (isCurrent()) {
+        setBreedOptions([]);
+        setBreedLoadFailed(true);
+      }
+      console.warn('[Companion] Unable to load breed code entries', error);
+    } finally {
+      if (isCurrent()) {
+        setBreedLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!category) {
+      // Invalidate anything in flight, so a late response cannot repopulate the
+      // picker after the user cleared the category.
+      requestTicket.current += 1;
+      setBreedOptions([]);
+      setBreedLoadFailed(false);
+      setBreedLoading(false);
+      return;
+    }
+
+    load(category).catch(() => undefined);
+  }, [category, load]);
+
+  const retryBreeds = useCallback(() => {
+    // Guarded so an impatient second tap cannot fire a duplicate lookup.
+    if (!category || breedLoading) {
+      return;
+    }
+    load(category).catch(() => undefined);
+  }, [category, breedLoading, load]);
+
+  return {breedOptions, breedLoadFailed, breedLoading, retryBreeds};
+};

--- a/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
+++ b/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
@@ -61,10 +61,9 @@ import {usePreferences} from '@/features/preferences/PreferencesContext';
 import {convertWeight} from '@/shared/utils/measurementSystem';
 import {getFreshStoredTokens} from '@/features/auth/sessionManager';
 import {neuterTerm} from '@/features/companion/utils/neuterTerm';
+import {useBreedOptions} from '@/features/companion/hooks/useBreedOptions';
 import {
-  fetchBreedCodeEntries,
   fetchSpeciesCodeEntries,
-  type BreedCodeEntry,
   type SpeciesCodeEntry,
 } from '@/features/companion/services/codeEntriesService';
 
@@ -167,11 +166,6 @@ export const AddCompanionScreen: React.FC<AddCompanionScreenProps> = ({
   const speciesByCategoryRef = useRef<
     Partial<Record<CompanionCategory, SpeciesCodeEntry>>
   >({});
-  const [breedOptions, setBreedOptions] = useState<Breed[]>([]);
-  // An empty picker caused by a failed lookup used to look identical to a
-  // species that genuinely has no breeds. Breed is required, so that dead end
-  // blocked companion creation entirely with nothing explaining why.
-  const [breedLoadFailed, setBreedLoadFailed] = useState(false);
 
   // Track which bottom sheet is currently open
   const openBottomSheetRef = useRef<'breed' | 'bloodGroup' | 'country' | null>(
@@ -347,68 +341,31 @@ export const AddCompanionScreen: React.FC<AddCompanionScreenProps> = ({
     };
   }, [getValues, setValue]);
 
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      if (!category) {
-        setBreedOptions([]);
-        setBreedLoadFailed(false);
-        setValue('speciesCode', null, {shouldValidate: false});
-        setValue('breed', null, {shouldValidate: false});
-        setValue('breedCode', null, {shouldValidate: false});
-        return;
-      }
+  const {breedOptions, breedLoadFailed, breedLoading, retryBreeds} =
+    useBreedOptions({
+      category,
+      speciesQueryFor: cat => CATEGORY_TO_SPECIES_QUERY[cat],
+      speciesLabelFor: cat => CATEGORY_TO_SPECIES_LABEL[cat],
+      speciesCodeFor: cat => speciesByCategoryRef.current[cat]?.code,
+    });
 
-      setValue(
-        'speciesCode',
-        speciesByCategoryRef.current[category]?.code ?? null,
-        {
-          shouldValidate: false,
-        },
-      );
+  // The hook owns the lookup; this effect owns only the form resets that must
+  // happen when the category changes.
+  useEffect(() => {
+    if (!category) {
+      setValue('speciesCode', null, {shouldValidate: false});
       setValue('breed', null, {shouldValidate: false});
       setValue('breedCode', null, {shouldValidate: false});
+      return;
+    }
 
-      try {
-        const tokens = await getFreshStoredTokens();
-        if (!tokens?.accessToken) {
-          if (mounted) {
-            setBreedLoadFailed(true);
-          }
-          return;
-        }
-        const entries = await fetchBreedCodeEntries(
-          CATEGORY_TO_SPECIES_QUERY[category],
-          tokens.accessToken,
-        );
-        if (!mounted) {
-          return;
-        }
-
-        const mappedBreeds: Breed[] = entries.map(
-          (entry: BreedCodeEntry, index: number) => ({
-            speciesId: index + 1,
-            speciesName: CATEGORY_TO_SPECIES_LABEL[category],
-            breedId: index + 1,
-            breedName: entry.display,
-            speciesCode:
-              entry.meta?.speciesCode ??
-              speciesByCategoryRef.current[category]?.code,
-            breedCode: entry.code,
-          }),
-        );
-        setBreedOptions(mappedBreeds);
-        setBreedLoadFailed(false);
-      } catch (error) {
-        setBreedOptions([]);
-        setBreedLoadFailed(true);
-        console.warn('[Companion] Unable to load breed code entries', error);
-      }
-    })();
-
-    return () => {
-      mounted = false;
-    };
+    setValue(
+      'speciesCode',
+      speciesByCategoryRef.current[category]?.code ?? null,
+      {shouldValidate: false},
+    );
+    setValue('breed', null, {shouldValidate: false});
+    setValue('breedCode', null, {shouldValidate: false});
   }, [category, setValue]);
 
   // Handle Android back button
@@ -1227,6 +1184,8 @@ export const AddCompanionScreen: React.FC<AddCompanionScreenProps> = ({
         ref={breedSheetRef}
         breeds={breedOptions}
         loadFailed={breedLoadFailed}
+        loading={breedLoading}
+        onRetry={retryBreeds}
         selectedBreed={breed}
         onSave={handleBreedSave}
       />

--- a/apps/mobileAppYC/src/shared/components/common/BreedBottomSheet/BreedBottomSheet.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/BreedBottomSheet/BreedBottomSheet.tsx
@@ -19,6 +19,14 @@ interface BreedBottomSheetProps {
   onSave: (breed: Breed | null) => void;
   /** The lookup failed rather than returning an empty list. */
   loadFailed?: boolean;
+  /** A lookup is in flight, so the list is empty for a third reason again. */
+  loading?: boolean;
+  /**
+   * Re-run the breed lookup. Without this a failed lookup is a dead end:
+   * breed is a required field, so the user cannot finish creating a companion
+   * and cannot make the picker try again either.
+   */
+  onRetry?: () => void;
 }
 
 export const BreedBottomSheet = ({
@@ -26,6 +34,8 @@ export const BreedBottomSheet = ({
   selectedBreed,
   onSave,
   loadFailed = false,
+  loading = false,
+  onRetry,
   ref,
 }: BreedBottomSheetProps & {ref?: React.Ref<BreedBottomSheetRef>}) => {
   const {t} = useTranslation();
@@ -58,6 +68,17 @@ export const BreedBottomSheet = ({
     },
   }));
 
+  // Three reasons the list can be empty, and they are not interchangeable:
+  // still loading, the lookup failed, or the species really has no breeds.
+  const resolveEmptyMessage = () => {
+    if (loading) {
+      return t('common.loading');
+    }
+    return loadFailed
+      ? t('companion.breedLoadFailed')
+      : t('companion.breedNoneAvailable');
+  };
+
   const handleSave = (item: SelectItem | null) => {
     const breed = item
       ? breeds.find(b => b.breedId.toString() === item.id) || null
@@ -73,10 +94,13 @@ export const BreedBottomSheet = ({
       selectedItem={selectedItem}
       onSave={handleSave}
       searchPlaceholder="Search from 200+ breeds"
-      emptyMessage={
-        loadFailed
-          ? t('companion.breedLoadFailed')
-          : t('companion.breedNoneAvailable')
+      emptyMessage={resolveEmptyMessage()}
+      emptyAction={
+        // Only on failure. A species that genuinely has no breeds is not
+        // something a retry can fix, and offering one there would be a lie.
+        loadFailed && !loading && onRetry
+          ? {label: t('common.try_again'), onPress: onRetry}
+          : undefined
       }
       mode="select"
       maxListHeight={600}

--- a/apps/mobileAppYC/src/shared/components/common/GenericSelectBottomSheet/GenericSelectBottomSheet.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/GenericSelectBottomSheet/GenericSelectBottomSheet.tsx
@@ -97,6 +97,12 @@ interface GenericSelectBottomSheetProps {
   snapPoints?: [string, string];
   hasSearch?: boolean;
   emptyMessage?: string;
+  /**
+   * Optional control rendered under `emptyMessage`. Exists so an empty list
+   * that is empty because the LOOKUP FAILED can offer a way out: without it a
+   * failed lookup is a dead end in any sheet whose field is required.
+   */
+  emptyAction?: {label: string; onPress: () => void};
   customContent?: React.ReactNode;
   mode?: 'select' | 'confirm'; // 'select' = auto-close on select, 'confirm' = show save/cancel buttons
   maxListHeight?: number;
@@ -114,6 +120,7 @@ export const GenericSelectBottomSheet = ({
   snapPoints = ['90%', '95%'],
   hasSearch = true,
   emptyMessage = 'No items available',
+  emptyAction,
   customContent,
   mode = 'confirm',
   maxListHeight = 400,
@@ -155,6 +162,16 @@ export const GenericSelectBottomSheet = ({
   const renderEmptyList = () => (
     <View style={styles.emptyContainer}>
       <Text style={styles.emptyText}>{emptyMessage}</Text>
+      {emptyAction ? (
+        <PressableOpacity
+          testID="select-sheet-empty-action"
+          accessibilityRole="button"
+          accessibilityLabel={emptyAction.label}
+          onPress={emptyAction.onPress}
+          style={styles.emptyAction}>
+          <Text style={styles.emptyActionLabel}>{emptyAction.label}</Text>
+        </PressableOpacity>
+      ) : null}
     </View>
   );
 
@@ -371,6 +388,18 @@ const createStyles = (theme: any, maxListHeight: number, bottomInset: number) =>
     emptyText: {
       ...theme.typography.body,
       color: theme.colors.textSecondary,
+      textAlign: 'center',
+    },
+    emptyAction: {
+      minHeight: 44,
+      justifyContent: 'center',
+      paddingHorizontal: theme.spacing['5'],
+      marginTop: theme.spacing['3'],
+    },
+    emptyActionLabel: {
+      ...theme.typography.button,
+      fontSize: 15,
+      color: theme.colors.blueText,
       textAlign: 'center',
     },
     listWrapper: {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Breed is a required field on Add Companion. When the breed lookup fails, the picker says so and offers nothing else, so the user cannot select a breed and cannot finish creating a companion. There is no way to make it try again short of backing out of the form and losing the answers already entered.

PR #2416 added `breedLoadFailed`, which correctly separated "the lookup failed" from "this species has no breeds". That was the right first half. The second half, a way to act on it, was never added.

The failure is also the mechanism behind the "no network request at all" half of #2371, which the original investigation could not substantiate. It is not that the effect fails to run. `AddCompanionScreen` read a token first and returned early when there was none:

```ts
const tokens = await getFreshStoredTokens();
if (!tokens?.accessToken) {
  setBreedLoadFailed(true);
  return;                     // <- before fetchBreedCodeEntries is ever called
}
```

So a failed token read sends **zero** breed traffic. The request the user is waiting for is never made, which is exactly what "no request for 8 minutes" looks like from the outside.

None of this had test coverage, because the logic sat inside a 1300-line screen that is listed in `sonar.coverage.exclusions`.

## What is the new behavior?

**`useBreedOptions`** (new hook) owns the lookup and the three states the picker has to tell apart: loading, failed, and "this species genuinely has no breeds". Extracted from the screen so it can actually be tested. The no-token path now reports a retryable failure rather than presenting as an empty list.

**`GenericSelectBottomSheet`** gains an optional `emptyAction`, rendered under the empty message. Any select sheet whose field is required can now offer a way out of a failed lookup instead of a dead end, rather than this being a breed-specific patch.

**`BreedBottomSheet`** offers Try Again only on failure. A species that genuinely has no breeds is not something a retry can fix and offering one there would be a lie. The control is also withheld while a lookup is in flight, so an impatient second tap cannot fire a duplicate request.

Two further details worth flagging, because both were reachable before:

- **Retry re-runs only the fetch.** The category-change form resets stay in the screen, so retrying no longer costs the user their species and other answers.
- **A request ticket discards responses from a superseded category.** Switching species while a slow lookup is in flight could previously land the old species' breeds on the new one.

## Validation performed

- `npx tsc --noEmit`: exit 0
- `pnpm --filter mobileAppYC run lint`: exit 0, zero warnings
- Full Jest suite: **477 suites, 7741 tests** passing
- New coverage: 10 hook tests (including the zero-traffic no-token path and the superseded-category race), 4 `BreedBottomSheet` tests, 2 `GenericSelectBottomSheet` tests
- **Four mutation checks**, each reverted, the specific test confirmed failing, then restored

One of those mutation checks is worth recording honestly: it initially reported a pass, which would have meant the superseded-category guard was untested. The replacement string had the wrong indentation and silently matched nothing, so I had verified nothing. Fixing the harness exposed a second problem, that the test asserted before the stale response had a chance to land, so it passed for the wrong reason. Both were fixed and the check then failed as it should.

Note for anyone building this branch locally: `pnpm --filter @yosemite-crew/database run prisma:generate` may be needed after pulling, or the pre-push hook fails on `packages/database` with `Module '"@prisma/client"' has no exported member 'PrismaClient'`. That is a stale generated client, not a code problem, and is unrelated to this diff.

## Related Issue(s)

Refs #2371
