### PR TITLE
fix(repo): resolve the six Codex findings on the dev to main promotion

### DIFF
--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -143,8 +143,16 @@ jobs:
       # event ever writes; left optional, a failure posted later cannot block a
       # merge. So a non-promotion and an exempt `main-direct` pull request both
       # get an explicit pass here rather than silence.
+      # `always()` is load-bearing, not decoration. Without it this step is
+      # skipped whenever "Check the head branch" above exits 1, which is exactly
+      # the disallowed pull request this context is supposed to settle for. Made
+      # required on main's ruleset, such a pull request would then sit forever on
+      # a `promotion-guard/dev-contains-main` status that no event will ever
+      # write, instead of showing the actionable rejection the step above already
+      # produced. The retarget guard is kept: a bot pull request that was moved to
+      # dev is no longer a pull request into main and needs no status at all.
       - name: dev must contain main
-        if: steps.retarget.outputs.retargeted != 'true'
+        if: always() && steps.retarget.outputs.retargeted != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REPO: ${{ github.repository }}

--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -61,18 +61,64 @@ type AdmitBody = {
  * `tx.appointment.create`. It is a different source from the one
  * `withOrgPermissions()` authorises, which is why the two must be compared.
  */
+const ORGANIZATION_REFERENCE_PREFIX = "Organization/";
+
+/**
+ * One organisation id, in one spelling.
+ *
+ * `withOrgPermissions()` normalizes whitespace and nothing else - see
+ * `normalizeOrgId` in middlewares/rbac.ts - so `x-org-id: Organization/org_a`
+ * reaches this controller as `"Organization/org_a"`, while the body reference
+ * naming that same organisation resolves to `"org_a"`. Comparing the two
+ * strictly answered 403 to a caller writing to the tenant it was authorised
+ * for, which is the guard refusing valid work rather than catching an escape.
+ * Both sides go through here before they meet.
+ */
+const bareOrganisationId = (value: string): string => {
+  const trimmed = value.trim();
+  return trimmed.startsWith(ORGANIZATION_REFERENCE_PREFIX)
+    ? trimmed.slice(ORGANIZATION_REFERENCE_PREFIX.length).trim()
+    : trimmed;
+};
+
+/**
+ * The subset of an appointment body this tenant guard reads, and no more.
+ *
+ * Deliberately narrow: the service validates the full payload, and a second
+ * definition of a valid appointment here would drift from that one. What the
+ * guard cannot afford is to GUESS. `req.body` is `unknown` at runtime whatever
+ * the handler's TypeScript annotation claims, and every shape the old manual
+ * traversal failed to understand produced `undefined` - indistinguishable from
+ * "this body names no organisation", which is the branch that lets a write
+ * through with no tenant comparison at all. Parsing turns that silence into a
+ * refusal.
+ *
+ * `participant` is `nullish` because a body genuinely may not carry one, and
+ * the service rejects that downstream on its own terms. A participant list
+ * that is PRESENT but malformed is a different thing and is refused here.
+ */
+const tenantGuardBodySchema = z.object({
+  participant: z
+    .array(
+      z.object({
+        actor: z.object({ reference: z.string().nullish() }).nullish(),
+      }),
+    )
+    .nullish(),
+});
+
+type TenantGuardBody = z.infer<typeof tenantGuardBodySchema>;
+
 const resolveBodyOrganisationId = (
-  body: AppointmentRequestDTO | undefined,
+  body: TenantGuardBody,
 ): string | undefined => {
-  const participants = body?.participant;
-  if (!Array.isArray(participants)) return undefined;
-  for (const participant of participants) {
-    const reference = participant?.actor?.reference;
+  for (const participant of body.participant ?? []) {
+    const reference = participant.actor?.reference;
     if (
       typeof reference === "string" &&
-      reference.startsWith("Organization/")
+      reference.startsWith(ORGANIZATION_REFERENCE_PREFIX)
     ) {
-      const id = reference.slice("Organization/".length).trim();
+      const id = bareOrganisationId(reference);
       if (id) return id;
     }
   }
@@ -209,10 +255,23 @@ export const AppointmentController = {
         return res.status(400).json({ message: "Missing organisationId" });
       }
 
-      const bodyOrganisationId = resolveBodyOrganisationId(req.body);
+      // safeParse, not parse: `parseError` in the shared helper has no ZodError
+      // branch, so a thrown ZodError would leave here as a 500 carrying the
+      // serialised issue list. A body this guard cannot read is a bad request.
+      const parsedBody = tenantGuardBodySchema.safeParse(req.body);
+      if (!parsedBody.success) {
+        logger.warn(
+          "Rejected an appointment whose participant list could not be read",
+        );
+        return res.status(400).json({
+          message: "The appointment participants are malformed.",
+        });
+      }
+
+      const bodyOrganisationId = resolveBodyOrganisationId(parsedBody.data);
       if (
         bodyOrganisationId &&
-        bodyOrganisationId !== authorisedOrganisationId
+        bodyOrganisationId !== bareOrganisationId(authorisedOrganisationId)
       ) {
         logger.warn(
           "Rejected an appointment naming an organisation the caller is not authorised for",

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -259,6 +259,68 @@ describe("AppointmentPrismaController", () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
+    /* `withOrgPermissions()` normalizes whitespace and nothing else, so a
+       caller sending `x-org-id: Organization/org_a` arrives here with the
+       prefix still attached while the body reference for that same practice
+       resolves to the bare `org_a`. Comparing the two spellings strictly
+       answered 403 to a caller writing to its OWN tenant, which is the guard
+       breaking valid work rather than catching an escape. */
+    it("accepts an authorised id that still carries its FHIR prefix", async () => {
+      (req as any).organisationId = "Organization/org_a";
+      req.body = bodyNaming("org_a");
+      mockedService.createAppointmentFromPms.mockResolvedValue({
+        id: "appt_5",
+      } as any);
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    /* Both sides prefixed is the same question asked the other way round. */
+    it("still refuses a different organisation when both carry the prefix", async () => {
+      (req as any).organisationId = "Organization/org_a";
+      req.body = bodyNaming("org_b");
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    /* The annotation on `req.body` is erased at runtime, so a participant list
+       that is not a list of participants used to read as `undefined` - which is
+       indistinguishable from "names no organisation", the branch that lets the
+       write through with no comparison at all. It is now refused instead. */
+    it("refuses a participant list it cannot read rather than skipping the guard", async () => {
+      (req as any).organisationId = "org_a";
+      req.body = {
+        resourceType: "Appointment",
+        participant: [{ actor: { reference: 42 } }],
+      } as any;
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    /* A body carrying no participant key at all is a legitimate absence, not a
+       malformed one: the service rejects it on its own terms. */
+    it("does not treat an absent participant list as malformed", async () => {
+      (req as any).organisationId = "org_a";
+      req.body = { resourceType: "Appointment", participant: null } as any;
+      mockedService.createAppointmentFromPms.mockResolvedValue({
+        id: "appt_6",
+      } as any);
+
+      await AppointmentController.createFromPms(req as any, res as any);
+
+      expect(mockedService.createAppointmentFromPms).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
     /* A body naming no organisation is left to the service, which already
        rejects it. Inventing a tenant for an ambiguous request is not this
        guard's job. */

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -426,7 +426,10 @@ const usePractice = (slug: string): PracticeView => {
 const useSlots = (slug: string, serviceId: string | null, date: string) => {
   const [result, setResult] = useState<SlotsResult | null>(null);
 
-  const key = serviceId ? `${serviceId}|${date}` : null;
+  // `date` is "" whenever the reader clears the native date input. There is no
+  // such day to ask for, so this holds the previous result instead of fetching
+  // slots for an empty string and rendering whatever the API makes of it.
+  const key = serviceId && date ? `${serviceId}|${date}` : null;
 
   useEffect(() => {
     if (!serviceId || !key) return;
@@ -586,8 +589,17 @@ const DayAndTime = ({
         aria-describedby="book-day-hint"
         onChange={(event) => onDateChange(event.target.value)}
       />
+      {/*
+        A native date input can be cleared, and the change handler stores the ""
+        it fires with. `formatLongDay("")` builds `new Date("T00:00:00Z")`, which
+        is an Invalid Date, and Intl throws `RangeError: Invalid time value` on
+        it - mid-render, on a public page, so clearing the field took the whole
+        booking form down. The day is dropped from the hint until one is chosen
+        again rather than formatted.
+      */}
       <p id="book-day-hint" className={META_TEXT}>
-        {formatLongDay(date)} · you can book up to {bookingWindowDays} days ahead.
+        {date ? `${formatLongDay(date)} · ` : null}you can book up to {bookingWindowDays} days
+        ahead.
       </p>
     </div>
 
@@ -916,9 +928,11 @@ const BookClient = ({ slug }: { slug: string }) => {
   // the test's getByText for the service name is singular - it would throw
   // "found multiple elements". Any recap renders "{name} · {n} min", never the
   // bare name.
-  const summaryLine = chosen
-    ? `${chosen.name} · ${chosen.durationMinutes} min · ${formatLongDay(date)} · ${selectedTime}`
-    : '';
+  // `date` guarded for the same reason as the hint above: formatting "" throws.
+  const summaryLine =
+    chosen && date
+      ? `${chosen.name} · ${chosen.durationMinutes} min · ${formatLongDay(date)} · ${selectedTime}`
+      : '';
 
   // Five days at most, clamped to the practice's booking window, so a 3-day
   // window renders three chips. Pure state, no fetch of its own.

--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -145,6 +145,33 @@ describe('BookClient', () => {
     expect(input.max).not.toBe('');
   });
 
+  /*
+   * A native date input has a clear affordance, and clearing it fires onChange
+   * with "". That reached `formatLongDay("")`, which builds
+   * `new Date("T00:00:00Z")` - an Invalid Date - and Intl throws
+   * `RangeError: Invalid time value` formatting it. The throw happened during
+   * render of a PUBLIC page, so clearing the field took the whole booking form
+   * down rather than asking for another date.
+   */
+  it('survives the reader clearing the preferred day', async () => {
+    await renderPage();
+    await waitFor(() => screen.getByRole('button', { name: '09:00' }));
+
+    const slotCallsBefore = getSlotsMock.mock.calls.length;
+
+    expect(() =>
+      fireEvent.change(screen.getByLabelText('Preferred day'), { target: { value: '' } })
+    ).not.toThrow();
+
+    // The form is still standing and still says how far ahead you can book.
+    expect(screen.getByLabelText('Preferred day')).toBeInTheDocument();
+    expect(screen.getByText(/you can book up to/)).toBeInTheDocument();
+
+    // And no request went out for a day that does not exist.
+    await waitFor(() => expect(getSlotsMock.mock.calls.length).toBe(slotCallsBefore));
+    expect(getSlotsMock).not.toHaveBeenCalledWith(expect.anything(), expect.anything(), '');
+  });
+
   it('reports a slot loading failure without pretending there are no times', async () => {
     getSlotsMock.mockRejectedValue(
       new PublicBookingRequestError('Date outside the booking window', 400)

--- a/apps/frontend/src/app/__tests__/lib/postAuthRedirect.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/postAuthRedirect.test.ts
@@ -198,6 +198,26 @@ describe('resolvePostAuthRedirect', () => {
       ).resolves.toBe('/developers/home');
     });
 
+    /* The failure fallback used to key on "holds the developer role" alone, so
+       a dual-role account that signed in at the PRACTICE door was diverted to
+       the portal the moment loadOrgs had a bad minute. A transient network
+       failure is not a statement about which product the person asked for. */
+    it('keeps a dual-role account on its practice when orgs fail to load', async () => {
+      (loadOrgs as jest.Mock).mockRejectedValue(new Error('network'));
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['member', 'developer'] })
+      ).resolves.toBe('/appointments');
+    });
+
+    /* The same failure, for someone who did ask for the portal, still lands there. */
+    it('sends a dual-role account to the portal on failure when it used the developer door', async () => {
+      (loadOrgs as jest.Mock).mockRejectedValue(new Error('network'));
+      globalThis.sessionStorage.setItem('devAuth', 'true');
+      await expect(
+        resolvePostAuthRedirect({ fallbackRole: 'member', roles: ['member', 'developer'] })
+      ).resolves.toBe('/developers/home');
+    });
+
     // Using the developer form is not itself an entitlement.
     it('does not divert a practice-only account that used the developer door', async () => {
       withPractice();

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -124,6 +124,16 @@ const ARTICLES: Record<string, Article> = {
  *   `proposed`.
  * - the host is not hardcoded, because the session is issued for whichever
  *   origin `NEXT_PUBLIC_BASE_URL` names.
+ * - the COMPANION'S PARENT is required, as a `RelatedPerson/...` participant.
+ *   `fromFHIRAppointment` (packages/types/src/appointment.ts) reads the parent
+ *   from that reference and falls back to `unknown-owner` without it;
+ *   `createAppointment` then hands that literal to
+ *   `assertParentManagesCompanion` and the write is refused. A sample missing
+ *   it fails just as reliably as the /v2 path did, only later and with a less
+ *   obvious message.
+ * - `end`, `minutesDuration` and `serviceType` are read too: `endTime` falls
+ *   back to "now" and `durationMinutes` to 0 when they are absent, so the
+ *   appointment lands at a time nobody asked for.
  */
 const CURL_SAMPLE = String.raw`curl -X POST \
   "$YC_API_BASE"/fhir/v1/appointment/pms \
@@ -133,9 +143,24 @@ const CURL_SAMPLE = String.raw`curl -X POST \
   -d '{
     "resourceType": "Appointment",
     "start": "2026-07-17T10:30:00+02:00",
+    "end": "2026-07-17T11:00:00+02:00",
+    "minutesDuration": 30,
+    "serviceType": [
+      {
+        "coding": [
+          {
+            "system": "http://example.org/appointment-types",
+            "code": "<appointment-type-id>",
+            "display": "Wellness exam"
+          }
+        ],
+        "text": "Wellness exam"
+      }
+    ],
     "participant": [
       { "actor": { "reference": "Organization/<practice-id>" } },
-      { "actor": { "reference": "Patient/<companion-id>" } }
+      { "actor": { "reference": "Patient/<companion-id>" } },
+      { "actor": { "reference": "RelatedPerson/<parent-id>" } }
     ]
   }'`;
 

--- a/apps/frontend/src/app/lib/postAuthRedirect.ts
+++ b/apps/frontend/src/app/lib/postAuthRedirect.ts
@@ -48,6 +48,18 @@ export const hasDeveloperRole = (roles?: readonly (string | null | undefined)[] 
  * empty list always falls back to the one role that is known rather than
  * answering no.
  */
+/**
+ * True when the developer role is the ONLY role this account holds.
+ *
+ * `hasDeveloperRole` answers "does this account have developer access", which
+ * is the right question when deciding whether the portal is reachable at all.
+ * It is the wrong question for a fallback that has to choose a destination
+ * without being told which product the person asked for: a dual-role account
+ * answers yes to it and still belongs in its practice.
+ */
+const holdsOnlyDeveloperRole = (roles: readonly string[]) =>
+  roles.length > 0 && roles.every(isDeveloperRole);
+
 export const resolveHeldRoles = (
   roles?: readonly (string | null | undefined)[] | null,
   singleRole?: string | null
@@ -204,7 +216,21 @@ export const resolvePostAuthRedirect = async ({
   try {
     await loadOrgs({ silent: true });
   } catch {
-    return isDeveloper ? '/developers/home' : resolveDefaultOpenScreenRoute(fallbackRole);
+    /*
+     * A transient org load failure carries no information about which product
+     * the person asked for, so it must not change where they land.
+     *
+     * Execution only reaches here when the developer door was NOT used - the
+     * check above returns first when it was - so a dual-role account that
+     * signed in at the practice door is on its way to its practice. Keying
+     * this on `isDeveloper` sent it to the portal instead, undoing the very
+     * routing the door check exists to provide, and it did so only when the
+     * network happened to fail. Only an account whose sole role is developer
+     * has nowhere else to land.
+     */
+    return holdsOnlyDeveloperRole(heldRoles)
+      ? '/developers/home'
+      : resolveDefaultOpenScreenRoute(fallbackRole);
   }
 
   const { orgIds, primaryOrgId } = useOrgStore.getState();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Codex left six findings on the dev to main promotion (#2585), one P1 and five P2. All six are in code that promotion introduces, so they are defects this release would ship. Two of them I confirmed against the code before touching anything, because a review comment is a claim, not a fact.

**The public booking page crashes when the date is cleared.** A native date input has a clear affordance, and the change handler stores the `""` it fires with. Reproduced:

```
formatLongDay("")  ->  new Date("T00:00:00Z")  ->  RangeError: Invalid time value
```

`formatLongDay(date)` is called unconditionally in the render and again in the recap, so clearing "Preferred day" throws mid-render and takes the whole form down. On a public page.

**The new tenant guard 403s valid same-tenant writes.** `normalizeOrgId` in `middlewares/rbac.ts` trims whitespace and nothing else, so the two sides of the comparison disagree about spelling:

| Source | `x-org-id: Organization/org_a` yields |
| --- | --- |
| `resolveAuthorizedOrganisationId` | `Organization/org_a` |
| `resolveBodyOrganisationId` | `org_a` |

A caller writing to the tenant it is authorised for got a 403. That is the guard refusing valid work rather than catching an escape, and it arrived with the cross-tenant fix itself (#2576).

## What is the new behavior?

**Booking page.** The day is dropped from the hint and the recap until one is chosen again, and `useSlots` no longer keys on an empty date, so nothing asks the API for slots on `""`.

**Tenant guard, prefix.** Both sides pass through `bareOrganisationId` before they meet, so one organisation in two spellings compares equal. A genuinely different organisation is still refused.

**Tenant guard, validation (the P1).** `req.body` is `unknown` at runtime whatever the handler annotation claims, and every shape the manual traversal failed to understand produced `undefined` - which is indistinguishable from "this body names no organisation", the branch that lets a write through with no comparison at all. A narrow Zod schema now parses the participant list first.

`safeParse`, not `parse`: `parseError` in `appointment-controller.helpers.ts` has no ZodError branch, so a thrown ZodError would leave as a **500** carrying the serialised issue list. A body this guard cannot read is a 400. An absent participant list stays a legitimate absence and is still passed to the service, which rejects it on its own terms; a present but malformed one is refused here.

**Dual-role redirect.** The org-load failure fallback keyed on "holds the developer role", so an account that signed in at the practice door was diverted to the portal whenever `loadOrgs()` had a bad minute. A transient network failure says nothing about which product the person asked for. Only an account whose sole role is developer falls back there now.

**Docs sample.** Without a `RelatedPerson/` participant, `fromFHIRAppointment` assigns `unknown-owner` and `assertParentManagesCompanion` rejects the write, so the advertised sample failed just as reliably as the `/v2` path it replaced, only later and less obviously. Added, along with the `end`, `minutesDuration` and `serviceType` fields that otherwise default to now and zero.

**Promotion guard.** `dev must contain main` had no `always()`, so it was skipped whenever the head-branch check above it exited 1 - exactly the disallowed pull request the context exists to settle. Made required on main's ruleset, such a pull request would wait forever on a status no event will ever write.

## Validation

Mutation-checked, because a passing suite and an absent one look identical from the outside. Each fix was reverted in turn and the test written for it failed, and only that one:

| Reverted | Result |
| --- | --- |
| `bareOrganisationId` on the authorised side | 1 failed, 37 passed |
| the Zod `safeParse` guard | 1 failed, 37 passed |
| the empty-date guard and the `useSlots` key | 1 failed |
| the dual-role failure fallback | 1 failed |

```
backend    38 tests pass (4 new)
frontend   89 tests pass across the 4 touched suites (3 new)
type-check clean, both apps
eslint     clean, all changed files
promotion-guard.yml parses; the step condition reads
           always() && steps.retarget.outputs.retargeted != 'true'
```

One note on the backend type-check: it fails in a fresh worktree with five `TS7006` errors in test files nobody here touched, and it does so on unmodified `dev` too. The cause is stale workspace `dist` output, not this branch: `pnpm --filter "@yosemite-crew/*" run build` makes it clean.

## Deliberately not changed

`postAuthRedirect.ts` has a second `isDeveloper ? ... : ...` on the no-organisations path. The same argument arguably applies to a dual-role account with no practice yet, but that branch was not raised, its current behaviour is defensible, and a routing change nobody asked for does not belong in a release fix.

## Related Issue(s)

Refs #2585
