### PR TITLE
chore(repo): bump desktop and mobile versions for the release train

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yosemite-crew/desktop",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "description": "Desktop shell for Yosemite Crew PIMS — Windows, macOS, Linux.",
   "author": "Yosemite Crew",

--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,8 +143,8 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "1.6.1"
+        versionCode 20
+        versionName "1.6.2"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''
         ]

--- a/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
+++ b/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = mobileAppYC/mobileAppYC.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 9TZWPYQ45S;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = mobileAppYC/Info.plist;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -403,7 +403,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = mobileAppYC/mobileAppYC.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 9TZWPYQ45S;
 				INFOPLIST_FILE = mobileAppYC/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Yosemite Crew";
@@ -413,7 +413,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Desktop and mobile have each accumulated a release worth of work that is already on `main` and has never been tagged. Measured against each surface's own last release tag rather than against `main`, which is the distinction that hides this:

```
apps/desktop    v0.1.0-beta.4..dev    21 files, 3235 insertions
apps/mobileAppYC  mobile-v1.6.1..dev  310 files, 9882 insertions
```

Both version files still read the version that was already shipped, so neither surface can be tagged where it stands.

**Desktop `0.1.0-beta.4`** is the version published as `v0.1.0-beta.4` on 2026-08-19. Since then: DEA compliance logs made survivable and failing loudly, durable-log writes carrying a traversal segment refused, a compliance log directory that escapes its parent refused, and a real witness required before waste counts as witnessed (#2521).

**Mobile `1.6.1` / build 19** is the version published as `mobile-v1.6.1` on 2026-08-21. Since then: the splash loop reshot from the marketing master, onboarding ring descender clipping and last-slide spacing repaired, sessions refreshing again now that token expiry decodes without `node:buffer`, lists reporting that they failed to load instead of showing an empty state, the breed picker able to retry, and the dark-mode and WCAG contrast sweep across Home, sign-up, the map and the wallet.

## What is the new behavior?

Versions only, three files, seven lines. No behaviour changes.

```
apps/desktop/package.json                      0.1.0-beta.4 -> 0.1.0-beta.5
apps/mobileAppYC/android/app/build.gradle      versionName 1.6.1 -> 1.6.2, versionCode 19 -> 20
apps/mobileAppYC/ios/.../project.pbxproj       MARKETING_VERSION 1.6.1 -> 1.6.2 (both configs)
                                               CURRENT_PROJECT_VERSION 19 -> 20 (both configs)
```

The mobile side was set with `node scripts/mobile/version.mjs --set 1.6.2`, which rewrites every configuration in both files and moves the build number to `max(current)+1`, so the two platforms cannot drift. `--check` passes:

```
android  versionName 1.6.2  versionCode 20
ios      MARKETING_VERSION 1.6.2  CURRENT_PROJECT_VERSION 20
both platforms agree.
```

## Why this has to land before the promotion

Neither surface can be tagged without it, and both failure modes are ones this repo has already paid for.

`electron-builder` names its release from `apps/desktop/package.json`, not from the pushed tag. Tagging `v0.1.0-beta.5` against a package still reading `beta.4` publishes the signed installers into an orphan draft at `v0.1.0-beta.4` and leaves the tagged release with no assets, which is exactly what happened on `desktop-v0.1.0-beta.3` (2026-08-08). The `verify` job in `desktop-release.yml` now fails the run rather than letting that through, so without this bump the desktop release simply does not build.

Both app stores reject a version that is not higher than the live one. `mobile-release.yml` checks this in `preflight` specifically so the rejection does not arrive after a full signed build and an upload attempt.

No test reads either version: the desktop fixtures hard-code their own (`BASE_CTX.appVersion = '0.1.0'` in `diagnostics.test.ts`, `'0.1.0-beta.4'` as channel-derivation input in `updater.test.ts`), and `pnpm-lock.yaml` does not record workspace package versions.

## Related Issue(s)

Refs #2585
