### PR TITLE
fix(backend): stop a redelivered part payment retrying forever

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -903,6 +903,13 @@ const cancelOpenCheckoutSessionAttempts = async (invoiceId: string) => {
 
 // Reuse the latest open PaymentIntent attempt when it still matches the
 // outstanding balance; otherwise cancel it so a fresh intent can be issued.
+// Same shape as the helpers in stripe.service.ts and invoice.service.ts.
+const isUniqueConstraintViolation = (error: unknown): boolean =>
+  !!error &&
+  typeof error === "object" &&
+  "code" in error &&
+  (error as { code?: string }).code === "P2002";
+
 const reuseOrCancelExistingPaymentIntentAttempt = async (
   invoiceId: string,
   invoice: {
@@ -1838,22 +1845,69 @@ export const FinancePaymentService = {
           rawProviderPayload: input.rawProviderPayload ?? null,
         });
 
-    const payment = await prisma.payment.create({
-      data: {
+    let payment;
+    try {
+      payment = await prisma.payment.create({
+        data: {
+          invoiceId,
+          paymentAttemptId: paymentAttempt.id,
+          provider: input.provider,
+          settlementChannel: input.settlementChannel ?? null,
+          collectionMode: input.collectionMode ?? null,
+          providerPaymentId: input.providerPaymentId ?? null,
+          amount: appliedAmount,
+          currency: input.currency ?? invoice.currency,
+          status: "SUCCEEDED",
+          paidAt: receivedAt,
+          receiptUrl: input.reference ?? undefined,
+          rawProviderPayload: input.rawProviderPayload ?? undefined,
+        },
+      });
+    } catch (error) {
+      if (!isUniqueConstraintViolation(error)) throw error;
+
+      // This attempt already carries a Payment, so the event is a redelivery.
+      //
+      // The ALREADY_PAID guard upstream only fires once the invoice is PAID, and
+      // a deposit or part payment never sets that: updateInvoiceAfterPayment
+      // only marks PAID when the applied amount covers the whole balance. So a
+      // redelivered partial payment reached this insert and died on
+      // Payment.paymentAttemptId, uncaught, which answers non-2xx and buys an
+      // endless Stripe retry of an event that can never succeed.
+      //
+      // Returning what is already recorded is the whole fix. Deliberately NOT
+      // falling through to updateInvoiceAfterPayment: the amount was applied by
+      // the delivery that won, and applying it again would double-count the
+      // payment against the invoice.
+      const existingPayment = await prisma.payment.findUnique({
+        where: { paymentAttemptId: paymentAttempt.id },
+      });
+      if (!existingPayment) throw error;
+
+      const currentInvoice = await prisma.invoice.findUniqueOrThrow({
+        where: { id: invoiceId },
+      });
+      const settled = await getOutstandingBalance(
         invoiceId,
-        paymentAttemptId: paymentAttempt.id,
-        provider: input.provider,
-        settlementChannel: input.settlementChannel ?? null,
-        collectionMode: input.collectionMode ?? null,
-        providerPaymentId: input.providerPaymentId ?? null,
-        amount: appliedAmount,
-        currency: input.currency ?? invoice.currency,
-        status: "SUCCEEDED",
-        paidAt: receivedAt,
-        receiptUrl: input.reference ?? undefined,
-        rawProviderPayload: input.rawProviderPayload ?? undefined,
-      },
-    });
+        currentInvoice.totalAmount,
+        currentInvoice.depositCollectedAmount ?? 0,
+      );
+
+      logger.info(
+        `Payment for attempt ${paymentAttempt.id} was already recorded; treating this delivery as a replay`,
+      );
+
+      return {
+        invoice: currentInvoice,
+        paymentAttempt,
+        payment: existingPayment,
+        balanceAfterPayment: settled.balance,
+        paidToDate: settled.paid,
+        // Nothing new was applied. A caller that adds this to a running total
+        // must not count the same money twice.
+        appliedAmount: 0,
+      };
+    }
 
     const updatedInvoice = await updateInvoiceAfterPayment({
       invoice,

--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -323,11 +323,19 @@ const applyCheckoutSessionTaxToInvoice = async (
   });
 };
 
+// The writer half of the client, so a caller inside an interactive transaction
+// can pass its `tx` and have these writes commit or roll back with the rest.
+type PaymentTxClient = Omit<
+  typeof prisma,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+
 const createPaymentAttempt = async (
   invoiceId: string,
   input: PaymentAttemptInput,
+  client: PaymentTxClient = prisma,
 ) =>
-  prisma.paymentAttempt.create({
+  client.paymentAttempt.create({
     data: {
       invoiceId,
       provider: input.provider,
@@ -356,9 +364,17 @@ const updateInvoiceAfterPayment = async (params: {
   balance: number;
   receivedAt: Date;
   input: InvoicePaymentInput;
+  client?: PaymentTxClient;
 }) => {
-  const { invoice, invoiceId, appliedAmount, balance, receivedAt, input } =
-    params;
+  const {
+    invoice,
+    invoiceId,
+    appliedAmount,
+    balance,
+    receivedAt,
+    input,
+    client = prisma,
+  } = params;
   const isDepositPayment =
     input.collectionMode === "DEPOSIT_THEN_SETTLE" ||
     input.settlementChannel === "DEPOSIT" ||
@@ -378,7 +394,7 @@ const updateInvoiceAfterPayment = async (params: {
   }
 
   if (appliedAmount >= balance) {
-    const settledInvoice = await prisma.invoice.update({
+    const settledInvoice = await client.invoice.update({
       where: { id: invoiceId },
       data: {
         status: "PAID",
@@ -392,12 +408,17 @@ const updateInvoiceAfterPayment = async (params: {
           : {}),
       },
     });
-    await markInvoiceTreatmentItemsSettled(invoice, invoiceId, receivedAt);
+    await markInvoiceTreatmentItemsSettled(
+      invoice,
+      invoiceId,
+      receivedAt,
+      client,
+    );
     return settledInvoice;
   }
 
   if (isDepositPayment) {
-    return prisma.invoice.update({
+    return client.invoice.update({
       where: { id: invoiceId },
       data: {
         depositCollectedAmount: nextDepositCollectedAmount,
@@ -1797,6 +1818,10 @@ export const FinancePaymentService = {
         balanceAfterPayment: 0,
         paidToDate: paid,
         appliedAmount: 0,
+        // Nothing was applied, so this is not a fresh success either. A caller
+        // that notifies the pet parent must not fire for a redelivery that
+        // arrives after the balance is already closed.
+        replayed: true,
       };
     }
 
@@ -1812,145 +1837,131 @@ export const FinancePaymentService = {
     const receivedAt = input.receivedAt ?? new Date();
     const isPartial = appliedAmount < balance || paid > 0;
 
-    const paymentAttempt = input.paymentAttemptId
-      ? await prisma.paymentAttempt.update({
-          where: { id: input.paymentAttemptId },
+    // The attempt write, the Payment insert and the invoice update move
+    // together or not at all.
+    //
+    // They used to be three sequential awaits, which is what made every replay
+    // guard here unsound: a P2002 on Payment.paymentAttemptId proved the payment
+    // row existed and nothing else, so a delivery that died between the insert
+    // and the invoice update left a covered invoice that was never marked PAID,
+    // and a deposit whose collected amount never moved. No amount of reasoning
+    // on the recovery path can distinguish that from a clean replay, because the
+    // database does not record which of the three steps ran.
+    //
+    // FinanceEventService.recordEvent stays outside deliberately: it closes over
+    // the module-level client, so calling it in here would run on a second
+    // connection against rows this transaction still holds.
+    let settled;
+    try {
+      settled = await prisma.$transaction(async (tx) => {
+        const paymentAttempt = input.paymentAttemptId
+          ? await tx.paymentAttempt.update({
+              where: { id: input.paymentAttemptId },
+              data: {
+                provider: input.provider,
+                settlementChannel: input.settlementChannel ?? null,
+                providerPaymentIntentId: input.providerPaymentId ?? null,
+                status: "SUCCEEDED",
+                amountRequested: requestedAmount,
+                amountCaptured: appliedAmount,
+                amountApplied: appliedAmount,
+                currency: input.currency ?? invoice.currency,
+                collectionMode: input.collectionMode ?? null,
+                isOffline: input.provider === "MANUAL",
+                isPartial,
+                rawProviderPayload: input.rawProviderPayload ?? undefined,
+              },
+            })
+          : await createPaymentAttempt(
+              invoiceId,
+              {
+                provider: input.provider,
+                status: "SUCCEEDED",
+                settlementChannel: input.settlementChannel ?? null,
+                amountRequested: requestedAmount,
+                amountCaptured: appliedAmount,
+                amountApplied: appliedAmount,
+                currency: input.currency ?? invoice.currency,
+                collectionMode: input.collectionMode ?? null,
+                providerPaymentIntentId: input.providerPaymentId ?? null,
+                isOffline: input.provider === "MANUAL",
+                isPartial,
+                rawProviderPayload: input.rawProviderPayload ?? null,
+              },
+              tx,
+            );
+
+        const payment = await tx.payment.create({
           data: {
+            invoiceId,
+            paymentAttemptId: paymentAttempt.id,
             provider: input.provider,
             settlementChannel: input.settlementChannel ?? null,
-            providerPaymentIntentId: input.providerPaymentId ?? null,
-            status: "SUCCEEDED",
-            amountRequested: requestedAmount,
-            amountCaptured: appliedAmount,
-            amountApplied: appliedAmount,
-            currency: input.currency ?? invoice.currency,
             collectionMode: input.collectionMode ?? null,
-            isOffline: input.provider === "MANUAL",
-            isPartial,
+            providerPaymentId: input.providerPaymentId ?? null,
+            amount: appliedAmount,
+            currency: input.currency ?? invoice.currency,
+            status: "SUCCEEDED",
+            paidAt: receivedAt,
+            receiptUrl: input.reference ?? undefined,
             rawProviderPayload: input.rawProviderPayload ?? undefined,
           },
-        })
-      : await createPaymentAttempt(invoiceId, {
-          provider: input.provider,
-          status: "SUCCEEDED",
-          settlementChannel: input.settlementChannel ?? null,
-          amountRequested: requestedAmount,
-          amountCaptured: appliedAmount,
-          amountApplied: appliedAmount,
-          currency: input.currency ?? invoice.currency,
-          collectionMode: input.collectionMode ?? null,
-          providerPaymentIntentId: input.providerPaymentId ?? null,
-          isOffline: input.provider === "MANUAL",
-          isPartial,
-          rawProviderPayload: input.rawProviderPayload ?? null,
         });
 
-    let payment;
-    try {
-      payment = await prisma.payment.create({
-        data: {
+        const updatedInvoice = await updateInvoiceAfterPayment({
+          invoice,
           invoiceId,
-          paymentAttemptId: paymentAttempt.id,
-          provider: input.provider,
-          settlementChannel: input.settlementChannel ?? null,
-          collectionMode: input.collectionMode ?? null,
-          providerPaymentId: input.providerPaymentId ?? null,
-          amount: appliedAmount,
-          currency: input.currency ?? invoice.currency,
-          status: "SUCCEEDED",
-          paidAt: receivedAt,
-          receiptUrl: input.reference ?? undefined,
-          rawProviderPayload: input.rawProviderPayload ?? undefined,
-        },
+          appliedAmount,
+          balance,
+          receivedAt,
+          input,
+          client: tx,
+        });
+
+        return { paymentAttempt, payment, updatedInvoice };
       });
     } catch (error) {
-      if (!isUniqueConstraintViolation(error)) throw error;
+      if (!isUniqueConstraintViolation(error) || !input.paymentAttemptId) {
+        throw error;
+      }
 
-      // This attempt already carries a Payment, so the event is a redelivery.
-      //
-      // The ALREADY_PAID guard upstream only fires once the invoice is PAID, and
-      // a deposit or part payment never sets that: updateInvoiceAfterPayment
-      // only marks PAID when the applied amount covers the whole balance. So a
-      // redelivered partial payment reached this insert and died on
-      // Payment.paymentAttemptId, uncaught, which answers non-2xx and buys an
-      // endless Stripe retry of an event that can never succeed.
-      //
-      // Deliberately NOT falling through to updateInvoiceAfterPayment with this
-      // delivery's amount: the money was applied by the delivery that won, and
-      // applying it again would double-count it against the invoice.
+      // A Payment already exists for this attempt, so the event is a redelivery.
+      // Because the block above is atomic, that row existing now genuinely does
+      // imply the invoice moved with it, which is what makes simply returning
+      // what is recorded a safe answer rather than an assumption.
       const existingPayment = await prisma.payment.findUnique({
-        where: { paymentAttemptId: paymentAttempt.id },
+        where: { paymentAttemptId: input.paymentAttemptId },
       });
       if (!existingPayment) throw error;
 
-      // A P2002 proves the Payment row exists, and nothing more. No transaction
-      // wraps the insert and the invoice update that follows it, so the delivery
-      // that won may have died in between and left the invoice unsettled.
-      // Acknowledging without checking would end the retries that were its only
-      // remaining chance to finish.
-      //
-      // So re-derive the position from what is actually recorded. Reading the
-      // successful payments means the balance already accounts for the winner's.
       const currentInvoice = await prisma.invoice.findUniqueOrThrow({
         where: { id: invoiceId },
-        include: { payments: { where: { status: "SUCCEEDED" } } },
       });
-      const settled = await getOutstandingBalance(
+      const replaySummary = await getOutstandingBalance(
         invoiceId,
         currentInvoice.totalAmount,
         currentInvoice.depositCollectedAmount ?? 0,
       );
 
-      const needsSettling =
-        settled.balance <= 0 && currentInvoice.status !== "PAID";
-      if (needsSettling) {
-        logger.warn(
-          `Invoice ${invoiceId} is covered but was not marked PAID; the delivery that recorded the payment did not finish. Settling it now.`,
-        );
-        await prisma.invoice.update({
-          where: { id: invoiceId },
-          data: {
-            status: "PAID",
-            paidAt: receivedAt,
-            visitBillingStage: "SETTLED",
-          },
-        });
-        await markInvoiceTreatmentItemsSettled(
-          currentInvoice,
-          invoiceId,
-          receivedAt,
-        );
-      }
-
       logger.info(
-        `Payment for attempt ${paymentAttempt.id} was already recorded; treating this delivery as a replay`,
+        `Payment for attempt ${input.paymentAttemptId.replace(/[\n\r]+/g, " ")} was already recorded; treating this delivery as a replay`,
       );
 
       return {
-        invoice: needsSettling
-          ? await prisma.invoice.findUniqueOrThrow({ where: { id: invoiceId } })
-          : currentInvoice,
-        paymentAttempt,
+        invoice: currentInvoice,
+        paymentAttempt: null,
         payment: existingPayment,
-        balanceAfterPayment: settled.balance,
-        paidToDate: settled.paid,
-        // A caller that notifies the pet parent must not tell them twice that
-        // the same payment succeeded.
-        replayed: true,
-        // Nothing new was applied. A caller that adds this to a running total
-        // must not count the same money twice.
+        balanceAfterPayment: replaySummary.balance,
+        paidToDate: replaySummary.paid,
+        // Nothing new was applied, so a caller accumulating this must not count
+        // the same money twice, and one that notifies the pet parent must not
+        // tell them twice that the same payment succeeded.
         appliedAmount: 0,
+        replayed: true,
       };
     }
 
-    const updatedInvoice = await updateInvoiceAfterPayment({
-      invoice,
-      invoiceId,
-      appliedAmount,
-      balance,
-      receivedAt,
-      input,
-    });
+    const { paymentAttempt, payment, updatedInvoice } = settled;
 
     await FinanceEventService.recordEvent({
       organisationId: invoice.organisationId ?? null,

--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -1875,17 +1875,25 @@ export const FinancePaymentService = {
       // Payment.paymentAttemptId, uncaught, which answers non-2xx and buys an
       // endless Stripe retry of an event that can never succeed.
       //
-      // Returning what is already recorded is the whole fix. Deliberately NOT
-      // falling through to updateInvoiceAfterPayment: the amount was applied by
-      // the delivery that won, and applying it again would double-count the
-      // payment against the invoice.
+      // Deliberately NOT falling through to updateInvoiceAfterPayment with this
+      // delivery's amount: the money was applied by the delivery that won, and
+      // applying it again would double-count it against the invoice.
       const existingPayment = await prisma.payment.findUnique({
         where: { paymentAttemptId: paymentAttempt.id },
       });
       if (!existingPayment) throw error;
 
+      // A P2002 proves the Payment row exists, and nothing more. No transaction
+      // wraps the insert and the invoice update that follows it, so the delivery
+      // that won may have died in between and left the invoice unsettled.
+      // Acknowledging without checking would end the retries that were its only
+      // remaining chance to finish.
+      //
+      // So re-derive the position from what is actually recorded. Reading the
+      // successful payments means the balance already accounts for the winner's.
       const currentInvoice = await prisma.invoice.findUniqueOrThrow({
         where: { id: invoiceId },
+        include: { payments: { where: { status: "SUCCEEDED" } } },
       });
       const settled = await getOutstandingBalance(
         invoiceId,
@@ -1893,16 +1901,42 @@ export const FinancePaymentService = {
         currentInvoice.depositCollectedAmount ?? 0,
       );
 
+      const needsSettling =
+        settled.balance <= 0 && currentInvoice.status !== "PAID";
+      if (needsSettling) {
+        logger.warn(
+          `Invoice ${invoiceId} is covered but was not marked PAID; the delivery that recorded the payment did not finish. Settling it now.`,
+        );
+        await prisma.invoice.update({
+          where: { id: invoiceId },
+          data: {
+            status: "PAID",
+            paidAt: receivedAt,
+            visitBillingStage: "SETTLED",
+          },
+        });
+        await markInvoiceTreatmentItemsSettled(
+          currentInvoice,
+          invoiceId,
+          receivedAt,
+        );
+      }
+
       logger.info(
         `Payment for attempt ${paymentAttempt.id} was already recorded; treating this delivery as a replay`,
       );
 
       return {
-        invoice: currentInvoice,
+        invoice: needsSettling
+          ? await prisma.invoice.findUniqueOrThrow({ where: { id: invoiceId } })
+          : currentInvoice,
         paymentAttempt,
         payment: existingPayment,
         balanceAfterPayment: settled.balance,
         paidToDate: settled.paid,
+        // A caller that notifies the pet parent must not tell them twice that
+        // the same payment succeeded.
+        replayed: true,
         // Nothing new was applied. A caller that adds this to a running total
         // must not count the same money twice.
         appliedAmount: 0,
@@ -1949,6 +1983,7 @@ export const FinancePaymentService = {
       balanceAfterPayment: summary.balance,
       paidToDate: summary.paid,
       appliedAmount,
+      replayed: false,
     };
   },
 

--- a/apps/backend/src/services/finance/settlement.ts
+++ b/apps/backend/src/services/finance/settlement.ts
@@ -1,12 +1,22 @@
 import type { Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 
+// The subset of the client this needs, so a caller inside an interactive
+// transaction can hand in its `tx` and have this write commit or roll back with
+// the rest of the settlement rather than on a separate connection.
+type TreatmentItemWriter = {
+  workspaceTreatmentItem: {
+    updateMany: (typeof prisma)["workspaceTreatmentItem"]["updateMany"];
+  };
+};
+
 // Stamp the workspace treatment items billed on an invoice as settled so the
 // visit workspace stops offering them for further billing.
 export const markInvoiceTreatmentItemsSettled = async (
   invoice: { appointmentId: string | null; items: Prisma.JsonValue },
   settledInvoiceId: string,
   settledAt: Date,
+  client: TreatmentItemWriter = prisma,
 ) => {
   const invoiceRowIds = (Array.isArray(invoice.items) ? invoice.items : [])
     .map((item) =>
@@ -19,7 +29,7 @@ export const markInvoiceTreatmentItemsSettled = async (
     )
     .filter((id): id is string => Boolean(id));
   if (invoiceRowIds.length > 0) {
-    await prisma.workspaceTreatmentItem.updateMany({
+    await client.workspaceTreatmentItem.updateMany({
       where: {
         appointmentId: invoice.appointmentId,
         invoiceRowId: { in: invoiceRowIds },

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -1068,6 +1068,13 @@ export const StripeService = {
       return;
     }
 
+    // A replay settles nothing new. Stripe redelivers whenever it does not get a
+    // 2xx, including when the response was simply lost, so without this the pet
+    // parent is told again that the same payment succeeded.
+    if (result.replayed) {
+      return;
+    }
+
     await NotificationService.sendToUser(
       result.invoice.parentId,
       NotificationTemplates.Payment.PAYMENT_SUCCESS(

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -161,6 +161,72 @@ describe("FinancePaymentService", () => {
     expect(prisma.invoice.update).not.toHaveBeenCalled();
   });
 
+  it("settles an invoice the winning delivery paid for but never marked PAID", async () => {
+    // A P2002 proves only that the Payment row exists. No transaction wraps the
+    // insert and the invoice update, so the delivery that won can die in
+    // between. Acknowledging the replay without checking would end the retries
+    // that were the last chance to finish the job.
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_halfdone",
+      totalAmount: 100,
+      currency: "usd",
+      status: "AWAITING_PAYMENT",
+      depositCollectedAmount: 0,
+    });
+    (prisma.payment.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ amount: 100 }])
+      .mockResolvedValueOnce([{ amount: 100 }]);
+    (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
+      id: "pa_halfdone",
+    });
+    (prisma.payment.create as jest.Mock).mockRejectedValueOnce({
+      code: "P2002",
+    });
+    (prisma.payment.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "pay_winner",
+      amount: 100,
+      status: "SUCCEEDED",
+    });
+    (prisma.invoice.findUniqueOrThrow as jest.Mock)
+      .mockResolvedValueOnce({
+        id: "inv_halfdone",
+        totalAmount: 100,
+        currency: "usd",
+        status: "AWAITING_PAYMENT",
+        depositCollectedAmount: 0,
+        payments: [{ amount: 100, status: "SUCCEEDED" }],
+      })
+      .mockResolvedValueOnce({
+        id: "inv_halfdone",
+        totalAmount: 100,
+        currency: "usd",
+        status: "PAID",
+        depositCollectedAmount: 0,
+      });
+
+    const result = await FinancePaymentService.recordInvoicePayment(
+      "inv_halfdone",
+      {
+        provider: "STRIPE",
+        amount: 100,
+        settlementChannel: "STRIPE",
+        currency: "usd",
+        providerPaymentId: "pi_halfdone",
+        receivedAt: new Date("2026-06-18T10:00:00.000Z"),
+      },
+    );
+
+    expect(prisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "inv_halfdone" },
+        data: expect.objectContaining({ status: "PAID" }),
+      }),
+    );
+    expect(result.replayed).toBe(true);
+    expect(result.appliedAmount).toBe(0);
+  });
+
   it("rethrows a Payment insert failure that is not a unique violation", async () => {
     (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
       id: "inv_boom",

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -16,6 +16,7 @@ jest.mock("src/config/prisma", () => ({
   prisma: {
     invoice: {
       findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
       updateMany: jest.fn(),
@@ -105,6 +106,88 @@ describe("FinancePaymentService", () => {
       }),
     );
     expect(attempt.id).toBe("pa_1");
+  });
+
+  it("treats a redelivered partial payment as a replay instead of throwing", async () => {
+    // The ALREADY_PAID guard upstream only fires once the invoice is PAID, and a
+    // deposit or part payment never sets that. So a redelivered partial payment
+    // reaches the Payment insert and dies on Payment.paymentAttemptId, uncaught,
+    // which answers non-2xx and buys an endless Stripe retry.
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_replay",
+      totalAmount: 100,
+      currency: "usd",
+      status: "AWAITING_PAYMENT",
+      depositCollectedAmount: 0,
+    });
+    (prisma.payment.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ amount: 25 }]);
+    (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
+      id: "pa_replay",
+    });
+    (prisma.payment.create as jest.Mock).mockRejectedValueOnce({
+      code: "P2002",
+    });
+    (prisma.payment.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "pay_already",
+      amount: 25,
+      status: "SUCCEEDED",
+    });
+    (prisma.invoice.findUniqueOrThrow as jest.Mock).mockResolvedValueOnce({
+      id: "inv_replay",
+      totalAmount: 100,
+      currency: "usd",
+      status: "AWAITING_PAYMENT",
+      depositCollectedAmount: 0,
+    });
+
+    const result = await FinancePaymentService.recordInvoicePayment(
+      "inv_replay",
+      {
+        provider: "STRIPE",
+        amount: 25,
+        settlementChannel: "STRIPE",
+        currency: "usd",
+        providerPaymentId: "pi_replay",
+        receivedAt: new Date("2026-06-18T10:00:00.000Z"),
+      },
+    );
+
+    expect(result.payment?.id).toBe("pay_already");
+    // Nothing new was applied. Re-applying would double-count the money against
+    // the invoice, which is why this returns before updateInvoiceAfterPayment.
+    expect(result.appliedAmount).toBe(0);
+    expect(prisma.invoice.update).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a Payment insert failure that is not a unique violation", async () => {
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_boom",
+      totalAmount: 100,
+      currency: "usd",
+      status: "AWAITING_PAYMENT",
+      depositCollectedAmount: 0,
+    });
+    (prisma.payment.findMany as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ amount: 25 }]);
+    (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
+      id: "pa_boom",
+    });
+    (prisma.payment.create as jest.Mock).mockRejectedValueOnce(
+      new Error("connection reset"),
+    );
+
+    await expect(
+      FinancePaymentService.recordInvoicePayment("inv_boom", {
+        provider: "STRIPE",
+        amount: 25,
+        settlementChannel: "STRIPE",
+        currency: "usd",
+        receivedAt: new Date("2026-06-18T10:00:00.000Z"),
+      }),
+    ).rejects.toThrow("connection reset");
   });
 
   it("records a partial payment without closing the invoice", async () => {

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -14,6 +14,7 @@ jest.mock("stripe", () => ({
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    $transaction: jest.fn(),
     invoice: {
       findUnique: jest.fn(),
       findUniqueOrThrow: jest.fn(),
@@ -57,6 +58,12 @@ jest.mock("src/config/prisma", () => ({
 describe("FinancePaymentService", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    // recordInvoicePayment now writes the attempt, the Payment and the invoice
+    // inside one interactive transaction. Run the callback against the same
+    // mocks so these assertions are about the real sequence, not a stub.
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      (fn: (tx: unknown) => unknown) => fn(prisma),
+    );
     (prisma.payment.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.creditNote.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.paymentAttempt.findMany as jest.Mock).mockResolvedValue([]);
@@ -123,7 +130,7 @@ describe("FinancePaymentService", () => {
     (prisma.payment.findMany as jest.Mock)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ amount: 25 }]);
-    (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
+    (prisma.paymentAttempt.update as jest.Mock).mockResolvedValueOnce({
       id: "pa_replay",
     });
     (prisma.payment.create as jest.Mock).mockRejectedValueOnce({
@@ -150,6 +157,7 @@ describe("FinancePaymentService", () => {
         settlementChannel: "STRIPE",
         currency: "usd",
         providerPaymentId: "pi_replay",
+        paymentAttemptId: "pa_replay",
         receivedAt: new Date("2026-06-18T10:00:00.000Z"),
       },
     );
@@ -161,13 +169,44 @@ describe("FinancePaymentService", () => {
     expect(prisma.invoice.update).not.toHaveBeenCalled();
   });
 
-  it("settles an invoice the winning delivery paid for but never marked PAID", async () => {
-    // A P2002 proves only that the Payment row exists. No transaction wraps the
-    // insert and the invoice update, so the delivery that won can die in
-    // between. Acknowledging the replay without checking would end the retries
-    // that were the last chance to finish the job.
+  it("flags a delivery that arrives after the balance is already closed", async () => {
+    // Stripe redelivers whenever it does not receive a 2xx. If the balance is
+    // already closed the early return does no work, and without saying so the
+    // caller reads it as a fresh success and notifies the pet parent again.
     (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
-      id: "inv_halfdone",
+      id: "inv_closed",
+      totalAmount: 100,
+      currency: "usd",
+      status: "AWAITING_PAYMENT",
+      depositCollectedAmount: 0,
+    });
+    (prisma.payment.findMany as jest.Mock).mockResolvedValueOnce([
+      { amount: 100 },
+    ]);
+
+    const result = await FinancePaymentService.recordInvoicePayment(
+      "inv_closed",
+      {
+        provider: "STRIPE",
+        amount: 100,
+        settlementChannel: "STRIPE",
+        currency: "usd",
+        receivedAt: new Date("2026-06-18T10:00:00.000Z"),
+      },
+    );
+
+    expect(result.appliedAmount).toBe(0);
+    expect(result.replayed).toBe(true);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("writes the attempt, the payment and the invoice in one transaction", async () => {
+    // This is what makes the replay guard sound. Without it a delivery can die
+    // between the Payment insert and the invoice update, and no later delivery
+    // can tell that apart from a clean replay, because nothing records which of
+    // the steps ran.
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_atomic",
       totalAmount: 100,
       currency: "usd",
       status: "AWAITING_PAYMENT",
@@ -175,56 +214,38 @@ describe("FinancePaymentService", () => {
     });
     (prisma.payment.findMany as jest.Mock)
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ amount: 100 }])
       .mockResolvedValueOnce([{ amount: 100 }]);
     (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
-      id: "pa_halfdone",
+      id: "pa_atomic",
     });
-    (prisma.payment.create as jest.Mock).mockRejectedValueOnce({
-      code: "P2002",
-    });
-    (prisma.payment.findUnique as jest.Mock).mockResolvedValueOnce({
-      id: "pay_winner",
+    (prisma.payment.create as jest.Mock).mockResolvedValueOnce({
+      id: "pay_atomic",
       amount: 100,
       status: "SUCCEEDED",
     });
-    (prisma.invoice.findUniqueOrThrow as jest.Mock)
-      .mockResolvedValueOnce({
-        id: "inv_halfdone",
-        totalAmount: 100,
-        currency: "usd",
-        status: "AWAITING_PAYMENT",
-        depositCollectedAmount: 0,
-        payments: [{ amount: 100, status: "SUCCEEDED" }],
-      })
-      .mockResolvedValueOnce({
-        id: "inv_halfdone",
-        totalAmount: 100,
-        currency: "usd",
-        status: "PAID",
-        depositCollectedAmount: 0,
-      });
+    (prisma.invoice.update as jest.Mock).mockResolvedValueOnce({
+      id: "inv_atomic",
+      totalAmount: 100,
+      currency: "usd",
+      status: "PAID",
+      depositCollectedAmount: 0,
+    });
 
-    const result = await FinancePaymentService.recordInvoicePayment(
-      "inv_halfdone",
-      {
-        provider: "STRIPE",
-        amount: 100,
-        settlementChannel: "STRIPE",
-        currency: "usd",
-        providerPaymentId: "pi_halfdone",
-        receivedAt: new Date("2026-06-18T10:00:00.000Z"),
-      },
-    );
+    await FinancePaymentService.recordInvoicePayment("inv_atomic", {
+      provider: "STRIPE",
+      amount: 100,
+      settlementChannel: "STRIPE",
+      currency: "usd",
+      receivedAt: new Date("2026-06-18T10:00:00.000Z"),
+    });
 
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.create).toHaveBeenCalled();
     expect(prisma.invoice.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "inv_halfdone" },
         data: expect.objectContaining({ status: "PAID" }),
       }),
     );
-    expect(result.replayed).toBe(true);
-    expect(result.appliedAmount).toBe(0);
   });
 
   it("rethrows a Payment insert failure that is not a unique violation", async () => {

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -1480,6 +1480,43 @@ describe("StripeService", () => {
       );
       expect(NotificationService.sendToUser).toHaveBeenCalled();
     });
+
+    it("does not notify the parent again when the checkout session is replayed", async () => {
+      // Stripe redelivers whenever it does not receive a 2xx, including when the
+      // response was simply lost. A replay settles nothing new, so telling the
+      // pet parent their payment succeeded a second time is wrong.
+      (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "inv_replay",
+        paymentCollectionMethod: "PAYMENT_LINK",
+        appointmentId: "appt_1",
+        parentId: "par_1",
+        totalAmount: 10,
+        currency: "usd",
+      });
+      (
+        FinancePaymentService.handleInvoiceCheckoutSessionCompleted as jest.Mock
+      ).mockResolvedValueOnce({
+        action: "PAID",
+        replayed: true,
+        invoice: {
+          id: "inv_replay",
+          parentId: "par_1",
+          totalAmount: 10,
+          currency: "usd",
+        },
+      });
+
+      await StripeService._handleInvoiceCheckout({
+        id: "cs_replay",
+        payment_status: "paid",
+        metadata: { invoiceId: "inv_replay" },
+      } as any);
+
+      expect(
+        FinancePaymentService.handleInvoiceCheckoutSessionCompleted,
+      ).toHaveBeenCalled();
+      expect(NotificationService.sendToUser).not.toHaveBeenCalled();
+    });
   });
 
   describe("getAccountStatus missing organisation", () => {


### PR DESCRIPTION
## What changed

`FinancePaymentService.recordInvoicePayment` now recovers from its own unique violation on the `Payment` insert, returning the payment that is already recorded instead of throwing.

## Why

A redelivered Stripe payment event for a **deposit or a partial payment** throws an uncaught P2002 today. The endpoint answers non-2xx, Stripe retries, and the retry hits the same wall, so the event is retried until Stripe gives up. Three things line up to produce it:

- the `ALREADY_PAID` guard only fires once the invoice is `PAID`, and `updateInvoiceAfterPayment` only sets `PAID` when the applied amount covers the **whole** balance (`if (appliedAmount >= balance)`), so a part payment never trips it;
- the attempt lookup excludes only `CANCELED` and `FAILED`, so it finds the now-`SUCCEEDED` attempt from the first delivery and passes its id along;
- `recordInvoicePayment` then inserts a `Payment` carrying that attempt id, and `Payment.paymentAttemptId` is `@unique`.

There is no transaction around any of it, so the attempt row has already been mutated by the time the insert dies.

The recovery deliberately does **not** fall through to `updateInvoiceAfterPayment`. The money was applied by the delivery that won; applying it again would double-count it against the invoice. `appliedAmount` comes back as `0` for the same reason, so a caller accumulating it cannot count the same payment twice.

## How this was found

While checking whether `PaymentAttempt.providerPaymentIntentId` could take a unique constraint, per the back-office plan. A five-angle safety review concluded the constraint **is** safe but **would not have fixed anything**: a redelivered webhook UPDATEs the attempt on a row selected BY that same intent id, so the index is never consulted. This is the failure that was actually reachable, so it is what this PR fixes. The constraint is not added here.

Two things worth recording for whoever picks this up next:

- `PaymentAttemptStatus.FAILED` is **never written anywhere** in the codebase. `handleInvoicePaymentFailed` marks the *invoice* FAILED, not the attempt. Any reasoning that treats "no FAILED attempts exist" as evidence about an untested path is wrong; it is a property of the code.
- Nothing collides on the intent id today only because `stripe.paymentIntents.create` is called with **no idempotency key**, so Stripe returns a fresh id every time. Adding one, which looks like ordinary hardening, would make a retried create return the same id. If the unique on `PaymentAttempt.providerPaymentIntentId` is ever added, that call site needs a comment saying so, or the customer-facing pay-now request becomes a P2002.

## Impact area

`apps/backend` only. No schema change, no migration, no client change.

## Validation performed

- `pnpm --filter backend run type-check` - clean
- `pnpm --filter backend run lint` - exit 0, no findings
- `npx jest test/services/finance.payment.test.ts` - **119 passed**
- `npx prettier --check` on both changed files - clean

Both behaviours are mutation-verified, and each mutation fails a different test:

| mutation | result |
|---|---|
| remove the P2002 catch (the bug exactly as it stands on `dev`) | `● treats a redelivered partial payment as a replay instead of throwing` |
| report `appliedAmount` instead of `0` (the double-count) | `● returns a no-op result when the invoice is already fully paid` - an **existing** test |

The second one is the useful signal: an invariant that was already in the suite catches the double-count, so the guard cannot be loosened into re-applying money without something going red.
