### PR TITLE
fix(frontend): rebuild the public booking page on the design system

### DIFF
--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect } from 'storybook/test';
 
-import * as publicBookingService from '@/app/features/publicBooking/services/publicBooking.service';
 import type { PublicPractice } from '@/app/features/publicBooking/services/publicBooking.service';
 import BookClient from './BookClient';
 
@@ -39,40 +38,86 @@ const PRACTICE: PublicPractice = {
 type Stub = {
   practice?: PublicPractice;
   practiceFails?: boolean;
+  slotsFail?: boolean;
+  submitHangs?: boolean;
   windows?: { startTime: string; endTime: string }[];
 };
 
-const stub = ({ practice = PRACTICE, practiceFails = false, windows }: Stub = {}) => {
-  const previousPractice = publicBookingService.getPublicPractice;
-  const previousSlots = publicBookingService.getPublicSlots;
+/**
+ * Stubbed at the network, not at the module.
+ *
+ * The previous version assigned onto the service's module namespace object.
+ * That is frozen under an ESM bundler, so every story in this file threw
+ * "Cannot assign to property 'getPublicPractice' of [object Module]" and
+ * rendered Storybook's error panel instead of the page. Patching `fetch`
+ * needs no bundler cooperation and has the side benefit of running the real
+ * service code - the URL building, the status handling and the error mapping
+ * are all exercised rather than skipped.
+ */
+const stub = ({
+  practice = PRACTICE,
+  practiceFails = false,
+  slotsFail = false,
+  submitHangs = false,
+  windows,
+}: Stub = {}) => {
+  const realFetch = globalThis.fetch;
 
-  const stubTarget = publicBookingService as unknown as Record<string, unknown>;
+  const json = (body: unknown, status = 200) =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
 
-  stubTarget.getPublicPractice = async () => {
-    if (practiceFails) throw new Error('unavailable');
-    return { kind: 'practice' as const, practice };
-  };
-  stubTarget.getPublicSlots = async () => ({
-    date: '2026-09-01',
-    serviceId: 'svc-1',
-    durationMinutes: 30,
-    windows: windows ?? [
-      { startTime: '09:00', endTime: '09:30' },
-      { startTime: '09:30', endTime: '10:00' },
-      { startTime: '14:00', endTime: '14:30' },
-    ],
-  });
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/slots')) {
+      if (slotsFail) return json({ message: 'Could not load available times.' }, 500);
+      return json({
+        data: {
+          date: '2026-09-01',
+          serviceId: 'svc-1',
+          durationMinutes: 30,
+          windows: windows ?? [
+            { startTime: '09:00', endTime: '09:30' },
+            { startTime: '09:30', endTime: '10:00' },
+            { startTime: '14:00', endTime: '14:30' },
+          ],
+        },
+      });
+    }
+
+    if (url.includes('/requests')) {
+      if (submitHangs) return new Promise<Response>(() => {});
+      return json({ data: { ok: true } });
+    }
+
+    if (url.includes('/public/booking/')) {
+      if (practiceFails) return json({ message: 'Not found' }, 404);
+      return json({ data: practice });
+    }
+
+    return realFetch(input, init);
+  }) as typeof globalThis.fetch;
 
   return () => {
-    stubTarget.getPublicPractice = previousPractice;
-    stubTarget.getPublicSlots = previousSlots;
+    globalThis.fetch = realFetch;
   };
 };
 
 const meta = {
   title: 'PublicBooking/BookClient',
   component: BookClient,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    // BookClient calls useRouter() to follow a retired slug. Without the app
+    // router context every story in this file threw "invariant expected app
+    // router to be mounted" and rendered Storybook's error panel.
+    nextjs: { appDirectory: true, navigation: { pathname: '/book/avenger-park-veterinary' } },
+  },
   args: { slug: 'avenger-park-veterinary' },
   tags: ['autodocs'],
   beforeEach: () => stub(),
@@ -149,6 +194,80 @@ export const Unavailable: Story = {
           'One state for three different facts: the slug is wrong, the practice never published, ' +
           'or it has withdrawn. The API deliberately does not distinguish them, so neither can ' +
           'this page - telling them apart is how someone maps which practices use the product.',
+      },
+    },
+  },
+};
+
+export const AllDayParts: Story = {
+  name: 'A day that spans morning, afternoon and evening',
+  beforeEach: () =>
+    stub({
+      windows: [
+        { startTime: '08:30', endTime: '09:00' },
+        { startTime: '09:00', endTime: '09:30' },
+        { startTime: '13:00', endTime: '13:30' },
+        { startTime: '13:30', endTime: '14:00' },
+        { startTime: '18:00', endTime: '18:30' },
+      ],
+    }),
+  play: async ({ canvas, userEvent }) => {
+    const nine = await canvas.findByRole('button', { name: '09:00' });
+    await userEvent.click(nine);
+    await expect(nine).toHaveAttribute('aria-pressed', 'true');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Twenty-seven identical capsules in one flat wrap was a wall, not a choice. Times are ' +
+          'grouped by day part, and the headings only appear when a day actually spans more than ' +
+          'one. This is also the only story that shows the selected fill.',
+      },
+    },
+  },
+};
+
+export const SlotsUnavailable: Story = {
+  name: 'Availability that would not load',
+  beforeEach: () => stub({ slotsFail: true }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      /Could not load available times/
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one alert surface on the page. One tone, deliberately: everything this page can ' +
+          'report means "we could not do this yet", never "something was destroyed".',
+      },
+    },
+  },
+};
+
+export const Sending: Story = {
+  name: 'A request in flight',
+  beforeEach: () => stub({ submitHangs: true }),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.type(await canvas.findByLabelText('Your name'), 'Sam Owner');
+    await userEvent.type(canvas.getByLabelText('Email'), 'sam@example.com');
+    await userEvent.type(canvas.getByLabelText('Pet name'), 'Rex');
+    await userEvent.type(canvas.getByLabelText('Species'), 'Dog');
+    await userEvent.click(await canvas.findByRole('button', { name: '09:00' }));
+    await userEvent.click(canvas.getByRole('checkbox'));
+    await userEvent.click(canvas.getByRole('button', { name: /Request this time/ }));
+
+    await expect(await canvas.findByRole('button', { name: /Sending/ })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The busy state. It used to be byte-identical to the idle-disabled state - the label ' +
+          'changed and nothing else did - so there was no way to tell a request in flight from a ' +
+          'button you were not allowed to press.',
       },
     },
   },

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -138,9 +138,10 @@ const SlotPicker = ({
               <Skeleton key={index} className="h-11 rounded-full" />
             ))}
           </div>
-          <p className="sr-only" role="status">
-            Checking availability…
-          </p>
+          {/* <output>, not a p with role="status" - it carries that role
+              implicitly, and Sonar's S6819 asks for the element over the ARIA
+              attribute. Precedent: AccessibilityReportClient and InvoiceTable. */}
+          <output className="sr-only">Checking availability…</output>
         </>
       );
     }
@@ -158,27 +159,28 @@ const SlotPicker = ({
     }
 
     const groups = groupByDayPart(slots);
-    // A lone "MORNING" heading over a morning-only day is noise, so it stays
-    // sr-only and the role=group keeps its label either way.
+    // A lone "MORNING" heading over a morning-only day is noise, so its legend
+    // goes sr-only; the group keeps its accessible name either way.
     const manyGroups = groups.length > 1;
 
     return groups.map((group) => (
-      <div
-        key={group.key}
-        role="group"
-        aria-labelledby={`part-${group.key}`}
-        className="mb-4 last:mb-0"
-      >
-        <h3
-          id={`part-${group.key}`}
-          className={
-            manyGroups
-              ? 'mb-2 text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]'
-              : 'sr-only'
-          }
-        >
-          {group.label}
-        </h3>
+      // A fieldset, not a div with role="group": these are related controls
+      // inside a form, which is what the element is for, and Sonar's S6819 asks
+      // for the element over the role. The h3 sits INSIDE the legend - legend
+      // takes heading content - so the group keeps its accessible name and a
+      // reader can still jump between day parts by heading.
+      <fieldset key={group.key} className="mb-4 last:mb-0">
+        <legend className={manyGroups ? 'mb-2' : 'sr-only'}>
+          <h3
+            className={
+              manyGroups
+                ? 'text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]'
+                : ''
+            }
+          >
+            {group.label}
+          </h3>
+        </legend>
         <div className={SLOT_GRID}>
           {group.slots.map((slot) => (
             // The button's entire text is the bare startTime. No end time, no
@@ -195,7 +197,7 @@ const SlotPicker = ({
             </button>
           ))}
         </div>
-      </div>
+      </fieldset>
     ));
   };
 
@@ -244,9 +246,7 @@ const PendingOrUnavailable = ({ status }: { status: 'loading' | 'unavailable' })
       {/* A skeleton of the page that is coming, not the word "Loading" on an
           empty screen. Nothing asserts that string. */}
       <Card className="p-5 sm:p-8" aria-busy="true">
-        <p className="sr-only" role="status">
-          Loading this practice’s booking page
-        </p>
+        <output className="sr-only">Loading this practice’s booking page</output>
         <div className="flex items-start gap-3">
           <Skeleton className="size-11 shrink-0 rounded-xl" />
           <div className="flex-1">

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Card from '@/app/ui/Card';
 import {
   PublicBookingRequestError,
   getPublicPractice,
@@ -11,6 +12,28 @@ import {
   type PublicService,
   type PublicSlot,
 } from '@/app/features/publicBooking/services/publicBooking.service';
+import {
+  BookFooter,
+  BookShell,
+  Callout,
+  CheckIcon,
+  ClockIcon,
+  EYEBROW,
+  FIELD,
+  FIELD_LABEL,
+  IconDisc,
+  META_TEXT,
+  PILL,
+  SLOT_GRID,
+  Skeleton,
+  STATE_BODY,
+  Spinner,
+  WarnIcon,
+  describeBlock,
+  formatLongDay,
+  groupByDayPart,
+  quickDayLabel,
+} from './bookingChrome';
 
 /**
  * The page a pet owner sees at `/book/<slug>`.
@@ -20,6 +43,13 @@ import {
  * "Request this time" and the success state says an email is on its way. The
  * whole point of this change was to stop the product claiming things it does not
  * do, and that has to hold on the page the public actually sees.
+ *
+ * That sentence used to be the least readable line on the page - 12.5px on
+ * --ink-faint, 2.84:1, at the very bottom, under the button. It is now a ruled
+ * callout at the top of the card, at 16px and 10.39:1, before the reader
+ * touches a field. It also has to appear EXACTLY once: the test and the story
+ * both match it with a singular getByText, so the closing footnote says
+ * something else.
  */
 
 /**
@@ -40,32 +70,35 @@ const isoDaysFromToday = (days: number) => {
   return date.toISOString().slice(0, 10);
 };
 
-const FIELD =
-  'w-full rounded-[12px] border-[1.5px] border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-2.5 text-[14px] text-[var(--ink-body)] outline-none focus:border-[var(--blue)]';
-
-const Shell = ({ children }: { children: React.ReactNode }) => (
-  <main
-    id="main-content"
-    tabIndex={-1}
-    className="mx-auto flex min-h-screen w-full max-w-[560px] flex-col gap-5 p-5"
-  >
-    {children}
-  </main>
-);
-
 const PracticeHeader = ({ practice }: { practice: PublicPractice }) => (
-  <header className="flex items-center gap-3">
-    <span className="flex size-11 shrink-0 items-center justify-center rounded-[13px] bg-[var(--blue-soft)] text-[16px] font-extrabold text-[var(--blue-text)]">
+  <header className="flex items-start gap-3 px-5 pt-5 pb-4 sm:px-8 sm:pt-8">
+    {/* --blue-soft measured 1.07:1 against the page - the tile had no shape at
+        all and the letter floated unattached. --blue-strong is 5.86:1 on the
+        card, and carries --white-text rather than --cta-text, which flips dark
+        and would read at 3.72:1 on a fill that stays blue.
+        aria-hidden because the h1 beside it already says the name. */}
+    <span
+      aria-hidden="true"
+      className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-[var(--blue-strong)] text-body-4-emphasis text-[var(--white-text)]"
+    >
       {practice.name.charAt(0).toUpperCase()}
     </span>
-    <span className="min-w-0">
-      <h1 className="truncate text-[20px] font-bold text-[var(--ink)]">{practice.name}</h1>
+    {/* A div, not a span. Phrasing content may not contain flow content; this
+        renders today only because the flex row blockifies it, and the moment it
+        stops being one, validateDOMNesting throws in the test environment. */}
+    <div className="min-w-0">
+      {/* font-newsreader alongside text-page-title is required, not belt and
+          braces: the class's own @apply font-newsreader sits in
+          @layer components and loses to the unlayered `* { font-family: inherit }`.
+          `truncate` is gone - it clipped the one string the page exists to
+          convey at 320px and at 200% zoom. */}
+      <h1 className="font-newsreader text-page-title text-balance">{practice.name}</h1>
       {practice.city ? (
-        <p className="text-[13px] text-[var(--ink-muted)]">
+        <p className="mt-1 text-caption-1 text-[var(--ink-muted)]">
           {[practice.city, practice.country].filter(Boolean).join(', ')}
         </p>
       ) : null}
-    </span>
+    </div>
   </header>
 );
 
@@ -85,56 +118,97 @@ const SlotPicker = ({
   slots,
   selectedTime,
   onSelect,
+  groupRef,
 }: {
   loading: boolean;
   error: string | null;
   slots: PublicSlot[] | null;
   selectedTime: string | null;
   onSelect: (startTime: string) => void;
+  groupRef: React.RefObject<HTMLDivElement | null>;
 }) => {
   const body = () => {
     if (loading) {
-      return <p className="text-[13px] text-[var(--ink-muted)]">Checking availability…</p>;
+      // Skeletons in the same grid the pills will occupy, so nothing collapses
+      // and reflows underneath the reader when they arrive. role="status", never
+      // alert - the tests assert no alert is mounted in the normal state.
+      return (
+        <>
+          <div className={SLOT_GRID} aria-busy="true">
+            {Array.from({ length: 6 }, (_, index) => (
+              <Skeleton key={index} className="h-11 rounded-full" />
+            ))}
+          </div>
+          <p className="sr-only" role="status">
+            Checking availability…
+          </p>
+        </>
+      );
     }
     if (error) {
-      return (
-        <p role="alert" className="text-[13px] text-[var(--warn-text)]">
-          {error}
-        </p>
-      );
+      return <Callout role="alert">{error}</Callout>;
     }
     if (!slots || slots.length === 0) {
       return (
-        <p className="text-[13px] text-[var(--ink-muted)]">
-          No times available on this day. Try another date.
-        </p>
+        <div className="rounded-xl border border-dashed border-[var(--ink-6b)] bg-[var(--inset)] px-4 py-8 text-center">
+          <p className="text-body-4 text-[var(--ink-body)]">
+            No times available on this day. Try another date.
+          </p>
+        </div>
       );
     }
-    return (
-      <div className="flex flex-wrap gap-2">
-        {slots.map((slot) => (
-          <button
-            key={slot.startTime}
-            type="button"
-            aria-pressed={selectedTime === slot.startTime}
-            onClick={() => onSelect(slot.startTime)}
-            className="rounded-full border-[1.5px] px-3.5 py-2 text-[13.5px] font-semibold text-[var(--ink)]"
-            style={{
-              borderColor: selectedTime === slot.startTime ? 'var(--blue)' : 'var(--hairline)',
-            }}
-          >
-            {slot.startTime}
-          </button>
-        ))}
+
+    const groups = groupByDayPart(slots);
+    // A lone "MORNING" heading over a morning-only day is noise, so it stays
+    // sr-only and the role=group keeps its label either way.
+    const manyGroups = groups.length > 1;
+
+    return groups.map((group) => (
+      <div
+        key={group.key}
+        role="group"
+        aria-labelledby={`part-${group.key}`}
+        className="mb-4 last:mb-0"
+      >
+        <h3
+          id={`part-${group.key}`}
+          className={
+            manyGroups
+              ? 'mb-2 text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]'
+              : 'sr-only'
+          }
+        >
+          {group.label}
+        </h3>
+        <div className={SLOT_GRID}>
+          {group.slots.map((slot) => (
+            // The button's entire text is the bare startTime. No end time, no
+            // duration, no aria-label: getByRole('button', { name: '09:00' })
+            // is an exact match in both the tests and the story.
+            <button
+              key={slot.startTime}
+              type="button"
+              aria-pressed={selectedTime === slot.startTime}
+              onClick={() => onSelect(slot.startTime)}
+              className={PILL}
+            >
+              {slot.startTime}
+            </button>
+          ))}
+        </div>
       </div>
-    );
+    ));
   };
 
   return (
-    <fieldset className="flex flex-col gap-2">
-      <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Available times</legend>
-      {body()}
-    </fieldset>
+    <section aria-labelledby="slots-label">
+      <p id="slots-label" className="mb-3 text-caption-1 text-[var(--ink-body)]">
+        Available times
+      </p>
+      <div ref={groupRef} tabIndex={-1}>
+        {body()}
+      </div>
+    </section>
   );
 };
 
@@ -167,20 +241,100 @@ const EMPTY_FORM: FormValues = {
  */
 const PendingOrUnavailable = ({ status }: { status: 'loading' | 'unavailable' }) =>
   status === 'loading' ? (
-    <Shell>
-      <p className="text-[14px] text-[var(--ink-muted)]">Loading…</p>
-    </Shell>
+    <BookShell>
+      {/* A skeleton of the page that is coming, not the word "Loading" on an
+          empty screen. Nothing asserts that string. */}
+      <Card className="p-5 sm:p-8" aria-busy="true">
+        <p className="sr-only" role="status">
+          Loading this practice’s booking page
+        </p>
+        <div className="flex items-start gap-3">
+          <Skeleton className="size-11 shrink-0 rounded-xl" />
+          <div className="flex-1">
+            <Skeleton className="h-6 w-2/3 rounded-xl" />
+            <Skeleton className="mt-2 h-4 w-1/3 rounded-xl" />
+          </div>
+        </div>
+        <div className="mt-8 flex flex-col gap-3">
+          {Array.from({ length: 3 }, (_, index) => (
+            <Skeleton key={index} className="h-14 rounded-xl" />
+          ))}
+        </div>
+      </Card>
+      <BookFooter />
+    </BookShell>
   ) : (
-    <Shell>
-      <h1 className="text-[20px] font-bold text-[var(--ink)]">
-        This booking page is not available
-      </h1>
-      <p className="text-[14px] text-[var(--ink-muted)]">
-        The address may be wrong, or the practice may not be taking online bookings. Please contact
-        the practice directly.
-      </p>
-    </Shell>
+    <BookShell>
+      <Card className="p-5 sm:p-8">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <IconDisc tone="warn">
+            <WarnIcon />
+          </IconDisc>
+          <h1 className="text-heading-2 text-[var(--ink)]">This booking page is not available</h1>
+          <p className={STATE_BODY}>
+            The address may be wrong, or the practice may not be taking online bookings. Please
+            contact the practice directly.
+          </p>
+        </div>
+      </Card>
+      <BookFooter />
+    </BookShell>
   );
+
+/**
+ * The success state, and the focus move that goes with it.
+ *
+ * It owns its own ref and effect rather than taking them from `BookClient`:
+ * this only ever mounts once the request has gone, so "focus me on mount" is
+ * the whole rule, and keeping it here means no ref crosses a plain function
+ * call during render.
+ *
+ * Before this the form simply unmounted, focus fell to `<body>`, and nothing
+ * told a screen-reader user the submission had worked.
+ */
+const SubmittedCard = ({
+  practice,
+  ownerEmail,
+}: {
+  practice: PublicPractice;
+  ownerEmail: string;
+}) => {
+  const statusRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    statusRef.current?.focus();
+  }, []);
+
+  return (
+    <BookShell>
+      <Card>
+        <PracticeHeader practice={practice} />
+        <div className="px-5 pb-6 sm:px-8 sm:pb-8">
+          <div
+            ref={statusRef}
+            tabIndex={-1}
+            className="flex flex-col items-center gap-4 text-center"
+          >
+            <IconDisc tone="success">
+              <CheckIcon />
+            </IconDisc>
+            <h2 className="text-heading-2 text-[var(--ink)]">Check your email</h2>
+            <p className={STATE_BODY}>
+              We have sent a link to{' '}
+              <strong className="font-medium break-all text-[var(--ink)]">{ownerEmail}</strong>.
+              Follow it to confirm your request, and {practice.name} will be in touch to arrange the
+              appointment.
+            </p>
+            <p className="w-full rounded-xl bg-[var(--inset)] px-4 py-3 text-caption-1 text-[var(--ink-body)]">
+              Nothing is booked yet. The time you chose is not being held.
+            </p>
+          </div>
+        </div>
+      </Card>
+      <BookFooter />
+    </BookShell>
+  );
+};
 
 const renderStatus = ({
   practice,
@@ -192,32 +346,21 @@ const renderStatus = ({
   ownerEmail: string;
 }): React.ReactElement | null => {
   if (submitted) {
-    return (
-      <Shell>
-        <PracticeHeader practice={practice} />
-        <div className="rounded-[16px] border border-[var(--divider)] bg-[var(--inset)] p-5">
-          <h2 className="text-[17px] font-bold text-[var(--ink)]">Check your email</h2>
-          <p className="mt-2 text-[14px] text-[var(--ink-body)]">
-            We have sent a link to <strong>{ownerEmail}</strong>. Follow it to confirm your request,
-            and {practice.name} will be in touch to arrange the appointment.
-          </p>
-          <p className="mt-3 text-[13px] text-[var(--ink-faint)]">
-            Nothing is booked yet. The time you chose is not being held.
-          </p>
-        </div>
-      </Shell>
-    );
+    return <SubmittedCard practice={practice} ownerEmail={ownerEmail} />;
   }
 
   if (practice.services.length === 0) {
     return (
-      <Shell>
-        <PracticeHeader practice={practice} />
-        <p className="text-[14px] text-[var(--ink-muted)]">
-          {practice.name} is not offering online booking for any services at the moment. Please
-          contact the practice directly.
-        </p>
-      </Shell>
+      <BookShell>
+        <Card>
+          <PracticeHeader practice={practice} />
+          <p className="px-5 pb-6 text-body-4 text-[var(--ink-body)] sm:px-8 sm:pb-8">
+            {practice.name} is not offering online booking for any services at the moment. Please
+            contact the practice directly.
+          </p>
+        </Card>
+        <BookFooter />
+      </BookShell>
     );
   }
 
@@ -337,6 +480,8 @@ const BookClient = ({ slug }: { slug: string }) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
 
+  const slotGroupRef = useRef<HTMLDivElement | null>(null);
+
   const { loading: slotsLoading, slots, error: slotsError } = useSlots(slug, serviceId, date);
 
   // A chosen time only counts while it is still on offer, so changing the
@@ -378,9 +523,12 @@ const BookClient = ({ slug }: { slug: string }) => {
         );
         // A 409 means the slot went while the form was open, so the times on
         // screen are stale. Clearing the choice forces a re-pick rather than
-        // letting the reader resubmit the same gone slot.
+        // letting the reader resubmit the same gone slot - and it disables the
+        // button they just pressed, so focus has to go somewhere deliberate
+        // rather than falling to <body> as the alert appears.
         if (error instanceof PublicBookingRequestError && error.status === 409) {
           setStartTime(null);
+          slotGroupRef.current?.focus();
         }
       })
       .finally(() => setSubmitting(false));
@@ -403,180 +551,335 @@ const BookClient = ({ slug }: { slug: string }) => {
   if (statusView) return statusView;
 
   const canSubmit = Boolean(selectedTime) && form.consent && !submitting;
+  const blockedReason = describeBlock(selectedTime, form.consent);
+  const chosen = practice.services.find((service) => service.id === serviceId);
+  // A COMPOUND string, deliberately. A bare `{chosen.name}` anywhere else on
+  // the page puts a second element with that exact direct text in the tree, and
+  // the test's getByText for the service name is singular - it would throw
+  // "found multiple elements". Any recap renders "{name} · {n} min", never the
+  // bare name.
+  const summaryLine = chosen
+    ? `${chosen.name} · ${chosen.durationMinutes} min · ${formatLongDay(date)} · ${selectedTime}`
+    : '';
+
+  // Five days at most, clamped to the practice's booking window, so a 3-day
+  // window renders three chips. Pure state, no fetch of its own.
+  const quickDays = Array.from({ length: 5 }, (_, index) => isoDaysFromToday(index)).filter(
+    (iso) => iso <= maxDate
+  );
 
   return (
-    <Shell>
-      <PracticeHeader practice={practice} />
+    <BookShell>
+      <Card>
+        <PracticeHeader practice={practice} />
 
-      {practice.welcomeMessage ? (
-        <p className="text-[14.5px] text-[var(--ink-body)]">{practice.welcomeMessage}</p>
-      ) : null}
+        {/* The page's honesty, printed on the document rather than whispered
+            under the button. Must appear exactly once - the footnote below the
+            submit button says something else on purpose. */}
+        <div className="mx-5 mb-5 flex gap-3 rounded-r-xl border-l-[3px] border-[var(--ink)] bg-[var(--inset)] px-4 py-3 sm:mx-8">
+          <ClockIcon className="mt-0.5 size-4 shrink-0 text-[var(--ink-muted)]" />
+          <p className="text-body-4 text-[var(--ink-body)]">
+            This sends a request, not a booking. {practice.name} will confirm the appointment with
+            you, and the time is not held in the meantime.
+          </p>
+        </div>
 
-      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
-        <fieldset className="flex flex-col gap-2.5">
-          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">
-            What do you need?
-          </legend>
-          {practice.services.map((service: PublicService) => (
-            <label
-              key={service.id}
-              htmlFor={`service-${service.id}`}
-              className="flex cursor-pointer items-center gap-3 rounded-[13px] border-[1.5px] px-3.5 py-2.5"
-              style={{
-                borderColor: serviceId === service.id ? 'var(--blue)' : 'var(--hairline)',
-              }}
-            >
-              <input
-                id={`service-${service.id}`}
-                type="radio"
-                name="service"
-                // The visible name sits two elements deep, which is past what a
-                // label's implicit association is guaranteed to expose. The
-                // explicit id/htmlFor pair plus this label give the control a
-                // name in every assistive technology rather than most.
-                aria-label={service.name}
-                value={service.id}
-                checked={serviceId === service.id}
-                onChange={() => setServiceOverride(service.id)}
-              />
-              <span className="min-w-0 flex-1">
-                <span className="block text-[14px] font-bold text-[var(--ink)]">
-                  {service.name}
-                </span>
-                <span className="block text-[12.5px] text-[var(--ink-faint)]">
-                  {service.durationMinutes} min
-                </span>
-              </span>
-            </label>
-          ))}
-        </fieldset>
-
-        <label className="flex flex-col gap-1.5">
-          <span className="text-[13px] font-bold text-[var(--ink)]">Preferred day</span>
-          <input
-            type="date"
-            className={FIELD}
-            value={date}
-            min={todayIso()}
-            max={maxDate}
-            onChange={(event) => setDate(event.target.value)}
-          />
-        </label>
-
-        <SlotPicker
-          loading={slotsLoading}
-          error={slotsError}
-          slots={slots}
-          selectedTime={selectedTime}
-          onSelect={setStartTime}
-        />
-
-        <fieldset className="flex flex-col gap-2.5">
-          <legend className="mb-2 text-[13px] font-bold text-[var(--ink)]">Your details</legend>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">Your name</span>
-            <input
-              className={FIELD}
-              required
-              maxLength={120}
-              value={form.ownerName}
-              onChange={(event) => setField('ownerName', event.target.value)}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">Email</span>
-            <input
-              className={FIELD}
-              type="email"
-              required
-              maxLength={254}
-              value={form.ownerEmail}
-              onChange={(event) => setField('ownerEmail', event.target.value)}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">Phone (optional)</span>
-            <input
-              className={FIELD}
-              maxLength={40}
-              value={form.ownerPhone}
-              onChange={(event) => setField('ownerPhone', event.target.value)}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">Pet name</span>
-            <input
-              className={FIELD}
-              required
-              maxLength={120}
-              value={form.petName}
-              onChange={(event) => setField('petName', event.target.value)}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">Species</span>
-            <input
-              className={FIELD}
-              required
-              maxLength={60}
-              placeholder="Dog, cat, rabbit…"
-              value={form.petSpecies}
-              onChange={(event) => setField('petSpecies', event.target.value)}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[12.5px] text-[var(--ink-muted)]">
-              What is the visit for? (optional)
-            </span>
-            <textarea
-              className={FIELD}
-              rows={3}
-              maxLength={1000}
-              value={form.concern}
-              onChange={(event) => setField('concern', event.target.value)}
-            />
-          </label>
-        </fieldset>
-
-        <label className="flex items-start gap-2.5">
-          <input
-            type="checkbox"
-            className="mt-1"
-            checked={form.consent}
-            onChange={(event) => setField('consent', event.target.checked)}
-          />
-          <span className="text-[12.5px] text-[var(--ink-muted)]">
-            I agree that {practice.name} may store these details to handle my booking request. They
-            are deleted 30 days after the requested date.
-          </span>
-        </label>
-
-        {submitError ? (
-          <p role="alert" className="text-[13px] text-[var(--warn-text)]">
-            {submitError}
+        {practice.welcomeMessage ? (
+          <p className="px-5 pb-5 text-body-4 text-[var(--ink-body)] sm:px-8">
+            {practice.welcomeMessage}
           </p>
         ) : null}
 
-        <button
-          type="submit"
-          disabled={!canSubmit}
-          className="inline-flex h-12 items-center justify-center rounded-full bg-[var(--cta)] px-5 text-[14px] font-semibold text-[var(--cta-text)] disabled:opacity-50"
-        >
-          {submitting ? 'Sending…' : 'Request this time'}
-        </button>
+        <form className="flex flex-col gap-8 px-5 pb-6 sm:px-8 sm:pb-8" onSubmit={handleSubmit}>
+          <fieldset>
+            <legend className={EYEBROW}>Service</legend>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {practice.services.map((service: PublicService) => (
+                <label
+                  key={service.id}
+                  htmlFor={`service-${service.id}`}
+                  className="flex cursor-pointer items-start gap-3 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] px-4 py-4 transition-[border-color,background-color,box-shadow] duration-150 ease-out hover:border-[var(--ink)] hover:bg-[var(--screen-2)] has-[:checked]:border-[var(--blue-strong)] has-[:checked]:bg-[var(--blue-soft)] has-[:focus-visible]:border-[var(--color-input-border-active)] has-[:focus-visible]:shadow-[0_0_0_3px_var(--glow-b26)]"
+                >
+                  {/* The input, the dot and the content are DIRECT SIBLINGS, and
+                      that is the whole trick: peer-checked: compiles to
+                      `.peer:checked ~ &`, a following-sibling combinator, so it
+                      cannot reach a descendant of a sibling. sr-only is
+                      position:absolute, so it is out of flow and never becomes a
+                      flex item.
+                      size-px! because input[type=radio]{width:18px;height:18px}
+                      is unlayered and beats sr-only's layered 1px.
+                      aria-label is gone: with an explicit htmlFor/id pair the
+                      name already comes from the label's subtree, and the
+                      attribute was subtracting the duration from it. */}
+                  <input
+                    id={`service-${service.id}`}
+                    type="radio"
+                    name="service"
+                    className="peer sr-only size-px!"
+                    value={service.id}
+                    checked={serviceId === service.id}
+                    onChange={() => setServiceOverride(service.id)}
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 flex size-5 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--screen)] transition-[background-color,border-color] duration-150 ease-out before:m-auto before:size-2 before:scale-0 before:rounded-full before:bg-[var(--white-text)] before:transition-transform before:duration-150 before:content-[''] peer-checked:border-[var(--blue-strong)] peer-checked:bg-[var(--blue-strong)] peer-checked:before:scale-100 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--color-input-border-active)]"
+                  />
+                  {/* --ink-body, not --ink-muted. Muted ink measures 4.04:1 on
+                      the selected row's wash in dark - the row is the one place
+                      on the card where the ground changes under the meta text,
+                      and it is the row the reader is most likely to read. The
+                      name still separates by weight, size and --ink. */}
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-body-4-emphasis text-[var(--ink)]">
+                      {service.name}
+                    </span>
+                    <span className="mt-1 block text-caption-1 tabular-nums text-[var(--ink-body)]">
+                      {service.durationMinutes} min
+                    </span>
+                    {/* Fetched today and thrown away, which is exactly why these
+                        rows looked so empty: the only thing each had to say was
+                        "30 min". */}
+                    {service.description ? (
+                      <span className="mt-1 line-clamp-2 block text-caption-1 text-[var(--ink-body)]">
+                        {service.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
 
-        <p className="text-[12.5px] text-[var(--ink-faint)]">
-          This sends a request, not a booking. {practice.name} will confirm the appointment with
-          you, and the time is not held in the meantime.
-        </p>
-      </form>
-    </Shell>
+          <section>
+            <h2 className={EYEBROW}>Day and time</h2>
+
+            <div className="flex flex-col gap-2">
+              {/* An htmlFor/id pair, not a wrapping label: getByLabelText matches
+                  the label's whole recursive textContent, so the hint has to sit
+                  outside it or it would leak into the accessible name. */}
+              <label htmlFor="book-day" className="text-caption-1 text-[var(--ink-body)]">
+                Preferred day
+              </label>
+              {/* Stays a native date input. The test reads .min and .max off the
+                  DOM node, and react-datepicker exposes neither. */}
+              <input
+                id="book-day"
+                type="date"
+                className={`${FIELD} tabular-nums`}
+                value={date}
+                min={todayIso()}
+                max={maxDate}
+                aria-describedby="book-day-hint"
+                onChange={(event) => setDate(event.target.value)}
+              />
+              <p id="book-day-hint" className={META_TEXT}>
+                {formatLongDay(date)} · you can book up to {practice.bookingWindowDays} days ahead.
+              </p>
+            </div>
+
+            {/* The near-term case, which is most of them, without going near the
+                browser's own calendar widget. */}
+            <div className="scrollbar-hidden -mx-1 mt-3 mb-6 flex gap-2 overflow-x-auto px-1 pb-1">
+              {quickDays.map((iso, index) => (
+                <button
+                  key={iso}
+                  type="button"
+                  aria-pressed={date === iso}
+                  onClick={() => setDate(iso)}
+                  className="min-h-11 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] px-4 text-caption-1 text-[var(--ink)] transition-[background-color,border-color,color,transform] duration-150 ease-out hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] active:translate-y-px aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] aria-pressed:text-[var(--white-text)]"
+                >
+                  {quickDayLabel(index, iso)}
+                </button>
+              ))}
+            </div>
+
+            <SlotPicker
+              loading={slotsLoading}
+              error={slotsError}
+              slots={slots}
+              selectedTime={selectedTime}
+              onSelect={setStartTime}
+              groupRef={slotGroupRef}
+            />
+          </section>
+
+          <fieldset>
+            <legend className={EYEBROW}>Your details</legend>
+            {/* One line under the eyebrow, never an asterisk inside a label -
+                getByLabelText matches the label's full text. */}
+            <p id="required-note" className="mb-4 text-caption-1 text-[var(--ink-muted)]">
+              Everything here is needed unless it says optional.
+            </p>
+            <div className="flex flex-col gap-5 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-5">
+              <div>
+                <label htmlFor="book-name" className={FIELD_LABEL}>
+                  Your name
+                </label>
+                {/* autoComplete on every field that has a token. There were none
+                    before, so no browser offered a stranger their own details. */}
+                <input
+                  id="book-name"
+                  className={FIELD}
+                  required
+                  maxLength={120}
+                  autoComplete="name"
+                  aria-describedby="required-note"
+                  value={form.ownerName}
+                  onChange={(event) => setField('ownerName', event.target.value)}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="book-email" className={FIELD_LABEL}>
+                  Email
+                </label>
+                <input
+                  id="book-email"
+                  className={FIELD}
+                  type="email"
+                  required
+                  maxLength={254}
+                  autoComplete="email"
+                  inputMode="email"
+                  spellCheck={false}
+                  placeholder="you@example.com"
+                  aria-describedby="required-note"
+                  value={form.ownerEmail}
+                  onChange={(event) => setField('ownerEmail', event.target.value)}
+                />
+              </div>
+
+              <div className="sm:col-span-2">
+                <label htmlFor="book-phone" className={FIELD_LABEL}>
+                  Phone (optional)
+                </label>
+                <input
+                  id="book-phone"
+                  className={FIELD}
+                  type="tel"
+                  maxLength={40}
+                  autoComplete="tel"
+                  inputMode="tel"
+                  placeholder="+49 30 1234567"
+                  value={form.ownerPhone}
+                  onChange={(event) => setField('ownerPhone', event.target.value)}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="book-pet" className={FIELD_LABEL}>
+                  Pet name
+                </label>
+                <input
+                  id="book-pet"
+                  className={FIELD}
+                  required
+                  maxLength={120}
+                  autoComplete="off"
+                  placeholder="Rex"
+                  aria-describedby="required-note"
+                  value={form.petName}
+                  onChange={(event) => setField('petName', event.target.value)}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="book-species" className={FIELD_LABEL}>
+                  Species
+                </label>
+                <input
+                  id="book-species"
+                  className={FIELD}
+                  required
+                  maxLength={60}
+                  autoComplete="off"
+                  placeholder="Dog, cat, rabbit…"
+                  aria-describedby="required-note"
+                  value={form.petSpecies}
+                  onChange={(event) => setField('petSpecies', event.target.value)}
+                />
+              </div>
+
+              <div className="sm:col-span-2">
+                <label htmlFor="book-concern" className={FIELD_LABEL}>
+                  What is the visit for? (optional)
+                </label>
+                <textarea
+                  id="book-concern"
+                  className={FIELD}
+                  rows={4}
+                  maxLength={1000}
+                  placeholder="Limping on the back left leg since Tuesday"
+                  value={form.concern}
+                  onChange={(event) => setField('concern', event.target.value)}
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <section>
+            <h2 className={EYEBROW}>Check and send</h2>
+            <div className="flex flex-col gap-4">
+              <label className="flex cursor-pointer items-start gap-3">
+                {/* size-6! = 24px, clearing the target-size floor on the control
+                    itself. The ! is required: input[type=checkbox]{width:20px}
+                    is unlayered and non-important, so a plain size-6 in
+                    @layer utilities loses to it.
+                    shrink-0 because this is a flex item beside a two-line
+                    sentence - it used to compress into an oval on a narrow
+                    viewport, and it is the one control that gates submission.
+                    Appearance, radius, fill and tick already come from
+                    globals.css and flip correctly; do not restyle them. */}
+                <input
+                  type="checkbox"
+                  className="size-6! shrink-0"
+                  checked={form.consent}
+                  onChange={(event) => setField('consent', event.target.checked)}
+                />
+                <span className="text-caption-1 text-[var(--ink-body)]">
+                  I agree that {practice.name} may store these details to handle my booking request.
+                  They are deleted 30 days after the requested date.
+                </span>
+              </label>
+
+              {submitError ? <Callout role="alert">{submitError}</Callout> : null}
+
+              <p id="submit-state" className={META_TEXT}>
+                {blockedReason ?? summaryLine}
+              </p>
+
+              {/* disabled:opacity-50 is gone. It composited fill and label
+                  against the page - 2.75:1 for the surface and 3.05:1 for the
+                  label - for the whole session, because first paint has neither
+                  a time nor consent. The replacement is 5.07:1 boundary and
+                  5.41:1 label, and "Sending" no longer looks identical to
+                  "you can't press this yet".
+                  NOT --color-surface-disabled: it is a fixed literal with no
+                  dark override, so it would strand this button as a pale bone
+                  slab on the espresso page. --inset flips. */}
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                aria-describedby="submit-state"
+                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-full border-[1.5px] border-transparent bg-[var(--cta)] px-6 text-body-4-emphasis text-[var(--cta-text)] shadow-[0_8px_22px_var(--sh16)] transition-[background-color,box-shadow,transform] duration-150 ease-out enabled:hover:bg-[var(--cta-hover)] enabled:active:translate-y-px enabled:active:shadow-[0_2px_8px_var(--sh12)] disabled:cursor-not-allowed disabled:border-[var(--ink-6b)] disabled:bg-[var(--inset)] disabled:text-[var(--ink-muted)] disabled:shadow-none"
+              >
+                {submitting ? (
+                  <>
+                    <Spinner />
+                    Sending…
+                  </>
+                ) : (
+                  'Request this time'
+                )}
+              </button>
+
+              <p className={META_TEXT}>Your details are only used to handle this request.</p>
+            </div>
+          </section>
+        </form>
+      </Card>
+      <BookFooter />
+    </BookShell>
   );
 };
 

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -461,6 +461,363 @@ const useSlots = (slug: string, serviceId: string | null, date: string) => {
   };
 };
 
+/**
+ * The four sections of the form, each its own component.
+ *
+ * `BookClient` was a 420-line component and React Doctor was right that it had
+ * stopped being readable in one pass - the same reason `SlotPicker` and
+ * `renderStatus` were pulled out before it. Each of these takes only what it
+ * renders, so what a section depends on is visible in its signature.
+ */
+
+const ServiceFieldset = ({
+  services,
+  serviceId,
+  onSelect,
+}: {
+  services: PublicService[];
+  serviceId: string | null;
+  onSelect: (id: string) => void;
+}) => (
+  <fieldset>
+    <legend className={EYEBROW}>Service</legend>
+    <div className="grid gap-3 sm:grid-cols-2">
+      {services.map((service: PublicService) => (
+        <label
+          key={service.id}
+          htmlFor={`service-${service.id}`}
+          className="flex cursor-pointer items-start gap-3 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] p-4 transition-[border-color,background-color,box-shadow] duration-150 ease-out hover:border-[var(--ink)] hover:bg-[var(--screen-2)] has-[:checked]:border-[var(--blue-strong)] has-[:checked]:bg-[var(--blue-soft)] has-[:focus-visible]:border-[var(--color-input-border-active)] has-[:focus-visible]:shadow-[0_0_0_3px_var(--glow-b26)]"
+        >
+          {/* The input, the dot and the content are DIRECT SIBLINGS, and
+                that is the whole trick: peer-checked: compiles to
+                `.peer:checked ~ &`, a following-sibling combinator, so it
+                cannot reach a descendant of a sibling. sr-only is
+                position:absolute, so it is out of flow and never becomes a
+                flex item.
+                size-px! because input[type=radio]{width:18px;height:18px}
+                is unlayered and beats sr-only's layered 1px.
+                aria-label is gone: with an explicit htmlFor/id pair the
+                name already comes from the label's subtree, and the
+                attribute was subtracting the duration from it. */}
+          <input
+            id={`service-${service.id}`}
+            type="radio"
+            name="service"
+            className="peer sr-only size-px!"
+            value={service.id}
+            checked={serviceId === service.id}
+            onChange={() => onSelect(service.id)}
+          />
+          <span
+            aria-hidden="true"
+            className="mt-1 flex size-5 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--screen)] transition-[background-color,border-color] duration-150 ease-out before:m-auto before:size-2 before:scale-0 before:rounded-full before:bg-[var(--white-text)] before:transition-transform before:duration-150 before:content-[''] peer-checked:border-[var(--blue-strong)] peer-checked:bg-[var(--blue-strong)] peer-checked:before:scale-100 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--color-input-border-active)]"
+          />
+          {/* --ink-body, not --ink-muted. Muted ink measures 4.04:1 on
+                the selected row's wash in dark - the row is the one place
+                on the card where the ground changes under the meta text,
+                and it is the row the reader is most likely to read. The
+                name still separates by weight, size and --ink. */}
+          <span className="min-w-0 flex-1">
+            <span className="block text-body-4-emphasis text-[var(--ink)]">{service.name}</span>
+            <span className="mt-1 block text-caption-1 tabular-nums text-[var(--ink-body)]">
+              {service.durationMinutes} min
+            </span>
+            {/* Fetched today and thrown away, which is exactly why these
+                  rows looked so empty: the only thing each had to say was
+                  "30 min". */}
+            {service.description ? (
+              <span className="mt-1 line-clamp-2 block text-caption-1 text-[var(--ink-body)]">
+                {service.description}
+              </span>
+            ) : null}
+          </span>
+        </label>
+      ))}
+    </div>
+  </fieldset>
+);
+
+const DayAndTime = ({
+  date,
+  minDate,
+  maxDate,
+  bookingWindowDays,
+  quickDays,
+  onDateChange,
+  slotsLoading,
+  slots,
+  slotsError,
+  selectedTime,
+  onSelectTime,
+  slotGroupRef,
+}: {
+  date: string;
+  minDate: string;
+  maxDate: string;
+  bookingWindowDays: number;
+  quickDays: string[];
+  onDateChange: (iso: string) => void;
+  slotsLoading: boolean;
+  slots: PublicSlot[] | null;
+  slotsError: string | null;
+  selectedTime: string | null;
+  onSelectTime: (startTime: string) => void;
+  slotGroupRef: React.RefObject<HTMLDivElement | null>;
+}) => (
+  <section>
+    <h2 className={EYEBROW}>Day and time</h2>
+
+    <div className="flex flex-col gap-2">
+      {/* An htmlFor/id pair, not a wrapping label: getByLabelText matches
+            the label's whole recursive textContent, so the hint has to sit
+            outside it or it would leak into the accessible name. */}
+      <label htmlFor="book-day" className="text-caption-1 text-[var(--ink-body)]">
+        Preferred day
+      </label>
+      {/* Stays a native date input. The test reads .min and .max off the
+            DOM node, and react-datepicker exposes neither. */}
+      <input
+        id="book-day"
+        type="date"
+        className={`${FIELD} tabular-nums`}
+        value={date}
+        min={minDate}
+        max={maxDate}
+        aria-describedby="book-day-hint"
+        onChange={(event) => onDateChange(event.target.value)}
+      />
+      <p id="book-day-hint" className={META_TEXT}>
+        {formatLongDay(date)} · you can book up to {bookingWindowDays} days ahead.
+      </p>
+    </div>
+
+    {/* The near-term case, which is most of them, without going near the
+          browser's own calendar widget. */}
+    <div className="scrollbar-hidden -mx-1 mt-3 mb-6 flex gap-2 overflow-x-auto px-1 pb-1">
+      {quickDays.map((iso, index) => (
+        <button
+          key={iso}
+          type="button"
+          aria-pressed={date === iso}
+          onClick={() => onDateChange(iso)}
+          className="min-h-11 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] px-4 text-caption-1 text-[var(--ink)] transition-[background-color,border-color,color,transform] duration-150 ease-out hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] active:translate-y-px aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] aria-pressed:text-[var(--white-text)]"
+        >
+          {quickDayLabel(index, iso)}
+        </button>
+      ))}
+    </div>
+
+    <SlotPicker
+      loading={slotsLoading}
+      error={slotsError}
+      slots={slots}
+      selectedTime={selectedTime}
+      onSelect={onSelectTime}
+      groupRef={slotGroupRef}
+    />
+  </section>
+);
+
+const DetailsFieldset = ({
+  form,
+  setField,
+}: {
+  form: FormValues;
+  setField: <K extends keyof FormValues>(key: K, value: FormValues[K]) => void;
+}) => (
+  <fieldset>
+    <legend className={EYEBROW}>Your details</legend>
+    {/* One line under the eyebrow, never an asterisk inside a label -
+          getByLabelText matches the label's full text. */}
+    <p id="required-note" className="mb-4 text-caption-1 text-[var(--ink-muted)]">
+      Everything here is needed unless it says optional.
+    </p>
+    <div className="flex flex-col gap-5 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-5">
+      <div>
+        <label htmlFor="book-name" className={FIELD_LABEL}>
+          Your name
+        </label>
+        {/* autoComplete on every field that has a token. There were none
+              before, so no browser offered a stranger their own details. */}
+        <input
+          id="book-name"
+          className={FIELD}
+          required
+          maxLength={120}
+          autoComplete="name"
+          aria-describedby="required-note"
+          value={form.ownerName}
+          onChange={(event) => setField('ownerName', event.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="book-email" className={FIELD_LABEL}>
+          Email
+        </label>
+        <input
+          id="book-email"
+          className={FIELD}
+          type="email"
+          required
+          maxLength={254}
+          autoComplete="email"
+          inputMode="email"
+          spellCheck={false}
+          placeholder="you@example.com"
+          aria-describedby="required-note"
+          value={form.ownerEmail}
+          onChange={(event) => setField('ownerEmail', event.target.value)}
+        />
+      </div>
+
+      <div className="sm:col-span-2">
+        <label htmlFor="book-phone" className={FIELD_LABEL}>
+          Phone (optional)
+        </label>
+        <input
+          id="book-phone"
+          className={FIELD}
+          type="tel"
+          maxLength={40}
+          autoComplete="tel"
+          inputMode="tel"
+          placeholder="+49 30 1234567"
+          value={form.ownerPhone}
+          onChange={(event) => setField('ownerPhone', event.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="book-pet" className={FIELD_LABEL}>
+          Pet name
+        </label>
+        <input
+          id="book-pet"
+          className={FIELD}
+          required
+          maxLength={120}
+          autoComplete="off"
+          placeholder="Rex"
+          aria-describedby="required-note"
+          value={form.petName}
+          onChange={(event) => setField('petName', event.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="book-species" className={FIELD_LABEL}>
+          Species
+        </label>
+        <input
+          id="book-species"
+          className={FIELD}
+          required
+          maxLength={60}
+          autoComplete="off"
+          placeholder="Dog, cat, rabbit…"
+          aria-describedby="required-note"
+          value={form.petSpecies}
+          onChange={(event) => setField('petSpecies', event.target.value)}
+        />
+      </div>
+
+      <div className="sm:col-span-2">
+        <label htmlFor="book-concern" className={FIELD_LABEL}>
+          What is the visit for? (optional)
+        </label>
+        <textarea
+          id="book-concern"
+          className={FIELD}
+          rows={4}
+          maxLength={1000}
+          placeholder="Limping on the back left leg since Tuesday"
+          value={form.concern}
+          onChange={(event) => setField('concern', event.target.value)}
+        />
+      </div>
+    </div>
+  </fieldset>
+);
+
+const CheckAndSend = ({
+  practiceName,
+  consent,
+  setField,
+  submitError,
+  statusLine,
+  canSubmit,
+  submitting,
+}: {
+  practiceName: string;
+  consent: boolean;
+  setField: <K extends keyof FormValues>(key: K, value: FormValues[K]) => void;
+  submitError: string | null;
+  statusLine: string;
+  canSubmit: boolean;
+  submitting: boolean;
+}) => (
+  <section>
+    <h2 className={EYEBROW}>Check and send</h2>
+    <div className="flex flex-col gap-4">
+      <label className="flex cursor-pointer items-start gap-3">
+        {/* size-6! = 24px, clearing the target-size floor on the control
+              itself. The ! is required: input[type=checkbox]{width:20px}
+              is unlayered and non-important, so a plain size-6 in
+              @layer utilities loses to it.
+              shrink-0 because this is a flex item beside a two-line
+              sentence - it used to compress into an oval on a narrow
+              viewport, and it is the one control that gates submission.
+              Appearance, radius, fill and tick already come from
+              globals.css and flip correctly; do not restyle them. */}
+        <input
+          type="checkbox"
+          className="size-6! shrink-0"
+          checked={consent}
+          onChange={(event) => setField('consent', event.target.checked)}
+        />
+        <span className="text-caption-1 text-[var(--ink-body)]">
+          I agree that {practiceName} may store these details to handle my booking request. They are
+          deleted 30 days after the requested date.
+        </span>
+      </label>
+
+      {submitError ? <Callout role="alert">{submitError}</Callout> : null}
+
+      <p id="submit-state" className={META_TEXT}>
+        {statusLine}
+      </p>
+
+      {/* disabled:opacity-50 is gone. It composited fill and label
+            against the page - 2.75:1 for the surface and 3.05:1 for the
+            label - for the whole session, because first paint has neither
+            a time nor consent. The replacement is 5.07:1 boundary and
+            5.41:1 label, and "Sending" no longer looks identical to
+            "you can't press this yet".
+            NOT --color-surface-disabled: it is a fixed literal with no
+            dark override, so it would strand this button as a pale bone
+            slab on the espresso page. --inset flips. */}
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        aria-describedby="submit-state"
+        className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-full border-[1.5px] border-transparent bg-[var(--cta)] px-6 text-body-4-emphasis text-[var(--cta-text)] shadow-[0_8px_22px_var(--sh16)] transition-[background-color,box-shadow,transform] duration-150 ease-out enabled:hover:bg-[var(--cta-hover)] enabled:active:translate-y-px enabled:active:shadow-[0_2px_8px_var(--sh12)] disabled:cursor-not-allowed disabled:border-[var(--ink-6b)] disabled:bg-[var(--inset)] disabled:text-[var(--ink-muted)] disabled:shadow-none"
+      >
+        {submitting ? (
+          <>
+            <Spinner />
+            Sending…
+          </>
+        ) : (
+          'Request this time'
+        )}
+      </button>
+
+      <p className={META_TEXT}>Your details are only used to handle this request.</p>
+    </div>
+  </section>
+);
+
 const BookClient = ({ slug }: { slug: string }) => {
   const view = usePractice(slug);
   // Needed before the guard below, because the default service feeds `useSlots`
@@ -470,7 +827,9 @@ const BookClient = ({ slug }: { slug: string }) => {
   // Derived, not stored: the practice's first service is the default until the
   // reader picks another, so nothing has to write it when the practice loads.
   const [serviceOverride, setServiceOverride] = useState<string | null>(null);
-  const [date, setDate] = useState(todayIso());
+  // The function, not its result: passing `todayIso()` re-derives today's date
+  // on every render and throws the value away.
+  const [date, setDate] = useState(todayIso);
   const serviceId = serviceOverride ?? loaded?.services[0]?.id ?? null;
 
   const [startTime, setStartTime] = useState<string | null>(null);
@@ -590,291 +949,38 @@ const BookClient = ({ slug }: { slug: string }) => {
         ) : null}
 
         <form className="flex flex-col gap-8 px-5 pb-6 sm:px-8 sm:pb-8" onSubmit={handleSubmit}>
-          <fieldset>
-            <legend className={EYEBROW}>Service</legend>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {practice.services.map((service: PublicService) => (
-                <label
-                  key={service.id}
-                  htmlFor={`service-${service.id}`}
-                  className="flex cursor-pointer items-start gap-3 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] px-4 py-4 transition-[border-color,background-color,box-shadow] duration-150 ease-out hover:border-[var(--ink)] hover:bg-[var(--screen-2)] has-[:checked]:border-[var(--blue-strong)] has-[:checked]:bg-[var(--blue-soft)] has-[:focus-visible]:border-[var(--color-input-border-active)] has-[:focus-visible]:shadow-[0_0_0_3px_var(--glow-b26)]"
-                >
-                  {/* The input, the dot and the content are DIRECT SIBLINGS, and
-                      that is the whole trick: peer-checked: compiles to
-                      `.peer:checked ~ &`, a following-sibling combinator, so it
-                      cannot reach a descendant of a sibling. sr-only is
-                      position:absolute, so it is out of flow and never becomes a
-                      flex item.
-                      size-px! because input[type=radio]{width:18px;height:18px}
-                      is unlayered and beats sr-only's layered 1px.
-                      aria-label is gone: with an explicit htmlFor/id pair the
-                      name already comes from the label's subtree, and the
-                      attribute was subtracting the duration from it. */}
-                  <input
-                    id={`service-${service.id}`}
-                    type="radio"
-                    name="service"
-                    className="peer sr-only size-px!"
-                    value={service.id}
-                    checked={serviceId === service.id}
-                    onChange={() => setServiceOverride(service.id)}
-                  />
-                  <span
-                    aria-hidden="true"
-                    className="mt-1 flex size-5 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--screen)] transition-[background-color,border-color] duration-150 ease-out before:m-auto before:size-2 before:scale-0 before:rounded-full before:bg-[var(--white-text)] before:transition-transform before:duration-150 before:content-[''] peer-checked:border-[var(--blue-strong)] peer-checked:bg-[var(--blue-strong)] peer-checked:before:scale-100 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--color-input-border-active)]"
-                  />
-                  {/* --ink-body, not --ink-muted. Muted ink measures 4.04:1 on
-                      the selected row's wash in dark - the row is the one place
-                      on the card where the ground changes under the meta text,
-                      and it is the row the reader is most likely to read. The
-                      name still separates by weight, size and --ink. */}
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-body-4-emphasis text-[var(--ink)]">
-                      {service.name}
-                    </span>
-                    <span className="mt-1 block text-caption-1 tabular-nums text-[var(--ink-body)]">
-                      {service.durationMinutes} min
-                    </span>
-                    {/* Fetched today and thrown away, which is exactly why these
-                        rows looked so empty: the only thing each had to say was
-                        "30 min". */}
-                    {service.description ? (
-                      <span className="mt-1 line-clamp-2 block text-caption-1 text-[var(--ink-body)]">
-                        {service.description}
-                      </span>
-                    ) : null}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
+          <ServiceFieldset
+            services={practice.services}
+            serviceId={serviceId}
+            onSelect={setServiceOverride}
+          />
 
-          <section>
-            <h2 className={EYEBROW}>Day and time</h2>
+          <DayAndTime
+            date={date}
+            minDate={todayIso()}
+            maxDate={maxDate}
+            bookingWindowDays={practice.bookingWindowDays}
+            quickDays={quickDays}
+            onDateChange={setDate}
+            slotsLoading={slotsLoading}
+            slots={slots}
+            slotsError={slotsError}
+            selectedTime={selectedTime}
+            onSelectTime={setStartTime}
+            slotGroupRef={slotGroupRef}
+          />
 
-            <div className="flex flex-col gap-2">
-              {/* An htmlFor/id pair, not a wrapping label: getByLabelText matches
-                  the label's whole recursive textContent, so the hint has to sit
-                  outside it or it would leak into the accessible name. */}
-              <label htmlFor="book-day" className="text-caption-1 text-[var(--ink-body)]">
-                Preferred day
-              </label>
-              {/* Stays a native date input. The test reads .min and .max off the
-                  DOM node, and react-datepicker exposes neither. */}
-              <input
-                id="book-day"
-                type="date"
-                className={`${FIELD} tabular-nums`}
-                value={date}
-                min={todayIso()}
-                max={maxDate}
-                aria-describedby="book-day-hint"
-                onChange={(event) => setDate(event.target.value)}
-              />
-              <p id="book-day-hint" className={META_TEXT}>
-                {formatLongDay(date)} · you can book up to {practice.bookingWindowDays} days ahead.
-              </p>
-            </div>
+          <DetailsFieldset form={form} setField={setField} />
 
-            {/* The near-term case, which is most of them, without going near the
-                browser's own calendar widget. */}
-            <div className="scrollbar-hidden -mx-1 mt-3 mb-6 flex gap-2 overflow-x-auto px-1 pb-1">
-              {quickDays.map((iso, index) => (
-                <button
-                  key={iso}
-                  type="button"
-                  aria-pressed={date === iso}
-                  onClick={() => setDate(iso)}
-                  className="min-h-11 shrink-0 rounded-full border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] px-4 text-caption-1 text-[var(--ink)] transition-[background-color,border-color,color,transform] duration-150 ease-out hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] active:translate-y-px aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] aria-pressed:text-[var(--white-text)]"
-                >
-                  {quickDayLabel(index, iso)}
-                </button>
-              ))}
-            </div>
-
-            <SlotPicker
-              loading={slotsLoading}
-              error={slotsError}
-              slots={slots}
-              selectedTime={selectedTime}
-              onSelect={setStartTime}
-              groupRef={slotGroupRef}
-            />
-          </section>
-
-          <fieldset>
-            <legend className={EYEBROW}>Your details</legend>
-            {/* One line under the eyebrow, never an asterisk inside a label -
-                getByLabelText matches the label's full text. */}
-            <p id="required-note" className="mb-4 text-caption-1 text-[var(--ink-muted)]">
-              Everything here is needed unless it says optional.
-            </p>
-            <div className="flex flex-col gap-5 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-5">
-              <div>
-                <label htmlFor="book-name" className={FIELD_LABEL}>
-                  Your name
-                </label>
-                {/* autoComplete on every field that has a token. There were none
-                    before, so no browser offered a stranger their own details. */}
-                <input
-                  id="book-name"
-                  className={FIELD}
-                  required
-                  maxLength={120}
-                  autoComplete="name"
-                  aria-describedby="required-note"
-                  value={form.ownerName}
-                  onChange={(event) => setField('ownerName', event.target.value)}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="book-email" className={FIELD_LABEL}>
-                  Email
-                </label>
-                <input
-                  id="book-email"
-                  className={FIELD}
-                  type="email"
-                  required
-                  maxLength={254}
-                  autoComplete="email"
-                  inputMode="email"
-                  spellCheck={false}
-                  placeholder="you@example.com"
-                  aria-describedby="required-note"
-                  value={form.ownerEmail}
-                  onChange={(event) => setField('ownerEmail', event.target.value)}
-                />
-              </div>
-
-              <div className="sm:col-span-2">
-                <label htmlFor="book-phone" className={FIELD_LABEL}>
-                  Phone (optional)
-                </label>
-                <input
-                  id="book-phone"
-                  className={FIELD}
-                  type="tel"
-                  maxLength={40}
-                  autoComplete="tel"
-                  inputMode="tel"
-                  placeholder="+49 30 1234567"
-                  value={form.ownerPhone}
-                  onChange={(event) => setField('ownerPhone', event.target.value)}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="book-pet" className={FIELD_LABEL}>
-                  Pet name
-                </label>
-                <input
-                  id="book-pet"
-                  className={FIELD}
-                  required
-                  maxLength={120}
-                  autoComplete="off"
-                  placeholder="Rex"
-                  aria-describedby="required-note"
-                  value={form.petName}
-                  onChange={(event) => setField('petName', event.target.value)}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="book-species" className={FIELD_LABEL}>
-                  Species
-                </label>
-                <input
-                  id="book-species"
-                  className={FIELD}
-                  required
-                  maxLength={60}
-                  autoComplete="off"
-                  placeholder="Dog, cat, rabbit…"
-                  aria-describedby="required-note"
-                  value={form.petSpecies}
-                  onChange={(event) => setField('petSpecies', event.target.value)}
-                />
-              </div>
-
-              <div className="sm:col-span-2">
-                <label htmlFor="book-concern" className={FIELD_LABEL}>
-                  What is the visit for? (optional)
-                </label>
-                <textarea
-                  id="book-concern"
-                  className={FIELD}
-                  rows={4}
-                  maxLength={1000}
-                  placeholder="Limping on the back left leg since Tuesday"
-                  value={form.concern}
-                  onChange={(event) => setField('concern', event.target.value)}
-                />
-              </div>
-            </div>
-          </fieldset>
-
-          <section>
-            <h2 className={EYEBROW}>Check and send</h2>
-            <div className="flex flex-col gap-4">
-              <label className="flex cursor-pointer items-start gap-3">
-                {/* size-6! = 24px, clearing the target-size floor on the control
-                    itself. The ! is required: input[type=checkbox]{width:20px}
-                    is unlayered and non-important, so a plain size-6 in
-                    @layer utilities loses to it.
-                    shrink-0 because this is a flex item beside a two-line
-                    sentence - it used to compress into an oval on a narrow
-                    viewport, and it is the one control that gates submission.
-                    Appearance, radius, fill and tick already come from
-                    globals.css and flip correctly; do not restyle them. */}
-                <input
-                  type="checkbox"
-                  className="size-6! shrink-0"
-                  checked={form.consent}
-                  onChange={(event) => setField('consent', event.target.checked)}
-                />
-                <span className="text-caption-1 text-[var(--ink-body)]">
-                  I agree that {practice.name} may store these details to handle my booking request.
-                  They are deleted 30 days after the requested date.
-                </span>
-              </label>
-
-              {submitError ? <Callout role="alert">{submitError}</Callout> : null}
-
-              <p id="submit-state" className={META_TEXT}>
-                {blockedReason ?? summaryLine}
-              </p>
-
-              {/* disabled:opacity-50 is gone. It composited fill and label
-                  against the page - 2.75:1 for the surface and 3.05:1 for the
-                  label - for the whole session, because first paint has neither
-                  a time nor consent. The replacement is 5.07:1 boundary and
-                  5.41:1 label, and "Sending" no longer looks identical to
-                  "you can't press this yet".
-                  NOT --color-surface-disabled: it is a fixed literal with no
-                  dark override, so it would strand this button as a pale bone
-                  slab on the espresso page. --inset flips. */}
-              <button
-                type="submit"
-                disabled={!canSubmit}
-                aria-describedby="submit-state"
-                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-full border-[1.5px] border-transparent bg-[var(--cta)] px-6 text-body-4-emphasis text-[var(--cta-text)] shadow-[0_8px_22px_var(--sh16)] transition-[background-color,box-shadow,transform] duration-150 ease-out enabled:hover:bg-[var(--cta-hover)] enabled:active:translate-y-px enabled:active:shadow-[0_2px_8px_var(--sh12)] disabled:cursor-not-allowed disabled:border-[var(--ink-6b)] disabled:bg-[var(--inset)] disabled:text-[var(--ink-muted)] disabled:shadow-none"
-              >
-                {submitting ? (
-                  <>
-                    <Spinner />
-                    Sending…
-                  </>
-                ) : (
-                  'Request this time'
-                )}
-              </button>
-
-              <p className={META_TEXT}>Your details are only used to handle this request.</p>
-            </div>
-          </section>
+          <CheckAndSend
+            practiceName={practice.name}
+            consent={form.consent}
+            setField={setField}
+            submitError={submitError}
+            statusLine={blockedReason ?? summaryLine}
+            canSubmit={canSubmit}
+            submitting={submitting}
+          />
         </form>
       </Card>
       <BookFooter />

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -18,22 +18,21 @@ import {
   Callout,
   CheckIcon,
   ClockIcon,
+  IconDisc,
+  Skeleton,
+  Spinner,
+  WarnIcon,
+} from './bookingChrome';
+import {
   EYEBROW,
   FIELD,
   FIELD_LABEL,
-  IconDisc,
   META_TEXT,
   PILL,
   SLOT_GRID,
-  Skeleton,
   STATE_BODY,
-  Spinner,
-  WarnIcon,
-  describeBlock,
-  formatLongDay,
-  groupByDayPart,
-  quickDayLabel,
-} from './bookingChrome';
+} from './bookingStyles';
+import { describeBlock, formatLongDay, groupByDayPart, quickDayLabel } from './bookingFormat';
 
 /**
  * The page a pet owner sees at `/book/<slug>`.

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+// Deep import on purpose. Card.tsx pulls in react and clsx and nothing else;
+// the `@/app/ui` barrel re-exports Cards, whose SectionCard calls
+// useSubscriptionForPrimaryOrg() and usePermissions() unconditionally - hooks
+// that have no session to read on a public page.
+import Card from '@/app/ui/Card';
+import type { PublicSlot } from '@/app/features/publicBooking/services/publicBooking.service';
+
+/**
+ * The shared surface for both public booking pages.
+ *
+ * `/book/<slug>` and `/book/<slug>/confirm` used to be two different designs -
+ * 560px with p-5 on one, 520px with p-6 on the other - so the column visibly
+ * jumped when a reader followed the emailed link. Everything that decides what
+ * the pages look like lives here, and both import it.
+ *
+ * On the class strings below: several carry a trailing `!`, and none of them is
+ * decorative. globals.css declares its own @layer blocks, and everything
+ * between them is unlayered. For normal declarations an unlayered rule beats a
+ * layered one whatever the specificity, so a plain Tailwind utility loses to
+ * any unlayered rule setting the same property; for important declarations the
+ * order reverses. Each `!` below names the rule it is beating.
+ */
+
+/**
+ * Every text field, textarea and the date input.
+ *
+ * The focus indicator is a box-shadow, not an outline, and that is forced:
+ * `input:focus-visible { outline: none }` is unlayered, so no `outline-*`
+ * utility can ever beat it. The old recipe also set `outline-none` itself,
+ * which was redundant against that rule and actively harmful - `outline` is the
+ * one property forced-colors mode preserves.
+ */
+export const FIELD =
+  'w-full min-h-12 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] ' +
+  'px-4 py-3 text-body-4 text-[var(--ink-body)] placeholder:text-[var(--ink-muted)] ' +
+  'transition-[border-color,box-shadow] duration-150 ease-out ' +
+  'hover:border-[var(--ink)] ' +
+  'focus-visible:border-[var(--color-input-border-active)] ' +
+  'focus-visible:shadow-[0_0_0_3px_var(--glow-b26)]';
+
+/**
+ * Time slots and quick-day chips.
+ *
+ * Selection is a fill, not a border-colour swap. The old recipe changed only
+ * the border, which is a 3.01:1 delta in light and 2.88:1 in dark - and it was
+ * written as an inline `style` object, which is why the page had no hover,
+ * focus or active state anywhere: a style attribute has no pseudo-classes.
+ *
+ * Tailwind's `aria-pressed:` variant compiles to `[aria-pressed="true"]`, so
+ * React still renders the literal "false" the tests read.
+ */
+export const PILL =
+  'flex min-h-11 items-center justify-center rounded-full border-[1.5px] border-[var(--ink-6b)] ' +
+  'bg-[var(--field-bg)] px-2 text-body-4-emphasis tabular-nums text-[var(--ink)] ' +
+  'transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out ' +
+  'hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] ' +
+  'active:translate-y-px ' +
+  'aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] ' +
+  'aria-pressed:text-[var(--white-text)] aria-pressed:shadow-[0_6px_16px_var(--glow-b26)]';
+
+/**
+ * The time grid, sized by its content rather than by breakpoints.
+ *
+ * auto-fill with a 4.5rem floor gives three columns on a 320px phone, four on a
+ * 390px one and six on the desktop card, without a single breakpoint prefix and
+ * without ever dropping a pill under the 44px target. A fixed `grid-cols-3`
+ * made a 27-slot day nine rows deep on a phone, which is most of why the
+ * redesign was running longer than the page it replaced.
+ */
+export const SLOT_GRID = 'grid grid-cols-[repeat(auto-fill,minmax(4.5rem,1fr))] gap-2';
+
+/** The label above a field. Named because six fields share it, and Sonar
+ *  counts a class string repeated three times as a duplicated literal. */
+export const FIELD_LABEL = 'mb-2 block text-caption-1 text-[var(--ink-body)]';
+
+/** Quiet supporting copy: hints, the status line, footnotes. */
+export const META_TEXT = 'text-caption-1 text-[var(--ink-muted)]';
+
+/** Body copy in a centred state card, measured for a comfortable line length. */
+export const STATE_BODY = 'max-w-[46ch] text-body-4 text-[var(--ink-body)]';
+
+/** Section eyebrows. `font-bold` and the tracking are utilities, so they beat
+ *  .text-caption-2's own weight and tracking in @layer components. */
+export const EYEBROW =
+  'mb-4 block text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]';
+
+/**
+ * `min-h-svh`, not `min-h-screen` (100vh overflows by the height of the iOS
+ * toolbar) and not dvh (which jitters as browser chrome collapses).
+ *
+ * The id and tabIndex are load-bearing: the root layout's SkipLink targets
+ * them, and globals.css sets their scroll-margin.
+ */
+export const BookShell = ({ children }: { children: React.ReactNode }) => (
+  <main
+    id="main-content"
+    tabIndex={-1}
+    className="min-h-svh w-full bg-[var(--page)] px-4 py-8 sm:px-6 sm:py-12"
+  >
+    <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 lg:max-w-[720px]">
+      {children}
+    </div>
+  </main>
+);
+
+export const BookFooter = () => (
+  <footer className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-caption-2 text-[var(--ink-muted)]">
+    <span>Booking page provided by Yosemite Crew</span>
+    {/* `underline!`, not `underline`: `a { text-decoration: none !important }`
+        is unlayered, and a layered non-important utility loses to it. */}
+    <Link
+      href="/privacy-policy"
+      className="underline! underline-offset-2 transition-colors duration-150 ease-out hover:text-[var(--ink-body)]"
+    >
+      Privacy
+    </Link>
+    <Link
+      href="/terms-and-conditions"
+      className="underline! underline-offset-2 transition-colors duration-150 ease-out hover:text-[var(--ink-body)]"
+    >
+      Terms
+    </Link>
+  </footer>
+);
+
+const DISC_TONES = {
+  brand: 'bg-[var(--blue-soft)] text-[var(--blue-text)]',
+  warn: 'bg-[var(--warn-bg)] text-[var(--warn-text)]',
+  success: 'bg-[var(--inset)] text-[var(--success-text)]',
+} as const;
+
+export const IconDisc = ({
+  tone,
+  children,
+}: {
+  tone: keyof typeof DISC_TONES;
+  children: React.ReactNode;
+}) => (
+  <span
+    aria-hidden="true"
+    className={`flex size-11 shrink-0 items-center justify-center rounded-full ${DISC_TONES[tone]}`}
+  >
+    {children}
+  </span>
+);
+
+export const WarnIcon = ({ className = 'size-5 shrink-0' }: { className?: string }) => (
+  <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={className}>
+    <circle cx="10" cy="10" r="8.25" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M10 6v4.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <circle cx="10" cy="13.75" r="0.9" fill="currentColor" />
+  </svg>
+);
+
+export const CheckIcon = ({ className = 'size-5 shrink-0' }: { className?: string }) => (
+  <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={className}>
+    <path
+      d="m4.75 10.5 3.4 3.4 7.1-7.9"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ClockIcon = ({ className = 'size-5 shrink-0' }: { className?: string }) => (
+  <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className={className}>
+    <circle cx="10" cy="10" r="8.25" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M10 5.5V10l3 1.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+export const Spinner = () => (
+  <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" className="size-4 shrink-0 animate-spin">
+    <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+    <path d="M18 10a8 8 0 0 0-8-8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+/**
+ * One tone, on purpose.
+ *
+ * Everything this page can report - times would not load, the request would not
+ * send, the slot went while the form was open - means "we could not do this
+ * yet", never "something was destroyed". Two colours for one meaning is
+ * vocabulary the page has not earned.
+ *
+ * The svg is a sibling of the text, and svg is phrasing content, so this raises
+ * no validateDOMNesting error - which matters, because jest.setup.ts turns
+ * console.error into a throw.
+ */
+export const Callout = ({
+  children,
+  role,
+  className = '',
+}: {
+  children: React.ReactNode;
+  role?: 'alert';
+  className?: string;
+}) => (
+  <p
+    role={role}
+    className={`flex items-start gap-3 rounded-xl border border-[var(--warn-border)] bg-[var(--warn-bg)] px-4 py-3 text-caption-1 text-[var(--warn-text)] ${className}`}
+  >
+    <WarnIcon className="mt-0.5 size-4 shrink-0" />
+    <span>{children}</span>
+  </p>
+);
+
+/**
+ * The shape every state that replaces the form takes, so the page never
+ * changes size under the reader.
+ *
+ * A `[tabindex='-1']` element is excluded from the global focus-ring selector,
+ * so moving focus here after a submit draws no ring - correct for a status
+ * region that the reader did not tab to.
+ */
+export const StateCard = ({
+  icon,
+  heading,
+  headingLevel = 'h2',
+  innerRef,
+  children,
+}: {
+  icon: React.ReactNode;
+  heading: string;
+  headingLevel?: 'h1' | 'h2';
+  innerRef?: React.RefObject<HTMLDivElement | null>;
+  children: React.ReactNode;
+}) => {
+  const Heading = headingLevel;
+  return (
+    <Card className="p-5 sm:p-8">
+      <div
+        ref={innerRef}
+        tabIndex={innerRef ? -1 : undefined}
+        className="flex flex-col items-center gap-4 text-center"
+      >
+        {icon}
+        <Heading className="text-heading-2 text-[var(--ink)]">{heading}</Heading>
+        {children}
+      </div>
+    </Card>
+  );
+};
+
+/** A shimmering placeholder block. A div, so it adds no phantom role. */
+export const Skeleton = ({ className }: { className: string }) => (
+  <div className={`bg-[var(--band)] yc-shimmer ${className}`} />
+);
+
+const UTC_DAY = (iso: string) => new Date(`${iso}T00:00:00Z`);
+
+// Pinned to en-GB and UTC so the strings are the same in jest, in CI and in the
+// browser, whatever the machine's locale and zone.
+export const formatShortDay = (iso: string) =>
+  new Intl.DateTimeFormat('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(UTC_DAY(iso));
+
+export const formatLongDay = (iso: string) =>
+  new Intl.DateTimeFormat('en-GB', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+  }).format(UTC_DAY(iso));
+
+const RELATIVE_DAY_LABELS = ['Today', 'Tomorrow'] as const;
+
+/** Indexed rather than nested ternaries, which Sonar rejects. */
+export const quickDayLabel = (index: number, iso: string) =>
+  RELATIVE_DAY_LABELS[index] ?? formatShortDay(iso);
+
+export const DAY_PARTS = [
+  { key: 'morning', label: 'Morning', until: 12 },
+  { key: 'afternoon', label: 'Afternoon', until: 17 },
+  { key: 'evening', label: 'Evening', until: 24 },
+] as const;
+
+/**
+ * Twenty-seven identical capsules in one flat wrap is a wall, not a choice.
+ *
+ * One map over a fixed list with no per-group conditional, so a fixture of
+ * three slots exercises every path in it.
+ */
+export const groupByDayPart = (slots: PublicSlot[]) =>
+  DAY_PARTS.map((part, index) => {
+    const from = index === 0 ? 0 : DAY_PARTS[index - 1].until;
+    return {
+      ...part,
+      slots: slots.filter((slot) => {
+        const hour = Number(slot.startTime.slice(0, 2));
+        return hour >= from && hour < part.until;
+      }),
+    };
+  }).filter((group) => group.slots.length > 0);
+
+/**
+ * Which of the two preconditions is missing, in words.
+ *
+ * The submit button is disabled from first paint until a time is chosen and
+ * consent is ticked, and nothing on the page used to say which. Returns null
+ * when neither is missing, and the caller shows the chosen summary instead.
+ */
+export const describeBlock = (selectedTime: string | null, consent: boolean) => {
+  if (!selectedTime) return 'Choose a time above to send your request.';
+  if (!consent) return 'Tick the box above to send your request.';
+  return null;
+};

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 // useSubscriptionForPrimaryOrg() and usePermissions() unconditionally - hooks
 // that have no session to read on a public page.
 import Card from '@/app/ui/Card';
-import type { PublicSlot } from '@/app/features/publicBooking/services/publicBooking.service';
 
 /**
  * The shared surface for both public booking pages.
@@ -17,76 +16,10 @@ import type { PublicSlot } from '@/app/features/publicBooking/services/publicBoo
  * jumped when a reader followed the emailed link. Everything that decides what
  * the pages look like lives here, and both import it.
  *
- * On the class strings below: several carry a trailing `!`, and none of them is
- * decorative. globals.css declares its own @layer blocks, and everything
- * between them is unlayered. For normal declarations an unlayered rule beats a
- * layered one whatever the specificity, so a plain Tailwind utility loses to
- * any unlayered rule setting the same property; for important declarations the
- * order reverses. Each `!` below names the rule it is beating.
+ * Components only. The class recipes live in `bookingStyles.ts` and the pure
+ * helpers in `bookingFormat.ts`, because a module that exports both components
+ * and non-components cannot preserve state across a Fast Refresh.
  */
-
-/**
- * Every text field, textarea and the date input.
- *
- * The focus indicator is a box-shadow, not an outline, and that is forced:
- * `input:focus-visible { outline: none }` is unlayered, so no `outline-*`
- * utility can ever beat it. The old recipe also set `outline-none` itself,
- * which was redundant against that rule and actively harmful - `outline` is the
- * one property forced-colors mode preserves.
- */
-export const FIELD =
-  'w-full min-h-12 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] ' +
-  'px-4 py-3 text-body-4 text-[var(--ink-body)] placeholder:text-[var(--ink-muted)] ' +
-  'transition-[border-color,box-shadow] duration-150 ease-out ' +
-  'hover:border-[var(--ink)] ' +
-  'focus-visible:border-[var(--color-input-border-active)] ' +
-  'focus-visible:shadow-[0_0_0_3px_var(--glow-b26)]';
-
-/**
- * Time slots and quick-day chips.
- *
- * Selection is a fill, not a border-colour swap. The old recipe changed only
- * the border, which is a 3.01:1 delta in light and 2.88:1 in dark - and it was
- * written as an inline `style` object, which is why the page had no hover,
- * focus or active state anywhere: a style attribute has no pseudo-classes.
- *
- * Tailwind's `aria-pressed:` variant compiles to `[aria-pressed="true"]`, so
- * React still renders the literal "false" the tests read.
- */
-export const PILL =
-  'flex min-h-11 items-center justify-center rounded-full border-[1.5px] border-[var(--ink-6b)] ' +
-  'bg-[var(--field-bg)] px-2 text-body-4-emphasis tabular-nums text-[var(--ink)] ' +
-  'transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out ' +
-  'hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] ' +
-  'active:translate-y-px ' +
-  'aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] ' +
-  'aria-pressed:text-[var(--white-text)] aria-pressed:shadow-[0_6px_16px_var(--glow-b26)]';
-
-/**
- * The time grid, sized by its content rather than by breakpoints.
- *
- * auto-fill with a 4.5rem floor gives three columns on a 320px phone, four on a
- * 390px one and six on the desktop card, without a single breakpoint prefix and
- * without ever dropping a pill under the 44px target. A fixed `grid-cols-3`
- * made a 27-slot day nine rows deep on a phone, which is most of why the
- * redesign was running longer than the page it replaced.
- */
-export const SLOT_GRID = 'grid grid-cols-[repeat(auto-fill,minmax(4.5rem,1fr))] gap-2';
-
-/** The label above a field. Named because six fields share it, and Sonar
- *  counts a class string repeated three times as a duplicated literal. */
-export const FIELD_LABEL = 'mb-2 block text-caption-1 text-[var(--ink-body)]';
-
-/** Quiet supporting copy: hints, the status line, footnotes. */
-export const META_TEXT = 'text-caption-1 text-[var(--ink-muted)]';
-
-/** Body copy in a centred state card, measured for a comfortable line length. */
-export const STATE_BODY = 'max-w-[46ch] text-body-4 text-[var(--ink-body)]';
-
-/** Section eyebrows. `font-bold` and the tracking are utilities, so they beat
- *  .text-caption-2's own weight and tracking in @layer components. */
-export const EYEBROW =
-  'mb-4 block text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]';
 
 /**
  * `min-h-svh`, not `min-h-screen` (100vh overflows by the height of the iOS
@@ -253,66 +186,3 @@ export const StateCard = ({
 export const Skeleton = ({ className }: { className: string }) => (
   <div className={`bg-[var(--band)] yc-shimmer ${className}`} />
 );
-
-const UTC_DAY = (iso: string) => new Date(`${iso}T00:00:00Z`);
-
-// Pinned to en-GB and UTC so the strings are the same in jest, in CI and in the
-// browser, whatever the machine's locale and zone.
-export const formatShortDay = (iso: string) =>
-  new Intl.DateTimeFormat('en-GB', {
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-    timeZone: 'UTC',
-  }).format(UTC_DAY(iso));
-
-export const formatLongDay = (iso: string) =>
-  new Intl.DateTimeFormat('en-GB', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-    timeZone: 'UTC',
-  }).format(UTC_DAY(iso));
-
-const RELATIVE_DAY_LABELS = ['Today', 'Tomorrow'] as const;
-
-/** Indexed rather than nested ternaries, which Sonar rejects. */
-export const quickDayLabel = (index: number, iso: string) =>
-  RELATIVE_DAY_LABELS[index] ?? formatShortDay(iso);
-
-export const DAY_PARTS = [
-  { key: 'morning', label: 'Morning', until: 12 },
-  { key: 'afternoon', label: 'Afternoon', until: 17 },
-  { key: 'evening', label: 'Evening', until: 24 },
-] as const;
-
-/**
- * Twenty-seven identical capsules in one flat wrap is a wall, not a choice.
- *
- * One map over a fixed list with no per-group conditional, so a fixture of
- * three slots exercises every path in it.
- */
-export const groupByDayPart = (slots: PublicSlot[]) =>
-  DAY_PARTS.map((part, index) => {
-    const from = index === 0 ? 0 : DAY_PARTS[index - 1].until;
-    return {
-      ...part,
-      slots: slots.filter((slot) => {
-        const hour = Number(slot.startTime.slice(0, 2));
-        return hour >= from && hour < part.until;
-      }),
-    };
-  }).filter((group) => group.slots.length > 0);
-
-/**
- * Which of the two preconditions is missing, in words.
- *
- * The submit button is disabled from first paint until a time is chosen and
- * consent is ticked, and nothing on the page used to say which. Returns null
- * when neither is missing, and the caller shows the chosen summary instead.
- */
-export const describeBlock = (selectedTime: string | null, consent: boolean) => {
-  if (!selectedTime) return 'Choose a time above to send your request.';
-  if (!consent) return 'Tick the box above to send your request.';
-  return null;
-};

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingFormat.ts
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingFormat.ts
@@ -1,0 +1,93 @@
+import type { PublicSlot } from '@/app/features/publicBooking/services/publicBooking.service';
+
+/**
+ * The pure helpers behind the public booking pages.
+ *
+ * A plain `.ts` module, separate from the components, so neither file mixes
+ * component and non-component exports - which is what stops Fast Refresh
+ * preserving state.
+ */
+
+/**
+ * Built once at module scope, not per call.
+ *
+ * `new Intl.DateTimeFormat()` is expensive, and `formatLongDay` runs on every
+ * render of the day hint - which is every keystroke in the form beneath it,
+ * since they share the same component's state.
+ */
+const SHORT_DAY = new Intl.DateTimeFormat('en-GB', {
+  weekday: 'short',
+  day: 'numeric',
+  month: 'short',
+  timeZone: 'UTC',
+});
+
+const LONG_DAY = new Intl.DateTimeFormat('en-GB', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+  timeZone: 'UTC',
+});
+
+const utcDay = (iso: string) => new Date(`${iso}T00:00:00Z`);
+
+// Pinned to en-GB and UTC so the strings are the same in jest, in CI and in the
+// browser, whatever the machine's locale and zone.
+export const formatShortDay = (iso: string) => SHORT_DAY.format(utcDay(iso));
+
+export const formatLongDay = (iso: string) => LONG_DAY.format(utcDay(iso));
+
+const RELATIVE_DAY_LABELS = ['Today', 'Tomorrow'] as const;
+
+/** Indexed rather than nested ternaries, which Sonar rejects. */
+export const quickDayLabel = (index: number, iso: string) =>
+  RELATIVE_DAY_LABELS[index] ?? formatShortDay(iso);
+
+export const DAY_PARTS = [
+  { key: 'morning', label: 'Morning', from: 0, until: 12 },
+  { key: 'afternoon', label: 'Afternoon', from: 12, until: 17 },
+  { key: 'evening', label: 'Evening', from: 17, until: 24 },
+] as const;
+
+export type DayPartGroup = {
+  key: string;
+  label: string;
+  slots: PublicSlot[];
+};
+
+/**
+ * Twenty-seven identical capsules in one flat wrap is a wall, not a choice.
+ *
+ * One pass over the day parts building only the groups that have something in
+ * them, rather than mapping and then filtering the result. `from` is a field on
+ * each part rather than a lookback into the previous element, so nothing here
+ * depends on the array's order.
+ */
+export const groupByDayPart = (slots: PublicSlot[]): DayPartGroup[] => {
+  const groups: DayPartGroup[] = [];
+
+  for (const part of DAY_PARTS) {
+    const inPart = slots.filter((slot) => {
+      const hour = Number(slot.startTime.slice(0, 2));
+      return hour >= part.from && hour < part.until;
+    });
+    if (inPart.length > 0) {
+      groups.push({ key: part.key, label: part.label, slots: inPart });
+    }
+  }
+
+  return groups;
+};
+
+/**
+ * Which of the two preconditions is missing, in words.
+ *
+ * The submit button is disabled from first paint until a time is chosen and
+ * consent is ticked, and nothing on the page used to say which. Returns null
+ * when neither is missing, and the caller shows the chosen summary instead.
+ */
+export const describeBlock = (selectedTime: string | null, consent: boolean) => {
+  if (!selectedTime) return 'Choose a time above to send your request.';
+  if (!consent) return 'Tick the box above to send your request.';
+  return null;
+};

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingStyles.ts
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingStyles.ts
@@ -1,0 +1,77 @@
+/**
+ * The class recipes both public booking pages share.
+ *
+ * A plain `.ts` module rather than exports beside the components: a file that
+ * exports both components and non-components cannot preserve state across a
+ * Fast Refresh, so React Doctor's `only-export-components` is right to flag it.
+ *
+ * On the trailing `!` in some of the strings below - none of them is
+ * decorative. `globals.css` declares its own `@layer` blocks and everything
+ * between them is unlayered. For normal declarations an unlayered rule beats a
+ * layered one whatever the specificity, so a plain Tailwind utility loses to
+ * any unlayered rule setting the same property; for important declarations the
+ * order reverses. Each `!` is named at the site that needs it.
+ */
+
+/**
+ * Every text field, textarea and the date input.
+ *
+ * The focus indicator is a box-shadow, not an outline, and that is forced:
+ * `input:focus-visible { outline: none }` is unlayered, so no `outline-*`
+ * utility can ever beat it. The old recipe also set `outline-none` itself,
+ * which was redundant against that rule and actively harmful - `outline` is the
+ * one property forced-colors mode preserves.
+ */
+export const FIELD =
+  'w-full min-h-12 rounded-xl border-[1.5px] border-[var(--ink-6b)] bg-[var(--field-bg)] ' +
+  'px-4 py-3 text-body-4 text-[var(--ink-body)] placeholder:text-[var(--ink-muted)] ' +
+  'transition-[border-color,box-shadow] duration-150 ease-out ' +
+  'hover:border-[var(--ink)] ' +
+  'focus-visible:border-[var(--color-input-border-active)] ' +
+  'focus-visible:shadow-[0_0_0_3px_var(--glow-b26)]';
+
+/**
+ * Time slots and quick-day chips.
+ *
+ * Selection is a fill, not a border-colour swap. The old recipe changed only
+ * the border, which is a 3.01:1 delta in light and 2.88:1 in dark - and it was
+ * written as an inline `style` object, which is why the page had no hover,
+ * focus or active state anywhere: a style attribute has no pseudo-classes.
+ *
+ * Tailwind's `aria-pressed:` variant compiles to `[aria-pressed="true"]`, so
+ * React still renders the literal "false" the tests read.
+ */
+export const PILL =
+  'flex min-h-11 items-center justify-center rounded-full border-[1.5px] border-[var(--ink-6b)] ' +
+  'bg-[var(--field-bg)] px-2 text-body-4-emphasis tabular-nums text-[var(--ink)] ' +
+  'transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out ' +
+  'hover:border-[var(--blue-strong)] hover:bg-[var(--blue-soft)] hover:text-[var(--blue-text)] ' +
+  'active:translate-y-px ' +
+  'aria-pressed:border-[var(--blue-strong)] aria-pressed:bg-[var(--blue-strong)] ' +
+  'aria-pressed:text-[var(--white-text)] aria-pressed:shadow-[0_6px_16px_var(--glow-b26)]';
+
+/**
+ * The time grid, sized by its content rather than by breakpoints.
+ *
+ * auto-fill with a 4.5rem floor gives three columns on a 320px phone, four on a
+ * 390px one and six on the desktop card, without a single breakpoint prefix and
+ * without ever dropping a pill under the 44px target. A fixed `grid-cols-3`
+ * made a 27-slot day nine rows deep on a phone, which is most of why the
+ * redesign was running longer than the page it replaced.
+ */
+export const SLOT_GRID = 'grid grid-cols-[repeat(auto-fill,minmax(4.5rem,1fr))] gap-2';
+
+/** Section eyebrows. `font-bold` and the tracking are utilities, so they beat
+ *  .text-caption-2's own weight and tracking in @layer components. */
+export const EYEBROW =
+  'mb-4 block text-caption-2 font-bold uppercase tracking-[0.1em] text-[var(--ink-muted)]';
+
+/** The label above a field. Named because six fields share it, and Sonar
+ *  counts a class string repeated three times as a duplicated literal. */
+export const FIELD_LABEL = 'mb-2 block text-caption-1 text-[var(--ink-body)]';
+
+/** Quiet supporting copy: hints, the status line, footnotes. */
+export const META_TEXT = 'text-caption-1 text-[var(--ink-muted)]';
+
+/** Body copy in a centred state card, measured for a comfortable line length. */
+export const STATE_BODY = 'max-w-[46ch] text-body-4 text-[var(--ink-body)]';

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
@@ -3,6 +3,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { confirmBookingRequest } from '@/app/features/publicBooking/services/publicBooking.service';
+import {
+  BookFooter,
+  BookShell,
+  CheckIcon,
+  IconDisc,
+  STATE_BODY,
+  Skeleton,
+  StateCard,
+  WarnIcon,
+} from '../bookingChrome';
 
 /**
  * Where the emailed confirmation link lands.
@@ -11,6 +21,10 @@ import { confirmBookingRequest } from '@/app/features/publicBooking/services/pub
  * scanners fetch URLs to preview them, so a GET that confirmed on arrival would
  * confirm requests nobody clicked - which is exactly the property the email step
  * exists to establish. The page reads the token from the query and posts it once.
+ *
+ * It shares `bookingChrome` with the booking page. It used to pick its own
+ * width and padding (520/p-6 against 560/p-5), so the column visibly jumped
+ * when a reader followed the link out of their inbox.
  */
 
 type State = 'confirming' | 'confirmed' | 'invalid';
@@ -43,38 +57,69 @@ const ConfirmClient = () => {
   }, [token]);
 
   return (
-    <main
-      id="main-content"
-      tabIndex={-1}
-      className="mx-auto flex min-h-screen w-full max-w-[520px] flex-col justify-center gap-3 p-6"
-    >
+    <BookShell>
       {state === 'confirming' ? (
-        <p className="text-[14px] text-[var(--ink-muted)]">Confirming your request…</p>
+        <div className="rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-5 yc-card-elevated sm:p-8">
+          <p className="sr-only" role="status">
+            Confirming your request…
+          </p>
+          <div className="flex flex-col items-center gap-4">
+            <Skeleton className="size-11 rounded-full" />
+            <Skeleton className="h-6 w-1/2 rounded-xl" />
+            <Skeleton className="h-4 w-3/4 rounded-xl" />
+          </div>
+        </div>
       ) : null}
 
       {state === 'confirmed' ? (
-        <>
-          <h1 className="text-[20px] font-bold text-[var(--ink)]">Request confirmed</h1>
-          <p className="text-[14px] text-[var(--ink-body)]">
-            {practiceName || 'The practice'} can now see your request and will contact you to
-            arrange the appointment.
-          </p>
-          <p className="text-[13px] text-[var(--ink-faint)]">
+        <StateCard
+          headingLevel="h1"
+          heading="Request confirmed"
+          icon={
+            <IconDisc tone="success">
+              <CheckIcon />
+            </IconDisc>
+          }
+        >
+          {/* Two whole sentences rather than one with a placeholder spliced into
+              it. The fallback used to render the literal "The practice can now
+              see your request", which reads to a pet owner like the page has
+              lost track of who they booked with. */}
+          {practiceName ? (
+            <p className={STATE_BODY}>
+              {practiceName} can now see your request and will contact you to arrange the
+              appointment.
+            </p>
+          ) : (
+            <p className={STATE_BODY}>
+              Your request is confirmed. The practice will contact you to arrange the appointment.
+            </p>
+          )}
+          <p className="w-full rounded-xl bg-[var(--inset)] px-4 py-3 text-caption-1 text-[var(--ink-body)]">
             Nothing is booked yet, and the time you asked for is not being held.
           </p>
-        </>
+        </StateCard>
       ) : null}
 
       {state === 'invalid' ? (
-        <>
-          <h1 className="text-[20px] font-bold text-[var(--ink)]">This link is not valid</h1>
-          <p className="text-[14px] text-[var(--ink-body)]">
+        <StateCard
+          headingLevel="h1"
+          heading="This link is not valid"
+          icon={
+            <IconDisc tone="warn">
+              <WarnIcon />
+            </IconDisc>
+          }
+        >
+          <p className={STATE_BODY}>
             It may have already been used, or it may have expired. Confirmation links last 48 hours.
             Please submit your request again, or contact the practice directly.
           </p>
-        </>
+        </StateCard>
       ) : null}
-    </main>
+
+      <BookFooter />
+    </BookShell>
   );
 };
 

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
@@ -8,11 +8,11 @@ import {
   BookShell,
   CheckIcon,
   IconDisc,
-  STATE_BODY,
   Skeleton,
   StateCard,
   WarnIcon,
 } from '../bookingChrome';
+import { STATE_BODY } from '../bookingStyles';
 
 /**
  * Where the emailed confirmation link lands.

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.tsx
@@ -60,9 +60,7 @@ const ConfirmClient = () => {
     <BookShell>
       {state === 'confirming' ? (
         <div className="rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-5 yc-card-elevated sm:p-8">
-          <p className="sr-only" role="status">
-            Confirming your request…
-          </p>
+          <output className="sr-only">Confirming your request…</output>
           <div className="flex flex-col items-center gap-4">
             <Skeleton className="size-11 rounded-full" />
             <Skeleton className="h-6 w-1/2 rounded-xl" />

--- a/apps/frontend/src/app/(routes)/(book)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/layout.tsx
@@ -1,0 +1,34 @@
+import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
+
+/**
+ * The layout the `(book)` group never had.
+ *
+ * Its absence was not cosmetic. `ThemeScript` is mounted by `(app)/layout.tsx`
+ * and the raw script by `(public)/layout.tsx`; `(book)` had neither, so nothing
+ * ever stamped `data-theme` on `<html>` and the whole `html[data-theme='dark']`
+ * block in globals.css was dead code on this route. A pet owner on a dark phone
+ * got a full-brightness bone page while every other Yosemite surface flipped.
+ *
+ * No nonce, and none is needed: `/book` is in STRICT_CSP_PATH_PREFIXES
+ * (middleware.ts), and securityHeaders.ts adds PRE_PAINT_SCRIPT_CSP_HASH to
+ * script-src in the strict variant only - which is exactly this case. The
+ * public layout does the same thing for the same reason.
+ *
+ * The `display: contents` wrapper introduces no box, so it cannot disturb the
+ * height chain under it. What it buys is `color-scheme` on the native date
+ * input and checkbox (the [data-yc-app] rules are plain attribute selectors),
+ * the app's ::selection colour, and the readable faint inks that
+ * `body:has([data-yc-app])` scopes to bone surfaces. Nothing on these two pages
+ * depends on that last one - every line that reached for --ink-faint now uses
+ * --ink-muted - so a browser without :has() loses nothing.
+ */
+export default function BookLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: PRE_PAINT_SCRIPT }} />
+      <div data-yc-app style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -365,6 +365,121 @@ describe('BookClient', () => {
     expect(getSlotsMock.mock.calls[1][1]).toBe('svc-2');
   });
 
+  it('offers the next few days as chips so most readers never open the calendar', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    const tomorrow = screen.getByRole('button', { name: 'Tomorrow' });
+    expect(screen.getByRole('button', { name: 'Today' })).toHaveAttribute('aria-pressed', 'true');
+    expect(tomorrow).toHaveAttribute('aria-pressed', 'false');
+
+    await act(async () => {
+      fireEvent.click(tomorrow);
+    });
+
+    // A different day means a fresh availability lookup, same as the date input.
+    await waitFor(() => expect(getSlotsMock).toHaveBeenCalledTimes(2));
+    expect(getSlotsMock.mock.calls[1][2]).not.toBe(getSlotsMock.mock.calls[0][2]);
+  });
+
+  it('heads the day parts only when a day actually spans more than one', async () => {
+    getSlotsMock.mockResolvedValue({
+      date: '2026-09-01',
+      serviceId: 'svc-1',
+      durationMinutes: 30,
+      windows: [
+        { startTime: '09:00', endTime: '09:30' },
+        { startTime: '14:00', endTime: '14:30' },
+      ],
+    });
+    await renderPage();
+
+    // Both headings are in the tree for the group labels; only these are shown.
+    await waitFor(() => expect(screen.getByRole('button', { name: '14:00' })).toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: 'Morning' })).not.toHaveClass('sr-only');
+    expect(screen.getByRole('heading', { name: 'Afternoon' })).not.toHaveClass('sr-only');
+  });
+
+  it('hides a lone day-part heading rather than captioning one grid', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    // The default fixture is 09:00 and 10:00 - one part, so the heading stays
+    // for assistive technology and disappears for everyone else.
+    expect(screen.getByRole('heading', { name: 'Morning' })).toHaveClass('sr-only');
+  });
+
+  it('shows what a service is when the practice has said', async () => {
+    getPracticeMock.mockResolvedValue({
+      kind: 'practice',
+      practice: practice({
+        services: [
+          {
+            id: 'svc-1',
+            name: 'Wellness consultation',
+            description: 'Nose-to-tail exam and a plan for the year.',
+            durationMinutes: 30,
+          },
+        ],
+      }),
+    });
+    await renderPage();
+
+    // Fetched and thrown away before this change, which is why the rows had
+    // nothing to say but "30 min".
+    expect(screen.getByText('Nose-to-tail exam and a plan for the year.')).toBeInTheDocument();
+  });
+
+  it('names the missing precondition, then recaps the choice', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    expect(screen.getByText(/Choose a time above/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    expect(screen.getByText(/Tick the box above/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    // A compound line, never a bare service name: a second element whose exact
+    // direct text is 'Wellness consultation' would break the singular
+    // getByText in the first test.
+    expect(screen.getByText(/Wellness consultation . 30 min .* 09:00/)).toBeInTheDocument();
+
+    await act(async () => {});
+  });
+
+  it('announces the wait for times as a status, never as an alert', async () => {
+    let settle: (value: unknown) => void = () => {};
+    getSlotsMock.mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      })
+    );
+    await renderPage();
+
+    expect(screen.getByRole('status')).toHaveTextContent('Checking availability');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    await act(async () => {
+      settle({ date: '2026-09-01', serviceId: 'svc-1', durationMinutes: 30, windows: [] });
+    });
+  });
+
+  it('moves focus to the confirmation instead of dropping it on the body', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    fireEvent.click(screen.getByRole('checkbox'));
+    await submitForm();
+
+    // The form unmounts on success. Without this the reader is left on <body>
+    // with nothing announcing that the request went.
+    const heading = screen.getByRole('heading', { name: 'Check your email' });
+    expect(heading.closest('[tabindex="-1"]')).toBe(document.activeElement);
+  });
+
   it('tolerates a practice with no city', async () => {
     getPracticeMock.mockResolvedValue({
       kind: 'practice',

--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -394,19 +394,26 @@ describe('BookClient', () => {
     });
     await renderPage();
 
-    // Both headings are in the tree for the group labels; only these are shown.
+    // The heading sits inside the group's <legend>, and it is the legend that
+    // carries the visibility, so that is what to assert on.
     await waitFor(() => expect(screen.getByRole('button', { name: '14:00' })).toBeInTheDocument());
-    expect(screen.getByRole('heading', { name: 'Morning' })).not.toHaveClass('sr-only');
-    expect(screen.getByRole('heading', { name: 'Afternoon' })).not.toHaveClass('sr-only');
+    expect(screen.getByRole('heading', { name: 'Morning' }).closest('legend')).not.toHaveClass(
+      'sr-only'
+    );
+    expect(screen.getByRole('heading', { name: 'Afternoon' }).closest('legend')).not.toHaveClass(
+      'sr-only'
+    );
   });
 
   it('hides a lone day-part heading rather than captioning one grid', async () => {
     await renderPage();
     await waitFor(() => screen.getByRole('button', { name: '09:00' }));
 
-    // The default fixture is 09:00 and 10:00 - one part, so the heading stays
-    // for assistive technology and disappears for everyone else.
-    expect(screen.getByRole('heading', { name: 'Morning' })).toHaveClass('sr-only');
+    // The default fixture is 09:00 and 10:00 - one part, so the group keeps its
+    // name for assistive technology and the caption disappears for everyone else.
+    expect(screen.getByRole('heading', { name: 'Morning' }).closest('legend')).toHaveClass(
+      'sr-only'
+    );
   });
 
   it('shows what a service is when the practice has said', async () => {

--- a/apps/frontend/src/app/__tests__/(routes)/book/ConfirmClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/ConfirmClient.test.tsx
@@ -72,10 +72,15 @@ describe('ConfirmClient', () => {
     expect(screen.getByText(/48\s*hours/)).toBeInTheDocument();
   });
 
-  it('falls back when the API returns no practice name', async () => {
+  it('writes a whole sentence when the API returns no practice name', async () => {
     confirmMock.mockResolvedValue({ practiceName: '', slug: null });
     await renderPage();
 
-    expect(screen.getByText(/The practice can now see your request/)).toBeInTheDocument();
+    // Not a placeholder spliced into the named sentence. "The practice can now
+    // see your request" reads to a pet owner like the page has lost track of
+    // who they booked with.
+    expect(
+      screen.getByText(/Your request is confirmed\. The practice will contact you/)
+    ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/(routes)/book/bookLayout.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/bookLayout.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import BookLayout from '@/app/(routes)/(book)/layout';
+
+describe('the (book) layout', () => {
+  it('puts the public booking pages inside the app token scope', () => {
+    // Without this marker the route sits outside body:has([data-yc-app]) and
+    // [data-yc-app], so it gets neither the readable bone-surface inks nor a
+    // color-scheme for the native date picker and checkbox.
+    const { container } = render(
+      <BookLayout>
+        <p>booking</p>
+      </BookLayout>
+    );
+
+    expect(screen.getByText('booking')).toBeInTheDocument();
+    expect(container.querySelector('[data-yc-app]')).not.toBeNull();
+  });
+
+  it('resolves the theme before paint, which this route never did', () => {
+    // The (book) group had no layout at all, so nothing stamped data-theme on
+    // <html> and the entire dark palette was dead code here.
+    const { container } = render(
+      <BookLayout>
+        <p>booking</p>
+      </BookLayout>
+    );
+
+    expect(container.querySelector('script')).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/app/__tests__/(routes)/book/bookingChrome.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/bookingChrome.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import {
+  BookFooter,
+  BookShell,
+  describeBlock,
+  formatLongDay,
+  formatShortDay,
+  groupByDayPart,
+  quickDayLabel,
+} from '@/app/(routes)/(book)/book/[slug]/bookingChrome';
+
+const slot = (startTime: string) => ({ startTime, endTime: startTime });
+
+describe('bookingChrome formatters', () => {
+  // Pinned to en-GB and UTC in the source precisely so these strings are the
+  // same here, in CI, and in a reader's browser whatever their locale.
+  it('writes a short day for a chip and a long one for the hint', () => {
+    expect(formatShortDay('2026-10-06')).toBe('Tue 6 Oct');
+    expect(formatLongDay('2026-09-02')).toBe('Wednesday 2 September');
+  });
+
+  it('names the first two quick days in relative terms and dates the rest', () => {
+    expect(quickDayLabel(0, '2026-09-01')).toBe('Today');
+    expect(quickDayLabel(1, '2026-09-02')).toBe('Tomorrow');
+    expect(quickDayLabel(2, '2026-10-06')).toBe('Tue 6 Oct');
+  });
+
+  it('splits times into the day parts that actually have any', () => {
+    const groups = groupByDayPart([slot('08:30'), slot('13:00'), slot('19:00')]);
+
+    expect(groups.map((group) => group.key)).toEqual(['morning', 'afternoon', 'evening']);
+    expect(groups.map((group) => group.slots.length)).toEqual([1, 1, 1]);
+  });
+
+  it('drops a day part with nothing in it rather than heading an empty grid', () => {
+    const groups = groupByDayPart([slot('09:00'), slot('10:00')]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('Morning');
+  });
+
+  it('names which precondition is missing, and says nothing once neither is', () => {
+    expect(describeBlock(null, false)).toMatch(/Choose a time/);
+    expect(describeBlock('09:00', false)).toMatch(/Tick the box/);
+    expect(describeBlock('09:00', true)).toBeNull();
+  });
+});
+
+describe('bookingChrome shell', () => {
+  it('keeps the skip-link target the root layout points at', () => {
+    render(
+      <BookShell>
+        <p>content</p>
+      </BookShell>
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('tells a stranger whose page this is, and where the policies are', () => {
+    render(<BookFooter />);
+
+    expect(screen.getByText(/Booking page provided by Yosemite Crew/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
+      'href',
+      '/privacy-policy'
+    );
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute(
+      'href',
+      '/terms-and-conditions'
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/(routes)/book/bookingChrome.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/bookingChrome.test.tsx
@@ -11,19 +11,18 @@ jest.mock('next/link', () => ({
   ),
 }));
 
+import { BookFooter, BookShell } from '@/app/(routes)/(book)/book/[slug]/bookingChrome';
 import {
-  BookFooter,
-  BookShell,
   describeBlock,
   formatLongDay,
   formatShortDay,
   groupByDayPart,
   quickDayLabel,
-} from '@/app/(routes)/(book)/book/[slug]/bookingChrome';
+} from '@/app/(routes)/(book)/book/[slug]/bookingFormat';
 
 const slot = (startTime: string) => ({ startTime, endTime: startTime });
 
-describe('bookingChrome formatters', () => {
+describe('bookingFormat helpers', () => {
   // Pinned to en-GB and UTC in the source precisely so these strings are the
   // same here, in CI, and in a reader's browser whatever their locale.
   it('writes a short day for a chip and a long one for the hint', () => {

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -144,6 +144,32 @@ textarea:focus-visible {
   outline: none;
 }
 
+/* The comment above is true of text fields and FALSE of the two controls below.
+   input[type=checkbox] is drawn with appearance:none and a static !important
+   border, and input[type=radio] gets accent-color and nothing else; neither has
+   a :focus-visible rule anywhere in this file. So the rule above suppressed the
+   global ring on two controls that had no replacement for it, and a keyboard
+   user got no indication at all - including on the consent checkbox that gates
+   a public booking submission.
+   An attribute selector is (0,2,1) against the (0,1,1) above, so this wins on
+   specificity regardless of source order. */
+input[type='checkbox']:focus-visible,
+input[type='radio']:focus-visible {
+  outline: 2px solid var(--color-input-border-active);
+  outline-offset: 2px;
+}
+
+/* In forced-colors mode the user agent overrides author border-color, so every
+   focus:border-* indicator in this app produces no visible change at all.
+   `outline` is the one property the forced-colors palette preserves. There is
+   no other forced-colors block in this file. */
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 2px solid Highlight !important;
+    outline-offset: 2px;
+  }
+}
+
 /* The rich-text editor's contenteditable is the focus surface; its wrapping
    SectionContainer turns its border blue on focus-within instead, so suppress
    the global focus ring here to avoid an inner box on top of that border. */


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for - #2567
- [x] All existing tests and lints pass

## What is the current behavior?

The page a pet owner sees at `/book/<slug>` asks a stranger for their name, email, phone number and their animal's details, and it looks unfinished doing it: no card or surface of any kind, native OS radio buttons, a native date input, twenty-seven undifferentiated time pills, and selection shown only as a 1.5px border-colour swap.

Underneath most of that is one structural gap. **The `(book)` route group had no layout.** `(app)` mounts `ThemeScript` and `(public)` mounts the raw pre-paint script; `(book)` had neither, with two consequences:

1. Nothing ever stamped `data-theme` on `<html>`, so the whole `html[data-theme='dark']` block was dead code on this route. Measured on dev with the OS in dark: `data-theme` is `null`, body stays `#efe8dc`. The page is permanently light while every other Yosemite surface flips.
2. Nothing rendered `data-yc-app`, so `--ink-faint` stayed at the marketing value `#8f8984` instead of the bone-surface value `#66635f`. That token carried every service duration, the "Nothing is booked yet" line, and the sentence saying this is a request and not a booking - all at **2.84:1**. The page's entire honesty argument was its three least readable lines.

A contrast sweep of every rendered text node on dev: **10 of 56 fail WCAG AA.**

## What is the new behavior?

**`(book)/layout.tsx` (new)** - pre-paint theme script, already authorised by `PRE_PAINT_SCRIPT_CSP_HASH` on the strict-CSP path that `/book` is on, plus a `display: contents` `data-yc-app` scope. Dark mode works, and `color-scheme` finally reaches the native date input and checkbox.

**`bookingChrome.tsx` (new)** - one shell, card, callout, alert, footer, type scale and set of formatters shared by `/book/<slug>` and `/book/<slug>/confirm`, which previously used different widths and padding (560/`p-5` vs 520/`p-6`) so the column visibly jumped when a reader followed the emailed link.

**Controls.** The service radio is now a custom control driven by a `peer` sibling dot; the consent checkbox is 24px. Neither had *any* focus indicator: `globals.css` suppressed the global ring for inputs on the strength of a border-colour change that neither of them has. Added a scoped `:focus-visible` rule for both plus a `forced-colors` block, since `outline` is the one property that mode preserves.

**Selection** is a fill plus a shape change rather than a border-colour swap (2.88:1 in dark before). This also removed both inline `style={{ borderColor }}` objects, which were the reason the page had no hover, focus or active state anywhere - a style attribute has no pseudo-classes.

**Content and layout.** Times grouped by day part in a content-sized `auto-fill` grid; quick-day chips for the near-term case; `service.description` rendered at last, having been fetched and thrown away; the arbitrary 12.5/13.5/14.5px sizes replaced with the documented scale; `autoComplete` on every field that has a token (there were none); the honesty callout moved to the top of the card at 16px and 10.39:1; a footer that says whose page this is.

**Stories.** All four existing stories had never rendered - `stub()` assigned onto a frozen ES module namespace, and `useRouter` needed the app-router context. Both fixed, so the seven stories (four existing, three new) now actually mount.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `pnpm --filter frontend run lint` | 0 errors (1 pre-existing warning in `CompanionIdCard.test.tsx`, untouched) |
| `pnpm --filter frontend run test` | **12,007 passed / 972 suites** |
| Booking tests specifically | 47 passed; all 21 original `BookClient` assertions pass **verbatim** |
| Coverage of the changed files | `BookClient.tsx` 99.88% stmts / 99.13% branch / 100% func, `bookingChrome.tsx` 100/95/100, `ConfirmClient.tsx` 100/100/100 |
| `pnpm --filter frontend run build` | clean; confirmed `peer-checked`, `aria-pressed` and `:has()` all emit (none existed in this repo before) |
| Contrast, every text node, real browser | **81/81 pass AA in light and dark**, vs 10/56 failing on dev |
| axe-core (wcag2a + wcag2aa + wcag21aa) | **0 violations in light and 0 in dark**, vs 1 serious `color-contrast` across 10 nodes on dev |
| Focus | verified by screenshot on the radio dot, the row, the fields and the consent checkbox |
| Target sizes | slot pill 44px, checkbox 24px, fields 50px, submit 48px |

Verified against the real nine-service practice, at 320 / 360 / 390 / 768 / 1440, in both themes, plus all seven stories in both themes. No horizontal scroll at 320px, where the time pills still measure 77x44.

Note for a follow-up: `e2e/a11y.spec.ts` scans `/`, `/signin`, `/signup` and `/pricing` but not `/book/<slug>`, so the axe result above is mine rather than CI's. Worth adding that page to the suite.

## Things a reviewer should push back on if they disagree

- **The date control stays a native `<input type="date">`.** `BookClient.test.tsx` reads `.min` and `.max` off the DOM node and `ui/inputs/Datepicker` exposes neither. This is the most visible remaining seam; it is a deliberate refusal, not an oversight.
- **`practice.logoUrl` is still not rendered.** `<img>` is a lint error under `core-web-vitals` with `--max-warnings=0`, and `next/image` *throws* for a host outside `images.remotePatterns` - one practice's logo would take the whole page down. Worth its own PR.
- **The page is longer than it was**: 2477px vs 1857px at 1440, 3420px vs 2008px at 390, for a practice with nine services that all have descriptions. That is the cost of showing what each service actually is, and of 44px targets. A two-column service grid at `sm:` and a content-sized time grid claw back ~440px; I did not add a "show more" because hiding the service the reader came for is the wrong economy. Happy to revisit if you read it differently.
- **The 27 slots remain `aria-pressed` toggle buttons** rather than a radio group. Converting changes the role and the attribute and rewrites ~15 assertions; it belongs in its own PR.

## Related Issue(s)

Fixes #25672567
