### PR TITLE
ci(repo): stop unpromoted code reaching production and stale dev reaching a promotion

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -155,11 +155,19 @@ jobs:
             echo "repo=/home/ubuntu/Yosemite-Crew"          >> "$GITHUB_OUTPUT"
             echo "pm2=yosemite-backend"                     >> "$GITHUB_OUTPUT"
             echo "default_ref=main"                         >> "$GITHUB_OUTPUT"
+            # Production runs only what has reached main. `default_ref` alone
+            # does not achieve that: `ref` is a free-text input that overrides
+            # it, and the environment's branch policy governs which branch the
+            # workflow runs from, not the ref the box checks out.
+            echo "promotion_branch=main"                    >> "$GITHUB_OUTPUT"
           else
             echo "host=63.179.216.42"                       >> "$GITHUB_OUTPUT"
             echo "repo=/home/ubuntu/fix/Yosemite-Crew"      >> "$GITHUB_OUTPUT"
             echo "pm2=1"                                    >> "$GITHUB_OUTPUT"
             echo "default_ref=dev"                          >> "$GITHUB_OUTPUT"
+            # Deliberately empty: dev is where work arrives before promotion, so
+            # constraining it would defeat the point of having a dev host.
+            echo "promotion_branch="                        >> "$GITHUB_OUTPUT"
           fi
           echo "ref=${INPUT_REF:-}" >> "$GITHUB_OUTPUT"
 
@@ -170,6 +178,7 @@ jobs:
           HOST: ${{ steps.target.outputs.host }}
           REPO: ${{ steps.target.outputs.repo }}
           PM2_TARGET: ${{ steps.target.outputs.pm2 }}
+          PROMOTION_BRANCH: ${{ steps.target.outputs.promotion_branch }}
           REF: ${{ steps.target.outputs.ref }}
           DEFAULT_REF: ${{ steps.target.outputs.default_ref }}
           # Passed as an env var rather than interpolated into the script below.
@@ -207,7 +216,7 @@ jobs:
 
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             -o ServerAliveInterval=30 "ubuntu@$HOST" \
-            "chmod +x /tmp/yc-deploy/api-deploy.sh && /tmp/yc-deploy/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
+            "chmod +x /tmp/yc-deploy/api-deploy.sh && REQUIRE_PROMOTED_FROM='$PROMOTION_BRANCH' /tmp/yc-deploy/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
 
       - name: Verify from outside
         shell: bash

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -134,31 +134,67 @@ jobs:
       #
       # Read through the compare API rather than a checkout: this workflow runs as
       # pull_request_target and must never fetch the pull request's code.
-      # Only real dev-to-main promotions. A `main-direct` pull request is the
-      # documented escape hatch for a change that must land before the pending
-      # back-merge, and `exit 0` in the step above ends that STEP, not the job -
-      # so without this condition the hatch failed here on AHEAD > 0, precisely
-      # in the emergency it exists for.
+      # Publishes `promotion-guard/dev-contains-main` on EVERY pull request into
+      # main, including the ones it does not apply to.
+      #
+      # Publishing only on failure, or only from the push job, breaks whichever
+      # way the context is configured: made required, a freshly opened or
+      # synchronized promotion would wait forever for a status no pull-request
+      # event ever writes; left optional, a failure posted later cannot block a
+      # merge. So a non-promotion and an exempt `main-direct` pull request both
+      # get an explicit pass here rather than silence.
       - name: dev must contain main
-        if: >-
-          steps.retarget.outputs.retargeted != 'true'
-          && github.event.pull_request.head.ref == 'dev'
-          && !contains(github.event.pull_request.labels.*.name, 'main-direct')
+        if: steps.retarget.outputs.retargeted != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
 
-          # `dev...main` describes main RELATIVE TO dev, so ahead_by counts the
+          post() { # post <state> <description>
+            gh api -X POST "repos/${BASE_REPO}/statuses/${HEAD_SHA}" \
+              -f state="$1" \
+              -f context="promotion-guard/dev-contains-main" \
+              -f description="$2" >/dev/null
+          }
+
+          # The escape hatch and non-promotions are not subject to the ancestry
+          # rule, but still need the context so a required check can settle.
+          if [[ "${HEAD_REF}" != "dev" ]]; then
+            post success "not a dev-to-main promotion"
+            echo "Head is '${HEAD_REF}', not dev - ancestry rule does not apply."
+            exit 0
+          fi
+          if [[ ",${LABELS}," == *",main-direct,"* ]]; then
+            post success "main-direct: exempt"
+            echo "main-direct label present - exempt from the ancestry rule."
+            exit 0
+          fi
+
+          # Resolve to immutable SHAs before comparing.
+          #
+          # Comparing the branch NAMES and then reading a head separately lets the
+          # two disagree: dev can move between the comparison and the status, and
+          # a result computed for one tree gets attached to another. Everything
+          # below is about two fixed commits.
+          DEV_SHA="$(gh api "repos/${BASE_REPO}/commits/dev" --jq '.sha')"
+          MAIN_SHA="$(gh api "repos/${BASE_REPO}/commits/main" --jq '.sha')"
+
+          # `<dev>...<main>` describes main RELATIVE TO dev, so ahead_by counts the
           # commits main holds that dev does not.
-          AHEAD="$(gh api "repos/${BASE_REPO}/compare/dev...main" --jq '.ahead_by')"
+          AHEAD="$(gh api "repos/${BASE_REPO}/compare/${DEV_SHA}...${MAIN_SHA}" --jq '.ahead_by')"
+          echo "dev ${DEV_SHA:0:9} vs main ${MAIN_SHA:0:9}: ahead_by=${AHEAD}"
 
           if [[ "${AHEAD}" -gt 0 ]]; then
+            post failure "dev is missing ${AHEAD} commit(s) that are on main"
             echo "::error::dev is missing ${AHEAD} commit(s) that are on main, so this promotion would leave them behind. Merge the open back-merge pull request (back-merge.yml opens one on every push to main) into dev first, then re-run this check."
             exit 1
           fi
 
+          post success "dev contains main"
           echo "dev contains main - nothing would be left behind."
 
   # The other half of the snapshot problem above: when main moves, walk the open
@@ -181,7 +217,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          AHEAD="$(gh api "repos/${BASE_REPO}/compare/dev...main" --jq '.ahead_by')"
+          # Immutable SHAs, for the same reason as the guard job: comparing branch
+          # names and then reading heads separately lets a result computed for one
+          # tree be attached to another.
+          DEV_SHA="$(gh api "repos/${BASE_REPO}/commits/dev" --jq '.sha')"
+          MAIN_SHA="$(gh api "repos/${BASE_REPO}/commits/main" --jq '.sha')"
+          AHEAD="$(gh api "repos/${BASE_REPO}/compare/${DEV_SHA}...${MAIN_SHA}" --jq '.ahead_by')"
+          echo "dev ${DEV_SHA:0:9} vs main ${MAIN_SHA:0:9}: ahead_by=${AHEAD}"
 
           if [[ "${AHEAD}" -gt 0 ]]; then
             STATE=failure
@@ -205,6 +247,9 @@ jobs:
             exit 0
           fi
 
+          # A promotion whose head moves after this listing gets its status from the
+          # pull-request path, which publishes on every synchronize - so a stale
+          # head here is superseded rather than left as the last word.
           while read -r NUMBER SHA; do
             [[ -z "${NUMBER}" ]] && continue
             echo "PR #${NUMBER} (${SHA}) -> ${STATE}"

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -113,3 +113,33 @@ jobs:
           fi
 
           echo "Head branch is dev - promotion allowed."
+
+      # dev must CONTAIN main before dev can be promoted into it again.
+      #
+      # Promotion merges dev into main, so anything sitting on main that dev does
+      # not have is not carried by the next promotion - it is simply left behind,
+      # and the promotion diff makes it look like a deletion. back-merge.yml opens
+      # a pull request to prevent exactly this, but opening one enforces nothing:
+      # on 2026-08-30 back-merge #2568 sat unmerged and dev was missing a commit
+      # that main had while a promotion was being prepared on top of it.
+      #
+      # Read through the compare API rather than a checkout: this workflow runs as
+      # pull_request_target and must never fetch the pull request's code.
+      - name: dev must contain main
+        if: steps.retarget.outputs.retargeted != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # `dev...main` describes main RELATIVE TO dev, so ahead_by counts the
+          # commits main holds that dev does not.
+          AHEAD="$(gh api "repos/${BASE_REPO}/compare/dev...main" --jq '.ahead_by')"
+
+          if [[ "${AHEAD}" -gt 0 ]]; then
+            echo "::error::dev is missing ${AHEAD} commit(s) that are on main, so this promotion would leave them behind. Merge the open back-merge pull request (back-merge.yml opens one on every push to main) into dev first, then re-run this check."
+            exit 1
+          fi
+
+          echo "dev contains main - nothing would be left behind."

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -17,9 +17,16 @@ on:
     # waiting forever on a status instead of getting the actionable error.
     types: [opened, reopened, synchronize, edited, labeled, unlabeled]
     branches: [main]
+  # A pull_request_target check is a snapshot of the moment it ran. It re-runs
+  # when the HEAD moves (`synchronize`) but never when the BASE does, so a
+  # promotion that passed the ancestry check below stays green after main
+  # advances - and can then merge while dev is missing the newer main commit,
+  # which is the state the check exists to refuse. Re-evaluate on main pushes.
+  push:
+    branches: [main]
 
 concurrency:
-  group: promotion-guard-${{ github.event.pull_request.number }}
+  group: promotion-guard-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 # pull_request_target runs against the BASE repository, so it must never check
@@ -28,10 +35,12 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   guard:
     name: Only dev may merge into main
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -125,8 +134,16 @@ jobs:
       #
       # Read through the compare API rather than a checkout: this workflow runs as
       # pull_request_target and must never fetch the pull request's code.
+      # Only real dev-to-main promotions. A `main-direct` pull request is the
+      # documented escape hatch for a change that must land before the pending
+      # back-merge, and `exit 0` in the step above ends that STEP, not the job -
+      # so without this condition the hatch failed here on AHEAD > 0, precisely
+      # in the emergency it exists for.
       - name: dev must contain main
-        if: steps.retarget.outputs.retargeted != 'true'
+        if: >-
+          steps.retarget.outputs.retargeted != 'true'
+          && github.event.pull_request.head.ref == 'dev'
+          && !contains(github.event.pull_request.labels.*.name, 'main-direct')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REPO: ${{ github.repository }}
@@ -143,3 +160,56 @@ jobs:
           fi
 
           echo "dev contains main - nothing would be left behind."
+
+  # The other half of the snapshot problem above: when main moves, walk the open
+  # dev-to-main promotions and restate the ancestry result as a commit status on
+  # each one's head. A promotion that was green before the push goes red here
+  # until the back-merge lands, instead of staying green on stale information.
+  #
+  # Mark `promotion-guard/dev-contains-main` required on main's ruleset for this
+  # to block rather than merely report.
+  recheck:
+    name: Re-check open promotions when main moves
+    if: github.event_name == 'push' && github.repository_owner == 'YosemiteCrew'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Restate dev-contains-main on every open promotion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          AHEAD="$(gh api "repos/${BASE_REPO}/compare/dev...main" --jq '.ahead_by')"
+
+          if [[ "${AHEAD}" -gt 0 ]]; then
+            STATE=failure
+            DESC="dev is missing ${AHEAD} commit(s) that are on main"
+          else
+            STATE=success
+            DESC="dev contains main"
+          fi
+          echo "${DESC}"
+
+          # Only dev-headed promotions. A main-direct pull request is exempt for
+          # the same reason it is exempt in the guard job above.
+          PRS="$(gh pr list --repo "${BASE_REPO}" --base main --state open \
+                   --json number,headRefName,headRefOid,labels \
+                   --jq '.[] | select(.headRefName == "dev")
+                             | select([.labels[].name] | index("main-direct") | not)
+                             | "\(.number) \(.headRefOid)"')"
+
+          if [[ -z "${PRS}" ]]; then
+            echo "No open dev-to-main promotion to restate."
+            exit 0
+          fi
+
+          while read -r NUMBER SHA; do
+            [[ -z "${NUMBER}" ]] && continue
+            echo "PR #${NUMBER} (${SHA}) -> ${STATE}"
+            gh api -X POST "repos/${BASE_REPO}/statuses/${SHA}" \
+              -f state="${STATE}" \
+              -f context="promotion-guard/dev-contains-main" \
+              -f description="${DESC}" >/dev/null
+          done <<< "${PRS}"

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -236,7 +236,13 @@ jobs:
 
           # Only dev-headed promotions. A main-direct pull request is exempt for
           # the same reason it is exempt in the guard job above.
-          PRS="$(gh pr list --repo "${BASE_REPO}" --base main --state open \
+          # `--head dev` filters SERVER-side. Without it `gh pr list` returns its
+          # default 30 items and the dev filter below runs on whatever came back,
+          # so with more than 30 pull requests open against main the promotion can
+          # be missed entirely - and a missed promotion keeps its earlier success
+          # while dev goes stale, which is the exact failure this job exists to
+          # prevent.
+          PRS="$(gh pr list --repo "${BASE_REPO}" --base main --head dev --state open \
                    --json number,headRefName,headRefOid,labels \
                    --jq '.[] | select(.headRefName == "dev")
                              | select([.labels[].name] | index("main-direct") | not)

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -72,7 +72,11 @@ say "checkout $GIT_REF"
 # parent ref breaking the whole fetch, and a qualified `origin/dev` being sent to
 # the remote as a branch name - are covered by tests/git-sync.test.sh against a
 # real remote, rather than only being found on a live box.
-deploy_git_sync "$REPO_DIR" "$GIT_REF"
+#
+# REQUIRE_PROMOTED_FROM names the branch a commit must have reached before this
+# host will run it. Set for production, empty for dev - dev is where things are
+# meant to arrive first.
+deploy_git_sync "$REPO_DIR" "$GIT_REF" "${REQUIRE_PROMOTED_FROM:-}"
 
 say "install"
 pnpm install --frozen-lockfile

--- a/scripts/deploy/lib/git-sync.sh
+++ b/scripts/deploy/lib/git-sync.sh
@@ -5,15 +5,72 @@
 # Extracted from api-deploy.sh so the two failure modes below can be tested
 # against a real remote instead of only being discovered on a live box.
 #
-# deploy_git_sync <repo-dir> <git-ref>
+# deploy_git_sync <repo-dir> <git-ref> [promotion-branch]
 #
 # Echoes the resolved short SHA. Returns non-zero if the ref cannot be resolved -
 # the caller runs under `set -e`, and a deploy that cannot find its ref must stop
 # rather than build whatever happens to be checked out.
+#
+# With a promotion-branch, the resolved commit must be an ancestor of that
+# branch or the deploy stops BEFORE the checkout. See
+# deploy_assert_ref_promoted for why that constraint exists.
+
+# deploy_assert_ref_promoted <candidate-sha> <promotion-branch>
+#
+# Refuse a commit that has not reached the promotion branch.
+#
+# The workflow resolves `TARGET_REF="${REF:-$DEFAULT_REF}"`, where DEFAULT_REF is
+# `main` for production but REF is a free-text dispatch input that overrides it.
+# The `production` environment's branch policy does NOT close this: it restricts
+# which branch the WORKFLOW runs from, not the ref the box checks out. So a
+# production deploy dispatched from main could, and on 2026-08-30 did, put
+# commits on the production box that were only ever on `dev` - `ce855cf9d` at
+# 11:42Z and `fd60d539d` at 11:47Z, while `main` was still `7f92970d8`. The
+# promotion that carried them landed at 12:08Z, twenty minutes later.
+#
+# Nobody merged to main to do that; the deploy simply went around the promotion.
+# This is the check that makes the branch policy mean what it appears to mean.
+#
+# Deploying an OLDER main commit stays allowed - that is a rollback, and an
+# ancestor of the promotion branch. Only never-promoted work is refused.
+deploy_assert_ref_promoted() {
+  local candidate="${1:?candidate commit required}"
+  local promotion_branch="${2:?promotion branch required}"
+
+  promotion_branch="${promotion_branch#origin/}"
+
+  # deploy_git_sync fetches only the ref being deployed, so the box's
+  # origin/<promotion_branch> can be arbitrarily stale. Fetch it explicitly.
+  # A stale one would fail this check rather than pass it - ancestry against an
+  # older branch head is a subset - so the failure mode is closed, not open.
+  git fetch --quiet origin "$promotion_branch" || {
+    echo "could not fetch '$promotion_branch' to check promotion" >&2
+    return 1
+  }
+
+  local promoted_head
+  promoted_head="$(git rev-parse --verify --quiet "origin/$promotion_branch")" || {
+    echo "could not resolve 'origin/$promotion_branch' after fetch" >&2
+    return 1
+  }
+
+  if git merge-base --is-ancestor "$candidate" "$promoted_head"; then
+    return 0
+  fi
+
+  {
+    echo "refusing to deploy $(git rev-parse --short "$candidate"): it is not an" \
+      "ancestor of origin/$promotion_branch."
+    echo "That commit has not been promoted. Merge it to $promotion_branch first," \
+      "then deploy."
+  } >&2
+  return 1
+}
 
 deploy_git_sync() {
   local repo_dir="${1:?repo dir required}"
   local git_ref="${2:?git ref required}"
+  local promotion_branch="${3:-}"
 
   cd "$repo_dir" || return 1
 
@@ -47,6 +104,13 @@ deploy_git_sync() {
     echo "could not resolve '$git_ref' (or 'origin/$git_ref') after fetch" >&2
     return 1
   }
+
+  # Before the checkout, not after: a refused deploy must leave the box on the
+  # commit it was already serving, not on unpromoted code with the build half
+  # done.
+  if [ -n "$promotion_branch" ]; then
+    deploy_assert_ref_promoted "$resolved" "$promotion_branch" || return 1
+  fi
 
   git checkout --detach "$resolved" --quiet
   git rev-parse --short HEAD

--- a/scripts/deploy/tests/git-sync.test.sh
+++ b/scripts/deploy/tests/git-sync.test.sh
@@ -169,6 +169,52 @@ fi
 check "leaves the checkout untouched when the ref cannot be resolved" \
   "$BEFORE" "$(git -C "$CLONE" rev-parse HEAD)"
 
+# ---------------------------------------------------------------------------
+# 4. The promotion guard.
+#
+# What this prevents actually happened. On 2026-08-30 the production box was put
+# on `ce855cf9d` at 11:42Z and `fd60d539d` at 11:47Z - both commits that existed
+# only on `dev`, while `main` still pointed at `7f92970d8`. The promotion that
+# carried them merged at 12:08Z, twenty minutes after they were already serving
+# production traffic.
+#
+# No merge rule was broken to do it. `TARGET_REF="${REF:-$DEFAULT_REF}"` lets a
+# free-text `ref` input override the `main` default, and the environment's branch
+# policy only constrains which branch the workflow runs FROM.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+
+# `main` at the first commit; `dev` then moves ahead of it.
+BASE="$(git_quiet -C "$CLONE" rev-parse HEAD)"
+git_quiet -C "$CLONE" push --quiet origin "$BASE:refs/heads/main"
+AHEAD="$(advance_dev "$REMOTE")"
+BEFORE="$(git -C "$CLONE" rev-parse HEAD)"
+
+if deploy_git_sync "$CLONE" dev main >/dev/null 2>&1; then
+  no "refuses a dev-only commit when main is required" "returned success"
+else
+  ok "refuses a dev-only commit when main is required"
+fi
+check "leaves the checkout untouched when the ref is unpromoted" \
+  "$BEFORE" "$(git -C "$CLONE" rev-parse HEAD)"
+
+# The same commit is fine once it reaches main - this is the promotion itself.
+git_quiet -C "$CLONE" push --quiet origin "$AHEAD:refs/heads/main"
+check "accepts the same commit once it is on main" \
+  "$(git -C "$CLONE" rev-parse --short "$AHEAD")" \
+  "$(deploy_git_sync "$CLONE" dev main 2>/dev/null || echo SYNC_FAILED)"
+
+# Rollback to an OLDER main commit stays allowed: it is an ancestor.
+check "allows a rollback to an earlier main commit" \
+  "$(git -C "$CLONE" rev-parse --short "$BASE")" \
+  "$(deploy_git_sync "$CLONE" "$BASE" main 2>/dev/null || echo SYNC_FAILED)"
+
+# With no promotion branch the guard is inert, which is how dev deploys work.
+check "is inert when no promotion branch is given" \
+  "$(git -C "$CLONE" rev-parse --short "$AHEAD")" \
+  "$(deploy_git_sync "$CLONE" dev 2>/dev/null || echo SYNC_FAILED)"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two rules about `main` are true, while the thing they exist to protect is not.

**1. A production deploy can ship a commit that was never on `main`.**

`deploy-api.yml` resolves `TARGET_REF="${REF:-$DEFAULT_REF}"`. `DEFAULT_REF` is `main` for production, but `ref` is a free-text `workflow_dispatch` input that overrides it. The `production` environment's branch policy does not close this: it restricts which branch the **workflow** runs from, not the ref the box checks out.

This is not hypothetical. On 2026-08-30 the production box was moved to `ce855cf9d` at 11:42Z and `fd60d539d` at 11:47Z. Both existed only on `dev`; `main` still pointed at `7f92970d8`. The promotion that carried them merged at 12:08Z, twenty minutes after they were already serving production traffic. The box's own reflog shows the two checkouts, and `git branch -r --contains HEAD` on that host returns only `origin/dev`.

No merge rule was broken to do it. The deploy went around the promotion.

**2. A promotion can run while `dev` is missing commits `main` has.**

Promotion merges `dev` into `main`, so anything on `main` that `dev` lacks is left behind rather than carried, and the promotion diff renders it as a deletion. `back-merge.yml` opens a pull request to prevent that, but opening one enforces nothing: back-merge #2568 sat unmerged while `dev` was a commit short of `main`.

## What is the new behavior?

**The box refuses unpromoted code.** `deploy_git_sync` takes an optional promotion branch and, when given one, requires the resolved commit to be an ancestor of it. The check runs **between resolve and checkout**, so a refusal leaves the host on the commit it was already serving rather than on unpromoted code with a half-finished build. The workflow passes `main` for production and an empty value for dev, because dev is where work is meant to arrive first.

Rolling back to an older `main` commit is still allowed - an ancestor is still promoted. Only never-promoted work is refused.

The promotion branch is fetched explicitly, because `deploy_git_sync` otherwise fetches only the ref being deployed and the box's `origin/main` can be arbitrarily stale. A stale one fails the check rather than passing it, so the failure mode is closed.

**The promotion guard refuses to promote onto a stale `dev`.** It reads `compare/dev...main` and fails when `ahead_by > 0`. Through the API rather than a checkout, because that workflow runs as `pull_request_target` and must never fetch the pull request's code.

## Validation

`scripts/deploy/tests/git-sync.test.sh` - 16 pass, 5 of them new:

- refuses a dev-only commit when main is required
- leaves the checkout untouched when the ref is unpromoted
- accepts the same commit once it is on main
- allows a rollback to an earlier main commit
- is inert when no promotion branch is given

Mutation-checked: removing the guard call fails exactly the two refusal cases and nothing else.

The compare-API semantics were verified against the live repository rather than assumed - `compare/dev...main` currently returns `ahead_by: 0, behind_by: 15`, and returned `ahead_by: 1` before back-merge #2568 was merged, which is the state this check now rejects.

## Related Issue(s)

Related to #2131
