### PR TITLE
test(backend): pin the contract that keeps the raw-body advisory out of reach

### DIFF
--- a/apps/backend/test/config/raw-body-limit-contract.test.ts
+++ b/apps/backend/test/config/raw-body-limit-contract.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "@jest/globals";
+import express from "express";
+import getRawBody from "raw-body";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+
+/**
+ * Pins the body-parser contract that keeps AIKIDO-2026-274460 out of reach.
+ *
+ * raw-body resolves at 2.5.3 on the request path and cannot be moved. 2.5.3 is
+ * the last release on the 2.x line - there is no patched 2.x - and the patched
+ * floor is 4.0.0, which express 4's body-parser@1.20.6 cannot take: it does
+ * `var getBody = require('raw-body')` and calls the result, while raw-body 4 is
+ * ESM, so require() hands back a namespace object and every request dies on
+ * "getBody is not a function". Closing this needs body-parser to adopt raw-body
+ * 4 upstream.
+ *
+ * What makes that survivable is not luck. The advisory is that raw-body skips
+ * BOTH of its size checks when its `limit` option is null:
+ *
+ *   var limit = bytes.parse(opts.limit)        // null for anything unparseable
+ *   if (limit !== null && length > limit) ...  // both guarded on limit !== null
+ *   if (limit !== null && received > limit) ...
+ *
+ * body-parser never lets that null through - it throws at configuration time
+ * instead. So the vulnerable branch is only reachable by calling raw-body
+ * directly, and nothing here does: it is in no workspace manifest, no source
+ * file imports it, and body-parser@1.20.6 is its only consumer in the tree.
+ *
+ * These tests exist because that containment is a property of a transitive
+ * dependency, invisible to every other test in the suite. Swapping the body
+ * parser, or a body-parser release that stops validating the limit, would
+ * silently reopen an unbounded-buffering hole while everything else stayed
+ * green.
+ */
+describe("raw-body limit containment", () => {
+  const listen = async (app: express.Express) => {
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = server.address() as AddressInfo;
+    return {
+      port,
+      close: () =>
+        new Promise<void>((resolve) => server.close(() => resolve())),
+    };
+  };
+
+  const postBytes = (port: number, size: number) =>
+    new Promise<number>((resolve, reject) => {
+      const body = Buffer.alloc(size, 0x61);
+      const request = http.request(
+        {
+          port,
+          host: "127.0.0.1",
+          path: "/",
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": body.length,
+          },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", () => resolve(response.statusCode ?? 0));
+        },
+      );
+      request.on("error", reject);
+      request.end(body);
+    });
+
+  // The defect itself. If this ever stops holding, raw-body has been patched
+  // and the override this test justifies can go.
+  it("raw-body buffers without bound when its limit is null", async () => {
+    const payload = Buffer.alloc(256 * 1024, 0x61);
+
+    const buffered = await getRawBody(Readable.from([payload]), {
+      limit: null,
+    });
+
+    expect(buffered.length).toBe(payload.length);
+  });
+
+  it("raw-body enforces a limit it can parse", async () => {
+    const payload = Buffer.alloc(256 * 1024, 0x61);
+
+    await expect(
+      getRawBody(Readable.from([payload]), { limit: 1024 }),
+    ).rejects.toMatchObject({ type: "entity.too.large" });
+  });
+
+  // The containment: every unparseable limit is refused up front, so the null
+  // above can never be what body-parser hands to raw-body.
+  const UNPARSEABLE = ["ten mb", "", "not-a-size", "mb"];
+
+  it.each(UNPARSEABLE)(
+    "express.json refuses the unparseable limit %p at configuration time",
+    (limit) => {
+      expect(() => express.json({ limit })).toThrow(TypeError);
+    },
+  );
+
+  it.each(UNPARSEABLE)(
+    "express.raw refuses the unparseable limit %p at configuration time",
+    (limit) => {
+      expect(() => express.raw({ limit })).toThrow(TypeError);
+    },
+  );
+
+  it.each(UNPARSEABLE)(
+    "express.urlencoded refuses the unparseable limit %p at configuration time",
+    (limit) => {
+      expect(() => express.urlencoded({ extended: true, limit })).toThrow(
+        TypeError,
+      );
+    },
+  );
+
+  // app.ts configures every parser without an explicit limit, so what actually
+  // protects the request path is body-parser's own default. Assert it bites.
+  it("enforces the default limit when app.ts passes none", async () => {
+    const app = express();
+    app.use(express.json());
+    app.post("/", (_req, res) => {
+      res.status(200).end();
+    });
+    app.use(
+      (
+        error: { status?: number },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        res.status(error.status ?? 500).end();
+      },
+    );
+
+    const server = await listen(app);
+
+    try {
+      // Comfortably over body-parser's 100kb default.
+      await expect(postBytes(server.port, 200 * 1024)).resolves.toBe(413);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("accepts a body under the default limit", async () => {
+    const app = express();
+    app.use(express.json());
+    app.post("/", (_req, res) => {
+      res.status(200).end();
+    });
+    app.use(
+      (
+        error: { status?: number },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        res.status(error.status ?? 500).end();
+      },
+    );
+
+    const server = await listen(app);
+
+    try {
+      // Well under 100kb, and valid JSON, so it reaches the handler.
+      const body = JSON.stringify({ a: "b".repeat(1024) });
+      const status = await new Promise<number>((resolve, reject) => {
+        const request = http.request(
+          {
+            port: server.port,
+            host: "127.0.0.1",
+            path: "/",
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "content-length": Buffer.byteLength(body),
+            },
+          },
+          (response) => {
+            response.resume();
+            response.on("end", () => resolve(response.statusCode ?? 0));
+          },
+        );
+        request.on("error", reject);
+        request.end(body);
+      });
+
+      expect(status).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`raw-body` sits at **2.5.3** on the backend's request path and has been the one CVE left open across #2536 → #2538 → #2541 → #2543. It cannot be moved:

- **2.5.3 is the last release on the 2.x line** — there is no patched 2.x to move to. Confirmed against the registry: the 2.x line ends at 2.5.3, 3.x at 3.0.2, and the patched floor is 4.0.0.
- **body-parser@1.20.6 cannot take raw-body 4.** It does `var getBody = require('raw-body')` and calls the result; raw-body 4 is ESM, so `require()` returns a namespace object and every request dies on `getBody is not a function`. #2543 dropped that override for exactly this reason.

Closing the advisory needs body-parser to adopt raw-body 4 upstream. Nothing in this repo can do it.

**What was never written down is why that is survivable** — and that gap is the actual risk. The advisory is that raw-body skips *both* of its size checks when `limit` is null:

```js
var limit = bytes.parse(opts.limit)        // null for anything unparseable
if (limit !== null && length > limit) ...  // both guarded on limit !== null
if (limit !== null && received > limit) ...
```

body-parser does **not** forward that null — it throws a `TypeError` at configuration time instead. So the vulnerable branch is reachable only by calling raw-body directly, and nothing here does: it is in no workspace manifest, no source file imports it, and `body-parser@1.20.6` is its only consumer in the lockfile.

Verified against a real server rather than by reading code:

| Probe | Result |
|---|---|
| `express.json({ limit: "ten mb" })` | `TypeError: option limit "ten mb" is invalid` — throws before a listener exists |
| `express.raw({ limit: "" })` | same |
| `express.json()` (the shape `app.ts:178` uses), POST 200kb | **413** — body-parser's 100kb default is enforced |
| `raw-body` called directly with `limit: null` | buffered 5 MB unbounded — the defect is real, nothing reaches it |

## What is the new behavior?

No application change. **No limits are altered and no dependency moves** — this adds one test file.

It locks down the containment, because that containment is a property of a *transitive* dependency and no other test in the suite touches it. Swapping the body parser, or a body-parser release that stops validating the limit, would silently reopen unbounded buffering with every other test still green.

Sixteen cases across four groups:

- **the defect** — raw-body buffers without bound on `limit: null`, and enforces a limit it can parse
- **the containment** — `express.json`, `express.raw` and `express.urlencoded` each refuse four unparseable limits at configuration time
- **the live default** — the no-explicit-limit shape `app.ts` actually configures returns 413 over 100kb, and 200 under it

The first case is deliberately written to **fail once raw-body is patched** — that is the signal this whole note can be deleted and the advisory closed properly.

## Validation

| Check | Result |
|---|---|
| new tests | **16 passed** |
| backend suite | **10,950 passed** (454 suites) |
| lint | clean |
| `tsc --noEmit` | clean |

The single backend failure is environmental and reproduces on unmodified `dev`: this sandbox sets `AWS_ACCESS_KEY_ID`, which the SES client test asserts is unset. CI does not set it.

## Related Issue(s)

Closes out the last item from #2536's original 30 CVEs. Follow-up to #2538, #2541, #2543 and #2558.