### PR TITLE
fix(frontend): show a failed lab order where the clinician is looking

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -328,7 +328,23 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
   it('surfaces a hook error message', () => {
     renderStep({ error: 'IDEXX request failed' });
 
-    expect(screen.getByText('IDEXX request failed')).toBeInTheDocument();
+    // Twice on purpose: once at the top of the IDEXX section, and once beside
+    // the Create Lab Order button. The order is placed from the Test Queue,
+    // several screens below the heading, so the top copy alone is off-screen at
+    // the moment it appears and the click reads as having done nothing.
+    expect(screen.getAllByText('IDEXX request failed')).toHaveLength(2);
+  });
+
+  it('shows the failure next to the Create Lab Order button', () => {
+    renderStep({ error: 'Companion not found.' });
+
+    const button = screen.getByRole('button', { name: /create lab order/i });
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toHaveTextContent('Companion not found.');
+    // Same container as the button, so it cannot render off-screen away from
+    // the action that failed.
+    expect(button.parentElement).toContainElement(alert);
   });
 
   it('removes a queued test through the hook action', () => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -536,7 +536,16 @@ const TestQueueSection = ({
       </div>
     )}
     {!readOnly && (
-      <div className="flex justify-end">
+      <div className="flex flex-col items-end gap-3">
+        {/* Beside the button, not only at the top of the section. The order is
+            placed from here, several screens below the section heading, so an
+            error rendered up there is off-screen at the moment it appears and
+            the click reads as having done nothing at all. */}
+        {s.error ? (
+          <p role="alert" className="text-body-4 text-text-error">
+            {s.error}
+          </p>
+        ) : null}
         <Primary
           text={s.creatingOrder ? 'Creating Lab Order…' : 'Create Lab Order'}
           icon={<IoFlaskOutline aria-hidden="true" />}


### PR DESCRIPTION
## What changed

The IDEXX order error now also renders beside the **Create Lab Order** button, inside the same container, with `role="alert"`.

## Why

Placing a lab order that the API refuses looked like nothing happened at all.

The error was already captured and already rendered, so this is not missing error handling. It rendered at the **top of the IDEXX section**, while the order is placed from the Test Queue several screens below it. At the moment the message appeared it was off-screen, so the click read as inert: the test stayed queued, the button stayed enabled, and the natural response is to click again, persisting another failed order each time.

## How it was found

By driving the real journey on dev, not by reading the code. Appointment `72fab213-7e15-4a84-913a-551fed080f03`, companion "Vincent", status IN_PROGRESS, whose `PatientOrganisation` link is `PENDING` - which `assertPatientOrgMembership` refuses by design, since a PENDING link is one the practice requested and the parent has not approved.

Searching, queueing and clicking Create Lab Order produced no visible change whatsoever. In the database that click had written:

```
status           ERROR
error            Companion not found.
responsePayload  null
```

`responsePayload: null` confirms the guard did its job and nothing was transmitted to IDEXX. The clinician simply was not told.

This is not an edge case on current data: on dev, **13 of 44 companions have an ACTIVE link**, and **34 of 74 historical lab orders** are for a pair without one, so roughly half of lab ordering takes this path today.

## Why in addition rather than instead

`error` is shared with the census actions further up the section, so moving the single render down to the Test Queue would only relocate the same problem for those. The duplicate is deliberate and cheap; consolidating the section's error surface is worth doing separately.

## What this does not do

Change the wording. "Companion not found." is deliberately vague so a cross-tenant probe cannot learn which patient ids exist, which is right for that case and wrong for a clinician standing in the companion's own workspace. Telling those two apart is a tenancy-model decision and belongs with #2472.

## Impact area

`apps/frontend` only. One component, plus its tests.

## Validation performed

- `npx tsc --noEmit` from `apps/frontend` - clean, exit 0
- `pnpm --filter frontend run lint` - exit 0 (one pre-existing unrelated warning in `CompanionIdCard.test.tsx`)
- `npx prettier --check` on both changed files - clean
- `npx jest src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx` - **48 passed**

Mutation-checked. Removing the new render, which is the bug exactly as it ships today, fails two tests and nothing else:

```
● surfaces a hook error message
● shows the failure next to the Create Lab Order button
Tests: 2 failed, 46 passed, 48 total
```

The existing `surfaces a hook error message` test was updated to expect both copies, and a new test asserts the alert is inside the button's own container so it cannot drift off-screen from the action again.

Fixes #2547.
