### PR TITLE
fix(backend): make user provisioning idempotent so a role can be corrected

### DIFF
--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -89,6 +89,23 @@ async function syncProfileToAuthProvider(
       });
     }
     if (profile.role) {
+      /*
+       * Drop the other self-assignable role first. `setUserRole` ADDS - it
+       * does not replace - so correcting `member` to `developer` would
+       * otherwise leave the account holding both, and `/v1/auth/me` answers
+       * with the first role the list returns. The correction would report
+       * success and change nothing the user can see.
+       *
+       * Only the self-assignable ones are cleared. Removing every other role
+       * would strip `superadmin` from an admin who did nothing more than
+       * re-provision their name, and this endpoint has no business revoking a
+       * role it was never allowed to grant.
+       */
+      for (const stale of SELF_ASSIGNABLE_ROLES) {
+        if (stale !== profile.role) {
+          await authService.removeUserRole(userId, stale);
+        }
+      }
       await authService.setUserRole(userId, profile.role);
     }
   } catch (syncError) {

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -130,11 +130,30 @@ async function reconcileNames(
   if (!profile.firstName || !profile.lastName) {
     return stored!;
   }
-  return UserService.updateName({
-    userId,
-    firstName: profile.firstName,
-    lastName: profile.lastName,
-  });
+  try {
+    return await UserService.updateName({
+      userId,
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+    });
+  } catch (nameError) {
+    /*
+     * `updateName` pushes the name to the auth provider BEFORE the database
+     * write, unguarded, so a provider outage would fail a request whose entire
+     * purpose is to be repeatable - while the sync below stays best-effort for
+     * exactly that reason. Serving the stored row keeps the endpoint available.
+     *
+     * Both stores are deliberately left untouched rather than forcing the
+     * database write through on its own: that would put the two out of step,
+     * and `updateName` no-ops once the database matches, so no later call could
+     * repair the provider side. Unchanged is recoverable; half-applied is not.
+     */
+    logger.warn(
+      "Could not reconcile stored names during provisioning",
+      nameError,
+    );
+    return stored!;
+  }
 }
 
 // Best-effort profile sync to the auth provider so /v1/auth/me can serve

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -74,33 +74,32 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
 /**
  * Whether the request's names can be acted on.
  *
- * Two shapes are acceptable: both names RESOLVE - from the body, the session
- * fallback, or one of each - or the request never mentioned them at all. The
- * second is the legitimate repeat call: once `pendingSignUp` is gone the client
- * posts no body, and the session carries no profile attributes either.
+ * A body that mentions either name must supply both, itself. The session
+ * fallback is for a body that says nothing about names at all - the legitimate
+ * repeat call, where `pendingSignUp` is gone so the client posts no body.
  *
- * Resolution is what matters, not where each half came from. A body naming only
- * `firstName` over a session that supplies `lastName` is complete, and creation
- * accepts exactly the same input - the two paths have to agree or the repeat
- * call rejects requests the first one allowed.
+ * Judged on the raw body rather than the resolved profile. Half a name in the
+ * body silently completed from the session is an ambiguous request answered
+ * with a guess: the caller asked to set one name, and the stored value it gets
+ * paired with may be exactly what they meant to replace. Every client sends
+ * both names or neither, so nothing legitimate is refused by insisting on it.
  *
- * The raw body still has to be consulted, because `trimmedString` collapses
- * `""`, whitespace and non-strings to `undefined`: without it an explicitly
- * blank pair is indistinguishable from an absent one, and the repeat path would
+ * The raw body also has to be read because `trimmedString` collapses `""`,
+ * whitespace and non-strings to `undefined` - without that an explicitly blank
+ * pair is indistinguishable from an absent one, and the repeat path would
  * answer 200 to a rename it had silently refused.
  */
 function namesAreUsable(
   req: AuthenticatedRequest,
   profile: { firstName?: string; lastName?: string },
 ): boolean {
-  if (profile.firstName && profile.lastName) {
-    return true;
-  }
-  if (profile.firstName || profile.lastName) {
-    return false;
-  }
   const body = (req.body ?? {}) as Record<string, unknown>;
-  return !("firstName" in body || "lastName" in body);
+  if ("firstName" in body || "lastName" in body) {
+    return Boolean(
+      trimmedString(body.firstName) && trimmedString(body.lastName),
+    );
+  }
+  return Boolean(profile.firstName) === Boolean(profile.lastName);
 }
 
 type AuthServiceForSync = NonNullable<ReturnType<typeof getAuthService>>;
@@ -265,24 +264,31 @@ async function syncProfileToAuthProvider(
   if (!authService) {
     return;
   }
-  try {
-    if (profile.firstName && profile.lastName) {
+  /*
+   * The two writes are isolated, not sequential steps of one try. Sharing a
+   * catch meant a failed name sync returned early and skipped the role
+   * entirely: the response was still 2xx, the client cleared its pending role,
+   * and the correction was lost to a failure in the half of this function that
+   * can afford to fail.
+   */
+  if (profile.firstName && profile.lastName) {
+    try {
       await authService.updateUserName(userId, {
         firstName: profile.firstName,
         lastName: profile.lastName,
       });
+    } catch (nameSyncError) {
+      // Genuinely best-effort: one call, nothing half-done, and the database
+      // already holds the authoritative copy.
+      logger.warn("Auth provider name sync failed", nameSyncError);
     }
-    if (profile.role) {
-      await applyRole(authService, userId, profile.role);
-    }
-  } catch (syncError) {
-    // The one failure that has already changed state. Absorbing it would make a
-    // half-applied replacement permanent, since the client clears its pending
-    // role on any 2xx and never sends it again.
-    if (syncError instanceof RoleReplacementIncomplete) {
-      throw syncError;
-    }
-    logger.warn("Auth provider profile sync failed", syncError);
+  }
+
+  // Not guarded. `applyRole` raises RoleReplacementIncomplete for anything that
+  // may have changed provider state, and that has to reach the client - it is
+  // the only thing here nothing else can repair.
+  if (profile.role) {
+    await applyRole(authService, userId, profile.role);
   }
 }
 

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -74,6 +74,21 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
 type AuthServiceForSync = NonNullable<ReturnType<typeof getAuthService>>;
 
 /**
+ * A role replacement that got halfway: the new role is granted, the old one is
+ * still attached.
+ *
+ * Distinct from every other provider failure because it is the only one that
+ * leaves state changed. The sync absorbs the rest; this one has to reach the
+ * client so it retries while it still holds the role to re-apply.
+ */
+class RoleReplacementIncomplete extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "RoleReplacementIncomplete";
+  }
+}
+
+/**
  * Move the account onto `role`, clearing the one it replaces.
  *
  * `setUserRole` ADDS - it does not replace - so correcting `member` to
@@ -92,20 +107,35 @@ async function applyRole(
   role: string,
 ): Promise<void> {
   /*
-   * Grant before revoking, never the other way round. The whole sync is
-   * best-effort - the caller logs a provider failure and still answers 2xx, so
-   * the client accepts it and does not retry. Removing first and then failing
-   * would leave the account with NO role behind a successful response, which
-   * is worse than the problem this fixes. Failing after the grant leaves it
-   * holding both, which is exactly the append-only state this replaced:
-   * recoverable, and repaired by the next call.
+   * Grant before revoking. A failure here has changed nothing, so the caller's
+   * best-effort catch can absorb it; revoking first and then failing would
+   * leave the account with no role at all behind a 2xx.
    */
   await authService.setUserRole(userId, role);
+
   const replaced = [...SELF_ASSIGNABLE_ROLES].filter(
     (candidate) => candidate !== role,
   );
-  for (const candidate of replaced) {
-    await authService.removeUserRole(userId, candidate);
+  try {
+    for (const candidate of replaced) {
+      await authService.removeUserRole(userId, candidate);
+    }
+  } catch (removalError) {
+    /*
+     * Past the point of no change: the account now holds both roles, and
+     * `/v1/auth/me` answers with whichever the list returns first, so the
+     * correction may be invisible.
+     *
+     * Nothing else repairs this. `provisionPendingSignUpUser` clears
+     * `pendingSignUp` on any 2xx, so a later provisioning call carries no role
+     * and never reaches this code - a 200 here would make the half-applied
+     * state permanent. Marked so the sync rethrows instead of absorbing it,
+     * leaving the client to retry while it still holds the role.
+     */
+    throw new RoleReplacementIncomplete(
+      `Granted ${role} but could not revoke the role it replaces`,
+      { cause: removalError },
+    );
   }
 }
 
@@ -130,41 +160,22 @@ async function reconcileNames(
   if (!profile.firstName || !profile.lastName) {
     return stored!;
   }
-  try {
-    return await UserService.updateName({
-      userId,
-      firstName: profile.firstName,
-      lastName: profile.lastName,
-    });
-  } catch (nameError) {
-    /*
-     * A rejected name is the caller's problem, not an outage: `updateName`
-     * raises UserServiceError for a name the service will not accept, and
-     * creation rejects the same payload outright. Swallowing it would answer
-     * 200 to a rename that was refused, and let the sync push the refused name
-     * into the provider anyway.
-     */
-    if (nameError instanceof UserServiceError) {
-      throw nameError;
-    }
-
-    /*
-     * Anything else is infrastructure. `updateName` pushes the name to the auth
-     * provider BEFORE its database write, unguarded, so a provider outage would
-     * fail a request whose entire purpose is to be repeatable - while the sync
-     * beside it stays best-effort for exactly that reason.
-     *
-     * Both stores are deliberately left untouched rather than forcing the
-     * database write through on its own: that would put the two out of step,
-     * and `updateName` no-ops once the database matches, so no later call could
-     * repair the provider side. Unchanged is recoverable; half-applied is not.
-     */
-    logger.warn(
-      "Could not reconcile stored names during provisioning",
-      nameError,
-    );
-    return stored!;
-  }
+  /*
+   * Failures propagate. `updateName` writes the auth provider BEFORE the
+   * database and is not atomic across the two, so a failure between them leaves
+   * the provider holding a name the database never took - and `updateName`
+   * no-ops once the database matches, so no later call repairs it. Answering
+   * 200 over the stored row would make that divergence permanent and invisible.
+   *
+   * Failing is safe here in a way it is not on the creation path: the row this
+   * reconciles already exists, so a 500 strands nothing. The client retries,
+   * and every retry re-runs the same idempotent write.
+   */
+  return UserService.updateName({
+    userId,
+    firstName: profile.firstName,
+    lastName: profile.lastName,
+  });
 }
 
 /**
@@ -234,6 +245,12 @@ async function syncProfileToAuthProvider(
       await applyRole(authService, userId, profile.role);
     }
   } catch (syncError) {
+    // The one failure that has already changed state. Absorbing it would make a
+    // half-applied replacement permanent, since the client clears its pending
+    // role on any 2xx and never sends it again.
+    if (syncError instanceof RoleReplacementIncomplete) {
+      throw syncError;
+    }
     logger.warn("Auth provider profile sync failed", syncError);
   }
 }

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -98,33 +98,47 @@ function suppliedNames(req: AuthenticatedRequest): {
 }
 
 /**
- * Whether the request's names can be acted on.
+ * Whether the names the BODY offers can be acted on.
  *
- * A body that mentions either name must supply both, itself. The session
- * fallback is for a body that says nothing about names at all - the legitimate
- * repeat call, where `pendingSignUp` is gone so the client posts no body.
+ * A body that mentions either name must supply both, itself. Half a name in
+ * the body silently completed from the session is an ambiguous request
+ * answered with a guess: the caller asked to set one name, and the stored
+ * value it gets paired with may be exactly what they meant to replace. Every
+ * client sends both names or neither, so nothing legitimate is refused.
  *
- * Judged on the raw body rather than the resolved profile. Half a name in the
- * body silently completed from the session is an ambiguous request answered
- * with a guess: the caller asked to set one name, and the stored value it gets
- * paired with may be exactly what they meant to replace. Every client sends
- * both names or neither, so nothing legitimate is refused by insisting on it.
- *
- * The raw body also has to be read because `trimmedString` collapses `""`,
+ * The raw body has to be read because `trimmedString` collapses `""`,
  * whitespace and non-strings to `undefined` - without that an explicitly blank
  * pair is indistinguishable from an absent one, and the repeat path would
  * answer 200 to a rename it had silently refused.
+ *
+ * A body that says nothing about names is not judged here at all: that is the
+ * legitimate repeat call, and whether it can proceed depends on whether the
+ * account already exists - which is not known yet.
  */
-function namesAreUsable(
-  req: AuthenticatedRequest,
-  profile: { firstName?: string; lastName?: string },
-): boolean {
+function bodyNamesAreUsable(req: AuthenticatedRequest): boolean {
   const body = (req.body ?? {}) as Record<string, unknown>;
-  if ("firstName" in body || "lastName" in body) {
-    return Boolean(
-      trimmedString(body.firstName) && trimmedString(body.lastName),
-    );
+  if (!("firstName" in body || "lastName" in body)) {
+    return true;
   }
+  return Boolean(trimmedString(body.firstName) && trimmedString(body.lastName));
+}
+
+/**
+ * Whether a NEW account can be created from these names.
+ *
+ * Applies to creation only. `UserService.create` requires both names, so a
+ * one-sided pair has to be refused - but refusing it before the account is
+ * looked up is what made the idempotent retry fail: under the cutover grace
+ * window a residual token can carry `given_name` without `family_name`
+ * (`legacy-token-verifier.ts` maps the two claims independently), so the
+ * no-body retry - which asks for no rename at all, and whose names are ignored
+ * for an existing account - was answered 400 for a lopsided token it never
+ * referred to.
+ */
+function creationNamesAreUsable(profile: {
+  firstName?: string;
+  lastName?: string;
+}): boolean {
   return Boolean(profile.firstName) === Boolean(profile.lastName);
 }
 
@@ -332,7 +346,7 @@ export const UserController = {
 
       const profile = resolveProvisioningProfile(authRequest);
 
-      if (!namesAreUsable(authRequest, profile)) {
+      if (!bodyNamesAreUsable(authRequest)) {
         return res
           .status(400)
           .json({ message: "Both first and last name are required." });
@@ -394,6 +408,16 @@ export const UserController = {
        * reconcile them.
        */
       const names = provisioned ? suppliedNames(authRequest) : profile;
+
+      // Only creation needs a complete pair, and only now is it known that this
+      // is a creation. `UserService.create` would reject a one-sided pair
+      // anyway; this answers with the endpoint's own message rather than the
+      // service's field-level one.
+      if (!provisioned && !creationNamesAreUsable(profile)) {
+        return res
+          .status(400)
+          .json({ message: "Both first and last name are required." });
+      }
 
       const { user, created } = provisioned
         ? {

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -138,10 +138,21 @@ async function reconcileNames(
     });
   } catch (nameError) {
     /*
-     * `updateName` pushes the name to the auth provider BEFORE the database
-     * write, unguarded, so a provider outage would fail a request whose entire
-     * purpose is to be repeatable - while the sync below stays best-effort for
-     * exactly that reason. Serving the stored row keeps the endpoint available.
+     * A rejected name is the caller's problem, not an outage: `updateName`
+     * raises UserServiceError for a name the service will not accept, and
+     * creation rejects the same payload outright. Swallowing it would answer
+     * 200 to a rename that was refused, and let the sync push the refused name
+     * into the provider anyway.
+     */
+    if (nameError instanceof UserServiceError) {
+      throw nameError;
+    }
+
+    /*
+     * Anything else is infrastructure. `updateName` pushes the name to the auth
+     * provider BEFORE its database write, unguarded, so a provider outage would
+     * fail a request whose entire purpose is to be repeatable - while the sync
+     * beside it stays best-effort for exactly that reason.
      *
      * Both stores are deliberately left untouched rather than forcing the
      * database write through on its own: that would put the two out of step,
@@ -153,6 +164,52 @@ async function reconcileNames(
       nameError,
     );
     return stored!;
+  }
+}
+
+/**
+ * Create the application user, or adopt the one a concurrent caller just made.
+ *
+ * The caller has already established that no row existed a moment ago, so this
+ * is the creation path. The 409 recovery covers only the narrow race: someone
+ * inserted between that lookup and this write.
+ */
+async function createOrAdopt(
+  userId: string,
+  email: string,
+  profile: { firstName?: string; lastName?: string },
+): Promise<{
+  user: Awaited<ReturnType<typeof UserService.create>>;
+  created: boolean;
+}> {
+  try {
+    return {
+      user: await UserService.create({
+        id: userId,
+        email,
+        firstName: profile.firstName!,
+        lastName: profile.lastName!,
+      }),
+      created: true,
+    };
+  } catch (error: unknown) {
+    if (!(error instanceof UserServiceError) || error.statusCode !== 409) {
+      throw error;
+    }
+
+    /*
+     * A 409 matches on id OR email, so it does not prove the row is this
+     * caller's. When nothing comes back for this id the row belongs to someone
+     * else and the conflict stands, rather than handing over their record.
+     */
+    const winner = await UserService.getById(userId);
+    if (!winner) {
+      throw error;
+    }
+    return {
+      user: await reconcileNames(userId, winner, profile),
+      created: false,
+    };
   }
 }
 
@@ -257,41 +314,12 @@ export const UserController = {
           .json({ message: "This account has been deleted." });
       }
 
-      let user: Awaited<ReturnType<typeof UserService.create>>;
-      let created = false;
-
-      if (provisioned) {
-        user = await reconcileNames(userId, provisioned, profile);
-      } else {
-        try {
-          user = await UserService.create({
-            id: userId,
-            email: email,
-            firstName: profile.firstName!,
-            lastName: profile.lastName!,
-          });
-          created = true;
-        } catch (error: unknown) {
-          const raced =
-            error instanceof UserServiceError && error.statusCode === 409;
-          if (!raced) {
-            throw error;
+      const { user, created } = provisioned
+        ? {
+            user: await reconcileNames(userId, provisioned, profile),
+            created: false,
           }
-
-          /*
-           * Lost a race: the lookup above found nothing, but someone inserted
-           * between it and this write. A 409 matches on id OR email, so it does
-           * not prove the row is this caller's - when nothing comes back for
-           * this id the row is someone else's and the conflict stands, rather
-           * than handing over another user's record.
-           */
-          const winner = await UserService.getById(userId);
-          if (!winner) {
-            throw error;
-          }
-          user = await reconcileNames(userId, winner, profile);
-        }
-      }
+        : await createOrAdopt(userId, email, profile);
 
       await syncProfileToAuthProvider(userId, profile);
 

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -91,13 +91,22 @@ async function applyRole(
   userId: string,
   role: string,
 ): Promise<void> {
+  /*
+   * Grant before revoking, never the other way round. The whole sync is
+   * best-effort - the caller logs a provider failure and still answers 2xx, so
+   * the client accepts it and does not retry. Removing first and then failing
+   * would leave the account with NO role behind a successful response, which
+   * is worse than the problem this fixes. Failing after the grant leaves it
+   * holding both, which is exactly the append-only state this replaced:
+   * recoverable, and repaired by the next call.
+   */
+  await authService.setUserRole(userId, role);
   const replaced = [...SELF_ASSIGNABLE_ROLES].filter(
     (candidate) => candidate !== role,
   );
   for (const candidate of replaced) {
     await authService.removeUserRole(userId, candidate);
   }
-  await authService.setUserRole(userId, role);
 }
 
 // Best-effort profile sync to the auth provider so /v1/auth/me can serve
@@ -179,7 +188,24 @@ export const UserController = {
           throw error;
         }
 
-        user = existing;
+        /*
+         * The sync below writes the submitted names into the auth provider
+         * whichever path got here, so the database has to accept them too.
+         * Returning the stored row untouched while pushing new names to the
+         * provider is how `/v1/auth/me` and `/fhir/v1/user/:id` end up
+         * disagreeing about someone's name, with no route back: updateName
+         * no-ops once the database already matches, so nothing later repairs
+         * the divergence. Idempotent by the same token - unchanged names cost
+         * a read.
+         */
+        user =
+          profile.firstName && profile.lastName
+            ? await UserService.updateName({
+                userId,
+                firstName: profile.firstName,
+                lastName: profile.lastName,
+              })
+            : existing;
         created = false;
       }
 

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -196,6 +196,21 @@ export const UserController = {
       const profile = resolveProvisioningProfile(authRequest);
 
       /*
+       * A repeat call may legitimately carry no names at all: once
+       * `pendingSignUp` is gone the client posts no body, and the session
+       * carries no profile attributes either. Carrying exactly one name is not
+       * that - it is a malformed request, which `UserService.create` rejects on
+       * the creation path. Reject it here too, rather than letting the repeat
+       * path read it as "no names supplied" and answer 200 to a rename that
+       * never happened.
+       */
+      if (Boolean(profile.firstName) !== Boolean(profile.lastName)) {
+        return res
+          .status(400)
+          .json({ message: "Both first and last name are required." });
+      }
+
+      /*
        * Provisioning is idempotent, and the client already relies on that -
        * a verification link reopened in a new tab runs this a second time.
        * It was not: `UserService.create` throws 409 for an existing user and
@@ -221,6 +236,26 @@ export const UserController = {
        * would never run.
        */
       const provisioned = await UserService.getById(userId);
+
+      /*
+       * `deleteById` is a soft delete: it sets `isActive: false` and keeps the
+       * row, while genuinely removing the profile, availability and
+       * organisation records around it. `getById` does not filter on that flag,
+       * so treating any returned row as provisioned would answer 200 for an
+       * account that was deleted - reporting success over a hollow identity and
+       * quietly resurrecting nothing. Creation cannot repair it either: the row
+       * still occupies the id and email. Refuse, as it did before this path
+       * existed; reactivation is a separate decision about what to restore.
+       */
+      // Explicitly false, not merely falsy: refuse only when the row positively
+      // says deleted. `isActive` is non-nullable in the schema, so an absent
+      // value means something unexpected upstream - and locking a real account
+      // out of provisioning is the worse way to be wrong about it.
+      if (provisioned?.isActive === false) {
+        return res
+          .status(409)
+          .json({ message: "This account has been deleted." });
+      }
 
       let user: Awaited<ReturnType<typeof UserService.create>>;
       let created = false;

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -74,16 +74,20 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
 /**
  * Whether the request's names can be acted on.
  *
- * Two shapes are acceptable: both names resolve, or the request never mentioned
- * them. The second is the legitimate repeat call - once `pendingSignUp` is gone
- * the client posts no body, and the session carries no profile attributes.
+ * Two shapes are acceptable: both names RESOLVE - from the body, the session
+ * fallback, or one of each - or the request never mentioned them at all. The
+ * second is the legitimate repeat call: once `pendingSignUp` is gone the client
+ * posts no body, and the session carries no profile attributes either.
  *
- * Everything else is malformed and gets a 400, which is what the creation path
- * has always done. Naming the fields at all is a commitment to supply both:
- * `trimmedString` collapses `""`, whitespace and non-strings to `undefined`, so
- * without this an explicitly blank pair would be indistinguishable from an
- * absent one, and the repeat path would answer 200 to a rename it silently
- * refused.
+ * Resolution is what matters, not where each half came from. A body naming only
+ * `firstName` over a session that supplies `lastName` is complete, and creation
+ * accepts exactly the same input - the two paths have to agree or the repeat
+ * call rejects requests the first one allowed.
+ *
+ * The raw body still has to be consulted, because `trimmedString` collapses
+ * `""`, whitespace and non-strings to `undefined`: without it an explicitly
+ * blank pair is indistinguishable from an absent one, and the repeat path would
+ * answer 200 to a rename it had silently refused.
  */
 function namesAreUsable(
   req: AuthenticatedRequest,
@@ -134,35 +138,34 @@ async function applyRole(
   userId: string,
   role: string,
 ): Promise<void> {
-  /*
-   * Grant before revoking. A failure here has changed nothing, so the caller's
-   * best-effort catch can absorb it; revoking first and then failing would
-   * leave the account with no role at all behind a 2xx.
-   */
-  await authService.setUserRole(userId, role);
-
   const replaced = [...SELF_ASSIGNABLE_ROLES].filter(
     (candidate) => candidate !== role,
   );
+
   try {
+    // Grant before revoking: failing the other way round would leave the
+    // account with no role at all.
+    await authService.setUserRole(userId, role);
     for (const candidate of replaced) {
       await authService.removeUserRole(userId, candidate);
     }
-  } catch (removalError) {
+  } catch (roleError) {
     /*
-     * Past the point of no change: the account now holds both roles, and
-     * `/v1/auth/me` answers with whichever the list returns first, so the
-     * correction may be invisible.
+     * Every failure in here is treated as half-applied, including one from the
+     * grant. `setUserRole` is itself three provider calls - create the role,
+     * attach it, write the metadata - so a rejection does not mean nothing
+     * changed: the role can already be attached with only the metadata write
+     * outstanding. Assuming otherwise is what left both roles on the account.
      *
-     * Nothing else repairs this. `provisionPendingSignUpUser` clears
+     * And nothing else repairs it. `provisionPendingSignUpUser` clears
      * `pendingSignUp` on any 2xx, so a later provisioning call carries no role
-     * and never reaches this code - a 200 here would make the half-applied
-     * state permanent. Marked so the sync rethrows instead of absorbing it,
-     * leaving the client to retry while it still holds the role.
+     * and never reaches this code at all. A 2xx here makes whatever state the
+     * provider is in permanent, so the failure has to reach the client while it
+     * still holds the role to retry with.
      */
     throw new RoleReplacementIncomplete(
-      `Granted ${role} but could not revoke the role it replaces`,
-      { cause: removalError },
+      `Could not settle the account on ${role}`,
+      { cause: roleError },
     );
   }
 }

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -71,6 +71,34 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
   };
 }
 
+/**
+ * Whether the request's names can be acted on.
+ *
+ * Two shapes are acceptable: both names resolve, or the request never mentioned
+ * them. The second is the legitimate repeat call - once `pendingSignUp` is gone
+ * the client posts no body, and the session carries no profile attributes.
+ *
+ * Everything else is malformed and gets a 400, which is what the creation path
+ * has always done. Naming the fields at all is a commitment to supply both:
+ * `trimmedString` collapses `""`, whitespace and non-strings to `undefined`, so
+ * without this an explicitly blank pair would be indistinguishable from an
+ * absent one, and the repeat path would answer 200 to a rename it silently
+ * refused.
+ */
+function namesAreUsable(
+  req: AuthenticatedRequest,
+  profile: { firstName?: string; lastName?: string },
+): boolean {
+  if (profile.firstName && profile.lastName) {
+    return true;
+  }
+  if (profile.firstName || profile.lastName) {
+    return false;
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  return !("firstName" in body || "lastName" in body);
+}
+
 type AuthServiceForSync = NonNullable<ReturnType<typeof getAuthService>>;
 
 /**
@@ -269,16 +297,7 @@ export const UserController = {
 
       const profile = resolveProvisioningProfile(authRequest);
 
-      /*
-       * A repeat call may legitimately carry no names at all: once
-       * `pendingSignUp` is gone the client posts no body, and the session
-       * carries no profile attributes either. Carrying exactly one name is not
-       * that - it is a malformed request, which `UserService.create` rejects on
-       * the creation path. Reject it here too, rather than letting the repeat
-       * path read it as "no names supplied" and answer 200 to a rename that
-       * never happened.
-       */
-      if (Boolean(profile.firstName) !== Boolean(profile.lastName)) {
+      if (!namesAreUsable(authRequest, profile)) {
         return res
           .status(400)
           .json({ message: "Both first and last name are required." });

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -72,6 +72,32 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
 }
 
 /**
+ * The names this request actually SUPPLIED, ignoring the session fallback.
+ *
+ * The fallback in `resolveProvisioningProfile` exists so first-time creation
+ * can proceed from session attributes when the body carries nothing. Applying
+ * it to an account that already exists is a different act: it overwrites a
+ * stored name with one the request never asked to change.
+ *
+ * That is not hypothetical. Under the cutover grace window
+ * (`AUTH_LEGACY_TOKEN_GRACE=true`) `legacy-token-verifier.ts` fills these from
+ * the `given_name`/`family_name` claims of a residual token. A token issued
+ * before the user renamed themselves still carries the old pair, so the
+ * no-body idempotent retry - which posts nothing precisely because it has
+ * nothing to say - would push those stale claims over the current record.
+ */
+function suppliedNames(req: AuthenticatedRequest): {
+  firstName?: string;
+  lastName?: string;
+} {
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  return {
+    firstName: trimmedString(body.firstName),
+    lastName: trimmedString(body.lastName),
+  };
+}
+
+/**
  * Whether the request's names can be acted on.
  *
  * A body that mentions either name must supply both, itself. The session
@@ -359,14 +385,24 @@ export const UserController = {
           .json({ message: "This account has been deleted." });
       }
 
+      /*
+       * An existing account is reconciled against what the request SUPPLIED,
+       * a new one against the profile including its session fallback. The
+       * database write and the provider sync take the same pair either way -
+       * letting them diverge is what leaves `/v1/auth/me` and
+       * `/fhir/v1/user/:id` reporting different names with nothing to
+       * reconcile them.
+       */
+      const names = provisioned ? suppliedNames(authRequest) : profile;
+
       const { user, created } = provisioned
         ? {
-            user: await reconcileNames(userId, provisioned, profile),
+            user: await reconcileNames(userId, provisioned, names),
             created: false,
           }
         : await createOrAdopt(userId, email, profile);
 
-      await syncProfileToAuthProvider(userId, profile);
+      await syncProfileToAuthProvider(userId, { ...names, role: profile.role });
 
       res.status(created ? 201 : 200).json(user);
     } catch (error: unknown) {

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -71,6 +71,35 @@ function resolveProvisioningProfile(req: AuthenticatedRequest): {
   };
 }
 
+type AuthServiceForSync = NonNullable<ReturnType<typeof getAuthService>>;
+
+/**
+ * Move the account onto `role`, clearing the one it replaces.
+ *
+ * `setUserRole` ADDS - it does not replace - so correcting `member` to
+ * `developer` would otherwise leave the account holding both, and
+ * `/v1/auth/me` answers with the first role the list returns. The correction
+ * would report success and change nothing the user can see.
+ *
+ * Only the self-assignable roles are cleared. Removing every other role would
+ * strip `superadmin` from an admin who did nothing more than re-provision
+ * their name, and this endpoint has no business revoking a role it was never
+ * allowed to grant.
+ */
+async function applyRole(
+  authService: AuthServiceForSync,
+  userId: string,
+  role: string,
+): Promise<void> {
+  const replaced = [...SELF_ASSIGNABLE_ROLES].filter(
+    (candidate) => candidate !== role,
+  );
+  for (const candidate of replaced) {
+    await authService.removeUserRole(userId, candidate);
+  }
+  await authService.setUserRole(userId, role);
+}
+
 // Best-effort profile sync to the auth provider so /v1/auth/me can serve
 // names and role without touching the database.
 async function syncProfileToAuthProvider(
@@ -89,24 +118,7 @@ async function syncProfileToAuthProvider(
       });
     }
     if (profile.role) {
-      /*
-       * Drop the other self-assignable role first. `setUserRole` ADDS - it
-       * does not replace - so correcting `member` to `developer` would
-       * otherwise leave the account holding both, and `/v1/auth/me` answers
-       * with the first role the list returns. The correction would report
-       * success and change nothing the user can see.
-       *
-       * Only the self-assignable ones are cleared. Removing every other role
-       * would strip `superadmin` from an admin who did nothing more than
-       * re-provision their name, and this endpoint has no business revoking a
-       * role it was never allowed to grant.
-       */
-      for (const stale of SELF_ASSIGNABLE_ROLES) {
-        if (stale !== profile.role) {
-          await authService.removeUserRole(userId, stale);
-        }
-      }
-      await authService.setUserRole(userId, profile.role);
+      await applyRole(authService, userId, profile.role);
     }
   } catch (syncError) {
     logger.warn("Auth provider profile sync failed", syncError);

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -109,6 +109,34 @@ async function applyRole(
   }
 }
 
+/**
+ * Take the submitted names into the database for an account that already
+ * exists, returning the row to serve back.
+ *
+ * The provider sync writes whatever names the request carried, so the database
+ * has to accept the same ones: returning the stored row untouched while pushing
+ * new names to the provider is how `/v1/auth/me` and `/fhir/v1/user/:id` end up
+ * reporting different names for one account, with nothing to reconcile them -
+ * `updateName` no-ops once the database matches, so no later call repairs it.
+ *
+ * A request carrying no names (the client posts no body once `pendingSignUp` is
+ * gone) leaves the stored ones alone rather than clearing them.
+ */
+async function reconcileNames(
+  userId: string,
+  stored: Awaited<ReturnType<typeof UserService.getById>>,
+  profile: { firstName?: string; lastName?: string },
+): Promise<Awaited<ReturnType<typeof UserService.create>>> {
+  if (!profile.firstName || !profile.lastName) {
+    return stored!;
+  }
+  return UserService.updateName({
+    userId,
+    firstName: profile.firstName,
+    lastName: profile.lastName,
+  });
+}
+
 // Best-effort profile sync to the auth provider so /v1/auth/me can serve
 // names and role without touching the database.
 async function syncProfileToAuthProvider(
@@ -164,49 +192,51 @@ export const UserController = {
        * this role), so a caller re-asserting one gains no privilege. It would
        * not have been safe against the old shape check.
        */
+      /*
+       * Look the user up BEFORE attempting to create. `UserService.create`
+       * validates first and last name before it checks for an existing row, and
+       * a repeat call routinely carries neither: once `pendingSignUp` is gone
+       * the client posts no body at all, and the session token no longer
+       * carries profile attributes. Going through create would answer 400 to a
+       * request whose only fault is being already done, and the recovery below
+       * would never run.
+       */
+      const provisioned = await UserService.getById(userId);
+
       let user: Awaited<ReturnType<typeof UserService.create>>;
-      let created = true;
-      try {
-        user = await UserService.create({
-          id: userId,
-          email: email,
-          firstName: profile.firstName!,
-          lastName: profile.lastName!,
-        });
-      } catch (error: unknown) {
-        const alreadyProvisioned =
-          error instanceof UserServiceError && error.statusCode === 409;
-        if (!alreadyProvisioned) {
-          throw error;
-        }
+      let created = false;
 
-        const existing = await UserService.getById(userId);
-        // A 409 means a row matched on id OR email. If it matched on email
-        // alone the row belongs to a different id, and serving it here would
-        // hand this caller another user's record - rethrow instead.
-        if (!existing) {
-          throw error;
-        }
+      if (provisioned) {
+        user = await reconcileNames(userId, provisioned, profile);
+      } else {
+        try {
+          user = await UserService.create({
+            id: userId,
+            email: email,
+            firstName: profile.firstName!,
+            lastName: profile.lastName!,
+          });
+          created = true;
+        } catch (error: unknown) {
+          const raced =
+            error instanceof UserServiceError && error.statusCode === 409;
+          if (!raced) {
+            throw error;
+          }
 
-        /*
-         * The sync below writes the submitted names into the auth provider
-         * whichever path got here, so the database has to accept them too.
-         * Returning the stored row untouched while pushing new names to the
-         * provider is how `/v1/auth/me` and `/fhir/v1/user/:id` end up
-         * disagreeing about someone's name, with no route back: updateName
-         * no-ops once the database already matches, so nothing later repairs
-         * the divergence. Idempotent by the same token - unchanged names cost
-         * a read.
-         */
-        user =
-          profile.firstName && profile.lastName
-            ? await UserService.updateName({
-                userId,
-                firstName: profile.firstName,
-                lastName: profile.lastName,
-              })
-            : existing;
-        created = false;
+          /*
+           * Lost a race: the lookup above found nothing, but someone inserted
+           * between it and this write. A 409 matches on id OR email, so it does
+           * not prove the row is this caller's - when nothing comes back for
+           * this id the row is someone else's and the conflict stands, rather
+           * than handing over another user's record.
+           */
+          const winner = await UserService.getById(userId);
+          if (!winner) {
+            throw error;
+          }
+          user = await reconcileNames(userId, winner, profile);
+        }
       }
 
       await syncProfileToAuthProvider(userId, profile);

--- a/apps/backend/src/controllers/web/user.controller.ts
+++ b/apps/backend/src/controllers/web/user.controller.ts
@@ -110,16 +110,53 @@ export const UserController = {
 
       const profile = resolveProvisioningProfile(authRequest);
 
-      const user = await UserService.create({
-        id: userId,
-        email: email,
-        firstName: profile.firstName!,
-        lastName: profile.lastName!,
-      });
+      /*
+       * Provisioning is idempotent, and the client already relies on that -
+       * a verification link reopened in a new tab runs this a second time.
+       * It was not: `UserService.create` throws 409 for an existing user and
+       * the catch below returned before the profile sync, so the role reached
+       * the auth provider on the FIRST call and never again. An account whose
+       * role was wrong at sign-up - or absent, from a sign-up that predates the
+       * role being sent - had no way to be corrected, and a developer sign-up
+       * that lost its provisioning call stayed locked out of the portal for good.
+       *
+       * Safe to sync on a repeat call only because the role is now an
+       * allow-list of `developer` and `member`: neither grants anything
+       * server-side (the developer routes authorise on org permissions, not on
+       * this role), so a caller re-asserting one gains no privilege. It would
+       * not have been safe against the old shape check.
+       */
+      let user: Awaited<ReturnType<typeof UserService.create>>;
+      let created = true;
+      try {
+        user = await UserService.create({
+          id: userId,
+          email: email,
+          firstName: profile.firstName!,
+          lastName: profile.lastName!,
+        });
+      } catch (error: unknown) {
+        const alreadyProvisioned =
+          error instanceof UserServiceError && error.statusCode === 409;
+        if (!alreadyProvisioned) {
+          throw error;
+        }
+
+        const existing = await UserService.getById(userId);
+        // A 409 means a row matched on id OR email. If it matched on email
+        // alone the row belongs to a different id, and serving it here would
+        // hand this caller another user's record - rethrow instead.
+        if (!existing) {
+          throw error;
+        }
+
+        user = existing;
+        created = false;
+      }
 
       await syncProfileToAuthProvider(userId, profile);
 
-      res.status(201).json(user);
+      res.status(created ? 201 : 200).json(user);
     } catch (error: unknown) {
       if (error instanceof UserServiceError) {
         res.status(error.statusCode).json({ message: error.message });

--- a/apps/backend/src/routers/auth.router.ts
+++ b/apps/backend/src/routers/auth.router.ts
@@ -42,8 +42,34 @@ router.get("/me", requireAnyAuth, async (req, res: Response, next) => {
     const sessionRoles = (session.roles ?? []).map((role) =>
       role.trim().toLowerCase(),
     );
+    /*
+     * Roles are looked up under `appUserId` - the same key they are WRITTEN
+     * under, and the same one the metadata read below uses.
+     *
+     * This read was the odd one out: `providerUserId` is the RECIPE user id,
+     * and `setUserRole`/`removeUserRole` have only ever written under
+     * `appUserId`. The two coincide for an ordinary account, so the mismatch
+     * was invisible - but not for the two cases this codebase actually
+     * creates:
+     *
+     * - A relinked legacy account. `config/auth-hooks.ts` remaps `appUserId`
+     *   to the legacy id, so a role correction lands under that key while this
+     *   read looked somewhere nothing was ever written. Provisioning answered
+     *   200, the client cleared `pendingSignUp`, and the correction was
+     *   invisible and unrepeatable.
+     * - A linked account. `AccountLinking` is enabled (MultiFactorAuth needs
+     *   it), so the recipe user id can differ from the primary one, and
+     *   SuperTokens keys roles on the primary - which is what `appUserId`
+     *   carries.
+     *
+     * Reading under the write's key is therefore correct or unchanged in every
+     * case, never worse. Note `middlewares/super-admin.ts` still carries the
+     * old expression; it is an authorisation check, and moving it would widen
+     * what that check can find, so it wants its own security review rather
+     * than a ride-along here.
+     */
     const lookupRoles = await authServiceForRouter.getUserRoles(
-      session.providerUserId ?? session.appUserId,
+      session.appUserId,
     );
     const normalizedLookupRoles = lookupRoles.map((role) =>
       role.trim().toLowerCase(),

--- a/apps/backend/src/routers/auth.router.ts
+++ b/apps/backend/src/routers/auth.router.ts
@@ -48,8 +48,27 @@ router.get("/me", requireAnyAuth, async (req, res: Response, next) => {
     const normalizedLookupRoles = lookupRoles.map((role) =>
       role.trim().toLowerCase(),
     );
+    /*
+     * The role store wins over the session claim, not the other way round.
+     *
+     * `st-role` is a copy of the roles taken when the access token was issued;
+     * the store is where a role change lands. Reading the claim first meant a
+     * correction was invisible for the life of the token: provisioning could
+     * move an account from `member` to `developer`, answer 200, and `/me` would
+     * keep serving `member` until the token refreshed or the user signed in
+     * again - so the account stayed routed to the wrong portal with nothing to
+     * show the correction had happened. Role REVOCATION had the same lag, which
+     * is the more serious direction.
+     *
+     * The lookup is not an added cost: it was already awaited above and its
+     * result discarded whenever the claim was non-empty.
+     *
+     * The claim stays the fallback for an empty lookup, which is what a
+     * provider that cannot answer looks like - degrading to the token's copy
+     * beats answering with no role at all.
+     */
     const resolvedRoles =
-      sessionRoles.length > 0 ? sessionRoles : normalizedLookupRoles;
+      normalizedLookupRoles.length > 0 ? normalizedLookupRoles : sessionRoles;
 
     let metadata: Record<string, unknown> = {};
     try {

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import isEmail from "validator/lib/isEmail.js";
+import { Prisma } from "@prisma/client";
 import { User } from "@yosemite-crew/types";
 import { getAuthService } from "@yosemite-crew/auth";
 import { OrganizationService } from "./organization.service";
@@ -184,24 +185,45 @@ export const UserService = {
       );
     }
 
-    const user = await prisma.user.create({
-      data: {
-        userId: attributes.userId,
-        email: attributes.email,
-        firstName: payload.firstName,
-        lastName: payload.lastName,
-        isActive: attributes.isActive,
-      },
-      select: {
-        userId: true,
-        email: true,
-        firstName: true,
-        lastName: true,
-        isActive: true,
-      },
-    });
+    try {
+      const user = await prisma.user.create({
+        data: {
+          userId: attributes.userId,
+          email: attributes.email,
+          firstName: payload.firstName,
+          lastName: payload.lastName,
+          isActive: attributes.isActive,
+        },
+        select: {
+          userId: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          isActive: true,
+        },
+      });
 
-    return toUserDomain(user);
+      return toUserDomain(user);
+    } catch (error) {
+      /*
+       * The check above is a read, so two first-time provisioning calls can
+       * both pass it before either insert lands - two verification tabs, or
+       * the client's own retry. `userId` and `email` are both unique, so the
+       * loser gets a raw P2002 here rather than the 409 the caller expects,
+       * and provisioning fails with a 500 on an account that now exists.
+       * Same conflict, same answer.
+       */
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new UserServiceError(
+          "User with the same id or email already exists.",
+          409,
+        );
+      }
+      throw error;
+    }
   },
 
   async getById(id: unknown): Promise<UserDomain | null> {

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -380,6 +380,35 @@ describe("UserController", () => {
       expect(mockRes.json).toHaveBeenCalledWith(renamed);
     });
 
+    /*
+     * updateName pushes the name to the auth provider before its database
+     * write and does not guard it, so a provider outage would fail a request
+     * whose whole point is to be repeatable. Serve the stored row instead -
+     * both stores untouched, so nothing is left half-applied.
+     */
+    it("stays available when the name reconciliation fails", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const existing = { id: "user-123", firstName: "Old", lastName: "Name" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+      (UserService.updateName as jest.Mock).mockRejectedValue(
+        new Error("metadata provider unavailable"),
+      );
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { firstName: "New", lastName: "Name" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(logger.warn).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(existing);
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -328,28 +328,6 @@ describe("UserController", () => {
       expect(order).toEqual(["set", "remove"]);
     });
 
-    it("keeps the old role when granting the new one fails", async () => {
-      mockAuthService = {
-        updateUserName: mockUpdateUserName,
-        setUserRole: mockSetUserRole.mockRejectedValue(
-          new Error("provider down"),
-        ),
-        removeUserRole: mockRemoveUserRole,
-      };
-      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
-
-      const req = createMockReq({
-        ...validAuthReq,
-        body: { role: "developer" },
-      });
-      await UserController.create(req, mockRes as Response);
-
-      // Nothing was revoked, so the account still has whatever it had.
-      expect(mockRemoveUserRole).not.toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(201);
-    });
-
     /*
      * The sync writes the submitted names to the auth provider on this path
      * too, so the database has to take them as well - otherwise /v1/auth/me
@@ -448,9 +426,13 @@ describe("UserController", () => {
       expect(mockRes.status).toHaveBeenCalledWith(500);
     });
 
-    // The other half: a failure BEFORE anything changed stays absorbed, so a
-    // provider hiccup does not fail a request that had nothing to correct.
-    it("still absorbs a failure that changed nothing", async () => {
+    /*
+     * A failed GRANT is half-applied too. setUserRole is three provider calls -
+     * create the role, attach it, write the metadata - so a rejection can leave
+     * the role already attached with only the metadata outstanding. Treating it
+     * as "nothing changed" is what left both roles on the account.
+     */
+    it("fails the request when granting the role fails", async () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole.mockRejectedValue(
@@ -467,8 +449,52 @@ describe("UserController", () => {
       await UserController.create(req, mockRes as Response);
 
       expect(mockRemoveUserRole).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+    });
+
+    // A name-sync failure carries no such hazard - one provider call, nothing
+    // half-applied - so it stays absorbed and provisioning still succeeds.
+    it("still absorbs a name sync failure", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName.mockRejectedValue(
+          new Error("provider unavailable"),
+        ),
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
       expect(logger.warn).toHaveBeenCalled();
       expect(mockRes.status).toHaveBeenCalledWith(201);
+    });
+
+    /*
+     * Both names resolve, one from the body and one from the session fallback.
+     * Creation accepts exactly this input, so the repeat path has to as well -
+     * rejecting it would make the repeat call stricter than the first.
+     */
+    it("accepts a body name completed by the session fallback", async () => {
+      const existing = { id: "user-123" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq({
+        userId: "user-123",
+        email: "test@example.com",
+        lastName: "SessionLast",
+        body: { firstName: "BodyFirst" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(UserService.updateName).toHaveBeenCalledWith({
+        userId: "user-123",
+        firstName: "BodyFirst",
+        lastName: "SessionLast",
+      });
+      expect(mockRes.status).toHaveBeenCalledWith(200);
     });
 
     /*

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -472,12 +472,22 @@ describe("UserController", () => {
     });
 
     /*
-     * Exactly one name is malformed, not the intentional no-body retry. The
-     * creation path has always rejected it; the repeat path must not read it as
-     * "no names supplied" and answer 200 to a rename that never happened.
+     * Naming the fields at all commits to supplying both. Only their complete
+     * absence is the intentional no-body retry - and `trimmedString` collapses
+     * "", whitespace and non-strings to undefined, so without checking the raw
+     * body an explicitly blank pair would be indistinguishable from an absent
+     * one and answer 200 to a rename it silently refused. Creation has always
+     * rejected every one of these.
      */
-    it.each([{ firstName: "OnlyFirst" }, { lastName: "OnlyLast" }])(
-      "rejects a half-supplied name: %o",
+    it.each([
+      { firstName: "OnlyFirst" },
+      { lastName: "OnlyLast" },
+      { firstName: "", lastName: "" },
+      { firstName: "   ", lastName: "   " },
+      { firstName: 42, lastName: true },
+      { firstName: null, lastName: null },
+    ])(
+      "rejects a name the body offers but does not supply: %o",
       async (body) => {
         (UserService.getById as jest.Mock).mockResolvedValue({
           id: "user-123",

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -281,6 +281,93 @@ describe("UserController", () => {
       );
     });
 
+    /*
+     * The sync is best-effort: a provider failure is logged and the request
+     * still answers 2xx, so the client accepts it and never retries. Revoking
+     * first and then failing would strip the account's only role behind a
+     * success. Granting first means a failure leaves both roles - the state
+     * this replaced, and repaired by the next call.
+     */
+    it("grants the new role before revoking the old one", async () => {
+      const order: string[] = [];
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole.mockImplementation(async () => {
+          order.push("set");
+        }),
+        removeUserRole: mockRemoveUserRole.mockImplementation(async () => {
+          order.push("remove");
+        }),
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(order).toEqual(["set", "remove"]);
+    });
+
+    it("keeps the old role when granting the new one fails", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole.mockRejectedValue(
+          new Error("provider down"),
+        ),
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      // Nothing was revoked, so the account still has whatever it had.
+      expect(mockRemoveUserRole).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+    });
+
+    /*
+     * The sync writes the submitted names to the auth provider on this path
+     * too, so the database has to take them as well - otherwise /v1/auth/me
+     * and /fhir/v1/user/:id disagree about the name with nothing to repair it.
+     */
+    it("updates stored names on a repeat call, not just provider metadata", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const renamed = { id: "user-123", firstName: "New", lastName: "Name" };
+      (UserService.create as jest.Mock).mockRejectedValue(
+        new UserServiceError(
+          "User with the same id or email already exists.",
+          409,
+        ),
+      );
+      (UserService.getById as jest.Mock).mockResolvedValue({ id: "user-123" });
+      (UserService.updateName as jest.Mock).mockResolvedValue(renamed);
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { firstName: "New", lastName: "Name" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(UserService.updateName).toHaveBeenCalledWith({
+        userId: "user-123",
+        firstName: "New",
+        lastName: "Name",
+      });
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(renamed);
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),
@@ -368,6 +455,9 @@ describe("UserController", () => {
         ),
       );
       (UserService.getById as jest.Mock).mockResolvedValue(existing);
+      // The repeat path pushes the submitted names through the service so the
+      // database and the provider cannot drift apart; unchanged names no-op.
+      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
 
       const req = createMockReq({
         ...validAuthReq,

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -81,6 +81,12 @@ describe("UserController", () => {
     (UserService.getById as jest.Mock).mockReset();
     (UserService.updateName as jest.Mock).mockReset();
     (UserService.deleteById as jest.Mock).mockReset();
+    // Same reason for the provider mocks: a mockRejectedValue set in one test
+    // stayed live for every later one, so a test asserting a failure downstream
+    // was silently failing upstream instead and passing for the wrong reason.
+    mockUpdateUserName.mockReset();
+    mockSetUserRole.mockReset();
+    mockRemoveUserRole.mockReset();
     mockRes = createMockRes();
     mockAuthService = null;
     mockResolveCanonicalUserIdImpl = jest.fn(async (value: string) => value);
@@ -386,7 +392,15 @@ describe("UserController", () => {
      * whose whole point is to be repeatable. Serve the stored row instead -
      * both stores untouched, so nothing is left half-applied.
      */
-    it("stays available when the name reconciliation fails", async () => {
+    /*
+     * updateName writes the provider before the database and is not atomic
+     * across the two, so a failure between them leaves the provider holding a
+     * name the database never took - and updateName no-ops once the database
+     * matches, so nothing later repairs it. A 200 over the stored row would
+     * make that permanent and invisible. Failing is safe: the row already
+     * exists, so nothing is stranded, and the retry re-runs the same write.
+     */
+    it("fails the request when the name write fails, rather than reporting success", async () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
@@ -395,7 +409,7 @@ describe("UserController", () => {
       const existing = { id: "user-123", firstName: "Old", lastName: "Name" };
       (UserService.getById as jest.Mock).mockResolvedValue(existing);
       (UserService.updateName as jest.Mock).mockRejectedValue(
-        new Error("metadata provider unavailable"),
+        new Error("write failed midway"),
       );
 
       const req = createMockReq({
@@ -404,9 +418,57 @@ describe("UserController", () => {
       });
       await UserController.create(req, mockRes as Response);
 
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).not.toHaveBeenCalledWith(existing);
+    });
+
+    /*
+     * The half-applied role replacement. Nothing else can repair it:
+     * provisionPendingSignUpUser clears pendingSignUp on any 2xx, so a later
+     * call carries no role and never re-enters this path. It has to reach the
+     * client while the client still holds the role to retry with.
+     */
+    it("fails the request when the stale role cannot be revoked", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole.mockRejectedValue(
+          new Error("provider unavailable"),
+        ),
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockSetUserRole).toHaveBeenCalledWith("user-123", "developer");
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+    });
+
+    // The other half: a failure BEFORE anything changed stays absorbed, so a
+    // provider hiccup does not fail a request that had nothing to correct.
+    it("still absorbs a failure that changed nothing", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole.mockRejectedValue(
+          new Error("provider unavailable"),
+        ),
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRemoveUserRole).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(200);
-      expect(mockRes.json).toHaveBeenCalledWith(existing);
+      expect(mockRes.status).toHaveBeenCalledWith(201);
     });
 
     /*

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -15,6 +15,7 @@ jest.mock("../../../src/utils/logger");
 
 const mockUpdateUserName = jest.fn();
 const mockSetUserRole = jest.fn();
+const mockRemoveUserRole = jest.fn();
 let mockResolveCanonicalUserIdImpl = jest.fn(async (value: string) => value);
 function mockResolveCanonicalUserId(value: string) {
   return mockResolveCanonicalUserIdImpl(value);
@@ -22,6 +23,7 @@ function mockResolveCanonicalUserId(value: string) {
 let mockAuthService: {
   updateUserName: typeof mockUpdateUserName;
   setUserRole: typeof mockSetUserRole;
+  removeUserRole: typeof mockRemoveUserRole;
 } | null = null;
 jest.mock("@yosemite-crew/auth", () => ({
   getAuthService: () => mockAuthService,
@@ -101,6 +103,7 @@ describe("UserController", () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       const mockUser = { id: "user-123" };
       (UserService.create as jest.Mock).mockResolvedValue(mockUser);
@@ -136,6 +139,7 @@ describe("UserController", () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
 
@@ -175,6 +179,7 @@ describe("UserController", () => {
         mockAuthService = {
           updateUserName: mockUpdateUserName,
           setUserRole: mockSetUserRole,
+          removeUserRole: mockRemoveUserRole,
         };
         (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
 
@@ -205,6 +210,7 @@ describe("UserController", () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
 
@@ -220,10 +226,66 @@ describe("UserController", () => {
       expect(mockSetUserRole).toHaveBeenCalledWith("user-123", expected);
     });
 
+    /*
+     * setUserRole ADDS a role. Without clearing the previous one the account
+     * holds both, and /v1/auth/me answers with whichever the role list returns
+     * first - so a correction reports 200 and changes nothing observable.
+     */
+    it("clears the other self-assignable role before setting the new one", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRemoveUserRole).toHaveBeenCalledWith("user-123", "member");
+      // Never the role being set - that would race its own addition.
+      expect(mockRemoveUserRole).not.toHaveBeenCalledWith(
+        "user-123",
+        "developer",
+      );
+      expect(mockSetUserRole).toHaveBeenCalledWith("user-123", "developer");
+    });
+
+    /*
+     * Only the self-assignable roles are cleared. Stripping everything would
+     * revoke superadmin from an admin who did nothing but re-provision a name,
+     * and this endpoint must not revoke a role it cannot grant.
+     */
+    it("leaves roles it cannot grant alone", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "member" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRemoveUserRole).toHaveBeenCalledTimes(1);
+      expect(mockRemoveUserRole).toHaveBeenCalledWith("user-123", "developer");
+      expect(mockRemoveUserRole).not.toHaveBeenCalledWith(
+        "user-123",
+        "superadmin",
+      );
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
 
@@ -296,6 +358,7 @@ describe("UserController", () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       const existing = { id: "user-123", email: "test@example.com" };
       (UserService.create as jest.Mock).mockRejectedValue(
@@ -324,6 +387,7 @@ describe("UserController", () => {
       mockAuthService = {
         updateUserName: mockUpdateUserName,
         setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
       };
       (UserService.create as jest.Mock).mockRejectedValue(
         new UserServiceError(

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -472,14 +472,13 @@ describe("UserController", () => {
     });
 
     /*
-     * Both names resolve, one from the body and one from the session fallback.
-     * Creation accepts exactly this input, so the repeat path has to as well -
-     * rejecting it would make the repeat call stricter than the first.
+     * Half a name in the body, silently completed from the session, is an
+     * ambiguous request answered with a guess - the stored value it gets paired
+     * with may be exactly what the caller meant to replace. Every client sends
+     * both or neither, so refusing this costs nothing real.
      */
-    it("accepts a body name completed by the session fallback", async () => {
-      const existing = { id: "user-123" };
-      (UserService.getById as jest.Mock).mockResolvedValue(existing);
-      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
+    it("refuses a body name completed by the session fallback", async () => {
+      (UserService.getById as jest.Mock).mockResolvedValue({ id: "user-123" });
 
       const req = createMockReq({
         userId: "user-123",
@@ -489,12 +488,57 @@ describe("UserController", () => {
       });
       await UserController.create(req, mockRes as Response);
 
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(UserService.updateName).not.toHaveBeenCalled();
+    });
+
+    // The session fallback still applies when the body says nothing about
+    // names - the repeat call the client actually makes.
+    it("still uses session names when the body omits them entirely", async () => {
+      const existing = { id: "user-123" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
       expect(UserService.updateName).toHaveBeenCalledWith({
         userId: "user-123",
-        firstName: "BodyFirst",
-        lastName: "SessionLast",
+        firstName: "John",
+        lastName: "Doe",
       });
       expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    /*
+     * The name sync and the role correction are isolated. Sharing a catch meant
+     * a failed name sync returned early and skipped the role entirely, while
+     * still answering 2xx - so the client cleared its pending role and the
+     * correction was lost to a failure in the half that can afford to fail.
+     */
+    it("still applies the role when the name sync fails", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName.mockRejectedValue(
+          new Error("provider name write failed"),
+        ),
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.create as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: {
+          firstName: "John",
+          lastName: "Doe",
+          role: "developer",
+        },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(logger.warn).toHaveBeenCalled();
+      expect(mockSetUserRole).toHaveBeenCalledWith("user-123", "developer");
+      expect(mockRes.status).toHaveBeenCalledWith(201);
     });
 
     /*

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -494,20 +494,94 @@ describe("UserController", () => {
 
     // The session fallback still applies when the body says nothing about
     // names - the repeat call the client actually makes.
-    it("still uses session names when the body omits them entirely", async () => {
-      const existing = { id: "user-123" };
+    /*
+     * The session fallback is for CREATION, not for an account that already
+     * exists. Under the cutover grace window the session names come from a
+     * residual token's `given_name`/`family_name` claims, so a token issued
+     * before the user renamed themselves still carries the old pair - and the
+     * no-body retry, which posts nothing precisely because it has nothing to
+     * say, would push those stale claims over the current record.
+     */
+    it("leaves stored names alone when the body omits them, even though the session carries them", async () => {
+      const existing = { id: "user-123", firstName: "Jane", lastName: "Roe" };
       (UserService.getById as jest.Mock).mockResolvedValue(existing);
-      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
 
       const req = createMockReq(validAuthReq);
       await UserController.create(req, mockRes as Response);
 
+      expect(UserService.updateName).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(existing);
+    });
+
+    // The provider sync has to take the same pair the database did; pushing
+    // session names it declined to store is the divergence `/v1/auth/me` and
+    // `/fhir/v1/user/:id` then report differently, with nothing to repair it.
+    it("does not push session names to the provider for an existing account", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.getById as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockUpdateUserName).not.toHaveBeenCalled();
+    });
+
+    it("updates names on a repeat call when the body supplies both", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const existing = { id: "user-123" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+      (UserService.updateName as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { firstName: "Ada", lastName: "Lovelace" },
+      });
+      await UserController.create(req, mockRes as Response);
+
       expect(UserService.updateName).toHaveBeenCalledWith({
         userId: "user-123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+      });
+      expect(mockUpdateUserName).toHaveBeenCalledWith("user-123", {
+        firstName: "Ada",
+        lastName: "Lovelace",
+      });
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    // Creation is the one place the fallback belongs: there is no stored name
+    // to overwrite, and refusing here would block a legitimate sign-up.
+    it("still uses session names when creating a new account", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const created = { id: "user-123" };
+      (UserService.getById as jest.Mock).mockResolvedValue(null);
+      (UserService.create as jest.Mock).mockResolvedValue(created);
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
+      expect(UserService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: "John", lastName: "Doe" }),
+      );
+      expect(mockUpdateUserName).toHaveBeenCalledWith("user-123", {
         firstName: "John",
         lastName: "Doe",
       });
-      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.status).toHaveBeenCalledWith(201);
     });
 
     /*

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -470,6 +470,37 @@ describe("UserController", () => {
       expect(mockRes.status).toHaveBeenCalledWith(200);
     });
 
+    /*
+     * A rejected name is the caller's problem, not an outage. Swallowing it
+     * would answer 200 to a rename the service refused, and let the sync push
+     * the refused name into the provider anyway - while creation rejects the
+     * same payload outright.
+     */
+    it("propagates a rejected name instead of reporting success", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      (UserService.getById as jest.Mock).mockResolvedValue({ id: "user-123" });
+      (UserService.updateName as jest.Mock).mockRejectedValue(
+        new UserServiceError("First name is invalid.", 400),
+      );
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { firstName: "$bad", lastName: "Name" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: "First name is invalid.",
+      });
+      // The refused name must not reach the provider either.
+      expect(mockUpdateUserName).not.toHaveBeenCalled();
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -409,6 +409,67 @@ describe("UserController", () => {
       expect(mockRes.json).toHaveBeenCalledWith(existing);
     });
 
+    /*
+     * Exactly one name is malformed, not the intentional no-body retry. The
+     * creation path has always rejected it; the repeat path must not read it as
+     * "no names supplied" and answer 200 to a rename that never happened.
+     */
+    it.each([{ firstName: "OnlyFirst" }, { lastName: "OnlyLast" }])(
+      "rejects a half-supplied name: %o",
+      async (body) => {
+        (UserService.getById as jest.Mock).mockResolvedValue({
+          id: "user-123",
+        });
+
+        const req = createMockReq({
+          userId: "user-123",
+          email: "test@example.com",
+          body,
+        });
+        await UserController.create(req, mockRes as Response);
+
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(UserService.updateName).not.toHaveBeenCalled();
+        expect(UserService.create).not.toHaveBeenCalled();
+      },
+    );
+
+    /*
+     * deleteById is a soft delete - isActive goes false and the row stays, while
+     * the profile, availability and organisation records around it are really
+     * gone. Answering 200 here would report success over a hollow identity.
+     */
+    it("refuses to provision over a deleted account", async () => {
+      (UserService.getById as jest.Mock).mockResolvedValue({
+        id: "user-123",
+        isActive: false,
+      });
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(409);
+      expect(UserService.create).not.toHaveBeenCalled();
+      expect(UserService.updateName).not.toHaveBeenCalled();
+      expect(mockSetUserRole).not.toHaveBeenCalled();
+    });
+
+    it("provisions normally for an active account", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const active = { id: "user-123", isActive: true };
+      (UserService.getById as jest.Mock).mockResolvedValue(active);
+      (UserService.updateName as jest.Mock).mockResolvedValue(active);
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
     it("never blocks creation on an auth provider sync failure", async () => {
       mockAuthService = {
         updateUserName: jest.fn().mockRejectedValue(new Error("provider down")),

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -266,17 +266,96 @@ describe("UserController", () => {
       expect(UserService.create).not.toHaveBeenCalled();
     });
 
-    it("should return specific status code if UserServiceError is thrown", async () => {
+    /*
+     * A 409 matches on id OR email. When no row comes back for THIS id the
+     * conflict was on the email, so the row belongs to someone else - serving
+     * it would hand this caller another user's record. Still a 409.
+     */
+    it("still returns 409 when the conflicting row is not this user's", async () => {
       // Now using the real class which the controller also uses
       (UserService.create as jest.Mock).mockRejectedValue(
         new UserServiceError("Conflict", 409),
       );
+      (UserService.getById as jest.Mock).mockResolvedValue(null);
 
       const req = createMockReq(validAuthReq);
       await UserController.create(req, mockRes as Response);
 
       expect(mockRes.status).toHaveBeenCalledWith(409);
       expect(mockRes.json).toHaveBeenCalledWith({ message: "Conflict" });
+      expect(mockSetUserRole).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The point of making this idempotent: an account provisioned before the
+     * role was sent, or with the wrong one, had no way back - the 409 returned
+     * before the sync ran, so the role was whatever the first call happened to
+     * set. A repeat call now corrects it.
+     */
+    it("syncs the role on a repeat call and returns the existing user", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+      };
+      const existing = { id: "user-123", email: "test@example.com" };
+      (UserService.create as jest.Mock).mockRejectedValue(
+        new UserServiceError(
+          "User with the same id or email already exists.",
+          409,
+        ),
+      );
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "developer" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockSetUserRole).toHaveBeenCalledWith("user-123", "developer");
+      // 200, not 201: nothing was created this time.
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(existing);
+    });
+
+    // The allow-list is what makes the repeat call safe, so it has to hold on
+    // this path too - not only on first provisioning.
+    it("still refuses a privileged role on a repeat call", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+      };
+      (UserService.create as jest.Mock).mockRejectedValue(
+        new UserServiceError(
+          "User with the same id or email already exists.",
+          409,
+        ),
+      );
+      (UserService.getById as jest.Mock).mockResolvedValue({ id: "user-123" });
+
+      const req = createMockReq({
+        ...validAuthReq,
+        body: { role: "superadmin" },
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockSetUserRole).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    // A non-409 UserServiceError is not "already provisioned" and must not be
+    // rewritten into a success.
+    it("passes a non-409 UserServiceError straight through", async () => {
+      (UserService.create as jest.Mock).mockRejectedValue(
+        new UserServiceError("Invalid user id", 400),
+      );
+
+      const req = createMockReq(validAuthReq);
+      await UserController.create(req, mockRes as Response);
+
+      expect(UserService.getById).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({ message: "Invalid user id" });
     });
 
     it("should return 500 and log error on generic exception", async () => {

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -502,6 +502,51 @@ describe("UserController", () => {
      * no-body retry, which posts nothing precisely because it has nothing to
      * say, would push those stale claims over the current record.
      */
+    /*
+     * A residual token can carry `given_name` without `family_name` - the
+     * verifier maps the two claims independently. The no-body retry asks for no
+     * rename at all, and its session names are ignored for an existing account,
+     * so refusing it over a lopsided token it never referred to would break the
+     * exact idempotency this endpoint exists to provide.
+     */
+    it.each([
+      ["only a session first name", { firstName: "John" }],
+      ["only a session last name", { lastName: "Doe" }],
+    ])("serves the no-body retry with %s", async (_label, sessionNames) => {
+      const existing = { id: "user-123" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq({
+        userId: "user-123",
+        email: "test@example.com",
+        ...sessionNames,
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(existing);
+      expect(UserService.updateName).not.toHaveBeenCalled();
+    });
+
+    // Creation still needs both: `UserService.create` requires them, so a
+    // one-sided pair cannot become a row.
+    it.each([
+      ["only a session first name", { firstName: "John" }],
+      ["only a session last name", { lastName: "Doe" }],
+    ])("refuses to CREATE from %s", async (_label, sessionNames) => {
+      (UserService.getById as jest.Mock).mockResolvedValue(null);
+
+      const req = createMockReq({
+        userId: "user-123",
+        email: "test@example.com",
+        ...sessionNames,
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(UserService.create).not.toHaveBeenCalled();
+    });
+
     it("leaves stored names alone when the body omits them, even though the session carries them", async () => {
       const existing = { id: "user-123", firstName: "Jane", lastName: "Roe" };
       (UserService.getById as jest.Mock).mockResolvedValue(existing);

--- a/apps/backend/test/controllers/web/user.controller.test.ts
+++ b/apps/backend/test/controllers/web/user.controller.test.ts
@@ -69,6 +69,18 @@ describe("UserController", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    /*
+     * clearAllMocks resets calls but NOT implementations, so a mockResolvedValue
+     * set in one test leaked into every later one. That was invisible while
+     * nothing read these on the default path; `create` now looks the user up
+     * first, so a leaked `getById` silently turned a creation test into a
+     * repeat-provisioning test. Reset the service mocks outright and let each
+     * test state its own starting point.
+     */
+    (UserService.create as jest.Mock).mockReset();
+    (UserService.getById as jest.Mock).mockReset();
+    (UserService.updateName as jest.Mock).mockReset();
+    (UserService.deleteById as jest.Mock).mockReset();
     mockRes = createMockRes();
     mockAuthService = null;
     mockResolveCanonicalUserIdImpl = jest.fn(async (value: string) => value);
@@ -507,9 +519,42 @@ describe("UserController", () => {
       const req = createMockReq(validAuthReq);
       await UserController.create(req, mockRes as Response);
 
-      expect(UserService.getById).not.toHaveBeenCalled();
+      /*
+       * Once for the up-front "is this already provisioned" lookup, and no
+       * more: only a 409 triggers the race recovery, so a 400 must not be
+       * quietly converted into a repeat-provisioning success.
+       */
+      expect(UserService.getById).toHaveBeenCalledTimes(1);
       expect(mockRes.status).toHaveBeenCalledWith(400);
       expect(mockRes.json).toHaveBeenCalledWith({ message: "Invalid user id" });
+    });
+
+    /*
+     * The repeat call the client actually makes: once `pendingSignUp` is gone
+     * it posts no body, and the session carries no names either. Create would
+     * reject that on name validation before ever looking for the existing row,
+     * so the lookup has to come first or provisioning can never be repeated.
+     */
+    it("serves a repeat call that carries no names at all", async () => {
+      mockAuthService = {
+        updateUserName: mockUpdateUserName,
+        setUserRole: mockSetUserRole,
+        removeUserRole: mockRemoveUserRole,
+      };
+      const existing = { id: "user-123", email: "test@example.com" };
+      (UserService.getById as jest.Mock).mockResolvedValue(existing);
+
+      const req = createMockReq({
+        userId: "user-123",
+        email: "test@example.com",
+      });
+      await UserController.create(req, mockRes as Response);
+
+      expect(UserService.create).not.toHaveBeenCalled();
+      // Nothing to write, so the stored names are left alone rather than cleared.
+      expect(UserService.updateName).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(existing);
     });
 
     it("should return 500 and log error on generic exception", async () => {

--- a/apps/backend/test/routers/auth.router.test.ts
+++ b/apps/backend/test/routers/auth.router.test.ts
@@ -8,12 +8,15 @@ const requireAnyAuth = jest.fn(
 );
 const mockSignOut = jest.fn();
 const mockGetUserRoles = jest.fn();
+const mockGetUserMetadata = jest.fn();
 let mockService: {
   signOut: typeof mockSignOut;
   getUserRoles: typeof mockGetUserRoles;
+  getUserMetadata: typeof mockGetUserMetadata;
 } | null = {
   signOut: mockSignOut,
   getUserRoles: mockGetUserRoles,
+  getUserMetadata: mockGetUserMetadata,
 };
 
 jest.mock("@yosemite-crew/auth", () => ({
@@ -94,7 +97,17 @@ const makeRes = () => {
 describe("auth.router", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockService = { signOut: mockSignOut, getUserRoles: mockGetUserRoles };
+    // `clearAllMocks` drops calls but keeps implementations, so a resolved
+    // value set by one test would leak into the next. Reset and re-establish
+    // the neutral default explicitly.
+    mockGetUserRoles.mockReset();
+    mockGetUserMetadata.mockReset();
+    mockGetUserMetadata.mockResolvedValue({});
+    mockService = {
+      signOut: mockSignOut,
+      getUserRoles: mockGetUserRoles,
+      getUserMetadata: mockGetUserMetadata,
+    };
   });
 
   it("exposes the normalized /me and /logout routes", () => {
@@ -154,6 +167,97 @@ describe("auth.router", () => {
       role: "superadmin",
     });
     expect(mockGetUserRoles).toHaveBeenCalledWith("st-user-1");
+  });
+
+  describe("GET /me role resolution", () => {
+    const meHandler = () =>
+      handlerFor("/me", "get") as (
+        req: Request,
+        res: Response,
+      ) => Promise<void>;
+
+    const meFor = async (session: Record<string, unknown>) => {
+      const res = makeRes();
+      await meHandler()(
+        { authSession: session } as unknown as Request,
+        res as unknown as Response,
+      );
+      return res;
+    };
+
+    const sessionWith = (roles: string[]) => ({
+      appUserId: "u1",
+      providerUserId: "st-user-1",
+      authProfile: "pims_web",
+      loginMethod: "emailpassword",
+      email: "vet@clinic.test",
+      roles,
+    });
+
+    /*
+     * The defect this PR exists to fix, seen from the read side: provisioning
+     * moves the account to `developer` in the role store, but the live session's
+     * access token still carries the `member` it was issued with. Preferring the
+     * claim kept the portal routing on the stale value.
+     */
+    it("prefers a corrected role from the store over a stale session claim", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["developer"]);
+
+      const res = await meFor(sessionWith(["member"]));
+
+      expect(res.body).toMatchObject({ role: "developer" });
+    });
+
+    it("reflects a revoked role without waiting for the token to refresh", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["member"]);
+
+      const res = await meFor(sessionWith(["superadmin"]));
+
+      expect(res.body).toMatchObject({ role: "member" });
+    });
+
+    it("still prefers superadmin when the store returns it among others", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["member", "superadmin"]);
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ role: "superadmin" });
+    });
+
+    it("normalizes case and surrounding whitespace from the store", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["  Developer  "]);
+
+      const res = await meFor(sessionWith(["member"]));
+
+      expect(res.body).toMatchObject({ role: "developer" });
+    });
+
+    // An empty lookup is what a provider that cannot answer looks like;
+    // the token's copy beats serving no role at all.
+    it("falls back to the session claim when the store returns nothing", async () => {
+      mockGetUserRoles.mockResolvedValueOnce([]);
+
+      const res = await meFor(sessionWith(["member"]));
+
+      expect(res.body).toMatchObject({ role: "member" });
+    });
+
+    it("falls back to provider metadata when neither source has a role", async () => {
+      mockGetUserRoles.mockResolvedValueOnce([]);
+      mockGetUserMetadata.mockResolvedValueOnce({ role: "developer" });
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ role: "developer" });
+    });
+
+    it("reports no role when no source has one", async () => {
+      mockGetUserRoles.mockResolvedValueOnce([]);
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ role: undefined });
+    });
   });
 
   it("revokes the session on POST /logout", async () => {

--- a/apps/backend/test/routers/auth.router.test.ts
+++ b/apps/backend/test/routers/auth.router.test.ts
@@ -166,7 +166,9 @@ describe("auth.router", () => {
       emailVerified: true,
       role: "superadmin",
     });
-    expect(mockGetUserRoles).toHaveBeenCalledWith("st-user-1");
+    // Looked up under appUserId - the key roles are written under - not the
+    // recipe user id the session also carries.
+    expect(mockGetUserRoles).toHaveBeenCalledWith("u1");
   });
 
   describe("GET /me role resolution", () => {
@@ -248,6 +250,28 @@ describe("auth.router", () => {
 
       const res = await meFor(sessionWith([]));
 
+      expect(res.body).toMatchObject({ role: "developer" });
+    });
+
+    /*
+     * The write side (`setUserRole`/`removeUserRole`) keys on `appUserId`, so
+     * the read has to as well. They coincide for an ordinary account, which is
+     * what hid this: a relinked legacy account has `appUserId` remapped by
+     * `auth-hooks.ts`, and a linked account has a recipe id distinct from the
+     * primary one SuperTokens keys roles on. Reading under `providerUserId`
+     * looked somewhere the correction was never written.
+     */
+    it("looks roles up under the id they are written under, not the recipe id", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["developer"]);
+
+      const res = await meFor({
+        appUserId: "legacy-app-id",
+        providerUserId: "st-recipe-id",
+        roles: ["member"],
+      });
+
+      expect(mockGetUserRoles).toHaveBeenCalledWith("legacy-app-id");
+      expect(mockGetUserRoles).not.toHaveBeenCalledWith("st-recipe-id");
       expect(res.body).toMatchObject({ role: "developer" });
     });
 

--- a/apps/backend/test/services/user.service.test.ts
+++ b/apps/backend/test/services/user.service.test.ts
@@ -54,6 +54,7 @@ jest.mock("src/services/user-organization.service", () => ({
   },
 }));
 
+import { Prisma } from "@prisma/client";
 import { UserService, UserServiceError } from "src/services/user.service";
 
 describe("UserService", () => {
@@ -123,6 +124,51 @@ describe("UserService", () => {
       message: "User with the same id or email already exists.",
       statusCode: 409,
     });
+  });
+
+  /*
+   * The duplicate check above is a read, so two first-time provisioning calls
+   * can both pass it before either insert lands - two verification tabs, or the
+   * client's own retry. `userId` and `email` are unique, so the loser gets a
+   * P2002 from the insert. Same conflict as the read found, so it has to
+   * surface the same way, or provisioning 500s on an account that now exists.
+   */
+  it("maps a concurrent insert conflict to the same 409", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    const conflict = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed",
+      { code: "P2002", clientVersion: "5.22.0" },
+    );
+    mockPrisma.user.create.mockRejectedValue(conflict);
+
+    await expect(
+      UserService.create({
+        id: "user-321",
+        email: "person@example.com",
+        firstName: "First",
+        lastName: "Last",
+        isActive: true,
+      }),
+    ).rejects.toMatchObject({
+      message: "User with the same id or email already exists.",
+      statusCode: 409,
+    });
+  });
+
+  it("rethrows a non-conflict database error untouched", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    const boom = new Error("connection lost");
+    mockPrisma.user.create.mockRejectedValue(boom);
+
+    await expect(
+      UserService.create({
+        id: "user-321",
+        email: "person@example.com",
+        firstName: "First",
+        lastName: "Last",
+        isActive: true,
+      }),
+    ).rejects.toBe(boom);
   });
 
   it("returns the existing user by id", async () => {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "test": "node --test \"dist/src/**/*.test.js\"",
+    "test": "pnpm run build && node --test \"dist/src/**/*.test.js\"",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
+    "test": "node --test \"dist/src/**/*.test.js\"",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/auth/src/auth-provider.ts
+++ b/packages/auth/src/auth-provider.ts
@@ -22,5 +22,7 @@ export interface AuthProvider {
 
   setUserRole?(appUserId: string, role: string): Promise<void>;
 
+  removeUserRole?(appUserId: string, role: string): Promise<void>;
+
   deleteUser?(appUserId: string): Promise<void>;
 }

--- a/packages/auth/src/auth-service.test.ts
+++ b/packages/auth/src/auth-service.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AuthService } from './auth-service.js';
+import type { AuthProvider } from './auth-provider.js';
+import type { AuthSession, RequestContext } from './types.js';
+
+type Call = { method: string; args: unknown[] };
+
+// The four members every provider must implement. The admin capabilities are
+// optional by design, so each test adds back only the ones it is about - which
+// is what makes the "provider omits it" cases below expressible at all.
+function baseProvider(calls: Call[]): AuthProvider {
+  return {
+    name: 'supertokens',
+    async getSession(ctx: RequestContext) {
+      calls.push({ method: 'getSession', args: [ctx] });
+      return null;
+    },
+    async requireSession() {
+      throw new Error('not used');
+    },
+    async signOut(ctx: RequestContext) {
+      calls.push({ method: 'signOut', args: [ctx] });
+    },
+  };
+}
+
+test('removeUserRole forwards the user id and role to the provider', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService({
+    ...baseProvider(calls),
+    async removeUserRole(appUserId: string, role: string) {
+      calls.push({ method: 'removeUserRole', args: [appUserId, role] });
+    },
+  });
+
+  await service.removeUserRole('user-123', 'member');
+
+  assert.deepEqual(calls, [{ method: 'removeUserRole', args: ['user-123', 'member'] }]);
+});
+
+/*
+ * The delegations use optional chaining, so a provider that does not implement
+ * removeUserRole makes this resolve rather than throw. That is deliberate - it
+ * is what lets product code stay provider-neutral - but it means a role
+ * replacement can half-apply in total silence: the grant lands, the revoke
+ * evaporates, and the caller still sees a fulfilled promise. Pinned here so the
+ * no-op stays a decision rather than becoming an accident.
+ */
+test('removeUserRole is a silent no-op when the provider omits it', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService(baseProvider(calls));
+
+  await assert.doesNotReject(() => service.removeUserRole('user-123', 'member'));
+  assert.deepEqual(calls, []);
+});
+
+test('setUserRole forwards the user id and role to the provider', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService({
+    ...baseProvider(calls),
+    async setUserRole(appUserId: string, role: string) {
+      calls.push({ method: 'setUserRole', args: [appUserId, role] });
+    },
+  });
+
+  await service.setUserRole('user-123', 'developer');
+
+  assert.deepEqual(calls, [{ method: 'setUserRole', args: ['user-123', 'developer'] }]);
+});
+
+test('setUserRole is a silent no-op when the provider omits it', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService(baseProvider(calls));
+
+  await assert.doesNotReject(() => service.setUserRole('user-123', 'developer'));
+  assert.deepEqual(calls, []);
+});
+
+/*
+ * Grant and revoke are separate provider calls, so a replacement is only
+ * correct if both carry the same user id. Asserting the pair together catches
+ * a divergence that either call passing on its own would hide.
+ */
+test('a role replacement grants and revokes against the same user id', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService({
+    ...baseProvider(calls),
+    async setUserRole(appUserId: string, role: string) {
+      calls.push({ method: 'setUserRole', args: [appUserId, role] });
+    },
+    async removeUserRole(appUserId: string, role: string) {
+      calls.push({ method: 'removeUserRole', args: [appUserId, role] });
+    },
+  });
+
+  await service.setUserRole('user-123', 'developer');
+  await service.removeUserRole('user-123', 'member');
+
+  assert.deepEqual(calls, [
+    { method: 'setUserRole', args: ['user-123', 'developer'] },
+    { method: 'removeUserRole', args: ['user-123', 'member'] },
+  ]);
+});
+
+test('a provider failure propagates rather than being absorbed', async () => {
+  const service = new AuthService({
+    ...baseProvider([]),
+    async removeUserRole() {
+      throw new Error('provider unavailable');
+    },
+  });
+
+  await assert.rejects(() => service.removeUserRole('user-123', 'member'), /provider unavailable/);
+});
+
+test('getUserRoles defaults to the public tenant and passes an explicit one through', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService({
+    ...baseProvider(calls),
+    async getUserRoles(appUserId: string, tenantId: string) {
+      calls.push({ method: 'getUserRoles', args: [appUserId, tenantId] });
+      return ['developer'];
+    },
+  });
+
+  assert.deepEqual(await service.getUserRoles('user-123'), ['developer']);
+  await service.getUserRoles('user-123', 'tenant-a');
+
+  assert.deepEqual(calls, [
+    { method: 'getUserRoles', args: ['user-123', 'public'] },
+    { method: 'getUserRoles', args: ['user-123', 'tenant-a'] },
+  ]);
+});
+
+test('getUserRoles answers with no roles when the provider omits it', async () => {
+  const service = new AuthService(baseProvider([]));
+
+  assert.deepEqual(await service.getUserRoles('user-123'), []);
+});
+
+test('getUserMetadata answers with an empty object when the provider omits it', async () => {
+  const service = new AuthService(baseProvider([]));
+
+  assert.deepEqual(await service.getUserMetadata('user-123'), {});
+});
+
+test('updateUserName forwards both names to the provider', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService({
+    ...baseProvider(calls),
+    async updateUserName(appUserId: string, name: { firstName: string; lastName: string }) {
+      calls.push({ method: 'updateUserName', args: [appUserId, name] });
+    },
+  });
+
+  await service.updateUserName('user-123', { firstName: 'Ada', lastName: 'Lovelace' });
+
+  assert.deepEqual(calls, [
+    { method: 'updateUserName', args: ['user-123', { firstName: 'Ada', lastName: 'Lovelace' }] },
+  ]);
+});
+
+test('providerName reports the configured provider', () => {
+  const service = new AuthService(baseProvider([]));
+
+  assert.equal(service.providerName, 'supertokens');
+});
+
+test('session reads and sign-out reach the provider with the request context', async () => {
+  const calls: Call[] = [];
+  const service = new AuthService(baseProvider(calls));
+  const ctx = { req: {}, res: {} } as unknown as RequestContext;
+
+  const session: AuthSession | null = await service.getSession(ctx);
+  await service.signOut(ctx);
+
+  assert.equal(session, null);
+  assert.deepEqual(
+    calls.map((call) => call.method),
+    ['getSession', 'signOut']
+  );
+});

--- a/packages/auth/src/auth-service.ts
+++ b/packages/auth/src/auth-service.ts
@@ -41,6 +41,10 @@ export class AuthService {
     await this.provider.setUserRole?.(appUserId, role);
   }
 
+  async removeUserRole(appUserId: string, role: string): Promise<void> {
+    await this.provider.removeUserRole?.(appUserId, role);
+  }
+
   async deleteUser(appUserId: string): Promise<void> {
     await this.provider.deleteUser?.(appUserId);
   }

--- a/packages/auth/src/providers/supertokens/supertokens-provider.ts
+++ b/packages/auth/src/providers/supertokens/supertokens-provider.ts
@@ -210,6 +210,19 @@ export class SuperTokensAuthProvider implements AuthProvider {
     await UserMetadata.updateUserMetadata(appUserId, { role });
   }
 
+  /**
+   * Takes one role off the user. Paired with `setUserRole`, which ADDS: a
+   * caller correcting a role has to drop the previous one itself, or the user
+   * ends up holding both and `/v1/auth/me` answers with whichever the role
+   * list happens to return first.
+   *
+   * Removing a role the user does not have is a no-op, not an error, so the
+   * caller need not read the current roles first.
+   */
+  async removeUserRole(appUserId: string, role: string): Promise<void> {
+    await UserRoles.removeUserRole(DEFAULT_TENANT_ID, appUserId, role);
+  }
+
   async deleteUser(appUserId: string): Promise<void> {
     await SuperTokens.deleteUser(appUserId);
   }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`POST /fhir/v1/user` provisions the application user after sign-up. `UserService.create` throws **409** for an existing user, and the controller's catch returned before `syncProfileToAuthProvider` ever ran:

```js
const user = await UserService.create({...});      // ← 409 for an existing user
await syncProfileToAuthProvider(userId, profile);  // ← never reached
```

`setUserRole` has exactly one call site, inside that sync. So a role reached the auth provider on the **first** provisioning call and never again, and there is no other route to it anywhere in the API.

The client already assumes this write is idempotent — `provisionBackendUser` retries it with backoff, and a verification link reopened in a new tab runs it a second time by design. It was the only caller relying on a property the endpoint did not have.

Two separate defects on the read side meant that even once a role *was* corrected, `/v1/auth/me` would not report it: it preferred the session's `st-role` claim over the role store, and it looked the store up under a different id than the one roles are written under.

## What is the new behavior?

### Writing the role — provisioning is idempotent

A 409 is treated as *already provisioned* rather than a failure: the user is looked up, names are reconciled, the role is applied, and the existing record is returned with **200**.

The lookup happens **before** `UserService.create`, not after it rejects. `create` validates first and last name before checking for an existing row, and a repeat call routinely carries neither — once `pendingSignUp` is gone the client posts no body at all. Going through `create` answered 400 to a request whose only fault was being already done, so the recovery could never be reached by the request that needed it.

Cases deliberately preserved:

- **A 409 on email rather than id.** `create` matches on `userId OR email`, so a conflict does not prove the row is the caller's. When the lookup returns nothing for this id the 409 stands — returning it would hand over another user's record.
- **A soft-deleted account.** `deleteById` sets `isActive: false` and keeps the row while really removing the profile, availability and organisation records. Provisioning refuses it rather than reporting success over a hollow identity.

### Names

Two rules, separated by what each is for — collapsing them produced two defects during review:

- **A body mentioning either name must supply both**, judged on the raw body before anything else. That is a client error whatever the account's state. Reading the raw body matters because `trimmedString` collapses `""`, whitespace and non-strings to `undefined`, so an explicitly blank pair would otherwise be indistinguishable from an absent one.
- **A complete pair is required only to CREATE**, and only once the lookup has shown this is a creation.

An **existing** account is reconciled only against what the body supplied; the session fallback belongs to creation alone. Under the cutover grace window (`AUTH_LEGACY_TOKEN_GRACE=true`) the legacy Cognito verifier fills the session names from a residual token's `given_name`/`family_name` claims, and it maps the two claims independently. So:

- a token issued before the user renamed themselves carries the old pair, and the no-body retry would have pushed those stale claims over the current record;
- a token carrying only one of the two would have made that same retry fail its paired-name check and return 400 — the PR's own bug, reintroduced one gate earlier.

The database write and the provider sync take the same pair either way; letting them diverge is what leaves `/v1/auth/me` and `/fhir/v1/user/:id` reporting different names with nothing to repair it.

### Reading the role — `/me` had to change twice

**It consulted the token, not the store.**

```diff
-const resolvedRoles = sessionRoles.length > 0 ? sessionRoles : normalizedLookupRoles;
+const resolvedRoles = normalizedLookupRoles.length > 0 ? normalizedLookupRoles : sessionRoles;
```

`st-role` is a copy of the roles taken when the access token was issued; the store is where a role change lands. Reading the claim first meant provisioning could move an account from `member` to `developer`, answer 200, and `/me` would keep serving `member` until the token refreshed. Revocation had the same lag, which is the more serious direction: removing `superadmin` took effect only at the next refresh.

This is not an added cost — `getUserRoles` was **already awaited unconditionally**, and its result discarded whenever the claim was non-empty. An empty lookup still falls back to the claim.

**And it consulted the store under the wrong key.** The lookup used `providerUserId ?? appUserId`, while `setUserRole`/`removeUserRole` have only ever written under `appUserId` — as did the `getUserMetadata` call four lines below it. The ids coincide for an ordinary account, which is what hid it:

| account | `appUserId` | `providerUserId` |
|---|---|---|
| ordinary | primary ✅ | same value ✅ |
| linked (MFA) | primary ✅ | recipe id ❌ |
| relinked legacy | legacy id | recipe id — nothing written here |

A relinked legacy account has `appUserId` remapped by `config/auth-hooks.ts`, so the correction landed under the legacy key while the read looked where nothing was written — and because provisioning still answered 200, the client cleared `pendingSignUp`, making it **unrepeatable**. A linked account (account linking is on, MultiFactorAuth requires it) has a recipe id distinct from the primary one SuperTokens keys roles on. Reading under the write's key is correct or unchanged in every row and never worse, since no path here has written a role under the recipe id.

### Partial-failure semantics

The provider sync is best-effort by design, but not uniformly — the distinction is whether a failure can leave state changed:

- **Name sync** — absorbed and logged. One provider call, nothing half-done, and the database holds the authoritative copy.
- **Role replacement** — propagated. `setUserRole` is three provider calls and `removeUserRole` a fourth, so any rejection may leave the role attached, the metadata stale, or both roles present. Nothing repairs that later: `provisionPendingSignUpUser` clears `pendingSignUp` on any 2xx, so a subsequent call carries no role and never re-enters the path.
- **Name persistence** — propagated. `UserService.updateName` writes the provider before the database and is not atomic across the two.

`applyRole` grants before revoking, so a failure leaves both roles rather than none, and clears only the self-assignable roles — stripping everything would revoke `superadmin` from an admin who did nothing but re-provision a name.

### Test coverage for the auth boundary

`removeUserRole` reached `AuthService` with no test of its own. `packages/auth` now has a suite following the `node --test` pattern `packages/database` already uses — no jest, no new dependency, and no workflow change, since `affected-matrix.mjs` derives `has_test` from `Boolean(scripts.test)` and `_test.yaml` already carries a non-jest runner step.

The case most worth pinning: the delegations use optional chaining, so a provider that omits `removeUserRole` makes the call *resolve rather than throw* — a replacement half-applies while the caller sees a fulfilled promise.

The script builds before invoking the runner. An unmatched glob reaches Node as zero inputs and exits 0, so on a fresh checkout — where `dist/` does not exist and `turbo`'s `dependsOn: ["^build"]` builds dependencies rather than the package itself — the suite would have reported success having executed nothing.

## Scope: what this does not do

**It does not give the product a way to repair historical accounts.** `pendingSignUp` is written only inside `signUp` after a successful *new* sign-up and cleared on any 2xx; `provisionBackendUser` sends no body without it. So for an already-provisioned account with a missing or wrong role, no UI path posts a role — the request reaches the repeat branch with `profile.role` undefined and skips `applyRole`.

What this PR delivers is that the endpoint now *accepts* a corrective role for an existing account, which an API caller can use. Repairing accounts through the product needs a deliberate flow (a "convert to developer account" action, or preserving the intended role past sign-up) — a product decision, not something to infer inside a provisioning fix.

**Known limits, not addressed:**

- **Two concurrency races, left together on purpose.** Overlapping provisioning calls with opposing *roles* can interleave grant/revoke and leave neither, and overlapping calls with different *names* can leave Prisma holding one pair while the provider holds the other — both answering 2xx. Each needs per-user serialisation or a version-conditional provider write, which means a locking primitive this codebase does not have. Fixing one and not the other would leave two adjacent operations with different concurrency guarantees, which is worse than two with the same documented limit. Both windows require the same user's own client to post *differing* payloads within the overlap.
- **`middlewares/super-admin.ts:29` still resolves roles as `providerUserId ?? appUserId`** — the same mismatch fixed in `/me`. Left deliberately: it is an authorisation check, so moving it changes what that check can find, in the permissive direction. It wants its own security review rather than a ride-along here.
- `AuthService` delegation is covered; the SuperTokens adapter's own call into `UserRoles.removeUserRole` would need SDK module mocking.

## Validation performed

- `apps/backend` — full suite **10,905 passing**. The single failure is `email.test.ts`, from AWS credentials injected by the sandbox proxy; confirmed failing identically on a stashed clean tree.
- `packages/auth` — **12 passing** via `node --test`, verified from a deleted `dist/`.
- Mutation-checked rather than assumed green. Each fix was reverted in place to confirm the tests fail for the right reason:
  - reverting the `/me` claim-vs-store precedence fails exactly three;
  - restoring `providerUserId ?? appUserId` in `/me` fails exactly two;
  - swapping the argument order in the `removeUserRole` delegation fails exactly two;
  - reverting the existing-account names to the resolved profile fails exactly two;
  - restoring the pre-lookup paired-name gate fails exactly two.
- `type-check` and `lint` clean for `backend` and `@yosemite-crew/auth`; the full monorepo pre-push gate passed (17 tasks).
- Coverage on new code 98.1%, 0 Sonar issues, 0 security hotspots.

Impact area: `apps/backend` (user provisioning controller and service, `/v1/auth/me` role resolution) and `packages/auth` (a `removeUserRole` capability on the provider boundary, plus the package's first test suite). No frontend, schema, or migration changes.

## Related Issue(s)

Follows #2532, which added the role allow-list this change depends on for its safety: the roles it can assign are `developer` and `member`, neither of which grants anything server-side, so re-asserting one escalates nothing.