### PR TITLE
fix(backend): use the CodeQL-recognised barrier when stripping line breaks from logs

### DIFF
--- a/apps/backend/src/controllers/app/chatWebhook.controller.ts
+++ b/apps/backend/src/controllers/app/chatWebhook.controller.ts
@@ -37,7 +37,10 @@ export const scanMessageAttachments = async (
     const result = await scanAttachmentUrl(url);
     if (!result.clean) {
       // The message id arrives in the webhook payload; strip line breaks so it
-      // cannot forge additional log lines.
+      // cannot forge additional log lines. Keep this exact /\n|\r/g form with an
+      // empty replacement: CodeQL's js/log-injection barrier rejects quantifiers
+      // such as [\n\r]+ and any non-empty replacement, and silently keeps
+      // reporting the sink.
       logger.warn(
         `Unsafe chat attachment on message ${messageId.replace(/\n|\r/g, "")} (${result.threat}); deleting message`,
       );

--- a/apps/backend/src/controllers/app/chatWebhook.controller.ts
+++ b/apps/backend/src/controllers/app/chatWebhook.controller.ts
@@ -39,7 +39,7 @@ export const scanMessageAttachments = async (
       // The message id arrives in the webhook payload; strip line breaks so it
       // cannot forge additional log lines.
       logger.warn(
-        `Unsafe chat attachment on message ${messageId.replace(/[\n\r]+/g, " ")} (${result.threat}); deleting message`,
+        `Unsafe chat attachment on message ${messageId.replace(/\n|\r/g, "")} (${result.threat}); deleting message`,
       );
       try {
         const client = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);

--- a/apps/backend/src/controllers/app/chatWebhook.controller.ts
+++ b/apps/backend/src/controllers/app/chatWebhook.controller.ts
@@ -37,12 +37,12 @@ export const scanMessageAttachments = async (
     const result = await scanAttachmentUrl(url);
     if (!result.clean) {
       // The message id arrives in the webhook payload; strip line breaks so it
-      // cannot forge additional log lines. Keep this exact /\n|\r/g form with an
-      // empty replacement: CodeQL's js/log-injection barrier rejects quantifiers
-      // such as [\n\r]+ and any non-empty replacement, and silently keeps
+      // cannot forge additional log lines. Two constraints on the form: no
+      // quantifier, and an empty replacement. CodeQL's js/log-injection barrier
+      // rejects [\n\r]+ and any non-empty replacement, and then silently keeps
       // reporting the sink.
       logger.warn(
-        `Unsafe chat attachment on message ${messageId.replace(/\n|\r/g, "")} (${result.threat}); deleting message`,
+        `Unsafe chat attachment on message ${messageId.replace(/[\n\r]/g, "")} (${result.threat}); deleting message`,
       );
       try {
         const client = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);

--- a/apps/backend/src/controllers/web/appointment.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.controller.ts
@@ -132,7 +132,10 @@ export const AppointmentController = {
     try {
       const { appointmentId } = req.params;
       // The id is caller-supplied; strip line breaks so it cannot forge
-      // additional log lines.
+      // additional log lines. Keep this exact /\n|\r/g form with an empty
+      // replacement: CodeQL's js/log-injection barrier rejects quantifiers such
+      // as [\n\r]+ and any non-empty replacement, and silently keeps reporting
+      // the sink.
       logger.info(
         "Accepting appointment with ID:",
         appointmentId.replace(/\n|\r/g, ""),

--- a/apps/backend/src/controllers/web/appointment.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.controller.ts
@@ -131,12 +131,11 @@ export const AppointmentController = {
   acceptRequested: async (req: Request, res: Response) => {
     try {
       const { appointmentId } = req.params;
-      logger.info("Request Path: ", req.params);
       // The id is caller-supplied; strip line breaks so it cannot forge
       // additional log lines.
       logger.info(
         "Accepting appointment with ID:",
-        appointmentId.replace(/[\n\r]+/g, " "),
+        appointmentId.replace(/\n|\r/g, ""),
       );
       const dto = req.body as AppointmentRequestDTO; // partial FHIR update fields
 

--- a/apps/backend/src/controllers/web/appointment.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.controller.ts
@@ -132,13 +132,12 @@ export const AppointmentController = {
     try {
       const { appointmentId } = req.params;
       // The id is caller-supplied; strip line breaks so it cannot forge
-      // additional log lines. Keep this exact /\n|\r/g form with an empty
-      // replacement: CodeQL's js/log-injection barrier rejects quantifiers such
-      // as [\n\r]+ and any non-empty replacement, and silently keeps reporting
-      // the sink.
+      // additional log lines. Two constraints on the form: no quantifier, and an
+      // empty replacement. CodeQL's js/log-injection barrier rejects [\n\r]+ and
+      // any non-empty replacement, and then silently keeps reporting the sink.
       logger.info(
         "Accepting appointment with ID:",
-        appointmentId.replace(/\n|\r/g, ""),
+        appointmentId.replace(/[\n\r]/g, ""),
       );
       const dto = req.body as AppointmentRequestDTO; // partial FHIR update fields
 

--- a/apps/backend/src/services/companion.service.ts
+++ b/apps/backend/src/services/companion.service.ts
@@ -236,7 +236,10 @@ const ensureCodeExists = async (code: string, type: "SPECIES" | "BREED") => {
 
   if (!entry) {
     // The code is caller-supplied; strip line breaks so it cannot forge
-    // additional log lines.
+    // additional log lines. Keep this exact /\n|\r/g form with an empty
+    // replacement: CodeQL's js/log-injection barrier rejects quantifiers such as
+    // [\n\r]+ and any non-empty replacement, and silently keeps reporting the
+    // sink.
     logger.warn(`Invalid ${type} code provided: ${code.replace(/\n|\r/g, "")}`);
     throw new CompanionServiceError(`Invalid ${type.toLowerCase()} code.`, 400);
   }

--- a/apps/backend/src/services/companion.service.ts
+++ b/apps/backend/src/services/companion.service.ts
@@ -237,9 +237,7 @@ const ensureCodeExists = async (code: string, type: "SPECIES" | "BREED") => {
   if (!entry) {
     // The code is caller-supplied; strip line breaks so it cannot forge
     // additional log lines.
-    logger.warn(
-      `Invalid ${type} code provided: ${code.replace(/[\n\r]+/g, " ")}`,
-    );
+    logger.warn(`Invalid ${type} code provided: ${code.replace(/\n|\r/g, "")}`);
     throw new CompanionServiceError(`Invalid ${type.toLowerCase()} code.`, 400);
   }
 };

--- a/apps/backend/src/services/companion.service.ts
+++ b/apps/backend/src/services/companion.service.ts
@@ -236,11 +236,12 @@ const ensureCodeExists = async (code: string, type: "SPECIES" | "BREED") => {
 
   if (!entry) {
     // The code is caller-supplied; strip line breaks so it cannot forge
-    // additional log lines. Keep this exact /\n|\r/g form with an empty
-    // replacement: CodeQL's js/log-injection barrier rejects quantifiers such as
-    // [\n\r]+ and any non-empty replacement, and silently keeps reporting the
-    // sink.
-    logger.warn(`Invalid ${type} code provided: ${code.replace(/\n|\r/g, "")}`);
+    // additional log lines. Two constraints on the form: no quantifier, and an
+    // empty replacement. CodeQL's js/log-injection barrier rejects [\n\r]+ and
+    // any non-empty replacement, and then silently keeps reporting the sink.
+    logger.warn(
+      `Invalid ${type} code provided: ${code.replace(/[\n\r]/g, "")}`,
+    );
     throw new CompanionServiceError(`Invalid ${type.toLowerCase()} code.`, 400);
   }
 };

--- a/apps/backend/test/controllers/chatWebhook.controller.test.ts
+++ b/apps/backend/test/controllers/chatWebhook.controller.test.ts
@@ -128,11 +128,12 @@ describe("scanMessageAttachments", () => {
     mockScan.mockResolvedValue({ clean: false, threat: "bad" });
     await scanMessageAttachments({
       type: "message.new",
-      message: { id: "m1\nforged line", attachments: [{ asset_url: "u" }] },
+      message: { id: "m1\r\nforged line", attachments: [{ asset_url: "u" }] },
     });
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toContain("m1 forged line");
+    expect(warn.mock.calls[0][0]).toContain("m1forged line");
     expect(warn.mock.calls[0][0]).not.toContain("\n");
+    expect(warn.mock.calls[0][0]).not.toContain("\r");
     warn.mockRestore();
   });
 

--- a/apps/backend/test/controllers/web/appointment.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.controller.test.ts
@@ -308,6 +308,27 @@ describe("AppointmentController", () => {
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
+    it("strips line breaks from the appointment id before logging it", async () => {
+      req.params = { appointmentId: "a1\r\nforged line" };
+      req.body = { status: "booked" };
+      mockedAppointmentService.approveRequestedFromPms.mockResolvedValue(
+        {} as any,
+      );
+
+      await AppointmentController.acceptRequested(req as any, res as Response);
+
+      const logged = mockedLogger.info.mock.calls.flat().join(" ");
+      expect(logged).toContain("a1forged line");
+      expect(logged).not.toContain("\n");
+      expect(logged).not.toContain("\r");
+      // The raw params object must never be logged: it is caller-controlled
+      // and carries the unsanitised id.
+      expect(mockedLogger.info).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ appointmentId: expect.anything() }),
+      );
+    });
+
     it("should handle error", async () => {
       mockedAppointmentService.approveRequestedFromPms.mockRejectedValue(
         new Error("Fail"),

--- a/apps/backend/test/services/companion.service.test.ts
+++ b/apps/backend/test/services/companion.service.test.ts
@@ -242,6 +242,37 @@ describe("CompanionService", () => {
     );
   });
 
+  it("strips line breaks from an invalid species code before logging it", async () => {
+    const logger = (await import("src/utils/logger")).default;
+    (logger.warn as jest.Mock).mockClear();
+    // jest.clearAllMocks() does not drain mockResolvedValueOnce queues, so
+    // reset the two mocks this case depends on rather than inheriting a
+    // leftover from an earlier test.
+    mockedPrisma.parentPatient.findFirst.mockReset();
+    mockedPrisma.codeEntry.findFirst.mockReset();
+    mockedPrisma.parentPatient.findFirst.mockResolvedValue(null);
+    // No matching code entry: drives ensureCodeExists down the invalid branch.
+    mockedPrisma.codeEntry.findFirst.mockResolvedValue(null);
+
+    try {
+      await expect(
+        CompanionService.create(
+          { ...companionPayload, speciesCode: "dog\r\nforged line" },
+          { parentId: "parent-1", organisationId: "org-1" },
+        ),
+      ).rejects.toEqual(expect.objectContaining({ statusCode: 400 }));
+
+      const logged = (logger.warn as jest.Mock).mock.calls.flat().join(" ");
+      expect(logged).toContain("dogforged line");
+      expect(logged).not.toContain("\n");
+      expect(logged).not.toContain("\r");
+    } finally {
+      // Leave both mocks pristine so the persistent values above cannot leak.
+      mockedPrisma.parentPatient.findFirst.mockReset();
+      mockedPrisma.codeEntry.findFirst.mockReset();
+    }
+  });
+
   it("rolls back the patient record when parent linking fails", async () => {
     mockedPrisma.parentPatient.findFirst.mockResolvedValueOnce(null);
     mockedPrisma.codeEntry.findFirst.mockResolvedValueOnce({ id: "species-1" });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The three open CodeQL code-scanning alerts on `main` are all `js/log-injection` (medium):

| Alert | File | Line |
| --- | --- | --- |
| [1322](https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1322) | `apps/backend/src/controllers/app/chatWebhook.controller.ts` | 42 |
| [1323](https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1323) | `apps/backend/src/controllers/web/appointment.controller.ts` | 139 |
| [1324](https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/1324) | `apps/backend/src/services/companion.service.ts` | 241 |

All three sites **already** sanitised the caller-supplied value with `.replace(/[\n\r]+/g, " ")`, and CodeQL kept reporting them anyway. The SARIF code flows from the latest analysis of `main` (commit `7f92970d8`) run straight *through* the `.replace(...)` node, so the call was never treated as a barrier.

The reason is in the query itself. `LogInjectionQuery.qll` defines exactly one string-replace barrier:

```ql
class StringReplaceSanitizer extends Sanitizer {
  StringReplaceSanitizer() {
    exists(string s | this.(StringReplaceCall).replaces(s, "") and s.regexpMatch("\\n"))
  }
}
```

The old idiom failed it in two independent, each-sufficient ways:

1. **The replacement had to be the empty string.** `StringReplaceCall.replaces(old, new)` binds `new` from the second argument, and the barrier demands `replaces(s, "")`. Replacing with `" "` gives `new = " "`, so the barrier never held.
2. **The `+` quantifier erased the matched string.** `getAReplacedString()` reads `getRegExp().getRoot().getAMatchedString()`. For `/[\n\r]+/g` the root term is the `RegExpPlus`, and `RegExpQuantifier` overrides neither `getAMatchedString()` nor `getConstantValue()`, so it falls through to `none()`. There was no `old` for `replaces` to bind at all.

Separately, `appointment.controller.ts` logged the entire unsanitised `req.params` object one line above the carefully sanitised one.

## What is the new behavior?

Use `.replace(/[\n\r]/g, "")`. The two constraints that matter are **no quantifier** and an **empty replacement**; the exact spelling is not what makes it a barrier. A non-inverted character class satisfies `getAMatchedString()` through `RegExpCharacterClass` (`Regexp.qll:907`), and the empty replacement satisfies `replaces("\n", "")`, so the barrier holds.

The CodeQL documentation's own example uses the `\n|\r` alternation, and that works too, but Sonar `typescript:S6035` flags an alternation that could be a character class and it failed the backend `new_maintainability_rating` gate on this PR. The character class satisfies both tools. Note that `[\n\r]` and `[\n\r]+` differ by one character and only the first is a barrier, which is why the code comments state the two constraints rather than naming a spelling.

- `chatWebhook.controller.ts`, `appointment.controller.ts`, `companion.service.ts`: swap the ineffective idiom for the recognised one.
- `appointment.controller.ts`: drop the leftover `logger.info("Request Path: ", req.params)` debug line, which logged raw caller-controlled request params on every accept.
- `chatWebhook.controller.test.ts`: the existing regression test asserted the cosmetic space separator. It now feeds `\r\n` and asserts that neither `\n` nor `\r` survives, which is the property that actually matters.

Runtime behaviour is unchanged apart from line breaks now being removed rather than replaced by a space. Every affected value is an opaque id or a lookup code, so none should contain a line break in legitimate use.

### Verification

- `pnpm --filter backend run type-check`: clean.
- `npx jest --testPathPatterns "chatWebhook.controller|web/appointment.controller|services/companion.service"`: 3 suites, 90 tests, all passing.
- `prettier --check` on all four touched files: clean.
- The definitive check is this PR's own CodeQL run, which analyses `refs/pull/<n>/merge`. The three alerts should stop being reported there.

Note that code scanning judges these alerts against `main`, so they will not read as closed until the next `dev` to `main` promotion, even though the fix lands here on `dev`.

## Related Issue(s)

Fixes code-scanning alerts 1322, 1323 and 1324.

