### PR TITLE
fix(frontend): give the developer portal its own phone navigation

### DIFF
--- a/apps/backend/src/controllers/web/pet-passport.controller.ts
+++ b/apps/backend/src/controllers/web/pet-passport.controller.ts
@@ -141,11 +141,13 @@ type PassportHandler = (req: Request, res: Response) => Promise<Response>;
 /**
  * A schema whose parsed OUTPUT is `Out`, whatever shape it accepts as input.
  *
- * The third parameter matters: `z.ZodType<Out>` pins Input to `Out` as well,
- * which rejects any schema carrying a transform - `completed` arrives as a
- * string and leaves as a boolean, so its input and output differ by design.
+ * The Input parameter is load-bearing: `z.ZodType<Out>` defaults Input to
+ * `unknown` in zod 4 but naming it keeps the intent explicit, and pinning it
+ * to `Out` would reject any schema carrying a transform - the aftercare
+ * `completed` filter arrives as a string and parses to a boolean, so its
+ * input and output differ by design.
  */
-type SchemaFor<Out> = z.ZodType<Out, z.ZodTypeDef, unknown>;
+type SchemaFor<Out> = z.ZodType<Out, unknown>;
 
 type HandlerConfig<POut, BOut> = {
   params: SchemaFor<POut>;

--- a/apps/backend/src/controllers/web/pet-passport.controller.ts
+++ b/apps/backend/src/controllers/web/pet-passport.controller.ts
@@ -128,10 +128,29 @@ const handleError = createOrgErrorHandler(
 
 type PassportHandler = (req: Request, res: Response) => Promise<Response>;
 
-type HandlerConfig<P extends z.ZodTypeAny, B extends z.ZodTypeAny> = {
-  params: P;
+/*
+ * The generics name the parsed OUTPUT types, not the schema types.
+ *
+ * Taking schemas as `extends z.ZodTypeAny` erased them: `z.ZodTypeAny` is
+ * `ZodType<any, ...>`, so `z.output<T>` collapses to `any`, and every value
+ * derived from a parse - the params, the body, whatever `run` builds from
+ * them - was silently untyped. Naming the outputs and accepting
+ * `z.ZodType<Out>` keeps the inference the call sites already provide, so no
+ * handler has to annotate anything.
+ */
+/**
+ * A schema whose parsed OUTPUT is `Out`, whatever shape it accepts as input.
+ *
+ * The third parameter matters: `z.ZodType<Out>` pins Input to `Out` as well,
+ * which rejects any schema carrying a transform - `completed` arrives as a
+ * string and leaves as a boolean, so its input and output differ by design.
+ */
+type SchemaFor<Out> = z.ZodType<Out, z.ZodTypeDef, unknown>;
+
+type HandlerConfig<POut, BOut> = {
+  params: SchemaFor<POut>;
   /** Body schema. Handlers without one never look at `req.body`. */
-  body?: B;
+  body?: SchemaFor<BOut>;
   /** Set when an absent body is equivalent to an empty one. */
   bodyDefaultsToEmpty?: boolean;
   /**
@@ -141,8 +160,8 @@ type HandlerConfig<P extends z.ZodTypeAny, B extends z.ZodTypeAny> = {
   parentScope?: boolean;
   fallback: string;
   run: (ctx: {
-    params: z.output<P>;
-    body: z.output<B>;
+    params: POut;
+    body: BOut;
     req: OrgRequest;
     res: Response;
   }) => Promise<Response>;
@@ -154,8 +173,8 @@ type HandlerConfig<P extends z.ZodTypeAny, B extends z.ZodTypeAny> = {
  * (400 "Invalid request body") and the service-error mapping.
  */
 const passportHandler =
-  <P extends z.ZodTypeAny, B extends z.ZodTypeAny = z.ZodUndefined>(
-    config: HandlerConfig<P, B>,
+  <POut, BOut = undefined>(
+    config: HandlerConfig<POut, BOut>,
   ): PassportHandler =>
   async (req: Request, res: Response): Promise<Response> => {
     try {
@@ -165,7 +184,7 @@ const passportHandler =
       if (!params.success) {
         return res.status(400).json({ message: "Invalid route parameters" });
       }
-      let body: unknown;
+      let body: BOut | undefined;
       if (config.body) {
         const source: unknown = config.bodyDefaultsToEmpty
           ? (req.body ?? {})
@@ -178,10 +197,9 @@ const passportHandler =
       }
       return await config.run({
         params: params.data,
-        // `body` is declared `unknown` because it stays unset when the handler
-        // declares no body schema, so it still needs the cast that params no
-        // longer does.
-        body: body as z.output<B>,
+        // `body` stays undefined when the handler declares no body schema, and
+        // that is exactly the case where `run` never reads it.
+        body: body as BOut,
         req: typedReq,
         res,
       });

--- a/apps/backend/src/controllers/web/shared/clinical-controller.helpers.ts
+++ b/apps/backend/src/controllers/web/shared/clinical-controller.helpers.ts
@@ -78,11 +78,13 @@ type SuccessStatus = 200 | 201 | 204;
 /**
  * A schema whose parsed OUTPUT is `Out`, whatever shape it accepts as input.
  *
- * The third parameter matters: `z.ZodType<Out>` pins Input to `Out` as well,
- * which rejects any schema carrying a transform - `completed` arrives as a
- * string and leaves as a boolean, so its input and output differ by design.
+ * The Input parameter is load-bearing: `z.ZodType<Out>` defaults Input to
+ * `unknown` in zod 4 but naming it keeps the intent explicit, and pinning it
+ * to `Out` would reject any schema carrying a transform - the aftercare
+ * `completed` filter arrives as a string and parses to a boolean, so its
+ * input and output differ by design.
  */
-type SchemaFor<Out> = z.ZodType<Out, z.ZodTypeDef, unknown>;
+type SchemaFor<Out> = z.ZodType<Out, unknown>;
 
 type BaseConfig<POut> = {
   params: SchemaFor<POut>;

--- a/apps/backend/src/controllers/web/shared/clinical-controller.helpers.ts
+++ b/apps/backend/src/controllers/web/shared/clinical-controller.helpers.ts
@@ -66,37 +66,50 @@ export const coerceDateFields = (
 
 type SuccessStatus = 200 | 201 | 204;
 
-type BaseConfig<P extends z.ZodTypeAny> = {
-  params: P;
+/*
+ * The generics name the parsed OUTPUT types, not the schema types.
+ *
+ * Taking schemas as `extends z.ZodTypeAny` erased them: `z.ZodTypeAny` is
+ * `ZodType<any, ...>`, so `z.output<T>` collapses to `any`, and everything
+ * derived from a parse - the params, the payload, and `run`'s return - was
+ * silently untyped. Naming the outputs and accepting `z.ZodType<Out>` keeps
+ * the inference the call sites already provide.
+ */
+/**
+ * A schema whose parsed OUTPUT is `Out`, whatever shape it accepts as input.
+ *
+ * The third parameter matters: `z.ZodType<Out>` pins Input to `Out` as well,
+ * which rejects any schema carrying a transform - `completed` arrives as a
+ * string and leaves as a boolean, so its input and output differ by design.
+ */
+type SchemaFor<Out> = z.ZodType<Out, z.ZodTypeDef, unknown>;
+
+type BaseConfig<POut> = {
+  params: SchemaFor<POut>;
   status?: SuccessStatus;
   fallback: string;
 };
 
-type ParamsOnlyConfig<P extends z.ZodTypeAny> = BaseConfig<P> & {
-  run: (ctx: { params: z.output<P>; userId: string | undefined }) => unknown;
+type ParamsOnlyConfig<POut> = BaseConfig<POut> & {
+  run: (ctx: { params: POut; userId: string | undefined }) => unknown;
 };
 
-type PayloadConfig<
-  P extends z.ZodTypeAny,
-  I extends z.ZodTypeAny,
-> = BaseConfig<P> & {
+type PayloadConfig<POut, IOut> = BaseConfig<POut> & {
   invalidInputMessage?: string;
   run: (ctx: {
-    params: z.output<P>;
-    input: z.output<I>;
+    params: POut;
+    input: IOut;
     userId: string | undefined;
   }) => unknown;
 };
 
-type WithBodyConfig<
-  P extends z.ZodTypeAny,
-  I extends z.ZodTypeAny,
-> = PayloadConfig<P, I> & { body: I };
+type WithBodyConfig<POut, IOut> = PayloadConfig<POut, IOut> & {
+  body: SchemaFor<IOut>;
+};
 
-type WithQueryConfig<
-  P extends z.ZodTypeAny,
-  I extends z.ZodTypeAny,
-> = PayloadConfig<P, I> & { query: I };
+type WithQueryConfig<POut, IOut> = PayloadConfig<POut, IOut> & {
+  query: SchemaFor<IOut>;
+};
 
 /**
  * Builds the error handler and request handler factory shared by the clinical
@@ -116,17 +129,18 @@ export const createClinicalHandlers = (errorClass: ServiceErrorClass) => {
     return res.status(500).json({ message: fallback });
   };
 
-  function handler<P extends z.ZodTypeAny, I extends z.ZodTypeAny>(
-    config: WithBodyConfig<P, I>,
+  function handler<POut, IOut>(
+    config: WithBodyConfig<POut, IOut>,
   ): ClinicalHandler;
-  function handler<P extends z.ZodTypeAny, I extends z.ZodTypeAny>(
-    config: WithQueryConfig<P, I>,
+  function handler<POut, IOut>(
+    config: WithQueryConfig<POut, IOut>,
   ): ClinicalHandler;
-  function handler<P extends z.ZodTypeAny>(
-    config: ParamsOnlyConfig<P>,
-  ): ClinicalHandler;
-  function handler<P extends z.ZodTypeAny, I extends z.ZodTypeAny>(
-    config: ParamsOnlyConfig<P> | WithBodyConfig<P, I> | WithQueryConfig<P, I>,
+  function handler<POut>(config: ParamsOnlyConfig<POut>): ClinicalHandler;
+  function handler<POut, IOut>(
+    config:
+      | ParamsOnlyConfig<POut>
+      | WithBodyConfig<POut, IOut>
+      | WithQueryConfig<POut, IOut>,
   ): ClinicalHandler {
     return async (req: Request, res: Response): Promise<Response> => {
       try {

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneHeader.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneHeader.test.tsx
@@ -7,9 +7,11 @@ import { useUniversalSearchStore } from '@/app/stores/universalSearchStore';
 import { startRouteLoader } from '@/app/lib/routeLoader';
 
 const mockPush = jest.fn();
+let mockPathname = '/dashboard';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
 }));
 
 jest.mock('next/image', () => {
@@ -29,6 +31,7 @@ const mockUsePrimaryOrg = usePrimaryOrg as unknown as jest.Mock;
 describe('PhoneHeader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPathname = '/dashboard';
     useUniversalSearchStore.getState().close();
   });
 
@@ -72,5 +75,45 @@ describe('PhoneHeader', () => {
     // Search + bell remain available.
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+  });
+
+  /*
+   * The portal is not org-scoped, so the chip named a clinic the page has
+   * nothing to do with, and tapping it navigated out of the portal entirely.
+   * Desktop has always hidden it here; the phone header was the shell that
+   * still showed it.
+   */
+  it.each([['/developers/home'], ['/developers/api-keys'], ['/developers/settings']])(
+    'hides the org switcher inside the developer portal (%s)',
+    (pathname) => {
+      mockPathname = pathname;
+      mockUsePrimaryOrg.mockReturnValue({
+        _id: 'org-1',
+        name: 'Groomer sample shop',
+        imageURL: null,
+        isVerified: true,
+      });
+
+      render(<PhoneHeader />);
+
+      expect(screen.queryByRole('button', { name: 'Switch organization' })).not.toBeInTheDocument();
+      expect(screen.queryByText('Groomer sample shop')).not.toBeInTheDocument();
+      // Falls back to the brand mark, which is what an account with no org sees.
+      expect(screen.getByText('Yosemite Crew')).toBeInTheDocument();
+    }
+  );
+
+  it('still shows the org switcher outside the portal for an org member', () => {
+    mockPathname = '/appointments';
+    mockUsePrimaryOrg.mockReturnValue({
+      _id: 'org-1',
+      name: 'Groomer sample shop',
+      imageURL: null,
+      isVerified: true,
+    });
+
+    render(<PhoneHeader />);
+
+    expect(screen.getByRole('button', { name: 'Switch organization' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneShell.test.tsx
@@ -186,4 +186,54 @@ describe('PhoneShell', () => {
     view.rerender(<PhoneShell />);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  /*
+   * The portal was served the PIMS tab bar: Home/Schedule/Patients/Chat all
+   * point at clinic routes, so a developer on a phone got a business menu and
+   * could reach API keys or plugins only through the More sheet. The desktop
+   * sidebar has always swapped appRoutes for devRoutes on this prefix.
+   */
+  it('serves the developer tab bar inside the portal, not the clinic one', () => {
+    setViewport(true);
+    setOrg();
+    mockUsePathname.mockReturnValue('/developers/home');
+
+    render(<PhoneShell />);
+
+    expect(screen.getByRole('button', { name: /Plugins/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Docs/ })).toBeInTheDocument();
+    // Home is the active tab on /developers/home, so the bar is tracking the
+    // portal's own routes rather than a clinic prefix.
+    expect(screen.getByRole('button', { name: /Home/ })).toHaveAttribute('aria-current', 'page');
+
+    fireEvent.click(screen.getByRole('button', { name: /API Keys/ }));
+    expect(mockPush).toHaveBeenCalledWith('/developers/api-keys');
+
+    // The clinic destinations are gone.
+    expect(screen.queryByRole('button', { name: /Schedule/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Chat/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the clinic tab bar outside the portal', () => {
+    setViewport(true);
+    setOrg();
+    mockUsePathname.mockReturnValue('/appointments');
+
+    render(<PhoneShell />);
+
+    expect(screen.getByRole('button', { name: /Schedule/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /API Keys/ })).not.toBeInTheDocument();
+  });
+
+  // The org chip named a clinic the portal has nothing to do with, and tapping
+  // it navigated out to /organizations.
+  it('drops the org switcher from the portal header', () => {
+    setViewport(true);
+    setOrg();
+    mockUsePathname.mockReturnValue('/developers/home');
+
+    render(<PhoneShell />);
+
+    expect(screen.queryByRole('button', { name: 'Switch organization' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { IoCaretDown, IoSearchOutline } from 'react-icons/io5';
 
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
@@ -17,9 +17,18 @@ import NotificationsBell from '@/app/ui/layout/Notifications/NotificationsBell';
  * a search icon-button that opens the universal search palette, and the
  * notifications bell. Reuses the existing org data and search store — no new
  * data or handlers are invented.
+ *
+ * The org switcher is suppressed inside the developer portal. The portal is not
+ * org-scoped, so the chip named a clinic the page has nothing to do with, and
+ * tapping it left the portal for `/organizations`. The desktop header has always
+ * hidden it on this prefix (`UserHeader`'s `!isDev`); the phone header was the
+ * one shell that still showed it. Falls back to the brand mark, which is what
+ * an account with no org already sees.
  */
 const PhoneHeader = () => {
   const router = useRouter();
+  const pathname = usePathname();
+  const isDevPortal = pathname?.startsWith('/developers') ?? false;
   const primaryOrg = usePrimaryOrg();
   const openUniversalSearch = useUniversalSearchStore((s) => s.open);
 
@@ -30,7 +39,7 @@ const PhoneHeader = () => {
 
   return (
     <header className="yc-phone-header">
-      {primaryOrg ? (
+      {primaryOrg && !isDevPortal ? (
         <button
           type="button"
           className="yc-phone-org"

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.tsx
@@ -18,6 +18,8 @@ import {
   PHONE_MORE_SECTIONS,
   PHONE_PRIMARY_ACTION_EVENT,
   PHONE_TABS,
+  DEV_PHONE_TABS,
+  DEV_PHONE_MORE_LINKS,
   resolveFabAction,
   type FabAction,
   type PhonePrimaryActionDetail,
@@ -46,7 +48,7 @@ const PhoneShell = () => {
   const { signOut } = useSignOut();
   const { canAny } = usePermissions();
   const [moreOpen, setMoreOpen] = useState(false);
-  const { pathname, isRouteEnabled, isActive, navigate } = usePhoneNavGate();
+  const { pathname, isDevPortal, isRouteEnabled, isActive, navigate } = usePhoneNavGate();
   const chatUnread = usePhoneShellStore((s) => s.chatUnread);
 
   // Mirrors the desktop avatar-menu logout: sign out, then land on the sign-in
@@ -72,7 +74,12 @@ const PhoneShell = () => {
 
   if (!isPhone) return null;
 
-  const tabItems: PhoneTabItem[] = PHONE_TABS.map((tab) => ({
+  // The portal gets its own bar. Without this the phone shell served the PIMS
+  // tabs inside `/developers`, so the developer portal's navigation was four
+  // clinic routes and its own pages were reachable only through More.
+  const tabs = isDevPortal ? DEV_PHONE_TABS : PHONE_TABS;
+
+  const tabItems: PhoneTabItem[] = tabs.map((tab) => ({
     key: tab.key,
     label: tab.label,
     icon: tab.icon,
@@ -93,14 +100,16 @@ const PhoneShell = () => {
       ? candidateFab
       : null;
 
-  const moreSections: PhoneMoreSection[] = PHONE_MORE_SECTIONS.map((section) => ({
-    key: section.key,
-    label: section.label,
-    context: section.context,
-    href: section.href,
-    icon: section.icon,
-    disabled: !isRouteEnabled(section.routeName),
-  }));
+  const moreSections: PhoneMoreSection[] = (isDevPortal ? [] : PHONE_MORE_SECTIONS).map(
+    (section) => ({
+      key: section.key,
+      label: section.label,
+      context: section.context,
+      href: section.href,
+      icon: section.icon,
+      disabled: !isRouteEnabled(section.routeName),
+    })
+  );
 
   return (
     <>
@@ -116,7 +125,7 @@ const PhoneShell = () => {
         open={moreOpen}
         onClose={() => setMoreOpen(false)}
         sections={moreSections}
-        links={PHONE_MORE_LINKS}
+        links={isDevPortal ? DEV_PHONE_MORE_LINKS : PHONE_MORE_LINKS}
         onNavigate={navigate}
         onSignOut={handleSignOut}
       />

--- a/apps/frontend/src/app/ui/layout/PhoneShell/phoneShellConfig.ts
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/phoneShellConfig.ts
@@ -1,6 +1,7 @@
 import type { IconType } from 'react-icons';
 import { PERMISSIONS, type Permission } from '@/app/lib/permissions';
 import {
+  IoBook,
   IoBookOutline,
   IoBusinessOutline,
   IoCalendar,
@@ -10,11 +11,15 @@ import {
   IoCheckmarkDoneOutline,
   IoCodeSlashOutline,
   IoCubeOutline,
+  IoExtensionPuzzle,
+  IoExtensionPuzzleOutline,
   IoEllipsisHorizontalCircle,
   IoEllipsisHorizontalCircleOutline,
   IoGitNetworkOutline,
   IoGrid,
   IoGridOutline,
+  IoKey,
+  IoKeyOutline,
   IoPaw,
   IoPawOutline,
   IoSettingsOutline,
@@ -27,7 +32,16 @@ import {
  * nothing here invents a destination that does not already exist in the app.
  */
 
-export type PhoneTabKey = 'home' | 'schedule' | 'patients' | 'chat' | 'more';
+export type PhoneTabKey =
+  | 'home'
+  | 'schedule'
+  | 'patients'
+  | 'chat'
+  | 'more'
+  | 'dev-home'
+  | 'dev-api-keys'
+  | 'dev-plugins'
+  | 'dev-docs';
 
 export type PhoneTabConfig = {
   key: PhoneTabKey;
@@ -101,6 +115,87 @@ export const PHONE_TABS: PhoneTabConfig[] = [
       '/settings',
       '/developers',
     ],
+  },
+];
+
+/**
+ * The developer portal's own bottom bar.
+ *
+ * `PHONE_TABS` is the PIMS set - Home/Schedule/Patients/Chat all point at clinic
+ * routes - and the portal was rendering it, so a developer on a phone got a
+ * business menu and no way to reach API keys or plugins except through More.
+ * The desktop sidebar has always swapped `appRoutes` for `devRoutes` on this
+ * same prefix; this is that switch, for the shell the phone actually shows.
+ *
+ * Deliberately no `routeName`: those exist so a tab can reuse the sidebar's
+ * ORG permission gate, and the portal is not org-scoped - `usePhoneNavGate`
+ * already short-circuits `isRouteEnabled` to true inside `/developers`. Giving
+ * these tabs an org route name would gate the portal on clinic membership.
+ *
+ * Website Builder is intentionally absent: the portal itself tells a phone
+ * visitor it is desktop-only, so a tab leading there would be a dead end.
+ */
+export const DEV_PHONE_TABS: PhoneTabConfig[] = [
+  {
+    key: 'dev-home',
+    label: 'Home',
+    icon: IoGridOutline,
+    activeIcon: IoGrid,
+    href: '/developers/home',
+    activePrefixes: ['/developers/home'],
+  },
+  {
+    key: 'dev-api-keys',
+    label: 'API Keys',
+    icon: IoKeyOutline,
+    activeIcon: IoKey,
+    href: '/developers/api-keys',
+    activePrefixes: ['/developers/api-keys'],
+  },
+  {
+    key: 'dev-plugins',
+    label: 'Plugins',
+    icon: IoExtensionPuzzleOutline,
+    activeIcon: IoExtensionPuzzle,
+    href: '/developers/plugins',
+    activePrefixes: ['/developers/plugins'],
+  },
+  {
+    key: 'dev-docs',
+    label: 'Docs',
+    icon: IoBookOutline,
+    activeIcon: IoBook,
+    href: '/developers/documentation',
+    activePrefixes: ['/developers/documentation'],
+  },
+  {
+    key: 'more',
+    label: 'More',
+    icon: IoEllipsisHorizontalCircleOutline,
+    activeIcon: IoEllipsisHorizontalCircle,
+    isMore: true,
+    activePrefixes: ['/developers/billing', '/developers/website-builder', '/developers/settings'],
+  },
+];
+
+/**
+ * What the More sheet offers inside the portal. The business sections
+ * (Tasks, Finance, Inventory...) are clinic routes and do not belong here;
+ * these are the developer destinations the bottom bar has no room for.
+ */
+export const DEV_PHONE_MORE_LINKS: MoreLinkConfig[] = [
+  { key: 'dev-billing', label: 'Billing', href: '/developers/billing', icon: IoWalletOutline },
+  {
+    key: 'dev-website-builder',
+    label: 'Website builder',
+    href: '/developers/website-builder',
+    icon: IoBusinessOutline,
+  },
+  {
+    key: 'dev-settings',
+    label: 'Settings',
+    href: '/developers/settings',
+    icon: IoSettingsOutline,
   },
 ];
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Found during live QA of the developer portal on `dev.yosemitecrew.com`, signed in as a real developer account.

On a phone, the portal renders the **PIMS shell**. The bottom bar is `PHONE_TABS` — Home, Schedule, Patients, Chat — every one of them a clinic route, and the header carries the org switcher, which names a clinic the portal has nothing to do with and navigates out to `/organizations` when tapped.

So a developer signing in on a phone gets a pet-business menu, and the portal's own pages — API keys, plugins, docs — are reachable only by opening the More sheet.

Neither shell was role-aware; both keyed off nothing at all. The other two shells already handle this, which is why it only shows at narrow widths:

| Shell | `/developers` handling |
|---|---|
| `Sidebar` | swaps `appRoutes` → `devRoutes` (`Sidebar.tsx:101`) ✅ |
| `UserHeader` | hides the org chip, retargets Settings (`:85, :186`) ✅ |
| `PhoneShell` | knows the prefix — `usePhoneNavGate` computes `isDevPortal`, used for the sign-in redirect — but the tab list and header were never given the switch ❌ |

## What is the new behavior?

- **`DEV_PHONE_TABS`** — Home, API Keys, Plugins, Docs, More — selected by the `isDevPortal` flag the nav gate already computes.
- **The org switcher is suppressed** on the same prefix, falling back to the brand mark an account with no org already sees.
- **The More sheet** drops the clinic sections (Tasks, Finance, Inventory…) and offers Billing, Website builder and Settings.

Two deliberate choices:

- **The developer tabs carry no `routeName`.** Those exist so a tab can reuse the sidebar's *org* permission gate, and the portal is not org-scoped — `usePhoneNavGate` already short-circuits `isRouteEnabled` inside `/developers`. Giving them an org route name would gate the portal on clinic membership.
- **Website Builder is absent from the bar**, because the portal already tells a phone visitor that page is desktop-only. A tab leading there would be a dead end.

## Why this touches `apps/backend`

Commits 2 and 3 are unrelated to the portal and would not normally ride along. They are here because **`dev` was failing its own pre-push gate**, which blocks every push to the repository:

```
apps/backend/src/controllers/web/pet-passport.controller.ts             2 errors
apps/backend/src/controllers/web/shared/clinical-controller.helpers.ts  4 errors
```

Reproduced on a clean `origin/dev` checkout with none of this branch's code present. They arrived with `7d7dd2658` (the zod validation migration).

The rule was reporting a real loss of type safety rather than noise. The shared handler factories took their schemas as `extends z.ZodTypeAny`. That constraint is:

```ts
ZodType<any, any, any>
```

so `z.output<T>` collapses to `any`, `safeParse().data` is `any`, and everything built from a parse — params, body, query payload, whatever `run` returns — is silently untyped.

Fixed by naming the parsed **output** types instead of the schema types:

```ts
type SchemaFor<Out> = z.ZodType<Out, unknown>;
```

Call-site inference is unchanged, so no handler needed an annotation. The Input parameter has to stay open rather than defaulting to `Out`: pinning it rejects any schema carrying a transform, such as the aftercare `completed` filter, which arrives as a string and parses to a boolean.

Types only; no runtime behaviour changes.

### A correction, since it shaped two of these commits

Commit 2 was validated against the **wrong dependency**. This branch was cut from a `dev` that had just moved backend to `zod@^4.4.0`, but the working container still had **3.25.76** installed. `z.ZodTypeDef` exists in zod 3 and is **removed in zod 4**, so the first version of the alias resolved cleanly locally and became an *error type* in CI — cascading to **620 lint errors** across every controller built on these factories.

Local lint, type-check, the full suite and the pre-push gate all passed against that stale tree. After `pnpm install --frozen-lockfile` the 620 errors reproduced exactly, and commit 3 fixes the alias against zod 4's real signature (`ZodType<out Output, out Input, out Internals>`).

Two claims from the earlier commit message are therefore withdrawn: the test count below is measured on the correct dependencies, and the `workspace.controller` zod-message case is **not** failing on `dev` — it was only failing here because stale zod 3 answered `"Required"` where the test correctly expects zod 4's `"expected string"`.

## Validation performed

All figures below are after `pnpm install --frozen-lockfile`.

- **Frontend** — 139 tests across `PhoneShell`, `PhoneHeader`, `Sidebar` and `UserHeader`; lint and type-check clean.
- **Backend** — lint and type-check clean (was 620 errors on the stale tree, 6 on `dev`); **10,921 tests passing**.
- Mutation-checked rather than assumed green: reverting the tab switch and the org-chip guard fails exactly the 5 new tests and nothing else.
- **Live QA** on `dev.yosemitecrew.com` established the defect before the fix: all 7 portal routes load with 0 console errors, the desktop sidebar is correct, and the phone bar showed `Home / Schedule / Pets / Chat / More` under a "Groomer sample shop" chip.

One backend test fails on this tree and is environmental, not from this change: `email.test.ts`, from AWS credentials the sandbox proxy injects.

Impact area: `apps/frontend` (phone shell navigation only — no desktop change) and `apps/backend` (handler generics, types only). No schema or migration changes.

## Related Issue(s)

Follows #2537. The `/developers` prefix switch this adds is the same one `Sidebar` and `UserHeader` have always applied.