### PR TITLE
fix(backend): strip line breaks from user data interpolated into log messages

### DIFF
--- a/apps/backend/src/services/ap-inbox.service.ts
+++ b/apps/backend/src/services/ap-inbox.service.ts
@@ -230,13 +230,13 @@ async function runInboundHandler(
       return handleAnnounce(targetOrgId, activity);
     default:
       // The type is an unvalidated string from a federated peer, so strip line
-      // breaks before it reaches the message. Keep the /\n|\r/g form with an
-      // empty replacement: a quantifier such as [\n\r]+ or a non-empty
+      // breaks before it reaches the message. Two constraints on the form: no
+      // quantifier, and an empty replacement. [\n\r]+ or a non-empty
       // replacement is not a CodeQL log-injection barrier. String() guards the
       // cast at the top of this file, since the body is parsed JSON and a peer
       // can send a non-string here.
       logger.info(
-        `[AP inbox] Unhandled activity type: ${String(activity.type).replace(/\n|\r/g, "")}`,
+        `[AP inbox] Unhandled activity type: ${String(activity.type).replace(/[\n\r]/g, "")}`,
         { actor: activity.actor },
       );
   }

--- a/apps/backend/src/services/ap-inbox.service.ts
+++ b/apps/backend/src/services/ap-inbox.service.ts
@@ -229,9 +229,16 @@ async function runInboundHandler(
     case "Announce":
       return handleAnnounce(targetOrgId, activity);
     default:
-      logger.info(`[AP inbox] Unhandled activity type: ${activity.type}`, {
-        actor: activity.actor,
-      });
+      // The type is an unvalidated string from a federated peer, so strip line
+      // breaks before it reaches the message. Keep the /\n|\r/g form with an
+      // empty replacement: a quantifier such as [\n\r]+ or a non-empty
+      // replacement is not a CodeQL log-injection barrier. String() guards the
+      // cast at the top of this file, since the body is parsed JSON and a peer
+      // can send a non-string here.
+      logger.info(
+        `[AP inbox] Unhandled activity type: ${String(activity.type).replace(/\n|\r/g, "")}`,
+        { actor: activity.actor },
+      );
   }
 }
 

--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -102,6 +102,15 @@ const buildFcmMessage = (
   return msg;
 };
 
+/**
+ * A log-safe prefix of a device token. The token is caller-supplied and only
+ * type-checked, so the six characters that reach the log are attacker-chosen.
+ * Keep the /\n|\r/g form with an empty replacement: a quantifier such as
+ * [\n\r]+ or a non-empty replacement is not a CodeQL log-injection barrier.
+ */
+const tokenPrefix = (token: string): string =>
+  token.slice(0, 6).replace(/\n|\r/g, "");
+
 export const NotificationService = {
   /**
    * Send a push notification to a single device token.
@@ -125,14 +134,14 @@ export const NotificationService = {
     try {
       const response = await admin.messaging().send(message, options?.dryRun);
       logger.info(
-        `Notification sent to token ${token.slice(0, 6)}…: ${response}`,
+        `Notification sent to token ${tokenPrefix(token)}…: ${response}`,
       );
       return { token, success: true };
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unknown FCM error";
       logger.error(
-        `Failed to send notification to token ${token.slice(0, 6)}…: ${message}`,
+        `Failed to send notification to token ${tokenPrefix(token)}…: ${message}`,
       );
 
       // If token is invalid, ask DeviceTokenService to remove/disable it
@@ -150,7 +159,7 @@ export const NotificationService = {
           await DeviceTokenService.removeToken(token);
         } catch (cleanupError) {
           logger.warn(
-            `Failed to clean up invalid token ${token.slice(0, 6)}… : ${
+            `Failed to clean up invalid token ${tokenPrefix(token)}… : ${
               cleanupError instanceof Error
                 ? cleanupError.message
                 : "Unknown error"

--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -105,11 +105,11 @@ const buildFcmMessage = (
 /**
  * A log-safe prefix of a device token. The token is caller-supplied and only
  * type-checked, so the six characters that reach the log are attacker-chosen.
- * Keep the /\n|\r/g form with an empty replacement: a quantifier such as
+ * Two constraints on the form: no quantifier, and an empty replacement.
  * [\n\r]+ or a non-empty replacement is not a CodeQL log-injection barrier.
  */
 const tokenPrefix = (token: string): string =>
-  token.slice(0, 6).replace(/\n|\r/g, "");
+  token.slice(0, 6).replace(/[\n\r]/g, "");
 
 export const NotificationService = {
   /**

--- a/apps/backend/src/services/task.recurrence.engine.ts
+++ b/apps/backend/src/services/task.recurrence.engine.ts
@@ -48,7 +48,17 @@ const computeNextDueAt = (
         });
         return interval.next().toDate();
       } catch (error) {
-        console.error("Invalid cron expression:", cronExpression, error);
+        // The expression is caller-supplied; strip line breaks so it cannot
+        // forge additional log lines. Keep the /\n|\r/g form with an empty
+        // replacement: a quantifier or a non-empty replacement is not a CodeQL
+        // log-injection barrier. `error` needs no strip: cron fields are
+        // whitespace-delimited, so cron-parser's "got value" echo is always a
+        // single field and can never contain a break.
+        console.error(
+          "Invalid cron expression:",
+          cronExpression.replace(/\n|\r/g, ""),
+          error,
+        );
         return null;
       }
     default:

--- a/apps/backend/src/services/task.recurrence.engine.ts
+++ b/apps/backend/src/services/task.recurrence.engine.ts
@@ -49,14 +49,14 @@ const computeNextDueAt = (
         return interval.next().toDate();
       } catch (error) {
         // The expression is caller-supplied; strip line breaks so it cannot
-        // forge additional log lines. Keep the /\n|\r/g form with an empty
-        // replacement: a quantifier or a non-empty replacement is not a CodeQL
-        // log-injection barrier. `error` needs no strip: cron fields are
+        // forge additional log lines. Two constraints on the form: no quantifier,
+        // and an empty replacement, or CodeQL's log-injection barrier does not
+        // fire. `error` needs no strip: cron fields are
         // whitespace-delimited, so cron-parser's "got value" echo is always a
         // single field and can never contain a break.
         console.error(
           "Invalid cron expression:",
-          cronExpression.replace(/\n|\r/g, ""),
+          cronExpression.replace(/[\n\r]/g, ""),
           error,
         );
         return null;

--- a/apps/backend/src/services/task.recurrence.engine.ts
+++ b/apps/backend/src/services/task.recurrence.engine.ts
@@ -51,12 +51,15 @@ const computeNextDueAt = (
         // The expression is caller-supplied; strip line breaks so it cannot
         // forge additional log lines. Two constraints on the form: no quantifier,
         // and an empty replacement, or CodeQL's log-injection barrier does not
-        // fire. `error` needs no strip: cron fields are
+        // fire. String() matters: the task controllers spread req.body straight
+        // through, so a stored cronExpression need not be a string, and a bare
+        // .replace() would throw here inside the catch and abort the whole
+        // engine run. `error` needs no strip: cron fields are
         // whitespace-delimited, so cron-parser's "got value" echo is always a
         // single field and can never contain a break.
         console.error(
           "Invalid cron expression:",
-          cronExpression.replace(/[\n\r]/g, ""),
+          String(cronExpression).replace(/[\n\r]/g, ""),
           error,
         );
         return null;

--- a/apps/backend/test/services/ap-inbox.service.test.ts
+++ b/apps/backend/test/services/ap-inbox.service.test.ts
@@ -1066,3 +1066,42 @@ describe("handleCreate / handleAnnounce", () => {
     expect(prismaMock.aPActivity.update).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("unhandled activity type", () => {
+  beforeEach(resetAll);
+
+  it("strips line breaks from the type before logging it", async () => {
+    const logger = jest.requireMock("src/utils/logger").default as {
+      info: jest.Mock;
+    };
+
+    await dispatch({
+      id: "urn:unhandled:1",
+      type: "Ping\r\nFAKE LOG LINE",
+      actor: "https://remote.example/actor",
+    });
+
+    const call = logger.info.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" && c[0].includes("Unhandled activity type"),
+    );
+    expect(call).toBeDefined();
+    const message = call![0] as string;
+    expect(message).toContain("PingFAKE LOG LINE");
+    expect(message).not.toContain("\n");
+    expect(message).not.toContain("\r");
+  });
+
+  it("does not throw when a peer sends a non-string type", async () => {
+    // The body is parsed JSON cast to AnyActivity, so `type` is not really
+    // guaranteed to be a string. Interpolation tolerated that; a bare
+    // .replace() would not.
+    await expect(
+      dispatch({
+        id: "urn:unhandled:2",
+        type: { nested: "object" } as unknown as string,
+        actor: "https://remote.example/actor",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/backend/test/services/notification.service.test.ts
+++ b/apps/backend/test/services/notification.service.test.ts
@@ -90,6 +90,22 @@ describe("NotificationService", () => {
       expect(res).toEqual({ token: "valid-token", success: true });
     });
 
+    it("strips line breaks from the token prefix before logging it", async () => {
+      mockSend.mockResolvedValueOnce("msg-id");
+
+      // The token is caller-supplied and only type-checked, so the six
+      // characters that reach the log are attacker-chosen.
+      await NotificationService.sendToDevice("ab\r\ncd-rest-of-token", payload);
+
+      const logged = (logger.info as jest.Mock).mock.calls
+        .flat()
+        .filter((c): c is string => typeof c === "string")
+        .join(" ");
+      expect(logged).toContain("abcd");
+      expect(logged).not.toContain("\n");
+      expect(logged).not.toContain("\r");
+    });
+
     it("uses default empty object for data if not provided", async () => {
       mockSend.mockResolvedValueOnce("msg-id");
       await NotificationService.sendToDevice("token", payload);

--- a/apps/backend/test/services/task.recurrence.engine.test.ts
+++ b/apps/backend/test/services/task.recurrence.engine.test.ts
@@ -69,6 +69,26 @@ describe("TaskRecurrenceEngine invalid cron logging", () => {
     expect(prismaMock.task.create).not.toHaveBeenCalled();
   });
 
+  it("does not abort the run when a stored cron expression is not a string", async () => {
+    // The task controllers spread req.body straight through, so an
+    // authenticated caller can persist a non-string cronExpression. A bare
+    // .replace() would throw inside the catch and kill the whole run, leaving
+    // every later master unprocessed on every future run.
+    const poisoned = master({
+      evil: "object",
+    } as unknown as string) as ReturnType<typeof master>;
+    poisoned.id = "task-poisoned";
+    const healthy = master("0 0 * * *");
+
+    prismaMock.task.findMany.mockResolvedValue([poisoned, healthy]);
+
+    await expect(TaskRecurrenceEngine.run()).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+    // The healthy master was still processed after the poisoned one.
+    expect(prismaMock.task.create).toHaveBeenCalled();
+  });
+
   it("leaves a valid cron expression alone and generates children", async () => {
     prismaMock.task.findMany.mockResolvedValue([master("0 0 * * *")]);
 

--- a/apps/backend/test/services/task.recurrence.engine.test.ts
+++ b/apps/backend/test/services/task.recurrence.engine.test.ts
@@ -1,0 +1,80 @@
+const prismaMock = {
+  task: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+  },
+};
+
+jest.mock("src/config/prisma", () => ({
+  __esModule: true,
+  prisma: prismaMock,
+}));
+
+import { TaskRecurrenceEngine } from "src/services/task.recurrence.engine";
+
+const master = (cronExpression: string) => ({
+  id: "task-1",
+  organisationId: "org-1",
+  appointmentId: null,
+  patientId: null,
+  createdBy: "user-1",
+  assignedBy: null,
+  assignedTo: "user-2",
+  audience: "STAFF",
+  source: "MANUAL",
+  libraryTaskId: null,
+  templateId: null,
+  category: "GENERAL",
+  name: "Recurring task",
+  description: null,
+  medication: null,
+  observationToolId: null,
+  dueAt: new Date("2026-01-01T00:00:00Z"),
+  timezone: "UTC",
+  status: "PENDING",
+  recurrence: { isMaster: true, type: "CUSTOM", cronExpression },
+  reminder: null,
+  syncWithCalendar: null,
+  attachments: null,
+});
+
+describe("TaskRecurrenceEngine invalid cron logging", () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.task.findFirst.mockResolvedValue(null);
+    prismaMock.task.create.mockResolvedValue({});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("strips line breaks from the cron expression before logging it", async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      master("bad\r\nFAKE LOG LINE"),
+    ]);
+
+    await TaskRecurrenceEngine.run();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = errorSpy.mock.calls[0][1] as string;
+    expect(logged).toBe("badFAKE LOG LINE");
+    expect(logged).not.toContain("\n");
+    expect(logged).not.toContain("\r");
+    // A cron that never parses generates nothing.
+    expect(prismaMock.task.create).not.toHaveBeenCalled();
+  });
+
+  it("leaves a valid cron expression alone and generates children", async () => {
+    prismaMock.task.findMany.mockResolvedValue([master("0 0 * * *")]);
+
+    await TaskRecurrenceEngine.run();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(prismaMock.task.create).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Follow-up to #2544. Three places interpolate untrusted data straight into a log message, or pass it as a bare argument. That is the shape that forges log lines, and none of them had a barrier.

CodeQL does not report any of them. The ActivityPub body reaches the service through a BullMQ job (`req` to `ApInboxQueue.add` to `Worker job.data`) and taint cannot cross that boundary, so a green code-scanning run says nothing about these sinks.

| File | What reaches the message |
| --- | --- |
| `services/ap-inbox.service.ts` | `activity.type`, an unvalidated string from a federated peer |
| `services/task.recurrence.engine.ts` | `cronExpression`, stored caller-supplied input, unbounded |
| `services/notification.service.ts` | six attacker-chosen characters of `deviceToken` via `slice` |

## What is the new behavior?

Each value is stripped of line breaks before it reaches the message.

Two details worth review:

**`String()` at the ActivityPub site.** The inbox body is `JSON.parse(rawBody) as AnyActivity`, an unchecked cast, so a peer can send `{"type": {...}}`. Template interpolation tolerated that; a bare `.replace()` would throw and take down the handler. `String(activity.type).replace(...)` keeps the current behavior. There is a test for it.

**`error` is deliberately not stripped** in the recurrence engine. Cron fields are whitespace-delimited, so a field can never contain a line break, and cron-parser's "got value" echo is always a single field. Checked empirically across eight inputs including `\r`, `\r\n` and leading newlines: the message never contains a break.

### On the barrier form

`.replace(/[\n\r]/g, "")`. The two constraints that matter are **no quantifier** and an **empty replacement**, because CodeQL's `StringReplaceSanitizer` requires `replaces(s, "")` and a quantifier root yields no matched string at all. A non-inverted character class satisfies that through `RegExpCharacterClass.getAMatchedString`, and unlike the `\n|\r` alternation it does not trip Sonar `typescript:S6035`. #2544 has been updated to the same form.

### Verification

- `tsc --noEmit` on the backend: clean. `prettier --check` on all six touched files: clean.
- `npx jest --testPathPatterns "ap-inbox.service|task.recurrence.engine|notification.service"`: 3 suites, 81 tests, all passing.
- **Every new test is mutation-verified.** Reverting the barrier to the old `[\n\r]+` / `" "` idiom fails all three, and dropping the `String()` guard fails the non-string case with `TypeError: activity.type.replace is not a function`. A test that passes with and without the fix proves nothing, which is how the original defect survived #2483 and #2494.

`task.recurrence.engine.ts` had no test file at all; this adds one.

### Deliberately not changed

Tainted values sitting in a plain object-literal log field, such as `logger.warn("...", { targetOrgId, keyId })` in the AP inbox worker, and the equivalent fields in merck, documenso, inventory-consumption and the user controllers. CodeQL never taints an object literal from a normal property value, so these are neither current nor future alerts, and winston's `json()` escapes newlines outside development. Changing them would be churn.

## Related Issue(s)

Follows up #2544.
