### PR TITLE
fix(frontend): alias the dark danger ink, and cover the passport's own toggle

### DIFF
--- a/apps/frontend/e2e/a11y.spec.ts
+++ b/apps/frontend/e2e/a11y.spec.ts
@@ -215,6 +215,13 @@ const stubPublicApi = async (page: Page) => {
   );
 };
 
+/**
+ * The warm-bone surface in each theme, read back off the element to prove a
+ * toggle actually repainted rather than only updating React state.
+ */
+const WARM_BONE_LIGHT_SCREEN = '#f7f3ec';
+const WARM_BONE_DARK_SCREEN = '#2f271e';
+
 for (const theme of ['light', 'dark'] as const) {
   test.describe(`Shared public pages — accessibility, ${theme} (WCAG 2.1 AA incl. contrast)`, () => {
     test.use({ colorScheme: theme });
@@ -255,6 +262,18 @@ for (const theme of ['light', 'dark'] as const) {
       // Now it disagrees with the root, which is the only state that activates
       // the overrides.
       await expect(main).toHaveAttribute('data-wb-theme', theme === 'dark' ? 'light' : 'dark');
+
+      // The attribute alone proves only that React updated its state. If either
+      // disagreement selector is broken or renamed, the attribute still flips,
+      // the override simply never applies, and the page sits in the perfectly
+      // valid root theme - where axe passes and the regression goes unseen.
+      // Verified by renaming both selectors: the attribute assertion stayed
+      // green. So assert the PALETTE repainted, which is what they exist to do.
+      const surface = await main.evaluate((el) =>
+        getComputedStyle(el).getPropertyValue('--screen').trim()
+      );
+      expect(surface).toBe(theme === 'dark' ? WARM_BONE_LIGHT_SCREEN : WARM_BONE_DARK_SCREEN);
+
       await expect(page.getByText(/expired/i).first()).toBeVisible();
 
       const results = await runAxeWithContrast(page);

--- a/apps/frontend/e2e/a11y.spec.ts
+++ b/apps/frontend/e2e/a11y.spec.ts
@@ -235,6 +235,32 @@ for (const theme of ['light', 'dark'] as const) {
       expect(results.violations).toEqual([]);
     });
 
+    test(`the passport survives its own theme toggle in ${theme}`, async ({ page }) => {
+      // The branch the other test cannot reach. #2578 keyed the warm-bone
+      // overrides on DISAGREEMENT: they apply only when the reader has pushed
+      // this page away from the root theme. Setting the OS scheme alone always
+      // leaves the two in agreement, so both new selectors - and every token
+      // inside them - stay unexercised, and a broken one would leave the suite
+      // green.
+      await page.goto('/passport/e2e-a11y');
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await expect(page.getByText('Luna')).toBeVisible();
+
+      // Before the toggle the attribute is absent: the page follows the root.
+      const main = page.locator('main.yc-warmbone');
+      await expect(main).not.toHaveAttribute('data-wb-theme', /.*/);
+
+      await page.getByRole('button', { name: /toggle light or dark theme/i }).click();
+
+      // Now it disagrees with the root, which is the only state that activates
+      // the overrides.
+      await expect(main).toHaveAttribute('data-wb-theme', theme === 'dark' ? 'light' : 'dark');
+      await expect(page.getByText(/expired/i).first()).toBeVisible();
+
+      const results = await runAxeWithContrast(page);
+      expect(results.violations).toEqual([]);
+    });
+
     test(`the shared companion card has no axe violations in ${theme}`, async ({ page }) => {
       await page.goto('/card/e2e-a11y');
       await page.waitForLoadState('networkidle').catch(() => {});

--- a/apps/frontend/src/app/__tests__/ui/tokens/warmboneTokenClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/warmboneTokenClosure.test.ts
@@ -111,6 +111,19 @@ describe('warm-bone overrides cover what the passport reads', () => {
     expect(Object.keys(base)).toEqual([]);
   });
 
+  it('scopes each override so it cannot apply when the themes agree', () => {
+    // Colour cannot catch this one. Drop the :not() from the dark override and
+    // it also applies under a dark root - where it paints the same dark values,
+    // so every rendered pixel is identical and no contrast test can see it.
+    // What comes back is defect 2's mechanism: the copy declaring tokens in the
+    // agreeing state, shadowing body:has([data-yc-app]) again. So it is asserted
+    // structurally, which is the only place it is visible.
+    expect(LIGHT_OVERRIDE).toContain("html[data-theme='dark']");
+    expect(DARK_OVERRIDE).toContain("html:not([data-theme='dark'])");
+    expect(CSS).toContain(DARK_OVERRIDE);
+    expect(CSS).toContain(LIGHT_OVERRIDE);
+  });
+
   it('aliases only to tokens that do not themselves flip', () => {
     // An override may alias a global token ONLY if that token resolves the same
     // under either root - otherwise the alias re-imports the very theme the

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1120,7 +1120,6 @@ html[data-theme='dark'] {
   --status-no-show-text: #f0a36c;
   --status-no-show-border: rgba(249, 115, 22, 0.5);
   --status-danger-bg: rgba(234, 55, 41, 0.18);
-  --danger-text: #f2938a;
   --status-danger-border: rgba(242, 147, 138, 0.42);
   /* The missing third. Every other status family here declares bg, border AND
      text; danger declared only two, so --status-danger-text fell through to the
@@ -1131,7 +1130,7 @@ html[data-theme='dark'] {
      It went unnoticed because .yc-warmbone carried a private copy that happened
      to declare the token, so the one page anybody looked at in dark mode looked
      right. Narrowing that copy (#2578) is what exposed this. */
-  --status-danger-text: #f2938a;
+  --status-danger-text: var(--danger-text);
 }
 
 /* Native control theming + flip transition, scoped to the marketing surface. */


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [x] There is an issue for the bug/feature this PR is for - follow-up to #2577 / #2578
- [x] All existing tests and lints pass

## What is the current behavior?

Two P1 review findings landed on #2579 and it merged before they were addressed. Both are correct.

### 1. A stray duplicate token, and a literal where an alias belongs

`html[data-theme='dark']` on `dev` currently contains:

```css
  --status-danger-bg: rgba(234, 55, 41, 0.18);
  --danger-text: #f2938a;                      /* <- stray: already declared 80 lines above */
  --status-danger-border: rgba(242, 147, 138, 0.42);
  ...
  --status-danger-text: #f2938a;               /* <- the same literal a third time */
```

**The stray line is residue from my own mutation test.** The first run of that script broke its paths part-way through, so its restore silently failed; the second run then took its backup *from the already-mutated file*, and every later "restore" faithfully put the mutation back. It never surfaced in a measurement because the real declaration below it still wins, so the passport and the danger pill both measured correct throughout.

The second half is worse, because it is a design mistake rather than an accident: the fix that shipped repeated `#f2938a` as an independent literal in a block that already declares that value — **recreating, inside the change meant to remove it, the exact drift mechanism #2578 is about.**

### 2. The new a11y coverage never exercises the branch #2578 added

#2578 keyed the warm-bone overrides on **disagreement**: they apply only once the reader has pushed the passport away from the root theme. The tests added in #2579 set the OS colour scheme and nothing else, which always leaves the page and the root in agreement — so both new selectors, and every token inside them, went unexercised. A broken selector or a sub-AA pair in either would have left the suite green.

## What is the new behavior?

- The stray `--danger-text` is gone, and `--status-danger-text` is now `var(--danger-text)`. One value, one owner.
- A new test per root theme clicks the passport's own toggle and re-runs axe on the far side, so the disagreement branch is behaviourally covered.

## Validation

`tsc` clean · lint 0 errors · `warmboneTokenClosure` 6/6 · new toggle tests 2/2.

**Mutation-checked, not assumed.** Putting the dark ink into the **light** override — the branch that activates only when the root is dark and the reader asks for light — fails the dark-root test with `insufficient color contrast of 1.8 (foreground #f2938a, background #f6e2da)`, while the light-root test correctly still passes. That is precisely the branch the review said was uncovered.

**Nothing regressed.** The app-wide danger pill is 5.49:1 dark / 5.74:1 light. All six passport theme states are unchanged: 5.49/6.52 dark, 5.74/6.48 light.

## Note for whoever runs this locally

The pre-push hook failed on this branch with `Module '@prisma/client' has no exported member 'PrismaClient'` — the generated client is per-worktree and had not been built here. `pnpm --filter @yosemite-crew/database exec prisma generate` fixes it. Unrelated to this change, but it silently blocks the push rather than reporting why.
