### PR TITLE
fix(repo): let one account hold both a practice role and the developer role

### DIFF
--- a/apps/backend/src/routers/auth.router.ts
+++ b/apps/backend/src/routers/auth.router.ts
@@ -125,6 +125,24 @@ router.get("/me", requireAnyAuth, async (req, res: Response, next) => {
         resolvedRoles.find((role: string) => role === "superadmin") ??
         resolvedRoles[0] ??
         (typeof metadata.role === "string" ? metadata.role : undefined),
+      /*
+       * The full set, because one account can legitimately hold several roles
+       * and `role` above can only answer with one of them.
+       *
+       * A user who is both a clinic member and a platform developer is a
+       * supported combination, and collapsing to `resolvedRoles[0]` made which
+       * one the client saw depend on the order the role store happened to
+       * return - so the same account could be routed to the practice or to the
+       * developer portal on different sign-ins. Callers that need to ask "does
+       * this account hold role X" read this; `role` stays for the single-role
+       * display callers that predate it.
+       */
+      roles:
+        resolvedRoles.length > 0
+          ? resolvedRoles
+          : typeof metadata.role === "string"
+            ? [metadata.role]
+            : [],
     });
   } catch (err) {
     next(err);

--- a/apps/backend/src/routers/auth.router.ts
+++ b/apps/backend/src/routers/auth.router.ts
@@ -104,6 +104,30 @@ router.get("/me", requireAnyAuth, async (req, res: Response, next) => {
       // of truth for identity.
     }
 
+    const metadataRole =
+      typeof metadata.role === "string" ? metadata.role : undefined;
+
+    /*
+     * The full set, because one account can legitimately hold several roles
+     * and `role` below can only answer with one of them.
+     *
+     * A user who is both a clinic member and a platform developer is a
+     * supported combination, and collapsing to `resolvedRoles[0]` made which
+     * one the client saw depend on the order the role store happened to
+     * return - so the same account could be routed to the practice or to the
+     * developer portal on different sign-ins. Callers that need to ask "does
+     * this account hold role X" read this; `role` stays for the single-role
+     * display callers that predate it.
+     *
+     * Metadata is the same last resort the single `role` falls back to, so the
+     * two fields cannot disagree about an account the role store cannot answer
+     * for.
+     */
+    let effectiveRoles: string[] = resolvedRoles;
+    if (effectiveRoles.length === 0 && metadataRole) {
+      effectiveRoles = [metadataRole];
+    }
+
     res.json({
       userId: session.appUserId,
       authProfile: session.authProfile,
@@ -124,25 +148,8 @@ router.get("/me", requireAnyAuth, async (req, res: Response, next) => {
       role:
         resolvedRoles.find((role: string) => role === "superadmin") ??
         resolvedRoles[0] ??
-        (typeof metadata.role === "string" ? metadata.role : undefined),
-      /*
-       * The full set, because one account can legitimately hold several roles
-       * and `role` above can only answer with one of them.
-       *
-       * A user who is both a clinic member and a platform developer is a
-       * supported combination, and collapsing to `resolvedRoles[0]` made which
-       * one the client saw depend on the order the role store happened to
-       * return - so the same account could be routed to the practice or to the
-       * developer portal on different sign-ins. Callers that need to ask "does
-       * this account hold role X" read this; `role` stays for the single-role
-       * display callers that predate it.
-       */
-      roles:
-        resolvedRoles.length > 0
-          ? resolvedRoles
-          : typeof metadata.role === "string"
-            ? [metadata.role]
-            : [],
+        metadataRole,
+      roles: effectiveRoles,
     });
   } catch (err) {
     next(err);

--- a/apps/backend/test/routers/auth.router.test.ts
+++ b/apps/backend/test/routers/auth.router.test.ts
@@ -202,6 +202,48 @@ describe("auth.router", () => {
      * access token still carries the `member` it was issued with. Preferring the
      * claim kept the portal routing on the stale value.
      */
+    /*
+     * `role` can only answer with one of the roles an account holds, and which
+     * one depends on the order the role store returns. Callers deciding what an
+     * account may reach need the whole set, so the response carries both.
+     */
+    it("returns every role the account holds, not just the one `role` names", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["member", "developer"]);
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ roles: ["member", "developer"] });
+    });
+
+    it("keeps `roles` in step with a role corrected in the store", async () => {
+      mockGetUserRoles.mockResolvedValueOnce(["developer"]);
+
+      const res = await meFor(sessionWith(["member"]));
+
+      expect(res.body).toMatchObject({
+        role: "developer",
+        roles: ["developer"],
+      });
+    });
+
+    it("falls back to the metadata role when neither source lists any", async () => {
+      mockGetUserRoles.mockResolvedValueOnce([]);
+      mockGetUserMetadata.mockResolvedValueOnce({ role: "developer" });
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ roles: ["developer"] });
+    });
+
+    it("answers with an empty role set rather than omitting it", async () => {
+      mockGetUserRoles.mockResolvedValueOnce([]);
+      mockGetUserMetadata.mockResolvedValueOnce({});
+
+      const res = await meFor(sessionWith([]));
+
+      expect(res.body).toMatchObject({ roles: [] });
+    });
+
     it("prefers a corrected role from the store over a stale session claim", async () => {
       mockGetUserRoles.mockResolvedValueOnce(["developer"]);
 

--- a/apps/frontend/src/app/__tests__/components/DevRouteGuard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DevRouteGuard.test.tsx
@@ -65,6 +65,52 @@ describe('DevRouteGuard', () => {
     expect(mockRedirect).toHaveBeenCalledWith('/developers/signin');
   });
 
+  // An account can hold the practice role and the developer role at once. The
+  // guard used to compare only `role`, which is whichever single role
+  // `/v1/auth/me` surfaced, so a dual-role account was shown the rejection
+  // screen on a portal it is entitled to.
+  describe('accounts holding more than one role', () => {
+    const renderGuard = (state: Record<string, unknown>) => {
+      mockUseAuthStore.mockImplementation(
+        () => ({ status: 'authenticated', signout: jest.fn(), ...state }) as any
+      );
+      return render(
+        <DevRouteGuard>
+          <div>child</div>
+        </DevRouteGuard>
+      );
+    };
+
+    it('admits an account whose developer role is not the one surfaced as `role`', () => {
+      const { getByText } = renderGuard({ role: 'member', roles: ['member', 'developer'] });
+      expect(getByText('child')).toBeInTheDocument();
+    });
+
+    it('admits it regardless of the order the role store returns', () => {
+      const { getByText } = renderGuard({ role: 'member', roles: ['developer', 'member'] });
+      expect(getByText('child')).toBeInTheDocument();
+    });
+
+    it('still rejects an account that holds no developer role', () => {
+      const { queryByText, getByText } = renderGuard({
+        role: 'member',
+        roles: ['member', 'owner'],
+      });
+      expect(queryByText('child')).not.toBeInTheDocument();
+      expect(getByText(/isn.t a developer account/i)).toBeInTheDocument();
+    });
+
+    it('falls back to the single role when the API sent no role list', () => {
+      const { getByText } = renderGuard({ role: 'developer', roles: [] });
+      expect(getByText('child')).toBeInTheDocument();
+    });
+
+    it('normalises casing and padding before deciding', () => {
+      const { getByText } = renderGuard({ role: 'member', roles: ['member', '  Developer  '] });
+      expect(getByText('child')).toBeInTheDocument();
+    });
+  });
+
   it('keeps the session and explains itself when authenticated without developer role', () => {
     const signout = jest.fn();
     mockUseAuthStore.mockImplementation(() => ({

--- a/apps/frontend/src/app/__tests__/lib/postAuthRedirect.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/postAuthRedirect.test.ts
@@ -1,4 +1,9 @@
-import { resolvePostAuthRedirect, sanitizeNextPath } from '@/app/lib/postAuthRedirect';
+import {
+  hasDeveloperRole,
+  resolveHeldRoles,
+  resolvePostAuthRedirect,
+  sanitizeNextPath,
+} from '@/app/lib/postAuthRedirect';
 import { loadOrgs } from '@/app/features/organization/services/orgService';
 import { loadProfiles } from '@/app/features/organization/services/profileService';
 import { loadAvailability } from '@/app/features/organization/services/availabilityService';
@@ -57,6 +62,7 @@ jest.mock('@/app/lib/defaultOpenScreen', () => ({
   resolveDefaultOpenScreenRoute: jest.fn((role?: string | null) =>
     String(role ?? '').toLowerCase() === 'owner' ? '/dashboard' : '/appointments'
   ),
+  resolveDefaultOpenScreenRouteForProfile: jest.fn(() => '/appointments'),
 }));
 
 jest.mock('@/app/lib/orgOnboarding', () => ({
@@ -70,6 +76,9 @@ jest.mock('@/app/lib/teamOnboarding', () => ({
 describe('resolvePostAuthRedirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // sessionStorage survives clearAllMocks, so a `devAuth` set by one case
+    // would silently decide the next one.
+    globalThis.sessionStorage.clear();
     (loadOrgs as jest.Mock).mockResolvedValue(undefined);
     (loadProfiles as jest.Mock).mockResolvedValue(undefined);
     (loadAvailability as jest.Mock).mockResolvedValue(undefined);
@@ -137,6 +146,94 @@ describe('resolvePostAuthRedirect', () => {
       '/appointments'
     );
   });
+
+  // One account can hold both the practice and the developer role. Before this,
+  // holding `developer` returned before any organization was loaded, so the
+  // practice was unreachable for exactly the accounts that had both.
+  describe('accounts holding both a practice role and the developer role', () => {
+    const withPractice = () => {
+      (useOrgStore.getState as jest.Mock).mockReturnValue({
+        membershipsByOrgId: { 'org-1': { roleDisplay: 'Member' } },
+        orgIds: ['org-1'],
+        orgsById: { 'org-1': { _id: 'org-1', isVerified: true, type: 'clinic' } },
+        primaryOrgId: 'org-1',
+      });
+    };
+
+    it('routes to the practice when the developer door was not used', async () => {
+      withPractice();
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['member', 'developer'] })
+      ).resolves.toBe('/appointments');
+    });
+
+    it('routes the same account to the portal when the developer door was used', async () => {
+      withPractice();
+      globalThis.sessionStorage.setItem('devAuth', 'true');
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['member', 'developer'] })
+      ).resolves.toBe('/developers/home');
+    });
+
+    // `role` is whichever one the role store happened to return first, so the
+    // practice role arriving there must not hide the developer membership.
+    it('honours the developer door even when the single role reads as the practice one', async () => {
+      withPractice();
+      globalThis.sessionStorage.setItem('devAuth', 'true');
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['developer', 'member'] })
+      ).resolves.toBe('/developers/home');
+    });
+
+    it('keeps sending a developer with no practice to the portal', async () => {
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'developer', roles: ['developer'] })
+      ).resolves.toBe('/developers/home');
+    });
+
+    it('sends a developer with no practice to the portal when orgs fail to load', async () => {
+      (loadOrgs as jest.Mock).mockRejectedValue(new Error('network'));
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'developer', roles: ['developer'] })
+      ).resolves.toBe('/developers/home');
+    });
+
+    // Using the developer form is not itself an entitlement.
+    it('does not divert a practice-only account that used the developer door', async () => {
+      withPractice();
+      globalThis.sessionStorage.setItem('devAuth', 'true');
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['member'] })
+      ).resolves.toBe('/appointments');
+    });
+
+    it('falls back to the single role when no role list is supplied', async () => {
+      withPractice();
+      globalThis.sessionStorage.setItem('devAuth', 'true');
+      await expect(resolvePostAuthRedirect({ fallbackRole: 'developer' })).resolves.toBe(
+        '/developers/home'
+      );
+    });
+  });
+});
+
+describe('hasDeveloperRole', () => {
+  it.each([
+    [['developer'], true],
+    [['member', 'developer'], true],
+    [['Developer'], true],
+    [['  developer  '], true],
+    [['member'], false],
+    [['member', 'owner'], false],
+    [[], false],
+  ])('reads %j as %s', (roles, expected) => {
+    expect(hasDeveloperRole(roles as string[])).toBe(expected);
+  });
+
+  it('treats a missing role set as not a developer', () => {
+    expect(hasDeveloperRole(undefined)).toBe(false);
+    expect(hasDeveloperRole(null)).toBe(false);
+  });
 });
 
 describe('sanitizeNextPath', () => {
@@ -164,5 +261,30 @@ describe('sanitizeNextPath', () => {
     [null],
   ])('drops the off-origin destination %j', (input) => {
     expect(sanitizeNextPath(input as string | null)).toBeUndefined();
+  });
+});
+
+describe('resolveHeldRoles', () => {
+  it('uses the role list when the API supplied one', () => {
+    expect(resolveHeldRoles(['member', 'developer'], 'member')).toEqual(['member', 'developer']);
+  });
+
+  /* An empty list is what a session stored before the API served `roles` looks
+     like. Reading it as "holds nothing" told real developers they were not
+     developers, so it has to fall back rather than answer no. */
+  it('falls back to the single role when the list is empty', () => {
+    expect(resolveHeldRoles([], 'developer')).toEqual(['developer']);
+    expect(resolveHeldRoles(undefined, 'developer')).toEqual(['developer']);
+    expect(resolveHeldRoles(null, 'developer')).toEqual(['developer']);
+  });
+
+  it('drops blanks and falls back when nothing named survives', () => {
+    expect(resolveHeldRoles([null, undefined], 'developer')).toEqual(['developer']);
+    expect(resolveHeldRoles([null, 'developer'], 'member')).toEqual(['developer']);
+  });
+
+  it('answers with nothing when neither source names a role', () => {
+    expect(resolveHeldRoles([], null)).toEqual([]);
+    expect(resolveHeldRoles(undefined, undefined)).toEqual([]);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
@@ -42,6 +42,25 @@ jest.mock('@/app/lib/postAuthRedirect', () => ({
     String(role ?? '')
       .trim()
       .toLowerCase() === 'developer',
+  /* Same reasoning as above, for the whole role set: the component asks these
+     two whether the signed-in account holds the developer role among however
+     many it has. Stubs would answer "no" for every account and the mismatch
+     tests would pass without exercising anything. */
+  hasDeveloperRole: (roles?: readonly (string | null | undefined)[] | null) =>
+    (roles ?? []).some(
+      (role) =>
+        String(role ?? '')
+          .trim()
+          .toLowerCase() === 'developer'
+    ),
+  resolveHeldRoles: (
+    roles?: readonly (string | null | undefined)[] | null,
+    singleRole?: string | null
+  ) => {
+    const named = (roles ?? []).filter((role): role is string => typeof role === 'string');
+    if (named.length > 0) return named;
+    return singleRole ? [singleRole] : [];
+  },
 }));
 
 // Mock the shared marketing foundation (AuthShell / AuthBrandContent) so its
@@ -334,6 +353,9 @@ describe('SignIn Page', () => {
     expect(mockSignIn).toHaveBeenCalledWith('test@example.com', 'pass123');
     expect(resolvePostAuthRedirect).toHaveBeenCalledWith({
       fallbackRole: undefined,
+      // The whole role set goes with the single role, so an account holding
+      // both a practice role and the developer one is not collapsed to one.
+      roles: [],
       redirectPath: undefined,
     });
     expect(mockRouterReplace).toHaveBeenCalledWith('/create-org');
@@ -359,6 +381,9 @@ describe('SignIn Page', () => {
     expect(mockSessionStorage.setItem).toHaveBeenCalledWith('devAuth', 'true');
     expect(resolvePostAuthRedirect).toHaveBeenCalledWith({
       fallbackRole: undefined,
+      // The whole role set goes with the single role, so an account holding
+      // both a practice role and the developer one is not collapsed to one.
+      roles: [],
       redirectPath: undefined,
     });
   });

--- a/apps/frontend/src/app/features/auth/pages/AuthedRedirectShell.tsx
+++ b/apps/frontend/src/app/features/auth/pages/AuthedRedirectShell.tsx
@@ -13,6 +13,7 @@ import { resolvePostAuthRedirect } from '@/app/lib/postAuthRedirect';
 export default function AuthedRedirectShell({ children }: Readonly<{ children: ReactNode }>) {
   const status = useAuthStore((s) => s.status);
   const role = useAuthStore((s) => s.role);
+  const roles = useAuthStore((s) => s.roles);
   const isAuthenticated = status === 'authenticated';
   const [route, setRoute] = useState<string | null>(null);
 
@@ -31,13 +32,13 @@ export default function AuthedRedirectShell({ children }: Readonly<{ children: R
   useEffect(() => {
     if (!isAuthenticated) return;
     let cancelled = false;
-    void resolvePostAuthRedirect({ fallbackRole: role }).then((nextRoute) => {
+    void resolvePostAuthRedirect({ fallbackRole: role, roles }).then((nextRoute) => {
       if (!cancelled) setRoute(nextRoute);
     });
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, role]);
+  }, [isAuthenticated, role, roles]);
 
   if (route) {
     redirect(route);

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
@@ -200,12 +200,11 @@ const SignInForm = ({
       resetSidebarPreference();
       // Set devAuth flag BEFORE redirect so DevRouteGuard can read it
       setStorageItem('session', 'devAuth', isDeveloper ? 'true' : 'false');
-      const storeAvailable = typeof useAuthStore.getState === 'function';
-      const signedInRole = storeAvailable ? useAuthStore.getState().role : role;
-      const signedInRoles = resolveHeldRoles(
-        storeAvailable ? useAuthStore.getState().roles : roles,
-        signedInRole
-      );
+      /* One snapshot, so the role and the role set cannot come from two
+         different reads of the store. */
+      const store = typeof useAuthStore.getState === 'function' ? useAuthStore.getState() : null;
+      const signedInRole = store ? store.role : role;
+      const signedInRoles = resolveHeldRoles(store ? store.roles : roles, signedInRole);
 
       /* Signing in through the developer form does not make an account a
          developer account. Say so, rather than routing on into the portal and

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
@@ -15,7 +15,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { getEmailValidationError, normalizeEmail } from '@/app/lib/validators';
 import { YosemiteLoader } from '@/app/ui/overlays/Loader';
 import {
-  isDeveloperRole,
+  hasDeveloperRole,
+  resolveHeldRoles,
   resolvePostAuthRedirect,
   sanitizeNextPath,
 } from '@/app/lib/postAuthRedirect';
@@ -139,7 +140,7 @@ const SignInForm = ({
     isDeveloperDefault ? 'developer' : 'business'
   );
   const isDeveloper = accountType === 'developer';
-  const { signIn, resendCode, role } = useAuthStore();
+  const { signIn, resendCode, role, roles } = useAuthStore();
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showErrorTost, ErrorTostPopup } = useErrorTost();
@@ -199,15 +200,19 @@ const SignInForm = ({
       resetSidebarPreference();
       // Set devAuth flag BEFORE redirect so DevRouteGuard can read it
       setStorageItem('session', 'devAuth', isDeveloper ? 'true' : 'false');
-      const signedInRole =
-        typeof useAuthStore.getState === 'function' ? useAuthStore.getState().role : role;
+      const storeAvailable = typeof useAuthStore.getState === 'function';
+      const signedInRole = storeAvailable ? useAuthStore.getState().role : role;
+      const signedInRoles = resolveHeldRoles(
+        storeAvailable ? useAuthStore.getState().roles : roles,
+        signedInRole
+      );
 
       /* Signing in through the developer form does not make an account a
          developer account. Say so, rather than routing on into the portal and
          letting DevRouteGuard bounce them - from the outside that was
          indistinguishable from a rejected password. The session stays valid;
          the account simply belongs elsewhere. */
-      if (isDeveloper && !isDeveloperRole(signedInRole)) {
+      if (isDeveloper && !hasDeveloperRole(signedInRoles)) {
         showErrorTost({
           message:
             'That account is not registered as a developer account. Create a developer account to use the portal.',
@@ -226,6 +231,7 @@ const SignInForm = ({
 
       const nextRoute = await resolvePostAuthRedirect({
         fallbackRole: signedInRole,
+        roles: signedInRoles,
         redirectPath: effectiveRedirectPath,
       });
       router.replace(nextRoute);

--- a/apps/frontend/src/app/features/auth/pages/VerifyEmail/VerifyEmail.tsx
+++ b/apps/frontend/src/app/features/auth/pages/VerifyEmail/VerifyEmail.tsx
@@ -71,6 +71,7 @@ const VerifyEmail = () => {
       }
       const route = await resolvePostAuthRedirect({
         fallbackRole: useAuthStore.getState().role,
+        roles: useAuthStore.getState().roles,
       });
       router.replace(route);
     } catch {

--- a/apps/frontend/src/app/lib/postAuthRedirect.ts
+++ b/apps/frontend/src/app/lib/postAuthRedirect.ts
@@ -11,6 +11,7 @@ import { computeOrgOnboardingStep } from '@/app/lib/orgOnboarding';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { useUserProfileStore } from '@/app/stores/profileStore';
 import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { getStorageItem } from '@/app/lib/browserStorage';
 
 const normalizeRole = (role?: string | null) =>
   String(role ?? '')
@@ -26,6 +27,49 @@ const normalizeRole = (role?: string | null) =>
  */
 export const isDeveloperRole = (role?: string | null) => normalizeRole(role) === 'developer';
 const isOwnerRole = (role?: string | null) => normalizeRole(role) === 'owner';
+
+/**
+ * True when ANY role the account holds is the developer role.
+ *
+ * One account can be both a practice member and a platform developer, so
+ * "is this a developer" is a question about the whole set, not about the one
+ * role `/v1/auth/me` happens to surface as `role`.
+ */
+export const hasDeveloperRole = (roles?: readonly (string | null | undefined)[] | null) =>
+  (roles ?? []).some((role) => isDeveloperRole(role));
+
+/**
+ * The role set to reason about, given both what the API sent and the single
+ * role callers already had.
+ *
+ * `roles` is empty for a session stored before the API served it, and for a
+ * sign-up whose provisioning call has not landed yet. Treating that emptiness
+ * as "holds nothing" told real developers they were not developers, so an
+ * empty list always falls back to the one role that is known rather than
+ * answering no.
+ */
+export const resolveHeldRoles = (
+  roles?: readonly (string | null | undefined)[] | null,
+  singleRole?: string | null
+): readonly string[] => {
+  // A list of only blanks is the same as no list: fall back rather than
+  // reporting that the account holds a role with no name.
+  const named = (roles ?? []).filter((role): role is string => typeof role === 'string');
+  if (named.length > 0) return named;
+  return singleRole ? [singleRole] : [];
+};
+
+/**
+ * Whether this session was started from the developer sign-in or sign-up form.
+ *
+ * `devAuth` is already written at every authentication entry point for
+ * `DevRouteGuard`, so it is the existing record of which door was used rather
+ * than a second source of truth invented here. Absent (a fresh tab, or a
+ * session restored by the shell) reads as "not the developer door", which
+ * sends dual-role accounts to their practice - the safer default, because a
+ * developer with no practice is still routed to the portal below.
+ */
+const enteredThroughDeveloperDoor = () => getStorageItem('session', 'devAuth') === 'true';
 
 // Only same-origin, absolute-path destinations are safe post-auth targets;
 // anything else (external URLs, protocol-relative //host) is dropped.
@@ -60,6 +104,12 @@ export const sanitizeNextPath = (value: string | null): string | undefined => {
 
 type ResolvePostAuthRedirectOptions = {
   fallbackRole?: string | null;
+  /**
+   * Every role the account holds. Supplied by callers that read the auth
+   * store; `fallbackRole` alone is used when it is absent, which is the
+   * single-role behaviour that predates dual-role accounts.
+   */
+  roles?: readonly string[] | null;
   redirectPath?: string;
 };
 
@@ -120,18 +170,33 @@ export const resolveOrgScopedRedirect = async ({
 
 export const resolvePostAuthRedirect = async ({
   fallbackRole,
+  roles,
   redirectPath,
 }: ResolvePostAuthRedirectOptions): Promise<string> => {
   if (redirectPath) {
     return redirectPath;
   }
 
-  /* The role decides this, and only the role. This used to also accept an
-     `isDeveloper` flag meaning "submitted the developer sign-in form", which is
-     true even for an account with no developer role - so it routed those users
-     to a page DevRouteGuard immediately rejects. Callers that care about the
-     mismatch check the role themselves; see SignIn. */
-  if (isDeveloperRole(fallbackRole)) {
+  const heldRoles = resolveHeldRoles(roles, fallbackRole);
+  const isDeveloper = hasDeveloperRole(heldRoles);
+
+  /*
+   * Holding the developer role no longer means the developer portal is the
+   * only place this account can go.
+   *
+   * The role used to short-circuit here unconditionally, which made the two
+   * memberships mutually exclusive in practice: an account that was both a
+   * practice member and a developer could never reach its practice, because
+   * this returned before any organization was ever loaded. The portal is the
+   * destination when the person actually asked for it by using the developer
+   * door; otherwise the account is routed by its practice membership like any
+   * other, and a developer with no practice still lands in the portal below.
+   *
+   * Coming through the developer door WITHOUT the role deliberately does not
+   * land here - SignIn reports that mismatch rather than routing on into a
+   * page DevRouteGuard would immediately reject.
+   */
+  if (isDeveloper && enteredThroughDeveloperDoor()) {
     return '/developers/home';
   }
 
@@ -139,7 +204,7 @@ export const resolvePostAuthRedirect = async ({
   try {
     await loadOrgs({ silent: true });
   } catch {
-    return resolveDefaultOpenScreenRoute(fallbackRole);
+    return isDeveloper ? '/developers/home' : resolveDefaultOpenScreenRoute(fallbackRole);
   }
 
   const { orgIds, primaryOrgId } = useOrgStore.getState();
@@ -154,7 +219,9 @@ export const resolvePostAuthRedirect = async ({
     } catch {
       // Ignore invite fetch failures — fall through to create-org
     }
-    return '/create-org';
+    /* A developer with no practice has nothing to create yet, so the portal is
+       their home rather than the practice-onboarding wizard. */
+    return isDeveloper ? '/developers/home' : '/create-org';
   }
 
   // No primary org selected → org selection page (invited user with multiple orgs)

--- a/apps/frontend/src/app/stores/authStore.ts
+++ b/apps/frontend/src/app/stores/authStore.ts
@@ -84,6 +84,8 @@ type AuthMeResponse = {
   email?: string | null;
   emailVerified?: boolean;
   role?: string | null;
+  /** Every role the account holds. `role` is only ever one of these. */
+  roles?: string[] | null;
 };
 
 type UserProfileResponse = {
@@ -98,6 +100,11 @@ export type AuthStore = {
   loading: boolean;
   error: string | null;
   role: string | null;
+  /**
+   * Every role the account holds, so callers can ask "is this also a
+   * developer" without `role` having to pick a winner. Empty when signed out.
+   */
+  roles: string[];
   mfaChallenge: MfaChallenge | null;
   pendingSignUp: PendingSignUp | null;
   signUp: (
@@ -199,11 +206,22 @@ const syncAuthenticatedState = async (
 ): Promise<AuthUser> => {
   const me = await fetchMe();
   const user = toAuthUser(me);
+  const pendingRole = get().pendingSignUp?.role ?? null;
+  const singleRole = me.role ?? pendingRole ?? null;
+  /*
+   * Prefer the full list the API now sends. An older API that only answers
+   * with `role`, or a sign-up whose provisioning call has not landed yet,
+   * degrades to the one role we do know rather than to no roles at all -
+   * which would read as "holds nothing" and route the account as if it had
+   * no developer access.
+   */
+  const roles = me.roles ?? (singleRole ? [singleRole] : []);
   set({
     user,
     loading: false,
     error: null,
-    role: me.role ?? get().pendingSignUp?.role ?? null,
+    role: singleRole,
+    roles,
     status,
     mfaChallenge: null,
   });
@@ -246,6 +264,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   loading: false,
   error: null,
   role: null,
+  roles: [],
   mfaChallenge: null,
   // Seeded from storage so a verification link opened in a new tab still knows
   // the name and role to provision with.
@@ -330,6 +349,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         error: message,
         user: null,
         role: null,
+        roles: [],
         status: 'unauthenticated',
         attributes: null,
       });
@@ -353,6 +373,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         error: failure.message,
         user: null,
         role: null,
+        roles: [],
         status: 'unauthenticated',
         attributes: null,
       });
@@ -464,6 +485,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
           status: 'unauthenticated',
           attributes: null,
           role: null,
+          roles: [],
         });
         return null;
       }
@@ -578,6 +600,7 @@ const resetAuthState = (set: (partial: Partial<AuthStore>) => void) => {
     status: 'unauthenticated',
     user: null,
     role: null,
+    roles: [],
     error: null,
     attributes: null,
     loading: false,

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { redirect, usePathname } from 'next/navigation';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { useAuthStore } from '@/app/stores/authStore';
+import { hasDeveloperRole, resolveHeldRoles } from '@/app/lib/postAuthRedirect';
 import NotADeveloperState from './NotADeveloperState';
 
 const isLocalDeveloperFallbackEnabled = () => {
@@ -27,12 +28,23 @@ const isLocalDeveloperFallbackEnabled = () => {
 const DevRouteGuard = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
   const authStore = useAuthStore();
-  const { status, role } = authStore;
+  const { status, role, roles } = authStore;
   const isPending = status === 'idle' || status === 'checking';
   const isDevPath = pathname?.startsWith('/developers');
   const devFlag =
     isLocalDeveloperFallbackEnabled() && getStorageItem('session', 'devAuth') === 'true';
-  const isDevRole = role === 'developer' || devFlag;
+  /*
+   * Asked of every role the account holds, not just the one `/v1/auth/me`
+   * surfaces as `role`.
+   *
+   * An account that is both a practice member and a developer can have `role`
+   * answer `member`, which read as "not a developer" and showed the rejection
+   * screen on a portal the account is entitled to. `roles` is populated from
+   * `role` when the API sends only the single field, so the fallback keeps
+   * single-role accounts behaving exactly as before.
+   */
+  const heldRoles = resolveHeldRoles(roles, role);
+  const isDevRole = hasDeveloperRole(heldRoles) || devFlag;
   const isAuthenticated = status === 'authenticated' || status === 'signin-authenticated';
 
   // Nothing renders until auth status is known - neither the children nor the

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
@@ -105,9 +105,11 @@ const OtpModal = ({
       logger.warn('Backend user provisioning did not complete; continuing signed in.');
     }
 
-    const storeAvailable = typeof useAuthStore.getState === 'function';
-    const signedInRole = storeAvailable ? useAuthStore.getState().role : role;
-    const signedInRoles = storeAvailable ? useAuthStore.getState().roles : undefined;
+    /* One snapshot, so the role and the role set cannot come from two
+       different reads of the store. */
+    const store = typeof useAuthStore.getState === 'function' ? useAuthStore.getState() : null;
+    const signedInRole = store ? store.role : role;
+    const signedInRoles = store ? store.roles : undefined;
     /* No `isDeveloper` here: a developer sign-up carries role 'developer' through
        pendingSignUp, so the role already says where to land. Passing the form
        flag instead used to route a non-developer to /developers/home, which the

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.tsx
@@ -105,14 +105,18 @@ const OtpModal = ({
       logger.warn('Backend user provisioning did not complete; continuing signed in.');
     }
 
-    const signedInRole =
-      typeof useAuthStore.getState === 'function' ? useAuthStore.getState().role : role;
+    const storeAvailable = typeof useAuthStore.getState === 'function';
+    const signedInRole = storeAvailable ? useAuthStore.getState().role : role;
+    const signedInRoles = storeAvailable ? useAuthStore.getState().roles : undefined;
     /* No `isDeveloper` here: a developer sign-up carries role 'developer' through
        pendingSignUp, so the role already says where to land. Passing the form
        flag instead used to route a non-developer to /developers/home, which the
-       route guard then rejected. */
+       route guard then rejected. The full role set goes with it so an account
+       that is both a practice member and a developer is not collapsed to
+       whichever single role `/v1/auth/me` happened to surface. */
     const nextRoute = await resolvePostAuthRedirect({
       fallbackRole: signedInRole,
+      roles: signedInRoles,
       redirectPath,
     });
     router.push(nextRoute);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

An account cannot usefully hold both a practice role and the `developer` role. Signing in to the practice takes a developer-and-member account to the developer portal, and the portal then refuses it. Both halves come from the same assumption: that an account has exactly one role.

`GET /v1/auth/me` collapses the role store to a single `role`, preferring `superadmin` and otherwise taking whichever role the store happens to return first. Everything downstream inherits that arbitrary choice:

- `resolvePostAuthRedirect` returns `/developers/home` as soon as the role reads `developer`, before any organization is loaded, so an account with a practice can never reach it.
- `DevRouteGuard` compares that same single role to `developer`, so when the store returns the practice role first the guard shows the not-a-developer screen on a portal the account is entitled to.

The two failures are opposite ends of one coin: whichever role wins, the other product is unreachable.

## What is the new behavior?

`/v1/auth/me` also returns `roles`, the full set. `role` is unchanged, so single-role display callers keep working.

Routing now asks two questions instead of one:

| Sign-in form | Holds `developer` | Has a practice | Lands |
| --- | --- | --- | --- |
| Developer | yes | either | `/developers/home` |
| Practice | yes | yes | the practice |
| Either | yes | no | `/developers/home` |
| Either | no | yes | the practice |
| Developer | no | either | practice routing, with the existing mismatch notice |

"Came in through the developer door" reads the `devAuth` marker already written at every authentication entry point for `DevRouteGuard`, rather than introducing a second source of truth. A developer with no practice still lands in the portal, so nothing regresses for single-role developer accounts.

`resolveHeldRoles` centralises the fallback used by the redirect, the guard and SignIn. An empty `roles` is what a session stored before the API served the field looks like; reading that as "holds nothing" told real developers they were not developers. The existing SignIn suite caught exactly that while this change was being made.

## Validation

- `tsc` clean for `apps/frontend` and `apps/backend`; `eslint` clean for both.
- 233 frontend tests across the 18 affected suites, and 29 backend `auth.router` tests.
- Every new branch was mutation-checked. Reverting the redirect condition, the guard comparison, and the `roles` metadata fallback each fails only its own tests, for the stated reason.
- The pre-push monorepo gate passes all 17 tasks.

## Notes

`apps/frontend/src/app/features/auth/components/PostAuthRedirect.tsx` is imported only by its own test and is left untouched. It still passes a single role, which is the pre-existing behaviour.

## Related Issue(s)

Related to #1582
