### PR TITLE
fix(frontend): stop the wizard calling a live booking page not live

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -324,12 +324,37 @@ describe('PublicBookingSetup', () => {
       expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
     });
 
-    it('shows the reserved slug without a copy button while the page is not live', async () => {
-      getConfigMock.mockResolvedValue(config({ slug: 'alpenblick-animal-clinic' }));
+    it('says the page is closed while it has not been opened', async () => {
+      getConfigMock.mockResolvedValue(
+        config({ slug: 'alpenblick-animal-clinic', publicBookingEnabled: false })
+      );
       await goToBranding();
 
       expect(screen.getByText('alpenblick-animal-clinic')).toBeInTheDocument();
-      expect(screen.getByText(/not live yet, so there is no link to share/)).toBeInTheDocument();
+      expect(screen.getByText(/Your booking page is closed/)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
+    });
+
+    it('does not claim a live page is closed just because no address is configured', async () => {
+      // The state that shipped wrong: `publicBookingEnabled` true with
+      // `publicUrl` null, because PUBLIC_BOOKING_BASE_URL is unset for the
+      // environment. The page IS reachable and taking bookings; saying it is not
+      // live is the same untruth this screen exists to remove, pointing the
+      // other way.
+      getConfigMock.mockResolvedValue(
+        config({
+          slug: 'alpenblick-animal-clinic',
+          publicBookingEnabled: true,
+          publicUrl: null,
+        })
+      );
+      await goToBranding();
+
+      expect(screen.getByText(/Your booking page is open/)).toBeInTheDocument();
+      expect(screen.getByText(/No public web address is configured/)).toBeInTheDocument();
+      expect(screen.queryByText(/is closed/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/not live/)).not.toBeInTheDocument();
+      // Still nothing to copy, because there is still no address.
       expect(screen.queryByRole('button', { name: /Copy/ })).not.toBeInTheDocument();
     });
 

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -447,3 +447,41 @@ export const BrandingPublished: Story = {
     },
   },
 };
+
+export const BrandingOpenWithoutAddress: Story = {
+  name: 'Step 2 - open, but no address configured',
+  beforeEach: () =>
+    seed({
+      config: config({
+        configured: true,
+        slug: 'avenger-park-veterinary',
+        publicBookingEnabled: true,
+        // Reachable, but this environment has no PUBLIC_BOOKING_BASE_URL, so the
+        // API can offer no link.
+        publicUrl: null,
+      }),
+    }),
+  play: async ({ canvas }) => {
+    await goToBranding(document.body);
+
+    await expect(await canvas.findByText(/Your booking page is open/)).toBeInTheDocument();
+    await expect(canvas.getByText(/No public web address is configured/)).toBeInTheDocument();
+
+    // The bug this story exists to prevent coming back.
+    await expect(canvas.queryByText(/is closed/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/not live/)).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state that shipped wrong. Whether the page is REACHABLE is `publicBookingEnabled`; ' +
+          'whether a LINK can be shown additionally needs an address configured for the ' +
+          'environment. The first version branched only on the link, so a practice whose page was ' +
+          'live and taking bookings was told it "is not live yet" - the same species of untruth ' +
+          'this screen was rewritten to remove, pointing the other way.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -243,14 +243,34 @@ const BookingServicesStep = ({
  *
  * `publicUrl` is only ever a value the API sent. Nothing here builds one.
  */
+/**
+ * What to say about an address we cannot show a link for.
+ *
+ * Three states, not two. Whether the page is REACHABLE is
+ * `publicBookingEnabled`; whether we can show a LINK to it additionally needs
+ * `PUBLIC_BOOKING_BASE_URL` configured for the environment. Collapsing those
+ * told a practice whose page was live and taking bookings that it "is not live
+ * yet" - the same species of untruth this screen was rewritten to remove, only
+ * pointing the other way.
+ */
+const describeAddress = (slug: string | null, publicBookingEnabled: boolean): string => {
+  if (!slug) return 'Save your setup and we will reserve a booking address for your practice.';
+  if (publicBookingEnabled) {
+    return 'Your booking page is open and pet parents can use it. No public web address is configured for this environment yet, so there is no link to copy here - ask whoever administers this environment to set one.';
+  }
+  return 'Your booking page is closed, so there is no link to share. We have reserved this address for you and will use it when you open the page.';
+};
+
 const BookingAddress = ({
   slug,
   publicUrl,
+  publicBookingEnabled,
   copied,
   onCopy,
 }: {
   slug: string | null;
   publicUrl: string | null;
+  publicBookingEnabled: boolean;
   copied: boolean;
   onCopy: (url: string) => void;
 }) => {
@@ -293,9 +313,7 @@ const BookingAddress = ({
         </span>
       </div>
       <span className="text-[11.5px] text-[var(--ink-faint)]">
-        {slug
-          ? 'Your booking page is not live yet, so there is no link to share. We have reserved this address for you and will use it when the page opens.'
-          : 'Save your setup and we will reserve a booking address for your practice.'}
+        {describeAddress(slug, publicBookingEnabled)}
       </span>
     </div>
   );
@@ -312,6 +330,7 @@ type BrandingStepProps = {
   onReplyToChange: (value: string) => void;
   slug: string | null;
   publicUrl: string | null;
+  publicBookingEnabled: boolean;
   copied: boolean;
   onCopy: (url: string) => void;
   onReplaceLogo: () => void;
@@ -335,6 +354,7 @@ const BookingBrandingStep = ({
   onReplyToChange,
   slug,
   publicUrl,
+  publicBookingEnabled,
   copied,
   onCopy,
   onReplaceLogo,
@@ -416,7 +436,13 @@ const BookingBrandingStep = ({
         </div>
       </div>
 
-      <BookingAddress slug={slug} publicUrl={publicUrl} copied={copied} onCopy={onCopy} />
+      <BookingAddress
+        slug={slug}
+        publicUrl={publicUrl}
+        publicBookingEnabled={publicBookingEnabled}
+        copied={copied}
+        onCopy={onCopy}
+      />
 
       <div className="flex items-center justify-between gap-3 px-3.5 py-3 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)]">
         <span className="text-[12.5px] text-[var(--ink-body)]">
@@ -702,6 +728,7 @@ const PublicBookingSetup = () => {
             onReplyToChange={setReplyTo}
             slug={config?.slug ?? null}
             publicUrl={config?.publicUrl ?? null}
+            publicBookingEnabled={config?.publicBookingEnabled ?? false}
             copied={copied}
             onCopy={handleCopy}
             onReplaceLogo={handleReplaceLogo}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Found by opening the page in a browser, not by a test.

After #2515 shipped, I published **Avenger Park, Avondale FC** on dev. `https://dev.yosemitecrew.com/book/avenger-park-avondale-fc` served the practice, its nine services and real 15-minute slots — while the wizard, on the same account at the same moment, said:

> Your booking page is not live yet, so there is no link to share.

`BookingAddress` branched on `publicUrl` alone. Two properties are involved and they are not the same one:

- whether the page is **reachable** is `publicBookingEnabled`
- whether a **link** can be shown additionally needs `PUBLIC_BOOKING_BASE_URL` configured for the environment

They diverge whenever that variable is unset, which is its shipped state — deliberately, so that no environment can serve an address that does not resolve. So the two-way branch reported a live, bookable page as closed.

This is the same species of untruth #2515 was written to remove, pointing the other way. It understates rather than overstates, so it invites nobody to publish a dead link — but a practice cannot act on a page it has been told does not exist, and it contradicts the success toast, which already got this right.

## What is the new behavior?

Three states instead of two:

| State | Copy |
| --- | --- |
| No slug yet | "Save your setup and we will reserve a booking address for your practice." |
| Open, no address configured | "Your booking page is open and pet parents can use it. No public web address is configured for this environment yet… ask whoever administers this environment to set one." |
| Closed | "Your booking page is closed, so there is no link to share. We have reserved this address for you…" |

The middle one is new. It states the fact the practice needs (the page is working), and names the remedy and its owner rather than leaving a dead end.

Still no copy button in either address-less state: there is genuinely nothing to copy.

## Impact area

`apps/frontend` only — the booking setup wizard's address block. No API, schema or behaviour change; nothing about what is published changes.

## Validation performed

- **44 tests passing**, `PublicBookingSetup.tsx` at 100% statements, branches, functions and lines.
- **Mutation checked.** Reintroducing the collapsed branch (deleting the `publicBookingEnabled` case) fails exactly the new test and nothing else — so the guard bites rather than passing vacuously.
- A story (`Step 2 - open, but no address configured`) pins the state so Chromatic guards it visually.
- Full frontend suite: **970 suites / 11984 tests**. `npx tsc --noemit` and `lint` clean (the one warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, untouched here). `storybook:build` succeeds.

### Worth saying plainly

Every automated gate on #2515 was green — 62 CI checks, 100% coverage on this exact file — and none of them caught this, because the tests asserted the behaviour I had written rather than the behaviour a practice needs. It took publishing a real practice and reading the two screens side by side. That is the argument for the visual pass, not for more unit tests.

## Related Issue(s)

Follow-up to #2515.

Fixes #
