### PR TITLE
fix(backend): bind a PMS appointment write to the organisation it is authorised for

### DIFF
--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -51,6 +51,34 @@ type AdmitBody = {
  * resource-scoped routes that is the appointment's own organisation, not
  * whatever the URL named, so it is the only value safe to filter on.
  */
+/**
+ * The organisation the request BODY names, via its FHIR `Organization`
+ * participant.
+ *
+ * This is the value the write is actually persisted under:
+ * `fromFHIRAppointment` (packages/types/src/appointment.ts) reads the same
+ * participant into `organisationId`, and that is what reaches
+ * `tx.appointment.create`. It is a different source from the one
+ * `withOrgPermissions()` authorises, which is why the two must be compared.
+ */
+const resolveBodyOrganisationId = (
+  body: AppointmentRequestDTO | undefined,
+): string | undefined => {
+  const participants = body?.participant;
+  if (!Array.isArray(participants)) return undefined;
+  for (const participant of participants) {
+    const reference = participant?.actor?.reference;
+    if (
+      typeof reference === "string" &&
+      reference.startsWith("Organization/")
+    ) {
+      const id = reference.slice("Organization/".length).trim();
+      if (id) return id;
+    }
+  }
+  return undefined;
+};
+
 const resolveAuthorizedOrganisationId = (req: Request): string | undefined => {
   const orgReq = req as OrgRequest;
   const organisationId = orgReq.organisationId ?? orgReq.params?.organisationId;
@@ -151,6 +179,50 @@ export const AppointmentController = {
     res: Response,
   ) => {
     try {
+      /*
+       * Bind the write to the organisation the caller is authorised for.
+       *
+       * `withOrgPermissions()` proves membership of the org the REQUEST NAMES -
+       * params, `x-org-id`, or query. The appointment is persisted under the org
+       * its BODY names, read from the FHIR `Organization` participant. Those were
+       * two unconnected sources: a caller with `appointments:edit:any` at org A
+       * could send `x-org-id: A` to pass the gate and `Organization/B` in the
+       * body, and the appointment was written to B.
+       *
+       * That is not only a stray row. The same body org drives the invoice
+       * `bootstrapForAppointment` opens and the ACTIVE `PatientOrganisation`
+       * link `linkByParent` creates, which is what grants a practice ongoing
+       * access to a companion's records.
+       *
+       * `withResourceOrgPermissions` (middlewares/rbac.ts) exists for exactly
+       * this hazard and its comment describes it, but it derives the tenant from
+       * an existing record - and a create has no record yet. So the comparison
+       * belongs here, alongside the four sibling handlers in this file that
+       * already call `resolveAuthorizedOrganisationId`.
+       *
+       * A body that names no organisation is left alone: the service already
+       * rejects it downstream, and inventing a tenant for an ambiguous request
+       * is not this guard's job.
+       */
+      const authorisedOrganisationId = resolveAuthorizedOrganisationId(req);
+      if (!authorisedOrganisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
+
+      const bodyOrganisationId = resolveBodyOrganisationId(req.body);
+      if (
+        bodyOrganisationId &&
+        bodyOrganisationId !== authorisedOrganisationId
+      ) {
+        logger.warn(
+          "Rejected an appointment naming an organisation the caller is not authorised for",
+        );
+        return res.status(403).json({
+          message:
+            "The appointment names a different organisation from the one this request is authorised for.",
+        });
+      }
+
       const { createPayment, paymentCollectionMethod } = req.query;
       const shouldCreatePayment =
         createPayment === "true" || createPayment === "1";

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -194,6 +194,7 @@ describe("AppointmentPrismaController", () => {
 
   it("creates PMS appointments with payment options", async () => {
     req.query = { createPayment: "1", paymentCollectionMethod: "clinic" };
+    (req as any).organisationId = "org_a";
     req.body = { resourceType: "Appointment" } as any;
     mockedService.createAppointmentFromPms.mockResolvedValue({
       id: "appt_2",
@@ -207,6 +208,72 @@ describe("AppointmentPrismaController", () => {
       "clinic",
     );
     expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  /*
+   * `withOrgPermissions()` proves membership of the org the REQUEST names
+   * (x-org-id / query / params). The appointment is persisted under the org its
+   * BODY names, via the FHIR Organization participant. Those were unconnected:
+   * a caller authorised at org A could write an appointment - plus its invoice
+   * and an ACTIVE PatientOrganisation link - into org B.
+   */
+  describe("binds the write to the authorised organisation", () => {
+    const bodyNaming = (orgId: string) =>
+      ({
+        resourceType: "Appointment",
+        participant: [{ actor: { reference: `Organization/${orgId}` } }],
+      }) as any;
+
+    it("refuses a body naming a different organisation", async () => {
+      (req as any).organisationId = "org_a";
+      req.body = bodyNaming("org_b");
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it("allows the body when it names the authorised organisation", async () => {
+      (req as any).organisationId = "org_a";
+      req.body = bodyNaming("org_a");
+      mockedService.createAppointmentFromPms.mockResolvedValue({
+        id: "appt_3",
+      } as any);
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    /* The real client sends the same org in both places - x-org-id from the
+       axios interceptor and Organization/<primaryOrgId> in the body - so this
+       is the path it takes, and the guard must not disturb it. */
+    it("refuses when no organisation is authorised at all", async () => {
+      req.body = bodyNaming("org_b");
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    /* A body naming no organisation is left to the service, which already
+       rejects it. Inventing a tenant for an ambiguous request is not this
+       guard's job. */
+    it("passes a body that names no organisation straight through", async () => {
+      (req as any).organisationId = "org_a";
+      req.body = { resourceType: "Appointment" } as any;
+      mockedService.createAppointmentFromPms.mockResolvedValue({
+        id: "appt_4",
+      } as any);
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
   });
 
   it("accepts and rejects requested appointments", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`POST /fhir/v1/appointment/pms` authorises one organisation and persists another.

- `withOrgPermissions()` proves an active membership of the org the **request** names - params, `x-org-id`, or query - and sets `req.organisationId` (`middlewares/rbac.ts:25-31, 106-121, 143`).
- The appointment is stored under the org its **body** names. `fromFHIRAppointment` reads the FHIR `Organization` participant into `organisationId` (`packages/types/src/appointment.ts:441-443, 541`), and that value reaches `tx.appointment.create` (`appointment.prisma.service.ts:1548`).
- `createFromPms` never compared the two.

So a caller holding `appointments:edit:any` at org A could send `x-org-id: A` to pass the gate and `Organization/B` in the body, and the write landed in org B.

The only org check further down is an existence check - `prisma.organization.findUnique({ where: { id: input.organisationId }, select: { type: true } })` (`appointment.prisma.service.ts:1444-1454`).

**The blast radius is wider than one row.** The same body-derived org drives the invoice `InvoiceService.bootstrapForAppointment` opens, and the **active `PatientOrganisation` link** `CompanionOrganisationService.linkByParent` creates - the link that grants a practice ongoing access to a companion's records.

`withResourceOrgPermissions` (`rbac.ts:155-199`) exists for precisely this hazard, and its comment says `withOrgPermissions()` "only proves the caller belongs to whatever organisation the request names". Every `:appointmentId` route uses it. A create has no record to derive a tenant from, so this route was left uncovered.

## What is the new behavior?

`createFromPms` resolves the authorised organisation with `resolveAuthorizedOrganisationId` - the helper four sibling handlers in this same file already use - and refuses a body naming a different one with 403.

A body naming **no** organisation is passed through unchanged. The service already rejects it downstream, and inventing a tenant for an ambiguous request is not this guard's job.

## Compatibility

No behaviour change for the real client. `apps/frontend/.../appointmentService.ts:186` sets `organisationId: primaryOrgId` in the payload, which `toAppointmentResponseDTO` emits as `Organization/${organisationId}` (`packages/types/src/appointment.ts:169`), while the axios interceptor sends `x-org-id: primaryOrgId` (`axios.ts:248`). Both sides already carry the same org, so the comparison passes.

## How this was established

Four independent reviewers were asked to **disprove** the finding, each from a different angle - the middleware chain, the persistence layer including RLS and Prisma constraints, exploitability of every assertion in the path, and whether the body participant is deliberately the source of truth. All four failed to refute it, at high confidence, and none found a blocking guard.

They also corrected the original report on two points worth recording: the live handler is `appointment.prisma.controller.ts`, not `appointment.controller.ts` (which is dead code with the same defect), and `extractOrgIdFromBody` only understands a flat `organisationId`, so a FHIR body cannot itself satisfy the gate - the caller must send `x-org-id` or `?organisationId=`, or the request 400s.

**Residual constraints, for triage rather than comfort.** This needs an authenticated insider, not an anonymous caller: an active membership carrying `appointments:edit:any` somewhere, knowledge of the target org's id, and - the real barrier - a catalog item **owned by the target org**, since `CatalogService.resolveSelection` filters `ProductItem` by that org and 404s otherwise.

## Validation

- 34 controller tests pass, four of them new: the refusal, the matching case, the missing-authorisation case, and the no-organisation body.
- Mutation-checked: removing the comparison fails only the refusal test.
- `tsc` and `eslint` clean for `apps/backend`. `tsc` caught a narrowing bug in the body helper during development.

## Related Issue(s)

Found by the Codex review on #2571.
