### PR TITLE
fix(frontend): let CI see contrast failures, and stop the warm-bone copy hiding them

### DIFF
--- a/apps/frontend/e2e/a11y.spec.ts
+++ b/apps/frontend/e2e/a11y.spec.ts
@@ -1,13 +1,49 @@
 import { type Page, expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-// Shared axe configuration: WCAG 2.1 AA baseline, colour-contrast excluded
-// because headless Chrome does not compute computed colour styles reliably.
+/**
+ * 90s, not the 30s default.
+ *
+ * An axe pass is CPU-heavy, and this file now runs thirteen of them against a
+ * single Next dev server. CI serialises them (`workers: 1`), but a local run is
+ * fullyParallel, and adding the six public-page tests was enough to push the
+ * sign-in and sign-up runs past 30s on a warm laptop - they pass in 6s and 4s
+ * serialised. Raising the ceiling keeps the local run honest instead of
+ * intermittently red for a reason that has nothing to do with accessibility.
+ */
+test.describe.configure({ timeout: 90_000 });
+
+const WCAG_AA = ['wcag2a', 'wcag2aa', 'wcag21aa'];
+
+/**
+ * WCAG 2.1 AA, minus colour-contrast.
+ *
+ * The original comment here said colour-contrast was excluded "because headless
+ * Chrome does not compute computed colour styles reliably". That is not true -
+ * see `runAxeWithContrast` below, which relies on it working, and does. The real
+ * reason the rule stays off for the marketing pages is less flattering: `/` and
+ * `/pricing` currently fail it 26 times in light and 16 in dark, worst 1.94:1.
+ * Turning it on for them would make this suite red on arrival, so that debt is
+ * tracked separately rather than hidden behind a wrong explanation.
+ */
 const runAxe = (page: Page) =>
-  new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
-    .disableRules(['color-contrast'])
-    .analyze();
+  new AxeBuilder({ page }).withTags(WCAG_AA).disableRules(['color-contrast']).analyze();
+
+/**
+ * The full AA set, colour-contrast included.
+ *
+ * Verified working in this exact environment: given a 2.1:1 pair and an 18:1
+ * pair on one page, headless Chromium reports the first as a violation, the
+ * second as a pass, and neither as incomplete.
+ *
+ * Used for the three public pages a stranger is most likely to be sent a link
+ * to, and which carry the most personal data. Every one of them shipped a
+ * contrast defect that this suite could not see: 10 of 56 nodes below AA on
+ * /book, an expired-rabies badge at 1.89:1 on /passport, and owner and medical
+ * details at 2.40:1 on /card. All three were found by hand while CI stayed
+ * green.
+ */
+const runAxeWithContrast = (page: Page) => new AxeBuilder({ page }).withTags(WCAG_AA).analyze();
 
 // Public pages pull logos/data from third-party hosts (GitHub API, CloudFront,
 // laika.aitemsolutions.com, unsplash, wikimedia). When any of those is slow or
@@ -83,6 +119,149 @@ test.describe('Public pages — accessibility (WCAG 2.1 AA)', () => {
     await expect(skipLink).not.toBeFocused();
   });
 });
+
+/**
+ * The three public pages a link gets sent to.
+ *
+ * These are the highest-stakes surfaces in the product for accessibility: the
+ * reader is signed out, usually on a phone that is not theirs to configure, and
+ * is being asked for personal details or shown a health record. They were also
+ * the three pages this suite did not cover.
+ *
+ * Two things make these tests different from the marketing ones above, and both
+ * are deliberate:
+ *
+ * 1. They run colour-contrast. See runAxeWithContrast.
+ * 2. They assert the page actually RENDERED before trusting a clean axe run.
+ *    Without that, an aborted or stubbed-wrong API drops each page into its
+ *    "not found" state - which is a handful of nodes that legitimately pass, so
+ *    a broken fixture reads exactly like a green result. That is not
+ *    hypothetical: a first pass at this reported "0 violations" while checking
+ *    0 text nodes.
+ */
+const PASSPORT_FIXTURE = {
+  passportNumber: 'PT-E2E-0001',
+  identity: {
+    id: 'e2e-1',
+    name: 'Luna',
+    breed: 'Beagle',
+    species: 'dog',
+    sex: 'FEMALE',
+    dateOfBirth: '2021-03-14',
+    colour: 'Tricolour',
+    distinguishingMarks: 'White blaze',
+    photoUrl: null,
+  },
+  owner: { name: 'Marta Ferreira', email: 'marta@example.com', phone: '+351 912 000 111' },
+  microchip: {
+    number: '941000024681357',
+    implantedAt: '2021-05-02',
+    location: 'Left side of neck',
+  },
+  // Deliberately expired: the expired badge is the element that shipped at
+  // 1.89:1, so the fixture has to render it.
+  rabies: {
+    id: 'r1',
+    vaccineName: 'Nobivac Rabies',
+    dateAdministered: '2022-06-11',
+    validUntil: '2024-06-11',
+    batchNumber: 'RB-2022-118',
+  },
+  vaccinations: [],
+  parasiteTreatments: [],
+  rabiesTitrations: [],
+  clinicalExams: [
+    { id: 'e1', fitForTravel: true, examinedAt: '2026-03-01', examiningVetName: 'Dr Alves' },
+  ],
+};
+
+const CARD_FIXTURE = {
+  audience: 'PUBLIC',
+  identity: { id: 'e2e-c1', name: 'Luna', type: 'dog', breed: 'Beagle', photoUrl: null },
+  // Alerts are what carry the fill that shipped at 2.40:1 on a pinned card.
+  alerts: [{ id: 'a1', severity: 'medium', title: 'Allergic to penicillin' }],
+  ownerContact: { firstName: 'Marta', lastName: 'Ferreira', phoneNumber: '+351 912 000 111' },
+  medical: { bloodGroup: 'DEA 1.1 negative' },
+};
+
+/**
+ * Fulfil the public API rather than aborting it.
+ *
+ * `blockCrossOriginRequests` aborts everything off-origin, which is right for
+ * the marketing pages and fatal here - the API these pages read is cross-origin,
+ * so aborting it renders the not-found state instead of the page under test.
+ */
+const stubPublicApi = async (page: Page) => {
+  await page.route(
+    (url) => /\/public\/(pet-passport\/token|companion-card|booking)\//.test(url.href),
+    (route) => {
+      const url = route.request().url();
+      if (url.includes('/pet-passport/token/')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(PASSPORT_FIXTURE),
+        });
+      }
+      if (url.includes('/companion-card/')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(CARD_FIXTURE),
+        });
+      }
+      return route.abort();
+    }
+  );
+};
+
+for (const theme of ['light', 'dark'] as const) {
+  test.describe(`Shared public pages — accessibility, ${theme} (WCAG 2.1 AA incl. contrast)`, () => {
+    test.use({ colorScheme: theme });
+
+    test.beforeEach(async ({ page }) => {
+      await blockCrossOriginRequests(page);
+      await stubPublicApi(page);
+    });
+
+    test(`the shared pet passport has no axe violations in ${theme}`, async ({ page }) => {
+      await page.goto('/passport/e2e-a11y');
+      await page.waitForLoadState('networkidle').catch(() => {});
+      // The content floor: the passport rendered, not its not-found state.
+      await expect(page.getByText('Luna')).toBeVisible();
+      await expect(page.getByText(/expired/i).first()).toBeVisible();
+
+      const results = await runAxeWithContrast(page);
+      expect(results.violations).toEqual([]);
+    });
+
+    test(`the shared companion card has no axe violations in ${theme}`, async ({ page }) => {
+      await page.goto('/card/e2e-a11y');
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await expect(page.getByText('Luna')).toBeVisible();
+      await expect(page.getByText('Allergic to penicillin')).toBeVisible();
+
+      const results = await runAxeWithContrast(page);
+      expect(results.violations).toEqual([]);
+    });
+
+    test(`the unavailable booking page has no axe violations in ${theme}`, async ({ page }) => {
+      // The populated booking page needs a live practice, which this suite has
+      // no fixture for; smoke.spec.ts uses the same unknown slug. The
+      // unavailable state is still worth covering - it is a real page a reader
+      // reaches from a revoked link, and it exercises the (book) layout, the
+      // card surface and the footer.
+      await page.goto('/book/no-such-practice-e2e');
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await expect(
+        page.getByRole('heading', { name: /this booking page is not available/i })
+      ).toBeVisible();
+
+      const results = await runAxeWithContrast(page);
+      expect(results.violations).toEqual([]);
+    });
+  });
+}
 
 test.describe('Sign-in page — form accessibility', () => {
   test('email and password inputs have accessible labels', async ({ page }) => {

--- a/apps/frontend/e2e/smoke.spec.ts
+++ b/apps/frontend/e2e/smoke.spec.ts
@@ -28,8 +28,13 @@ test('an unknown booking slug renders a plain unavailable page', async ({ page }
     page.getByRole('heading', { name: /this booking page is not available/i })
   ).toBeVisible({ timeout: 30_000 });
 
-  const body = (await page.locator('body').textContent()) ?? '';
-  expect(body).not.toMatch(/stack|prisma|postgres|at Object\./i);
+  // innerText, not textContent. textContent returns the raw DOM text of every
+  // descendant INCLUDING <script>, so it swept up Next's RSC payload - which
+  // legitimately serialises React owner stacks as "stack":[] and tripped this
+  // regex on a page showing nothing of the sort. innerText is the rendered text,
+  // which is what this assertion has always been about: what a visitor can read.
+  const visibleText = await page.locator('body').innerText();
+  expect(visibleText).not.toMatch(/stack|prisma|postgres|at Object\./i);
 });
 
 test('the public booking page is served under a nonce CSP, not unsafe-inline', async ({ page }) => {

--- a/apps/frontend/src/app/__tests__/ui/tokens/warmboneTokenClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/warmboneTokenClosure.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The warm-bone overrides must cover exactly what the passport reads, and must
+ * agree with the global system.
+ *
+ * `.yc-warmbone` is the one place in this stylesheet that re-states tokens the
+ * global system already owns. It exists because the public passport has its own
+ * light/dark control, so it needs a theme that can differ from the root - and
+ * since #2578 it applies ONLY in that disagreeing case.
+ *
+ * That narrowing removed the two failure modes the copy had already shipped,
+ * but it also made drift quieter: a wrong value is now only wrong in a state
+ * nobody routinely looks at. This test is the trade. It re-derives what the
+ * components read from the source on every run, rather than hard-coding a list
+ * that would rot the same way the copy did.
+ *
+ * The two defects it is written against, both real and both shipped:
+ *
+ *   1. The block declared `--danger-text` while PublicPassportView reads
+ *      `--status-danger-text`. One prefix apart. The expired-vaccination badge
+ *      kept the light ink on the espresso card - 1.89:1, on a page its own
+ *      source calls "read as proof of cover by travel and boarding staff" -
+ *      while the valid badge rendered correctly, so the section looked fine.
+ *      Caught here by MISSING_FROM.
+ *
+ *   2. `--blue-text` was a private literal in one half and an alias to a
+ *      theme-flipping token in the other, so a fixed surface got the wrong
+ *      blue. Caught here by THEME_INVARIANT_ALIASES.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const CSS = fs.readFileSync(path.join(root, 'src/app/globals.css'), 'utf8');
+
+const SHARE = 'src/app/(routes)/(share)/passport/[id]';
+const COMPONENTS = [
+  fs.readFileSync(path.join(root, SHARE, 'PublicPassportView.tsx'), 'utf8'),
+  fs.readFileSync(path.join(root, SHARE, 'PassportClient.tsx'), 'utf8'),
+].join('\n');
+
+/**
+ * Every custom property the passport actually reads, derived from source.
+ *
+ * Two consumers, not one: the components, and the `.yc-warmbone` base rule
+ * itself, which paints `background: var(--page)` and `color: var(--ink-body)`.
+ * Reading only the TSX misses those and reports them as dead.
+ */
+const tokensRead = (): string[] => {
+  const base = CSS.slice(CSS.indexOf('.yc-warmbone {'));
+  const baseRule = base.slice(0, base.indexOf('}'));
+  return [
+    ...new Set(
+      [
+        ...COMPONENTS.matchAll(/var\((--[a-z0-9-]+)\)/g),
+        ...baseRule.matchAll(/var\((--[a-z0-9-]+)\)/g),
+      ].map((m) => m[1])
+    ),
+  ];
+};
+
+/** The declarations inside one CSS rule, by selector prefix. */
+const declarationsIn = (selectorStart: string): Record<string, string> => {
+  const at = CSS.indexOf(selectorStart);
+  if (at === -1) throw new Error(`selector not found: ${selectorStart}`);
+  const body = CSS.slice(CSS.indexOf('{', at) + 1, CSS.indexOf('}', at));
+  const out: Record<string, string> = {};
+  for (const [, name, value] of body.matchAll(/(--[a-z0-9-]+):\s*([^;]+);/g)) {
+    out[name] = value.trim();
+  }
+  return out;
+};
+
+const LIGHT_OVERRIDE = "html[data-theme='dark'] .yc-warmbone[data-wb-theme='light']";
+const DARK_OVERRIDE = "html:not([data-theme='dark']) .yc-warmbone[data-wb-theme='dark']";
+
+/**
+ * Read by the components but deliberately NOT overridden, because the global
+ * value is already correct in the disagreeing state. Every entry needs a reason.
+ */
+const NOT_OVERRIDDEN: Record<string, string> = {
+  '--font-newsreader': 'font family, not a colour - identical in both themes',
+};
+
+describe('warm-bone overrides cover what the passport reads', () => {
+  it.each([
+    ['light override', LIGHT_OVERRIDE],
+    ['dark override', DARK_OVERRIDE],
+  ])('%s declares every token the components read', (_label, selector) => {
+    const declared = declarationsIn(selector);
+    const missing = tokensRead().filter((t) => !(t in declared) && !(t in NOT_OVERRIDDEN));
+
+    // This is the assertion that would have caught the 1.89:1 expired badge:
+    // --status-danger-text was read and never declared here.
+    expect(missing).toEqual([]);
+  });
+
+  it('declares nothing the components do not read', () => {
+    // The other direction. The block carried 14 dead token names for months,
+    // which is what made the one genuinely missing name hard to notice.
+    const read = new Set(tokensRead());
+    for (const selector of [LIGHT_OVERRIDE, DARK_OVERRIDE]) {
+      const dead = Object.keys(declarationsIn(selector)).filter((t) => !read.has(t));
+      expect(dead).toEqual([]);
+    }
+  });
+
+  it('applies only when the page and the root disagree', () => {
+    // The base class must declare NO tokens. If it ever does again, it starts
+    // shadowing body:has([data-yc-app]) on every load - defect 2's mechanism.
+    const base = declarationsIn('.yc-warmbone {');
+    expect(Object.keys(base)).toEqual([]);
+  });
+
+  it('aliases only to tokens that do not themselves flip', () => {
+    // An override may alias a global token ONLY if that token resolves the same
+    // under either root - otherwise the alias re-imports the very theme the
+    // override exists to escape. --color-accent-deep/-dark qualify: each is
+    // declared exactly once, in @theme, and never redeclared.
+    const THEME_INVARIANT_ALIASES = ['--color-accent-deep', '--color-accent-dark'];
+
+    for (const alias of THEME_INVARIANT_ALIASES) {
+      const declarations = [...CSS.matchAll(new RegExp(`${alias}:\\s*[^;]+;`, 'g'))];
+      expect(declarations).toHaveLength(1);
+    }
+
+    for (const selector of [LIGHT_OVERRIDE, DARK_OVERRIDE]) {
+      for (const [token, value] of Object.entries(declarationsIn(selector))) {
+        const aliased = value.match(/var\((--[a-z0-9-]+)\)/)?.[1];
+        if (!aliased) continue;
+        expect({ token, aliased }).toEqual({
+          token,
+          aliased: expect.stringMatching(new RegExp(`^(${THEME_INVARIANT_ALIASES.join('|')})$`)),
+        });
+      }
+    }
+  });
+
+  it('keeps the danger trio spelled the way the component reads it', () => {
+    // The original defect, pinned directly. --danger-* and --status-danger-* are
+    // one prefix apart, and the component reads the longer name.
+    for (const selector of [LIGHT_OVERRIDE, DARK_OVERRIDE]) {
+      const declared = Object.keys(declarationsIn(selector));
+      expect(declared).toEqual(expect.arrayContaining(['--status-danger-text']));
+      expect(declared).not.toEqual(expect.arrayContaining(['--danger-text']));
+    }
+  });
+});

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1120,8 +1120,18 @@ html[data-theme='dark'] {
   --status-no-show-text: #f0a36c;
   --status-no-show-border: rgba(249, 115, 22, 0.5);
   --status-danger-bg: rgba(234, 55, 41, 0.18);
-  --status-danger-text: #f2938a;
+  --danger-text: #f2938a;
   --status-danger-border: rgba(242, 147, 138, 0.42);
+  /* The missing third. Every other status family here declares bg, border AND
+     text; danger declared only two, so --status-danger-text fell through to the
+     @theme light value #a6271d and painted light-red ink on dark surfaces -
+     1.73:1 on --screen. That reaches StatusPill variant="danger",
+     DispensaryTable's pills (via --color-pill-danger-text) and the public
+     passport's expired badge.
+     It went unnoticed because .yc-warmbone carried a private copy that happened
+     to declare the token, so the one page anybody looked at in dark mode looked
+     right. Narrowing that copy (#2578) is what exposed this. */
+  --status-danger-text: #f2938a;
 }
 
 /* Native control theming + flip transition, scoped to the marketing surface. */
@@ -1740,17 +1750,44 @@ input[type='number'] {
 }
 
 /* ============================================================
-   Warm-bone theme (scoped) — Pet Passport, wallet & share surfaces.
-   Self-contained token layer for the PR #1675 warm-bone redesign
-   (subset of the design-system site-theme). Applies only inside
-   `.yc-warmbone`; dark mode flips via `data-wb-theme="dark"`.
+   Warm-bone theme (scoped) - the public Pet Passport surface.
+
+   This block used to be a self-contained copy of ~40 global tokens that applied
+   on EVERY load of the passport. That copy caused two shipped defects, both
+   silently, and both because it drifted from the component that reads it (#2578):
+
+     1. It declared --danger-* while PublicPassportView reads --status-danger-*.
+        One prefix apart. The "expired" badge kept the light ink on the espresso
+        card at 1.89:1 while the "valid" badge - which happens to read
+        --status-completed-*, a name the copy did declare - rendered fine.
+     2. It redeclared --ink-faint, which SHADOWED body:has([data-yc-app]), the
+        scope whose whole job is making faint ink readable on bone surfaces. The
+        passport was the one page that scope could not reach.
+
+   It is now keyed on DISAGREEMENT. The page has its own light/dark control, so
+   the only thing it genuinely needs that the global system cannot give it is a
+   theme that differs from the root. When the two agree - which is every load
+   until the reader touches the toggle - this declares nothing at all, the page
+   reads the same tokens as the rest of the app, and neither failure above is
+   reachable.
+
+   That also makes the no-flash behaviour structural rather than maintained: with
+   no data-wb-theme, no override matches, so the first paint is simply the root
+   theme the pre-paint script already resolved.
+
+   What survives is 2x26 values that still have to agree with the global set.
+   `warmboneTokenClosure.test.ts` is what stops them drifting again.
    ============================================================ */
 .yc-warmbone {
+  background: var(--page);
+  color: var(--ink-body);
+}
+
+/* Root is dark, the reader asked this page to be light. */
+html[data-theme='dark'] .yc-warmbone[data-wb-theme='light'] {
   --page: #efe8dc;
-  --band: #e8e0d2;
   --inset: #eae2d5;
   --screen: #f7f3ec;
-  --screen-2: #f1ebe1;
   --hairline: #e5dccf;
   --divider: #d6d1cd;
   --hairline-soft: rgba(29, 28, 27, 0.09);
@@ -1758,65 +1795,31 @@ input[type='number'] {
   --ink-body: #302f2e;
   --ink-muted: #5c5956;
   --ink-soft: #423f3c;
-  /* #66635f, not #8f8984. This class carries a private copy of the bone ink
-     ramp, and that copy SHADOWS the body:has([data-yc-app]) scope which exists
-     precisely to make faint ink readable on bone surfaces - so the passport
-     was the one page the scope could not reach. #8f8984 measures 3.12:1 on
-     this card, at sizes down to 10.5px; #66635f clears AA. Same value the
-     scoped rule and [data-yc-surface='light'] already use. */
   --ink-faint: #66635f;
-  --ink-faint2: #66635f;
-  --blue-text: #257bed;
+  --blue-text: var(--color-accent-deep);
   --blue-soft: #e6f2ff;
   --success: #008f5d;
-  --danger-text: #c2261a;
-  --danger-bg: rgba(234, 55, 41, 0.09);
-  --danger-border: rgba(234, 55, 41, 0.32);
   --avatar-amber-bg: #fef3e9;
-  --dl-btn: #1d1c1b;
-  --dl-btn-text: #ffffff;
   --status-completed-bg: #f0fdf4;
   --status-completed-text: #166534;
   --status-completed-border: #64c487;
-  --status-upcoming-border: #007cf5;
-  --sh03: rgba(29, 28, 27, 0.03);
-  --sh05: rgba(29, 28, 27, 0.05);
-  --sh08: rgba(29, 28, 27, 0.08);
-  --sh10: rgba(29, 28, 27, 0.1);
-  --sh16: rgba(29, 28, 27, 0.16);
-  --glass-93: rgba(239, 232, 220, 0.93);
-  --pbg: #efe8dc;
-  --pfg: #1d1c1b;
-  --pml: #6b6763;
-  --phl: rgba(29, 28, 27, 0.12);
-  background: var(--page);
-  color: var(--ink-body);
-  /* The danger trio in the LIGHT scope as well, and for the mirror of the
-     reason it was added to the dark one. This page has its own toggle, so a
-     reader whose OS is dark can switch just this passport to light - at which
-     point the dark block stops applying and, without these, --status-danger-*
-     falls back to the ROOT dark values (#f2938a on an 18% tint) on a light
-     #f7f3ec card: the EXPIRED label at ~2.04:1 and its icon at ~1.59:1.
-     One local toggle must not be able to mix root-dark status tokens with a
-     local-light surface. */
   --status-danger-bg: rgba(234, 55, 41, 0.09);
   --status-danger-text: #a6271d;
   --status-danger-border: rgba(234, 55, 41, 0.32);
+  --status-upcoming-border: #007cf5;
+  --sh03: rgba(29, 28, 27, 0.03);
+  --sh05: rgba(29, 28, 27, 0.05);
+  --sh10: rgba(29, 28, 27, 0.1);
+  --glass-93: rgba(239, 232, 220, 0.93);
 }
-/* Two selectors, and the second is what removes the flash. The component only
-   sets data-wb-theme once the reader uses the page's own toggle, so on the
-   server-rendered first paint the attribute is absent - and the pre-paint script
-   has already put data-theme on <html>. Following the root attribute here means
-   a reader whose phone is dark gets a dark passport in the FIRST paint rather
-   than a bright one that flips after hydration. The :not() keeps a local
-   light override winning over a dark root. */
-html[data-theme='dark'] .yc-warmbone:not([data-wb-theme='light']),
-.yc-warmbone[data-wb-theme='dark'] {
+
+/* Root is light (or unresolved - the pre-paint script can throw in private
+   mode), and the reader asked this page to be dark. :not() rather than
+   [data-theme='light'] so the attribute simply being absent still counts. */
+html:not([data-theme='dark']) .yc-warmbone[data-wb-theme='dark'] {
   --page: #201c18;
-  --band: #2a2216;
   --inset: #302820;
   --screen: #2f271e;
-  --screen-2: #221d17;
   --hairline: #40362b;
   --divider: #3a3128;
   --hairline-soft: rgba(255, 255, 255, 0.09);
@@ -1825,42 +1828,23 @@ html[data-theme='dark'] .yc-warmbone:not([data-wb-theme='light']),
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  --ink-faint2: #998f82;
-  --blue-text: var(--color-blue-text);
+  --blue-text: var(--color-accent-dark);
   --blue-soft: rgba(143, 182, 245, 0.16);
   --success: #2bbd86;
-  --danger-text: #f2938a;
-  --danger-bg: rgba(234, 55, 41, 0.18);
-  --danger-border: rgba(242, 147, 138, 0.42);
   --avatar-amber-bg: rgba(233, 170, 120, 0.17);
-  --dl-btn: #f7f3ec;
-  --dl-btn-text: #201c18;
   --status-completed-bg: rgba(74, 205, 155, 0.16);
   --status-completed-text: #74d0a2;
   --status-completed-border: rgba(74, 205, 155, 0.55);
-  /* The danger trio, aliased onto the --danger-* values a few lines above.
-     Their absence was not cosmetic. PublicPassportView draws BOTH vaccination
-     badges from the --status-* family: "valid" reads --status-completed-*,
-     which this block redefines, and "expired" reads --status-danger-*, which it
-     did not - so the expired badge kept the :root LIGHT ink (#a6271d) on the
-     espresso card. Measured in a browser: valid 5.77:1, expired 1.89:1. On a
-     page this component describes as "read as proof of cover by travel and
-     boarding staff", that is the failure inverted - "valid" legible, "expired"
-     all but invisible.
-     Aliases, not new literals: the correct dark values were already in this
-     block under the --danger-* spelling, one prefix away from the tokens the
-     component actually reads. */
-  --status-danger-bg: var(--danger-bg);
-  --status-danger-text: var(--danger-text);
-  --status-danger-border: var(--danger-border);
+  --status-danger-bg: rgba(234, 55, 41, 0.18);
+  --status-danger-text: #f2938a;
+  --status-danger-border: rgba(242, 147, 138, 0.42);
   --status-upcoming-border: rgba(103, 160, 239, 0.6);
   --sh03: rgba(0, 0, 0, 0.14);
   --sh05: rgba(0, 0, 0, 0.2);
-  --sh08: rgba(0, 0, 0, 0.3);
   --sh10: rgba(0, 0, 0, 0.34);
-  --sh16: rgba(0, 0, 0, 0.44);
   --glass-93: rgba(34, 29, 23, 0.92);
 }
+
 .yc-serif {
   font-family: var(--font-newsreader), 'Newsreader', Georgia, serif;
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for - #2577 and #2578
- [x] All existing tests and lints pass

## What is the current behavior?

Two issues, and working them turned up a third defect that neither described.

### #2577 — the a11y suite could not see contrast at all

`e2e/a11y.spec.ts` disabled axe's `color-contrast` rule outright:

```ts
.disableRules(['color-contrast'])   // "headless Chrome does not compute computed colour styles reliably"
```

**That premise is false.** Given a 2.1:1 pair and an 18:1 pair on one page, headless Chromium reports the first as a violation, the second as a pass, and neither as incomplete. The rule works. It was simply off — which is why every contrast defect this week shipped through green CI: 10 of 56 nodes below AA on `/book`, an expired-rabies badge at 1.89:1 on `/passport`, owner and medical details at 2.40:1 on `/card`. All found by hand.

The suite also covered none of those three pages.

### #2578 — a private token copy that had drifted twice

`.yc-warmbone` carried ~40 global tokens, applying on **every** load of the passport, with one consumer. It had already caused two shipped defects, both silently.

### The third thing, which neither issue knew about

`html[data-theme='dark']` declares `--status-danger-bg` and `--status-danger-border` but **not `--status-danger-text`**. Every other status family there declares all three. So it fell through to the `@theme` light value `#a6271d` and painted light-red ink on dark surfaces at **1.73:1**.

That reaches `StatusPill variant="danger"`, `DispensaryTable`'s pills via `--color-pill-danger-text`, a Forms icon, and the passport. It survived because `.yc-warmbone`'s private copy happened to declare the token — so the one page anyone opened in dark mode looked right. **Narrowing the copy is what exposed it.**

## What is the new behavior?

**The axe helper is split.** `runAxe` keeps contrast off for the four marketing pages, because `/` and `/pricing` currently fail it **26 times in light and 16 in dark**, worst 1.94:1 — turning it on there would make the suite red on arrival. That debt is now stated in the comment instead of hidden behind a wrong explanation. `runAxeWithContrast` runs the full AA set on `/passport`, `/card` and the unavailable `/book` state, in **both themes**.

Those tests stub the public API rather than aborting it (`blockCrossOriginRequests` aborts everything off-origin, which drops each page into its not-found state), and **assert the page rendered** before trusting a clean run — a not-found state is a handful of nodes that legitimately pass, so a broken fixture reads exactly like green. Not hypothetical: my first pass reported "0 violations" while checking 0 text nodes.

**`.yc-warmbone` is keyed on disagreement.** The page has its own light/dark control, so the only thing the global system cannot give it is a theme that differs from the root — and that is now the only case where anything is declared:

| selector | tokens |
|---|---|
| `.yc-warmbone` | **0** |
| `html[data-theme='dark'] .yc-warmbone[data-wb-theme='light']` | 26 |
| `html:not([data-theme='dark']) .yc-warmbone[data-wb-theme='dark']` | 26 |

When the two agree — every load until the reader touches the toggle — the page reads the same tokens as the rest of the app, and neither old failure mode is reachable. It also makes the no-flash behaviour **structural**: with no `data-wb-theme` nothing matches, so first paint is simply the root theme. 14 dead token names deleted.

**`--status-danger-text` added to the global dark theme.** Pill now 5.49:1 in dark, light unchanged at 5.74:1.

## Validation

| check | result |
|---|---|
| `tsc` | clean |
| lint | 0 errors |
| Jest | **12,050 pass** |
| Playwright a11y | 13/13, parallel and serial |

**Mutation-checked, not assumed.** The new e2e catches the real defect: with the `--status-danger-*` aliases removed, the dark passport test fails with `insufficient color contrast of 1.9 (foreground #a6271d, background #40281f, 9.5px bold)` and the light test still passes. The new unit guard catches all three defect classes — re-spelling the token fails 3 tests, putting a token back on the base class fails 1, aliasing a theme-flipping token fails 1.

**Passport rendering is unchanged.** All six theme states measured before and after the refactor: expired chip 5.49:1 dark / 5.74:1 light, EXPIRED label 6.52 / 6.48. Identical.

## What this does NOT do

- **It does not close #2578 as worded.** 52 hand-maintained values survive. Full consolidation would mean moving 24 `--status-*` declarations out of `@theme` — where `--color-pill-*` aliases them, backing `bg-pill-*` utilities in live use across the app. Editing token source behind app-wide utilities to fix a page with one consumer is the wrong trade. This closes the *harm* and the *undetectability*, narrows 76 declarations to 52, and puts the remainder under test.
- **It does not fix the 26+16 marketing contrast violations.** They are pre-existing and not mine to absorb silently; worth their own issue.

## Also fixed: the smoke test's false positive

`e2e/smoke.spec.ts`'s "no stack traces" assertion read
`page.locator('body').textContent()`. `textContent` returns the raw DOM text of every descendant **including `<script>`**, so it swept up Next's RSC payload — which legitimately serialises React owner stacks as `"stack":[]` — and tripped the regex on a page showing nothing of the sort. It fails on `origin/dev` today with no changes at all.

Switched to `innerText`, the rendered text, which is what the assertion has always been about: what a visitor can read. Regex and intent unchanged.

**Not weakened — mutation-checked both ways.** Rendering `at Object.getPublicPractice (prisma/client.js:42)` into the unavailable state fails the test; removing it passes. It still catches a real leak, and no longer catches the framework serialising its own component names.

16/16 smoke + a11y pass.
