### PR TITLE
fix(frontend): match story fetch stubs on the parsed host, not a substring

### DIFF
--- a/apps/frontend/src/app/features/marketing/pages/About/About.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/About/About.stories.tsx
@@ -75,6 +75,9 @@ const NON_HUMAN_PAYLOAD = CONTRIBUTOR_PAYLOAD.filter(
    the network entirely while the cache is inside its 5 minute TTL and already holds
    a Discord string. Seeding both keys is therefore the whole of "the stats
    resolved", with no request to intercept. */
+const GITHUB_API_HOST = 'api.github.com';
+const CONTRIBUTORS_PATH = '/contributors';
+const COMMUNITY_API_PATH = '/api/community/';
 const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
 const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
@@ -126,7 +129,20 @@ const withAboutData =
     const originalFetch = globalThis.fetch;
     globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.includes('api.github.com') && url.includes('/contributors')) {
+      /*
+       * Matched on the parsed host and path, not on substrings of the whole URL.
+       * `url.includes('api.github.com')` is also true of
+       * `https://evil.example/?next=api.github.com`, which is the shape CodeQL
+       * flags as js/incomplete-url-substring-sanitization. The base only exists so
+       * a relative same-origin path still parses.
+       */
+      let parsed: URL | null = null;
+      try {
+        parsed = new URL(url, 'http://localhost');
+      } catch {
+        parsed = null;
+      }
+      if (parsed?.hostname === GITHUB_API_HOST && parsed.pathname.endsWith(CONTRIBUTORS_PATH)) {
         // A promise that never settles leaves the hook on its initial `null`, which
         // is the loading branch - there is no separate loading flag to set.
         if (contributors === 'pending') return new Promise<Response>(() => {});
@@ -135,7 +151,7 @@ const withAboutData =
       // The stats hook talks to same-origin route handlers, which do not exist in
       // Storybook. Answering them here keeps the failure deliberate rather than
       // leaving it to whatever the dev server returns for an unknown path.
-      if (url.includes('/api/community/')) {
+      if (parsed?.pathname.startsWith(COMMUNITY_API_PATH)) {
         return Promise.resolve(new Response('upstream unavailable', { status: 503 }));
       }
       return originalFetch.call(globalThis, input, init);

--- a/apps/frontend/src/app/features/overview/pages/OverviewPage.stories.tsx
+++ b/apps/frontend/src/app/features/overview/pages/OverviewPage.stories.tsx
@@ -78,9 +78,30 @@ const buildContributors = (count: number) =>
   Array.from({ length: count }, (_, index) => ({ login: `contributor-${index}` }));
 
 const SUMMARY_HOST = 'raw.githubusercontent.com';
-const REPO_URL = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
+const REPO_HOST = 'api.github.com';
+const REPO_PATH = '/repos/YosemiteCrew/Yosemite-Crew';
 const CONTRIBUTORS_PATH = '/contributors';
 const STATUS_HOST = 'api.openstatus.dev';
+
+/*
+ * Route the stub on the parsed host, never on a substring of the whole URL.
+ * `url.includes('api.github.com')` is also true of
+ * `https://evil.example/?next=api.github.com`, so a substring test decides which
+ * fixture answers a request using text an attacker could put anywhere in it. The
+ * stub only ever sees URLs this story controls, but the shape is the one CodeQL
+ * flags as js/incomplete-url-substring-sanitization and it is not worth carrying
+ * in a file that exists to be copied.
+ *
+ * The base is only there so a relative same-origin path still parses; every URL
+ * matched below is absolute.
+ */
+const parseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url, 'http://localhost');
+  } catch {
+    return null;
+  }
+};
 
 const jsonResponse = (body: unknown) =>
   new Response(JSON.stringify(body), {
@@ -111,25 +132,28 @@ const withGithubStats = (fixture: StatsFixture | 'never-resolves') => () => {
 
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
+    const parsed = parseUrl(url);
 
-    if (url.includes(STATUS_HOST)) {
+    if (parsed?.hostname === STATUS_HOST) {
       return Promise.resolve(jsonResponse({ status: 'operational' }));
     }
 
-    // The summary URL carries a `?t=` cache-buster, so match on the host.
-    const isStatsRequest = url.includes(SUMMARY_HOST) || url.startsWith(REPO_URL);
-    if (!isStatsRequest) {
+    // The summary URL carries a `?t=` cache-buster, which is why the host is
+    // matched rather than the full URL.
+    const isSummaryRequest = parsed?.hostname === SUMMARY_HOST;
+    const isRepoRequest = parsed?.hostname === REPO_HOST && parsed.pathname.startsWith(REPO_PATH);
+    if (!isSummaryRequest && !isRepoRequest) {
       return original.call(globalThis, input, init);
     }
 
     if (fixture === 'never-resolves') {
       return new Promise<Response>(() => {});
     }
-    if (url.includes(SUMMARY_HOST)) {
+    if (isSummaryRequest) {
       return Promise.resolve(jsonResponse(buildSummary(fixture.dailyClones)));
     }
-    // Checked before the repo URL: the contributors endpoint is a path under it.
-    if (url.includes(CONTRIBUTORS_PATH)) {
+    // Checked before the repo root: the contributors endpoint is a path under it.
+    if (parsed?.pathname.endsWith(CONTRIBUTORS_PATH)) {
       return Promise.resolve(jsonResponse(buildContributors(fixture.contributors)));
     }
     return Promise.resolve(jsonResponse({ stargazers_count: fixture.stargazers }));


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two Storybook fetch stubs route requests by testing whether the host appears anywhere in the URL string:

```ts
if (url.includes(STATUS_HOST)) { ... }
const isStatsRequest = url.includes(SUMMARY_HOST) || url.startsWith(REPO_URL);
if (url.includes('api.github.com') && url.includes('/contributors')) { ... }
```

`String.includes` does not know where in the URL it matched, so a host named in a query parameter, in a path segment, or as a prefix of a longer registered domain all satisfy it. CodeQL reports this as `js/incomplete-url-substring-sanitization`, high severity, and it is currently blocking the dev to main promotion (#2585): `main`'s ruleset carries a `code_scanning` rule with `security_alerts_threshold: high_or_higher`, so any open CodeQL alert at high or above refuses the merge.

Alerts 1332, 1333 and 1334.

## What is the new behavior?

Both stubs parse the URL once and compare `hostname` exactly. Paths are matched on `pathname`, which excludes the query string, so a cache-buster or `?per_page=100&anon=true` cannot reach the path test.

Routing is unchanged for every URL the hooks actually request. Checked against the real constants in `useOverviewStats.ts` and `assets.ts`:

```
ok  old=summary      new=summary      raw.githubusercontent.com/.../summary.json
ok  old=summary      new=summary      .../summary.json?t=1735689600000
ok  old=stargazers   new=stargazers   api.github.com/repos/YosemiteCrew/Yosemite-Crew
ok  old=contributors new=contributors .../contributors?per_page=100&anon=true
ok  old=status       new=status       api.openstatus.dev/public/status/yosemite-crew
ok  old=passthrough  new=passthrough  example.com/other
ok  old=passthrough  new=passthrough  /api/community/github-releases
```

What does change is the set of URLs that were being answered from fixtures and should not have been:

```
old=summary  new=passthrough  https://evil.example/?next=raw.githubusercontent.com
old=summary  new=passthrough  https://raw.githubusercontent.com.evil.example/summary.json
old=status   new=passthrough  https://evil.example/api.openstatus.dev/x
```

These are stories, so nothing here ships: `.stories.tsx` files are not imported by the app. The reason to fix rather than dismiss is that the alerts block the promotion either way, the fix is smaller than the dismissal rationale, and these two files are the pattern every new story stub gets copied from.

## The fourth alert is dismissed, not fixed

Alert 1331, `js/clear-text-storage-of-sensitive-data`, on `AppointmentLockWindowPreference.stories.tsx:85`. The flagged flow is a story decorator saving `localStorage` before it overwrites it and putting it back on unmount:

```ts
const previousSaved = globalThis.localStorage.getItem(STORAGE_KEY);
// ...
globalThis.localStorage.setItem(STORAGE_KEY, previousSaved);
```

`getItem` to `setItem` on the same key is what the rule matches. The key is `yc_appointment_lock_window` and the value is an appointment lock window duration, which is not sensitive, and the round trip is correct test hygiene: without it a story leaves its fixture behind in the developer's browser. Rewriting correct cleanup to satisfy a taint path would be the wrong trade, so it is dismissed as a false positive rather than changed.

## Validation

```
pnpm --filter frontend run type-check          clean
npx eslint <both story files>                  clean
npx jest --testPathPatterns "OverviewPage|About"   2 suites, 11 tests, all pass
```

## Related Issue(s)

Refs #2585
