### PR TITLE
docs(backend): correct two public booking comments that misdescribe the code

### DIFF
--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -60,10 +60,17 @@ const CONFIRMATION_VALID_HOURS = 48;
 /**
  * How long a request may be stored.
  *
- * Thirty days after the requested appointment, or after submission for one that
- * is never confirmed. Long enough for a practice to work through its queue and
- * for a no-show to be explicable; short enough that a stranger's contact details
- * do not sit in a veterinary database indefinitely because nobody deleted them.
+ * Thirty days after the REQUESTED APPOINTMENT, for every request - including one
+ * that is never confirmed. Long enough for a practice to work through its queue
+ * and for a no-show to be explicable; short enough that a stranger's contact
+ * details do not sit in a veterinary database indefinitely because nobody
+ * deleted them.
+ *
+ * Measured from the requested date rather than from submission, which is what
+ * the requester is told when they consent: "They are deleted 30 days after the
+ * requested date" (BookClient.tsx). The schema and its migration say the same.
+ * Changing the basis to submission would be a change to a promise already made
+ * to a member of the public, not an implementation detail.
  */
 const RETENTION_DAYS = 30;
 
@@ -358,9 +365,20 @@ const buildConfirmationUrl = (slug: string, token: string): string | null => {
 /**
  * How many unconfirmed requests one email address may hold against one practice.
  *
- * The per-IP limiter on the route caps volume from a single source; this caps
- * the damage from a distributed one, because the practice's inbox is the real
- * target. Only PENDING rows count, so confirming genuinely frees the budget.
+ * A soft guard against someone submitting the same request repeatedly, not an
+ * anti-abuse control - do not reason about abuse from this number.
+ *
+ * It is not one for two reasons. `normalizeEmail` below only trims and
+ * lowercases, so `a+1@x.com` and `a+2@x.com` are separate keys with separate
+ * budgets that deliver to one mailbox; and the key includes the practice, so
+ * every published practice grants the same address another three. The binding
+ * control on this route is the per-IP write budget in
+ * `booking-page-public.router.ts`.
+ *
+ * Nor is a pending row visible to the practice: the practice is notified only
+ * from `confirm`, which needs the token mailed to the requester, and the queue
+ * read filters PENDING out. Only PENDING rows count here, so confirming frees
+ * the budget.
  */
 const MAX_PENDING_PER_EMAIL = 3;
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two comments in `apps/backend/src/services/public-booking.service.ts` describe rules the code does not implement. Both sit directly above the constant they explain, so they are what a reader consults first.

**`RETENTION_DAYS`** says a request is purged thirty days after the appointment "or after submission for one that is never confirmed". There is no second branch - `:538` gives every row `requestedStart + 30d`. This one matters because retention is a promise already made to a member of the public: the consent checkbox in `BookClient.tsx:556` says "deleted 30 days after the requested date", and `schema.prisma` and the migration agree. The comment was the only source claiming otherwise, and it is the source that makes the system look non-compliant with its own consent text.

**`MAX_PENDING_PER_EMAIL`** calls itself a defence against a distributed attacker "because the practice's inbox is the real target". A pending row never reaches the practice: notification happens only inside `confirm` (`:586`, sending at `:629`), which requires the token mailed to the requester, and the queue read filters `PENDING` out (`:668`). The cap is also bypassable with no concurrency at all, because `normalizeEmail` (`:367`) trims and lowercases only, and the key includes the practice.

## What is the new behavior?

Both comments describe what the code does.

`RETENTION_DAYS` now states the basis explicitly and records why it is the requested date rather than submission, so a future change to that basis is recognised as a change to a promise rather than an implementation detail.

`MAX_PENDING_PER_EMAIL` is now described as the resubmit guard it is, with the two reasons it is not an anti-abuse control and a pointer to the per-IP write budget in `booking-page-public.router.ts` that is.

Comments only. No behaviour change.

## Validation

Every factual claim in the new comments was checked against the code rather than taken from the issue:

- consent text at `BookClient.tsx:556`
- per-IP write budget, 10 per 15 minutes, at `booking-page-public.router.ts:32-34`
- `PENDING` filtered from the queue read at `:668`
- `practiceNotificationEmail` has exactly two references, its definition at `:446` and its use at `:629`, inside `async confirm` which begins at `:586`

68 public booking tests pass.

## Related Issue(s)

Fixes #2562
Fixes #2563
