### PR TITLE
fix(frontend): make the story suite offline-deterministic and close the phone overflow set

### DIFF
--- a/apps/frontend/.storybook/offline-guard.ts
+++ b/apps/frontend/.storybook/offline-guard.ts
@@ -1,0 +1,311 @@
+/**
+ * Default offline guard for the Storybook preview.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Storybook renders the shipped components, and a lot of them fetch on mount.
+ * Nothing in the preview points those calls anywhere safe:
+ *
+ *   - `src/app/services/axios.ts` builds its instance with
+ *     `baseURL: process.env.NEXT_PUBLIC_BASE_URL`. When that variable IS set in
+ *     the shell that started Storybook, every request leaves the browser for
+ *     `https://devapi.yosemitecrew.com` and is refused by CORS from
+ *     `http://localhost:6117`. When it is NOT set, `baseURL` is empty and the
+ *     same requests hit the Storybook dev server as `/fhir/v1/...` and 404.
+ *     Same story file, two different behaviours, decided by a shell variable.
+ *   - `src/app/stores/authStore.ts` calls `initAuthClient()` at MODULE TOP
+ *     LEVEL, so merely importing the auth store boots SuperTokens against
+ *     whatever `NEXT_PUBLIC_BASE_URL` holds at that instant. SuperTokens then
+ *     installs its own global `fetch`/`XMLHttpRequest` interceptors and starts
+ *     firing `/auth/session/refresh` at that host for the rest of the session.
+ *     Several stories legitimately write `process.env.NEXT_PUBLIC_BASE_URL` in
+ *     a decorator, and `initialized` never resets - so in a runner that reuses
+ *     one page across many stories, ONE story's env write decides where a later
+ *     story's session refresh goes. That is the shape of the ~175-story CORS
+ *     failure: it is order-dependent, and it is invisible in a runner that
+ *     reloads the page per story.
+ *
+ * The consequence is the thing worth fixing: with ~5% of the suite failing for
+ * reasons that have nothing to do with the components, nobody can read the
+ * suite as a signal, and a real regression hides in the noise.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Wraps the two browser primitives every one of those calls passes through -
+ * `fetch` and `XMLHttpRequest.prototype.open/send` - and answers anything bound
+ * for the real API offline instead of letting it leave the page. Both are
+ * needed: axios picks the XHR adapter in a browser, while SuperTokens' session
+ * refresh and the handful of raw-`fetch` services go through `fetch`.
+ *
+ * DESIGN NOTES (this is global to all 3,291 stories, so the choices are narrow
+ * on purpose)
+ *
+ * 1. It guards the PRIMITIVES, not the app's axios instance. Guarding
+ *    `api.defaults.adapter` would have been fewer lines, but 29 story files
+ *    already swap `api.defaults.adapter` themselves and 19 more patch
+ *    `XMLHttpRequest.prototype` - a guard on the adapter would have been the
+ *    thing those stories overwrite and restore, and restoring it wrongly would
+ *    silently disarm the guard for every story after them. At the primitive
+ *    layer a per-story adapter swap wins by construction: axios calls the
+ *    story's adapter and never reaches XHR at all. It also keeps this file free
+ *    of app imports, so the preview does not drag `authStore` (and its
+ *    top-level `initAuthClient()`) into every story that never wanted it.
+ *
+ * 2. Per-story stubs still win. The guard installs once, while the preview
+ *    annotations are evaluated - before any CSF module is imported. A story
+ *    that swaps `globalThis.fetch`, or captures
+ *    `XMLHttpRequest.prototype.open/send` at module scope and restores them
+ *    later, is capturing and restoring the GUARDED functions. Its stub sits in
+ *    front of the guard while it runs, its cleanup puts the guard back, and the
+ *    calls it chooses not to answer fall through to the guard instead of
+ *    escaping. That "fall through to the real transport" line several stories
+ *    already have now means "fall through to something offline".
+ *
+ * 3. The answer is an offline `404`, NOT a `200` with an empty payload. This
+ *    was the one choice worth measuring rather than reasoning about, and the
+ *    obvious answer is the wrong one here.
+ *
+ *    A `200 []` was tried first and broke three of the six stories in
+ *    `AppointmentInfo/Info/AppointmentInfo.stories.tsx` on the spot ("Room:
+ *    Consult 2" gone, an input with no value, a validation message that never
+ *    appeared). The reason generalises to most of the suite: the established
+ *    pattern here is to SEED a Zustand store in `beforeEach` and let the
+ *    component's own fetch fail, so the loader `catch`es and the seeded data
+ *    survives. AppointmentInfo says so in its own comment - "edit mode opens
+ *    `catch`es into `timeSlots: []` ... that is what makes the edit-mode
+ *    stories below deterministic without any MSW wiring". A SUCCESSFUL empty
+ *    response is the one thing that defeats that: the loader takes its happy
+ *    path and overwrites the seeded fixture with nothing.
+ *
+ *    `404` is also the status the suite is already calibrated against. With no
+ *    `.env` in the preview, `baseURL` is empty today and these calls already
+ *    land on the Storybook dev server as `/fhir/v1/...` and 404. So the guard
+ *    does not introduce a third behaviour - it makes the behaviour every story
+ *    was written against the ONLY behaviour, whether or not
+ *    `NEXT_PUBLIC_BASE_URL` is set in the shell.
+ *
+ *    It is not an unhandled rejection either. `fetch` RESOLVES with an
+ *    `ok: false` response, and the XHR fires `loadend` with a status, so axios
+ *    rejects into the `catch` every one of these services already has - the
+ *    same path they take today.
+ *
+ * 4. It answers rather than pretends the call never happened, and it logs, so
+ *    an author can see which of their stories is leaning on an unmocked call.
+ *
+ * NOT COVERED, on purpose: `WebSocket`, `navigator.sendBeacon`, and subresource
+ * loads (`<img src>`, `<script src>`), none of which go through `fetch`/XHR.
+ * No story in the suite has been observed to need them, and widening the guard
+ * to the whole network layer would start intercepting things Storybook itself
+ * depends on.
+ */
+
+/**
+ * Answered to every blocked call. See design note 3 for why this is a 404 and
+ * not an empty success - a successful empty response overwrites the store
+ * fixtures the suite seeds, a failed one leaves them alone.
+ */
+const BLOCKED_STATUS = 404;
+const BLOCKED_STATUS_TEXT = 'Not Found';
+const BLOCKED_BODY = JSON.stringify({
+  error: 'Blocked by the Storybook offline guard - no request left the browser.',
+});
+const JSON_CONTENT_TYPE = 'application/json';
+
+/**
+ * Same-origin paths the Storybook dev server genuinely owns.
+ *
+ * The rule is an allowlist rather than a blocklist of API prefixes, because the
+ * app's endpoints change every week and Storybook's own surface does not. A
+ * missed API prefix would let a real call escape; a missed Storybook prefix
+ * fails loudly the first time the suite is run, which is the failure that gets
+ * fixed rather than the one that rots.
+ *
+ * `/__` covers Vite's `__vite_ping`, which the HMR client polls to decide when
+ * the dev server is back after a restart. Answering it from here would freeze
+ * that decision on a lie in either direction, and the preview would stop
+ * picking up edits.
+ */
+const STORYBOOK_OWNED_PREFIXES = [
+  '/index.json',
+  '/iframe.html',
+  '/sb-',
+  '/storybook',
+  '/@', // /@vite/, /@id/, /@fs/, /@react-refresh
+  '/src/',
+  '/node_modules/',
+  '/.storybook/',
+  '/virtual:',
+  '/__', // /__vite_ping
+  '/fonts/',
+  '/images/',
+  '/static/',
+  '/favicon',
+  '/apple-touch-icon',
+  '/web-app-manifest',
+  '/site.webmanifest',
+];
+
+/** Static files served from the staticDirs roots rather than from a folder. */
+const ASSET_EXTENSION =
+  /\.(css|js|mjs|cjs|jsx|ts|tsx|json|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|webp|avif|ico|txt|md|mdx|html|wasm)($|\?)/i;
+
+type GuardedXhr = XMLHttpRequest & {
+  __ycGuardUrl?: string;
+  __ycGuardMethod?: string;
+};
+
+let installed = false;
+
+/**
+ * Deduped by method + pathname (query deliberately dropped: a search-as-you-type
+ * endpoint would otherwise print a line per keystroke and bury the signal).
+ */
+const reported = new Set<string>();
+
+const resolveUrl = (target: unknown): URL | null => {
+  try {
+    if (typeof target === 'string') return new URL(target, globalThis.location.href);
+    if (target instanceof URL) return target;
+    const candidate = (target as { url?: unknown } | null)?.url;
+    if (typeof candidate === 'string') return new URL(candidate, globalThis.location.href);
+  } catch {
+    // An address this file cannot parse is an address the network cannot reach
+    // either, so it is left alone rather than guessed at.
+    return null;
+  }
+  return null;
+};
+
+const isStorybookOwned = (url: URL): boolean => {
+  // data:, blob:, filesystem: never leave the page.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return true;
+  // Anything off this origin is the real internet, whatever its path looks like.
+  if (url.origin !== globalThis.location.origin) return false;
+  if (STORYBOOK_OWNED_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) return true;
+  return ASSET_EXTENSION.test(url.pathname);
+};
+
+const report = (method: string, url: URL) => {
+  const key = `${method} ${url.origin}${url.pathname}`;
+  if (reported.has(key)) return;
+  reported.add(key);
+  // console.info, not warn/error: the story QA runner treats console errors as
+  // failures, and an unmocked call is a note to the author, not a broken story.
+  console.info(
+    `[storybook offline guard] ${key} was answered offline with ${BLOCKED_STATUS}. ` +
+      'This story is relying on an unmocked API call - stub it if the response matters.'
+  );
+};
+
+const installFetchGuard = () => {
+  // Captured once. Reading globalThis.fetch inside the wrapper would recurse
+  // through whatever a story installed on top of it.
+  const realFetch = globalThis.fetch.bind(globalThis);
+
+  const guardedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = resolveUrl(input);
+    if (url === null || isStorybookOwned(url)) return realFetch(input, init);
+
+    const method = init?.method ?? (input as Request)?.method ?? 'GET';
+    report(method.toUpperCase(), url);
+
+    // Resolved, not rejected: a rejected fetch is what CORS does today, and it
+    // is the shape that turns into an unhandled rejection. Callers already
+    // branch on `res.ok`.
+    return Promise.resolve(
+      new Response(BLOCKED_BODY, {
+        status: BLOCKED_STATUS,
+        statusText: BLOCKED_STATUS_TEXT,
+        headers: { 'content-type': JSON_CONTENT_TYPE },
+      })
+    );
+  };
+
+  globalThis.fetch = guardedFetch as typeof globalThis.fetch;
+};
+
+/**
+ * Hand a caller a finished 404 on a request that was never sent.
+ *
+ * Own data properties shadow the prototype's accessors - that is the only way
+ * to write `status`/`responseText` on a real XMLHttpRequest. This mirrors the
+ * technique SoapCodedTermPicker.stories.tsx and ChangeRoom.stories.tsx already
+ * use, so axios's XHR adapter is being fed a shape this repo has proven it
+ * accepts.
+ */
+const answerOffline = (xhr: XMLHttpRequest, url: URL) => {
+  const define = (key: string, value: unknown) =>
+    Object.defineProperty(xhr, key, { value, configurable: true });
+
+  define('readyState', 4);
+  define('status', BLOCKED_STATUS);
+  define('statusText', BLOCKED_STATUS_TEXT);
+  define('responseText', BLOCKED_BODY);
+  define('response', BLOCKED_BODY);
+  define('responseURL', url.href);
+  // axios reads the header block to build `response.headers`; an unsent XHR
+  // returns '' from the real method, which loses the content type and with it
+  // any caller that branches on it.
+  define('getAllResponseHeaders', () => `content-type: ${JSON_CONTENT_TYPE}\r\n`);
+
+  xhr.dispatchEvent(new Event('readystatechange'));
+  xhr.dispatchEvent(new ProgressEvent('load'));
+  // axios settles on `onloadend`; dispatching the event runs the `on*` handler
+  // as well as any addEventListener subscriber.
+  xhr.dispatchEvent(new ProgressEvent('loadend'));
+};
+
+const installXhrGuard = () => {
+  const realOpen = XMLHttpRequest.prototype.open;
+  const realSend = XMLHttpRequest.prototype.send;
+
+  XMLHttpRequest.prototype.open = function guardedOpen(
+    this: GuardedXhr,
+    method: string,
+    url: string | URL,
+    isAsync?: boolean,
+    username?: string | null,
+    password?: string | null
+  ) {
+    this.__ycGuardUrl = String(url);
+    this.__ycGuardMethod = String(method).toUpperCase();
+    // Still opened for real: a blocked request is decided at send() time, and
+    // everything the caller does between open() and send() (setRequestHeader,
+    // withCredentials, timeout) has to keep working on a genuine instance.
+    realOpen.call(this, method, url, isAsync ?? true, username, password);
+  };
+
+  XMLHttpRequest.prototype.send = function guardedSend(
+    this: GuardedXhr,
+    body?: Document | XMLHttpRequestBodyInit | null
+  ) {
+    const url = this.__ycGuardUrl === undefined ? null : resolveUrl(this.__ycGuardUrl);
+    if (url === null || isStorybookOwned(url)) {
+      realSend.call(this, body ?? null);
+      return;
+    }
+
+    report(this.__ycGuardMethod ?? 'GET', url);
+    // Answered on a later tick rather than inline, so a caller that attaches
+    // its handlers after send() still sees the events. Callers that attach
+    // before (axios does) are unaffected.
+    setTimeout(() => answerOffline(this, url), 0);
+  };
+};
+
+/**
+ * Idempotent, browser-only. Called from `preview.ts` at module scope so it is
+ * in place before the first CSF module is imported - see design note 2, the
+ * ordering is what lets per-story stubs capture and restore the guard rather
+ * than the pristine primitives.
+ */
+export const installOfflineGuard = (): void => {
+  if (installed) return;
+  if (globalThis.window === undefined) return;
+  if (typeof globalThis.fetch !== 'function') return;
+  if (typeof globalThis.XMLHttpRequest !== 'function') return;
+
+  installed = true;
+  installFetchGuard();
+  installXhrGuard();
+};

--- a/apps/frontend/.storybook/preview.ts
+++ b/apps/frontend/.storybook/preview.ts
@@ -1,6 +1,17 @@
 import type { Preview } from '@storybook/react';
 import React from 'react';
 import '../src/app/globals.css';
+import { installOfflineGuard } from './offline-guard';
+
+/**
+ * Installed here, at preview module scope, rather than from a decorator or a
+ * `beforeAll`: it has to be in place before the first story module is imported,
+ * because the stories that stub the network capture the primitives at THEIR
+ * module scope and restore what they captured. Installed first, the guard is
+ * what they capture and put back; installed later, their cleanup would quietly
+ * uninstall it for every story after them.
+ */
+installOfflineGuard();
 
 /**
  * Newsreader and Satoshi both resolve from `globals.css` @font-face rules served

--- a/apps/frontend/src/app/__tests__/stores/appointmentWorkspaceStore.test.ts
+++ b/apps/frontend/src/app/__tests__/stores/appointmentWorkspaceStore.test.ts
@@ -394,6 +394,41 @@ describe('appointmentWorkspaceStore', () => {
     ).toBeUndefined();
   });
 
+  it('refuses to add, update or remove services on a discharged encounter', () => {
+    seed();
+    getStore().addLineItem(APPT, {
+      refId: 's1',
+      kind: 'SERVICE',
+      name: 'X-ray',
+      qty: 1,
+      unitPriceCents: 5000,
+      amountCents: 5000,
+    });
+    const existing = getStore().getEncounter(APPT)!.services.at(-1)!;
+
+    getStore().markDischarged(APPT, new Date().toISOString());
+    expect(getStore().getEncounter(APPT)?.viewOnly).toBe(true);
+
+    /* The editor already hides its search and locks its rows when `readOnly` is
+       passed, but that is a UI gate on one call site. A discharged encounter must
+       not gain, lose or re-price billable services through the action itself -
+       otherwise any future caller reaching past the editor reopens the hole. */
+    getStore().addLineItem(APPT, {
+      refId: 's2',
+      kind: 'SERVICE',
+      name: 'Ultrasound',
+      qty: 1,
+      unitPriceCents: 9000,
+      amountCents: 9000,
+    });
+    getStore().updateLineItem(APPT, existing.id, { qty: 99 });
+    getStore().removeLineItem(APPT, existing.id);
+
+    const services = getStore().getEncounter(APPT)!.services;
+    expect(services.map((s) => s.name)).toEqual(['X-ray']);
+    expect(services[0].qty).toBe(1);
+  });
+
   it('does not create local schedule rows when adding line items', () => {
     // The task store is the single source of truth for schedule tasks — adding a
     // line item must NOT push a local-only schedule row (which would duplicate the

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.stories.tsx
@@ -151,9 +151,20 @@ const meta = {
   decorators: [
     /* The labels have no ground of their own - in the planner they sit on the
        --screen-2 band that CalendarTeamNamesRow paints. Rendering them on the bare
-       preview canvas would hide every contrast problem the header actually has. */
+       preview canvas would hide every contrast problem the header actually has.
+
+       The band also SCROLLS, which is not decoration either. This grid is `min-w-max`
+       on a 170px-per-column track and CalendarTeamNamesRow is `min-w-max` around it,
+       because the header has to stay in lockstep with the appointment columns beneath
+       it - it is built to be wider than the screen and to scroll with the planner.
+       A band that only painted the colour let that overrun escape onto the document,
+       so a width sweep read the deliberate design as a phone-layout bug. maxWidth
+       keeps the band inside whatever canvas it is given; the overrun scrolls. */
     (Story) => (
-      <div data-band="" style={{ width: 520, background: 'var(--screen-2)' }}>
+      <div
+        data-band=""
+        style={{ width: 520, maxWidth: '100%', overflowX: 'auto', background: 'var(--screen-2)' }}
+      >
         <Story />
       </div>
     ),

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
@@ -77,15 +77,32 @@ const meta = {
           '666px of pills in a 276px box with the third cut mid-word. With few pills the fade ' +
           'falls on empty background and costs nothing, and the two cases look nothing alike.\n\n' +
           'The stories assert the tooltip bubble has its text, not merely that a hover ' +
-          'happened - an empty bubble would pass the weaker check.',
+          'happened - an empty bubble would pass the weaker check.\n\n' +
+          'This row is the **desktop branch**. `AppointmentWorkspace` calls `useIsPhone()` ' +
+          '(`max-width: 767px`) and returns `PhoneWorkspaceShell` instead below that, so ' +
+          'WorkspaceHeader never renders on a phone and a phone-width screenshot of it is ' +
+          'not a bug report. Measured down to a 620px canvas, the row itself fits with room ' +
+          'to spare; what does not fit at that width is the `Admit` + hospitalize + Quick ' +
+          'Actions cluster, which is `shrink-0` by design and needs 429px on its own.',
       },
     },
   },
   tags: ['autodocs'],
   decorators: [
+    /* The frame carries the floor this row actually has. `AppointmentWorkspace` calls
+       `useIsPhone()` at `max-width: 767px` and returns `PhoneWorkspaceShell` instead,
+       so WorkspaceHeader has no phone rendering to get wrong - and measured at 620,
+       660, 700 and 768px canvases it overflows at none of them. Below that the Admit
+       + hospitalize + Quick Actions cluster is `shrink-0` at 429px and simply will not
+       go, which is why a 390px sweep read this desktop row as a broken phone layout.
+       min-w states the floor without capping anything (a 1280px canvas is unchanged),
+       and the scroller keeps a narrower preview from dragging the document sideways
+       rather than pretending the row fits. */
     (Story) => (
-      <div className="p-6">
-        <Story />
+      <div className="w-full overflow-x-auto">
+        <div className="min-w-[620px] p-6">
+          <Story />
+        </div>
       </div>
     ),
   ],
@@ -167,8 +184,13 @@ export const OverflowingAlerts: Story = {
   name: 'Alert strip overflowing (fade)',
   args: { alerts: MANY_ALERTS },
   decorators: [
+    /* `w-full max-w-[900px]`, not a bare `w-[900px]`. The number is here to constrain
+       the strip so the fade has something to hide, and a max-width does that at every
+       canvas; a fixed 900 also dragged the preview document 534px wide on a 390px
+       sweep, which reads as a layout bug in a component that does not render at 390
+       at all. Narrower canvases now overflow the strip harder, which is the point. */
     (Story) => (
-      <div className="w-[900px] p-6">
+      <div className="w-full max-w-[900px]">
         <Story />
       </div>
     ),
@@ -178,6 +200,12 @@ export const OverflowingAlerts: Story = {
     const strip = canvas.getByTestId('workspace-alert-strip');
     await expect(strip).toBeInTheDocument();
     await expect(within(strip).getByText('Bite risk')).toBeInTheDocument();
+
+    /* The strip really is overflowing, which nothing here asserted before - and the
+       fade is `mask-image`, so a strip that happened to fit would show no difference
+       a screenshot could catch. Without this the story could quietly stop being about
+       overflow the next time the frame around it moved. */
+    await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth);
     // The "+" stays reachable at the end of the scrolling strip.
     await expect(within(strip).getByRole('button', { name: 'Add alert' })).toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
@@ -109,9 +109,13 @@ const meta = {
           'it opens on `mouseenter`/`focusin` listeners attached in an effect - there is no prop ' +
           'that reveals it. It carries the only legal-consent copy in the flow.\n\n' +
           'The alert rows are worth watching while both of those move: each is a fieldset with an ' +
-          'explicit `gridTemplateColumns: "1fr 160px 48px"`. A malformed template there is exactly ' +
-          'the bug that shipped on the task popover - the browser drops the declaration and the ' +
-          'three children collapse into one column, which still looks deliberate.',
+          'explicit `gridTemplateColumns: "minmax(0, 1fr) 160px 48px"`. A malformed template ' +
+          'there is exactly the bug that shipped on the task popover - the browser drops the ' +
+          'declaration and the three children collapse into one column, which still looks ' +
+          'deliberate. The `minmax(0, ...)` is load-bearing too: written as a bare `1fr` the ' +
+          "label column inherited the grid item's automatic minimum size and floored at the " +
+          "browser's default <input> width, so the row could not squeeze and pushed 18px past a " +
+          '390px phone instead.',
       },
     },
   },
@@ -377,9 +381,66 @@ export const PhoneSheet: Story = {
       description: {
         story:
           'The `sheet` variant drops the `mx-auto max-w-[760px]` wrapper for a plain `w-full`, ' +
-          'because the phone bottom sheet already owns the width and the sticky footer. At 375 the ' +
-          'alert fieldset is the pressure point: its `1fr 160px 48px` template leaves the label ' +
-          'input under 130px wide.',
+          'because the phone bottom sheet already owns the width and the sticky footer. Step one ' +
+          'of the create wizard has no alert row - for that pressure point see the narrow-frame ' +
+          'story below, which is where the template actually had to be fixed.',
+      },
+    },
+  },
+};
+
+export const AlertRowNarrow: Story = {
+  name: 'Alert row in a 390px frame',
+  decorators: [
+    /* A 390px CONTAINER, not the mobile viewport global - that global is applied by
+       the manager to the preview iframe and is inert for a runner loading iframe.html
+       directly. It also does not matter here: this row is sized by its grid template,
+       not by a media query, so a box reproduces it exactly. */
+    (Story) => (
+      <div data-frame="" style={{ width: 390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas.getByRole('textbox', { name: /Diabetic/ });
+    const fieldset = label.closest('fieldset') as HTMLElement;
+    const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
+
+    /* The label column really squeezes. A bare `1fr` has an `auto` min track sizing
+       function, which turns on the grid item's automatic minimum size, and the item
+       here wraps an <input> whose intrinsic width is the browser's default `size`
+       (~168px). So the row floored at 392px - 168 label + 160 priority + 48 button +
+       two 8px gaps - and overflowed a 390px screen by 18px rather than narrowing,
+       which is the one thing a `1fr` column is supposed to be able to do. */
+    await expect(label.getBoundingClientRect().width).toBeLessThan(168);
+
+    // Priority and the add button keep their fixed tracks; only the label gives way.
+    const [, priority, add] = [...fieldset.children].filter(
+      (child) => child.tagName !== 'LEGEND'
+    ) as HTMLElement[];
+    await expect(Math.round(priority.getBoundingClientRect().width)).toBe(160);
+    await expect(Math.round(add.getBoundingClientRect().width)).toBe(48);
+
+    // And the row fits. Nothing here sits in a scroller, so this reads as it looks.
+    await expect(fieldset.getBoundingClientRect().right).toBeLessThanOrEqual(
+      frame.getBoundingClientRect().right
+    );
+  },
+  parameters: {
+    /* `fullscreen`, so the 390px frame below IS 390px. Under the file's `padded`
+       layout the canvas adds 16px a side and the frame lands at 406 - a story about
+       fitting a phone that does not itself fit one. It has to live in this object:
+       a second `parameters` key on the same story silently replaces the first, and
+       the layout would go missing with nothing to show for it. */
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The companion alert row at phone width. Label, priority and the add button ' +
+          'share one grid: the two right-hand tracks are fixed at 160px and 48px, so ' +
+          'every pixel the screen does not have has to come out of the label.',
       },
     },
   },

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.tsx
@@ -454,7 +454,14 @@ const PatientDetailsColumn = ({
       <span className="text-body-4 text-text-secondary">Alerts (optional)</span>
       <fieldset
         className="grid items-center gap-2"
-        style={{ gridTemplateColumns: '1fr 160px 48px' }}
+        /* minmax(0, 1fr), not a bare 1fr. A bare `1fr` has an `auto` MIN track sizing
+           function, which switches on the grid item's automatic minimum size - so this
+           column could never go below the min-content of a FormInput, and an <input>
+           carries the browser's default `size` intrinsic width (~168px). Label + 160 +
+           48 + gaps therefore floored at 392px and pushed the phone sheet 18px past a
+           390px screen instead of squeezing the label, which is what the layout reads
+           as it should do. Zeroing the min lets the label take whatever is left. */
+        style={{ gridTemplateColumns: 'minmax(0, 1fr) 160px 48px' }}
       >
         <legend className="sr-only">Add alert</legend>
         <FormInput
@@ -697,7 +704,14 @@ const ClientDetailsColumn = ({
       <span className="text-body-4 text-text-secondary">Alerts (optional)</span>
       <fieldset
         className="grid items-center gap-2"
-        style={{ gridTemplateColumns: '1fr 160px 48px' }}
+        /* minmax(0, 1fr), not a bare 1fr. A bare `1fr` has an `auto` MIN track sizing
+           function, which switches on the grid item's automatic minimum size - so this
+           column could never go below the min-content of a FormInput, and an <input>
+           carries the browser's default `size` intrinsic width (~168px). Label + 160 +
+           48 + gaps therefore floored at 392px and pushed the phone sheet 18px past a
+           390px screen instead of squeezing the label, which is what the layout reads
+           as it should do. Zeroing the min lets the label take whatever is left. */
+        style={{ gridTemplateColumns: 'minmax(0, 1fr) 160px 48px' }}
       >
         <legend className="sr-only">Add client alert</legend>
         <FormInput

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
@@ -313,6 +313,58 @@ export const Editable: Story = {
   },
 };
 
+export const NarrowFrame: Story = {
+  name: 'Editable in a 320px frame',
+  args: { editable: true, additionalDiscount: 7.5, onRemoveItem: fn() },
+  decorators: [
+    /* A container, not a viewport. The scroller is `overflow-x-auto` on a plain div,
+       so what it does or does not clip is decided by its own box - which means this
+       reproduces at the 1280px width the runner actually loads. Pinning the `mobile`
+       viewport global would not: that global is applied by the manager and is inert
+       when a runner loads iframe.html directly. */
+    (Story) => (
+      <div data-frame="" style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
+    const table = canvas.getByRole('table');
+
+    // The table really is wider than the frame - otherwise nothing below is tested.
+    await expect(table.getBoundingClientRect().width).toBeGreaterThan(
+      frame.getBoundingClientRect().width
+    );
+
+    /* The header's `sr-only` Actions label is `position: absolute`, and an absolutely
+       positioned box is clipped only by a scroll container that sits in its
+       containing-block chain. While this scroller was unpositioned the label's
+       offsetParent was the BODY, so it sat at the table's full 780px and dragged the
+       DOCUMENT to 780px on a 390px phone - measured - while the table itself stayed
+       neatly contained.
+
+       offsetParent, not geometry, because geometry cannot see a clip: the label
+       reports the same 795px right edge whether the scroller crops it or not, which
+       is the whole reason a 1px hidden element got to scroll the page sideways
+       without anyone noticing. For an absolutely positioned box, "my offsetParent is
+       the scroller" IS the statement "the scroller clips me". */
+    const scroller = table.parentElement as HTMLElement;
+    await expect(canvas.getByText('Actions').offsetParent).toBe(scroller);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The nine-column editable table in a box far narrower than itself. The table is ' +
+          'meant to overrun and scroll; what must not happen is anything reaching past the ' +
+          'scroller, which is why the wrapper is `relative`.',
+      },
+    },
+  },
+};
+
 export const SingleRow: Story = {
   name: 'One row',
   args: { items: [ITEMS[0]] },

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
@@ -133,8 +133,15 @@ const PackageBreakdownTable = ({
   const additionalDiscountAmt = (afterItemDiscounts * additionalDiscount) / 100;
   const totalCost = afterItemDiscounts - additionalDiscountAmt;
 
+  // `relative` on the scroller is load-bearing, not decoration. The editable header
+  // carries an `sr-only` span, which is `position: absolute` with no offsets. An
+  // absolutely positioned box is only clipped by a scroll container that sits in its
+  // containing-block chain, and a bare `overflow-x-auto` div is not positioned - so
+  // the span escaped this scroller, landed at the table's full 780px width and dragged
+  // the whole DOCUMENT to 780px on a 390px phone. The table was contained the entire
+  // time; one 1px hidden label was scrolling the page sideways.
   return (
-    <div className="w-full overflow-x-auto -mx-1 px-1">
+    <div className="relative w-full overflow-x-auto -mx-1 px-1">
       <table className="min-w-full text-body-4 text-text-primary border-separate border-spacing-0">
         <colgroup>
           <col className="w-8" />

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitySearchBar.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitySearchBar.stories.tsx
@@ -45,7 +45,15 @@ const Harness = ({
 
   return (
     <div className="flex min-h-[420px] flex-col gap-4 p-6">
-      <div className="flex items-center gap-3">
+      {/* `flex-wrap ... sm:flex-nowrap`, copied from SpecialityAccordionRevamp rather
+          than invented. It matters below the `sm` breakpoint, where the bar drops
+          `sm:w-64 sm:ml-auto` for a plain `w-full` and keeps `shrink-0`: in a row that
+          cannot wrap, a full-width item that refuses to shrink overflows by exactly the
+          width of whatever sits beside it - 75px of speciality name, measured at 390.
+          The real accordion wraps it onto its own line and never sees that. A harness
+          that models the parent loosely turns the parent's layout into a bug report
+          against the child. */}
+      <div className="flex flex-wrap items-center gap-3 sm:flex-nowrap">
         <span className="text-[15px] font-bold text-[var(--ink)]">{specialityName}</span>
         <SpecialitySearchBar
           searchRef={searchRef}

--- a/apps/frontend/src/app/stores/appointmentWorkspaceStore.ts
+++ b/apps/frontend/src/app/stores/appointmentWorkspaceStore.ts
@@ -708,23 +708,44 @@ export const useAppointmentWorkspaceStore = create<AppointmentWorkspaceState>((s
       stepStatus: { ...enc.stepStatus, DIAGNOSTICS: 'IN_PROGRESS' },
     })),
 
+  /* `viewOnly` is set by `markDischarged`, and a discharged encounter must not
+     gain, lose or re-price billable services. The editor already hides its search
+     and locks its rows when `readOnly` is passed, but that is a UI gate on one
+     call site - this makes the store itself refuse, so a future caller cannot
+     mutate a closed encounter by going straight to the action.
+
+     Safe against hydration: the bootstrap merges services through
+     `preferNonEmpty(patch.services, enc.services)` in the encounter patch, never
+     through these three, so loading a discharged appointment still fills in. */
   addLineItem: (appointmentId, item) =>
-    patchEnc(set, appointmentId, (enc) => ({
-      ...enc,
-      services: [...enc.services, { ...item, id: nextId('li') }],
-    })),
+    patchEnc(set, appointmentId, (enc) =>
+      enc.viewOnly
+        ? enc
+        : {
+            ...enc,
+            services: [...enc.services, { ...item, id: nextId('li') }],
+          }
+    ),
 
   updateLineItem: (appointmentId, id, patch) =>
-    patchEnc(set, appointmentId, (enc) => ({
-      ...enc,
-      services: enc.services.map((s) => (s.id === id ? { ...s, ...patch } : s)),
-    })),
+    patchEnc(set, appointmentId, (enc) =>
+      enc.viewOnly
+        ? enc
+        : {
+            ...enc,
+            services: enc.services.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+          }
+    ),
 
   removeLineItem: (appointmentId, id) =>
-    patchEnc(set, appointmentId, (enc) => ({
-      ...enc,
-      services: enc.services.filter((s) => s.id !== id),
-    })),
+    patchEnc(set, appointmentId, (enc) =>
+      enc.viewOnly
+        ? enc
+        : {
+            ...enc,
+            services: enc.services.filter((s) => s.id !== id),
+          }
+    ),
 
   addPrescription: (appointmentId, item, persistedId) =>
     patchEnc(set, appointmentId, (enc) => ({

--- a/apps/frontend/src/app/ui/layout/PageSkeleton.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PageSkeleton.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
 import PageSkeleton from './PageSkeleton';
 
 /**
@@ -43,4 +45,46 @@ export const Settings: Story = {
 /** Dashboard template: four stat tiles over a 2×2 card grid. */
 export const Dashboard: Story = {
   args: { variant: 'dashboard' },
+};
+
+/**
+ * The planner skeleton at phone width. It is the placeholder for appointments,
+ * tasks and the appointment workspace, so it is the first thing a phone visit to
+ * any of those routes paints - and its title row used to need 568px: a fixed w-72
+ * subtitle bar beside a nested action row that will not shrink under 264px.
+ */
+export const PlannerPhone: Story = {
+  name: 'Planner at 390px',
+  args: { variant: 'planner' },
+  decorators: [
+    /* A 390px CONTAINER, not the mobile viewport global. That global is applied by
+       the Storybook manager to the preview iframe, so it is inert for any runner
+       that loads iframe.html directly - measured: root stays the browser width and
+       the story quietly passes at 1280. The wrap this asserts is driven by the box,
+       not by a media query, so a container reproduces it honestly. */
+    (Story) => (
+      <div data-frame="" style={{ width: 390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
+    const titleRow = frame.querySelector('div > div') as HTMLElement;
+    const [titles, actions] = [...titleRow.children] as HTMLElement[];
+
+    // Two lines, not one: the action bars sit below the title, not beside it.
+    await expect(actions.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      titles.getBoundingClientRect().bottom
+    );
+
+    /* And nothing reaches past the frame. Nothing here is inside a scroller, so a
+       right-edge comparison means what it looks like it means - unlike a clipped
+       box, which keeps reporting its full width whatever the scroller does to it. */
+    const frameRight = frame.getBoundingClientRect().right;
+    const past = [...frame.querySelectorAll<HTMLElement>('*')].filter(
+      (el) => el.getBoundingClientRect().right > frameRight + 0.5
+    );
+    await expect(past).toHaveLength(0);
+  },
 };

--- a/apps/frontend/src/app/ui/layout/PageSkeleton.tsx
+++ b/apps/frontend/src/app/ui/layout/PageSkeleton.tsx
@@ -18,8 +18,13 @@ const GENERIC_ROWS = [
 
 const PlannerSkeleton = () => (
   <div className="flex flex-col gap-3 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-4! md:pb-3! lg:pl-5! lg:pr-5! lg:pt-4! lg:pb-3!">
-    {/* Title row */}
-    <div className="flex items-center justify-between gap-4">
+    {/* Title row. `flex-wrap` is the phone case, not a nicety: the subtitle bar is a
+        fixed w-72 and the three action bars are a nested flex row that will not shrink
+        below its own 264px, so on a 390px screen the row needed 568px and pushed the
+        whole page sideways - while the route it stands in for (planner: appointments,
+        tasks, the workspace) is one every phone visit loads first. Wrapping puts the
+        action bars on a second line instead. */}
+    <div className="flex flex-wrap items-center justify-between gap-4">
       <div className="flex flex-col gap-2">
         <div className={`h-7 w-44 ${shimmer}`} />
         <div className={`h-4 w-72 ${shimmer}`} />

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 import { IoDocumentTextOutline, IoPulseOutline } from 'react-icons/io5';
 
 import TabToggle, { type TabOption } from './TabToggle';
@@ -21,7 +21,13 @@ const meta = {
           'Underlined tab strip used inside the appointment workspace side modal (record, documents ' +
           'and tasks panels). Segments share the width equally; the active tab is bold `--blue-text` ' +
           'over a 2px `--blue` underline that sits on the shared `card-border` hairline. Pass `panelId` ' +
-          'to wire `aria-controls` to the panel each tab reveals.',
+          'to wire `aria-controls` to the panel each tab reveals.\n\n' +
+          'Segments are `flex-1` with `px-6` and no `min-w-0`, so "share the width equally" only ' +
+          'holds while there is width to share: below that the strip stops shrinking and pushes ' +
+          'instead. Measured floors are 219px for the two-tab strip and 430px for the four-tab ' +
+          'one. Every call site today passes exactly two short tabs - Vitals / Observation Tool, ' +
+          'Forms / Records, Employee task / Parent task - so the two-tab floor is the one that ' +
+          'ships, and it clears a 390px phone with room to spare.',
       },
     },
   },
@@ -63,8 +69,11 @@ export const WithIcons: Story = {
 };
 
 /**
- * Four tabs with longer labels. Segments are `flex-1`, so the strip stays even
- * while the labels get tighter — the case where a label would start to wrap.
+ * Four tabs in a box too small for them. No call site has four - this is the shape of
+ * the limit, not of anything shipping. Labels wrap onto a second line first, which is
+ * as far as wrapping gets you: `flex-1` without `min-w-0` floors each segment at its
+ * longest WORD plus 48px of padding, so a fully wrapped strip still needs 430px and
+ * pushes anyway. Two rows of text and a sideways shove, not one or the other.
  */
 export const ManyTabs: Story = {
   name: 'Many tabs, long labels',
@@ -76,6 +85,54 @@ export const ManyTabs: Story = {
       { key: 'imaging', label: 'Imaging' },
     ],
     activeKey: 'consent',
+  },
+  decorators: [
+    /* 340px is under the 430px this strip needs, which is the whole point - and the
+       frame scrolls so the demonstration stays inside the story instead of dragging
+       the preview document 56px wide, which is what a phone-width sweep saw and read
+       as a layout bug in a component no call site pushes this far.
+
+       A container, not the mobile viewport global: that global is applied by the
+       manager to the preview iframe and is inert for a runner loading iframe.html
+       directly, and nothing here branches on a media query anyway. */
+    (Story) => (
+      <div data-frame="" style={{ width: 340, overflowX: 'auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
+    const strip = within(canvasElement).getByRole('tablist');
+    const widths = [...strip.children].map((tab) => tab.getBoundingClientRect().width);
+
+    /* The floor is real: the four segments together need more than the box, and no
+       label has wrapped to buy that back. Asserted as a relation rather than against
+       430px, so a font or padding change moves the number without failing here. */
+    await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth);
+    await expect(widths.reduce((sum, width) => sum + width, 0)).toBeGreaterThan(
+      frame.getBoundingClientRect().width
+    );
+
+    /* And wrapping has already happened - it is not what saves this. A Range over the
+       label's TEXT NODE returns one client rect per line box, which counts lines
+       rather than inferring them from a height. The range has to be the text node and
+       not the button: the button is a flex container, so its contents measure as one
+       flex item however many lines the text inside runs to.
+
+       "All documents" and "Consent forms" have both broken in two and the strip still
+       does not fit - and "Imaging" is one word, so it could not have wrapped however
+       tight the box got. That is the shape of the floor: a label bottoms out at its
+       longest word, and a one-word label bottoms out immediately. */
+    const linesIn = (tab: Element) => {
+      const label = [...tab.childNodes].find((node) => node.nodeType === Node.TEXT_NODE);
+      const range = globalThis.document.createRange();
+      range.selectNodeContents(label as Node);
+      return range.getClientRects().length;
+    };
+    const lineCounts = [...strip.children].map(linesIn);
+    await expect(lineCounts.filter((lines) => lines > 1).length).toBeGreaterThan(1);
+    await expect(linesIn(within(canvasElement).getByRole('tab', { name: 'Imaging' }))).toBe(1);
   },
 };
 

--- a/apps/frontend/src/app/ui/widgets/Labels/Labels.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Labels/Labels.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 import { useState } from 'react';
 import Labels from './Labels';
 
@@ -33,7 +33,14 @@ const meta = {
   title: 'Widgets/Labels',
   component: Labels,
   parameters: {
-    layout: 'centered',
+    /* `padded`, not `centered`. The strip is `w-full` inside an `inline-flex` root, and
+       the centered layout hands the story a shrink-to-fit box - so `w-full` resolved
+       against a container that was itself sized by its content, the row grew to its
+       max-content and its own `overflow-x-auto` never engaged. On a 390px canvas that
+       put 55px of pills past the edge of a component built specifically to scroll them.
+       The component centres its own pills when there are three or fewer
+       (`useCenteredLayout`); it needs a real width from the page, not from the canvas. */
+    layout: 'padded',
     docs: {
       description: {
         component:
@@ -102,6 +109,41 @@ export const WithStatuses: Story = {
 export const WithSubLabels: Story = {
   name: 'With sub-labels',
   render: () => <LabelsWithSubLabelsStory />,
+};
+
+/**
+ * The strip in a box narrower than its pills. Four labels are past
+ * `useCenteredLayout`, so this is the scrolling branch.
+ */
+export const NarrowFrame: Story = {
+  name: 'In a 320px frame',
+  render: () => <BasicLabelsStory />,
+  decorators: [
+    /* A container, not the mobile viewport global: that global is applied by the
+       Storybook manager to the preview iframe and is inert for a runner loading
+       iframe.html directly. Nothing here depends on a media query anyway - the
+       overflow is decided by the box the strip is given. */
+    (Story) => (
+      <div data-frame="" style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
+    const strip = within(canvasElement).getByRole('tablist');
+
+    // There is genuinely more here than fits, or the rest of this asserts nothing.
+    await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth);
+
+    /* And the strip absorbs it instead of the page. This is the failure the story
+       layout hid: under `layout: 'centered'` the strip sat in a shrink-to-fit box,
+       so `w-full` resolved against its own content, the row grew to max-content and
+       `overflow-x-auto` had nothing left to do. */
+    await expect(strip.getBoundingClientRect().width).toBeLessThanOrEqual(
+      frame.getBoundingClientRect().width
+    );
+  },
 };
 
 export const Disabled: Story = {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

The three items left open after #2560 and #2580.

## 1. The story suite is now deterministic offline

Stories reach the network through three seams that converge only at the browser primitives: the shared axios instance (XHR adapter, `baseURL` captured at module load), the SuperTokens auth client, and `authStore`, which calls `initAuthClient()` at module top level - so merely importing it boots SuperTokens and starts firing `/auth/session/refresh`.

All three read `NEXT_PUBLIC_BASE_URL`, and nothing pins it for Storybook. **That is the real defect, and it corrected the premise I started from.** With the variable set the suite talks to devapi and ~175 stories fail on CORS; with it unset the same stories fall back to same-origin 404s and pass. Two behaviours from one shell variable - which is why the failure count moved depending on which worktree I measured in.

There is an amplifier: `AuthCallback.stories.tsx` and `GithubSignInButton.stories.tsx` legitimately write that variable in a decorator, and SuperTokens never resets its `initialized` flag. In a runner that reuses one page, **one story's env write decides where a later story's session refresh goes.**

`.storybook/offline-guard.ts` wraps `fetch` and `XMLHttpRequest` at preview module scope and answers anything bound for the real API offline. Two choices worth reviewing:

- **Primitives, not `api.defaults.adapter`.** 29 story files already swap that adapter and 19 more patch `XMLHttpRequest.prototype`. A guard living there is the thing those stories overwrite and restore, and one wrong restore silently disarms it for everything after. At the primitive layer a per-story stub wins by construction.
- **404, not `200 []`.** The empty-success version was tried first and broke three `AppointmentInfo` stories immediately: this suite seeds a store and relies on the fetch *failing* so the loader `catch`es and the fixture survives. A successful empty response takes the happy path and overwrites the fixture with nothing.

## 2. Three components no longer overflow a phone

Measured at a real 390px viewport, then each of the seven remaining families classified by reading the story **and** the component. Three were app bugs, four were story artefacts. No component was widened to satisfy a story.

- **PackageBreakdownTable**, +390px. The table was never the problem - it already sits in `overflow-x-auto`. The escape was the editable header's `sr-only` "Actions" span: absolutely positioned, and an absolute box is clipped only by a scroll container in its containing-block chain. The scroller was unpositioned, so the span's `offsetParent` was the BODY. One word: `relative`.
- **PageSkeleton** (planner), +190px. Title row needed 568px. This is the loading placeholder for appointments, tasks and the workspace, so it is the first thing a phone paints on those routes.
- **AddCompanionFormMode**, +18px. A bare `1fr` has an `auto` minimum, which switches on the item's automatic minimum size - and the item wraps an input carrying the browser's ~168px intrinsic width, so the row refused to squeeze. `minmax(0, 1fr)`.

## 3. The store refuses service edits on a discharged encounter

`addLineItem` / `updateLineItem` / `removeLineItem` now return the encounter untouched when `viewOnly`. The editor already gated its UI, but that was one call site. Safe against hydration: the bootstrap merges services through `preferNonEmpty(patch.services, enc.services)`, never through these three. Mutation-checked - removing the guard fails the test.

## Validation performed

- `tsc --noEmit` clean; `eslint` 0 errors (1 pre-existing warning in an untouched file).
- Full suite: **975 suites, 12,055 tests**, all passing.
- Offline guard verified per file, guard off vs on, across eleven of the worst offenders - every file matches its baseline exactly, and zero requests leave the browser.
- Every story file touched verified in isolation: 54 stories, all passing.

## Left deliberately, both needing a design call

**WorkspaceHeader** below ~620px: the right-hand cluster (timer, Admit, hospitalize, Quick Actions) is `shrink-0` at 429px, so the row cannot fit 390 even with the identity block collapsed. It never renders there - `useIsPhone` swaps in `PhoneWorkspaceShell` below 768 - so there is no bug today. Making it work on a phone means choosing what a clinician loses in one tap during a live consult.

**TabToggle** has no overflow affordance. No call site is near its 430px four-tab floor today, but a third tab or a longer label would push a side modal sideways with nothing to absorb it.

Also surfaced and **not** chased: `ShareEntityModal` fails all 11 of its stories on "The result of getSnapshot should be cached to avoid an infinite loop" - a real `useSyncExternalStore` unmemoised-selector bug, unrelated to this PR and worth its own task.

## Related Issue(s)

<!-- Follow-up to #2560 and #2580; no separate issue. -->
