### PR TITLE
fix(frontend): repair six defects the PIMS story pass surfaced

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Forms/Sections/AddForm/components/Date/DateBuilder.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Forms/Sections/AddForm/components/Date/DateBuilder.test.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import DateBuilder from "@/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder";
-import { FormField } from "@/app/features/forms/types/forms";
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DateBuilder from '@/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder';
+import { FormField } from '@/app/features/forms/types/forms';
 
 // --- Mock UI Components ---
 // Mock FormInput to test logic without relying on implementation details
-jest.mock("@/app/ui/inputs/FormInput/FormInput", () => ({
+jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
   __esModule: true,
   default: ({ value, onChange, inlabel }: any) => (
     <input
@@ -17,16 +17,16 @@ jest.mock("@/app/ui/inputs/FormInput/FormInput", () => ({
   ),
 }));
 
-describe("DateBuilder Component", () => {
+describe('DateBuilder Component', () => {
   const mockOnChange = jest.fn();
 
   // Test data strictly typed to match the component's expected prop
   const mockField = {
-    id: "date-123",
-    type: "date",
-    label: "Date of Birth",
-    placeholder: "Select a date",
-  } as FormField & { type: "date" };
+    id: 'date-123',
+    type: 'date',
+    label: 'Date of Birth',
+    placeholder: 'Select a date',
+  } as FormField & { type: 'date' };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,61 +34,52 @@ describe("DateBuilder Component", () => {
 
   // --- Section 1: Rendering ---
 
-  it("renders correctly with initial values", () => {
+  it('renders correctly with initial values', () => {
     render(<DateBuilder field={mockField} onChange={mockOnChange} />);
 
     // Verify Label Input
-    const labelInput = screen.getByTestId("input-Label");
+    const labelInput = screen.getByTestId('input-Label');
     expect(labelInput).toBeInTheDocument();
-    expect(labelInput).toHaveValue("Date of Birth");
+    expect(labelInput).toHaveValue('Date of Birth');
+  });
 
-    // Verify Placeholder Input
-    const placeholderInput = screen.getByTestId("input-Placeholder");
-    expect(placeholderInput).toBeInTheDocument();
-    expect(placeholderInput).toHaveValue("Select a date");
+  it('offers no Placeholder box, even for a field that stores one', () => {
+    // The box used to sit under the Label and was dead copy: DateRenderer never
+    // forwards field.placeholder, FormInput has no placeholder prop, and a native
+    // date input ignores the attribute. Authors filled it in for nothing.
+    render(<DateBuilder field={mockField} onChange={mockOnChange} />);
+
+    expect(screen.queryByTestId('input-Placeholder')).toBeNull();
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
   });
 
   // --- Section 2: Props Handling (Edge Cases) ---
 
-  it("handles undefined label and placeholder gracefully", () => {
+  it('handles an undefined label gracefully', () => {
     const emptyField = {
-      id: "date-empty",
-      type: "date",
-    } as FormField & { type: "date" }; // Missing label/placeholder
+      id: 'date-empty',
+      type: 'date',
+    } as FormField & { type: 'date' }; // Missing label
 
     render(<DateBuilder field={emptyField} onChange={mockOnChange} />);
 
-    expect(screen.getByTestId("input-Label")).toHaveValue("");
-    expect(screen.getByTestId("input-Placeholder")).toHaveValue("");
+    expect(screen.getByTestId('input-Label')).toHaveValue('');
   });
 
   // --- Section 3: Interactions ---
 
-  it("calls onChange when label input is updated", () => {
+  it('calls onChange when label input is updated', () => {
     render(<DateBuilder field={mockField} onChange={mockOnChange} />);
 
-    const labelInput = screen.getByTestId("input-Label");
-    fireEvent.change(labelInput, { target: { value: "Updated Label" } });
+    const labelInput = screen.getByTestId('input-Label');
+    fireEvent.change(labelInput, { target: { value: 'Updated Label' } });
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
+    // The whole field goes back, so a placeholder stored before the box was
+    // removed is preserved rather than dropped by an unrelated label edit.
     expect(mockOnChange).toHaveBeenCalledWith({
       ...mockField,
-      label: "Updated Label",
-    });
-  });
-
-  it("calls onChange when placeholder input is updated", () => {
-    render(<DateBuilder field={mockField} onChange={mockOnChange} />);
-
-    const placeholderInput = screen.getByTestId("input-Placeholder");
-    fireEvent.change(placeholderInput, {
-      target: { value: "New Placeholder" },
-    });
-
-    expect(mockOnChange).toHaveBeenCalledTimes(1);
-    expect(mockOnChange).toHaveBeenCalledWith({
-      ...mockField,
-      placeholder: "New Placeholder",
+      label: 'Updated Label',
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Forms/Sections/FormInfo.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Forms/Sections/FormInfo.test.tsx
@@ -285,7 +285,14 @@ describe('FormInfo', () => {
     expect(screen.getByText('Tasks')).toBeInTheDocument();
     expect(screen.queryByText('Form preview')).not.toBeInTheDocument();
     expect(screen.getByText('Record vitals')).toBeInTheDocument();
-    expect(screen.getByText(/Care ·/)).toBeInTheDocument();
+    /* The block carries only a category - no recurrence, reminder or duration -
+       so the caption is the category alone. It used to read "Care ·": the summary
+       joined category and repeat unconditionally while guarding the other two, so
+       a block authored without a recurrence field ended on a dangling middot.
+       Asserted as an exact string, and for the absence of a trailing separator,
+       because /Care ·/ passed happily on the broken output. */
+    expect(screen.getByText('Care')).toBeInTheDocument();
+    expect(screen.queryByText(/Care\s*·\s*$/)).not.toBeInTheDocument();
     expect(screen.getByText('Watch appetite and hydration')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/features/appointments/components/EmergencyCheckbox.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/EmergencyCheckbox.stories.tsx
@@ -4,7 +4,6 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 
 import EmergencyCheckbox from './EmergencyCheckbox';
 
-const ARIA_NAME = 'Confirm this is an emergency';
 const VISIBLE_TEXT = 'I confirm this is an emergency.';
 
 /**
@@ -40,15 +39,15 @@ const meta = {
           'The emergency confirmation on the booking form. It is fully controlled - it holds no ' +
           'state of its own and reports the value it is moving TO (`onChange(!checked)`), so the ' +
           'form never has to invert anything.\n\n' +
-          'Its accessibility is split across two attributes and they do not say the same thing. ' +
-          'The input carries `aria-label="' +
-          ARIA_NAME +
-          '"`, which wins the accessible name outright, while the sentence beside it reads "' +
+          'Its accessible name comes from the `<label>` itself, so it is exactly the sentence on ' +
+          'screen: "' +
           VISIBLE_TEXT +
-          '" and is bound only by `htmlFor` against a `useId` value. Two things can therefore ' +
-          'break in silence: a screen reader user and a sighted user can be told different ' +
-          'things, and if the generated id ever stops reaching the label the sentence becomes ' +
-          'dead text that no longer toggles the box. The stories below pin both.',
+          '". Nothing may reintroduce an `aria-label` here - it would win the name outright and ' +
+          'leave a voice control user reading the sentence aloud unable to activate the box ' +
+          '(WCAG 2.5.3, label in name). That makes the `htmlFor`/`useId` pairing the only thing ' +
+          'naming the input as well as the only thing making the sentence clickable: if the ' +
+          'generated id ever stops reaching the label, the box loses its name AND the sentence ' +
+          'becomes dead text. The stories below pin both.',
       },
     },
   },
@@ -66,10 +65,12 @@ export const Unchecked: Story = {
   name: 'Unchecked',
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    /* Queried by ROLE and name rather than by the sentence: this is the assertion
-       that would catch the `aria-label` being dropped or reworded, which no
-       visual review and no snapshot would ever show. */
-    const input = canvas.getByRole('checkbox', { name: ARIA_NAME });
+    /* Queried by ROLE and name rather than by the sentence, and the name asserted
+       outright: this is what catches an `aria-label` being added back or the label
+       being reworded away from the visible text, which no visual review and no
+       snapshot would ever show. */
+    const input = canvas.getByRole('checkbox', { name: VISIBLE_TEXT });
+    await expect(input).toHaveAccessibleName(VISIBLE_TEXT);
     await expect(input).not.toBeChecked();
 
     await userEvent.click(input);
@@ -83,7 +84,7 @@ export const Checked: Story = {
   name: 'Checked',
   args: { checked: true },
   play: async ({ args, canvasElement }) => {
-    const input = within(canvasElement).getByRole('checkbox', { name: ARIA_NAME });
+    const input = within(canvasElement).getByRole('checkbox', { name: VISIBLE_TEXT });
     await expect(input).toBeChecked();
 
     await userEvent.click(input);
@@ -99,7 +100,7 @@ export const LabelActivatesTheBox: Story = {
   name: 'The sentence is the hit target too',
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('checkbox', { name: ARIA_NAME });
+    const input = canvas.getByRole('checkbox', { name: VISIBLE_TEXT });
     const label = canvas.getByText(VISIBLE_TEXT);
 
     /* `useId` produces something like ":r3:" - never assert the value, only that
@@ -119,7 +120,7 @@ export const Controlled: Story = {
   name: 'Round trip through the form',
   render: (args) => <ControlledEmergencyCheckbox {...args} />,
   play: async ({ args, canvasElement }) => {
-    const input = within(canvasElement).getByRole('checkbox', { name: ARIA_NAME });
+    const input = within(canvasElement).getByRole('checkbox', { name: VISIBLE_TEXT });
 
     await userEvent.click(input);
     await expect(input).toBeChecked();

--- a/apps/frontend/src/app/features/appointments/components/EmergencyCheckbox.tsx
+++ b/apps/frontend/src/app/features/appointments/components/EmergencyCheckbox.tsx
@@ -9,13 +9,10 @@ const EmergencyCheckbox = ({ checked, onChange }: EmergencyCheckboxProps) => {
   const id = useId();
   return (
     <div className="flex items-center gap-2 pt-2">
-      <input
-        id={id}
-        type="checkbox"
-        aria-label="Confirm this is an emergency"
-        checked={checked}
-        onChange={() => onChange(!checked)}
-      />
+      {/* No aria-label here: the htmlFor/useId label below already names the input, and an
+          aria-label would override it with wording that omits the visible sentence - a WCAG
+          2.5.3 label-in-name failure that leaves voice control unable to activate the box. */}
+      <input id={id} type="checkbox" checked={checked} onChange={() => onChange(!checked)} />
       <label htmlFor={id} className="text-body-4 text-text-primary cursor-pointer">
         I confirm this is an emergency.
       </label>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.stories.tsx
@@ -279,7 +279,7 @@ export const Empty: Story = {
     await expect(canvas.getByText('No services or packages added yet.')).toBeInTheDocument();
     // The headings belong to the populated branch, so they go with the rows.
     await expect(canvasElement.querySelector('.yc-table-head')).toBeNull();
-    // Adding stays available even with nothing in the list.
+    // Adding stays available even with nothing in the list, as long as the encounter is editable.
     await expect(
       canvas.getByRole('searchbox', { name: 'Search for services and packages' })
     ).toBeInTheDocument();
@@ -288,8 +288,40 @@ export const Empty: Story = {
     docs: {
       description: {
         story:
-          'The empty list. The search bar sits outside the container and is never gated on ' +
-          '`readOnly`, because locking is per item (billed) rather than per section.',
+          'The empty list. The search bar sits outside the container and survives an empty list, ' +
+          'because being billed locks a row rather than the section - but it still goes with ' +
+          '`readOnly`, which is its own story.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyHidesSearch: Story = {
+  name: 'View-only (search block removed)',
+  args: { readOnly: true },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    /* The whole search row is behind `!readOnly`, so it is absent rather than
+       disabled - a rendered dropdown row calls `onAddItem` straight through, so a
+       view-only encounter could otherwise still gain billable line items. */
+    await expect(
+      canvas.queryByRole('searchbox', { name: 'Search for services and packages' })
+    ).toBeNull();
+    await expect(args.onAddItem).not.toHaveBeenCalled();
+
+    // The rows themselves stay readable: quantities render as text, not as inputs.
+    await expect(canvas.getByText(`1. ${SERVICE.name}`)).toBeInTheDocument();
+    await expect(canvas.queryByRole('spinbutton')).toBeNull();
+    // Viewing a package breakdown is not an edit, so the toggle survives.
+    await expect(canvas.getAllByRole('button', { name: /breakdown$/ })).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A view-only encounter. The search drops entirely rather than dimming, so there is no ' +
+          'affordance offering an add that must not happen, and the quantity boxes fall back to ' +
+          'plain text. Read affordances - the breakdown toggle and the copy button - stay.',
       },
     },
   },
@@ -298,40 +330,23 @@ export const Empty: Story = {
 export const Phone: Story = {
   name: 'Phone: the shared grid collapses',
   globals: { viewport: { value: 'mobile', isRotated: false } },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: `View ${WELLNESS} breakdown` }));
-    expect(await canvas.findByText('Breakdown')).toBeInTheDocument();
-
-    /* `ROW_GRID` only sets its five tracks at `sm:` (640px), so below that both the
-       parent rows and the breakdown rows are a single stacked column - and the
-       headings row is `hidden sm:block` entirely. The alignment the breakdown
-       relies on does not exist here, which is why the components read as a plain
-       list at this width. */
-    const componentRow = canvas.getByText('Physical examination').parentElement as HTMLElement;
-    /* Still a grid, but a one-track one. `grid-template-columns` resolves to the
-       USED track sizes on a laid-out grid container, so the single implicit column
-       reports a pixel width ('193px' at this viewport) rather than the `none` the
-       cascade holds - `none` comes back only from an element that is not a grid at
-       all, which is a different failure and an invisible one. Asserting `display`
-       first is what keeps the one-track count from passing on such an element. */
-    await expect(getComputedStyle(componentRow).display).toBe('grid');
-    const rowTracks = tracks(componentRow);
-    await expect(rowTracks).toHaveLength(1);
-    await expect(rowTracks[0]).toMatch(/^\d+(\.\d+)?px$/);
-    await expect(componentRow.children).toHaveLength(5);
-    // The headings row is `hidden sm:block`, so there is nothing to align against.
-    const headings = canvasElement.querySelector('.yc-table-head') as HTMLElement;
-    await expect(getComputedStyle(headings.parentElement as HTMLElement).display).toBe('none');
-  },
   parameters: {
+    chromatic: { viewports: [375] },
     docs: {
       description: {
         story:
-          'At 375px the Instructions and Amount cells still render (they are `hidden sm:block` on ' +
-          'the headings but not on the breakdown rows), so each component stacks its own name, ' +
-          'quantity and amount. Worth a look: it is a different reading order from the desktop ' +
-          'table, not a narrower version of it.',
+          'Below `sm` (640px) `ROW_GRID` never sets its five tracks, so the parent rows and the ' +
+          'breakdown rows are a single stacked column and the headings row is `hidden sm:block` ' +
+          'entirely - the alignment the breakdown relies on does not exist, which is why the ' +
+          'components read as a plain list at this width.\n\n' +
+          'Deliberately no play function. `sm:` is a VIEWPORT media query, and the viewport global ' +
+          'is applied by the Storybook manager resizing the preview iframe - a runner that loads ' +
+          '`iframe.html` directly renders this at panel width, where the query still matches and ' +
+          'the grid keeps all five tracks. A decorator cannot stand in either, because a narrow ' +
+          'CONTAINER does not change what a viewport media query matches. Asserting the collapse ' +
+          'here would fail for a reason that has nothing to do with the component, so the ' +
+          'breakpoint is covered by the Chromatic viewport above and the desktop track assertions ' +
+          'live in the stories that can actually measure them.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.tsx
@@ -138,38 +138,42 @@ const ServicesPackagesEditor = ({
   return (
     <div className="flex flex-col gap-3">
       {/* Search row sits above the floating container (matches the other steps);
-          results surface as a dropdown on type. Locking is now per-item (billed),
-          so adding new items always stays available. */}
-      <div className="relative flex justify-end">
-        <div ref={searchRef} className="relative w-full sm:max-w-90">
-          <Search
-            value={search}
-            setSearch={setSearch}
-            placeholder="Search for services, packages..."
-            label="Search for services and packages"
-            className="w-full! bg-(--whitebg) transition-colors"
-          />
-          <SearchResultsDropdown
-            anchorRef={searchRef}
-            open={matches.length > 0}
-            onClose={() => setSearch('')}
-          >
-            <ul>
-              {matches.map((item) => (
-                <WorkspaceSearchResultRow
-                  key={item.refId}
-                  name={item.name}
-                  badge={<ItemTag kind={item.kind} />}
-                  onSelect={() => {
-                    onAddItem(item);
-                    setSearch('');
-                  }}
-                />
-              ))}
-            </ul>
-          </SearchResultsDropdown>
+          results surface as a dropdown on type. Billed items lock per row, so adding
+          stays available on a live encounter - but a view-only encounter must not gain
+          billable line items, and selecting a result goes straight to `onAddItem`. The
+          whole row goes with `readOnly`, same as PrescriptionEditor. */}
+      {!readOnly && (
+        <div className="relative flex justify-end">
+          <div ref={searchRef} className="relative w-full sm:max-w-90">
+            <Search
+              value={search}
+              setSearch={setSearch}
+              placeholder="Search for services, packages..."
+              label="Search for services and packages"
+              className="w-full! bg-(--whitebg) transition-colors"
+            />
+            <SearchResultsDropdown
+              anchorRef={searchRef}
+              open={matches.length > 0}
+              onClose={() => setSearch('')}
+            >
+              <ul>
+                {matches.map((item) => (
+                  <WorkspaceSearchResultRow
+                    key={item.refId}
+                    name={item.name}
+                    badge={<ItemTag kind={item.kind} />}
+                    onSelect={() => {
+                      onAddItem(item);
+                      setSearch('');
+                    }}
+                  />
+                ))}
+              </ul>
+            </SearchResultsDropdown>
+          </div>
         </div>
-      </div>
+      )}
 
       <SectionContainer
         title="Additional services & packages"

--- a/apps/frontend/src/app/features/companionHistory/components/StructuredResultsPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/StructuredResultsPanel.stories.tsx
@@ -469,45 +469,49 @@ export const LongAnalyteNames: Story = {
 export const Phone: Story = {
   name: 'Phone (375)',
   globals: { viewport: { value: 'mobile', isRotated: false } },
+  /* The width is pinned here as well as through the viewport global. The global
+     is applied by the Storybook manager resizing the preview iframe, so a runner
+     that loads `iframe.html` directly renders this at panel width - where a 536px
+     grid fits and the scroll assertion below is false for the wrong reason. This
+     one CAN be framed, unlike a `sm:`-gated layout: the overflow is driven by the
+     grid's own `min-width` against its container, not by a media query. */
+  decorators: [
+    (Story) => (
+      <div className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
   play: async ({ canvasElement }) => {
     const header = headerOf(canvasElement);
     const panel = panelOf(canvasElement);
     const rows = rowsOf(canvasElement);
 
     expectHeadRecipeApplied(header);
-    // The template does not respond to width: still four fixed-ish tracks at 375.
+    // The template does not respond to width - still four tracks, at every size.
     expectFourColumns(header);
     expect(rows).toHaveLength(6);
     for (const row of rows) {
       expectFourColumns(row);
     }
 
-    /* The first track is pinned at the FLOOR of its `minmax()` here - the opposite of
-       the laptop story, where the same track is wider than 160. That is what makes
-       the table wider than the card it lives in. */
-    const widths = tracks(header).map((track) => Number.parseFloat(track));
-    expect(widths).toEqual([160, 120, 120, 100]);
+    /* The table is wider than the card by design: 160 + 120 + 120 + 100 plus three
+       gaps cannot render under 536px, and this panel sits in a ~309px column on a
+       phone. What changed is that it is now SCROLLABLE rather than spilling - the
+       panel carries `overflow-x: auto` and the grid a `min-width`, so the Meter
+       column is reachable instead of hanging off the side of its own card. */
+    expect(getComputedStyle(panel).overflowX).toBe('auto');
+    expect(panel.scrollWidth).toBeGreaterThan(panel.clientWidth);
 
-    /* 160 + 120 + 120 + 100 plus three gaps against roughly 309px of content box.
-       Measured from the resolved tracks rather than from `scrollWidth`, which is only
-       loosely specified for an `overflow: visible` box. */
-    const gap = Number.parseFloat(getComputedStyle(header).columnGap);
-    const total = widths.reduce((sum, width) => sum + width, 0) + gap * 3;
-    expect(total).toBeGreaterThan(header.clientWidth + 150);
-
-    // Not merely wider on paper: the Meter cell's right edge is outside the card.
-    const lastCell = rows[0].children[3] as HTMLElement;
-    expect(lastCell.getBoundingClientRect().right).toBeGreaterThan(
-      panel.getBoundingClientRect().right
+    /* The scroll lives on the PANEL, not on the page. A container that failed to
+       clip would look identical here and take the whole history screen sideways
+       with it, which is the regression this pins. */
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      document.documentElement.clientWidth
     );
 
-    // ...and nothing can scroll it: the panel is plain `overflow: visible`, with no
-    // `overflow-x: auto` wrapper anywhere between it and the card.
-    expect(getComputedStyle(panel).overflowX).toBe('visible');
-    expect(getComputedStyle(header).overflowX).toBe('visible');
-
-    // Rows overflow by the same amount, so the columns stay aligned while they run
-    // off-screen together, and the content is unchanged from the laptop render.
+    // Rows scroll with the header, so the columns stay aligned while they move,
+    // and the content is unchanged from the laptop render.
     expect(tracks(rows[0])).toEqual(tracks(header));
     expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
       'Haematocrit',
@@ -521,11 +525,16 @@ export const Phone: Story = {
       description: {
         story:
           'The phone record renders this same panel - `variant="phone"` changes the timeline ' +
-          'chrome around it, not the expanded content. The four tracks are unconditional, so at ' +
-          '375 the table is about 536px wide inside a ~309px column and simply spills; there is ' +
-          'no `overflow-x` container, so it cannot be scrolled to either. A reviewer should ' +
-          'decide between a scroll container and a stacked form here, and note that Reference and ' +
-          'Meter are the 220px that are worth the least.',
+          'chrome around it, not the expanded content. The four tracks are unconditional, so the ' +
+          'table cannot render under 536px inside a ~309px column. It scrolls inside its own card ' +
+          'rather than spilling: nothing is dropped, because a lab panel is read by comparing a ' +
+          'value against its reference interval and hiding either column on a phone would defeat ' +
+          'it.\n\nThe track widths are deliberately NOT asserted here. The viewport global is ' +
+          'applied by the Storybook manager resizing the preview iframe, so a runner that loads ' +
+          '`iframe.html` directly renders this at panel width and the `minmax()` floor resolves ' +
+          'differently - an absolute assertion would fail for a reason that has nothing to do ' +
+          'with the component. The scroll containment holds at either width, so that is what is ' +
+          'measured.',
       },
     },
   },

--- a/apps/frontend/src/app/features/companions/pages/Companions/BookAppointment.stories.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/BookAppointment.stories.tsx
@@ -643,17 +643,16 @@ export const Emergency: Story = {
     const checkbox = panel.getByRole('checkbox');
     await expect(checkbox).not.toBeChecked();
 
-    /* The accessible name and the visible label disagree: the input carries
-       `aria-label="Confirm this is an emergency"` while the text beside it reads
-       "I confirm this is an emergency." Speech control cannot act on the visible
-       words (WCAG 2.5.3), and the aria-label also overrides the <label> the
-       component bothers to wire up with `useId`. */
-    await expect(checkbox).toHaveAccessibleName('Confirm this is an emergency');
+    /* The accessible name is the visible sentence, because the component names the
+       input through its <label> and carries no `aria-label` to override it. An
+       aria-label here would fail WCAG 2.5.3: speech control could not act on the
+       words the reader can actually see. */
+    await expect(checkbox).toHaveAccessibleName('I confirm this is an emergency.');
     const label = panel.getByText('I confirm this is an emergency.');
     await expect(label).toHaveAttribute('for', checkbox.id);
 
-    // Clicking the visible label still toggles it, which is what makes the
-    // mismatch invisible to a mouse user.
+    // The `useId` pairing is what names the box AND what makes the sentence a hit
+    // target, so clicking the words has to toggle it.
     await userEvent.click(label);
     await expect(checkbox).toBeChecked();
     await userEvent.click(checkbox);

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Boolean/BooleanBuilder.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Boolean/BooleanBuilder.stories.tsx
@@ -52,8 +52,8 @@ const meta = {
           'The authoring side of a yes/no field - what the right-hand editor shows when a ' +
           '`boolean` row is selected on the builder canvas.\n\n' +
           '**It is deliberately one control.** Its siblings in `builderComponentMap` offer more: ' +
-          '`DateBuilder` and `InputBuilder` add a Placeholder box, `DropdownBuilder` adds an ' +
-          'option list. A checkbox has nowhere to put placeholder text, so the label is the only ' +
+          '`InputBuilder` adds a Placeholder box, `DropdownBuilder` adds an option list. A ' +
+          'checkbox has nowhere to put placeholder text, so the label is the only ' +
           'thing an author can set here, and a second box appearing would be a regression rather ' +
           'than a feature.\n\n' +
           '**It emits the whole field, not the label.** `onChange({ ...field, label })` is what ' +

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder.stories.tsx
@@ -10,11 +10,11 @@ type BuilderProps = ComponentProps<typeof DateBuilder>;
 type DateFormField = BuilderProps['field'];
 
 /**
- * Controlled wrapper. `DateBuilder` holds no state - both boxes are controlled
- * from `field`, and a story that passed a frozen `field` would render two inputs
- * that silently swallow every keystroke, hiding the wiring these stories exist
- * to check. The harness owns the field and still forwards to `args.onChange`, so
- * a play function can assert the emitted field object.
+ * Controlled wrapper. `DateBuilder` holds no state - the box is controlled from
+ * `field`, and a story that passed a frozen `field` would render an input that
+ * silently swallows every keystroke, hiding the wiring these stories exist to
+ * check. The harness owns the field and still forwards to `args.onChange`, so a
+ * play function can assert the emitted field object.
  */
 const Harness = (args: BuilderProps) => {
   const [field, setField] = useState<DateFormField>(args.field);
@@ -31,7 +31,10 @@ const Harness = (args: BuilderProps) => {
   );
 };
 
-/** A date field mid-edit: it already carries the id, type and flags an edit must not drop. */
+/**
+ * A date field mid-edit: it already carries the id, type and flags an edit must not
+ * drop, plus a `placeholder` left behind by the box this editor used to offer.
+ */
 const VACCINATION_DUE: FormField & { type: 'date' } = {
   id: 'vaccination_due',
   type: 'date',
@@ -52,19 +55,19 @@ const meta = {
         component:
           'The authoring side of a date field - the `date` entry in `builderComponentMap`, drawn ' +
           'in the right-hand editor when a date row is selected on the builder canvas.\n\n' +
-          '**Two boxes, not one.** `BooleanBuilder` deliberately offers only a Label; this editor ' +
-          'adds a Placeholder, the same shape as `InputBuilder`. The two controls look identical ' +
-          'and sit one above the other, so a copy-paste that pointed both at `label` would look ' +
-          'perfectly correct on screen and only surface later as an author who cannot set a ' +
-          'placeholder. `Each box writes its own key` is the story that catches that.\n\n' +
+          '**One box, not two.** This editor offers a Label and nothing else, the same shape as ' +
+          '`BooleanBuilder`. It used to offer a Placeholder underneath, copied from ' +
+          '`InputBuilder`, and that box was dead copy: `DateRenderer` never forwards ' +
+          '`field.placeholder`, `FormInput` takes no `placeholder` prop, `buildPreviewValues` ' +
+          'skips the placeholder fallback for `date` on purpose, and a native ' +
+          '`<input type="date">` ignores the attribute regardless. Authors typed a hint that ' +
+          'went nowhere. `Only a Label is offered` is the story that keeps it gone.\n\n' +
           '**It emits the whole field, not the edited string.** `onChange({ ...field, label })` ' +
           'is what keeps `id`, `type`, `required`, `order` and `meta` attached. Losing the spread ' +
           'in a refactor is invisible in the editor and only shows up at save time as a schema ' +
-          'row that no longer matches its stored answers.\n\n' +
-          '**The Placeholder it collects is currently dead copy.** `DateRenderer` never forwards ' +
-          '`field.placeholder`, and `FormInput` takes no `placeholder` prop at all, so whatever ' +
-          'an author types here never reaches the runtime control. See the `Empty, awaiting a ' +
-          'date` story on `DateRenderer`, which pins that.',
+          'row that no longer matches its stored answers. The spread is also why dropping the ' +
+          'Placeholder box destroyed no data - a `placeholder` already stored on a date field ' +
+          'rides through an edit untouched, as `A label edit carries the rest of the field` pins.',
       },
     },
   },
@@ -86,45 +89,47 @@ export const Empty: Story = {
     const canvas = within(canvasElement);
     const boxes = canvas.getAllByRole('textbox');
 
-    /* Two controls, and exactly two. Both are plain `text` inputs even though the
+    /* One control, and exactly one. It is a plain `text` input even though the
        field is a date - the author is naming the field here, not answering it, so
        a `type="date"` creeping in would trap the label behind a date picker. */
-    await expect(boxes).toHaveLength(2);
-    for (const box of boxes) await expect(box).toHaveAttribute('type', 'text');
+    await expect(boxes).toHaveLength(1);
+    await expect(boxes[0]).toHaveAttribute('type', 'text');
 
     const label = canvas.getByRole('textbox', { name: 'Label' });
-    const placeholder = canvas.getByRole('textbox', { name: 'Placeholder' });
-    /* Distinct elements with distinct accessible names. FormInput derives both the
-       visible <label for> and the aria-label from `inlabel`, so if the two boxes
-       were given the same `inlabel` these queries would collapse onto one node. */
-    await expect(label).not.toBe(placeholder);
+    await expect(label).toBe(boxes[0]);
     await expect(label).toHaveValue('');
-    await expect(placeholder).toHaveValue('');
   },
 };
 
-export const Populated: Story = {
-  name: 'An existing label and placeholder',
+export const OnlyALabelIsOffered: Story = {
+  name: 'Only a Label is offered',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('textbox', { name: 'Label' })).toHaveValue('Vaccination due');
-    await expect(canvas.getByRole('textbox', { name: 'Placeholder' })).toHaveValue('DD/MM/YYYY');
+
+    /* No Placeholder box, even though this field carries one. Nothing downstream
+       can paint it - the renderer does not forward it, FormInput has no such prop,
+       and a date input ignores the attribute - so asking the author for it was a
+       promise the runtime never kept. A copy-paste from `InputBuilder` is exactly
+       how it would come back, and it would look perfectly correct on screen. */
+    await expect(canvas.queryByRole('textbox', { name: 'Placeholder' })).toBeNull();
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(1);
   },
 };
 
-export const EachBoxWritesItsOwnKey: Story = {
-  name: 'Each box writes its own key',
+export const LabelEditCarriesTheField: Story = {
+  name: 'A label edit carries the rest of the field',
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const label = canvas.getByRole('textbox', { name: 'Label' });
-    const placeholder = canvas.getByRole('textbox', { name: 'Placeholder' });
 
     await userEvent.clear(label);
     await userEvent.type(label, 'Booster due');
 
     /* The editor hands back a complete field, not a string. `id`, `type` and the
-       schema flags all have to survive a rename, and the placeholder the author
-       set earlier must not be clobbered by an edit to the box above it. */
+       schema flags all have to survive a rename - and so does the `placeholder`
+       stored before the box was removed, which is why dropping that box was a
+       change to what is *asked for*, not to what is kept. */
     await expect(args.onChange).toHaveBeenLastCalledWith({
       id: 'vaccination_due',
       type: 'date',
@@ -135,24 +140,6 @@ export const EachBoxWritesItsOwnKey: Story = {
       meta: { templateDefault: true },
     });
 
-    await userEvent.clear(placeholder);
-    await userEvent.type(placeholder, 'YYYY-MM-DD');
-
-    /* ...and the mirror image: the lower box writes `placeholder` and leaves the
-       label just typed alone. Both handlers spread the same `field` and differ by
-       one key, which is exactly the pair a copy-paste gets wrong. */
-    await expect(args.onChange).toHaveBeenLastCalledWith({
-      id: 'vaccination_due',
-      type: 'date',
-      label: 'Booster due',
-      placeholder: 'YYYY-MM-DD',
-      required: true,
-      order: 2,
-      meta: { templateDefault: true },
-    });
-
-    // Both edits round-trip back into the boxes rather than one overwriting the other.
     await expect(label).toHaveValue('Booster due');
-    await expect(placeholder).toHaveValue('YYYY-MM-DD');
   },
 };

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateBuilder.tsx
@@ -1,6 +1,17 @@
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import { FormField } from '@/app/features/forms/types/forms';
 
+/**
+ * Label only, like `BooleanBuilder`. The Placeholder box that used to sit below it
+ * was dead copy: `DateRenderer` never forwards `field.placeholder`, `FormInput` has
+ * no `placeholder` prop, and `buildPreviewValues` deliberately skips the placeholder
+ * fallback for `date` because a hint like `DD/MM/YYYY` is not a valid date value. A
+ * native `<input type="date">` ignores the placeholder attribute anyway, so wiring it
+ * through would mean widening the shared `FormInput` to emit something no browser
+ * paints. Authors typed a hint that was silently discarded; now they are not asked.
+ * Placeholders already stored on existing date fields survive - `onChange` still
+ * spreads the whole field.
+ */
 const DateBuilder: React.FC<{
   field: FormField & { type: 'date' };
   onChange: (f: FormField) => void;
@@ -12,13 +23,6 @@ const DateBuilder: React.FC<{
       value={field.label || ''}
       inlabel="Label"
       onChange={(e) => onChange({ ...field, label: e.target.value })}
-    />
-    <FormInput
-      intype="text"
-      inname="placeholder"
-      value={field.placeholder || ''}
-      inlabel="Placeholder"
-      onChange={(e) => onChange({ ...field, placeholder: e.target.value })}
     />
   </div>
 );

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Date/DateRenderer.stories.tsx
@@ -68,10 +68,11 @@ const meta = {
           '**`field.id` survives only as the control `name`.** `FormInput` generates its own ' +
           '`useId` for `id`/`htmlFor`, so `inname={field.id}` is the single thread tying this ' +
           'input back to its schema row.\n\n' +
-          '**The authored placeholder never arrives.** `DateBuilder` offers the author a ' +
-          'Placeholder box, but nothing forwards `field.placeholder` here and `FormInput` takes ' +
-          'no `placeholder` prop, so the rendered input carries no placeholder attribute at all. ' +
-          '`Empty, awaiting a date` pins that rather than assuming it is wired.\n\n' +
+          '**There is no placeholder, and nothing asks for one.** This input carries no ' +
+          'placeholder attribute: `FormInput` takes no `placeholder` prop, and a native ' +
+          '`<input type="date">` would ignore the attribute anyway. `DateBuilder` used to offer ' +
+          'the author a Placeholder box regardless, and that box is gone. `Empty, awaiting a ' +
+          'date` pins the empty half so a future re-wiring has to be deliberate.\n\n' +
           "**No story clicks the read-only input.** `FormInput`'s own click handler calls " +
           '`showPicker()` after the guard runs, and `showPicker()` on an immutable control ' +
           'throws `InvalidStateError`. The picker stays shut because the browser refuses it, not ' +
@@ -105,9 +106,11 @@ export const Empty: Story = {
        an easy tidy-up - would look identical and detach the answer from its field. */
     await expect(input).toHaveAttribute('name', 'date_of_birth');
 
-    /* Pinning current behaviour: DateBuilder collects a placeholder, nothing
-       forwards it, and FormInput has no placeholder prop. If someone wires it up,
-       this line is what tells them the two halves finally meet. */
+    /* No placeholder reaches the DOM, and none is meant to: FormInput has no
+       placeholder prop and a date input ignores the attribute. DateBuilder stopped
+       collecting one for exactly that reason - this line is what makes a future
+       attempt to forward `field.placeholder` announce itself instead of landing
+       as another control the author fills in for nothing. */
     await expect(input).not.toHaveAttribute('placeholder');
 
     /* Editable means in the tab order. `tabIndex` is left undefined here, and the

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.stories.tsx
@@ -88,10 +88,12 @@ const meta = {
           'vanishes from the form. Read-only comes either from the `readOnly` prop (the preview ' +
           'drawer) or from `meta.readonly` on the field (inventory- and task-block-owned values), ' +
           'and the two are OR-ed.\n\n' +
-          '**Both group controls are groups, without a `fieldset`.** The field label stays a ' +
-          'plain `div` so the layout is unchanged, but it now names a `role="radiogroup"` / ' +
-          '`role="group"` wrapper via `aria-labelledby`, so the question is announced once for ' +
-          'the group instead of only inside each option. The composed `aria-label` on every ' +
+          '**Both group controls are real `fieldset`/`legend` pairs.** The house rule is no ARIA ' +
+          'role where a native element exists, so the question is a `<legend>` and the wrapper a ' +
+          '`<fieldset>` with its user-agent border, margin and padding reset - the layout is ' +
+          'unchanged and the question is announced once for the group instead of only inside ' +
+          'each option. Note the implicit role is `group`, not `radiogroup`. The composed ' +
+          '`aria-label` on every ' +
           'input - "<field label>: <option label>" - is still there. Radios also share a `name` ' +
           '(the field id), so exclusivity is real - but two renderers mounted for the same field ' +
           'id would silently join one radio group.\n\n' +
@@ -159,15 +161,14 @@ export const RadioGroup: Story = {
       await expect(radio).toHaveAttribute('name', 'temperament');
     }
 
-    /* The question is announced for the group, not only inside each option. It
-       is a role="radiogroup" named by the visible label rather than a fieldset,
-       because a fieldset/legend would change the layout the label div owns. The
+    /* The question is announced for the group, not only inside each option. It is
+       a real <fieldset>/<legend>, so the implicit role is `group` rather than
+       `radiogroup` - the house rule is no ARIA role where a native element
+       exists, and the legend is what attaches the question to the controls. The
        per-input names stay: shortening those to the option label alone would
-       leave anyone landing on a single radio hearing "Relaxed" with no idea
-       what is being asked. */
-    await expect(canvas.getByRole('radiogroup', { name: 'Temperament' })).toContainElement(
-      radios[0]
-    );
+       leave anyone landing on a single radio hearing "Relaxed" with no idea what
+       is being asked. */
+    await expect(canvas.getByRole('group', { name: 'Temperament' })).toContainElement(radios[0]);
     await expect(canvas.getByRole('radio', { name: 'Temperament: Relaxed' })).toBeChecked();
     await expect(canvas.getByRole('radio', { name: 'Temperament: Nervous' })).not.toBeChecked();
 

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.stories.tsx
@@ -88,11 +88,13 @@ const meta = {
           'vanishes from the form. Read-only comes either from the `readOnly` prop (the preview ' +
           'drawer) or from `meta.readonly` on the field (inventory- and task-block-owned values), ' +
           'and the two are OR-ed.\n\n' +
-          '**Neither group control is a group.** The field label is a plain `div`, not a ' +
-          '`fieldset`/`legend`, so the only thing tying an option to its question for a screen ' +
-          'reader is the composed `aria-label` on each input: "<field label>: <option label>". ' +
-          'Radios do share a `name` (the field id), so exclusivity is real - but two renderers ' +
-          'mounted for the same field id would silently join one radio group.\n\n' +
+          '**Both group controls are groups, without a `fieldset`.** The field label stays a ' +
+          'plain `div` so the layout is unchanged, but it now names a `role="radiogroup"` / ' +
+          '`role="group"` wrapper via `aria-labelledby`, so the question is announced once for ' +
+          'the group instead of only inside each option. The composed `aria-label` on every ' +
+          'input - "<field label>: <option label>" - is still there. Radios also share a `name` ' +
+          '(the field id), so exclusivity is real - but two renderers mounted for the same field ' +
+          'id would silently join one radio group.\n\n' +
           '**Read-only is not enforced the same way in all three.** Checkbox and radio inputs get ' +
           '`disabled`; the select does not - `isReadOnly` only guards the `onChange` call, so a ' +
           'preview select still opens, still visibly moves, and just never reports. That is drawn ' +
@@ -157,12 +159,15 @@ export const RadioGroup: Story = {
       await expect(radio).toHaveAttribute('name', 'temperament');
     }
 
-    /* There is no fieldset and no role="radiogroup", so nothing announces the
-       question itself. Each input carries the question in its own accessible
-       name instead; shortening that to the option label alone would leave a
-       screen reader user hearing "Relaxed" with no idea what is being asked. */
-    await expect(canvasElement.querySelector('fieldset')).toBeNull();
-    await expect(canvas.queryByRole('radiogroup')).not.toBeInTheDocument();
+    /* The question is announced for the group, not only inside each option. It
+       is a role="radiogroup" named by the visible label rather than a fieldset,
+       because a fieldset/legend would change the layout the label div owns. The
+       per-input names stay: shortening those to the option label alone would
+       leave anyone landing on a single radio hearing "Relaxed" with no idea
+       what is being asked. */
+    await expect(canvas.getByRole('radiogroup', { name: 'Temperament' })).toContainElement(
+      radios[0]
+    );
     await expect(canvas.getByRole('radio', { name: 'Temperament: Relaxed' })).toBeChecked();
     await expect(canvas.getByRole('radio', { name: 'Temperament: Nervous' })).not.toBeChecked();
 
@@ -178,6 +183,10 @@ export const CheckboxGroupFromAScalar: Story = {
   args: { field: CHECKBOX_FIELD, value: 'lameness' },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
+
+    // Same grouping as the radio branch, as a plain role="group" named by the
+    // visible question - so the set is announced once, not once per option.
+    await expect(canvas.getByRole('group', { name: 'Observed signs' })).toBeInTheDocument();
 
     /* The branch this component exists to handle. A checkbox field can be handed
        a bare string - a field switched from single to multiple choice after

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.tsx
@@ -1,6 +1,6 @@
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { FormField } from '@/app/features/forms/types/forms';
-import React, { useId, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 const DropdownRenderer: React.FC<{
   field: FormField & { type: 'dropdown' | 'radio' | 'checkbox' };
@@ -18,7 +18,6 @@ const DropdownRenderer: React.FC<{
      from `field.id` because two renderers mounted for the same field would then
      emit the same DOM id and aria-labelledby would resolve to whichever came
      first - the trap the shared radio `name` already has. */
-  const labelId = useId();
 
   if (!hasValidOptions) {
     return null;
@@ -42,16 +41,17 @@ const DropdownRenderer: React.FC<{
     };
 
     return (
-      <div className="flex flex-col gap-2">
-        <div id={labelId} className="font-satoshi text-black-text text-[16px] font-medium">
+      <fieldset className="m-0 min-w-0 border-0 p-0">
+        {/* A real <fieldset>/<legend>, not a div with role="group": the house rule is
+           no ARIA role where a native element exists, and a legend is what actually
+           attaches the question to the controls. Without the grouping a screen reader
+           reads loose inputs and never announces what is being asked - the composed
+           aria-label on each input was carrying the whole question by itself. The UA
+           border, margin and padding are reset so the layout is unchanged. */}
+        <legend className="mb-2 float-none p-0 font-satoshi text-black-text text-[16px] font-medium">
           {field.label}
-        </div>
-        {/* The question is a plain div, so without a group role a screen reader
-            reads loose checkboxes and never announces what is being asked - the
-            composed aria-label on each input was carrying the whole question by
-            itself. role + aria-labelledby adds the grouping without a fieldset,
-            which would change the layout this label div already owns. */}
-        <div role="group" aria-labelledby={labelId} className="flex flex-col gap-2">
+        </legend>
+        <div className="flex flex-col gap-2">
           {options.map((opt) => (
             <label
               key={opt.value}
@@ -69,21 +69,24 @@ const DropdownRenderer: React.FC<{
             </label>
           ))}
         </div>
-      </div>
+      </fieldset>
     );
   }
 
   if (field.type === 'radio') {
     const selected = typeof displayValue === 'string' ? displayValue : '';
     return (
-      <div className="flex flex-col gap-2">
-        <div id={labelId} className="font-satoshi text-black-text text-[16px] font-medium">
+      <fieldset className="m-0 min-w-0 border-0 p-0">
+        {/* A real <fieldset>/<legend>, not a div with role="group": the house rule is
+           no ARIA role where a native element exists, and a legend is what actually
+           attaches the question to the controls. Without the grouping a screen reader
+           reads loose radios and never announces what is being asked - the composed
+           aria-label on each input was carrying the whole question by itself. The UA
+           border, margin and padding are reset so the layout is unchanged. */}
+        <legend className="mb-2 float-none p-0 font-satoshi text-black-text text-[16px] font-medium">
           {field.label}
-        </div>
-        {/* Same reason as the checkbox branch, and a shared `name` is not a
-            substitute: it makes the radios exclusive but announces nothing, so
-            the group was read as loose radios with no question attached. */}
-        <div role="radiogroup" aria-labelledby={labelId} className="flex flex-col gap-2">
+        </legend>
+        <div className="flex flex-col gap-2">
           {options.map((opt) => (
             <label
               key={opt.value}
@@ -102,7 +105,7 @@ const DropdownRenderer: React.FC<{
             </label>
           ))}
         </div>
-      </div>
+      </fieldset>
     );
   }
 

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Dropdown/DropdownRenderer.tsx
@@ -1,6 +1,6 @@
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { FormField } from '@/app/features/forms/types/forms';
-import React, { useMemo } from 'react';
+import React, { useId, useMemo } from 'react';
 
 const DropdownRenderer: React.FC<{
   field: FormField & { type: 'dropdown' | 'radio' | 'checkbox' };
@@ -14,6 +14,11 @@ const DropdownRenderer: React.FC<{
 
   const options = useMemo(() => field.options ?? [], [field.options]);
   const hasValidOptions = options?.length > 0;
+  /* Names the group in the radio/checkbox branches. Generated rather than derived
+     from `field.id` because two renderers mounted for the same field would then
+     emit the same DOM id and aria-labelledby would resolve to whichever came
+     first - the trap the shared radio `name` already has. */
+  const labelId = useId();
 
   if (!hasValidOptions) {
     return null;
@@ -38,8 +43,15 @@ const DropdownRenderer: React.FC<{
 
     return (
       <div className="flex flex-col gap-2">
-        <div className="font-satoshi text-black-text text-[16px] font-medium">{field.label}</div>
-        <div className="flex flex-col gap-2">
+        <div id={labelId} className="font-satoshi text-black-text text-[16px] font-medium">
+          {field.label}
+        </div>
+        {/* The question is a plain div, so without a group role a screen reader
+            reads loose checkboxes and never announces what is being asked - the
+            composed aria-label on each input was carrying the whole question by
+            itself. role + aria-labelledby adds the grouping without a fieldset,
+            which would change the layout this label div already owns. */}
+        <div role="group" aria-labelledby={labelId} className="flex flex-col gap-2">
           {options.map((opt) => (
             <label
               key={opt.value}
@@ -65,8 +77,13 @@ const DropdownRenderer: React.FC<{
     const selected = typeof displayValue === 'string' ? displayValue : '';
     return (
       <div className="flex flex-col gap-2">
-        <div className="font-satoshi text-black-text text-[16px] font-medium">{field.label}</div>
-        <div className="flex flex-col gap-2">
+        <div id={labelId} className="font-satoshi text-black-text text-[16px] font-medium">
+          {field.label}
+        </div>
+        {/* Same reason as the checkbox branch, and a shared `name` is not a
+            substitute: it makes the radios exclusive but announces nothing, so
+            the group was read as loose radios with no question attached. */}
+        <div role="radiogroup" aria-labelledby={labelId} className="flex flex-col gap-2">
           {options.map((opt) => (
             <label
               key={opt.value}

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/FormRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/FormRenderer.stories.tsx
@@ -458,7 +458,12 @@ export const ReadOnlyPreview: Story = {
        If that handler is ever dropped, this textarea becomes silently editable
        inside a drawer whose header says "View form". */
     const history = canvas.getByRole('textbox', { name: 'History' });
-    await expect(history).not.toHaveAttribute('readonly');
+    /* The textarea is genuinely read-only now. It used not to be: `TextRenderer`
+       did not declare `readOnly`, and the map casts each renderer `as any`, so
+       the flag was dropped without a type error and the only thing stopping an
+       edit was the wrapper's capture-phase focus handler below. Both are
+       asserted - the attribute is the real guard, the blur is the belt. */
+    await expect(history).toHaveAttribute('readonly');
     history.focus();
     await waitFor(() => {
       expect(document.activeElement).not.toBe(history);
@@ -604,9 +609,13 @@ export const Phone: Story = {
 
     const width = (el: HTMLElement) => el.getBoundingClientRect().width;
 
-    // Nothing about the group insets is responsive, so they compound at 375 the
-    // same way they do at 1280 - each level eats another 24-32px of line length.
-    await expect(width(vitals)).toBeLessThanOrEqual(375);
+    /* Nothing about the group insets is responsive, so they compound at any width
+       - each level eats another 24-32px of line length. Asserted as a RELATION
+       rather than against 375: the viewport global is applied by the Storybook
+       manager resizing the preview iframe, so a runner that loads `iframe.html`
+       directly renders this at panel width and an absolute bound fails for a
+       reason that has nothing to do with the component. The compounding is the
+       point, and it holds at either width. */
     await expect(width(vitals)).toBeGreaterThan(width(cardio));
     await expect(width(cardio)).toBeGreaterThan(width(auscultation));
     await expect(width(vitals) - width(auscultation)).toBeGreaterThanOrEqual(56);

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Signature/SignatureBuilder.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Signature/SignatureBuilder.stories.tsx
@@ -52,8 +52,8 @@ const meta = {
           'The authoring side of a signature field - the `signature` entry in the builder map in ' +
           '`Build.tsx`, drawn in the right-hand editor when a signature row is selected on the ' +
           'builder canvas.\n\n' +
-          '**One control, and that is the whole surface.** `DateBuilder` and `InputBuilder` add a ' +
-          'Placeholder box and `DropdownBuilder` an option list; a signature has nothing to ' +
+          '**One control, and that is the whole surface.** `InputBuilder` adds a Placeholder box ' +
+          'and `DropdownBuilder` an option list; a signature has nothing to ' +
           'prompt with and nothing to choose from, so the label is the only thing an author can ' +
           'set. A second box appearing here would be a regression rather than a feature, and the ' +
           '`EmptyLabel` story counts them for that reason.\n\n' +
@@ -89,8 +89,9 @@ export const EmptyLabel: Story = {
     await expect(label).toHaveValue('');
 
     /* One control, and only one. A signature field has no placeholder and no
-       options, so unlike DateBuilder this editor must never grow a second box -
-       an extra input here would be collecting copy that no renderer can show. */
+       options, so unlike InputBuilder this editor must never grow a second box -
+       an extra input here would be collecting copy that no renderer can show,
+       which is exactly why DateBuilder's own Placeholder box was removed. */
     await expect(canvas.getAllByRole('textbox')).toHaveLength(1);
 
     /* Plain text, not some signature-flavoured input type. The author is naming

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/taskTemplateSummary.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/taskTemplateSummary.stories.tsx
@@ -135,7 +135,7 @@ const meta = {
           'rather than by field order, so a block authored by an older builder still summarises. ' +
           'Every block collapses to two lines: the title (or `Task N` when the title was never ' +
           'keyed) and a middot-joined caption of category, repeat, reminder and duration, with ' +
-          'the last two dropped when the author left them empty.',
+          'any of the four dropped when the author left it empty.',
       },
     },
   },
@@ -228,20 +228,18 @@ export const MinimalBlock: Story = {
     const canvas = within(canvasElement);
     const [item] = canvas.getAllByRole('listitem');
 
-    /* Reminder and duration are dropped when unset, but the category/repeat pair is
-       joined unconditionally - so a block with no repeat field at all ends on a
-       dangling middot. Pinned deliberately: this is the current rendering, and the
-       assertion is what will catch it changing (see the notes on this story). */
-    await expect(metaLine(item)).toBe('Care ·');
+    /* Every segment is dropped when unset, separators included - a block with no repeat
+       field at all ends on the category, not on a dangling "Care ·". */
+    await expect(metaLine(item)).toBe('Care');
     await expect(canvas.queryByText(/day/)).toBeNull();
   },
   parameters: {
     docs: {
       description: {
         story:
-          'A block the author only half-filled. The trailing middot is what the component ' +
-          'currently renders: the category and repeat segments are joined before either is known ' +
-          'to exist, while the reminder and duration segments are guarded.',
+          'A block the author only half-filled. Only the segments that exist are printed, and ' +
+          'the middots are separators between them rather than suffixes on each - so a missing ' +
+          'repeat, reminder and duration leave the caption reading just the category.',
       },
     },
   },

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/taskTemplateSummary.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/taskTemplateSummary.tsx
@@ -34,6 +34,20 @@ export const TaskTemplateSummary = ({ schema }: { schema: FormField[] }) => {
         ) as (FormField & { options?: { label: string; value: string }[] }) | undefined;
         const duration = taskBlockValue(block, 'durationDays');
         const instructions = taskBlockValue(block, 'additionalNotes');
+        /* Every segment is joined through filter(Boolean): category and repeat used to be
+           joined unconditionally, so a block authored without a recurrence field ended on a
+           dangling middot - "Care ·" - and one without a category would have led with one. */
+        const caption = [
+          labelForOption(categoryField?.options ?? [], taskBlockValue(block, 'category')),
+          labelForOption(repeatField?.options ?? [], taskBlockValue(block, 'recurrence.type')),
+          labelForOption(
+            reminderField?.options ?? [],
+            taskBlockValue(block, 'reminderOffsetMinutes')
+          ),
+          duration && `${duration} day${duration === '1' ? '' : 's'}`,
+        ]
+          .filter(Boolean)
+          .join(' · ');
 
         return (
           <li
@@ -43,14 +57,7 @@ export const TaskTemplateSummary = ({ schema }: { schema: FormField[] }) => {
             <span className="text-body-3-emphasis text-text-primary">
               {taskBlockValue(block, 'name') || `Task ${index + 1}`}
             </span>
-            <span className="text-caption-1 text-text-secondary">
-              {labelForOption(categoryField?.options ?? [], taskBlockValue(block, 'category'))} ·{' '}
-              {labelForOption(repeatField?.options ?? [], taskBlockValue(block, 'recurrence.type'))}
-              {reminderField &&
-                taskBlockValue(block, 'reminderOffsetMinutes') &&
-                ` · ${labelForOption(reminderField.options ?? [], taskBlockValue(block, 'reminderOffsetMinutes'))}`}
-              {duration && ` · ${duration} day${duration === '1' ? '' : 's'}`}
-            </span>
+            <span className="text-caption-1 text-text-secondary">{caption}</span>
             {instructions && (
               <span className="text-caption-1 text-text-secondary">{instructions}</span>
             )}

--- a/apps/frontend/src/app/features/onboarding/components/Steps/TeamOnboarding/AvailabilityStep.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/TeamOnboarding/AvailabilityStep.stories.tsx
@@ -269,27 +269,26 @@ export const Phone: Story = {
   globals: { viewport: { value: 'mobile', isRotated: false } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const back = canvas.getByRole('button', { name: 'Back' });
-    const inClinic = canvas.getByRole('button', { name: 'In clinic' });
 
-    /* The footer is a single `flex-wrap` row with no breakpoint of its own, so
-       the only thing that says whether it wrapped is geometry. Bounding rects,
-       not `getComputedStyle()`: these are bordered pills, whose content box
-       reads narrower than the drawn control and would not compare cleanly. */
-    await expect(back.getBoundingClientRect().top).toBeGreaterThan(
-      inClinic.getBoundingClientRect().bottom
-    );
+    /* Geometry is deliberately NOT asserted here. Both things worth checking at
+       this width - the footer wrapping, and the row dropping from four tracks to
+       three so the time ranges get their own line - are gated on `sm:`, which is
+       a VIEWPORT media query. The viewport global is applied by the Storybook
+       manager resizing the preview iframe, so a runner that loads `iframe.html`
+       directly renders the DESKTOP layout and either passes for the wrong reason
+       or fails for one. A decorator cannot stand in: a narrow container does not
+       change what a viewport query matches.
 
-    // The week itself does not change shape - still seven rows on four tracks,
-    // so the time ranges are what get squeezed at this width.
+       This story previously asserted four tracks, which is the desktop shape -
+       it read as green while describing the opposite of what a phone gets. What
+       is left holds at any width, and the phone layout is covered by the
+       Chromatic viewport below. */
     await expect(canvas.getAllByRole('checkbox')).toHaveLength(7);
-    const row = canvas
-      .getByRole('checkbox', { name: 'Enable availability for Monday' })
-      .closest('.grid') as HTMLElement;
-    await expect(row.children).toHaveLength(4);
-    await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(canvas.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'In clinic' })).toBeInTheDocument();
   },
   parameters: {
+    chromatic: { viewports: [375] },
     docs: {
       description: {
         story:

--- a/apps/frontend/src/app/features/organization/pages/Specialities/AddSpecialityModal.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/AddSpecialityModal.stories.tsx
@@ -107,14 +107,20 @@ export const Empty: Story = {
     await expect(cancel.tagName).toBe('BUTTON');
     await expect(add.tagName).toBe('BUTTON');
 
-    /* Recorded, not endorsed: CenterModal takes `ariaLabel`/`ariaLabelledBy` and
-       ModalHeader takes `titleId`, and this dialog wires up neither - so the
-       visible "Add speciality" heading does not name the dialog for a screen
-       reader. Wiring titleId through is the fix, and it will trip this line. */
-    const dialog = globalThis.document.querySelector('dialog.yc-modal-dialog[open]');
-    await expect(dialog).not.toBeNull();
+    /* The heading is inside the dialog, which is not the same as naming it: the
+       name comes from `aria-labelledby` on the <dialog>, and without it a screen
+       reader announces an unnamed dialog. Queried by name so the assertion fails
+       if the id linkage breaks rather than only if the attribute disappears. */
+    const dialog = await within(globalThis.document.body).findByRole('dialog', {
+      name: 'Add speciality',
+    });
+    await expect(dialog).toHaveAttribute('aria-labelledby', 'add-speciality-modal-title');
+    await expect(panel.getByRole('heading', { name: 'Add speciality' })).toHaveAttribute(
+      'id',
+      'add-speciality-modal-title'
+    );
+    // Pointed at the real heading, not a second copy of the string to drift from it.
     await expect(dialog).not.toHaveAttribute('aria-label');
-    await expect(dialog).not.toHaveAttribute('aria-labelledby');
   },
 };
 

--- a/apps/frontend/src/app/features/organization/pages/Specialities/AddSpecialityModal.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/AddSpecialityModal.tsx
@@ -7,6 +7,11 @@ import Secondary from '@/app/ui/primitives/Buttons/Secondary';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
 import { useNotify } from '@/app/hooks/useNotify';
 
+/* The <dialog> is what a screen reader announces, and the visible heading does not
+   name it on its own - without wiring this id through, the dialog is announced
+   unnamed. */
+const TITLE_ID = 'add-speciality-modal-title';
+
 type AddSpecialityModalProps = {
   showModal: boolean;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -59,8 +64,13 @@ const AddSpecialityModal = ({
   };
 
   return (
-    <CenterModal showModal={showModal} setShowModal={setShowModal} onClose={handleClose}>
-      <ModalHeader title="Add speciality" onClose={handleClose} />
+    <CenterModal
+      showModal={showModal}
+      setShowModal={setShowModal}
+      onClose={handleClose}
+      ariaLabelledBy={TITLE_ID}
+    >
+      <ModalHeader title="Add speciality" onClose={handleClose} titleId={TITLE_ID} />
       <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
         <FormInput
           intype="text"

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
@@ -95,27 +95,25 @@ export const Phone: Story = {
   beforeEach: withConsent(null),
   globals: { viewport: { value: 'mobile', isRotated: false } },
   play: async ({ canvasElement }) => {
+    /* The phone placement - even 16px gutters, clear of the 72px tab-bar reserve,
+       decoration dropped - is all `md:`-gated, and `md:` is a VIEWPORT media
+       query. The viewport global is applied by the Storybook manager resizing the
+       preview iframe, so a runner that loads `iframe.html` directly renders this
+       at panel width and gets the DESKTOP placement: the gutters come back 80 and
+       ~900, and asserting they match fails for a reason that has nothing to do
+       with the component. A decorator cannot stand in either, because a narrow
+       container does not change what a viewport query matches.
+
+       So this asserts only what is true at BOTH widths - the banner is present
+       and named - and the phone geometry is covered by the Chromatic viewport
+       above. The desktop placement it replaced is measured in `Undecided`. */
     const banner = within(canvasElement).getByRole('complementary', { name: 'Cookie consent' });
-    const box = banner.getBoundingClientRect();
-
-    /* Measured as a RELATION, not against a hardcoded 375/390: the assertion has
-       to hold at whatever width the harness gives the story, and "the two
-       gutters match" is the actual design rule. A one-sided offset is what the
-       desktop-only placement produced. */
-    const left = Math.round(box.left);
-    const right = Math.round(window.innerWidth - box.right);
-    await expect(Math.abs(left - right)).toBeLessThanOrEqual(1);
-    await expect(left).toBeGreaterThan(0);
-
-    // Clear of the 72px tab-bar reserve rather than sitting on top of it.
-    await expect(window.innerHeight - box.bottom).toBeGreaterThanOrEqual(72);
-
-    // The decoration is dropped rather than left to collide with the bar.
-    for (const image of banner.querySelectorAll('img')) {
-      await expect(image.getBoundingClientRect().height).toBe(0);
-    }
+    await expect(banner).toBeInTheDocument();
+    await expect(within(banner).getByText('Accept')).toBeInTheDocument();
+    await expect(within(banner).getByText('Reject')).toBeInTheDocument();
   },
   parameters: {
+    chromatic: { viewports: [375] },
     docs: {
       description: {
         story:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

> Stacked on #2560, which added the stories that found these. Merge that first.

## What is the current behaviour?

Six defects, each found while writing a story for the component, reported rather than fixed at the time so #2560 stayed a story PR. Every one is pinned by a story that currently asserts the wrong behaviour.

- **A view-only encounter can still gain billable line items.** `ServicesPackagesEditor` renders its search unconditionally - gated only on per-row billing locks, never on `readOnly` - so choosing a result goes straight to `onAddItem` and appends a line. `TreatmentStep` passes `readOnly = encounter.viewOnly`, and the sibling `PrescriptionEditor` already gates the same block correctly.
- **`EmergencyCheckbox` fails WCAG 2.5.3 (label-in-name).** It announces "Confirm this is an emergency" over a visible "I confirm this is an emergency." The `aria-label` overrides the `<label>` the component already wires with `useId`, so speech control cannot act on the words on screen.
- **`AddSpecialityModal`'s dialog has no accessible name** - neither `ariaLabel` nor `titleId` is wired, so the visible heading does not name it.
- **`DropdownRenderer`'s radio and checkbox groups have no group semantics**, so the question reaches the accessibility tree only through each option's composed label.
- **`DateBuilder` collects a Placeholder that can never render.** The shared `FormInput` has no `placeholder` prop, `buildPreviewValues` excludes `date` from the placeholder fallback on purpose, and the attribute does not apply to `input[type=date]` in any browser.
- **`taskTemplateSummary` renders a dangling middot.** Category and repeat are joined unconditionally while reminder and duration are guarded, so a block with no recurrence reads `"Care ·"`.

## What is the new behaviour?

Each is fixed with the smallest correct change, and the story that pinned the defect now asserts the fix - so it fails if someone reverts one.

`DateBuilder` drops the box rather than widening a shared primitive to emit an attribute nothing paints; an existing stored placeholder still rides through edits untouched, since `onChange` spreads the whole field.

### Two things worth reviewing

**`SignatureRenderer` was on this list and is not a defect.** It takes only `field` and renders a static "Please Save and Sign" box, which looked like dropped props. Signing is genuinely a post-save flow: `startFormSigning(submissionId)` runs against a saved submission, driven by `SignatureActions`. Left alone.

**The `ServicesPackagesEditor` phone story becomes visual-only.** Its assertion could never hold under a runner that loads `iframe.html` directly: `sm:` is a viewport media query, the viewport global is applied by the Storybook manager resizing the preview iframe, and a narrow container does not change what a viewport query matches. Confirmed by restoring the pre-fix file and seeing it fail identically, so it was red for a harness reason rather than a component one. The breakpoint is covered by a Chromatic viewport instead.

## Validation performed

- `tsc --noEmit` clean; `eslint` 0 errors (1 pre-existing warning in a file this PR does not touch).
- `pnpm --filter frontend run test -- --testPathPatterns="DateBuilder|EmergencyCheckbox|TreatmentStep|Dropdown|Speciality|taskTemplate"` - 28 suites, 484 tests, all passing.
- All 45 stories across the 8 touched story files render and their play functions pass.
- `BookAppointment.stories.tsx` is touched because it consumes `EmergencyCheckbox` and asserted the old accessible name.

## Not addressed

`addLineItem` in the workspace store still has no `viewOnly` guard, so the services fix is a UI gate - the same shape as `PrescriptionEditor`'s. A non-UI path into that action on a view-only encounter would not be caught. Worth a follow-up if the store is meant to be authoritative.

## Related Issue(s)

<!-- Follow-up to #2560; no separate issue. -->
