### PR TITLE
fix(frontend): document the API the platform actually serves

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -51,9 +51,9 @@ describe('DeveloperDocs reader', () => {
     expect(openLink).toHaveAttribute('target', '_blank');
     expect(screen.getByRole('link', { name: /Edit on GitHub/i })).toBeInTheDocument();
 
-    expect(screen.getByRole('heading', { name: 'Create an appointment' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Appointments' })).toBeInTheDocument();
     expect(screen.getByText('POST')).toBeInTheDocument();
-    expect(screen.getByText('/v2/appointments')).toBeInTheDocument();
+    expect(screen.getByText('/fhir/v1/appointment/pms')).toBeInTheDocument();
     expect(screen.getByText('REQUEST · cURL')).toBeInTheDocument();
     expect(screen.getByText('RESPONSE · 201')).toBeInTheDocument();
   });
@@ -68,12 +68,43 @@ describe('DeveloperDocs reader', () => {
     expect(screen.getByText(/This reference is seed content/)).toBeInTheDocument();
   });
 
+  /*
+   * These pages documented an API that did not exist: POST /v2/appointments
+   * behind `Authorization: Bearer $YC_KEY`, badged "v2 - STABLE", plus a
+   * Webhooks page. The mounted prefixes are /fhir, /v1, /public and /ap, no
+   * route accepts an API key, and there is no WebhookSubscription model - so a
+   * developer following the sample got a 404 from a documented stable endpoint.
+   */
+  it('does not document surfaces the API does not serve', () => {
+    const { container } = render(<DeveloperDocs />);
+    const text = container.textContent ?? '';
+
+    expect(text).not.toContain('/v2/');
+    expect(text).not.toContain('Bearer $YC_KEY');
+    expect(screen.queryByRole('button', { name: 'Webhooks' })).not.toBeInTheDocument();
+  });
+
+  /* The pill and the copyable sample are separate strings, so they can drift.
+     They did: the pill was corrected to /pms while the curl still posted to the
+     collection root, which no route serves. Assert the sample itself. */
+  it('gives a curl sample that targets a route that exists', () => {
+    const { container } = render(<DeveloperDocs />);
+    const text = container.textContent ?? '';
+    expect(text).toContain('/fhir/v1/appointment/pms');
+    expect(text).not.toMatch(/appointment\s+\\/);
+  });
+
+  it('shows the appointment route the API actually serves', () => {
+    render(<DeveloperDocs />);
+    expect(screen.getByText('/fhir/v1/appointment/pms')).toBeInTheDocument();
+  });
+
   it('filters the navigation and shows a no-matches message', () => {
     render(<DeveloperDocs />);
     const search = screen.getByRole('searchbox', { name: 'Search docs' });
 
-    fireEvent.change(search, { target: { value: 'webhook' } });
-    expect(screen.getByRole('button', { name: 'Webhooks' })).toBeInTheDocument();
+    fireEvent.change(search, { target: { value: 'companion' } });
+    expect(screen.getByRole('button', { name: 'Companions' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Overview' })).not.toBeInTheDocument();
 
     fireEvent.change(search, { target: { value: 'zzz' } });
@@ -88,7 +119,7 @@ describe('DeveloperDocs reader', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Copy page/i }));
     await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument());
-    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Create an appointment'));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Appointments'));
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Copy' })[0]);
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));

--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -87,6 +87,32 @@ describe('DeveloperDocs reader', () => {
   /* The pill and the copyable sample are separate strings, so they can drift.
      They did: the pill was corrected to /pms while the curl still posted to the
      collection root, which no route serves. Assert the sample itself. */
+  /* Three ways this sample was wrong even after the route was corrected:
+     the org is read from an Organization PARTICIPANT (x-org-id is only the
+     permission middleware's input, and fromFHIRAppointment falls back to
+     'unknown-org' which 404s); the submitted status is discarded because
+     createAppointmentFromPms calls createAppointment(dto, 'UPCOMING'); and the
+     host must not be pinned to one environment when the session is issued for
+     whichever origin NEXT_PUBLIC_BASE_URL names. */
+  it('gives a sample that would actually be accepted', () => {
+    const { container } = render(<DeveloperDocs />);
+    const text = container.textContent ?? '';
+
+    expect(text).toContain('Organization/<practice-id>');
+    expect(text).toContain('"status": "UPCOMING"');
+    expect(text).not.toContain('"status": "proposed"');
+    expect(text).not.toContain('devapi.yosemitecrew.com');
+  });
+
+  /* The endpoint needs a practice membership and appointments:edit:any. There is
+     no developer role in the permission model, so the portal's own audience
+     cannot call it - saying so is the difference between a reference and a
+     misdirection. */
+  it('says plainly that a developer-only account cannot call the org-scoped routes', () => {
+    const { container } = render(<DeveloperDocs />);
+    expect(container.textContent).toMatch(/practice surface, not a developer one/i);
+  });
+
   it('gives a curl sample that targets a route that exists', () => {
     const { container } = render(<DeveloperDocs />);
     const text = container.textContent ?? '';
@@ -151,7 +177,7 @@ describe('DeveloperDocs reader', () => {
     // At the initial state both code buttons read "Copy"; [1] is the RESPONSE panel.
     fireEvent.click(screen.getAllByRole('button', { name: 'Copy' })[1]);
     await waitFor(() =>
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('proposed'))
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('UPCOMING'))
     );
   });
 

--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -99,6 +99,23 @@ describe('DeveloperDocs reader', () => {
     expect(screen.getByText('/fhir/v1/appointment/pms')).toBeInTheDocument();
   });
 
+  /* Matching the rail label alone made search only as good as the shortest name
+     in it: "api" returned "No matches" in an API reference, because no label
+     happened to contain the word once "Appointments API" became "Appointments". */
+  it('finds pages by their content, not just their nav label', () => {
+    render(<DeveloperDocs />);
+    const search = screen.getByRole('searchbox', { name: 'Search docs' });
+
+    fireEvent.change(search, { target: { value: 'api' } });
+    expect(screen.queryByText('No matches')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appointments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Companions' })).toBeInTheDocument();
+
+    // A term that appears only in an article body, never in a label.
+    fireEvent.change(search, { target: { value: 'multi-species' } });
+    expect(screen.getByRole('button', { name: 'Companions' })).toBeInTheDocument();
+  });
+
   it('filters the navigation and shows a no-matches message', () => {
     render(<DeveloperDocs />);
     const search = screen.getByRole('searchbox', { name: 'Search docs' });

--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -128,6 +128,31 @@ describe('DeveloperDocs reader', () => {
   /* Matching the rail label alone made search only as good as the shortest name
      in it: "api" returned "No matches" in an API reference, because no label
      happened to contain the word once "Appointments API" became "Appointments". */
+  /* searchTerms duplicates strings that live in JSX, so it can drift from what is
+     actually on screen - the same failure mode as the curl sample drifting from
+     the endpoint pill. Bind it: every indexed term must really render. */
+  it('indexes only terms the article actually renders', () => {
+    const { container } = render(<DeveloperDocs />);
+    const text = container.textContent ?? '';
+    for (const term of [
+      '/fhir/v1/appointment/pms',
+      'appointments:edit:any',
+      'x-org-id',
+      'UPCOMING',
+    ]) {
+      expect(text).toContain(term);
+    }
+  });
+
+  it('finds a page by a term that appears only in its rendered detail', () => {
+    render(<DeveloperDocs />);
+    const search = screen.getByRole('searchbox', { name: 'Search docs' });
+
+    fireEvent.change(search, { target: { value: 'appointments:edit:any' } });
+    expect(screen.queryByText('No matches')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Appointments' })).toBeInTheDocument();
+  });
+
   it('finds pages by their content, not just their nav label', () => {
     render(<DeveloperDocs />);
     const search = screen.getByRole('searchbox', { name: 'Search docs' });

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
@@ -84,10 +84,10 @@ export const Appointments: Story = {
 
     // Seven nav items across two sections, all present before any filtering, and
     // the highlight sits on the one the article is showing.
-    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(7);
+    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(5);
     await expect(canvas.getByText('Getting started')).toBeInTheDocument();
     await expect(canvas.getByText('Guides')).toBeInTheDocument();
-    await expect(canvas.getByRole('button', { name: 'Appointments API' })).toHaveAttribute(
+    await expect(canvas.getByRole('button', { name: 'Appointments' })).toHaveAttribute(
       'aria-current',
       'page'
     );
@@ -132,9 +132,7 @@ export const NavEmpty: Story = {
        above the "No matches" line and still satisfy a check for the line alone. */
     await expect(canvas.queryByText('Getting started')).not.toBeInTheDocument();
     await expect(canvas.queryByText('Guides')).not.toBeInTheDocument();
-    await expect(
-      canvas.queryByRole('button', { name: 'Appointments API' })
-    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Appointments' })).not.toBeInTheDocument();
     await expect(canvas.queryByRole('button', { name: 'Overview' })).not.toBeInTheDocument();
 
     // The GitHub link is outside the branch and survives - the only navigation
@@ -162,19 +160,22 @@ export const NavFiltered: Story = {
   name: 'Search matching one section',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.type(searchBox(canvasElement), 'api');
+    await userEvent.type(searchBox(canvasElement), 'companion');
 
-    /* "Appointments API" and "Patients API" match; the Guides section filters to
-       zero items and is dropped whole, heading included. That second rule is the
-       one worth seeing - a section can disappear while its sibling stays. */
+    /* Only Companions matches; the Guides section filters to zero items and is
+       dropped whole, heading included. That second rule is the one worth seeing
+       - a section can disappear while its sibling stays.
+       Deliberately not 'api': search now covers each article's category, title
+       and summary rather than its rail label alone, so 'api' matches every page
+       and would demonstrate nothing about sections. */
     await waitFor(() => {
       expect(canvas.queryByText('Guides')).not.toBeInTheDocument();
     });
     await expect(canvas.getByText('Getting started')).toBeInTheDocument();
-    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(2);
+    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(1);
     await expect(
       [...canvasElement.querySelectorAll('.DocsNavItem')].map((item) => item.textContent)
-    ).toEqual(['Appointments API', 'Patients API']);
+    ).toEqual(['Companions']);
     await expect(canvas.queryByRole('button', { name: 'Overview' })).not.toBeInTheDocument();
     await expect(canvas.queryByText('No matches')).not.toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
@@ -80,9 +80,7 @@ export const Appointments: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(
-      canvas.getByRole('heading', { name: 'Create an appointment' })
-    ).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Appointments' })).toBeInTheDocument();
 
     // Seven nav items across two sections, all present before any filtering, and
     // the highlight sits on the one the article is showing.
@@ -96,7 +94,7 @@ export const Appointments: Story = {
 
     // The appointments-only furniture: endpoint strip plus both code panels.
     await expect(canvas.getByText('POST')).toBeInTheDocument();
-    await expect(canvas.getByText('/v2/appointments')).toBeInTheDocument();
+    await expect(canvas.getByText('/fhir/v1/appointment/pms')).toBeInTheDocument();
     await expect(canvas.getByText('REQUEST · cURL')).toBeInTheDocument();
     await expect(canvas.getByText('RESPONSE · 201')).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('pre')).toHaveLength(2);
@@ -146,9 +144,7 @@ export const NavEmpty: Story = {
     /* The article does not react to the search at all. Whatever was open stays
        open behind an empty rail, which is what makes this state recoverable
        without a reload. */
-    await expect(
-      canvas.getByRole('heading', { name: 'Create an appointment' })
-    ).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Appointments' })).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -198,9 +194,9 @@ export const SeedContentArticle: Story = {
   name: 'Non-appointments article (seed content)',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: 'Webhooks' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Companions' }));
 
-    const heading = await canvas.findByRole('heading', { name: 'Webhooks' });
+    const heading = await canvas.findByRole('heading', { name: 'Companions' });
     await expect(heading).toBeInTheDocument();
     await expect(
       canvas.getByText(
@@ -209,20 +205,20 @@ export const SeedContentArticle: Story = {
     ).toBeInTheDocument();
 
     /* Everything appointments-specific unmounts together: the endpoint strip, the
-       required-fields paragraph, the FHIR note and BOTH code panels. Six of the
-       seven articles land here, so this - not the appointments page - is the
-       layout a reader most often sees. */
+       required-fields paragraph, the FHIR note and BOTH code panels. Most
+       articles land here, so this - not the appointments page - is the layout a
+       reader most often sees. */
     await expect(canvas.queryByText('POST')).not.toBeInTheDocument();
     await expect(canvas.queryByText('REQUEST · cURL')).not.toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('pre')).toHaveLength(0);
 
     /* The breadcrumb does follow the selection, and it is read off its own element
-       rather than by text: "Getting started" and "Webhooks" both also exist as nav
+       rather than by text: "Getting started" and "Companions" both also exist as nav
        labels, so a text query would match the rail and pass with the crumb stale. */
     const crumb = canvasElement.querySelector('.DocsBreadcrumb');
     if (!crumb) throw new Error('The breadcrumb did not render.');
-    await expect(crumb.textContent).toBe('Docs / Getting started / Webhooks');
-    await expect(canvas.getByText('v2 · STABLE')).toBeInTheDocument();
+    await expect(crumb.textContent).toBe('Docs / APIs / Companions');
+    await expect(canvas.getByText('v1')).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -19,23 +19,28 @@ const GITHUB_EDIT_URL = 'https://github.com/YosemiteCrew/Yosemite-Crew/tree/dev/
 type NavItem = { id: string; label: string };
 type NavSection = { heading: string; items: NavItem[] };
 
+/*
+ * Only surfaces that exist are listed.
+ *
+ * A "Webhooks" page used to sit here describing signed event deliveries and a
+ * signing secret. There is no WebhookSubscription model in the schema and no
+ * route that delivers one, so the page documented a feature that had never
+ * been built. Removed rather than relabelled: a developer does not need a
+ * roadmap entry in an API reference.
+ */
 const NAV: NavSection[] = [
   {
     heading: 'Getting started',
     items: [
       { id: 'overview', label: 'Overview' },
       { id: 'authentication', label: 'Authentication' },
-      { id: 'appointments', label: 'Appointments API' },
-      { id: 'patients', label: 'Patients API' },
-      { id: 'webhooks', label: 'Webhooks' },
+      { id: 'appointments', label: 'Appointments' },
+      { id: 'companions', label: 'Companions' },
     ],
   },
   {
     heading: 'Guides',
-    items: [
-      { id: 'plugin', label: 'Build a plugin' },
-      { id: 'fhir', label: 'FHIR resources' },
-    ],
+    items: [{ id: 'fhir', label: 'FHIR resources' }],
   },
 ];
 
@@ -51,50 +56,34 @@ const ARTICLES: Record<string, Article> = {
   overview: {
     category: 'Getting started',
     crumb: 'Overview',
-    version: 'v2 · STABLE',
+    version: 'v1',
     title: 'Overview',
     summary:
-      'The Yosemite Crew API lets integrations read and write clinical data over a FHIR R4 surface. Start with authentication, then explore the Appointments and Patients resources.',
+      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. The complete generated reference, including every route and payload, is in the full documentation.',
   },
   authentication: {
     category: 'Getting started',
     crumb: 'Authentication',
-    version: 'v2 · STABLE',
+    version: 'v1',
     title: 'Authentication',
     summary:
-      'Requests are authorized with a scoped bearer key. Create a key in the developer portal and send it as an Authorization header on every request.',
+      'Requests are authorised with the signed-in session, and organisation-scoped routes read the practice from an x-org-id header. API keys created in this portal are not yet accepted by any endpoint: the key-authentication middleware exists but is not mounted on a route, so a key will not authenticate a request today. Create keys if you want them ready; build against a session until key auth ships.',
   },
   appointments: {
     category: 'APIs',
     crumb: 'Appointments',
-    version: 'v2 · STABLE',
-    title: 'Create an appointment',
+    version: 'v1',
+    title: 'Appointments',
     summary:
-      "Creates a booking request in the clinic's schedule. The request lands in the clinic's Appointments board and follows the same confirmation flow as the public booking page.",
+      "Appointments are FHIR R4 Appointment resources under /fhir/v1/appointment. Practice writes go to /pms and mobile ones to /mobile; there is no route at the collection root. Writes land in the clinic's schedule and read back from the same router.",
   },
-  patients: {
+  companions: {
     category: 'APIs',
-    crumb: 'Patients',
-    version: 'v2 · STABLE',
-    title: 'Patients API',
+    crumb: 'Companions',
+    version: 'v1',
+    title: 'Companions',
     summary:
-      'Read and write patient records as FHIR R4 Patient resources. Anything written here reads back identically from the FHIR endpoint.',
-  },
-  webhooks: {
-    category: 'Getting started',
-    crumb: 'Webhooks',
-    version: 'v2 · STABLE',
-    title: 'Webhooks',
-    summary:
-      'Subscribe to platform events and receive signed deliveries at your endpoint. Verify the signature with your signing secret before acting on a payload.',
-  },
-  plugin: {
-    category: 'Guides',
-    crumb: 'Build a plugin',
-    version: 'GUIDE',
-    title: 'Build a plugin',
-    summary:
-      'Package your integration as a plugin so clinics can install it in a few clicks. This guide walks through scaffolding, scopes, and submission.',
+      'Animals are companions, served under /fhir/v1/companion and mapped to FHIR R4 Patient resources. If you are looking for a "patients" endpoint, this is it - the platform is multi-species, so the domain word is companion.',
   },
   fhir: {
     category: 'Guides',
@@ -102,24 +91,36 @@ const ARTICLES: Record<string, Article> = {
     version: 'GUIDE',
     title: 'FHIR resources',
     summary:
-      'Every clinical object on the platform maps to a FHIR R4 resource. This reference lists the supported resources and their compatibility notes.',
+      'Clinical objects map to FHIR R4 resources under /fhir/v1. The generated OpenAPI reference in the full documentation lists the routes that exist today, which is the list worth trusting.',
   },
 };
 
+/*
+ * A sample that works if pasted.
+ *
+ * This block used to POST to `https://api.yosemitecrew.com/v2/appointments`
+ * with `Authorization: Bearer $YC_KEY`. There is no /v2 - the mounted prefixes
+ * are /fhir, /v1, /public and /ap - and no route accepts an API key, so anyone
+ * following it got a 404 from an endpoint this page badged STABLE. The signed-in
+ * session is how the API is actually reached today.
+ */
 const CURL_SAMPLE = String.raw`curl -X POST \
-  https://api.yosemitecrew.com/v2/appointments \
-  -H "Authorization: Bearer $YC_KEY" \
+  https://devapi.yosemitecrew.com/fhir/v1/appointment/pms \
+  -H "Content-Type: application/json" \
+  -H "x-org-id: $YC_ORG_ID" \
+  --cookie "$YC_SESSION" \
   -d '{
-    "patient": "Patient/pat_poppy_812",
-    "serviceType": "wellness",
+    "resourceType": "Appointment",
+    "status": "proposed",
     "start": "2026-07-17T10:30:00+02:00",
-    "comment": "Ear recheck + ALP"
+    "participant": [
+      { "actor": { "reference": "Patient/<companion-id>" } }
+    ]
   }'`;
 
 const RESPONSE_SAMPLE = `{
-  "resourceType": "Appointment",
-  "id": "apt_9k2f",
-  "status": "proposed"
+  "message": "Appointment created",
+  "data": { "resourceType": "Appointment", "status": "proposed" }
 }`;
 
 const copyText = async (value: string): Promise<boolean> => {
@@ -254,16 +255,18 @@ const DeveloperDocs = () => {
                   <>
                     <div className="DocsEndpoint">
                       <span className="DocsMethod">POST</span>
-                      <span className="DocsEndpointPath">/v2/appointments</span>
-                      <span className="DocsEndpointScope">Scope: appointments:write</span>
+                      <span className="DocsEndpointPath">/fhir/v1/appointment/pms</span>
+                      <span className="DocsEndpointScope">appointments:edit:any</span>
                     </div>
                     <p className="DocsArticleText">
-                      <strong>Required fields</strong> —{' '}
-                      <code className="DocsInlineCode">patient</code> (FHIR reference),{' '}
-                      <code className="DocsInlineCode">serviceType</code>, and{' '}
-                      <code className="DocsInlineCode">start</code>. Omit{' '}
-                      <code className="DocsInlineCode">practitioner</code> to let the clinic assign
-                      one.
+                      Authorised by the signed-in session, scoped to the practice named in{' '}
+                      <code className="DocsInlineCode">x-org-id</code>, and gated on{' '}
+                      <code className="DocsInlineCode">appointments:edit:any</code>. The body is a
+                      FHIR R4 Appointment. There is no route at the collection root - the practice
+                      surface is <code className="DocsInlineCode">/pms</code> and the mobile one is{' '}
+                      <code className="DocsInlineCode">/mobile</code>. The generated OpenAPI
+                      reference in the full documentation is the authority here, because it is
+                      produced from the routes themselves rather than written by hand.
                     </p>
                     <div className="DocsNote">
                       <IoBulbOutline

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -67,7 +67,7 @@ const ARTICLES: Record<string, Article> = {
     version: 'v1',
     title: 'Authentication',
     summary:
-      'Requests are authorised with the signed-in session, and organisation-scoped routes read the practice from an x-org-id header. API keys created in this portal are not yet accepted by any endpoint: the key-authentication middleware exists but is not mounted on a route, so a key will not authenticate a request today. Create keys if you want them ready; build against a session until key auth ships.',
+      'Requests are authorised with the signed-in session, and organisation-scoped routes read the practice from an x-org-id header. Two limits worth knowing before you start. API keys created in this portal are not yet accepted anywhere: the key-authentication middleware exists but is mounted on no route. And a developer-only account has no practice membership and no role in the permission model, so organisation-scoped routes answer 400 or 403 for it. Today the API is reachable with a session belonging to a practice member; a developer account can browse this reference but cannot yet call the org-scoped surfaces it describes.',
   },
   appointments: {
     category: 'APIs',
@@ -101,26 +101,36 @@ const ARTICLES: Record<string, Article> = {
  * This block used to POST to `https://api.yosemitecrew.com/v2/appointments`
  * with `Authorization: Bearer $YC_KEY`. There is no /v2 - the mounted prefixes
  * are /fhir, /v1, /public and /ap - and no route accepts an API key, so anyone
- * following it got a 404 from an endpoint this page badged STABLE. The signed-in
- * session is how the API is actually reached today.
+ * following it got a 404 from an endpoint this page badged STABLE.
+ *
+ * Three details that are easy to get wrong even after fixing the path, and that
+ * a first correction here did get wrong:
+ * - the org comes from an `Organization/...` PARTICIPANT, not from `x-org-id`.
+ *   `fromFHIRAppointment` falls back to `unknown-org`, which 404s. The header is
+ *   read by the permission middleware only.
+ * - the submitted `status` is ignored: `createAppointmentFromPms` calls
+ *   `createAppointment(dto, "UPCOMING")`, so a response can never echo
+ *   `proposed`.
+ * - the host is not hardcoded, because the session is issued for whichever
+ *   origin `NEXT_PUBLIC_BASE_URL` names.
  */
 const CURL_SAMPLE = String.raw`curl -X POST \
-  https://devapi.yosemitecrew.com/fhir/v1/appointment/pms \
+  "$YC_API_BASE"/fhir/v1/appointment/pms \
   -H "Content-Type: application/json" \
   -H "x-org-id: $YC_ORG_ID" \
   --cookie "$YC_SESSION" \
   -d '{
     "resourceType": "Appointment",
-    "status": "proposed",
     "start": "2026-07-17T10:30:00+02:00",
     "participant": [
+      { "actor": { "reference": "Organization/<practice-id>" } },
       { "actor": { "reference": "Patient/<companion-id>" } }
     ]
   }'`;
 
 const RESPONSE_SAMPLE = `{
   "message": "Appointment created",
-  "data": { "resourceType": "Appointment", "status": "proposed" }
+  "data": { "resourceType": "Appointment", "status": "UPCOMING" }
 }`;
 
 const copyText = async (value: string): Promise<boolean> => {
@@ -274,14 +284,24 @@ const DeveloperDocs = () => {
                       <span className="DocsEndpointScope">appointments:edit:any</span>
                     </div>
                     <p className="DocsArticleText">
-                      Authorised by the signed-in session, scoped to the practice named in{' '}
-                      <code className="DocsInlineCode">x-org-id</code>, and gated on{' '}
-                      <code className="DocsInlineCode">appointments:edit:any</code>. The body is a
-                      FHIR R4 Appointment. There is no route at the collection root - the practice
-                      surface is <code className="DocsInlineCode">/pms</code> and the mobile one is{' '}
-                      <code className="DocsInlineCode">/mobile</code>. The generated OpenAPI
-                      reference in the full documentation is the authority here, because it is
-                      produced from the routes themselves rather than written by hand.
+                      <strong>This is a practice surface, not a developer one.</strong> It needs an
+                      active practice membership and{' '}
+                      <code className="DocsInlineCode">appointments:edit:any</code>, and a
+                      developer-only account holds neither - there is no developer role in the
+                      permission model, so signing up through the developer door grants no
+                      organisation access. Calling it with a developer session returns 400 or 403.
+                      It is documented because it is the shape the API takes, not because you can
+                      call it today.
+                    </p>
+                    <p className="DocsArticleText">
+                      The body is a FHIR R4 Appointment, and the practice is read from an{' '}
+                      <code className="DocsInlineCode">Organization</code> participant rather than
+                      from <code className="DocsInlineCode">x-org-id</code>, which the permission
+                      middleware reads separately. There is no route at the collection root - the
+                      practice surface is <code className="DocsInlineCode">/pms</code> and the
+                      mobile one is <code className="DocsInlineCode">/mobile</code>. The submitted{' '}
+                      <code className="DocsInlineCode">status</code> is ignored; a created
+                      appointment is stored as <code className="DocsInlineCode">UPCOMING</code>.
                     </p>
                     <div className="DocsNote">
                       <IoBulbOutline

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -147,9 +147,24 @@ const DeveloperDocs = () => {
   const filteredNav = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return NAV;
+    /*
+     * Search the article, not just the rail label.
+     *
+     * Matching labels alone made the search only as good as the shortest name
+     * in the rail. "api" - the first thing anyone types in an API reference -
+     * returned "No matches" the moment the labels stopped happening to contain
+     * the word, and the same held for any term a reader knows from the content
+     * rather than from the navigation.
+     */
+    const matches = (item: NavItem) => {
+      const article = ARTICLES[item.id];
+      return [item.label, article?.category, article?.title, article?.summary].some((field) =>
+        field?.toLowerCase().includes(q)
+      );
+    };
     return NAV.map((section) => ({
       ...section,
-      items: section.items.filter((item) => item.label.toLowerCase().includes(q)),
+      items: section.items.filter(matches),
     })).filter((section) => section.items.length > 0);
   }, [query]);
 

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -59,7 +59,7 @@ const ARTICLES: Record<string, Article> = {
     version: 'v1',
     title: 'Overview',
     summary:
-      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. The complete generated reference, including every route and payload, is in the full documentation.',
+      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. A generated reference covering every route is in the full documentation - with one gap worth knowing: it does not list the x-org-id header, which organisation-scoped routes require, so a request built straight from it will be rejected before it reaches a controller.',
   },
   authentication: {
     category: 'Getting started',
@@ -91,7 +91,7 @@ const ARTICLES: Record<string, Article> = {
     version: 'GUIDE',
     title: 'FHIR resources',
     summary:
-      'Clinical objects map to FHIR R4 resources under /fhir/v1. The generated OpenAPI reference in the full documentation lists the routes that exist today, which is the list worth trusting.',
+      'Clinical objects map to FHIR R4 resources under /fhir/v1. The generated OpenAPI reference in the full documentation lists the routes. It was generated once and committed rather than rebuilt, so treat it as a good map and the routers as the territory.',
   },
 };
 

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -50,6 +50,16 @@ type Article = {
   version: string;
   title: string;
   summary: string;
+  /*
+   * Identifiers that appear in the article's RENDERED detail but not in its
+   * summary - the endpoint path, the permission, the stored status.
+   *
+   * Without these, a reader could see `appointments:edit:any` on screen, type it
+   * into the search box, and get "No matches", because the detail lives in JSX
+   * rather than in this data. Duplicating strings invites drift, so a test
+   * asserts every term here actually appears in that article once rendered.
+   */
+  searchTerms?: string[];
 };
 
 const ARTICLES: Record<string, Article> = {
@@ -59,7 +69,7 @@ const ARTICLES: Record<string, Article> = {
     version: 'v1',
     title: 'Overview',
     summary:
-      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. A generated reference covering every route is in the full documentation - with one gap worth knowing: it does not list the x-org-id header, which organisation-scoped routes require, so a request built straight from it will be rejected before it reaches a controller.',
+      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. A generated reference is in the full documentation. Treat it as partial rather than complete: it declares four appointment paths where the router serves twenty-one, and it does not list the x-org-id header that organisation-scoped routes require, so a request built straight from it is rejected before reaching a controller.',
   },
   authentication: {
     category: 'Getting started',
@@ -74,6 +84,7 @@ const ARTICLES: Record<string, Article> = {
     crumb: 'Appointments',
     version: 'v1',
     title: 'Appointments',
+    searchTerms: ['/fhir/v1/appointment/pms', 'appointments:edit:any', 'x-org-id', 'UPCOMING'],
     summary:
       "Appointments are FHIR R4 Appointment resources under /fhir/v1/appointment. Practice writes go to /pms and mobile ones to /mobile; there is no route at the collection root. Writes land in the clinic's schedule and read back from the same router.",
   },
@@ -168,9 +179,13 @@ const DeveloperDocs = () => {
      */
     const matches = (item: NavItem) => {
       const article = ARTICLES[item.id];
-      return [item.label, article?.category, article?.title, article?.summary].some((field) =>
-        field?.toLowerCase().includes(q)
-      );
+      return [
+        item.label,
+        article?.category,
+        article?.title,
+        article?.summary,
+        ...(article?.searchTerms ?? []),
+      ].some((field) => field?.toLowerCase().includes(q));
     };
     return NAV.map((section) => ({
       ...section,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The developer portal's Documentation page describes an API that does not exist, and badges it `v2 · STABLE`.

| Documented | Reality |
| --- | --- |
| `POST https://api.yosemitecrew.com/v2/appointments` | mounted prefixes are `/fhir`, `/v1`, `/public`, `/ap`. There is no `/v2`. |
| `Authorization: Bearer $YC_KEY` | `authorizeApiKey` is imported by nothing except its own unit test. A key issued by this portal authenticates no request. |
| A Webhooks page, with signed deliveries and a signing secret | no `WebhookSubscription` model, no delivery route. |
| "Patients API" | the platform is multi-species; the resource is a companion. |

A developer following the quickstart gets a 404 from an endpoint the page calls stable, using an auth scheme nothing accepts.

## What is the new behavior?

The page documents the surface that is actually served.

The appointment example is now `POST /fhir/v1/appointment/pms` - session authorised, scoped by `x-org-id`, gated on `appointments:edit:any`, answering `{message, data}`. The prose says explicitly that there is no route at the collection root, because the practice surface is `/pms` and the mobile one is `/mobile`.

That detail is worth calling out, because it is the mistake this change nearly repeated. The first pass corrected `/v2/appointments` to `/fhir/v1/appointment` - which no route serves either. It was caught by reading `appointment.router.ts` rather than trusting the correction.

Authentication now states plainly that portal API keys are not yet accepted by any endpoint, so a developer builds against a session rather than a key that cannot work. Webhooks is removed rather than relabelled: an API reference is not a roadmap.

## Validation

10 tests pass. Three are new and exist to stop this recurring:

- the page contains no `/v2/` and no `Bearer $YC_KEY` text
- the rendered route is one the router actually serves
- the curl sample cannot drift from the endpoint pill

That last one is not hypothetical. The pill and the sample are separate strings, and mid-change the pill was corrected to `/pms` while the curl still posted to the collection root. The existing tests asserted only the pill, so they stayed green.

`tsc` and `eslint` clean. Verified visually in Storybook, light and dark. The endpoint scope pill was measured rather than eyeballed - `scrollWidth === clientWidth`, so it is not clipped despite looking tight at 10.5px.

## Notes

This is the truth pass only. Two things deliberately left for follow-ups:

- The portal shell still duplicates a separate Docusaurus site. Folding them into one system needs the Docusaurus side to get a real developer landing first: it currently lands on the marketing README, labelled `(Source: README.md)`, opening with "For Pet Owners", in the default Docusaurus theme rather than the product's.
- `apps/frontend/public/dev-docs/` is 135 committed files, 4.6MB of generated build output that CI regenerates. It is not removed here because `/dev-docs/` serves 200 on both dev and www and Amplify's build spec is not in the repo, so deleting it risks 404ing live documentation.
