### PR TITLE
fix(repo): clear the nanoid CVE and correct the Node version record

### DIFF
--- a/.github/workflows/_core.yaml
+++ b/.github/workflows/_core.yaml
@@ -26,9 +26,6 @@ on:
 permissions:
   contents: read
 
-env:
-  NODE_VERSION: '20'
-
 jobs:
   detect:
     name: Detect affected workspaces

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -22,7 +22,6 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
   # Per-app merged-coverage floors.
   #
   # frontend carries the exact gate that frontend-quality's type-check-and-test

--- a/apps/mobileAppYC/jest.config.js
+++ b/apps/mobileAppYC/jest.config.js
@@ -20,9 +20,11 @@ module.exports = {
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', {configFile: './babel.config.js'}],
   },
-  // Allow RN and related packages to be transformed, even within pnpm's virtual store
+  // Allow RN and related packages to be transformed, even within pnpm's virtual store.
+  // `nanoid` is ESM-only from v5; @react-navigation and @gorhom/portal import it,
+  // so without transforming it Jest parses its `export` and fails the suite.
   transformIgnorePatterns: [
-    'node_modules/(?!(\\.pnpm/[^/]+/node_modules/)?(react|react-dom|react-native|react-native-blob-util|@react-native|@react-native-community|@react-native-documents|react-clone-referenced-element|@react-navigation|react-native-gesture-handler|react-native-reanimated|react-native-worklets|react-native-safe-area-context|react-native-screens|react-native-vector-icons|@react-native-async-storage|@react-native-firebase|react-redux|redux|@reduxjs|immer|@callstack/liquid-glass|uuid|stream-chat-react-native|react-native-markdown-package|react-native-url-polyfill|mime)/)',
+    'node_modules/(?!(\\.pnpm/[^/]+/node_modules/)?(react|react-dom|react-native|react-native-blob-util|@react-native|@react-native-community|@react-native-documents|react-clone-referenced-element|@react-navigation|react-native-gesture-handler|react-native-reanimated|react-native-worklets|react-native-safe-area-context|react-native-screens|react-native-vector-icons|@react-native-async-storage|@react-native-firebase|react-redux|redux|@reduxjs|immer|@callstack/liquid-glass|uuid|stream-chat-react-native|react-native-markdown-package|react-native-url-polyfill|mime|nanoid)/)',
   ],
   moduleFileExtensions: [
     'ios.js',

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
       "inline-style-parser@<=0.2.9": "0.2.9",
       "nodemailer": "9.0.5",
       "immer": "11.1.15",
-      "nanoid@3": "3.3.18",
+      "nanoid@3": "5.1.16",
       "tar": "7.5.22",
       "tar-fs@<=3.1.3": "3.1.3",
       "fast-uri": "4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ overrides:
   inline-style-parser@<=0.2.9: 0.2.9
   nodemailer: 9.0.5
   immer: 11.1.15
-  nanoid@3: 3.3.18
+  nanoid@3: 5.1.16
   tar: 7.5.22
   tar-fs@<=3.1.3: 3.1.3
   fast-uri: 4.1.3
@@ -7997,7 +7997,7 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 5.1.16
       react: 19.1.4
       react-native: 0.81.6(patch_hash=m4qqoly5dlwssem2g7gghw2o44)(@babel/core@7.29.7)(@react-native-community/cli@20.0.2)(@react-native/metro-config@0.81.6)(@types/react@19.2.18)(react@19.1.4)
     dev: false
@@ -11134,7 +11134,7 @@ packages:
       '@react-navigation/routers': 7.6.4
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.18
+      nanoid: 5.1.16
       query-string: 7.1.3
       react: 19.1.4
       react-is: 19.2.8
@@ -11221,7 +11221,7 @@ packages:
       '@react-navigation/core': 7.21.12(react@19.1.4)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.18
+      nanoid: 5.1.16
       react: 19.1.4
       react-native: 0.81.6(patch_hash=m4qqoly5dlwssem2g7gghw2o44)(@babel/core@7.29.7)(@react-native-community/cli@20.0.2)(@react-native/metro-config@0.81.6)(@types/react@19.2.18)(react@19.1.4)
       standard-navigation: 0.0.8(react@19.1.4)
@@ -11231,7 +11231,7 @@ packages:
   /@react-navigation/routers@7.6.4:
     resolution: {integrity: sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==}
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 5.1.16
     dev: false
 
   /@react-types/shared@3.36.1(react@19.2.4):
@@ -24179,9 +24179,9 @@ packages:
     dev: true
     optional: true
 
-  /nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+  /nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   /napi-postinstall@0.3.4:
@@ -26006,7 +26006,7 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 5.1.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -29165,7 +29165,7 @@ packages:
       lodash.mergewith: 4.6.2
       lodash.throttle: 4.1.1
       lodash.uniqby: 4.7.0
-      nanoid: 3.3.18
+      nanoid: 5.1.16
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-dropzone: 14.4.1(react@19.2.4)


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2538 landed 28 of the 30 CVEs from #2536 and left two, both MEDIUM: `nanoid` and `raw-body`. This clears `nanoid`, and establishes that `raw-body` cannot be cleared — for a different reason than the one #2538 gave.

**Both of #2538's stated reasons were wrong, and one of them was my own.**

## What is the new behavior?

### nanoid 3 → 5.1.16 — cleared

Fixes the MEDIUM CVE where a negative `size` sends `customAlphabet` and `nanoid` into an infinite loop, hanging the calling thread.

#2536 called this blocked because nanoid 5 is ESM-only and `postcss` does `require('nanoid/non-secure')`. That does not hold: `require(esm)` has been unflagged since Node 20.19, and the frontend builds fine on nanoid 5.

The real blocker was narrower and specific to **Jest**, not Node: 18 mobile suites failed with `Jest encountered an unexpected token`. React Native's Jest setup only transforms `node_modules` on an allowlist. `@react-navigation` and `@gorhom` are on it, but `nanoid` — which they import — was not, so Jest loaded its `export` statements raw. Metro does not have this problem; it babel-transforms `node_modules` by default. Only the test runner needed telling.

Adding `nanoid` to `transformIgnorePatterns` fixes it — the same treatment `uuid` and `mime` already get in that list.

### raw-body → 4 — confirmed not adoptable, and not for the reason given

#2538 said this needs `engines.node >=22` against Node 20 runners. **The runners are already on Node 22**, so that reason was false (see below). But raw-body 4 still breaks Express, for a reason no Node version fixes:

```js
// body-parser@1.20.6/lib/read.js
var getBody = require('raw-body')   // raw-body 4 → { __esModule, default, getRawBody, getRawBodyWeb }
...
getBody(stream, opts, cb)           // TypeError: getBody is not a function
```

Under `require(esm)`, Node hands back the **module namespace object**, not the callable default. body-parser calls it directly, so every request 500s. Driven through a real Express server:

| Request | raw-body 4 | reverted |
|---|---|---|
| POST json | `500 getBody is not a function` | `200 {"a":1,"b":"x"}` |
| POST urlencoded | `500` | `200` |
| Over `limit` | `500` | `413 entity.too.large` |
| utf-8 round trip | `500` | `200` |

This is also exactly why **jose 6 was fine** in #2538 and raw-body is not: supertokens uses `jose_1.createRemoteJWKSet`, a *named* export off the namespace, which survives the interop. raw-body's consumer wants the callable default, which does not.

Unblocking it needs `body-parser` itself to adopt raw-body 4, which upstream has not done. Not a Node question at all.

### The Node version record

`_core.yaml` and `_test.yaml` each declared `NODE_VERSION: '20'` and **never referenced it**. Those jobs take Node from `./.github/actions/setup`, whose `node-version` input defaults to `'22'` — matching `.nvmrc` — and no caller overrides it. A CI log for `test / Test @yosemite-crew/database` confirms:

```
with:
  node-version: 22
Found in cache @ /opt/hostedtoolcache/node/22.23.2/x64
node: v22.23.2
```

I read that dead variable as the runner version while triaging #2536, concluded raw-body was blocked on it, and put that into #2538's description. Removing it so the next person does not repeat the mistake. `cd-frontend.yaml` and `chromatic.yml` keep theirs — those two genuinely consume the variable and do run Node 20.

## Validation

| Workspace | Result |
|---|---|
| mobileAppYC | **7,741 passed** (477 suites) — all 18 previously-failing suites recover; lint clean |
| frontend | **11,984 passed** (970 suites); `next build` clean on **Node 20.20.2** and 22 |

Plus the Express/body-parser matrix above, run on Node 22.

**Not covered here:** a real Metro bundle, which needs an Android or iOS toolchain this environment lacks. The Jest boundary is the one that was broken, and it is now exercised.

## Related Issue(s)

Follow-up to #2538. Closes out #2536's list at **29 of 30**; `raw-body` remains, blocked upstream on `body-parser`.
