### PR TITLE
fix(frontend): give the shared passport and card pages a readable theme

### DIFF
--- a/apps/frontend/src/app/(routes)/(share)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/layout.tsx
@@ -1,0 +1,36 @@
+import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
+
+/**
+ * The layout the `(share)` group never had.
+ *
+ * `/passport/<id>` and `/card/<token>` are the two pages in this product most
+ * likely to be opened on a phone belonging to someone who has never used
+ * Yosemite - a boarding desk scanning a collar tag, a vet reading a shared
+ * record - and they were the only route group with no theme resolution at all.
+ * Nothing stamped `data-theme` on <html>, so the whole `html[data-theme='dark']`
+ * block in globals.css was dead code here.
+ *
+ * No nonce, and none needed, but for a different reason than `(book)`: `/card`
+ * and `/passport` are NOT in STRICT_CSP_PATH_PREFIXES, so they get the
+ * permissive CSP variant whose script-src carries 'unsafe-inline' and
+ * deliberately omits PRE_PAINT_SCRIPT_CSP_HASH (per the CSP spec a hash makes
+ * the browser ignore 'unsafe-inline', which would break hydration across the
+ * static marketing pages). This is the same path `(public)/layout.tsx` relies
+ * on.
+ *
+ * The `display: contents` wrapper introduces no box. It buys `color-scheme` for
+ * native controls, the app's ::selection colour, and - the reason this issue
+ * was filed - the readable bone-surface inks from `body:has([data-yc-app])`.
+ * Without it `--ink-faint` stayed at the marketing value #8f8984, which is
+ * 3.12:1 on the passport's --screen card at font sizes down to 10.5px.
+ */
+export default function ShareLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: PRE_PAINT_SCRIPT }} />
+      <div data-yc-app style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
@@ -13,7 +13,19 @@ type Theme = 'light' | 'dark';
 const PassportClient = ({ id }: PassportClientProps) => {
   const [passport, setPassport] = useState<PetPassportDTO | null>(null);
   const [state, setState] = useState<LoadState>('loading');
-  const [theme, setTheme] = useState<Theme>('light');
+  // Starts from the theme the reader already chose, not always light. The
+  // pre-paint script in (share)/layout.tsx resolves that onto <html> before
+  // first paint, so reading it here has no flash. Kept as local state because
+  // this page also has its own toggle - the two now agree on the initial value
+  // instead of the page ignoring the phone.
+  //
+  // A lazy initialiser: on the server there is no document, and calling it on
+  // every render would re-read the DOM for a value only the first render uses.
+  const [theme, setTheme] = useState<Theme>(() =>
+    typeof document !== 'undefined' && document.documentElement.dataset.theme === 'dark'
+      ? 'dark'
+      : 'light'
+  );
 
   useEffect(() => {
     let active = true;

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
@@ -50,7 +50,11 @@ const PassportClient = ({ id }: PassportClientProps) => {
     <main
       id="main-content"
       tabIndex={-1}
-      data-wb-theme={theme}
+      // Only stamped once the reader uses this page's own toggle. Left absent,
+      // the CSS follows html[data-theme], which the pre-paint script sets before
+      // first paint - so a dark phone gets a dark passport immediately instead
+      // of a bright one that flips after hydration.
+      data-wb-theme={override ?? undefined}
       className="yc-warmbone flex min-h-screen w-full flex-col items-center px-4 py-10"
     >
       <button

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
@@ -2,30 +2,31 @@
 
 import { useEffect, useState } from 'react';
 import { IoMoonOutline, IoSunnyOutline } from 'react-icons/io5';
+import { useTheme, type Theme } from '@/app/ui/theme';
 import PublicPassportView from './PublicPassportView';
 import { getPublicPassport } from '@/app/features/petPassport/services/petPassport.service';
 import type { PetPassportDTO } from '@yosemite-crew/types';
 
 type PassportClientProps = { id: string };
 type LoadState = 'loading' | 'ready' | 'unavailable';
-type Theme = 'light' | 'dark';
 
 const PassportClient = ({ id }: PassportClientProps) => {
   const [passport, setPassport] = useState<PetPassportDTO | null>(null);
   const [state, setState] = useState<LoadState>('loading');
-  // Starts from the theme the reader already chose, not always light. The
-  // pre-paint script in (share)/layout.tsx resolves that onto <html> before
-  // first paint, so reading it here has no flash. Kept as local state because
-  // this page also has its own toggle - the two now agree on the initial value
-  // instead of the page ignoring the phone.
-  //
-  // A lazy initialiser: on the server there is no document, and calling it on
-  // every render would re-read the DOM for a value only the first render uses.
-  const [theme, setTheme] = useState<Theme>(() =>
-    typeof document !== 'undefined' && document.documentElement.dataset.theme === 'dark'
-      ? 'dark'
-      : 'light'
-  );
+  // The reader's resolved theme, read through useSyncExternalStore rather than
+  // off the DOM in a state initialiser. That earlier version was a hydration
+  // bug: the server has no `document`, so it rendered light and emitted the moon
+  // icon, while the client initialised dark - a mismatched tree React 19 has to
+  // throw away and regenerate. `useTheme` exists for exactly this and supplies a
+  // server snapshot, so both passes agree.
+  const { theme: resolvedTheme } = useTheme();
+
+  // The page keeps its own sun/moon control, so the reader can flip just this
+  // passport without changing their preference everywhere. null means "no local
+  // override yet - follow the phone", which is why this starts from the theme
+  // rather than from a hardcoded 'light'.
+  const [override, setOverride] = useState<Theme | null>(null);
+  const theme: Theme = override ?? resolvedTheme;
 
   useEffect(() => {
     let active = true;
@@ -43,7 +44,7 @@ const PassportClient = ({ id }: PassportClientProps) => {
     };
   }, [id]);
 
-  const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  const toggleTheme = () => setOverride(theme === 'dark' ? 'light' : 'dark');
 
   return (
     <main

--- a/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
@@ -38,33 +38,56 @@ describe('PassportClient (public pet passport page)', () => {
     expect(await screen.findByText('This passport could not be found.')).toBeInTheDocument();
   });
 
-  it('takes the theme from the shared store, not from the DOM', async () => {
-    // The contract, and the regression it guards. Reading
-    // document.documentElement in a state initialiser makes the server render
-    // light (no `document` there) and the client hydrate dark - a mismatch React
-    // 19 repairs by discarding the tree. `useTheme` is the repo's
-    // useSyncExternalStore wrapper and supplies a server snapshot, so both
-    // passes agree.
+  it('leaves the theme to the root attribute until the reader overrides it', async () => {
+    // Two regressions in one contract.
     //
-    // Asserting THROUGH the mocked hook is what gives this test teeth: an
-    // implementation that reads the DOM instead would ignore the mock and keep
-    // rendering light. A renderToString+hydrateRoot test cannot show this in
-    // jsdom, where `document` exists during the server pass too, so both passes
-    // would agree and the test would pass against the bug.
+    // First: the theme comes from `useTheme` - the repo's useSyncExternalStore
+    // wrapper, which has a server snapshot - not from reading
+    // document.documentElement in a state initialiser. That earlier version
+    // rendered light on the server and dark on the client, a mismatch React 19
+    // repairs by discarding the tree. Asserting through the mocked hook is what
+    // gives this teeth: a DOM-reading implementation ignores the mock.
+    //
+    // Second: with no local override the attribute is ABSENT, so
+    // `.yc-warmbone` follows html[data-theme], which the pre-paint script sets
+    // before first paint. Stamping the resolved value here instead would emit
+    // data-wb-theme="light" from the server and paint the passport bright until
+    // hydration corrected it.
     mockedUseTheme.mockReturnValue({ theme: 'dark' });
     mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
 
     render(<PassportClient id="p1" />);
     await screen.findByTestId('passport');
 
-    expect(screen.getByRole('main')).toHaveAttribute('data-wb-theme', 'dark');
+    expect(screen.getByRole('main')).not.toHaveAttribute('data-wb-theme');
+  });
+
+  it('stamps the attribute only once the reader uses the toggle', async () => {
+    // The override still has to win, including over a dark root - that is the
+    // whole point of keeping a per-page control.
+    mockedUseTheme.mockReturnValue({ theme: 'dark' });
+    mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
+
+    render(<PassportClient id="p1" />);
+    await screen.findByTestId('passport');
+
+    await userEvent.click(screen.getByRole('button', { name: /toggle light or dark theme/i }));
+    expect(screen.getByRole('main')).toHaveAttribute('data-wb-theme', 'light');
   });
 
   it('toggles between light and dark warm-bone themes', async () => {
     mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
     render(<PassportClient id="p1" />);
+    // Awaited, not fired-and-forgotten: the passport fetch resolves into state,
+    // and leaving it in flight is a React update outside act(), which
+    // jest.setup.ts turns into a thrown error.
+    await screen.findByTestId('passport');
+
     const main = document.getElementById('main-content');
-    expect(main).toHaveAttribute('data-wb-theme', 'light');
+    // Absent, not "light". The attribute now appears only once the reader
+    // overrides; until then the surface follows html[data-theme], which is what
+    // stops the passport painting bright for a dark reader before hydration.
+    expect(main).not.toHaveAttribute('data-wb-theme');
 
     const toggle = screen.getByRole('button', { name: /toggle light or dark theme/i });
     await userEvent.click(toggle);

--- a/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
@@ -32,6 +32,22 @@ describe('PassportClient (public pet passport page)', () => {
     expect(await screen.findByText('This passport could not be found.')).toBeInTheDocument();
   });
 
+  it('opens in the theme the reader already chose, not always light', async () => {
+    // The page has its own sun/moon toggle, but it used to hardcode 'light' on
+    // mount, so a reader whose phone is dark got a full-brightness passport and
+    // had to press the button every time. (share)/layout.tsx now resolves the
+    // theme onto <html> before paint; this seeds from it.
+    document.documentElement.dataset.theme = 'dark';
+    try {
+      mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
+      render(<PassportClient id="p1" />);
+      await screen.findByTestId('passport');
+      expect(screen.getByRole('main')).toHaveAttribute('data-wb-theme', 'dark');
+    } finally {
+      delete document.documentElement.dataset.theme;
+    }
+  });
+
   it('toggles between light and dark warm-bone themes', async () => {
     mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
     render(<PassportClient id="p1" />);

--- a/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/share/passport/PassportClient.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PassportClient from '@/app/(routes)/(share)/passport/[id]/PassportClient';
+import { useTheme } from '@/app/ui/theme';
 import { getPublicPassport } from '@/app/features/petPassport/services/petPassport.service';
 import type { PetPassportDTO } from '@yosemite-crew/types';
 
 jest.mock('@/app/features/petPassport/services/petPassport.service', () => ({
   getPublicPassport: jest.fn(),
 }));
+jest.mock('@/app/ui/theme', () => ({ useTheme: jest.fn() }));
 jest.mock('@/app/(routes)/(share)/passport/[id]/PublicPassportView', () => ({
   __esModule: true,
   default: ({ passport }: { passport: PetPassportDTO }) => (
@@ -15,8 +17,12 @@ jest.mock('@/app/(routes)/(share)/passport/[id]/PublicPassportView', () => ({
 }));
 
 const mockedFetch = getPublicPassport as jest.Mock;
+const mockedUseTheme = useTheme as jest.Mock;
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseTheme.mockReturnValue({ theme: 'light' });
+});
 
 describe('PassportClient (public pet passport page)', () => {
   it('renders the passport on success', async () => {
@@ -32,20 +38,26 @@ describe('PassportClient (public pet passport page)', () => {
     expect(await screen.findByText('This passport could not be found.')).toBeInTheDocument();
   });
 
-  it('opens in the theme the reader already chose, not always light', async () => {
-    // The page has its own sun/moon toggle, but it used to hardcode 'light' on
-    // mount, so a reader whose phone is dark got a full-brightness passport and
-    // had to press the button every time. (share)/layout.tsx now resolves the
-    // theme onto <html> before paint; this seeds from it.
-    document.documentElement.dataset.theme = 'dark';
-    try {
-      mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
-      render(<PassportClient id="p1" />);
-      await screen.findByTestId('passport');
-      expect(screen.getByRole('main')).toHaveAttribute('data-wb-theme', 'dark');
-    } finally {
-      delete document.documentElement.dataset.theme;
-    }
+  it('takes the theme from the shared store, not from the DOM', async () => {
+    // The contract, and the regression it guards. Reading
+    // document.documentElement in a state initialiser makes the server render
+    // light (no `document` there) and the client hydrate dark - a mismatch React
+    // 19 repairs by discarding the tree. `useTheme` is the repo's
+    // useSyncExternalStore wrapper and supplies a server snapshot, so both
+    // passes agree.
+    //
+    // Asserting THROUGH the mocked hook is what gives this test teeth: an
+    // implementation that reads the DOM instead would ignore the mock and keep
+    // rendering light. A renderToString+hydrateRoot test cannot show this in
+    // jsdom, where `document` exists during the server pass too, so both passes
+    // would agree and the test would pass against the bug.
+    mockedUseTheme.mockReturnValue({ theme: 'dark' });
+    mockedFetch.mockResolvedValue({ identity: { id: 'p1', name: 'Poppy' } });
+
+    render(<PassportClient id="p1" />);
+    await screen.findByTestId('passport');
+
+    expect(screen.getByRole('main')).toHaveAttribute('data-wb-theme', 'dark');
   });
 
   it('toggles between light and dark warm-bone themes', async () => {

--- a/apps/frontend/src/app/__tests__/routes/share/shareLayout.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/share/shareLayout.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ShareLayout from '@/app/(routes)/(share)/layout';
+
+describe('the (share) layout', () => {
+  it('puts the shared passport and card pages inside the app token scope', () => {
+    // Without this marker the routes sit outside body:has([data-yc-app]), so
+    // --ink-faint stays at the marketing value - 3.12:1 on the passport card,
+    // at font sizes down to 10.5px.
+    const { container } = render(
+      <ShareLayout>
+        <p>shared record</p>
+      </ShareLayout>
+    );
+
+    expect(screen.getByText('shared record')).toBeInTheDocument();
+    expect(container.querySelector('[data-yc-app]')).not.toBeNull();
+  });
+
+  it('resolves the theme before paint, which this group never did', () => {
+    // (share) was the last route group with no theme resolution at all, so the
+    // whole html[data-theme='dark'] block was dead code on these two pages.
+    const { container } = render(
+      <ShareLayout>
+        <p>shared record</p>
+      </ShareLayout>
+    );
+
+    expect(container.querySelector('script')).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1791,7 +1791,26 @@ input[type='number'] {
   --phl: rgba(29, 28, 27, 0.12);
   background: var(--page);
   color: var(--ink-body);
+  /* The danger trio in the LIGHT scope as well, and for the mirror of the
+     reason it was added to the dark one. This page has its own toggle, so a
+     reader whose OS is dark can switch just this passport to light - at which
+     point the dark block stops applying and, without these, --status-danger-*
+     falls back to the ROOT dark values (#f2938a on an 18% tint) on a light
+     #f7f3ec card: the EXPIRED label at ~2.04:1 and its icon at ~1.59:1.
+     One local toggle must not be able to mix root-dark status tokens with a
+     local-light surface. */
+  --status-danger-bg: rgba(234, 55, 41, 0.09);
+  --status-danger-text: #a6271d;
+  --status-danger-border: rgba(234, 55, 41, 0.32);
 }
+/* Two selectors, and the second is what removes the flash. The component only
+   sets data-wb-theme once the reader uses the page's own toggle, so on the
+   server-rendered first paint the attribute is absent - and the pre-paint script
+   has already put data-theme on <html>. Following the root attribute here means
+   a reader whose phone is dark gets a dark passport in the FIRST paint rather
+   than a bright one that flips after hydration. The :not() keeps a local
+   light override winning over a dark root. */
+html[data-theme='dark'] .yc-warmbone:not([data-wb-theme='light']),
 .yc-warmbone[data-wb-theme='dark'] {
   --page: #201c18;
   --band: #2a2216;
@@ -2086,6 +2105,17 @@ body:has([data-yc-app]) {
      and --blue-text aliases it so the two cannot drift apart again. */
   --color-blue-text: var(--color-accent-deep);
   --blue-text: var(--color-blue-text);
+
+  /* Surfaces, not only inks. `bg-card-bg` reads --color-card-bg, which was left
+     inheriting the dark #221d17 while the text sitting on it was pinned light -
+     the companion card's medium/low alert labels landed at 2.40:1. A
+     fixed-light surface has to pin the fills its children sit on, not just the
+     text colours. Each alias is re-declared here rather than only --screen-2,
+     because an alias declared at :root computes THERE and descendants inherit
+     the already-substituted value. */
+  --screen-2: #f1ebe1;
+  --color-neutral-100: var(--screen-2);
+  --color-card-bg: var(--color-neutral-100);
 }
 
 html[data-theme='dark'] body:has([data-yc-app]) {

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1758,8 +1758,14 @@ input[type='number'] {
   --ink-body: #302f2e;
   --ink-muted: #5c5956;
   --ink-soft: #423f3c;
-  --ink-faint: #8f8984;
-  --ink-faint2: #a9a39e;
+  /* #66635f, not #8f8984. This class carries a private copy of the bone ink
+     ramp, and that copy SHADOWS the body:has([data-yc-app]) scope which exists
+     precisely to make faint ink readable on bone surfaces - so the passport
+     was the one page the scope could not reach. #8f8984 measures 3.12:1 on
+     this card, at sizes down to 10.5px; #66635f clears AA. Same value the
+     scoped rule and [data-yc-surface='light'] already use. */
+  --ink-faint: #66635f;
+  --ink-faint2: #66635f;
   --blue-text: #257bed;
   --blue-soft: #e6f2ff;
   --success: #008f5d;
@@ -1813,6 +1819,21 @@ input[type='number'] {
   --status-completed-bg: rgba(74, 205, 155, 0.16);
   --status-completed-text: #74d0a2;
   --status-completed-border: rgba(74, 205, 155, 0.55);
+  /* The danger trio, aliased onto the --danger-* values a few lines above.
+     Their absence was not cosmetic. PublicPassportView draws BOTH vaccination
+     badges from the --status-* family: "valid" reads --status-completed-*,
+     which this block redefines, and "expired" reads --status-danger-*, which it
+     did not - so the expired badge kept the :root LIGHT ink (#a6271d) on the
+     espresso card. Measured in a browser: valid 5.77:1, expired 1.89:1. On a
+     page this component describes as "read as proof of cover by travel and
+     boarding staff", that is the failure inverted - "valid" legible, "expired"
+     all but invisible.
+     Aliases, not new literals: the correct dark values were already in this
+     block under the --danger-* spelling, one prefix away from the tokens the
+     component actually reads. */
+  --status-danger-bg: var(--danger-bg);
+  --status-danger-text: var(--danger-text);
+  --status-danger-border: var(--danger-border);
   --status-upcoming-border: rgba(103, 160, 239, 0.6);
   --sh03: rgba(0, 0, 0, 0.14);
   --sh05: rgba(0, 0, 0, 0.2);
@@ -2049,6 +2070,16 @@ body:has([data-yc-app]) {
   --color-grey-bg: var(--ink-faint);
   --black-grey: var(--ink-faint);
   --black-grey-Text: var(--ink-faint);
+
+  /* The brand ink, pinned with the rest. It was the one accent this block
+     missed, and the omission is visible: --color-text-brand flips to #8fb6f5
+     in dark, which on these deliberately-white cards measures 2.06:1.
+     Two surfaces hit it today - the pet passport's "Next due" lines, and the
+     three mailto/report links in AccessibilityReportClient, which already
+     carried this pin and still rendered pale blue on white. A fixed-light
+     surface needs its ACCENTS fixed too, not only its greys. */
+  --color-text-brand: var(--color-accent-deep);
+  --blue-text: var(--color-accent-deep);
 }
 
 html[data-theme='dark'] body:has([data-yc-app]) {

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -2079,7 +2079,13 @@ body:has([data-yc-app]) {
      carried this pin and still rendered pale blue on white. A fixed-light
      surface needs its ACCENTS fixed too, not only its greys. */
   --color-text-brand: var(--color-accent-deep);
-  --blue-text: var(--color-accent-deep);
+  /* BOTH spellings. globals.css already warns that this token is written two
+     ways; pinning only --blue-text left `text-blue-text` resolving to the
+     inherited dark #8fb6f5, so a child could still paint the 2.06:1 pale blue
+     this pin exists to remove. --color-blue-text is the one the utility reads,
+     and --blue-text aliases it so the two cannot drift apart again. */
+  --color-blue-text: var(--color-accent-deep);
+  --blue-text: var(--color-blue-text);
 }
 
 html[data-theme='dark'] body:has([data-yc-app]) {

--- a/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.tsx
@@ -51,7 +51,17 @@ const CompanionIdCard = ({ card }: CompanionIdCardProps) => {
     : undefined;
 
   return (
-    <div className="flex flex-col gap-4 rounded-2xl border border-card-border bg-white p-5">
+    // data-yc-surface="light" for the same reason as PetPassportView: this card
+    // is a literal `bg-white` - --color-white is documented as intentionally
+    // never re-pointed - while its text-text-primary / text-text-secondary inks
+    // are theme tokens that flip. Until (share) got a layout the pairing was
+    // unreachable, because /card never resolved a dark theme at all; giving the
+    // group a layout is exactly what makes it reachable, so the pin ships with
+    // it rather than after it.
+    <div
+      data-yc-surface="light"
+      className="flex flex-col gap-4 rounded-2xl border border-card-border bg-white p-5"
+    >
       <div className="flex items-center gap-3">
         <Image
           alt={identity.name}

--- a/apps/frontend/src/app/ui/cards/PetPassport/PetPassportView.tsx
+++ b/apps/frontend/src/app/ui/cards/PetPassport/PetPassportView.tsx
@@ -87,7 +87,19 @@ const PetPassportView = ({ passport }: PetPassportViewProps) => {
   const species = SPECIES_LABEL[identity.species] ?? 'Other';
 
   return (
-    <div className="flex flex-col gap-5 rounded-2xl border border-card-border bg-white p-5">
+    // data-yc-surface="light" is load-bearing, not decorative. This card is a
+    // literal `bg-white` - globals.css documents --color-white as
+    // "intentionally NOT re-pointed", so it stays pure white in dark mode -
+    // while every ink inside it is a theme token that DOES flip. Measured in a
+    // browser before this pin: all 58 text nodes in the card failed AA in dark,
+    // the worst at 1.34:1, which is cream text on white. Passport numbers,
+    // microchip numbers and vaccination dates, unreadable.
+    // The pin is exactly what /payment-status and /accessibility/report use for
+    // the same reason: a surface that is fixed light needs its inks fixed too.
+    <div
+      data-yc-surface="light"
+      className="flex flex-col gap-5 rounded-2xl border border-card-border bg-white p-5"
+    >
       <div className="flex items-center gap-3">
         <Image
           alt={identity.name}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for - #2569
- [x] All existing tests and lints pass

## What is the current behavior?

#2569 reported that `(share)` is the last route group with no `layout.tsx`, so `/passport/<id>` and `/card/<token>` never resolve a theme and `--ink-faint` stays at the marketing value. Verifying that turned up three more contrast failures with the same cause. **Every ratio below was measured in a browser, not derived from the tokens.**

### The one that is not cosmetic

`PublicPassportView` draws both vaccination badges from the `--status-*` family. The warm-bone dark block redefines `--status-completed-*` but **never `--status-danger-*`** - one prefix away from `--danger-*`, which it does define. So the expired badge kept the `:root` **light** ink `#a6271d` on an espresso card:

| badge | light | dark, before | dark, after |
|---|---|---|---|
| VALID | 6.81:1 | 5.77:1 | 5.77:1 |
| **EXPIRED** | 5.74:1 | **1.89:1** | **5.49:1** |

`PublicPassportView.tsx:47-49` says this page is *"read as proof of cover by travel and boarding staff"*. The failure was inverted: **valid** legible, **expired** all but invisible. That is the wrong way round for a rabies record.

This was reachable before this PR, because the passport already ships its own sun/moon toggle - it is not a state the reader had to opt into via OS settings.

### The rest

**`--ink-faint` on both pages** — now `#66635f` instead of `#8f8984` (3.12:1 on the passport card, at sizes down to 10.5px). The passport needed a second edit: `.yc-warmbone` carries a private copy of the bone ink ramp that **shadows** `body:has([data-yc-app])`, so the scope could not reach the one page the issue was about. I only caught that because I measured `--ink-faint` on the rendered `<main>` rather than trusting the layout to be sufficient.

**The passport's own toggle** hardcoded `'light'` on mount, so a reader whose phone is dark got a full-brightness health record and had to press the button every visit. It now seeds from the resolved theme. The toggle stays - removing a shipped control is a product call, not a bug fix.

**Two surfaces outside `(share)`,** included because the cause is one shared rule and splitting them would leave the rule half-fixed:

- The **in-app pet passport** is a literal `bg-white` card (`--color-white` is documented as intentionally never re-pointed) whose inks are theme tokens. In dark mode **all 58 text nodes failed AA, worst 1.34:1** - cream on white, passport and microchip numbers included. Pinned with `data-yc-surface="light"`, the guard `/payment-status` already uses. Now **0 of 58 fail, worst 5.97:1**.
- That pin covered the grey ramp but **not the brand accent**, so `--color-text-brand` stayed `#8fb6f5` on white. Adding it to the pin also repairs three links on the **accessibility report page** - already pinned, and still rendering pale blue on white in dark. Now **6.48:1 in both themes**.

## What is the new behavior?

`(share)/layout.tsx`, matching `(book)`. These routes are **not** under the strict CSP, so the inline pre-paint script is authorised by `'unsafe-inline'` rather than by `PRE_PAINT_SCRIPT_CSP_HASH` - the same path `(public)/layout.tsx` relies on, and no header changes.

Verified on the running app, both pages, both themes:

| | before | after |
|---|---|---|
| `data-theme` | `null` | `light` / `dark` |
| `[data-yc-app]` | absent | present |
| body background | always `rgb(239,232,220)` | flips to `rgb(32,28,24)` |
| passport `data-wb-theme` | always `light` | follows the phone |
| `--ink-faint` on `<main>` | `#8f8984` | `#66635f` |

## Validation

`tsc` clean · lint 0 errors · **12,035 tests pass** · 2 new tests for the layout, 1 for the theme seeding.

## The judgement call, in case you disagree

The issue offered two options: make these pages theme-aware, or pin them light as documents. **I went theme-aware**, on three grounds:

1. **The passport already has a dark mode, with a visible toggle.** It was not "permanently light" - it was permanently *broken*, and pinning would have frozen that. The expired-badge failure only exists because that dark mode is reachable.
2. **The share pages use 53 design tokens and zero hardcoded colour literals**, so they flip cleanly. The usual argument against - "you get a half-dark page" - does not apply here. I checked before deciding.
3. `(book)` settled the same question for the same audience last week.

The strongest argument the other way is that a passport is a document, and documents do not change colour. I find that outweighed by who actually opens these links: a signed-out pet owner on their own phone, often at night, and a boarding desk in a dim room. The in-app passport **is** pinned light in this PR, because it is a literal white card - so both patterns are now used deliberately rather than by omission.
