### PR TITLE
feat(frontend): give estimates a screen and the convert action a button

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/finance/estimates/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/finance/estimates/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Estimates — Yosemite Crew' };
+import React from 'react';
+import ProtectedEstimates from '@/app/features/finance/pages/Estimates';
+
+const page = () => {
+  return <ProtectedEstimates />;
+};
+
+export default page;

--- a/apps/frontend/src/app/(routes)/(app)/finance/estimates/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/finance/estimates/page.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from 'next';
+
 export const metadata: Metadata = { title: 'Estimates — Yosemite Crew' };
-import React from 'react';
-import ProtectedEstimates from '@/app/features/finance/pages/Estimates';
 
-const page = () => {
-  return <ProtectedEstimates />;
-};
-
-export default page;
+// Re-exported rather than wrapped: the route adds no behaviour of its own, so a
+// local component that only returns the screen is indirection without intent.
+export { default } from '@/app/features/finance/pages/Estimates';

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
@@ -292,7 +292,6 @@ describe('CreateEstimateDialog', () => {
 
     expect(onSubmit).toHaveBeenCalledWith({
       patientId: 'c2',
-      currency: 'USD',
       notes: 'Pre-op quote',
       validUntil: '2026-12-31T00:00:00.000Z',
       items: [
@@ -356,5 +355,16 @@ describe('CreateEstimateDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Cancel creating this estimate' }));
 
     expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('refuses every dismissal route while a create is in flight', async () => {
+    const { setOpen } = setup({ saving: true });
+
+    // ModalBase also closes on Escape and on an outside click, and neither
+    // consults the disabled Cancel button. A create cannot be cancelled, so a
+    // dismissal mid-flight can let one succeed invisibly and a retry mint a
+    // second estimate.
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel creating this estimate' }));
+    expect(setOpen).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
@@ -367,4 +367,27 @@ describe('CreateEstimateDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Cancel creating this estimate' }));
     expect(setOpen).not.toHaveBeenCalled();
   });
+
+  it('refuses a validity date that has already passed', () => {
+    // Nothing derives EXPIRED from validUntil, so a lapsed quote stays a DRAFT
+    // that can still be sent, approved and converted. Creation is the only
+    // place it is caught.
+    expect(validateDraft('pat-1', [draftLine()], '2020-01-01', '2026-09-01')).toEqual({
+      ok: false,
+      message: 'The validity date cannot be in the past.',
+    });
+  });
+
+  it('accepts today and any future validity date', () => {
+    expect(validateDraft('pat-1', [draftLine()], '2026-09-01', '2026-09-01').ok).toBe(true);
+    expect(validateDraft('pat-1', [draftLine()], '2027-01-01', '2026-09-01').ok).toBe(true);
+    expect(validateDraft('pat-1', [draftLine()], '', '2026-09-01').ok).toBe(true);
+  });
+
+  it('does not offer a past date in the picker', () => {
+    setup();
+
+    // Belt and braces with the validation above: the input itself refuses one.
+    expect(screen.getByLabelText('Valid until (optional)')).toHaveAttribute('min');
+  });
 });

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
@@ -29,9 +29,8 @@ jest.mock('@/app/ui/primitives/Buttons', () => ({
   ),
 }));
 
-import CreateEstimateDialog, {
-  validateDraft,
-} from '@/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog';
+import CreateEstimateDialog from '@/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog';
+import { validateDraft } from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
 import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
 
 /** The dialog's internal draft-line shape, which `validateDraft` takes. */

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
@@ -1,0 +1,361 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+// Passthrough: the modal's own portal/overlay behaviour is covered by
+// CenterModal's tests, and rendering the children inline keeps the form
+// queryable without the dialog machinery.
+jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
+  __esModule: true,
+  default: ({ showModal, children, ariaLabel }: any) =>
+    showModal ? (
+      <div role="dialog" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+import CreateEstimateDialog, {
+  validateDraft,
+} from '@/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog';
+import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
+
+/** The dialog's internal draft-line shape, which `validateDraft` takes. */
+type DraftLineShape = {
+  key: string;
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  taxRate: string;
+};
+
+const draftLine = (overrides: Partial<DraftLineShape> = {}): DraftLineShape => ({
+  key: 'line-0',
+  description: 'Dental clean',
+  quantity: '2',
+  unitPrice: '50',
+  taxRate: '10',
+  ...overrides,
+});
+
+describe('validateDraft', () => {
+  it('accepts a complete draft', () => {
+    expect(validateDraft('c1', [draftLine()])).toEqual({ ok: true });
+  });
+
+  it('requires a companion', () => {
+    expect(validateDraft('', [draftLine()])).toEqual({
+      ok: false,
+      message: 'Choose a companion for this estimate.',
+    });
+  });
+
+  it('requires at least one line', () => {
+    expect(validateDraft('c1', [])).toEqual({ ok: false, message: 'Add at least one line.' });
+  });
+
+  it('requires a description on every line', () => {
+    expect(validateDraft('c1', [draftLine({ description: '   ' })])).toEqual({
+      ok: false,
+      message: 'Every line needs a description.',
+    });
+  });
+
+  it('rejects a quantity of zero or below', () => {
+    expect(validateDraft('c1', [draftLine({ quantity: '0' })])).toEqual({
+      ok: false,
+      message: 'Quantity for "Dental clean" must be above zero.',
+    });
+    expect(validateDraft('c1', [draftLine({ quantity: '-2' })])).toEqual({
+      ok: false,
+      message: 'Quantity for "Dental clean" must be above zero.',
+    });
+  });
+
+  it('reads an unparseable number as zero rather than NaN', () => {
+    expect(validateDraft('c1', [draftLine({ quantity: 'abc' })])).toEqual({
+      ok: false,
+      message: 'Quantity for "Dental clean" must be above zero.',
+    });
+  });
+
+  it('rejects a negative unit price but allows a free line', () => {
+    expect(validateDraft('c1', [draftLine({ unitPrice: '-1' })])).toEqual({
+      ok: false,
+      message: 'Unit price for "Dental clean" cannot be negative.',
+    });
+    expect(validateDraft('c1', [draftLine({ unitPrice: '0' })])).toEqual({ ok: true });
+  });
+
+  it('rejects tax below 0 or above 100', () => {
+    expect(validateDraft('c1', [draftLine({ taxRate: '-0.5' })])).toEqual({
+      ok: false,
+      message: 'Tax for "Dental clean" must be between 0 and 100.',
+    });
+    expect(validateDraft('c1', [draftLine({ taxRate: '101' })])).toEqual({
+      ok: false,
+      message: 'Tax for "Dental clean" must be between 0 and 100.',
+    });
+    expect(validateDraft('c1', [draftLine({ taxRate: '100' })])).toEqual({ ok: true });
+  });
+
+  it('validates every line, not just the first', () => {
+    expect(
+      validateDraft('c1', [
+        draftLine(),
+        draftLine({ key: 'line-1', description: 'X-ray', unitPrice: '-5' }),
+      ])
+    ).toEqual({ ok: false, message: 'Unit price for "X-ray" cannot be negative.' });
+  });
+});
+
+const COMPANIONS = [
+  { id: 'c1', name: 'Bruno' },
+  { id: 'c2', name: 'Mango' },
+];
+
+type DialogProps = React.ComponentProps<typeof CreateEstimateDialog>;
+
+const setup = (overrides: Partial<DialogProps> = {}) => {
+  const onSubmit = jest.fn();
+  const setOpen = jest.fn();
+  const view = render(
+    <CreateEstimateDialog
+      open
+      setOpen={setOpen}
+      companions={COMPANIONS}
+      currency="USD"
+      saving={false}
+      error={null}
+      onSubmit={onSubmit}
+      {...overrides}
+    />
+  );
+  return { onSubmit, setOpen, ...view };
+};
+
+/** The line's own total sits immediately before that line's Remove button. */
+const lineTotal = (index: number) =>
+  screen.getByRole('button', { name: `Remove line ${index}` }).previousElementSibling?.textContent;
+
+/** Each summary row is a label span followed by its value span. */
+const summaryValue = (label: string) => screen.getByText(label).nextElementSibling?.textContent;
+
+const createButton = () => screen.getByRole('button', { name: 'Create this estimate' });
+
+const fillLine = async (
+  index: number,
+  values: { description: string; quantity: string; unitPrice: string; taxRate: string }
+) => {
+  await userEvent.type(screen.getByLabelText(`Line ${index} description`), values.description);
+  await userEvent.clear(screen.getByLabelText(`Line ${index} quantity`));
+  await userEvent.type(screen.getByLabelText(`Line ${index} quantity`), values.quantity);
+  await userEvent.clear(screen.getByLabelText(`Line ${index} unit price`));
+  await userEvent.type(screen.getByLabelText(`Line ${index} unit price`), values.unitPrice);
+  await userEvent.clear(screen.getByLabelText(`Line ${index} tax percent`));
+  await userEvent.type(screen.getByLabelText(`Line ${index} tax percent`), values.taxRate);
+};
+
+describe('CreateEstimateDialog', () => {
+  it('renders nothing while closed', () => {
+    setup({ open: false });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens with one empty line and a zeroed summary', () => {
+    setup();
+
+    expect(screen.getByRole('dialog', { name: 'Create an estimate' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'New estimate' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Line 1 description')).toHaveValue('');
+    expect(screen.queryByLabelText('Line 2 description')).not.toBeInTheDocument();
+    expect(lineTotal(1)).toBe('$0.00');
+    expect(summaryValue('Subtotal')).toBe('$0.00');
+    expect(summaryValue('Tax')).toBe('$0.00');
+    expect(summaryValue('Total')).toBe('$0.00');
+    expect(screen.getByRole('option', { name: 'Bruno' })).toBeInTheDocument();
+  });
+
+  it('recomputes the line total and the summary as the line is typed', async () => {
+    setup();
+
+    await fillLine(1, {
+      description: 'Dental clean',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+
+    expect(lineTotal(1)).toBe('$100.00');
+    expect(summaryValue('Subtotal')).toBe('$100.00');
+    expect(summaryValue('Tax')).toBe('$10.00');
+    expect(summaryValue('Total')).toBe('$110.00');
+  });
+
+  it('adds and removes lines, keeping the last one', async () => {
+    setup();
+
+    expect(screen.getByRole('button', { name: 'Remove line 1' })).toBeDisabled();
+
+    await fillLine(1, {
+      description: 'Dental clean',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Add another estimate line' }));
+
+    expect(screen.getByLabelText('Line 2 description')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove line 1' })).toBeEnabled();
+
+    await fillLine(2, { description: 'X-ray', quantity: '1', unitPrice: '25', taxRate: '0' });
+
+    expect(lineTotal(2)).toBe('$25.00');
+    expect(summaryValue('Subtotal')).toBe('$125.00');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove line 2' }));
+
+    expect(screen.queryByLabelText('Line 2 description')).not.toBeInTheDocument();
+    expect(summaryValue('Subtotal')).toBe('$100.00');
+    expect(screen.getByRole('button', { name: 'Remove line 1' })).toBeDisabled();
+  });
+
+  it('blocks a submit with no companion chosen', async () => {
+    const { onSubmit } = setup();
+
+    await fillLine(1, {
+      description: 'Dental clean',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+    await userEvent.click(createButton());
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Choose a companion for this estimate.'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('blocks a submit with an invalid line and clears the message once it is fixed', async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c1');
+    await userEvent.click(createButton());
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Every line needs a description.');
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await fillLine(1, {
+      description: 'Dental clean',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+    await userEvent.click(createButton());
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits the draft as a CreateEstimateInput with numeric items and an ISO validUntil', async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c2');
+    fireEvent.change(screen.getByLabelText('Valid until (optional)'), {
+      target: { value: '2026-12-31' },
+    });
+    await fillLine(1, {
+      description: '  Dental clean  ',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Add another estimate line' }));
+    await fillLine(2, { description: 'X-ray', quantity: '1', unitPrice: '25', taxRate: '0' });
+    await userEvent.type(screen.getByLabelText('Notes (optional)'), 'Pre-op quote');
+    await userEvent.click(createButton());
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      patientId: 'c2',
+      currency: 'USD',
+      notes: 'Pre-op quote',
+      validUntil: '2026-12-31T00:00:00.000Z',
+      items: [
+        { description: 'Dental clean', quantity: 2, unitPrice: 50, taxRate: 10 },
+        { description: 'X-ray', quantity: 1, unitPrice: 25, taxRate: 0 },
+      ],
+    });
+
+    const [input] = onSubmit.mock.calls[0] as [CreateEstimateInput];
+    expect(typeof input.items[0].quantity).toBe('number');
+    expect(typeof input.items[0].unitPrice).toBe('number');
+    expect(typeof input.items[0].taxRate).toBe('number');
+  });
+
+  it('omits the optional fields when they were left empty', async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c1');
+    await fillLine(1, {
+      description: 'Dental clean',
+      quantity: '2',
+      unitPrice: '50',
+      taxRate: '10',
+    });
+    await userEvent.click(createButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: undefined, validUntil: undefined })
+    );
+  });
+
+  it('disables both buttons and reports progress while saving', () => {
+    setup({ saving: true });
+
+    expect(screen.getByRole('button', { name: 'Create this estimate' })).toHaveTextContent(
+      'Creating...'
+    );
+    expect(screen.getByRole('button', { name: 'Create this estimate' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel creating this estimate' })).toBeDisabled();
+  });
+
+  it('renders an error handed down from the page', () => {
+    setup({ error: 'The estimate could not be created.' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The estimate could not be created.');
+  });
+
+  it('prefers its own validation message over the page error', async () => {
+    setup({ error: 'The estimate could not be created.' });
+
+    await userEvent.click(createButton());
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Choose a companion for this estimate.'
+    );
+  });
+
+  it('closes on cancel', async () => {
+    const { setOpen } = setup();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel creating this estimate' }));
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
@@ -1,0 +1,434 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+// Renders children so the gated action row is exercised; the permission logic
+// itself is covered by PermissionGate's own tests.
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
+import EstimateList from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
+import EstimateDetail, {
+  type EstimateAction,
+} from '@/app/features/finance/pages/Estimates/Sections/EstimateDetail';
+import type { Estimate, EstimateItem, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+const makeItem = (overrides: Partial<EstimateItem> = {}): EstimateItem => ({
+  id: 'item-1',
+  description: 'Consultation',
+  quantity: 2,
+  unitPrice: 40,
+  taxRate: 20,
+  lineTotal: 80,
+  notes: null,
+  ...overrides,
+});
+
+// Figures are internally consistent: 80 + 50 subtotal, 20% of the first line as
+// tax, so a reader can check the totals against the lines by hand.
+const makeEstimate = (overrides: Partial<Estimate> = {}): Estimate => ({
+  id: 'est-1',
+  organisationId: 'org-1',
+  patientId: 'pet-1',
+  encounterId: null,
+  status: 'DRAFT',
+  validUntil: '2026-09-30T00:00:00.000Z',
+  subtotal: 130,
+  taxAmount: 16,
+  total: 146,
+  currency: 'USD',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: null,
+  createdBy: null,
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+  items: [
+    makeItem(),
+    makeItem({
+      id: 'item-2',
+      description: 'Vaccination',
+      quantity: 1,
+      unitPrice: 50,
+      taxRate: 0,
+      lineTotal: 50,
+      notes: 'Annual booster',
+    }),
+  ],
+  ...overrides,
+});
+
+const closestRow = (element: HTMLElement): HTMLElement => {
+  const row = element.closest('tr');
+  if (!row) throw new Error('Expected the element to sit inside a table row.');
+  return row;
+};
+
+describe('EstimateStatusBadge', () => {
+  const labels: [EstimateStatus, string][] = [
+    ['DRAFT', 'Draft'],
+    ['SENT', 'Sent'],
+    ['APPROVED', 'Approved'],
+    ['CONVERTED', 'Converted'],
+    ['DECLINED', 'Declined'],
+    ['EXPIRED', 'Expired'],
+  ];
+
+  it.each(labels)('renders the human label for %s', (status, label) => {
+    render(<EstimateStatusBadge status={status} />);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('colours the pill from the status token set', () => {
+    render(<EstimateStatusBadge status="CONVERTED" />);
+
+    // Read the inline style attribute rather than computed style: jsdom does
+    // not resolve `var()` references, so a computed-style match would compare
+    // two empty strings and pass for any token.
+    const style = screen.getByText('Converted').getAttribute('style') ?? '';
+    expect(style).toContain('var(--color-pill-success-bg)');
+    expect(style).toContain('var(--color-pill-success-text)');
+    expect(style).toContain('var(--color-pill-success-border)');
+  });
+});
+
+describe('EstimateList', () => {
+  const estimates = [
+    makeEstimate({ id: 'est-1', patientId: 'pet-1', total: 146, status: 'DRAFT' }),
+    makeEstimate({
+      id: 'est-2',
+      patientId: 'pet-2',
+      total: 1234.5,
+      status: 'APPROVED',
+      validUntil: null,
+    }),
+  ];
+
+  const names: Record<string, string> = { 'pet-1': 'Rex', 'pet-2': 'Milo' };
+  const companionName = (patientId: string) => names[patientId] ?? 'Unknown companion';
+
+  const renderList = (overrides: Partial<React.ComponentProps<typeof EstimateList>> = {}) => {
+    const onSelect = jest.fn();
+    render(
+      <EstimateList
+        estimates={estimates}
+        activeEstimateId={null}
+        onSelect={onSelect}
+        companionName={companionName}
+        {...overrides}
+      />
+    );
+    return { onSelect };
+  };
+
+  const rowFor = (name: string): HTMLElement =>
+    closestRow(screen.getByRole('button', { name: `Open the estimate for ${name}` }));
+
+  it('renders a row per estimate with the companion name resolved through the prop', () => {
+    renderList();
+
+    // One header row plus one row per estimate.
+    expect(screen.getAllByRole('row')).toHaveLength(3);
+    expect(within(rowFor('Rex')).getByText('Rex')).toBeInTheDocument();
+    expect(within(rowFor('Milo')).getByText('Milo')).toBeInTheDocument();
+  });
+
+  it('renders the total with two decimals', () => {
+    renderList();
+
+    expect(within(rowFor('Rex')).getAllByRole('cell')[4]).toHaveTextContent('$146.00');
+    expect(within(rowFor('Milo')).getAllByRole('cell')[4]).toHaveTextContent('$1,234.50');
+  });
+
+  it('calls onSelect with the estimate whose name button was clicked', async () => {
+    const { onSelect } = renderList();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open the estimate for Milo' }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(estimates[1]);
+  });
+
+  it('renders a dash for a null valid-until date', () => {
+    renderList();
+
+    expect(within(rowFor('Milo')).getAllByRole('cell')[3]).toHaveTextContent('-');
+    expect(within(rowFor('Rex')).getAllByRole('cell')[3]).not.toHaveTextContent('-');
+  });
+
+  it('renders a dash for an unparseable date rather than "Invalid Date"', () => {
+    renderList({
+      estimates: [makeEstimate({ id: 'est-3', patientId: 'pet-1', validUntil: 'not-a-date' })],
+    });
+
+    expect(within(rowFor('Rex')).getAllByRole('cell')[3]).toHaveTextContent('-');
+  });
+
+  it('renders the status badge for each row', () => {
+    renderList();
+
+    expect(within(rowFor('Rex')).getByText('Draft')).toBeInTheDocument();
+    expect(within(rowFor('Milo')).getByText('Approved')).toBeInTheDocument();
+  });
+
+  it('highlights the active row only', () => {
+    renderList({ activeEstimateId: 'est-2' });
+
+    // classList, not a substring match: the base row classes already carry
+    // `hover:bg-card-hover`, which any `toContain` check would match.
+    expect(rowFor('Milo').classList.contains('bg-card-hover')).toBe(true);
+    expect(rowFor('Rex').classList.contains('bg-card-hover')).toBe(false);
+  });
+});
+
+describe('EstimateDetail', () => {
+  const ARIA_LABELS: Record<EstimateAction, string> = {
+    send: 'Mark this estimate as sent',
+    decline: 'Decline this estimate',
+    approve: 'Approve this estimate',
+    convert: 'Convert this estimate to an invoice',
+  };
+
+  const IDLE_LABELS: Record<EstimateAction, string> = {
+    send: 'Mark as sent',
+    decline: 'Decline',
+    approve: 'Approve',
+    convert: 'Convert to invoice',
+  };
+
+  const PENDING_LABELS: Record<EstimateAction, string> = {
+    send: 'Sending...',
+    decline: 'Declining...',
+    approve: 'Approving...',
+    convert: 'Converting...',
+  };
+
+  const ALL_ACTIONS: EstimateAction[] = ['send', 'decline', 'approve', 'convert'];
+
+  const renderDetail = (overrides: Partial<React.ComponentProps<typeof EstimateDetail>> = {}) => {
+    const onAction = jest.fn();
+    render(
+      <EstimateDetail
+        estimate={makeEstimate()}
+        companionName="Rex"
+        pendingAction={null}
+        onAction={onAction}
+        error={null}
+        {...overrides}
+      />
+    );
+    return { onAction };
+  };
+
+  const actionButton = (action: EstimateAction) =>
+    screen.queryByRole('button', { name: ARIA_LABELS[action] });
+
+  const lineRow = (description: string): HTMLElement => closestRow(screen.getByText(description));
+
+  const summaryValue = (label: string): string => {
+    const value = screen.getByText(label, { selector: 'span' }).nextElementSibling;
+    if (!value) throw new Error(`Expected a value beside the "${label}" summary label.`);
+    return value.textContent ?? '';
+  };
+
+  it('renders every line item with its description, quantity, unit price, tax and line total', () => {
+    renderDetail();
+
+    const consultation = within(lineRow('Consultation')).getAllByRole('cell');
+    expect(consultation[0]).toHaveTextContent('Consultation');
+    expect(consultation[1]).toHaveTextContent('2');
+    expect(consultation[2]).toHaveTextContent('$40.00');
+    expect(consultation[3]).toHaveTextContent('20%');
+    expect(consultation[4]).toHaveTextContent('$80.00');
+
+    const vaccination = within(lineRow('Vaccination')).getAllByRole('cell');
+    expect(vaccination[0]).toHaveTextContent('Vaccination');
+    expect(vaccination[0]).toHaveTextContent('Annual booster');
+    expect(vaccination[1]).toHaveTextContent('1');
+    expect(vaccination[2]).toHaveTextContent('$50.00');
+    expect(vaccination[3]).toHaveTextContent('0%');
+    expect(vaccination[4]).toHaveTextContent('$50.00');
+  });
+
+  it('renders the subtotal, tax and total', () => {
+    renderDetail();
+
+    expect(summaryValue('Subtotal')).toBe('$130.00');
+    expect(summaryValue('Tax')).toBe('$16.00');
+    expect(summaryValue('Total')).toBe('$146.00');
+  });
+
+  it('renders the companion name and the status badge in the header', () => {
+    renderDetail({ estimate: makeEstimate({ status: 'SENT' }) });
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Rex' })).toBeInTheDocument();
+    expect(screen.getByText('Sent')).toBeInTheDocument();
+  });
+
+  describe('action gating', () => {
+    const gating: [EstimateStatus, EstimateAction[]][] = [
+      ['DRAFT', ['send', 'decline', 'approve']],
+      ['SENT', ['decline', 'approve']],
+      ['APPROVED', ['convert']],
+      ['DECLINED', []],
+      ['EXPIRED', []],
+      ['CONVERTED', []],
+    ];
+
+    it.each(gating)('offers only the accepted transitions for %s', (status, allowed) => {
+      renderDetail({ estimate: makeEstimate({ status }) });
+
+      for (const action of ALL_ACTIONS) {
+        const button = actionButton(action);
+        if (allowed.includes(action)) {
+          expect(button).toBeInTheDocument();
+          expect(button).toHaveTextContent(IDLE_LABELS[action]);
+        } else {
+          expect(button).not.toBeInTheDocument();
+        }
+      }
+    });
+
+    it('offers no lifecycle action at all once the estimate is converted', () => {
+      renderDetail({ estimate: makeEstimate({ status: 'CONVERTED' }) });
+
+      expect(screen.queryAllByRole('button')).toHaveLength(0);
+    });
+  });
+
+  describe('action dispatch', () => {
+    const dispatch: [EstimateAction, EstimateStatus][] = [
+      ['send', 'DRAFT'],
+      ['decline', 'DRAFT'],
+      ['approve', 'SENT'],
+      ['convert', 'APPROVED'],
+    ];
+
+    it.each(dispatch)('calls onAction with "%s"', async (action, status) => {
+      const { onAction } = renderDetail({ estimate: makeEstimate({ status }) });
+
+      await userEvent.click(screen.getByRole('button', { name: ARIA_LABELS[action] }));
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith(action);
+    });
+  });
+
+  describe('pendingAction', () => {
+    const pending: [EstimateAction, EstimateStatus][] = [
+      ['send', 'DRAFT'],
+      ['decline', 'DRAFT'],
+      ['approve', 'SENT'],
+      ['convert', 'APPROVED'],
+    ];
+
+    it.each(pending)(
+      'shows the pending label for "%s" and disables every button',
+      (action, status) => {
+        renderDetail({ estimate: makeEstimate({ status }), pendingAction: action });
+
+        const button = screen.getByRole('button', { name: ARIA_LABELS[action] });
+        expect(button).toHaveTextContent(PENDING_LABELS[action]);
+        expect(button).not.toHaveTextContent(IDLE_LABELS[action]);
+
+        const buttons = screen.getAllByRole('button');
+        expect(buttons.length).toBeGreaterThan(0);
+        for (const other of buttons) expect(other).toBeDisabled();
+      }
+    );
+
+    it('leaves the other buttons on their idle labels while one is in flight', () => {
+      renderDetail({ estimate: makeEstimate({ status: 'DRAFT' }), pendingAction: 'approve' });
+
+      expect(actionButton('send')).toHaveTextContent('Mark as sent');
+      expect(actionButton('decline')).toHaveTextContent('Decline');
+      expect(actionButton('approve')).toHaveTextContent('Approving...');
+    });
+
+    it('enables the buttons when nothing is in flight', () => {
+      renderDetail({ estimate: makeEstimate({ status: 'DRAFT' }) });
+
+      for (const button of screen.getAllByRole('button')) expect(button).toBeEnabled();
+    });
+  });
+
+  describe('the converted estimate', () => {
+    it('explains why converting again is not offered and links to the invoice', () => {
+      renderDetail({
+        estimate: makeEstimate({ status: 'CONVERTED', convertedToInvoiceId: 'inv-9' }),
+      });
+
+      expect(screen.getByText(/converted to an invoice/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'View the invoice' })).toHaveAttribute(
+        'href',
+        '/finance?invoiceId=inv-9'
+      );
+    });
+
+    it('shows no invoice link when nothing has been converted', () => {
+      renderDetail({ estimate: makeEstimate({ status: 'APPROVED' }) });
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.queryByText(/converted to an invoice/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the error in an alert', () => {
+    renderDetail({ error: 'The estimate has already been converted.' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The estimate has already been converted.');
+  });
+
+  it('renders no alert without an error', () => {
+    renderDetail();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the decline reason when there is one', () => {
+    renderDetail({
+      estimate: makeEstimate({ status: 'DECLINED', declineReason: 'Ran out of budget' }),
+    });
+
+    expect(screen.getByText('Declined: Ran out of budget')).toBeInTheDocument();
+  });
+
+  it('renders no decline line when there is no reason', () => {
+    renderDetail({ estimate: makeEstimate({ status: 'DECLINED' }) });
+
+    expect(screen.queryByText(/^Declined:/)).not.toBeInTheDocument();
+  });
+
+  it('renders the estimate notes when present', () => {
+    renderDetail({ estimate: makeEstimate({ notes: 'Quoted before the dental x-rays.' }) });
+
+    expect(screen.getByText('Quoted before the dental x-rays.')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
@@ -250,25 +250,57 @@ describe('EstimateDetail', () => {
   const actionButton = (action: EstimateAction) =>
     screen.queryByRole('button', { name: ARIA_LABELS[action] });
 
-  const lineRow = (description: string): HTMLElement => closestRow(screen.getByText(description));
+  /**
+   * One line of the estimate. The detail renders its lines through the shared
+   * TableHead recipe over a CSS grid, matching InvoiceBilledItems, so a line is
+   * a grid row rather than a <tr> - the cells are its direct children.
+   */
+  const lineRow = (description: string): HTMLElement => {
+    const row = screen.getByText(description).closest('div[style*="grid-template-columns"]');
+    if (!row) throw new Error(`No estimate line row found for "${description}".`);
+    return row as HTMLElement;
+  };
 
+  const lineCells = (description: string): HTMLElement[] =>
+    Array.from(lineRow(description).children) as HTMLElement[];
+
+  /**
+   * Scoped to the totals group, because "Tax" is also a column header on the
+   * line-items table above and an unscoped query matches both.
+   */
   const summaryValue = (label: string): string => {
-    const value = screen.getByText(label, { selector: 'span' }).nextElementSibling;
+    const totals = screen.getByRole('group', { name: 'Estimate totals' });
+    const value = within(totals).getByText(label).nextElementSibling;
     if (!value) throw new Error(`Expected a value beside the "${label}" summary label.`);
     return value.textContent ?? '';
   };
 
+  it('says so when an estimate has no lines at all', () => {
+    renderDetail({ estimate: makeEstimate({ items: [] }) });
+
+    expect(screen.getByText('This estimate has no lines.')).toBeInTheDocument();
+  });
+
+  it('omits the notes line when an item carries none', () => {
+    renderDetail();
+
+    // Consultation has no notes; Vaccination does. The notes span must exist
+    // for one and not the other, rather than rendering an empty element.
+    expect(lineCells('Consultation')[0].querySelectorAll('span')).toHaveLength(1);
+    expect(lineCells('Vaccination')[0].querySelectorAll('span').length).toBeGreaterThan(1);
+  });
+
   it('renders every line item with its description, quantity, unit price, tax and line total', () => {
     renderDetail();
 
-    const consultation = within(lineRow('Consultation')).getAllByRole('cell');
+    const consultation = lineCells('Consultation');
     expect(consultation[0]).toHaveTextContent('Consultation');
     expect(consultation[1]).toHaveTextContent('2');
     expect(consultation[2]).toHaveTextContent('$40.00');
     expect(consultation[3]).toHaveTextContent('20%');
     expect(consultation[4]).toHaveTextContent('$80.00');
 
-    const vaccination = within(lineRow('Vaccination')).getAllByRole('cell');
+    const vaccination = lineCells('Vaccination');
     expect(vaccination[0]).toHaveTextContent('Vaccination');
     expect(vaccination[0]).toHaveTextContent('Annual booster');
     expect(vaccination[1]).toHaveTextContent('1');

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
@@ -269,8 +269,10 @@ describe('EstimateDetail', () => {
    * line-items table above and an unscoped query matches both.
    */
   const summaryValue = (label: string): string => {
-    const totals = screen.getByRole('group', { name: 'Estimate totals' });
-    const value = within(totals).getByText(label).nextElementSibling;
+    // Anchored on the <dt>, so "Tax" here is never confused with the "Tax"
+    // column header on the lines table above.
+    const term = screen.getAllByText(label).find((node) => node.tagName === 'DT');
+    const value = term?.nextElementSibling;
     if (!value) throw new Error(`Expected a value beside the "${label}" summary label.`);
     return value.textContent ?? '';
   };

--- a/apps/frontend/src/app/__tests__/features/finance/estimateTotals.test.ts
+++ b/apps/frontend/src/app/__tests__/features/finance/estimateTotals.test.ts
@@ -1,0 +1,182 @@
+import {
+  computeEstimateTotals,
+  computeLineTotal,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+import type { EstimateItemInput } from '@/app/features/finance/types/estimate';
+
+/**
+ * `computeTotals` from `apps/backend/src/services/estimate.service.ts` (line 51),
+ * transcribed verbatim.
+ *
+ * The client preview and the server have to agree operation for operation, not
+ * just to a rounded penny: the estimate the user reads and approves in the
+ * editor is the one the service then writes to `subtotal` / `taxAmount` /
+ * `total`. Comparing against a copy of the server's own loop is what makes the
+ * parity block below a regression test rather than a restatement of the client.
+ */
+const backendComputeTotals = (items: EstimateItemInput[]) => {
+  let subtotal = 0;
+  let taxAmount = 0;
+  for (const item of items) {
+    const lineTotal = item.quantity * item.unitPrice;
+    const lineTax = lineTotal * ((item.taxRate ?? 0) / 100);
+    subtotal += lineTotal;
+    taxAmount += lineTax;
+  }
+  return { subtotal, taxAmount, total: subtotal + taxAmount };
+};
+
+const CONSULTATION: EstimateItemInput = {
+  description: 'Consultation',
+  quantity: 2,
+  unitPrice: 45,
+  taxRate: 0,
+};
+
+const VACCINE: EstimateItemInput = {
+  description: 'Vaccine',
+  quantity: 1,
+  unitPrice: 30.5,
+  taxRate: 5,
+};
+
+const DENTAL: EstimateItemInput = {
+  description: 'Dental scale and polish',
+  quantity: 2,
+  unitPrice: 50,
+  taxRate: 20,
+};
+
+/** A line the create form left untouched, so `taxRate` is absent rather than 0. */
+const UNTAXED_KEY_ABSENT: EstimateItemInput = {
+  description: 'Nail clip',
+  quantity: 3,
+  unitPrice: 12,
+};
+
+describe('computeEstimateTotals', () => {
+  it('returns zeroes for an estimate with no lines', () => {
+    expect(computeEstimateTotals([])).toEqual({ subtotal: 0, taxAmount: 0, total: 0 });
+  });
+
+  it('totals a single untaxed line', () => {
+    expect(computeEstimateTotals([CONSULTATION])).toEqual({
+      subtotal: 90,
+      taxAmount: 0,
+      total: 90,
+    });
+  });
+
+  it('sums multiple lines', () => {
+    // 1.5250000000000001, not 1.525: neither side rounds, and the backend's
+    // identical loop produces the identical float, so pinning the artefact is
+    // what proves the two agree. Rounding belongs at the render edge.
+    expect(computeEstimateTotals([CONSULTATION, VACCINE])).toEqual({
+      subtotal: 120.5,
+      taxAmount: 30.5 * (5 / 100),
+      total: 122.025,
+    });
+    expect(computeEstimateTotals([CONSULTATION, VACCINE]).taxAmount).toBeCloseTo(1.525, 10);
+  });
+
+  it('treats an omitted taxRate as 0 rather than NaN', () => {
+    const totals = computeEstimateTotals([UNTAXED_KEY_ABSENT]);
+
+    expect(totals).toEqual({ subtotal: 36, taxAmount: 0, total: 36 });
+    expect(Number.isNaN(totals.taxAmount)).toBe(false);
+  });
+
+  it('applies a 20% rate to that line only, leaving the line total pre-tax', () => {
+    expect(computeEstimateTotals([DENTAL])).toEqual({
+      subtotal: 100,
+      taxAmount: 20,
+      total: 120,
+    });
+  });
+
+  it('keeps fractional money unrounded, e.g. 3 x 19.99', () => {
+    expect(
+      computeEstimateTotals([{ description: 'Wormer', quantity: 3, unitPrice: 19.99 }])
+    ).toEqual({ subtotal: 59.97, taxAmount: 0, total: 59.97 });
+  });
+
+  it('keeps fractional money unrounded once tax is on it too', () => {
+    expect(
+      computeEstimateTotals([{ description: 'Wormer', quantity: 3, unitPrice: 19.99, taxRate: 20 }])
+    ).toEqual({ subtotal: 59.97, taxAmount: 11.994, total: 71.964 });
+  });
+
+  it('rates each line separately instead of applying one rate to the subtotal', () => {
+    const totals = computeEstimateTotals([DENTAL, VACCINE]);
+
+    // Per line: 100 @ 20% = 20, and 30.5 @ 5% = 1.525.
+    expect(totals.taxAmount).toBe(21.525);
+    // A single blended rate over the 130.5 subtotal would land anywhere between
+    // 6.525 (all 5%) and 26.1 (all 20%), so this pins the per-line shape.
+    expect(totals.taxAmount).not.toBe(130.5 * 0.2);
+    expect(totals.taxAmount).not.toBe(130.5 * 0.05);
+  });
+
+  it('excludes tax from the subtotal and folds it back in for the total', () => {
+    const totals = computeEstimateTotals([DENTAL, VACCINE]);
+
+    expect(totals.subtotal).toBe(computeLineTotal(2, 50) + computeLineTotal(1, 30.5));
+    expect(totals.total).toBe(totals.subtotal + totals.taxAmount);
+  });
+});
+
+describe('computeEstimateTotals matches the backend computeTotals', () => {
+  const CASES: ReadonlyArray<readonly [string, EstimateItemInput[]]> = [
+    ['no lines', []],
+    ['one untaxed line', [CONSULTATION]],
+    ['one line with taxRate omitted', [UNTAXED_KEY_ABSENT]],
+    ['one line at 20%', [DENTAL]],
+    ['mixed rates across lines', [DENTAL, VACCINE, CONSULTATION]],
+    [
+      'fractional unit price',
+      [{ description: 'Wormer', quantity: 3, unitPrice: 19.99, taxRate: 20 }],
+    ],
+    ['a zero-quantity line', [{ description: 'Removed', quantity: 0, unitPrice: 80, taxRate: 20 }]],
+    [
+      'a credit line',
+      [DENTAL, { description: 'Goodwill credit', quantity: 1, unitPrice: -25, taxRate: 20 }],
+    ],
+  ];
+
+  it.each(CASES)('agrees on %s, to the last bit of the float', (_label, items) => {
+    expect(computeEstimateTotals(items)).toEqual(backendComputeTotals(items));
+  });
+
+  it('keeps the same three-key shape the service returns', () => {
+    expect(Object.keys(computeEstimateTotals([DENTAL])).sort()).toEqual([
+      'subtotal',
+      'taxAmount',
+      'total',
+    ]);
+  });
+});
+
+describe('computeLineTotal', () => {
+  it('multiplies quantity by unit price', () => {
+    expect(computeLineTotal(3, 20)).toBe(60);
+  });
+
+  it('excludes tax, matching the lineTotal the service writes', () => {
+    // estimate.service.ts writes `lineTotal: item.quantity * item.unitPrice`
+    // on create and on update, with taxRate stored beside it, never inside it.
+    expect(computeLineTotal(DENTAL.quantity, DENTAL.unitPrice)).toBe(100);
+    expect(computeEstimateTotals([DENTAL]).subtotal).toBe(100);
+  });
+
+  it('returns 0 for a zero quantity', () => {
+    expect(computeLineTotal(0, 199)).toBe(0);
+  });
+
+  it('keeps fractional prices unrounded', () => {
+    expect(computeLineTotal(3, 19.99)).toBe(59.97);
+  });
+
+  it('carries a negative unit price through as a credit', () => {
+    expect(computeLineTotal(2, -15.25)).toBe(-30.5);
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/estimateTypes.test.ts
+++ b/apps/frontend/src/app/__tests__/features/finance/estimateTypes.test.ts
@@ -1,0 +1,194 @@
+import {
+  ESTIMATE_STATUSES,
+  EstimateStatusFilters,
+  canApprove,
+  canConvert,
+  canDecline,
+  canSend,
+  estimateStatusBadge,
+} from '@/app/features/finance/types/estimate';
+import type { EstimateStatus } from '@/app/features/finance/types/estimate';
+
+type Lifecycle = {
+  send: boolean;
+  approve: boolean;
+  decline: boolean;
+  convert: boolean;
+};
+
+/**
+ * What `EstimateService` in `apps/backend/src/services/estimate.service.ts`
+ * actually accepts, read off the guards themselves:
+ *
+ *   markSent (~451)  `existing.status !== "DRAFT"` -> 409
+ *   approve  (~277)  `existing.status !== "SENT" && existing.status !== "DRAFT"` -> 409
+ *   decline  (~413)  `existing.status !== "SENT" && existing.status !== "DRAFT"` -> 409
+ *   convert  (~323)  `existing.status !== "APPROVED"` -> 409
+ *
+ * The predicates exist so the UI disables an action instead of offering it and
+ * letting the request 409, so a predicate that is more permissive than the row
+ * below is a button that always fails, and one that is stricter is a lifecycle
+ * step the user can no longer reach.
+ */
+const BACKEND_ACCEPTS: Record<EstimateStatus, Lifecycle> = {
+  DRAFT: { send: true, approve: true, decline: true, convert: false },
+  SENT: { send: false, approve: true, decline: true, convert: false },
+  APPROVED: { send: false, approve: false, decline: false, convert: true },
+  DECLINED: { send: false, approve: false, decline: false, convert: false },
+  EXPIRED: { send: false, approve: false, decline: false, convert: false },
+  CONVERTED: { send: false, approve: false, decline: false, convert: false },
+};
+
+/** The shape `dropdownStatusFromToken` builds, spelled out so the test pins the tokens. */
+const pill = (name: string, key: string, prefix: string) => ({
+  name,
+  key,
+  bg: `var(--${prefix}-bg)`,
+  text: `var(--${prefix}-text)`,
+  border: `var(--${prefix}-border)`,
+  dropdownText: `var(--${prefix}-text)`,
+});
+
+describe('ESTIMATE_STATUSES', () => {
+  it('lists the six statuses in lifecycle order', () => {
+    expect(ESTIMATE_STATUSES).toEqual([
+      'DRAFT',
+      'SENT',
+      'APPROVED',
+      'DECLINED',
+      'EXPIRED',
+      'CONVERTED',
+    ]);
+  });
+
+  it('covers every status the guard table below asserts on', () => {
+    expect(Object.keys(BACKEND_ACCEPTS).sort()).toEqual([...ESTIMATE_STATUSES].sort());
+  });
+});
+
+describe('lifecycle predicates', () => {
+  it.each([...ESTIMATE_STATUSES])(
+    'gates %s exactly as the service does',
+    (status: EstimateStatus) => {
+      const expected = BACKEND_ACCEPTS[status];
+
+      expect({
+        send: canSend(status),
+        approve: canApprove(status),
+        decline: canDecline(status),
+        convert: canConvert(status),
+      }).toEqual(expected);
+    }
+  );
+
+  it('only lets a DRAFT be sent', () => {
+    expect(canSend('DRAFT')).toBe(true);
+    expect(canSend('SENT')).toBe(false);
+    expect(canSend('APPROVED')).toBe(false);
+    expect(canSend('DECLINED')).toBe(false);
+    expect(canSend('EXPIRED')).toBe(false);
+    expect(canSend('CONVERTED')).toBe(false);
+  });
+
+  it('lets a DRAFT or a SENT estimate be approved', () => {
+    expect(canApprove('DRAFT')).toBe(true);
+    expect(canApprove('SENT')).toBe(true);
+    expect(canApprove('APPROVED')).toBe(false);
+    expect(canApprove('DECLINED')).toBe(false);
+    expect(canApprove('EXPIRED')).toBe(false);
+    expect(canApprove('CONVERTED')).toBe(false);
+  });
+
+  it('lets a DRAFT or a SENT estimate be declined', () => {
+    expect(canDecline('DRAFT')).toBe(true);
+    expect(canDecline('SENT')).toBe(true);
+    expect(canDecline('APPROVED')).toBe(false);
+    expect(canDecline('DECLINED')).toBe(false);
+    expect(canDecline('EXPIRED')).toBe(false);
+    expect(canDecline('CONVERTED')).toBe(false);
+  });
+
+  it('only lets an APPROVED estimate be converted', () => {
+    expect(canConvert('APPROVED')).toBe(true);
+    expect(canConvert('DRAFT')).toBe(false);
+    expect(canConvert('SENT')).toBe(false);
+    expect(canConvert('DECLINED')).toBe(false);
+    expect(canConvert('EXPIRED')).toBe(false);
+    // CONVERTED is false on purpose: `convert` short-circuits an already
+    // converted estimate back to the caller, so re-offering the button would
+    // only ever be a no-op the user cannot tell from a fresh conversion.
+    expect(canConvert('CONVERTED')).toBe(false);
+  });
+
+  it('approves and declines on the same set of statuses', () => {
+    ESTIMATE_STATUSES.forEach((status) => {
+      expect(canApprove(status)).toBe(canDecline(status));
+    });
+  });
+
+  it('offers no action at all on the three terminal statuses', () => {
+    (['DECLINED', 'EXPIRED', 'CONVERTED'] as const).forEach((status) => {
+      expect([canSend(status), canApprove(status), canDecline(status), canConvert(status)]).toEqual(
+        [false, false, false, false]
+      );
+    });
+  });
+});
+
+describe('EstimateStatusFilters', () => {
+  it('leads with All and then follows the lifecycle', () => {
+    expect(EstimateStatusFilters.map((option) => option.key)).toEqual([
+      'all',
+      'DRAFT',
+      'SENT',
+      'APPROVED',
+      'CONVERTED',
+      'DECLINED',
+      'EXPIRED',
+    ]);
+  });
+
+  it('gives All the neutral pill tokens', () => {
+    expect(EstimateStatusFilters[0]).toEqual(pill('All', 'all', 'color-pill-neutral'));
+  });
+});
+
+describe('estimateStatusBadge', () => {
+  it.each([
+    ['DRAFT', 'Draft', 'color-pill-neutral'],
+    ['SENT', 'Sent', 'color-pill-info'],
+    ['APPROVED', 'Approved', 'color-pill-progress'],
+    ['CONVERTED', 'Converted', 'color-pill-success'],
+    ['DECLINED', 'Declined', 'color-pill-warning'],
+    ['EXPIRED', 'Expired', 'color-pill-warning'],
+  ])('returns the %s badge', (status, label, prefix) => {
+    expect(estimateStatusBadge(status as EstimateStatus)).toEqual({
+      label,
+      bg: `var(--${prefix}-bg)`,
+      text: `var(--${prefix}-text)`,
+      border: `var(--${prefix}-border)`,
+    });
+  });
+
+  it('has a badge for every status, with no undefined field', () => {
+    ESTIMATE_STATUSES.forEach((status) => {
+      const badge = estimateStatusBadge(status);
+      expect(Object.values(badge).every((value) => typeof value === 'string')).toBe(true);
+    });
+  });
+
+  it('agrees with the filter pill for the same status', () => {
+    // The badge and the filter row must never drift. Both derive from the same
+    // token map, and this pins that: for every status, the badge's tokens equal
+    // the pill's, and its label equals the pill's name.
+    ESTIMATE_STATUSES.forEach((status) => {
+      const option = EstimateStatusFilters.find((entry) => entry.key === status);
+      const badge = estimateStatusBadge(status);
+      expect(option).toBeDefined();
+      expect(badge.label).toBe(option?.name);
+      expect(badge.bg).toBe(option?.bg);
+      expect(badge.text).toBe(option?.text);
+      expect(badge.border).toBe(option?.border);
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/hooks/useEstimates.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useEstimates.test.ts
@@ -1,0 +1,290 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+const estimateServiceMock = {
+  listEstimates: jest.fn(),
+  getEstimateErrorMessage: jest.fn(),
+};
+jest.mock('@/app/features/finance/services/estimateService', () => ({
+  listEstimates: (...args: unknown[]) => estimateServiceMock.listEstimates(...args),
+  getEstimateErrorMessage: (...args: unknown[]) =>
+    estimateServiceMock.getEstimateErrorMessage(...args),
+}));
+
+import { useEstimates } from '@/app/features/finance/hooks/useEstimates';
+
+/** A promise plus the handles to settle it, so a test can inspect mid-flight state. */
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeEstimate = (
+  id: string,
+  status: EstimateStatus = 'DRAFT',
+  overrides: Partial<Estimate> = {}
+): Estimate => ({
+  id,
+  organisationId: 'org-1',
+  patientId: 'pet-1',
+  encounterId: null,
+  status,
+  validUntil: null,
+  subtotal: 100,
+  taxAmount: 20,
+  total: 120,
+  currency: 'GBP',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: null,
+  createdBy: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  items: [],
+  ...overrides,
+});
+
+const ids = (rows: Estimate[]) => rows.map((row) => row.id);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  estimateServiceMock.listEstimates.mockResolvedValue([]);
+  estimateServiceMock.getEstimateErrorMessage.mockImplementation(
+    (error: unknown, fallback: string) =>
+      error instanceof Error && error.message ? error.message : fallback
+  );
+});
+
+describe('useEstimates', () => {
+  it('does not fetch without an organisation id', async () => {
+    const { result } = renderHook(() => useEstimates(undefined));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.estimates).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(estimateServiceMock.listEstimates).not.toHaveBeenCalled();
+  });
+
+  it('loads the organisation estimates', async () => {
+    estimateServiceMock.listEstimates.mockResolvedValue([
+      makeEstimate('est-1'),
+      makeEstimate('est-2', 'SENT'),
+    ]);
+
+    const { result } = renderHook(() => useEstimates('org-1'));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(ids(result.current.estimates)).toEqual(['est-1', 'est-2']);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('asks the service for every status when no filter is set', async () => {
+    const { result } = renderHook(() => useEstimates('org-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(estimateServiceMock.listEstimates).toHaveBeenCalledWith('org-1', undefined);
+  });
+
+  it('passes the status filter through to the service', async () => {
+    const { result } = renderHook(() => useEstimates('org-1', 'APPROVED'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(estimateServiceMock.listEstimates).toHaveBeenCalledWith('org-1', {
+      status: 'APPROVED',
+    });
+  });
+
+  it('captures a load failure and stops loading', async () => {
+    estimateServiceMock.listEstimates.mockRejectedValue(new Error('Estimates unavailable.'));
+
+    const { result } = renderHook(() => useEstimates('org-1'));
+
+    await waitFor(() => expect(result.current.error).toBe('Estimates unavailable.'));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.estimates).toEqual([]);
+    expect(estimateServiceMock.getEstimateErrorMessage).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Unable to load estimates.'
+    );
+  });
+
+  it('falls back to the default message when the failure carries none', async () => {
+    estimateServiceMock.listEstimates.mockRejectedValue({ response: { status: 500 } });
+
+    const { result } = renderHook(() => useEstimates('org-1'));
+
+    await waitFor(() => expect(result.current.error).toBe('Unable to load estimates.'));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('refetches on reload', async () => {
+    estimateServiceMock.listEstimates
+      .mockResolvedValueOnce([makeEstimate('est-1')])
+      .mockResolvedValueOnce([makeEstimate('est-1'), makeEstimate('est-2')]);
+
+    const { result } = renderHook(() => useEstimates('org-1'));
+    await waitFor(() => expect(ids(result.current.estimates)).toEqual(['est-1']));
+
+    act(() => result.current.reload());
+
+    await waitFor(() => expect(ids(result.current.estimates)).toEqual(['est-1', 'est-2']));
+    expect(estimateServiceMock.listEstimates).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the previous organisation rows while the new organisation loads', async () => {
+    // Otherwise the table shows another organisation's estimates during the switch.
+    estimateServiceMock.listEstimates.mockResolvedValue([makeEstimate('org-1-est')]);
+    const { result, rerender } = renderHook(({ orgId }) => useEstimates(orgId), {
+      initialProps: { orgId: 'org-1' as string | undefined },
+    });
+    await waitFor(() => expect(ids(result.current.estimates)).toEqual(['org-1-est']));
+
+    const pending = deferred<Estimate[]>();
+    estimateServiceMock.listEstimates.mockReturnValue(pending.promise);
+    rerender({ orgId: 'org-2' });
+
+    expect(result.current.estimates).toEqual([]);
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      pending.resolve([makeEstimate('org-2-est', 'DRAFT', { organisationId: 'org-2' })]);
+      await pending.promise;
+    });
+
+    expect(ids(result.current.estimates)).toEqual(['org-2-est']);
+    expect(estimateServiceMock.listEstimates).toHaveBeenLastCalledWith('org-2', undefined);
+  });
+
+  it('refetches when the status filter changes', async () => {
+    estimateServiceMock.listEstimates.mockResolvedValue([makeEstimate('draft-1', 'DRAFT')]);
+    const { result, rerender } = renderHook(({ status }) => useEstimates('org-1', status), {
+      initialProps: { status: undefined as EstimateStatus | undefined },
+    });
+    await waitFor(() => expect(ids(result.current.estimates)).toEqual(['draft-1']));
+
+    estimateServiceMock.listEstimates.mockResolvedValue([makeEstimate('sent-1', 'SENT')]);
+    rerender({ status: 'SENT' });
+
+    await waitFor(() => expect(ids(result.current.estimates)).toEqual(['sent-1']));
+    expect(estimateServiceMock.listEstimates).toHaveBeenCalledTimes(2);
+    expect(estimateServiceMock.listEstimates).toHaveBeenLastCalledWith('org-1', {
+      status: 'SENT',
+    });
+  });
+
+  it('ignores a response that lands after unmount', async () => {
+    const pending = deferred<Estimate[]>();
+    estimateServiceMock.listEstimates.mockReturnValue(pending.promise);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useEstimates('org-1'));
+    unmount();
+
+    await act(async () => {
+      pending.resolve([makeEstimate('est-late')]);
+      await pending.promise;
+    });
+
+    // No state update on the unmounted hook => no React act/update warning.
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('ignores a rejection that lands after unmount', async () => {
+    const pending = deferred<never>();
+    estimateServiceMock.listEstimates.mockReturnValue(pending.promise);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useEstimates('org-1'));
+    unmount();
+
+    await act(async () => {
+      pending.reject(new Error('too late'));
+      await pending.promise.catch(() => undefined);
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(estimateServiceMock.getEstimateErrorMessage).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  describe('upsert', () => {
+    it('adds an unknown estimate to the front of the list', async () => {
+      estimateServiceMock.listEstimates.mockResolvedValue([
+        makeEstimate('est-1'),
+        makeEstimate('est-2'),
+      ]);
+      const { result } = renderHook(() => useEstimates('org-1'));
+      await waitFor(() => expect(result.current.estimates).toHaveLength(2));
+
+      act(() => result.current.upsert(makeEstimate('est-new')));
+
+      expect(ids(result.current.estimates)).toEqual(['est-new', 'est-1', 'est-2']);
+    });
+
+    it('replaces a known estimate in place', async () => {
+      estimateServiceMock.listEstimates.mockResolvedValue([
+        makeEstimate('est-1'),
+        makeEstimate('est-2'),
+        makeEstimate('est-3'),
+      ]);
+      const { result } = renderHook(() => useEstimates('org-1'));
+      await waitFor(() => expect(result.current.estimates).toHaveLength(3));
+
+      act(() => result.current.upsert(makeEstimate('est-2', 'APPROVED', { total: 999 })));
+
+      expect(ids(result.current.estimates)).toEqual(['est-1', 'est-2', 'est-3']);
+      expect(result.current.estimates[1].status).toBe('APPROVED');
+      expect(result.current.estimates[1].total).toBe(999);
+    });
+
+    it('keeps an estimate whose new status still matches the active filter', async () => {
+      estimateServiceMock.listEstimates.mockResolvedValue([
+        makeEstimate('est-1', 'DRAFT'),
+        makeEstimate('est-2', 'DRAFT'),
+      ]);
+      const { result } = renderHook(() => useEstimates('org-1', 'DRAFT'));
+      await waitFor(() => expect(result.current.estimates).toHaveLength(2));
+
+      act(() => result.current.upsert(makeEstimate('est-1', 'DRAFT', { notes: 'edited' })));
+
+      expect(ids(result.current.estimates)).toEqual(['est-1', 'est-2']);
+      expect(result.current.estimates[0].notes).toBe('edited');
+    });
+
+    it('drops an estimate whose new status no longer matches the active filter', async () => {
+      // Approving under the "Draft" pill must remove the row, not leave a row
+      // reading APPROVED inside a list filtered to DRAFT.
+      estimateServiceMock.listEstimates.mockResolvedValue([
+        makeEstimate('est-1', 'DRAFT'),
+        makeEstimate('est-2', 'DRAFT'),
+      ]);
+      const { result } = renderHook(() => useEstimates('org-1', 'DRAFT'));
+      await waitFor(() => expect(result.current.estimates).toHaveLength(2));
+
+      act(() => result.current.upsert(makeEstimate('est-1', 'APPROVED')));
+
+      expect(ids(result.current.estimates)).toEqual(['est-2']);
+      expect(result.current.estimates.some((row) => row.status !== 'DRAFT')).toBe(false);
+    });
+
+    it('does not add a brand-new estimate that the active filter excludes', async () => {
+      estimateServiceMock.listEstimates.mockResolvedValue([makeEstimate('est-1', 'DRAFT')]);
+      const { result } = renderHook(() => useEstimates('org-1', 'DRAFT'));
+      await waitFor(() => expect(result.current.estimates).toHaveLength(1));
+
+      act(() => result.current.upsert(makeEstimate('est-new', 'CONVERTED')));
+
+      expect(ids(result.current.estimates)).toEqual(['est-1']);
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/hooks/useEstimates.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useEstimates.test.ts
@@ -287,4 +287,24 @@ describe('useEstimates', () => {
       expect(ids(result.current.estimates)).toEqual(['est-1']);
     });
   });
+
+  it('discards an upsert for a different organisation', async () => {
+    // A create or lifecycle response can land after the user has switched
+    // organisation. The list refetch is keyed on organisationId and discarded,
+    // but the merge is not, so without this guard an estimate belonging to the
+    // previous organisation appears in the new one's list.
+    estimateServiceMock.listEstimates.mockResolvedValue([]);
+    const { result } = renderHook(() => useEstimates('org-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.upsert(makeEstimate('est-other', 'DRAFT', { organisationId: 'org-2' }));
+    });
+    expect(result.current.estimates).toHaveLength(0);
+
+    act(() => {
+      result.current.upsert(makeEstimate('est-mine', 'DRAFT', { organisationId: 'org-1' }));
+    });
+    expect(result.current.estimates.map((e) => e.id)).toEqual(['est-mine']);
+  });
 });

--- a/apps/frontend/src/app/__tests__/lib/money.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/money.test.ts
@@ -1,4 +1,4 @@
-import { formatMoney } from '@/app/lib/money';
+import { currencySymbol, formatMoney, formatMoneyPrecise } from '@/app/lib/money';
 
 describe('formatMoney', () => {
   it('formats USD correctly', () => {
@@ -28,5 +28,72 @@ describe('formatMoney', () => {
   it('formats negative amounts', () => {
     const result = formatMoney(-200, 'USD');
     expect(result).toContain('200');
+  });
+});
+
+describe('formatMoneyPrecise', () => {
+  it('keeps both decimal places', () => {
+    expect(formatMoneyPrecise(45.5, 'GBP')).toBe('£45.50');
+  });
+
+  it('renders a whole number with .00 rather than bare units', () => {
+    expect(formatMoneyPrecise(100, 'USD')).toBe('$100.00');
+  });
+
+  it('uses the pound symbol for GBP and the dollar symbol for USD', () => {
+    expect(formatMoneyPrecise(12.34, 'GBP')).toBe('£12.34');
+    expect(formatMoneyPrecise(12.34, 'USD')).toBe('$12.34');
+  });
+
+  it('formats zero as 0.00', () => {
+    expect(formatMoneyPrecise(0, 'GBP')).toBe('£0.00');
+  });
+
+  it('keeps thousand separators alongside the minor units', () => {
+    expect(formatMoneyPrecise(1234.5, 'USD')).toBe('$1,234.50');
+  });
+
+  it('formats a negative amount', () => {
+    expect(formatMoneyPrecise(-12.5, 'USD')).toBe('-$12.50');
+  });
+
+  it('rounds a third decimal away rather than truncating', () => {
+    expect(formatMoneyPrecise(9.999, 'USD')).toBe('$10.00');
+    expect(formatMoneyPrecise(1.005, 'USD')).toBe('$1.01');
+  });
+
+  it('does not round to whole units the way formatMoney does', () => {
+    // formatMoney is for dashboard tiles; a figure that has to reconcile with
+    // another figure - an estimate line against its total - needs the pennies.
+    expect(formatMoney(9.99, 'USD')).toBe('$10');
+    expect(formatMoneyPrecise(9.99, 'USD')).toBe('$9.99');
+  });
+});
+
+describe('currencySymbol', () => {
+  it('returns the bare symbol for the codes the finance screens use', () => {
+    expect(currencySymbol('USD')).toBe('$');
+    expect(currencySymbol('GBP')).toBe('£');
+    expect(currencySymbol('EUR')).toBe('€');
+    expect(currencySymbol('INR')).toBe('₹');
+  });
+
+  it('returns the code itself when there is no distinct symbol for it', () => {
+    expect(currencySymbol('XYZ')).toBe('XYZ');
+  });
+
+  it('falls back to the code rather than throwing on a malformed one', () => {
+    expect(currencySymbol('US')).toBe('US');
+    expect(currencySymbol('not-a-code')).toBe('not-a-code');
+  });
+
+  it('falls back to the code when the runtime emits no currency part', () => {
+    const formatToParts = jest
+      .spyOn(Intl.NumberFormat.prototype, 'formatToParts')
+      .mockReturnValue([{ type: 'integer', value: '0' }]);
+
+    expect(currencySymbol('USD')).toBe('USD');
+
+    formatToParts.mockRestore();
   });
 });

--- a/apps/frontend/src/app/__tests__/lib/money.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/money.test.ts
@@ -97,3 +97,23 @@ describe('currencySymbol', () => {
     formatToParts.mockRestore();
   });
 });
+
+describe('formatMoneyPrecise currency precision', () => {
+  it('uses each currency its own minor unit rather than a fixed two digits', () => {
+    // JPY has no minor unit and KWD has three. Pinning two digits displayed a
+    // different amount from the one stored - KWD 1.234 as 1.23.
+    expect(formatMoneyPrecise(1234, 'JPY')).not.toContain('.');
+    expect(formatMoneyPrecise(1.234, 'KWD')).toContain('1.234');
+    expect(formatMoneyPrecise(45.5, 'GBP')).toBe('£45.50');
+  });
+
+  it('falls back instead of throwing on a code that is not a currency', () => {
+    // CreateEstimateSchema only checks the code's length, so "123" is an
+    // API-valid estimate. Intl throws a RangeError on it, and this helper runs
+    // on every line and total with no error boundary above it - one such record
+    // would blank the screen.
+    expect(() => formatMoneyPrecise(9.5, '123')).not.toThrow();
+    expect(formatMoneyPrecise(9.5, '123')).toBe('123 9.50');
+    expect(formatMoneyPrecise(9.5, 'ZZ')).toBe('ZZ 9.50');
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -75,6 +75,11 @@ jest.mock('@/app/features/companions/services/companionService', () => ({
   loadCompanionsForPrimaryOrg: (...args: unknown[]) => mockLoadCompanions(...args),
 }));
 
+const mockLoadInvoices = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/app/features/billing/services/invoiceService', () => ({
+  loadInvoicesForOrgPrimaryOrg: (...args: unknown[]) => mockLoadInvoices(...args),
+}));
+
 // Mock the transport, not the hook, so the page's real load/merge/error paths run.
 const mockEstimateService = {
   listEstimates: jest.fn(),
@@ -229,7 +234,8 @@ describe('Finance > Estimates page', () => {
     await userEvent.click(row);
 
     expect(detailHeading('Bruno')).toBeInTheDocument();
-    expect(screen.getByText('Estimate line items')).toBeInTheDocument();
+    // The detail's totals group, which only the open estimate renders.
+    expect(screen.getByRole('group', { name: 'Estimate totals' })).toBeInTheDocument();
     expect(screen.getByText('Dental clean')).toBeInTheDocument();
   });
 
@@ -401,6 +407,60 @@ describe('Finance > Estimates page', () => {
     expect(screen.getByText('No estimate currently has this status.')).toBeInTheDocument();
     expect(detailHeading('Bruno')).not.toBeInTheDocument();
     expect(mockEstimateService.listEstimates).toHaveBeenCalledTimes(2);
+
+    // Converting mints an Invoice. The invoice store already holds an entry for
+    // this organisation, so useLoadInvoicesForPrimaryOrg would skip loading and
+    // the "View the invoice" link would point at a row the store has never
+    // seen. Only a forced refetch fixes that.
+    await waitFor(() =>
+      expect(mockLoadInvoices).toHaveBeenCalledWith({ force: true, silent: true })
+    );
+  });
+
+  it('still reports success when the post-convert invoice refetch fails', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([buildEstimate({ status: 'APPROVED' })]);
+    mockEstimateService.convertEstimate.mockResolvedValue(
+      buildEstimate({ status: 'CONVERTED', convertedToInvoiceId: 'inv-1' })
+    );
+    mockLoadInvoices.mockRejectedValueOnce(new Error('network down'));
+    // The page logs the refetch failure; the shared setup turns console.error
+    // into a thrown assertion, so it is silenced for this one case.
+    const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Convert this estimate to an invoice' })
+    );
+
+    // The conversion itself succeeded, so the user is told so - a failed
+    // background refresh must not be reported as a failed conversion.
+    await waitFor(() =>
+      expect(mockNotify).toHaveBeenCalledWith(
+        'success',
+        expect.objectContaining({ title: 'Invoice created' })
+      )
+    );
+    await waitFor(() => expect(logged).toHaveBeenCalled());
+    logged.mockRestore();
+  });
+
+  it('does not refetch invoices for a non-converting action', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([buildEstimate({ status: 'DRAFT' })]);
+    mockEstimateService.approveEstimate.mockResolvedValue(buildEstimate({ status: 'APPROVED' }));
+
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Approve this estimate' }));
+
+    await waitFor(() =>
+      expect(mockEstimateService.approveEstimate).toHaveBeenCalledWith('org-1', 'est-1')
+    );
+    expect(mockLoadInvoices).not.toHaveBeenCalled();
   });
 
   it('closes the detail when the status filter changes', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -58,6 +58,11 @@ jest.mock('@/app/stores/orgStore', () => ({
   useOrgStore: (selector: any) => selector(mockOrgState),
 }));
 
+const mockSearchState = { query: '' };
+jest.mock('@/app/stores/searchStore', () => ({
+  useSearchStore: (selector: any) => selector(mockSearchState),
+}));
+
 const mockCompanionState: {
   companionsById: Record<string, { id: string; name: string }>;
   companionsIdsByOrgId: Record<string, string[]>;
@@ -148,11 +153,13 @@ const filterPill = (label: string) => screen.getByRole('button', { name: label }
 beforeEach(() => {
   jest.clearAllMocks();
   mockOrgState.primaryOrgId = 'org-1';
+  mockSearchState.query = '';
   mockCompanionState.companionsById = {
     c1: { id: 'c1', name: 'Bruno' },
     c2: { id: 'c2', name: '' },
+    'pet-2': { id: 'pet-2', name: 'Mango' },
   };
-  mockCompanionState.companionsIdsByOrgId = { 'org-1': ['c1', 'c2'] };
+  mockCompanionState.companionsIdsByOrgId = { 'org-1': ['c1', 'c2', 'pet-2'] };
   mockLoadCompanions.mockResolvedValue(undefined);
   mockEstimateService.listEstimates.mockResolvedValue([buildEstimate()]);
 });
@@ -334,7 +341,6 @@ describe('Finance > Estimates page', () => {
     await waitFor(() =>
       expect(mockEstimateService.createEstimate).toHaveBeenCalledWith('org-1', {
         patientId: 'c2',
-        currency: 'USD',
         notes: undefined,
         validUntil: undefined,
         items: [{ description: 'Dental clean', quantity: 1, unitPrice: 50, taxRate: 0 }],
@@ -475,26 +481,27 @@ describe('Finance > Estimates page', () => {
     await waitFor(() => expect(detailHeading('Bruno')).not.toBeInTheDocument());
   });
 
-  it('loads companions when the organisation has none cached, and logs a failure', async () => {
+  it('surfaces a companion-loading failure and blocks creation until it is fixed', async () => {
     mockCompanionState.companionsById = {};
     mockCompanionState.companionsIdsByOrgId = {};
     mockLoadCompanions.mockRejectedValue(new Error('companions unavailable'));
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<ProtectedEstimates />);
 
     await waitFor(() => expect(mockLoadCompanions).toHaveBeenCalledTimes(1));
+    // Visible, not console-only: without companions the picker is empty, so
+    // "New estimate" would open a dialog that can only tell the user to choose
+    // a companion that is not there.
     await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith(
-        'Failed to load companions for the estimates page:',
-        expect.any(Error)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Companions could not be loaded, so a new estimate cannot be started.'
       )
     );
+    expect(screen.getByRole('button', { name: 'Create a new estimate' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Retry loading companions' })).toBeInTheDocument();
     expect(
       await screen.findByRole('button', { name: 'Open the estimate for Unknown companion' })
     ).toBeInTheDocument();
-
-    consoleError.mockRestore();
   });
 
   it('does not reload companions that are already cached', async () => {
@@ -543,5 +550,33 @@ describe('Finance > Estimates status filters', () => {
     await waitFor(() =>
       expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', undefined)
     );
+  });
+
+  it('filters the list by the shared header search', async () => {
+    mockSearchState.query = 'bruno';
+    mockEstimateService.listEstimates.mockResolvedValue([
+      buildEstimate({ id: 'est-1' }),
+      buildEstimate({ id: 'est-2', patientId: 'pet-2' }),
+    ]);
+
+    render(<ProtectedEstimates />);
+
+    // The finance header stays visible on this route and already writes to the
+    // search store, so the control looked functional while doing nothing.
+    await screen.findByRole('button', { name: 'Open the estimate for Bruno' });
+    expect(
+      screen.queryByRole('button', { name: 'Open the estimate for Mango' })
+    ).not.toBeInTheDocument();
+    mockSearchState.query = '';
+  });
+
+  it('says so when a search matches nothing', async () => {
+    mockSearchState.query = 'zzzz';
+    mockEstimateService.listEstimates.mockResolvedValue([buildEstimate({ id: 'est-1' })]);
+
+    render(<ProtectedEstimates />);
+
+    expect(await screen.findByText('No estimate matches that search.')).toBeInTheDocument();
+    mockSearchState.query = '';
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -1,0 +1,487 @@
+import React from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+jest.mock('@/app/ui/layout/guards/ProtectedRoute', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/layout/guards/OrgGuard', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+// Renders children so the page gate, the "New estimate" gate and the detail's
+// action gate are all exercised; PermissionGate has its own tests.
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ href, text, ariaLabel, onClick, isDisabled }: any) =>
+    href ? (
+      <a href={href} aria-label={ariaLabel}>
+        {text}
+      </a>
+    ) : (
+      <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+        {text}
+      </button>
+    ),
+}));
+
+jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
+  __esModule: true,
+  default: ({ showModal, children, ariaLabel }: any) =>
+    showModal ? (
+      <div role="dialog" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+const mockNotify = jest.fn();
+jest.mock('@/app/hooks/useNotify', () => ({
+  useNotify: () => ({ notify: mockNotify }),
+}));
+
+const mockOrgState = { primaryOrgId: 'org-1' as string | null };
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: (selector: any) => selector(mockOrgState),
+}));
+
+const mockCompanionState: {
+  companionsById: Record<string, { id: string; name: string }>;
+  companionsIdsByOrgId: Record<string, string[]>;
+} = { companionsById: {}, companionsIdsByOrgId: {} };
+jest.mock('@/app/stores/companionStore', () => ({
+  useCompanionStore: (selector: any) => selector(mockCompanionState),
+}));
+
+jest.mock('@/app/hooks/useBilling', () => ({
+  useCurrencyForPrimaryOrg: () => 'USD',
+}));
+
+const mockLoadCompanions = jest.fn();
+jest.mock('@/app/features/companions/services/companionService', () => ({
+  loadCompanionsForPrimaryOrg: (...args: unknown[]) => mockLoadCompanions(...args),
+}));
+
+// Mock the transport, not the hook, so the page's real load/merge/error paths run.
+const mockEstimateService = {
+  listEstimates: jest.fn(),
+  createEstimate: jest.fn(),
+  markEstimateSent: jest.fn(),
+  approveEstimate: jest.fn(),
+  declineEstimate: jest.fn(),
+  convertEstimate: jest.fn(),
+};
+jest.mock('@/app/features/finance/services/estimateService', () => ({
+  listEstimates: (...args: unknown[]) => mockEstimateService.listEstimates(...args),
+  createEstimate: (...args: unknown[]) => mockEstimateService.createEstimate(...args),
+  markEstimateSent: (...args: unknown[]) => mockEstimateService.markEstimateSent(...args),
+  approveEstimate: (...args: unknown[]) => mockEstimateService.approveEstimate(...args),
+  declineEstimate: (...args: unknown[]) => mockEstimateService.declineEstimate(...args),
+  convertEstimate: (...args: unknown[]) => mockEstimateService.convertEstimate(...args),
+  getEstimateErrorMessage: (error: unknown, fallback: string) => {
+    const body = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
+    if (typeof body === 'string' && body.trim()) return body.trim();
+    if (error instanceof Error && error.message.trim()) return error.message.trim();
+    return fallback;
+  },
+}));
+
+import ProtectedEstimates from '@/app/features/finance/pages/Estimates';
+
+const buildEstimate = (overrides: Partial<Estimate> = {}): Estimate => ({
+  id: 'est-1',
+  organisationId: 'org-1',
+  patientId: 'c1',
+  encounterId: null,
+  status: 'DRAFT',
+  validUntil: '2026-12-31T00:00:00.000Z',
+  subtotal: 100,
+  taxAmount: 10,
+  total: 110,
+  currency: 'USD',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: null,
+  createdBy: null,
+  createdAt: '2026-09-01T10:00:00.000Z',
+  updatedAt: '2026-09-01T10:00:00.000Z',
+  items: [
+    {
+      id: 'item-1',
+      description: 'Dental clean',
+      quantity: 2,
+      unitPrice: 50,
+      taxRate: 10,
+      lineTotal: 100,
+      notes: null,
+    },
+  ],
+  ...overrides,
+});
+
+const rowFor = (name: string) =>
+  screen.getByRole('button', { name: `Open the estimate for ${name}` });
+const detailHeading = (name: string) => screen.queryByRole('heading', { level: 2, name });
+const filterPill = (label: string) => screen.getByRole('button', { name: label });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOrgState.primaryOrgId = 'org-1';
+  mockCompanionState.companionsById = {
+    c1: { id: 'c1', name: 'Bruno' },
+    c2: { id: 'c2', name: '' },
+  };
+  mockCompanionState.companionsIdsByOrgId = { 'org-1': ['c1', 'c2'] };
+  mockLoadCompanions.mockResolvedValue(undefined);
+  mockEstimateService.listEstimates.mockResolvedValue([buildEstimate()]);
+});
+
+describe('Finance > Estimates page', () => {
+  it('shows the "nothing yet" empty state under the all filter', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+
+    render(<ProtectedEstimates />);
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Estimates' })).toBeInTheDocument();
+    expect(await screen.findByText('No estimates yet')).toBeInTheDocument();
+    expect(
+      screen.getByText('Create an estimate to quote a treatment plan before it is invoiced.')
+    ).toBeInTheDocument();
+    expect(mockEstimateService.listEstimates).toHaveBeenCalledWith('org-1', undefined);
+  });
+
+  it('words the empty state differently under a status filter', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+
+    render(<ProtectedEstimates />);
+    await screen.findByText('No estimates yet');
+
+    await userEvent.click(filterPill('Sent'));
+
+    expect(await screen.findByText('No estimate currently has this status.')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Create an estimate to quote a treatment plan before it is invoiced.')
+    ).not.toBeInTheDocument();
+    expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', { status: 'SENT' });
+  });
+
+  it('shows the skeleton while the list is in flight', async () => {
+    let resolveList!: (rows: Estimate[]) => void;
+    mockEstimateService.listEstimates.mockReturnValue(
+      new Promise<Estimate[]>((resolve) => {
+        resolveList = resolve;
+      })
+    );
+
+    const { container } = render(<ProtectedEstimates />);
+
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveList([]);
+    });
+
+    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument();
+    expect(screen.getByText('No estimates yet')).toBeInTheDocument();
+  });
+
+  it('surfaces a load failure and retries it', async () => {
+    mockEstimateService.listEstimates
+      .mockRejectedValueOnce(new Error('Unable to load estimates.'))
+      .mockResolvedValueOnce([buildEstimate()]);
+
+    render(<ProtectedEstimates />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load estimates.');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry loading estimates' }));
+
+    expect(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(mockEstimateService.listEstimates).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders a row and opens its detail on click', async () => {
+    render(<ProtectedEstimates />);
+
+    const row = await screen.findByRole('button', { name: 'Open the estimate for Bruno' });
+    expect(screen.getByText('$110.00')).toBeInTheDocument();
+    expect(detailHeading('Bruno')).not.toBeInTheDocument();
+
+    await userEvent.click(row);
+
+    expect(detailHeading('Bruno')).toBeInTheDocument();
+    expect(screen.getByText('Estimate line items')).toBeInTheDocument();
+    expect(screen.getByText('Dental clean')).toBeInTheDocument();
+  });
+
+  it('runs a lifecycle action, merges the result and confirms it', async () => {
+    mockEstimateService.markEstimateSent.mockResolvedValue(buildEstimate({ status: 'SENT' }));
+
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Mark this estimate as sent' }));
+
+    await waitFor(() =>
+      expect(mockEstimateService.markEstimateSent).toHaveBeenCalledWith('org-1', 'est-1')
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Estimate sent' })
+    );
+    // The merged row is a SENT estimate, so sending is no longer offered.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Mark this estimate as sent' })
+      ).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('button', { name: 'Approve this estimate' })).toBeInTheDocument();
+  });
+
+  it('declines an estimate through the decline endpoint', async () => {
+    mockEstimateService.declineEstimate.mockResolvedValue(buildEstimate({ status: 'DECLINED' }));
+
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Decline this estimate' }));
+
+    await waitFor(() =>
+      expect(mockEstimateService.declineEstimate).toHaveBeenCalledWith('org-1', 'est-1')
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Estimate declined' })
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Decline this estimate' })
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  it('reports a failed action without dropping the row', async () => {
+    mockEstimateService.approveEstimate.mockRejectedValue({
+      response: { data: { error: 'This estimate cannot be approved.' } },
+    });
+
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Approve this estimate' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('This estimate cannot be approved.');
+    expect(mockNotify).toHaveBeenCalledWith('error', {
+      title: 'Estimate not updated',
+      text: 'This estimate cannot be approved.',
+    });
+    expect(rowFor('Bruno')).toBeInTheDocument();
+    expect(detailHeading('Bruno')).toBeInTheDocument();
+  });
+
+  it('creates an estimate and selects the new row', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+    mockEstimateService.createEstimate.mockResolvedValue(
+      buildEstimate({ id: 'est-2', patientId: 'c2' })
+    );
+
+    render(<ProtectedEstimates />);
+    await screen.findByText('No estimates yet');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
+    // A companion with no stored name is still selectable, under a placeholder.
+    expect(within(dialog).getByRole('option', { name: 'Unnamed companion' })).toBeInTheDocument();
+
+    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c2');
+    await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
+    await userEvent.clear(within(dialog).getByLabelText('Line 1 unit price'));
+    await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create this estimate' }));
+
+    await waitFor(() =>
+      expect(mockEstimateService.createEstimate).toHaveBeenCalledWith('org-1', {
+        patientId: 'c2',
+        currency: 'USD',
+        notes: undefined,
+        validUntil: undefined,
+        items: [{ description: 'Dental clean', quantity: 1, unitPrice: 50, taxRate: 0 }],
+      })
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Estimate created' })
+    );
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    // The created estimate is selected, so its detail is already open.
+    expect(detailHeading('Unknown companion')).toBeInTheDocument();
+  });
+
+  it('keeps the create dialog open and shows the reason when creating fails', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+    mockEstimateService.createEstimate.mockRejectedValue({
+      response: { data: { error: 'items: Required' } },
+    });
+
+    render(<ProtectedEstimates />);
+    await screen.findByText('No estimates yet');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
+    const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
+    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c1');
+    await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
+    await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create this estimate' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('items: Required');
+    expect(screen.getByRole('dialog', { name: 'Create an estimate' })).toBeInTheDocument();
+  });
+
+  it('drops a converted estimate out of the filtered list and closes its detail', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([buildEstimate({ status: 'APPROVED' })]);
+    mockEstimateService.convertEstimate.mockResolvedValue(
+      buildEstimate({ status: 'CONVERTED', convertedToInvoiceId: 'inv-1' })
+    );
+
+    render(<ProtectedEstimates />);
+    await screen.findByRole('button', { name: 'Open the estimate for Bruno' });
+
+    await userEvent.click(filterPill('Approved'));
+    await waitFor(() =>
+      expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', {
+        status: 'APPROVED',
+      })
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+    expect(detailHeading('Bruno')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Convert this estimate to an invoice' })
+    );
+
+    await waitFor(() =>
+      expect(mockEstimateService.convertEstimate).toHaveBeenCalledWith('org-1', 'est-1')
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Invoice created' })
+    );
+    // The estimate no longer matches the APPROVED pill, so it leaves the list
+    // and the detail panel must not keep showing the stale row.
+    await waitFor(() => expect(screen.getByText('No estimates yet')).toBeInTheDocument());
+    expect(screen.getByText('No estimate currently has this status.')).toBeInTheDocument();
+    expect(detailHeading('Bruno')).not.toBeInTheDocument();
+    expect(mockEstimateService.listEstimates).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes the detail when the status filter changes', async () => {
+    render(<ProtectedEstimates />);
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    );
+    expect(detailHeading('Bruno')).toBeInTheDocument();
+
+    await userEvent.click(filterPill('Draft'));
+
+    await waitFor(() => expect(detailHeading('Bruno')).not.toBeInTheDocument());
+  });
+
+  it('loads companions when the organisation has none cached, and logs a failure', async () => {
+    mockCompanionState.companionsById = {};
+    mockCompanionState.companionsIdsByOrgId = {};
+    mockLoadCompanions.mockRejectedValue(new Error('companions unavailable'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<ProtectedEstimates />);
+
+    await waitFor(() => expect(mockLoadCompanions).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to load companions for the estimates page:',
+        expect.any(Error)
+      )
+    );
+    expect(
+      await screen.findByRole('button', { name: 'Open the estimate for Unknown companion' })
+    ).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  it('does not reload companions that are already cached', async () => {
+    render(<ProtectedEstimates />);
+
+    await screen.findByRole('button', { name: 'Open the estimate for Bruno' });
+    expect(mockLoadCompanions).not.toHaveBeenCalled();
+  });
+
+  it('queries nothing without a primary organisation and links back to invoices', async () => {
+    mockOrgState.primaryOrgId = null;
+
+    render(<ProtectedEstimates />);
+
+    expect(await screen.findByText('No estimates yet')).toBeInTheDocument();
+    expect(mockEstimateService.listEstimates).not.toHaveBeenCalled();
+    expect(mockLoadCompanions).not.toHaveBeenCalled();
+    expect(screen.getByRole('link', { name: 'Back to invoices' })).toHaveAttribute(
+      'href',
+      '/finance'
+    );
+  });
+});
+
+describe('Finance > Estimates status filters', () => {
+  it('asks the API for each status the pills offer', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+    render(<ProtectedEstimates />);
+    await screen.findByText('No estimates yet');
+
+    const statuses: { label: string; key: EstimateStatus }[] = [
+      { label: 'Draft', key: 'DRAFT' },
+      { label: 'Converted', key: 'CONVERTED' },
+      { label: 'Declined', key: 'DECLINED' },
+      { label: 'Expired', key: 'EXPIRED' },
+    ];
+
+    for (const { label, key } of statuses) {
+      await userEvent.click(filterPill(label));
+      await waitFor(() =>
+        expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', { status: key })
+      );
+    }
+
+    await userEvent.click(filterPill('All'));
+    await waitFor(() =>
+      expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', undefined)
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -234,8 +234,8 @@ describe('Finance > Estimates page', () => {
     await userEvent.click(row);
 
     expect(detailHeading('Bruno')).toBeInTheDocument();
-    // The detail's totals group, which only the open estimate renders.
-    expect(screen.getByRole('group', { name: 'Estimate totals' })).toBeInTheDocument();
+    // The detail's totals list, which only the open estimate renders.
+    expect(document.querySelector('dl[aria-label="Estimate totals"]')).toBeInTheDocument();
     expect(screen.getByText('Dental clean')).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -579,4 +579,37 @@ describe('Finance > Estimates status filters', () => {
     expect(await screen.findByText('No estimate matches that search.')).toBeInTheDocument();
     mockSearchState.query = '';
   });
+
+  it("moves to the new estimate's filter after creating under another status", async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([buildEstimate({ status: 'APPROVED' })]);
+    mockEstimateService.createEstimate.mockResolvedValue(
+      buildEstimate({ id: 'est-new', status: 'DRAFT' })
+    );
+
+    render(<ProtectedEstimates />);
+    await screen.findByRole('button', { name: 'Open the estimate for Bruno' });
+    await userEvent.click(filterPill('Approved'));
+    await waitFor(() =>
+      expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', {
+        status: 'APPROVED',
+      })
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
+    const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
+    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c1');
+    await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
+    await userEvent.clear(within(dialog).getByLabelText('Line 1 unit price'));
+    await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create this estimate' }));
+
+    // A new estimate is always DRAFT, so under the Approved filter it would be
+    // refused by upsert and the success toast would sit above an unchanged
+    // list. The page moves to the filter the estimate actually lives under.
+    await waitFor(() =>
+      expect(mockEstimateService.listEstimates).toHaveBeenLastCalledWith('org-1', {
+        status: 'DRAFT',
+      })
+    );
+  });
 });

--- a/apps/frontend/src/app/__tests__/services/estimateService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/estimateService.test.ts
@@ -1,0 +1,464 @@
+import {
+  approveEstimate,
+  convertEstimate,
+  createEstimate,
+  declineEstimate,
+  deleteEstimate,
+  getEstimate,
+  getEstimateErrorMessage,
+  listEstimates,
+  markEstimateSent,
+  updateEstimate,
+} from '@/app/features/finance/services/estimateService';
+import type { CreateEstimateInput, Estimate } from '@/app/features/finance/types/estimate';
+import { deleteData, getData, patchData, postData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+  patchData: jest.fn(),
+  deleteData: jest.fn(),
+}));
+
+const mockGetData = getData as jest.Mock;
+const mockPostData = postData as jest.Mock;
+const mockPatchData = patchData as jest.Mock;
+const mockDeleteData = deleteData as jest.Mock;
+
+const ESTIMATES_PATH = '/v1/pms/organisation/org-1/estimates';
+const ESTIMATE_PATH = `${ESTIMATES_PATH}/est-1`;
+
+const estimate: Estimate = {
+  id: 'est-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  status: 'DRAFT',
+  validUntil: null,
+  subtotal: 100,
+  taxAmount: 20,
+  total: 120,
+  currency: 'GBP',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: null,
+  createdBy: 'user-1',
+  createdAt: '2026-08-01T09:00:00.000Z',
+  updatedAt: '2026-08-01T09:00:00.000Z',
+  items: [
+    {
+      id: 'item-1',
+      description: 'Consultation',
+      quantity: 1,
+      unitPrice: 100,
+      taxRate: 20,
+      lineTotal: 120,
+      notes: null,
+    },
+  ],
+};
+
+const createInput: CreateEstimateInput = {
+  patientId: 'pat-1',
+  items: [{ description: 'Consultation', quantity: 1, unitPrice: 100 }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('listEstimates', () => {
+  it('reads the organisation estimates with no filters', async () => {
+    mockGetData.mockResolvedValue({ data: [estimate] });
+
+    const estimates = await listEstimates('org-1');
+
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATES_PATH, {});
+    expect(estimates).toEqual([estimate]);
+  });
+
+  it('passes the status filter as a params argument, not a query string', async () => {
+    mockGetData.mockResolvedValue({ data: [] });
+
+    await listEstimates('org-1', { status: 'APPROVED' });
+
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATES_PATH, { status: 'APPROVED' });
+    const [path] = mockGetData.mock.calls[0];
+    expect(path).not.toContain('?');
+  });
+
+  it('passes the patient filter as a params argument, not a query string', async () => {
+    mockGetData.mockResolvedValue({ data: [] });
+
+    await listEstimates('org-1', { patientId: 'pat-9' });
+
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATES_PATH, { patientId: 'pat-9' });
+    const [path] = mockGetData.mock.calls[0];
+    expect(path).not.toContain('?');
+  });
+
+  it('passes both filters together', async () => {
+    mockGetData.mockResolvedValue({ data: [] });
+
+    await listEstimates('org-1', { patientId: 'pat-9', status: 'SENT' });
+
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATES_PATH, {
+      patientId: 'pat-9',
+      status: 'SENT',
+    });
+  });
+
+  it('omits empty filter values', async () => {
+    mockGetData.mockResolvedValue({ data: [] });
+
+    await listEstimates('org-1', { patientId: '', status: undefined });
+
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATES_PATH, {});
+  });
+
+  it('returns an empty array when the body is an object rather than a list', async () => {
+    mockGetData.mockResolvedValue({ data: { error: 'Bad gateway' } });
+
+    await expect(listEstimates('org-1')).resolves.toEqual([]);
+  });
+
+  it('returns an empty array when the body is null', async () => {
+    mockGetData.mockResolvedValue({ data: null });
+
+    await expect(listEstimates('org-1')).resolves.toEqual([]);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(listEstimates('')).rejects.toThrow('Organisation ID missing');
+    expect(mockGetData).not.toHaveBeenCalled();
+  });
+
+  it('propagates a transport failure', async () => {
+    mockGetData.mockRejectedValue(new Error('network down'));
+
+    await expect(listEstimates('org-1')).rejects.toThrow('network down');
+  });
+});
+
+describe('getEstimate', () => {
+  it('reads one estimate by id', async () => {
+    mockGetData.mockResolvedValue({ data: estimate });
+
+    await expect(getEstimate('org-1', 'est-1')).resolves.toEqual(estimate);
+    expect(mockGetData).toHaveBeenCalledWith(ESTIMATE_PATH);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(getEstimate('', 'est-1')).rejects.toThrow('Organisation ID missing');
+    expect(mockGetData).not.toHaveBeenCalled();
+  });
+});
+
+describe('createEstimate', () => {
+  it('POSTs the input to the estimates collection', async () => {
+    mockPostData.mockResolvedValue({ data: estimate });
+
+    await expect(createEstimate('org-1', createInput)).resolves.toEqual(estimate);
+    expect(mockPostData).toHaveBeenCalledWith(ESTIMATES_PATH, createInput);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(createEstimate('', createInput)).rejects.toThrow('Organisation ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('markEstimateSent', () => {
+  it('POSTs an empty body to the send action', async () => {
+    mockPostData.mockResolvedValue({ data: { ...estimate, status: 'SENT' } });
+
+    const sent = await markEstimateSent('org-1', 'est-1');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/send`, {});
+    expect(sent.status).toBe('SENT');
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(markEstimateSent('', 'est-1')).rejects.toThrow('Organisation ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('approveEstimate', () => {
+  it('POSTs an empty body to the approve action', async () => {
+    mockPostData.mockResolvedValue({ data: { ...estimate, status: 'APPROVED' } });
+
+    const approved = await approveEstimate('org-1', 'est-1');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/approve`, {});
+    expect(approved.status).toBe('APPROVED');
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(approveEstimate('', 'est-1')).rejects.toThrow('Organisation ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('declineEstimate', () => {
+  it('sends the reason when one is given', async () => {
+    mockPostData.mockResolvedValue({ data: { ...estimate, status: 'DECLINED' } });
+
+    const declined = await declineEstimate('org-1', 'est-1', 'Owner declined the plan');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/decline`, {
+      reason: 'Owner declined the plan',
+    });
+    expect(declined.status).toBe('DECLINED');
+  });
+
+  it('sends an empty body when no reason is given', async () => {
+    mockPostData.mockResolvedValue({ data: estimate });
+
+    await declineEstimate('org-1', 'est-1');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/decline`, {});
+  });
+
+  it('sends an empty body for a blank reason rather than an empty string', async () => {
+    mockPostData.mockResolvedValue({ data: estimate });
+
+    await declineEstimate('org-1', 'est-1', '');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/decline`, {});
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(declineEstimate('', 'est-1', 'nope')).rejects.toThrow('Organisation ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('convertEstimate', () => {
+  it('POSTs an empty body to the convert action', async () => {
+    mockPostData.mockResolvedValue({
+      data: { ...estimate, status: 'CONVERTED', convertedToInvoiceId: 'inv-1' },
+    });
+
+    const converted = await convertEstimate('org-1', 'est-1');
+
+    expect(mockPostData).toHaveBeenCalledWith(`${ESTIMATE_PATH}/convert`, {});
+    expect(converted.convertedToInvoiceId).toBe('inv-1');
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(convertEstimate('', 'est-1')).rejects.toThrow('Organisation ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateEstimate', () => {
+  it('PATCHes the changed fields onto the estimate', async () => {
+    mockPatchData.mockResolvedValue({ data: { ...estimate, notes: 'Revised' } });
+
+    const updated = await updateEstimate('org-1', 'est-1', { notes: 'Revised' });
+
+    expect(mockPatchData).toHaveBeenCalledWith(ESTIMATE_PATH, { notes: 'Revised' });
+    expect(updated.notes).toBe('Revised');
+  });
+
+  it('PATCHes replacement items', async () => {
+    mockPatchData.mockResolvedValue({ data: estimate });
+
+    await updateEstimate('org-1', 'est-1', {
+      items: [{ description: 'Dental', quantity: 2, unitPrice: 50 }],
+      currency: 'EUR',
+    });
+
+    expect(mockPatchData).toHaveBeenCalledWith(ESTIMATE_PATH, {
+      items: [{ description: 'Dental', quantity: 2, unitPrice: 50 }],
+      currency: 'EUR',
+    });
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(updateEstimate('', 'est-1', { notes: 'x' })).rejects.toThrow(
+      'Organisation ID missing'
+    );
+    expect(mockPatchData).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteEstimate', () => {
+  it('DELETEs the estimate and resolves with nothing', async () => {
+    mockDeleteData.mockResolvedValue({ data: null });
+
+    await expect(deleteEstimate('org-1', 'est-1')).resolves.toBeUndefined();
+    expect(mockDeleteData).toHaveBeenCalledWith(ESTIMATE_PATH);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(deleteEstimate('', 'est-1')).rejects.toThrow('Organisation ID missing');
+    expect(mockDeleteData).not.toHaveBeenCalled();
+  });
+
+  it('propagates a transport failure', async () => {
+    mockDeleteData.mockRejectedValue(new Error('Request failed with status code 409'));
+
+    await expect(deleteEstimate('org-1', 'est-1')).rejects.toThrow(
+      'Request failed with status code 409'
+    );
+  });
+});
+
+describe('getEstimateErrorMessage', () => {
+  it('reads the string error the controller sends for a service failure', () => {
+    const error = {
+      message: 'Request failed with status code 400',
+      response: { data: { error: 'Only APPROVED estimates can be converted.' } },
+    };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe(
+      'Only APPROVED estimates can be converted.'
+    );
+  });
+
+  it('trims a padded string error', () => {
+    const error = { response: { data: { error: '  Estimate not found  ' } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('Estimate not found');
+  });
+
+  it('renders a zod flatten as readable text rather than [object Object]', () => {
+    const error = {
+      response: {
+        data: { error: { formErrors: ['bad'], fieldErrors: { items: ['Required'] } } },
+      },
+    };
+
+    const message = getEstimateErrorMessage(error, 'fallback');
+
+    expect(message).toBe('bad. items: Required');
+    expect(message).not.toContain('[object Object]');
+  });
+
+  it('renders field errors only', () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            formErrors: [],
+            fieldErrors: { items: ['Required'], patientId: ['Expected string'] },
+          },
+        },
+      },
+    };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe(
+      'items: Required. patientId: Expected string'
+    );
+  });
+
+  it('renders several messages for one field', () => {
+    const error = {
+      response: {
+        data: { error: { fieldErrors: { currency: ['Too short', 'Too long'] } } },
+      },
+    };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe(
+      'currency: Too short. currency: Too long'
+    );
+  });
+
+  it('renders form errors only', () => {
+    const error = {
+      response: { data: { error: { formErrors: ['Invalid body'], fieldErrors: {} } } },
+    };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('Invalid body');
+  });
+
+  it('falls back when the flatten carries no messages at all', () => {
+    const error = { response: { data: { error: { formErrors: [], fieldErrors: {} } } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('falls back when the flatten has neither key', () => {
+    const error = { response: { data: { error: {} } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('ignores non-string entries inside the flatten', () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            formErrors: [1, 'kept'],
+            fieldErrors: { items: 'not an array', notes: [null, 'too long'] },
+          },
+        },
+      },
+    };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('kept. notes: too long');
+  });
+
+  it('falls back when formErrors is not an array and there is nothing else', () => {
+    const error = { response: { data: { error: { formErrors: 'nope' } } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('reads a plain message body', () => {
+    const error = { response: { data: { message: 'x' } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('x');
+  });
+
+  it('prefers the error key over the message key', () => {
+    const error = { response: { data: { error: 'from error', message: 'from message' } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('from error');
+  });
+
+  it('falls back for a blank string body', () => {
+    const error = { response: { data: { error: '   ' } } };
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('returns the message of a plain Error', () => {
+    expect(getEstimateErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+  });
+
+  it('falls back for an Error with a blank message', () => {
+    expect(getEstimateErrorMessage(new Error('   '), 'fallback')).toBe('fallback');
+  });
+
+  it('prefers the response body over the axios Error message', () => {
+    const error = Object.assign(new Error('Request failed with status code 409'), {
+      response: { data: { error: 'Estimate already converted.' } },
+    });
+
+    expect(getEstimateErrorMessage(error, 'fallback')).toBe('Estimate already converted.');
+  });
+
+  it('falls back for null and undefined', () => {
+    expect(getEstimateErrorMessage(null, 'fallback')).toBe('fallback');
+    expect(getEstimateErrorMessage(undefined, 'fallback')).toBe('fallback');
+  });
+
+  it('falls back for a string and a number', () => {
+    expect(getEstimateErrorMessage('nope', 'fallback')).toBe('fallback');
+    expect(getEstimateErrorMessage(404, 'fallback')).toBe('fallback');
+  });
+
+  it('falls back when the response data is not an object', () => {
+    expect(getEstimateErrorMessage({ response: { data: 'oops' } }, 'fallback')).toBe('fallback');
+  });
+
+  it('falls back when there is no response at all', () => {
+    expect(getEstimateErrorMessage({ config: {} }, 'fallback')).toBe('fallback');
+  });
+});

--- a/apps/frontend/src/app/features/finance/hooks/useEstimates.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useEstimates.ts
@@ -61,6 +61,11 @@ export const useEstimates = (organisationId?: string, status?: EstimateStatus): 
 
   const upsert = useCallback(
     (estimate: Estimate) => {
+      // A create or lifecycle response can land after the user has switched
+      // organisation. The list refetch is keyed on organisationId and so is
+      // discarded, but this merge is not - without the guard an estimate from
+      // the previous organisation is inserted into the new one's list.
+      if (organisationId && estimate.organisationId !== organisationId) return;
       setEstimates((current) => {
         const index = current.findIndex((row) => row.id === estimate.id);
         // A lifecycle action changes the status, which can move the estimate out
@@ -76,7 +81,7 @@ export const useEstimates = (organisationId?: string, status?: EstimateStatus): 
         return next;
       });
     },
-    [status]
+    [status, organisationId]
   );
 
   const reload = useCallback(() => setReloadToken((token) => token + 1), []);

--- a/apps/frontend/src/app/features/finance/hooks/useEstimates.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useEstimates.ts
@@ -1,0 +1,85 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getEstimateErrorMessage,
+  listEstimates,
+} from '@/app/features/finance/services/estimateService';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+export type UseEstimates = {
+  estimates: Estimate[];
+  loading: boolean;
+  error: string | null;
+  /** Merge one estimate back in after a lifecycle action, without a refetch. */
+  upsert: (estimate: Estimate) => void;
+  reload: () => void;
+};
+
+/**
+ * List the organisation's estimates, optionally narrowed to one status.
+ *
+ * Filtering is done server-side rather than in the component so the status pills
+ * stay correct once an organisation has more estimates than one response holds.
+ */
+export const useEstimates = (organisationId?: string, status?: EstimateStatus): UseEstimates => {
+  const [estimates, setEstimates] = useState<Estimate[]>([]);
+  const [loading, setLoading] = useState(Boolean(organisationId));
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  // Render-phase reset, matching useOrganisationDiscountCap: without it, an org
+  // switch or a filter change would keep showing the previous list while the new
+  // one loads, and a failed load would leave estimates from another organisation
+  // on screen.
+  const loadKey = `${organisationId ?? ''}|${status ?? ''}|${reloadToken}`;
+  const [prevLoadKey, setPrevLoadKey] = useState(loadKey);
+  if (prevLoadKey !== loadKey) {
+    setPrevLoadKey(loadKey);
+    setEstimates([]);
+    setError(null);
+    setLoading(Boolean(organisationId));
+  }
+
+  useEffect(() => {
+    if (!organisationId) return undefined;
+    let active = true;
+    listEstimates(organisationId, status ? { status } : undefined)
+      .then((rows) => {
+        if (!active) return;
+        setEstimates(rows);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setError(getEstimateErrorMessage(err, 'Unable to load estimates.'));
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [organisationId, status, reloadToken]);
+
+  const upsert = useCallback(
+    (estimate: Estimate) => {
+      setEstimates((current) => {
+        const index = current.findIndex((row) => row.id === estimate.id);
+        // A lifecycle action changes the status, which can move the estimate out
+        // of the filter currently being viewed - approving under "Draft", or
+        // converting under "Approved". Dropping it keeps the list honest instead
+        // of showing a row whose status contradicts the active pill.
+        if (status && estimate.status !== status) {
+          return index === -1 ? current : current.filter((row) => row.id !== estimate.id);
+        }
+        if (index === -1) return [estimate, ...current];
+        const next = [...current];
+        next[index] = estimate;
+        return next;
+      });
+    },
+    [status]
+  );
+
+  const reload = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  return { estimates, loading, error, upsert, reload };
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import CreateEstimateDialog from './CreateEstimateDialog';
+
+const companions = [
+  { id: 'pat-1', name: 'Marnie Whitlock' },
+  { id: 'pat-2', name: 'Rufus Delacroix' },
+  { id: 'pat-3', name: 'Pepper Osei' },
+];
+
+const meta = {
+  title: 'Finance/CreateEstimateDialog',
+  component: CreateEstimateDialog,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The estimate editor.\n\n' +
+          'The running totals are computed by `computeEstimateTotals`, which deliberately mirrors ' +
+          "`computeTotals` in the backend's `EstimateService`: a line total excludes tax, tax is " +
+          'applied per line as a percentage of that line, and the estimate total is the sum. If ' +
+          'the two ever drift, the figure a client approves stops being the figure that is saved.\n\n' +
+          "Validation mirrors the controller's zod schema for the same reason - at least one line, " +
+          'a non-empty description, a quantity above zero, a non-negative price, tax within 0-100 - ' +
+          'so the user is told what is wrong before a request goes out, instead of reading a ' +
+          'flattened zod error afterwards.\n\n' +
+          'Currency is passed in from the organisation subscription rather than left to the API, ' +
+          "whose own default is GBP regardless of the clinic's currency.",
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    setOpen: () => {},
+    companions,
+    currency: 'GBP',
+    saving: false,
+    error: null,
+    onSubmit: () => {},
+  },
+} satisfies Meta<typeof CreateEstimateDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'A fresh draft',
+  play: async () => {
+    const canvas = within(document.body);
+    await expect(canvas.getByLabelText('Companion')).toBeInTheDocument();
+    // One empty line, so its Remove control is disabled.
+    await expect(canvas.getByRole('button', { name: 'Remove line 1' })).toBeDisabled();
+  },
+};
+
+export const LiveTotals: Story = {
+  name: 'Totals follow the lines',
+  play: async () => {
+    const canvas = within(document.body);
+    await userEvent.type(canvas.getByLabelText('Line 1 description'), 'Bloods');
+    const quantity = canvas.getByLabelText('Line 1 quantity');
+    await userEvent.clear(quantity);
+    await userEvent.type(quantity, '3');
+    await userEvent.type(canvas.getByLabelText('Line 1 unit price'), '19.99');
+    const tax = canvas.getByLabelText('Line 1 tax percent');
+    await userEvent.clear(tax);
+    await userEvent.type(tax, '20');
+
+    // 3 x 19.99 = 59.97 before tax; 20% of that is 11.99 (11.994 rounded for
+    // display only). The line cell shows the pre-tax figure, matching lineTotal.
+    await expect(canvas.getAllByText('£59.97').length).toBeGreaterThan(0);
+    await expect(canvas.getByText('£71.96')).toBeInTheDocument();
+  },
+};
+
+export const RejectsAnEmptyDraft: Story = {
+  name: 'Invalid draft is refused before any request',
+  play: async () => {
+    const canvas = within(document.body);
+    await userEvent.click(canvas.getByRole('button', { name: 'Create this estimate' }));
+    await expect(canvas.getByRole('alert')).toHaveTextContent(
+      'Choose a companion for this estimate.'
+    );
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving',
+  args: { saving: true },
+  play: async () => {
+    await expect(
+      within(document.body).getByRole('button', { name: 'Create this estimate' })
+    ).toBeDisabled();
+  },
+};
+
+export const ServerRejected: Story = {
+  name: 'The server refused it',
+  args: { error: 'Companion not found.' },
+  play: async () => {
+    await expect(within(document.body).getByRole('alert')).toHaveTextContent(
+      'Companion not found.'
+    );
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
@@ -1,21 +1,18 @@
 'use client';
-import React, { useMemo, useRef, useState } from 'react';
+import React from 'react';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
-import { formatMoneyPrecise } from '@/app/lib/money';
-import { computeEstimateTotals } from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
-import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/EstimateLineRow';
+import { useEstimateDraft } from '@/app/features/finance/pages/Estimates/Sections/useEstimateDraft';
 import {
-  emptyLine,
-  fieldClass,
-  inputClass,
-  toNumber,
-  validateDraft,
-  type DraftLine,
-} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+  EstimateHeaderFields,
+  EstimateLineEditor,
+  EstimateNotesField,
+  EstimateTotalsPanel,
+  type CompanionChoice,
+} from '@/app/features/finance/pages/Estimates/Sections/EstimateDraftFields';
 import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
 
-export type CompanionChoice = { id: string; name: string };
+export type { CompanionChoice };
 
 type CreateEstimateDialogProps = {
   open: boolean;
@@ -27,38 +24,14 @@ type CreateEstimateDialogProps = {
   onSubmit: (input: CreateEstimateInput) => void;
 };
 
-const LineColumnHeaders = () => (
-  <div
-    className="hidden sm:grid grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2 text-caption-2 text-text-tertiary"
-    aria-hidden="true"
-  >
-    <span>Description</span>
-    <span>Qty</span>
-    <span>Unit price</span>
-    <span>Tax %</span>
-    <span className="min-w-20 text-right">Line total</span>
-    <span />
-  </div>
-);
-
-type TotalsRowProps = { label: string; value: string; emphasis?: boolean };
-
-const TotalsRow = ({ label, value, emphasis = false }: TotalsRowProps) => (
-  <div className="flex items-center justify-between">
-    <span className="text-body-4 text-text-secondary">{label}</span>
-    <span className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
-      {value}
-    </span>
-  </div>
-);
-
 /**
  * The estimate editor.
  *
- * Totals come from `computeEstimateTotals`, which mirrors the backend's
- * `computeTotals` exactly, so the figure previewed here is the figure that is
- * saved. Validation mirrors the controller's zod schema for the same reason:
- * the user learns what is wrong before a request goes out.
+ * State and the payload live in `useEstimateDraft`; the form is assembled from
+ * the sections in `EstimateDraftFields`. Totals mirror the backend's
+ * `computeTotals` exactly, so the figure previewed here is the figure saved,
+ * and validation mirrors the controller's zod schema so the user learns what is
+ * wrong before a request goes out.
  */
 const CreateEstimateDialog = ({
   open,
@@ -69,64 +42,8 @@ const CreateEstimateDialog = ({
   error,
   onSubmit,
 }: CreateEstimateDialogProps) => {
-  const [patientId, setPatientId] = useState('');
-  const [notes, setNotes] = useState('');
-  const [validUntil, setValidUntil] = useState('');
-  const [lines, setLines] = useState<DraftLine[]>([emptyLine('line-0')]);
-  const [formError, setFormError] = useState<string | null>(null);
-
-  // A counter, not state: it only ever feeds the next React key, is never
-  // rendered, and as state every increment would re-render the dialog for
-  // nothing.
-  const nextKey = useRef(1);
-
-  const totals = useMemo(
-    () =>
-      computeEstimateTotals(
-        lines.map((line) => ({
-          description: line.description,
-          quantity: toNumber(line.quantity),
-          unitPrice: toNumber(line.unitPrice),
-          taxRate: toNumber(line.taxRate),
-        }))
-      ),
-    [lines]
-  );
-
-  const updateLine = (key: string, patch: Partial<DraftLine>) =>
-    setLines((current) => current.map((line) => (line.key === key ? { ...line, ...patch } : line)));
-
-  const addLine = () => {
-    setLines((current) => [...current, emptyLine(`line-${nextKey.current}`)]);
-    nextKey.current += 1;
-  };
-
-  const removeLine = (key: string) =>
-    setLines((current) =>
-      current.length === 1 ? current : current.filter((line) => line.key !== key)
-    );
-
-  const handleSubmit = () => {
-    const validation = validateDraft(patientId, lines);
-    if (!validation.ok) {
-      setFormError(validation.message);
-      return;
-    }
-    setFormError(null);
-    onSubmit({
-      patientId,
-      currency,
-      notes: notes.trim() || undefined,
-      // The API takes an ISO datetime; a date input yields yyyy-mm-dd only.
-      validUntil: validUntil ? new Date(`${validUntil}T00:00:00.000Z`).toISOString() : undefined,
-      items: lines.map((line) => ({
-        description: line.description.trim(),
-        quantity: toNumber(line.quantity),
-        unitPrice: toNumber(line.unitPrice),
-        taxRate: toNumber(line.taxRate),
-      })),
-    });
-  };
+  const draft = useEstimateDraft();
+  const message = draft.formError ?? error;
 
   return (
     <CenterModal
@@ -138,91 +55,29 @@ const CreateEstimateDialog = ({
       <div className="flex flex-col gap-4 p-6!">
         <h2 className="text-heading-4 text-text-primary">New estimate</h2>
 
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor="estimate-companion"
-            className="text-caption-2 font-bold text-text-tertiary"
-          >
-            Companion
-          </label>
-          <span className={fieldClass}>
-            <select
-              id="estimate-companion"
-              value={patientId}
-              onChange={(e) => setPatientId(e.target.value)}
-              className={inputClass}
-            >
-              <option value="">Choose a companion</option>
-              {companions.map((companion) => (
-                <option key={companion.id} value={companion.id}>
-                  {companion.name}
-                </option>
-              ))}
-            </select>
-          </span>
-        </div>
+        <EstimateHeaderFields
+          companions={companions}
+          patientId={draft.patientId}
+          setPatientId={draft.setPatientId}
+          validUntil={draft.validUntil}
+          setValidUntil={draft.setValidUntil}
+        />
 
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor="estimate-valid-until"
-            className="text-caption-2 font-bold text-text-tertiary"
-          >
-            Valid until (optional)
-          </label>
-          <span className={`${fieldClass} max-w-60`}>
-            <input
-              id="estimate-valid-until"
-              type="date"
-              value={validUntil}
-              onChange={(e) => setValidUntil(e.target.value)}
-              className={inputClass}
-            />
-          </span>
-        </div>
+        <EstimateLineEditor
+          lines={draft.lines}
+          currency={currency}
+          updateLine={draft.updateLine}
+          removeLine={draft.removeLine}
+          addLine={draft.addLine}
+        />
 
-        <div className="flex flex-col gap-2">
-          <span className="text-caption-2 font-bold text-text-tertiary">Lines</span>
-          <LineColumnHeaders />
-          {lines.map((line, index) => (
-            <EstimateLineRow
-              key={line.key}
-              line={line}
-              index={index}
-              currency={currency}
-              canRemove={lines.length > 1}
-              onChange={updateLine}
-              onRemove={removeLine}
-            />
-          ))}
-          <div>
-            <Secondary text="Add line" onClick={addLine} ariaLabel="Add another estimate line" />
-          </div>
-        </div>
+        <EstimateNotesField notes={draft.notes} setNotes={draft.setNotes} />
 
-        <div className="flex flex-col gap-1">
-          <label htmlFor="estimate-notes" className="text-caption-2 font-bold text-text-tertiary">
-            Notes (optional)
-          </label>
-          <span className={fieldClass}>
-            <textarea
-              id="estimate-notes"
-              value={notes}
-              rows={2}
-              onChange={(e) => setNotes(e.target.value)}
-              className={inputClass}
-            />
-          </span>
-        </div>
+        <EstimateTotalsPanel totals={draft.totals} currency={currency} />
 
-        <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
-          <TotalsRow label="Subtotal" value={formatMoneyPrecise(totals.subtotal, currency)} />
-          <TotalsRow label="Tax" value={formatMoneyPrecise(totals.taxAmount, currency)} />
-          <TotalsRow label="Total" value={formatMoneyPrecise(totals.total, currency)} emphasis />
-        </div>
-
-        {(formError ?? error) ? (
+        {message ? (
           <p role="alert" className="text-body-4 text-text-error">
-            {formError ?? error}
+            {message}
           </p>
         ) : null}
 
@@ -236,7 +91,7 @@ const CreateEstimateDialog = ({
           <Primary
             text={saving ? 'Creating...' : 'Create estimate'}
             isDisabled={saving}
-            onClick={handleSubmit}
+            onClick={() => draft.submit(onSubmit, currency)}
             ariaLabel="Create this estimate"
           />
         </div>

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
@@ -45,12 +45,27 @@ const CreateEstimateDialog = ({
   const draft = useEstimateDraft();
   const message = draft.formError ?? error;
 
+  /**
+   * ModalBase also closes on Escape and on an outside click, and those paths do
+   * not consult the disabled Cancel button. A create request cannot be
+   * cancelled, so dismissing mid-flight can let one succeed invisibly and a
+   * retry mint a second estimate. Swallowing the state change while saving
+   * closes every route out.
+   */
+  const setOpenUnlessSaving: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
+    if (saving) return;
+    setOpen(value);
+  };
+
   return (
     <CenterModal
       showModal={open}
-      setShowModal={setOpen}
+      setShowModal={setOpenUnlessSaving}
       ariaLabel="Create an estimate"
-      containerClassName="sm:w-[min(780px,92vw)]!"
+      // Capped and scrollable: the user can add unlimited lines, and the dialog
+      // locks body scroll, so an unbounded height puts the totals and the
+      // submit button off-screen with no way to reach them.
+      containerClassName="sm:w-[min(780px,92vw)]! max-h-[90vh] overflow-y-auto"
     >
       <div className="flex flex-col gap-4 p-6!">
         <h2 className="text-heading-4 text-text-primary">New estimate</h2>
@@ -85,13 +100,13 @@ const CreateEstimateDialog = ({
           <Secondary
             text="Cancel"
             isDisabled={saving}
-            onClick={() => setOpen(false)}
+            onClick={() => setOpenUnlessSaving(false)}
             ariaLabel="Cancel creating this estimate"
           />
           <Primary
             text={saving ? 'Creating...' : 'Create estimate'}
             isDisabled={saving}
-            onClick={() => draft.submit(onSubmit, currency)}
+            onClick={() => draft.submit(onSubmit)}
             ariaLabel="Create this estimate"
           />
         </div>

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
@@ -1,12 +1,18 @@
 'use client';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { formatMoneyPrecise } from '@/app/lib/money';
+import { computeEstimateTotals } from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/EstimateLineRow';
 import {
-  computeEstimateTotals,
-  computeLineTotal,
-} from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+  emptyLine,
+  fieldClass,
+  inputClass,
+  toNumber,
+  validateDraft,
+  type DraftLine,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
 import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
 
 export type CompanionChoice = { id: string; name: string };
@@ -21,72 +27,39 @@ type CreateEstimateDialogProps = {
   onSubmit: (input: CreateEstimateInput) => void;
 };
 
-type DraftLine = {
-  key: string;
-  description: string;
-  quantity: string;
-  unitPrice: string;
-  taxRate: string;
-};
+const LineColumnHeaders = () => (
+  <div
+    className="hidden sm:grid grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2 text-caption-2 text-text-tertiary"
+    aria-hidden="true"
+  >
+    <span>Description</span>
+    <span>Qty</span>
+    <span>Unit price</span>
+    <span>Tax %</span>
+    <span className="min-w-20 text-right">Line total</span>
+    <span />
+  </div>
+);
 
-const emptyLine = (key: string): DraftLine => ({
-  key,
-  description: '',
-  quantity: '1',
-  unitPrice: '',
-  taxRate: '0',
-});
+type TotalsRowProps = { label: string; value: string; emphasis?: boolean };
 
-/** A blank or unparseable numeric field reads as 0 rather than NaN. */
-const toNumber = (raw: string): number => {
-  const parsed = Number(raw.trim());
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
-const inputClass =
-  'min-w-0 flex-1 bg-transparent px-3 py-2 text-body-4 text-text-primary outline-none';
-const fieldClass =
-  'flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active';
+const TotalsRow = ({ label, value, emphasis = false }: TotalsRowProps) => (
+  <div className="flex items-center justify-between">
+    <span className="text-body-4 text-text-secondary">{label}</span>
+    <span className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
+      {value}
+    </span>
+  </div>
+);
 
 /**
- * Validate a draft the way the backend's zod schema does, so the user is told
- * what is wrong before a request is sent rather than reading a flattened zod
- * error afterwards. `items.min(1)`, `description.min(1)`, `quantity.positive()`
- * and `unitPrice.min(0)` all come from CreateEstimateSchema.
+ * The estimate editor.
+ *
+ * Totals come from `computeEstimateTotals`, which mirrors the backend's
+ * `computeTotals` exactly, so the figure previewed here is the figure that is
+ * saved. Validation mirrors the controller's zod schema for the same reason:
+ * the user learns what is wrong before a request goes out.
  */
-export const validateDraft = (
-  patientId: string,
-  lines: DraftLine[]
-): { ok: true } | { ok: false; message: string } => {
-  if (!patientId) return { ok: false, message: 'Choose a companion for this estimate.' };
-  if (lines.length === 0) return { ok: false, message: 'Add at least one line.' };
-  for (const line of lines) {
-    if (!line.description.trim()) {
-      return { ok: false, message: 'Every line needs a description.' };
-    }
-    if (toNumber(line.quantity) <= 0) {
-      return {
-        ok: false,
-        message: `Quantity for "${line.description.trim()}" must be above zero.`,
-      };
-    }
-    if (toNumber(line.unitPrice) < 0) {
-      return {
-        ok: false,
-        message: `Unit price for "${line.description.trim()}" cannot be negative.`,
-      };
-    }
-    const taxRate = toNumber(line.taxRate);
-    if (taxRate < 0 || taxRate > 100) {
-      return {
-        ok: false,
-        message: `Tax for "${line.description.trim()}" must be between 0 and 100.`,
-      };
-    }
-  }
-  return { ok: true };
-};
-
 const CreateEstimateDialog = ({
   open,
   setOpen,
@@ -100,8 +73,12 @@ const CreateEstimateDialog = ({
   const [notes, setNotes] = useState('');
   const [validUntil, setValidUntil] = useState('');
   const [lines, setLines] = useState<DraftLine[]>([emptyLine('line-0')]);
-  const [nextKey, setNextKey] = useState(1);
   const [formError, setFormError] = useState<string | null>(null);
+
+  // A counter, not state: it only ever feeds the next React key, is never
+  // rendered, and as state every increment would re-render the dialog for
+  // nothing.
+  const nextKey = useRef(1);
 
   const totals = useMemo(
     () =>
@@ -120,8 +97,8 @@ const CreateEstimateDialog = ({
     setLines((current) => current.map((line) => (line.key === key ? { ...line, ...patch } : line)));
 
   const addLine = () => {
-    setLines((current) => [...current, emptyLine(`line-${nextKey}`)]);
-    setNextKey((key) => key + 1);
+    setLines((current) => [...current, emptyLine(`line-${nextKey.current}`)]);
+    nextKey.current += 1;
   };
 
   const removeLine = (key: string) =>
@@ -205,123 +182,17 @@ const CreateEstimateDialog = ({
 
         <div className="flex flex-col gap-2">
           <span className="text-caption-2 font-bold text-text-tertiary">Lines</span>
-          {/*
-            Column headers, desktop only. The per-field labels below are visible on
-            phone and screen-reader-only from sm up, so every field is named at
-            every width - placeholders alone would leave the numeric boxes
-            unidentifiable the moment a value is typed into them.
-          */}
-          <div
-            className="hidden sm:grid grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2 text-caption-2 text-text-tertiary"
-            aria-hidden="true"
-          >
-            <span>Description</span>
-            <span>Qty</span>
-            <span>Unit price</span>
-            <span>Tax %</span>
-            <span className="min-w-20 text-right">Line total</span>
-            <span />
-          </div>
+          <LineColumnHeaders />
           {lines.map((line, index) => (
-            <div
+            <EstimateLineRow
               key={line.key}
-              className="grid grid-cols-[1fr_auto] sm:grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2"
-            >
-              <div className="flex flex-col gap-1 col-span-2 sm:col-span-1 min-w-0">
-                <label
-                  htmlFor={`${line.key}-description`}
-                  className="text-caption-2 text-text-tertiary sm:sr-only"
-                >
-                  {`Line ${index + 1} description`}
-                </label>
-                <span className={fieldClass}>
-                  <input
-                    id={`${line.key}-description`}
-                    type="text"
-                    value={line.description}
-                    placeholder="Description"
-                    onChange={(e) => updateLine(line.key, { description: e.target.value })}
-                    className={inputClass}
-                  />
-                </span>
-              </div>
-              <div className="flex flex-col gap-1 min-w-0">
-                <label
-                  htmlFor={`${line.key}-quantity`}
-                  className="text-caption-2 text-text-tertiary sm:sr-only"
-                >
-                  {`Line ${index + 1} quantity`}
-                </label>
-                <span className={fieldClass}>
-                  <input
-                    id={`${line.key}-quantity`}
-                    type="number"
-                    inputMode="decimal"
-                    min={0}
-                    value={line.quantity}
-                    placeholder="Qty"
-                    onChange={(e) => updateLine(line.key, { quantity: e.target.value })}
-                    className={inputClass}
-                  />
-                </span>
-              </div>
-              <div className="flex flex-col gap-1 min-w-0">
-                <label
-                  htmlFor={`${line.key}-unit-price`}
-                  className="text-caption-2 text-text-tertiary sm:sr-only"
-                >
-                  {`Line ${index + 1} unit price`}
-                </label>
-                <span className={fieldClass}>
-                  <input
-                    id={`${line.key}-unit-price`}
-                    type="number"
-                    inputMode="decimal"
-                    min={0}
-                    value={line.unitPrice}
-                    placeholder="Price"
-                    onChange={(e) => updateLine(line.key, { unitPrice: e.target.value })}
-                    className={inputClass}
-                  />
-                </span>
-              </div>
-              <div className="flex flex-col gap-1 min-w-0">
-                <label
-                  htmlFor={`${line.key}-tax-rate`}
-                  className="text-caption-2 text-text-tertiary sm:sr-only"
-                >
-                  {`Line ${index + 1} tax percent`}
-                </label>
-                <span className={fieldClass}>
-                  <input
-                    id={`${line.key}-tax-rate`}
-                    type="number"
-                    inputMode="decimal"
-                    min={0}
-                    max={100}
-                    value={line.taxRate}
-                    placeholder="Tax %"
-                    onChange={(e) => updateLine(line.key, { taxRate: e.target.value })}
-                    className={inputClass}
-                  />
-                </span>
-              </div>
-              <span className="text-body-4 text-text-secondary min-w-20 text-right pb-2! tabular-nums">
-                {formatMoneyPrecise(
-                  computeLineTotal(toNumber(line.quantity), toNumber(line.unitPrice)),
-                  currency
-                )}
-              </span>
-              <button
-                type="button"
-                onClick={() => removeLine(line.key)}
-                disabled={lines.length === 1}
-                aria-label={`Remove line ${index + 1}`}
-                className="text-body-4 text-text-secondary hover:text-text-primary disabled:opacity-40 pb-2!"
-              >
-                Remove
-              </button>
-            </div>
+              line={line}
+              index={index}
+              currency={currency}
+              canRemove={lines.length > 1}
+              onChange={updateLine}
+              onRemove={removeLine}
+            />
           ))}
           <div>
             <Secondary text="Add line" onClick={addLine} ariaLabel="Add another estimate line" />
@@ -344,24 +215,9 @@ const CreateEstimateDialog = ({
         </div>
 
         <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
-          <div className="flex items-center justify-between">
-            <span className="text-body-4 text-text-secondary">Subtotal</span>
-            <span className="text-body-3 text-text-primary">
-              {formatMoneyPrecise(totals.subtotal, currency)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-body-4 text-text-secondary">Tax</span>
-            <span className="text-body-3 text-text-primary">
-              {formatMoneyPrecise(totals.taxAmount, currency)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-body-4 text-text-secondary">Total</span>
-            <span className="text-body-2 text-text-primary">
-              {formatMoneyPrecise(totals.total, currency)}
-            </span>
-          </div>
+          <TotalsRow label="Subtotal" value={formatMoneyPrecise(totals.subtotal, currency)} />
+          <TotalsRow label="Tax" value={formatMoneyPrecise(totals.taxAmount, currency)} />
+          <TotalsRow label="Total" value={formatMoneyPrecise(totals.total, currency)} emphasis />
         </div>
 
         {(formError ?? error) ? (

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog.tsx
@@ -1,0 +1,392 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import {
+  computeEstimateTotals,
+  computeLineTotal,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
+
+export type CompanionChoice = { id: string; name: string };
+
+type CreateEstimateDialogProps = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  companions: CompanionChoice[];
+  currency: string;
+  saving: boolean;
+  error: string | null;
+  onSubmit: (input: CreateEstimateInput) => void;
+};
+
+type DraftLine = {
+  key: string;
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  taxRate: string;
+};
+
+const emptyLine = (key: string): DraftLine => ({
+  key,
+  description: '',
+  quantity: '1',
+  unitPrice: '',
+  taxRate: '0',
+});
+
+/** A blank or unparseable numeric field reads as 0 rather than NaN. */
+const toNumber = (raw: string): number => {
+  const parsed = Number(raw.trim());
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const inputClass =
+  'min-w-0 flex-1 bg-transparent px-3 py-2 text-body-4 text-text-primary outline-none';
+const fieldClass =
+  'flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active';
+
+/**
+ * Validate a draft the way the backend's zod schema does, so the user is told
+ * what is wrong before a request is sent rather than reading a flattened zod
+ * error afterwards. `items.min(1)`, `description.min(1)`, `quantity.positive()`
+ * and `unitPrice.min(0)` all come from CreateEstimateSchema.
+ */
+export const validateDraft = (
+  patientId: string,
+  lines: DraftLine[]
+): { ok: true } | { ok: false; message: string } => {
+  if (!patientId) return { ok: false, message: 'Choose a companion for this estimate.' };
+  if (lines.length === 0) return { ok: false, message: 'Add at least one line.' };
+  for (const line of lines) {
+    if (!line.description.trim()) {
+      return { ok: false, message: 'Every line needs a description.' };
+    }
+    if (toNumber(line.quantity) <= 0) {
+      return {
+        ok: false,
+        message: `Quantity for "${line.description.trim()}" must be above zero.`,
+      };
+    }
+    if (toNumber(line.unitPrice) < 0) {
+      return {
+        ok: false,
+        message: `Unit price for "${line.description.trim()}" cannot be negative.`,
+      };
+    }
+    const taxRate = toNumber(line.taxRate);
+    if (taxRate < 0 || taxRate > 100) {
+      return {
+        ok: false,
+        message: `Tax for "${line.description.trim()}" must be between 0 and 100.`,
+      };
+    }
+  }
+  return { ok: true };
+};
+
+const CreateEstimateDialog = ({
+  open,
+  setOpen,
+  companions,
+  currency,
+  saving,
+  error,
+  onSubmit,
+}: CreateEstimateDialogProps) => {
+  const [patientId, setPatientId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [validUntil, setValidUntil] = useState('');
+  const [lines, setLines] = useState<DraftLine[]>([emptyLine('line-0')]);
+  const [nextKey, setNextKey] = useState(1);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const totals = useMemo(
+    () =>
+      computeEstimateTotals(
+        lines.map((line) => ({
+          description: line.description,
+          quantity: toNumber(line.quantity),
+          unitPrice: toNumber(line.unitPrice),
+          taxRate: toNumber(line.taxRate),
+        }))
+      ),
+    [lines]
+  );
+
+  const updateLine = (key: string, patch: Partial<DraftLine>) =>
+    setLines((current) => current.map((line) => (line.key === key ? { ...line, ...patch } : line)));
+
+  const addLine = () => {
+    setLines((current) => [...current, emptyLine(`line-${nextKey}`)]);
+    setNextKey((key) => key + 1);
+  };
+
+  const removeLine = (key: string) =>
+    setLines((current) =>
+      current.length === 1 ? current : current.filter((line) => line.key !== key)
+    );
+
+  const handleSubmit = () => {
+    const validation = validateDraft(patientId, lines);
+    if (!validation.ok) {
+      setFormError(validation.message);
+      return;
+    }
+    setFormError(null);
+    onSubmit({
+      patientId,
+      currency,
+      notes: notes.trim() || undefined,
+      // The API takes an ISO datetime; a date input yields yyyy-mm-dd only.
+      validUntil: validUntil ? new Date(`${validUntil}T00:00:00.000Z`).toISOString() : undefined,
+      items: lines.map((line) => ({
+        description: line.description.trim(),
+        quantity: toNumber(line.quantity),
+        unitPrice: toNumber(line.unitPrice),
+        taxRate: toNumber(line.taxRate),
+      })),
+    });
+  };
+
+  return (
+    <CenterModal
+      showModal={open}
+      setShowModal={setOpen}
+      ariaLabel="Create an estimate"
+      containerClassName="sm:w-[min(780px,92vw)]!"
+    >
+      <div className="flex flex-col gap-4 p-6!">
+        <h2 className="text-heading-4 text-text-primary">New estimate</h2>
+
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="estimate-companion"
+            className="text-caption-2 font-bold text-text-tertiary"
+          >
+            Companion
+          </label>
+          <span className={fieldClass}>
+            <select
+              id="estimate-companion"
+              value={patientId}
+              onChange={(e) => setPatientId(e.target.value)}
+              className={inputClass}
+            >
+              <option value="">Choose a companion</option>
+              {companions.map((companion) => (
+                <option key={companion.id} value={companion.id}>
+                  {companion.name}
+                </option>
+              ))}
+            </select>
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="estimate-valid-until"
+            className="text-caption-2 font-bold text-text-tertiary"
+          >
+            Valid until (optional)
+          </label>
+          <span className={`${fieldClass} max-w-60`}>
+            <input
+              id="estimate-valid-until"
+              type="date"
+              value={validUntil}
+              onChange={(e) => setValidUntil(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-caption-2 font-bold text-text-tertiary">Lines</span>
+          {/*
+            Column headers, desktop only. The per-field labels below are visible on
+            phone and screen-reader-only from sm up, so every field is named at
+            every width - placeholders alone would leave the numeric boxes
+            unidentifiable the moment a value is typed into them.
+          */}
+          <div
+            className="hidden sm:grid grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2 text-caption-2 text-text-tertiary"
+            aria-hidden="true"
+          >
+            <span>Description</span>
+            <span>Qty</span>
+            <span>Unit price</span>
+            <span>Tax %</span>
+            <span className="min-w-20 text-right">Line total</span>
+            <span />
+          </div>
+          {lines.map((line, index) => (
+            <div
+              key={line.key}
+              className="grid grid-cols-[1fr_auto] sm:grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2"
+            >
+              <div className="flex flex-col gap-1 col-span-2 sm:col-span-1 min-w-0">
+                <label
+                  htmlFor={`${line.key}-description`}
+                  className="text-caption-2 text-text-tertiary sm:sr-only"
+                >
+                  {`Line ${index + 1} description`}
+                </label>
+                <span className={fieldClass}>
+                  <input
+                    id={`${line.key}-description`}
+                    type="text"
+                    value={line.description}
+                    placeholder="Description"
+                    onChange={(e) => updateLine(line.key, { description: e.target.value })}
+                    className={inputClass}
+                  />
+                </span>
+              </div>
+              <div className="flex flex-col gap-1 min-w-0">
+                <label
+                  htmlFor={`${line.key}-quantity`}
+                  className="text-caption-2 text-text-tertiary sm:sr-only"
+                >
+                  {`Line ${index + 1} quantity`}
+                </label>
+                <span className={fieldClass}>
+                  <input
+                    id={`${line.key}-quantity`}
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={line.quantity}
+                    placeholder="Qty"
+                    onChange={(e) => updateLine(line.key, { quantity: e.target.value })}
+                    className={inputClass}
+                  />
+                </span>
+              </div>
+              <div className="flex flex-col gap-1 min-w-0">
+                <label
+                  htmlFor={`${line.key}-unit-price`}
+                  className="text-caption-2 text-text-tertiary sm:sr-only"
+                >
+                  {`Line ${index + 1} unit price`}
+                </label>
+                <span className={fieldClass}>
+                  <input
+                    id={`${line.key}-unit-price`}
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    value={line.unitPrice}
+                    placeholder="Price"
+                    onChange={(e) => updateLine(line.key, { unitPrice: e.target.value })}
+                    className={inputClass}
+                  />
+                </span>
+              </div>
+              <div className="flex flex-col gap-1 min-w-0">
+                <label
+                  htmlFor={`${line.key}-tax-rate`}
+                  className="text-caption-2 text-text-tertiary sm:sr-only"
+                >
+                  {`Line ${index + 1} tax percent`}
+                </label>
+                <span className={fieldClass}>
+                  <input
+                    id={`${line.key}-tax-rate`}
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    max={100}
+                    value={line.taxRate}
+                    placeholder="Tax %"
+                    onChange={(e) => updateLine(line.key, { taxRate: e.target.value })}
+                    className={inputClass}
+                  />
+                </span>
+              </div>
+              <span className="text-body-4 text-text-secondary min-w-20 text-right pb-2! tabular-nums">
+                {formatMoneyPrecise(
+                  computeLineTotal(toNumber(line.quantity), toNumber(line.unitPrice)),
+                  currency
+                )}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeLine(line.key)}
+                disabled={lines.length === 1}
+                aria-label={`Remove line ${index + 1}`}
+                className="text-body-4 text-text-secondary hover:text-text-primary disabled:opacity-40 pb-2!"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          <div>
+            <Secondary text="Add line" onClick={addLine} ariaLabel="Add another estimate line" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="estimate-notes" className="text-caption-2 font-bold text-text-tertiary">
+            Notes (optional)
+          </label>
+          <span className={fieldClass}>
+            <textarea
+              id="estimate-notes"
+              value={notes}
+              rows={2}
+              onChange={(e) => setNotes(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
+          <div className="flex items-center justify-between">
+            <span className="text-body-4 text-text-secondary">Subtotal</span>
+            <span className="text-body-3 text-text-primary">
+              {formatMoneyPrecise(totals.subtotal, currency)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-body-4 text-text-secondary">Tax</span>
+            <span className="text-body-3 text-text-primary">
+              {formatMoneyPrecise(totals.taxAmount, currency)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-body-4 text-text-secondary">Total</span>
+            <span className="text-body-2 text-text-primary">
+              {formatMoneyPrecise(totals.total, currency)}
+            </span>
+          </div>
+        </div>
+
+        {(formError ?? error) ? (
+          <p role="alert" className="text-body-4 text-text-error">
+            {formError ?? error}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Secondary
+            text="Cancel"
+            isDisabled={saving}
+            onClick={() => setOpen(false)}
+            ariaLabel="Cancel creating this estimate"
+          />
+          <Primary
+            text={saving ? 'Creating...' : 'Create estimate'}
+            isDisabled={saving}
+            onClick={handleSubmit}
+            ariaLabel="Create this estimate"
+          />
+        </div>
+      </div>
+    </CenterModal>
+  );
+};
+
+export default CreateEstimateDialog;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.stories.tsx
@@ -1,0 +1,285 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import EstimateDetail from './EstimateDetail';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * Seeds the one store the gate reads, rather than mocking PermissionGate away.
+ * `usePermissions` derives the list from `roleCode`, so this exercises the real
+ * gate - which matters here, because the action row is the part of this
+ * component the gate hides, and stubbing it out would test nothing.
+ *
+ * All seven roles in ROLE_PERMISSIONS carry `billing:edit:any`, so a read-only
+ * billing user cannot be produced by picking a weaker role. The only route to
+ * one is `revokedPermissions`, which is what the read-only story below uses -
+ * and it is the realistic case anyway, since that is how a practice actually
+ * takes billing rights off one person.
+ */
+const seedRole = (roleCode: UserOrganization['roleCode'], revokedPermissions: string[] = []) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: {
+      [ORG_ID]: {
+        id: 'membership-1',
+        practitionerReference: 'Practitioner/practitioner-1',
+        organizationReference: `Organization/${ORG_ID}`,
+        roleCode,
+        roleDisplay: roleCode,
+        active: true,
+        revokedPermissions,
+      },
+    },
+    status: 'loaded',
+  });
+};
+
+// Seeded at module scope as well as per-story. Seeding only inside a decorator
+// leaves the gate resolving on the very first paint, and a play function that
+// runs against that frame sees no action row at all - which is exactly how this
+// showed up: two stories failing intermittently rather than every time.
+seedRole('OWNER');
+
+const item = (
+  id: string,
+  description: string,
+  quantity: number,
+  unitPrice: number,
+  taxRate: number,
+  notes: string | null = null
+) => ({
+  id,
+  description,
+  quantity,
+  unitPrice,
+  taxRate,
+  lineTotal: quantity * unitPrice,
+  notes,
+});
+
+/**
+ * Figures are deliberately not round. `formatMoneyPrecise` keeps both decimals,
+ * so 3 x 19.99 has to read as 59.97 - a story built on whole numbers would hide
+ * the rounding bug this component exists to avoid.
+ */
+const estimate = (overrides: Partial<Estimate> = {}): Estimate => ({
+  id: 'est-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  status: 'APPROVED',
+  validUntil: '2026-10-01T00:00:00.000Z',
+  subtotal: 179.97,
+  taxAmount: 20.0,
+  total: 199.97,
+  currency: 'GBP',
+  notes: 'Two-stage dental under general anaesthetic.',
+  approvedBy: 'user-1',
+  approvedAt: '2026-09-01T09:00:00.000Z',
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: null,
+  createdBy: 'user-1',
+  createdAt: '2026-08-30T09:00:00.000Z',
+  updatedAt: '2026-09-01T09:00:00.000Z',
+  items: [
+    item('i1', 'Dental scale and polish', 1, 120, 0),
+    item('i2', 'Pre-anaesthetic bloods', 3, 19.99, 20, 'Repeat on the day if delayed'),
+  ],
+  ...overrides,
+});
+
+const meta = {
+  title: 'Finance/EstimateDetail',
+  component: EstimateDetail,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'One estimate: its lines, its totals, and the lifecycle actions the backend will ' +
+          'currently accept.\n\n' +
+          'The action row is gated twice. `PermissionGate` hides it entirely without ' +
+          '`billing:edit:any`, and the status predicates decide which of the four actions is ' +
+          'offered - so the UI never presents a transition `EstimateService` would answer with a ' +
+          '409. Send is DRAFT only; approve and decline are DRAFT or SENT; convert is APPROVED ' +
+          'only. A CONVERTED estimate offers nothing and instead links to the invoice it became.\n\n' +
+          'Money uses `formatMoneyPrecise`, not the shared `formatMoney`, because that one rounds ' +
+          'to whole units - fine for a dashboard tile, wrong for a figure a client approves and ' +
+          'an invoice then has to match.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      seedRole('OWNER');
+      return <Story />;
+    },
+  ],
+  args: {
+    estimate: estimate(),
+    companionName: 'Marnie Whitlock',
+    pendingAction: null,
+    error: null,
+    onAction: () => {},
+  },
+} satisfies Meta<typeof EstimateDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Query by the accessible name, which is the aria-label, NOT the visible text -
+ * an aria-label replaces the label a button would otherwise get from its
+ * content. Matching the visible text here silently found nothing, and because
+ * the absent-action assertions then also "passed", the helper reported green
+ * while proving nothing about two of the four actions.
+ */
+const ACTIONS = {
+  'Mark as sent': 'Mark this estimate as sent',
+  Decline: 'Decline this estimate',
+  Approve: 'Approve this estimate',
+  'Convert to invoice': 'Convert this estimate to an invoice',
+} as const;
+
+type ActionLabel = keyof typeof ACTIONS;
+
+const expectActions = async (canvasElement: HTMLElement, expected: readonly ActionLabel[]) => {
+  const canvas = within(canvasElement);
+  for (const [label, accessibleName] of Object.entries(ACTIONS) as [ActionLabel, string][]) {
+    const found = canvas.queryByRole('button', { name: accessibleName });
+    if (expected.includes(label)) {
+      await expect(found).toBeInTheDocument();
+      // Guard against the failure this helper already had once: assert the
+      // visible text too, so a renamed aria-label cannot make the query match
+      // some other button.
+      await expect(found).toHaveTextContent(label);
+    } else {
+      await expect(found).not.toBeInTheDocument();
+    }
+  }
+};
+
+export const Approved: Story = {
+  name: 'Approved - the only state that can convert',
+  play: async ({ canvasElement }) => {
+    await expectActions(canvasElement, ['Convert to invoice']);
+    const canvas = within(canvasElement);
+    // 3 x 19.99 = 59.97, kept to the penny rather than rounded to 60.
+    await expect(canvas.getByText('£59.97')).toBeInTheDocument();
+    await expect(canvas.getByText('£199.97')).toBeInTheDocument();
+  },
+};
+
+export const Draft: Story = {
+  name: 'Draft - send, approve or decline',
+  args: { estimate: estimate({ status: 'DRAFT', approvedAt: null, approvedBy: null }) },
+  play: async ({ canvasElement }) => {
+    await expectActions(canvasElement, ['Mark as sent', 'Approve', 'Decline']);
+  },
+};
+
+export const Sent: Story = {
+  name: 'Sent - no longer sendable',
+  args: { estimate: estimate({ status: 'SENT' }) },
+  play: async ({ canvasElement }) => {
+    await expectActions(canvasElement, ['Approve', 'Decline']);
+  },
+};
+
+export const Converted: Story = {
+  name: 'Converted - no actions, links to the invoice',
+  args: {
+    estimate: estimate({ status: 'CONVERTED', convertedToInvoiceId: 'inv-77' }),
+  },
+  play: async ({ canvasElement }) => {
+    await expectActions(canvasElement, []);
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'View the invoice' });
+    await expect(link).toHaveAttribute('href', '/finance?invoiceId=inv-77');
+    await expect(
+      canvas.getByText(/Converting again would not create a second one/i)
+    ).toBeInTheDocument();
+  },
+};
+
+export const Declined: Story = {
+  name: 'Declined - reason shown, nothing to do',
+  args: {
+    estimate: estimate({
+      status: 'DECLINED',
+      declinedAt: '2026-09-01T10:00:00.000Z',
+      declineReason: 'Owner is seeking a second opinion.',
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    await expectActions(canvasElement, []);
+    await expect(within(canvasElement).getByText(/seeking a second opinion/i)).toBeInTheDocument();
+  },
+};
+
+export const Converting: Story = {
+  name: 'Converting - every action disabled',
+  args: { pendingAction: 'convert' },
+  play: async ({ canvasElement }) => {
+    const button = within(canvasElement).getByRole('button', { name: /Convert this estimate/i });
+    await expect(button).toBeDisabled();
+    await expect(button).toHaveTextContent('Converting...');
+  },
+};
+
+export const ActionFailed: Story = {
+  name: 'Action failed - the reason is on screen',
+  args: { error: 'Only APPROVED estimates can be converted.' },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByRole('alert')).toHaveTextContent(
+      'Only APPROVED estimates can be converted.'
+    );
+  },
+};
+
+/** Every lifecycle state side by side, for a one-glance check of the pill colours. */
+export const EveryStatus: Story = {
+  name: 'Every status',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      {(['DRAFT', 'SENT', 'APPROVED', 'CONVERTED', 'DECLINED', 'EXPIRED'] as EstimateStatus[]).map(
+        (status) => (
+          <EstimateDetail
+            key={status}
+            estimate={estimate({
+              status,
+              convertedToInvoiceId: status === 'CONVERTED' ? 'inv-77' : null,
+            })}
+            companionName="Marnie Whitlock"
+            pendingAction={null}
+            error={null}
+            onAction={() => {}}
+          />
+        )
+      )}
+    </div>
+  ),
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Billing edit revoked - no actions at all',
+  decorators: [
+    (Story) => {
+      seedRole('RECEPTIONIST', ['billing:edit:any']);
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    // The estimate is APPROVED, so convert would be offered to an editor. With
+    // billing:edit:any revoked the action row is absent rather than merely
+    // disabled, and the estimate itself still reads fine.
+    await expectActions(canvasElement, []);
+    await expect(within(canvasElement).getByText('Dental scale and polish')).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
@@ -63,7 +63,7 @@ const EstimateDetail = ({
         {estimate.convertedToInvoiceId ? (
           <Link
             href={`/finance?invoiceId=${estimate.convertedToInvoiceId}`}
-            className="text-body-4 text-text-link underline underline-offset-2"
+            className="text-body-4 text-blue-text underline underline-offset-2"
           >
             View the invoice
           </Link>

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
@@ -6,6 +6,7 @@ import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
+import EstimateLineItems from '@/app/features/finance/pages/Estimates/Sections/EstimateLineItems';
 import {
   canApprove,
   canConvert,
@@ -78,56 +79,13 @@ const EstimateDetail = ({
           </p>
         )}
 
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-140 border-collapse">
-            <caption className="sr-only">Estimate line items</caption>
-            <thead>
-              <tr className="border-b border-b-card-border">
-                <th scope="col" className="text-left text-body-4 text-text-secondary py-2!">
-                  Description
-                </th>
-                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
-                  Qty
-                </th>
-                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
-                  Unit price
-                </th>
-                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
-                  Tax
-                </th>
-                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
-                  Line total
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {estimate.items.map((item) => (
-                <tr key={item.id} className="border-b border-b-card-border last:border-b-0">
-                  <td className="py-2! text-body-3 text-text-primary">
-                    {item.description}
-                    {item.notes ? (
-                      <span className="block text-body-4 text-text-secondary">{item.notes}</span>
-                    ) : null}
-                  </td>
-                  <td className="py-2! text-body-3 text-text-primary text-right">
-                    {item.quantity}
-                  </td>
-                  <td className="py-2! text-body-3 text-text-primary text-right">
-                    {formatMoneyPrecise(item.unitPrice, estimate.currency)}
-                  </td>
-                  <td className="py-2! text-body-3 text-text-primary text-right">
-                    {item.taxRate}%
-                  </td>
-                  <td className="py-2! text-body-3 text-text-primary text-right">
-                    {formatMoneyPrecise(item.lineTotal, estimate.currency)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <EstimateLineItems estimate={estimate} />
 
-        <div className="flex flex-col gap-2 border-t border-t-card-border pt-4!">
+        <div
+          className="flex flex-col gap-2 border-t border-t-card-border pt-4!"
+          role="group"
+          aria-label="Estimate totals"
+        >
           {summaryRow('Subtotal', formatMoneyPrecise(estimate.subtotal, estimate.currency))}
           {summaryRow('Tax', formatMoneyPrecise(estimate.taxAmount, estimate.currency))}
           {summaryRow('Total', formatMoneyPrecise(estimate.total, estimate.currency), true)}

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
@@ -1,0 +1,191 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
+import {
+  canApprove,
+  canConvert,
+  canDecline,
+  canSend,
+  type Estimate,
+} from '@/app/features/finance/types/estimate';
+
+export type EstimateAction = 'send' | 'approve' | 'decline' | 'convert';
+
+type EstimateDetailProps = {
+  estimate: Estimate;
+  companionName: string;
+  /** Which action is in flight, so only that button shows a pending label. */
+  pendingAction: EstimateAction | null;
+  onAction: (action: EstimateAction) => void;
+  error: string | null;
+};
+
+const summaryRow = (label: string, value: string, emphasis = false) => (
+  <div className="flex items-center justify-between gap-4">
+    <span className="text-body-4 text-text-secondary">{label}</span>
+    <span className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
+      {value}
+    </span>
+  </div>
+);
+
+/**
+ * One estimate: its lines, its totals, and the lifecycle actions the backend
+ * will currently accept.
+ *
+ * Actions are gated twice - by `billing:edit:any` so a read-only user never sees
+ * them, and by the status predicates so the UI never offers a transition the
+ * service would reject with a 409.
+ */
+const EstimateDetail = ({
+  estimate,
+  companionName,
+  pendingAction,
+  onAction,
+  error,
+}: EstimateDetailProps) => {
+  const busy = pendingAction !== null;
+  const label = (action: EstimateAction, idle: string, pending: string) =>
+    pendingAction === action ? pending : idle;
+
+  return (
+    <div className="border border-card-border rounded-2xl flex flex-col">
+      <div className="px-6! py-4! border-b border-b-card-border flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <h2 className="text-heading-4 text-text-primary">{companionName}</h2>
+          <EstimateStatusBadge status={estimate.status} />
+        </div>
+        {estimate.convertedToInvoiceId ? (
+          <Link
+            href={`/finance?invoiceId=${estimate.convertedToInvoiceId}`}
+            className="text-body-4 text-text-link underline underline-offset-2"
+          >
+            View the invoice
+          </Link>
+        ) : null}
+      </div>
+
+      <div className="px-6! py-4! flex flex-col gap-4">
+        {estimate.status === 'CONVERTED' && (
+          <p className="text-body-4 text-text-secondary rounded-2xl bg-card-hover p-3!">
+            This estimate has been converted to an invoice. Converting again would not create a
+            second one.
+          </p>
+        )}
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-140 border-collapse">
+            <caption className="sr-only">Estimate line items</caption>
+            <thead>
+              <tr className="border-b border-b-card-border">
+                <th scope="col" className="text-left text-body-4 text-text-secondary py-2!">
+                  Description
+                </th>
+                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
+                  Qty
+                </th>
+                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
+                  Unit price
+                </th>
+                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
+                  Tax
+                </th>
+                <th scope="col" className="text-right text-body-4 text-text-secondary py-2!">
+                  Line total
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {estimate.items.map((item) => (
+                <tr key={item.id} className="border-b border-b-card-border last:border-b-0">
+                  <td className="py-2! text-body-3 text-text-primary">
+                    {item.description}
+                    {item.notes ? (
+                      <span className="block text-body-4 text-text-secondary">{item.notes}</span>
+                    ) : null}
+                  </td>
+                  <td className="py-2! text-body-3 text-text-primary text-right">
+                    {item.quantity}
+                  </td>
+                  <td className="py-2! text-body-3 text-text-primary text-right">
+                    {formatMoneyPrecise(item.unitPrice, estimate.currency)}
+                  </td>
+                  <td className="py-2! text-body-3 text-text-primary text-right">
+                    {item.taxRate}%
+                  </td>
+                  <td className="py-2! text-body-3 text-text-primary text-right">
+                    {formatMoneyPrecise(item.lineTotal, estimate.currency)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-col gap-2 border-t border-t-card-border pt-4!">
+          {summaryRow('Subtotal', formatMoneyPrecise(estimate.subtotal, estimate.currency))}
+          {summaryRow('Tax', formatMoneyPrecise(estimate.taxAmount, estimate.currency))}
+          {summaryRow('Total', formatMoneyPrecise(estimate.total, estimate.currency), true)}
+        </div>
+
+        {estimate.notes ? (
+          <p className="text-body-4 text-text-secondary whitespace-pre-line">{estimate.notes}</p>
+        ) : null}
+
+        {estimate.declineReason ? (
+          <p className="text-body-4 text-text-secondary">Declined: {estimate.declineReason}</p>
+        ) : null}
+
+        {error ? (
+          <p role="alert" className="text-body-4 text-text-error">
+            {error}
+          </p>
+        ) : null}
+
+        <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+          <div className="flex flex-wrap items-center justify-end gap-2 pt-2!">
+            {canSend(estimate.status) && (
+              <Secondary
+                text={label('send', 'Mark as sent', 'Sending...')}
+                isDisabled={busy}
+                onClick={() => onAction('send')}
+                ariaLabel="Mark this estimate as sent"
+              />
+            )}
+            {canDecline(estimate.status) && (
+              <Secondary
+                text={label('decline', 'Decline', 'Declining...')}
+                isDisabled={busy}
+                onClick={() => onAction('decline')}
+                ariaLabel="Decline this estimate"
+              />
+            )}
+            {canApprove(estimate.status) && (
+              <Secondary
+                text={label('approve', 'Approve', 'Approving...')}
+                isDisabled={busy}
+                onClick={() => onAction('approve')}
+                ariaLabel="Approve this estimate"
+              />
+            )}
+            {canConvert(estimate.status) && (
+              <Primary
+                text={label('convert', 'Convert to invoice', 'Converting...')}
+                isDisabled={busy}
+                onClick={() => onAction('convert')}
+                ariaLabel="Convert this estimate to an invoice"
+              />
+            )}
+          </div>
+        </PermissionGate>
+      </div>
+    </div>
+  );
+};
+
+export default EstimateDetail;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDetail.tsx
@@ -26,12 +26,21 @@ type EstimateDetailProps = {
   error: string | null;
 };
 
+/**
+ * One totals row as a description-list pair.
+ *
+ * `<dl>`/`<dt>`/`<dd>` rather than a div with `role="group"`: these are label
+ * and value pairs, which is exactly what a description list is for, so the
+ * semantics come from the markup instead of an ARIA role bolted onto a div
+ * (Sonar S6819). It also stops "Tax" here being indistinguishable from the
+ * "Tax" column header on the lines table above.
+ */
 const summaryRow = (label: string, value: string, emphasis = false) => (
-  <div className="flex items-center justify-between gap-4">
-    <span className="text-body-4 text-text-secondary">{label}</span>
-    <span className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
+  <div className="flex items-center justify-between gap-4" key={label}>
+    <dt className="text-body-4 text-text-secondary">{label}</dt>
+    <dd className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
       {value}
-    </span>
+    </dd>
   </div>
 );
 
@@ -81,15 +90,14 @@ const EstimateDetail = ({
 
         <EstimateLineItems estimate={estimate} />
 
-        <div
+        <dl
           className="flex flex-col gap-2 border-t border-t-card-border pt-4!"
-          role="group"
           aria-label="Estimate totals"
         >
           {summaryRow('Subtotal', formatMoneyPrecise(estimate.subtotal, estimate.currency))}
           {summaryRow('Tax', formatMoneyPrecise(estimate.taxAmount, estimate.currency))}
           {summaryRow('Total', formatMoneyPrecise(estimate.total, estimate.currency), true)}
-        </div>
+        </dl>
 
         {estimate.notes ? (
           <p className="text-body-4 text-text-secondary whitespace-pre-line">{estimate.notes}</p>

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
@@ -6,6 +6,7 @@ import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/Est
 import {
   fieldClass,
   inputClass,
+  todayIsoDate,
   type DraftLine,
 } from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
 import type { EstimateTotals } from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
@@ -56,6 +57,9 @@ export const EstimateHeaderFields = ({
         <input
           id="estimate-valid-until"
           type="date"
+          // A lapsed quote would still be sendable, approvable and convertible,
+          // because nothing derives EXPIRED from this date.
+          min={todayIsoDate()}
           value={validUntil}
           onChange={(e) => setValidUntil(e.target.value)}
           className={inputClass}

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
@@ -1,0 +1,170 @@
+'use client';
+import React from 'react';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/EstimateLineRow';
+import {
+  fieldClass,
+  inputClass,
+  type DraftLine,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import type { EstimateTotals } from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+
+export type CompanionChoice = { id: string; name: string };
+
+/** The companion picker and the optional expiry date. */
+export const EstimateHeaderFields = ({
+  companions,
+  patientId,
+  setPatientId,
+  validUntil,
+  setValidUntil,
+}: {
+  companions: CompanionChoice[];
+  patientId: string;
+  setPatientId: (value: string) => void;
+  validUntil: string;
+  setValidUntil: (value: string) => void;
+}) => (
+  <>
+    <div className="flex flex-col gap-1">
+      <label htmlFor="estimate-companion" className="text-caption-2 font-bold text-text-tertiary">
+        Companion
+      </label>
+      <span className={fieldClass}>
+        <select
+          id="estimate-companion"
+          value={patientId}
+          onChange={(e) => setPatientId(e.target.value)}
+          className={inputClass}
+        >
+          <option value="">Choose a companion</option>
+          {companions.map((companion) => (
+            <option key={companion.id} value={companion.id}>
+              {companion.name}
+            </option>
+          ))}
+        </select>
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="estimate-valid-until" className="text-caption-2 font-bold text-text-tertiary">
+        Valid until (optional)
+      </label>
+      <span className={`${fieldClass} max-w-60`}>
+        <input
+          id="estimate-valid-until"
+          type="date"
+          value={validUntil}
+          onChange={(e) => setValidUntil(e.target.value)}
+          className={inputClass}
+        />
+      </span>
+    </div>
+  </>
+);
+
+const LineColumnHeaders = () => (
+  <div
+    className="hidden sm:grid grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2 text-caption-2 text-text-tertiary"
+    aria-hidden="true"
+  >
+    <span>Description</span>
+    <span>Qty</span>
+    <span>Unit price</span>
+    <span>Tax %</span>
+    <span className="min-w-20 text-right">Line total</span>
+    <span />
+  </div>
+);
+
+/** The editable line items, with column headers on desktop. */
+export const EstimateLineEditor = ({
+  lines,
+  currency,
+  updateLine,
+  removeLine,
+  addLine,
+}: {
+  lines: DraftLine[];
+  currency: string;
+  updateLine: (key: string, patch: Partial<DraftLine>) => void;
+  removeLine: (key: string) => void;
+  addLine: () => void;
+}) => (
+  <div className="flex flex-col gap-2">
+    <span className="text-caption-2 font-bold text-text-tertiary">Lines</span>
+    <LineColumnHeaders />
+    {lines.map((line, index) => (
+      <EstimateLineRow
+        key={line.key}
+        line={line}
+        index={index}
+        currency={currency}
+        canRemove={lines.length > 1}
+        onChange={updateLine}
+        onRemove={removeLine}
+      />
+    ))}
+    <div>
+      <Secondary text="Add line" onClick={addLine} ariaLabel="Add another estimate line" />
+    </div>
+  </div>
+);
+
+/** Free-text notes carried onto the estimate. */
+export const EstimateNotesField = ({
+  notes,
+  setNotes,
+}: {
+  notes: string;
+  setNotes: (value: string) => void;
+}) => (
+  <div className="flex flex-col gap-1">
+    <label htmlFor="estimate-notes" className="text-caption-2 font-bold text-text-tertiary">
+      Notes (optional)
+    </label>
+    <span className={fieldClass}>
+      <textarea
+        id="estimate-notes"
+        value={notes}
+        rows={2}
+        onChange={(e) => setNotes(e.target.value)}
+        className={inputClass}
+      />
+    </span>
+  </div>
+);
+
+const TotalsRow = ({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+}) => (
+  <div className="flex items-center justify-between">
+    <span className="text-body-4 text-text-secondary">{label}</span>
+    <span className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
+      {value}
+    </span>
+  </div>
+);
+
+/** Running subtotal, tax and total, computed the way the backend computes them. */
+export const EstimateTotalsPanel = ({
+  totals,
+  currency,
+}: {
+  totals: EstimateTotals;
+  currency: string;
+}) => (
+  <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
+    <TotalsRow label="Subtotal" value={formatMoneyPrecise(totals.subtotal, currency)} />
+    <TotalsRow label="Tax" value={formatMoneyPrecise(totals.taxAmount, currency)} />
+    <TotalsRow label="Total" value={formatMoneyPrecise(totals.total, currency)} emphasis />
+  </div>
+);

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateLineItems.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateLineItems.tsx
@@ -1,0 +1,76 @@
+'use client';
+import React from 'react';
+import TableHead from '@/app/ui/tables/TableHead';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import type { Estimate } from '@/app/features/finance/types/estimate';
+
+type EstimateLineItemsProps = {
+  estimate: Estimate;
+};
+
+/**
+ * The estimate's line items.
+ *
+ * Built the way `InvoiceBilledItems` is built - the shared `TableHead` recipe
+ * over a CSS grid, with the same track on the header and the rows - so an
+ * estimate and the invoice it converts into read as one family rather than two
+ * independently styled tables.
+ */
+const gridTemplate = 'minmax(0,1.9fr) 50px 90px 60px 90px';
+
+const EstimateLineItems = ({ estimate }: EstimateLineItemsProps) => (
+  <div className="rounded-[14px] border border-card-border overflow-hidden">
+    <TableHead
+      columns={[
+        { key: 'description', label: 'Description' },
+        { key: 'qty', label: 'Qty' },
+        { key: 'unitPrice', label: 'Unit price', align: 'right' },
+        { key: 'tax', label: 'Tax', align: 'right' },
+        { key: 'lineTotal', label: 'Line total', align: 'right' },
+      ]}
+      track={gridTemplate}
+      gap="10px"
+      // Not sticky: this sits inside a detail card, where sticky resolves
+      // against the wrong container and strands the band mid-panel.
+      sticky={false}
+      className="px-4!"
+    />
+    {estimate.items.length === 0 ? (
+      <output className="block px-4 py-3 text-body-4 text-text-tertiary border-t border-card-border">
+        This estimate has no lines.
+      </output>
+    ) : (
+      estimate.items.map((item) => (
+        <div
+          key={item.id}
+          className="grid gap-2.5 px-4 py-[11px] border-t border-card-border text-body-4 text-text-primary items-center"
+          style={{ gridTemplateColumns: gridTemplate }}
+        >
+          <span className="min-w-0">
+            <span className="font-semibold block truncate" title={item.description}>
+              {item.description}
+            </span>
+            {item.notes ? (
+              <span
+                className="block text-caption-2 text-text-secondary truncate"
+                title={item.notes}
+              >
+                {item.notes}
+              </span>
+            ) : null}
+          </span>
+          <span className="tabular-nums">{item.quantity}</span>
+          <span className="text-right tabular-nums">
+            {formatMoneyPrecise(item.unitPrice, estimate.currency)}
+          </span>
+          <span className="text-right tabular-nums">{item.taxRate}%</span>
+          <span className="text-right tabular-nums font-bold">
+            {formatMoneyPrecise(item.lineTotal, estimate.currency)}
+          </span>
+        </div>
+      ))
+    )}
+  </div>
+);
+
+export default EstimateLineItems;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateLineRow.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateLineRow.tsx
@@ -1,0 +1,126 @@
+'use client';
+import React from 'react';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import { computeLineTotal } from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+import {
+  fieldClass,
+  inputClass,
+  toNumber,
+  type DraftLine,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+
+type EstimateLineRowProps = {
+  line: DraftLine;
+  index: number;
+  currency: string;
+  canRemove: boolean;
+  onChange: (key: string, patch: Partial<DraftLine>) => void;
+  onRemove: (key: string) => void;
+};
+
+type NumericFieldProps = {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  max?: number;
+  onChange: (value: string) => void;
+};
+
+/**
+ * Labels are visible on phone and screen-reader-only from sm up, where the
+ * column headers name the fields instead. A placeholder alone would leave the
+ * numeric boxes unidentifiable the moment a value is typed into them.
+ */
+const NumericField = ({ id, label, value, placeholder, max, onChange }: NumericFieldProps) => (
+  <div className="flex flex-col gap-1 min-w-0">
+    <label htmlFor={id} className="text-caption-2 text-text-tertiary sm:sr-only">
+      {label}
+    </label>
+    <span className={fieldClass}>
+      <input
+        id={id}
+        type="number"
+        inputMode="decimal"
+        min={0}
+        max={max}
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        className={inputClass}
+      />
+    </span>
+  </div>
+);
+
+/** One editable estimate line: description, quantity, unit price, tax and its running total. */
+const EstimateLineRow = ({
+  line,
+  index,
+  currency,
+  canRemove,
+  onChange,
+  onRemove,
+}: EstimateLineRowProps) => (
+  <div className="grid grid-cols-[1fr_auto] sm:grid-cols-[minmax(0,1fr)_4.5rem_6rem_4.5rem_auto_auto] items-end gap-2">
+    <div className="flex flex-col gap-1 col-span-2 sm:col-span-1 min-w-0">
+      <label
+        htmlFor={`${line.key}-description`}
+        className="text-caption-2 text-text-tertiary sm:sr-only"
+      >
+        {`Line ${index + 1} description`}
+      </label>
+      <span className={fieldClass}>
+        <input
+          id={`${line.key}-description`}
+          type="text"
+          value={line.description}
+          placeholder="Description"
+          onChange={(e) => onChange(line.key, { description: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <NumericField
+      id={`${line.key}-quantity`}
+      label={`Line ${index + 1} quantity`}
+      value={line.quantity}
+      placeholder="Qty"
+      onChange={(quantity) => onChange(line.key, { quantity })}
+    />
+    <NumericField
+      id={`${line.key}-unit-price`}
+      label={`Line ${index + 1} unit price`}
+      value={line.unitPrice}
+      placeholder="Price"
+      onChange={(unitPrice) => onChange(line.key, { unitPrice })}
+    />
+    <NumericField
+      id={`${line.key}-tax-rate`}
+      label={`Line ${index + 1} tax percent`}
+      value={line.taxRate}
+      placeholder="Tax %"
+      max={100}
+      onChange={(taxRate) => onChange(line.key, { taxRate })}
+    />
+
+    <span className="text-body-4 text-text-secondary min-w-20 text-right pb-2! tabular-nums">
+      {formatMoneyPrecise(
+        computeLineTotal(toNumber(line.quantity), toNumber(line.unitPrice)),
+        currency
+      )}
+    </span>
+    <button
+      type="button"
+      onClick={() => onRemove(line.key)}
+      disabled={!canRemove}
+      aria-label={`Remove line ${index + 1}`}
+      className="text-body-4 text-text-secondary hover:text-text-primary disabled:opacity-40 pb-2!"
+    >
+      Remove
+    </button>
+  </div>
+);
+
+export default EstimateLineRow;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import EstimateList from './EstimateList';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+const NAMES: Record<string, string> = {
+  'pat-1': 'Marnie Whitlock',
+  'pat-2': 'Rufus Delacroix',
+  'pat-3': 'Pepper Osei',
+};
+
+const row = (
+  id: string,
+  patientId: string,
+  status: EstimateStatus,
+  total: number,
+  validUntil: string | null
+): Estimate => ({
+  id,
+  organisationId: 'org-1',
+  patientId,
+  encounterId: null,
+  status,
+  validUntil,
+  subtotal: total,
+  taxAmount: 0,
+  total,
+  currency: 'GBP',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: status === 'CONVERTED' ? 'inv-1' : null,
+  createdBy: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+  items: [],
+});
+
+const meta = {
+  title: 'Finance/EstimateList',
+  component: EstimateList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The estimates list.\n\n' +
+          'The API returns a bare `patientId`, so the companion name is resolved by the caller ' +
+          'through the `companionName` prop rather than joined server-side. An id with no loaded ' +
+          'companion falls back to a readable label instead of printing a uuid at the user.\n\n' +
+          '`validUntil` is optional on the model and renders as a dash when absent, which is the ' +
+          'common case: nothing in the service ever sets EXPIRED, so an expiry date here is a note ' +
+          'to the clinic rather than something the system enforces.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    estimates: [
+      row('e1', 'pat-1', 'APPROVED', 199.97, '2026-10-01T00:00:00.000Z'),
+      row('e2', 'pat-2', 'DRAFT', 45.5, null),
+      row('e3', 'pat-3', 'CONVERTED', 1240.6, '2026-09-15T00:00:00.000Z'),
+    ],
+    activeEstimateId: 'e1',
+    onSelect: () => {},
+    companionName: (patientId: string) => NAMES[patientId] ?? 'Unknown companion',
+  },
+} satisfies Meta<typeof EstimateList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'A row per estimate',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Marnie Whitlock')).toBeInTheDocument();
+    // Both decimals survive: 45.5 must not print as "£46".
+    await expect(canvas.getByText('£45.50')).toBeInTheDocument();
+    await expect(canvas.getByText('£1,240.60')).toBeInTheDocument();
+  },
+};
+
+export const UnknownCompanion: Story = {
+  name: 'A companion that has not loaded',
+  args: {
+    estimates: [row('e9', 'pat-missing', 'SENT', 88, null)],
+    activeEstimateId: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Unknown companion')).toBeInTheDocument();
+    // No validUntil on this row, so the cell reads as a dash.
+    await expect(canvas.getAllByText('-').length).toBeGreaterThan(0);
+  },
+};
+
+export const SingleRow: Story = {
+  name: 'One estimate',
+  args: {
+    estimates: [row('e1', 'pat-1', 'DRAFT', 12, null)],
+    activeEstimateId: null,
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { formatMoneyPrecise } from '@/app/lib/money';
+import { formatDisplayDate } from '@/app/lib/date';
 import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
 import type { Estimate } from '@/app/features/finance/types/estimate';
 
@@ -13,11 +14,13 @@ type EstimateListProps = {
   companionName: (patientId: string) => string;
 };
 
-const formatDate = (value: string | null): string => {
-  if (!value) return '-';
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? '-' : parsed.toLocaleDateString();
-};
+/**
+ * Dates go through the shared helper rather than `toLocaleDateString`, which
+ * resolves against whatever locale and time zone the renderer happens to be in.
+ * On a server-rendered route that differs between server and client and
+ * produces a hydration mismatch.
+ */
+const formatDate = (value: string | null): string => formatDisplayDate(value ?? undefined, '-');
 
 /**
  * The estimates list. A table on desktop and stacked cards on phone, matching

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
@@ -1,13 +1,14 @@
 'use client';
-import React from 'react';
-import clsx from 'clsx';
+import React, { useMemo } from 'react';
 import { formatMoneyPrecise } from '@/app/lib/money';
 import { formatDisplayDate } from '@/app/lib/date';
+import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
 import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
 import type { Estimate } from '@/app/features/finance/types/estimate';
 
 type EstimateListProps = {
   estimates: Estimate[];
+  /** The open estimate, highlighted in the list. */
   activeEstimateId: string | null;
   onSelect: (estimate: Estimate) => void;
   /** Display name for a companion id, so the list is readable without a join. */
@@ -23,75 +24,72 @@ type EstimateListProps = {
 const formatDate = (value: string | null): string => formatDisplayDate(value ?? undefined, '-');
 
 /**
- * The estimates list. A table on desktop and stacked cards on phone, matching
- * how the invoice list splits, so the finance area reads consistently.
+ * The estimates list, rendered through the shared `GenericTable` so it inherits
+ * the app's column-header typography, contrast, sticky behaviour and pager
+ * rather than maintaining a second finance table of its own.
  */
 const EstimateList = ({
   estimates,
   activeEstimateId,
   onSelect,
   companionName,
-}: EstimateListProps) => (
-  <div className="border border-card-border rounded-2xl overflow-hidden">
-    <div className="overflow-x-auto">
-      <table className="w-full min-w-160 border-collapse">
-        <caption className="sr-only">Estimates for this organisation</caption>
-        <thead>
-          <tr className="border-b border-b-card-border bg-card-hover">
-            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
-              Companion
-            </th>
-            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
-              Status
-            </th>
-            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
-              Created
-            </th>
-            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
-              Valid until
-            </th>
-            <th scope="col" className="text-right text-body-4 text-text-secondary px-4! py-3!">
-              Total
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {estimates.map((estimate) => (
-            <tr
-              key={estimate.id}
-              className={clsx(
-                'border-b border-b-card-border last:border-b-0 cursor-pointer hover:bg-card-hover transition-colors',
-                estimate.id === activeEstimateId && 'bg-card-hover'
-              )}
-            >
-              <td className="px-4! py-3!">
-                <button
-                  type="button"
-                  onClick={() => onSelect(estimate)}
-                  className="text-body-3 text-text-primary text-left underline-offset-2 hover:underline"
-                  aria-label={`Open the estimate for ${companionName(estimate.patientId)}`}
-                >
-                  {companionName(estimate.patientId)}
-                </button>
-              </td>
-              <td className="px-4! py-3!">
-                <EstimateStatusBadge status={estimate.status} />
-              </td>
-              <td className="px-4! py-3! text-body-4 text-text-secondary">
-                {formatDate(estimate.createdAt)}
-              </td>
-              <td className="px-4! py-3! text-body-4 text-text-secondary">
-                {formatDate(estimate.validUntil)}
-              </td>
-              <td className="px-4! py-3! text-body-3 text-text-primary text-right">
-                {formatMoneyPrecise(estimate.total, estimate.currency)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  </div>
-);
+}: EstimateListProps) => {
+  const columns = useMemo<Column<Estimate>[]>(
+    () => [
+      {
+        key: 'patientId',
+        label: 'Companion',
+        render: (estimate) => (
+          <button
+            type="button"
+            onClick={() => onSelect(estimate)}
+            className="text-body-3 text-text-primary text-left underline-offset-2 hover:underline"
+            aria-label={`Open the estimate for ${companionName(estimate.patientId)}`}
+          >
+            {companionName(estimate.patientId)}
+          </button>
+        ),
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        render: (estimate) => <EstimateStatusBadge status={estimate.status} />,
+      },
+      {
+        key: 'createdAt',
+        label: 'Created',
+        render: (estimate) => formatDate(estimate.createdAt),
+      },
+      {
+        key: 'validUntil',
+        label: 'Valid until',
+        render: (estimate) => formatDate(estimate.validUntil),
+      },
+      {
+        key: 'total',
+        label: 'Total',
+        render: (estimate) => (
+          <span className="tabular-nums">
+            {formatMoneyPrecise(estimate.total, estimate.currency)}
+          </span>
+        ),
+      },
+    ],
+    [onSelect, companionName]
+  );
+
+  return (
+    <GenericTable
+      data={estimates}
+      columns={columns}
+      caption="Estimates for this organisation"
+      itemNoun="estimates"
+      pagination
+      // Kept through GenericTable's row hook rather than dropped: without it
+      // the detail panel below can belong to any row on screen.
+      rowClassName={(estimate) => (estimate.id === activeEstimateId ? 'bg-card-hover' : '')}
+    />
+  );
+};
 
 export default EstimateList;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
@@ -1,0 +1,94 @@
+'use client';
+import React from 'react';
+import clsx from 'clsx';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
+import type { Estimate } from '@/app/features/finance/types/estimate';
+
+type EstimateListProps = {
+  estimates: Estimate[];
+  activeEstimateId: string | null;
+  onSelect: (estimate: Estimate) => void;
+  /** Display name for a companion id, so the list is readable without a join. */
+  companionName: (patientId: string) => string;
+};
+
+const formatDate = (value: string | null): string => {
+  if (!value) return '-';
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? '-' : parsed.toLocaleDateString();
+};
+
+/**
+ * The estimates list. A table on desktop and stacked cards on phone, matching
+ * how the invoice list splits, so the finance area reads consistently.
+ */
+const EstimateList = ({
+  estimates,
+  activeEstimateId,
+  onSelect,
+  companionName,
+}: EstimateListProps) => (
+  <div className="border border-card-border rounded-2xl overflow-hidden">
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-160 border-collapse">
+        <caption className="sr-only">Estimates for this organisation</caption>
+        <thead>
+          <tr className="border-b border-b-card-border bg-card-hover">
+            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
+              Companion
+            </th>
+            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
+              Status
+            </th>
+            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
+              Created
+            </th>
+            <th scope="col" className="text-left text-body-4 text-text-secondary px-4! py-3!">
+              Valid until
+            </th>
+            <th scope="col" className="text-right text-body-4 text-text-secondary px-4! py-3!">
+              Total
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {estimates.map((estimate) => (
+            <tr
+              key={estimate.id}
+              className={clsx(
+                'border-b border-b-card-border last:border-b-0 cursor-pointer hover:bg-card-hover transition-colors',
+                estimate.id === activeEstimateId && 'bg-card-hover'
+              )}
+            >
+              <td className="px-4! py-3!">
+                <button
+                  type="button"
+                  onClick={() => onSelect(estimate)}
+                  className="text-body-3 text-text-primary text-left underline-offset-2 hover:underline"
+                  aria-label={`Open the estimate for ${companionName(estimate.patientId)}`}
+                >
+                  {companionName(estimate.patientId)}
+                </button>
+              </td>
+              <td className="px-4! py-3!">
+                <EstimateStatusBadge status={estimate.status} />
+              </td>
+              <td className="px-4! py-3! text-body-4 text-text-secondary">
+                {formatDate(estimate.createdAt)}
+              </td>
+              <td className="px-4! py-3! text-body-4 text-text-secondary">
+                {formatDate(estimate.validUntil)}
+              </td>
+              <td className="px-4! py-3! text-body-3 text-text-primary text-right">
+                {formatMoneyPrecise(estimate.total, estimate.currency)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+export default EstimateList;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge.tsx
@@ -1,0 +1,16 @@
+'use client';
+import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import { estimateStatusBadge, type EstimateStatus } from '@/app/features/finance/types/estimate';
+
+type EstimateStatusBadgeProps = {
+  status: EstimateStatus;
+};
+
+/** The estimate's lifecycle state, using the same tokens as the filter row. */
+const EstimateStatusBadge = ({ status }: EstimateStatusBadgeProps) => {
+  const { label, bg, text, border } = estimateStatusBadge(status);
+  return <StatusPill tokens={{ bg, text, border }} label={label} />;
+};
+
+export default EstimateStatusBadge;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateDraft.ts
@@ -1,0 +1,64 @@
+/**
+ * The estimate editor's draft state and its validation.
+ *
+ * Kept out of the dialog component file so Fast Refresh can preserve component
+ * state (a component file that also exports non-components forces a full
+ * reload), and so the validation can be tested without rendering anything.
+ */
+
+export type DraftLine = {
+  key: string;
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  taxRate: string;
+};
+
+export const emptyLine = (key: string): DraftLine => ({
+  key,
+  description: '',
+  quantity: '1',
+  unitPrice: '',
+  taxRate: '0',
+});
+
+/** A blank or unparseable numeric field reads as 0 rather than NaN. */
+export const toNumber = (raw: string): number => {
+  const parsed = Number(raw.trim());
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export type DraftValidation = { ok: true } | { ok: false; message: string };
+
+/**
+ * Validate a draft the way the backend's zod schema does, so the user is told
+ * what is wrong before a request is sent rather than reading a flattened zod
+ * error afterwards. `items.min(1)`, `description.min(1)`, `quantity.positive()`
+ * and `unitPrice.min(0)` all come from CreateEstimateSchema.
+ */
+export const validateDraft = (patientId: string, lines: DraftLine[]): DraftValidation => {
+  if (!patientId) return { ok: false, message: 'Choose a companion for this estimate.' };
+  if (lines.length === 0) return { ok: false, message: 'Add at least one line.' };
+  for (const line of lines) {
+    const described = line.description.trim();
+    if (!described) {
+      return { ok: false, message: 'Every line needs a description.' };
+    }
+    if (toNumber(line.quantity) <= 0) {
+      return { ok: false, message: `Quantity for "${described}" must be above zero.` };
+    }
+    if (toNumber(line.unitPrice) < 0) {
+      return { ok: false, message: `Unit price for "${described}" cannot be negative.` };
+    }
+    const taxRate = toNumber(line.taxRate);
+    if (taxRate < 0 || taxRate > 100) {
+      return { ok: false, message: `Tax for "${described}" must be between 0 and 100.` };
+    }
+  }
+  return { ok: true };
+};
+
+export const inputClass =
+  'min-w-0 flex-1 bg-transparent px-3 py-2 text-body-4 text-text-primary outline-none';
+export const fieldClass =
+  'flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active';

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateDraft.ts
@@ -30,14 +30,28 @@ export const toNumber = (raw: string): number => {
 
 export type DraftValidation = { ok: true } | { ok: false; message: string };
 
+/** Today as yyyy-mm-dd, for the date input's `min` and for validation. */
+export const todayIsoDate = (now: Date = new Date()): string => now.toISOString().slice(0, 10);
+
 /**
  * Validate a draft the way the backend's zod schema does, so the user is told
  * what is wrong before a request is sent rather than reading a flattened zod
  * error afterwards. `items.min(1)`, `description.min(1)`, `quantity.positive()`
  * and `unitPrice.min(0)` all come from CreateEstimateSchema.
  */
-export const validateDraft = (patientId: string, lines: DraftLine[]): DraftValidation => {
+export const validateDraft = (
+  patientId: string,
+  lines: DraftLine[],
+  validUntil = '',
+  today: string = todayIsoDate()
+): DraftValidation => {
   if (!patientId) return { ok: false, message: 'Choose a companion for this estimate.' };
+  // Nothing derives EXPIRED from validUntil - not the service, not a job - so a
+  // quote dated in the past stays a DRAFT that can still be sent, approved and
+  // converted. Refusing it at creation is the only place it is caught.
+  if (validUntil && validUntil < today) {
+    return { ok: false, message: 'The validity date cannot be in the past.' };
+  }
   if (lines.length === 0) return { ok: false, message: 'Add at least one line.' };
   for (const line of lines) {
     const described = line.description.trim();

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateTotals.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/estimateTotals.ts
@@ -1,0 +1,31 @@
+import type { EstimateItemInput } from '@/app/features/finance/types/estimate';
+
+export type EstimateTotals = {
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+};
+
+/**
+ * Client-side preview of an estimate's totals.
+ *
+ * Deliberately mirrors `computeTotals` in `apps/backend/src/services/
+ * estimate.service.ts`: the line total excludes tax, tax is applied per line as
+ * a percentage of that line, and the estimate total is the sum of both. If the
+ * two ever diverge, the figure the user approves is not the figure that is
+ * saved, so the editor's arithmetic has to stay pinned to the server's.
+ */
+export const computeEstimateTotals = (items: EstimateItemInput[]): EstimateTotals => {
+  let subtotal = 0;
+  let taxAmount = 0;
+  for (const item of items) {
+    const lineTotal = item.quantity * item.unitPrice;
+    subtotal += lineTotal;
+    taxAmount += lineTotal * ((item.taxRate ?? 0) / 100);
+  }
+  return { subtotal, taxAmount, total: subtotal + taxAmount };
+};
+
+/** One line's pre-tax total, matching `EstimateItem.lineTotal` as the backend writes it. */
+export const computeLineTotal = (quantity: number, unitPrice: number): number =>
+  quantity * unitPrice;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
@@ -26,7 +26,7 @@ export type EstimateDraft = {
   totals: EstimateTotals;
   formError: string | null;
   /** Validate and, if the draft is sound, hand the payload to `onSubmit`. */
-  submit: (onSubmit: (input: CreateEstimateInput) => void, currency: string) => void;
+  submit: (onSubmit: (input: CreateEstimateInput) => void) => void;
 };
 
 /**
@@ -73,7 +73,19 @@ export const useEstimateDraft = (): EstimateDraft => {
       current.length === 1 ? current : current.filter((line) => line.key !== key)
     );
 
-  const submit = (onSubmit: (input: CreateEstimateInput) => void, currency: string) => {
+  /**
+   * The currency is deliberately NOT sent.
+   *
+   * `useCurrencyForPrimaryOrg` reads `subscription.currency`, and the
+   * production path builds subscriptions through `normalizeSubscription`, which
+   * never populates it - so it always answers USD. Persisting that would stamp
+   * USD on every estimate for a non-USD clinic, override the API's own default,
+   * and then be copied onto the converted invoice. Omitting it lets the server
+   * decide, which is the only side that knows. The dialog still previews in the
+   * currency the rest of Finance displays; the saved estimate carries the
+   * server's, and the detail view renders that.
+   */
+  const submit = (onSubmit: (input: CreateEstimateInput) => void) => {
     const validation = validateDraft(patientId, lines);
     if (!validation.ok) {
       setFormError(validation.message);
@@ -82,7 +94,6 @@ export const useEstimateDraft = (): EstimateDraft => {
     setFormError(null);
     onSubmit({
       patientId,
-      currency,
       notes: notes.trim() || undefined,
       // The API takes an ISO datetime; a date input yields yyyy-mm-dd only.
       validUntil: validUntil ? new Date(`${validUntil}T00:00:00.000Z`).toISOString() : undefined,

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
@@ -1,0 +1,113 @@
+'use client';
+import { useMemo, useRef, useState } from 'react';
+import {
+  computeEstimateTotals,
+  type EstimateTotals,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateTotals';
+import {
+  emptyLine,
+  toNumber,
+  validateDraft,
+  type DraftLine,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import type { CreateEstimateInput } from '@/app/features/finance/types/estimate';
+
+export type EstimateDraft = {
+  patientId: string;
+  setPatientId: (value: string) => void;
+  notes: string;
+  setNotes: (value: string) => void;
+  validUntil: string;
+  setValidUntil: (value: string) => void;
+  lines: DraftLine[];
+  updateLine: (key: string, patch: Partial<DraftLine>) => void;
+  addLine: () => void;
+  removeLine: (key: string) => void;
+  totals: EstimateTotals;
+  formError: string | null;
+  /** Validate and, if the draft is sound, hand the payload to `onSubmit`. */
+  submit: (onSubmit: (input: CreateEstimateInput) => void, currency: string) => void;
+};
+
+/**
+ * The estimate editor's state and the payload it produces.
+ *
+ * Separated from the dialog so the component is composition rather than
+ * composition plus a state machine, and so the draft logic can be exercised
+ * without a modal around it.
+ */
+export const useEstimateDraft = (): EstimateDraft => {
+  const [patientId, setPatientId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [validUntil, setValidUntil] = useState('');
+  const [lines, setLines] = useState<DraftLine[]>([emptyLine('line-0')]);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // A counter, not state: it only ever feeds the next React key, is never
+  // rendered, and as state every increment would re-render for nothing.
+  const nextKey = useRef(1);
+
+  const totals = useMemo(
+    () =>
+      computeEstimateTotals(
+        lines.map((line) => ({
+          description: line.description,
+          quantity: toNumber(line.quantity),
+          unitPrice: toNumber(line.unitPrice),
+          taxRate: toNumber(line.taxRate),
+        }))
+      ),
+    [lines]
+  );
+
+  const updateLine = (key: string, patch: Partial<DraftLine>) =>
+    setLines((current) => current.map((line) => (line.key === key ? { ...line, ...patch } : line)));
+
+  const addLine = () => {
+    setLines((current) => [...current, emptyLine(`line-${nextKey.current}`)]);
+    nextKey.current += 1;
+  };
+
+  const removeLine = (key: string) =>
+    setLines((current) =>
+      current.length === 1 ? current : current.filter((line) => line.key !== key)
+    );
+
+  const submit = (onSubmit: (input: CreateEstimateInput) => void, currency: string) => {
+    const validation = validateDraft(patientId, lines);
+    if (!validation.ok) {
+      setFormError(validation.message);
+      return;
+    }
+    setFormError(null);
+    onSubmit({
+      patientId,
+      currency,
+      notes: notes.trim() || undefined,
+      // The API takes an ISO datetime; a date input yields yyyy-mm-dd only.
+      validUntil: validUntil ? new Date(`${validUntil}T00:00:00.000Z`).toISOString() : undefined,
+      items: lines.map((line) => ({
+        description: line.description.trim(),
+        quantity: toNumber(line.quantity),
+        unitPrice: toNumber(line.unitPrice),
+        taxRate: toNumber(line.taxRate),
+      })),
+    });
+  };
+
+  return {
+    patientId,
+    setPatientId,
+    notes,
+    setNotes,
+    validUntil,
+    setValidUntil,
+    lines,
+    updateLine,
+    addLine,
+    removeLine,
+    totals,
+    formError,
+    submit,
+  };
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/useEstimateDraft.ts
@@ -86,7 +86,7 @@ export const useEstimateDraft = (): EstimateDraft => {
    * server's, and the detail view renders that.
    */
   const submit = (onSubmit: (input: CreateEstimateInput) => void) => {
-    const validation = validateDraft(patientId, lines);
+    const validation = validateDraft(patientId, lines, validUntil);
     if (!validation.ok) {
       setFormError(validation.message);
       return;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -98,10 +98,10 @@ const EstimatesContent = () => {
 
   const companions = useMemo(() => {
     if (!primaryOrgId) return [];
-    return (companionsIdsByOrgId[primaryOrgId] ?? [])
-      .map((id) => companionsById[id])
-      .filter(Boolean)
-      .map((companion) => ({ id: companion.id, name: companion.name || 'Unnamed companion' }));
+    return (companionsIdsByOrgId[primaryOrgId] ?? []).flatMap((id) => {
+      const companion = companionsById[id];
+      return companion ? [{ id: companion.id, name: companion.name || 'Unnamed companion' }] : [];
+    });
   }, [primaryOrgId, companionsById, companionsIdsByOrgId]);
 
   const companionName = useCallback(

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -11,6 +11,7 @@ import { useNotify } from '@/app/hooks/useNotify';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { useCompanionStore } from '@/app/stores/companionStore';
 import { loadCompanionsForPrimaryOrg } from '@/app/features/companions/services/companionService';
+import { loadInvoicesForOrgPrimaryOrg } from '@/app/features/billing/services/invoiceService';
 import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
 import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
 import { useEstimates } from '@/app/features/finance/hooks/useEstimates';
@@ -121,6 +122,16 @@ const EstimatesContent = () => {
     try {
       const updated = await runAction(action, primaryOrgId, activeEstimate.id);
       upsert(updated);
+      if (action === 'convert') {
+        // Converting mints a new Invoice. The user normally arrives here from
+        // Finance, so the invoice store already holds an entry for this
+        // organisation and useLoadInvoicesForPrimaryOrg will skip loading -
+        // which leaves the new invoice absent and the "View the invoice" deep
+        // link unable to find it until a full reload. Force the refetch.
+        loadInvoicesForOrgPrimaryOrg({ force: true, silent: true }).catch((err: unknown) => {
+          console.error('Failed to refresh invoices after converting an estimate:', err);
+        });
+      }
       // A status change can move the estimate out of the active filter, in which
       // case `upsert` drops it and there is no longer a row to keep selected.
       if (statusFilter && updated.status !== statusFilter) setActiveEstimateId(null);

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -9,6 +9,7 @@ import { PERMISSIONS } from '@/app/lib/permissions';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useOrgStore } from '@/app/stores/orgStore';
+import { useSearchStore } from '@/app/stores/searchStore';
 import { useCompanionStore } from '@/app/stores/companionStore';
 import { loadCompanionsForPrimaryOrg } from '@/app/features/companions/services/companionService';
 import { loadInvoicesForOrgPrimaryOrg } from '@/app/features/billing/services/invoiceService';
@@ -44,6 +45,22 @@ const ACTION_LABELS: Record<EstimateAction, { title: string; text: string }> = {
   convert: { title: 'Invoice created', text: 'The estimate has been converted to an invoice.' },
 };
 
+/**
+ * Why the list is empty, which is three different situations: a search that
+ * matched nothing, a status filter with no members, or an organisation with no
+ * estimates at all. Extracted rather than nested in the JSX - Sonar S3358
+ * rejects a nested ternary, and the branches read better named.
+ */
+const emptyListMessage = (
+  hasQuery: boolean,
+  hasAnyEstimate: boolean,
+  activeStatus: string
+): string => {
+  if (hasQuery && hasAnyEstimate) return 'No estimate matches that search.';
+  if (activeStatus !== 'all') return 'No estimate currently has this status.';
+  return 'Create an estimate to quote a treatment plan before it is invoiced.';
+};
+
 const runAction = (
   action: EstimateAction,
   organisationId: string,
@@ -66,6 +83,7 @@ const EstimatesContent = () => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const currency = useCurrencyForPrimaryOrg();
 
+  const query = useSearchStore((s) => s.query);
   const [activeStatus, setActiveStatus] = useState('all');
   const statusFilter: EstimateStatus | undefined =
     activeStatus === 'all' ? undefined : (activeStatus as EstimateStatus);
@@ -82,6 +100,8 @@ const EstimatesContent = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [companionsError, setCompanionsError] = useState<string | null>(null);
+  const [companionsReloadToken, setCompanionsReloadToken] = useState(0);
 
   const companionsById = useCompanionStore((s) => s.companionsById);
   const companionsIdsByOrgId = useCompanionStore((s) => s.companionsIdsByOrgId);
@@ -92,10 +112,14 @@ const EstimatesContent = () => {
   useEffect(() => {
     if (!primaryOrgId) return;
     if ((companionsIdsByOrgId[primaryOrgId] ?? []).length > 0) return;
-    loadCompanionsForPrimaryOrg().catch((err: unknown) => {
-      console.error('Failed to load companions for the estimates page:', err);
+    // Surfaced, not just logged: without companions the picker is empty, so
+    // "New estimate" leads to a dialog that can only tell the user to choose a
+    // companion that is not there. The reset lives in the retry handler rather
+    // than here - a synchronous setState inside an effect cascades renders.
+    loadCompanionsForPrimaryOrg().catch(() => {
+      setCompanionsError('Companions could not be loaded, so a new estimate cannot be started.');
     });
-  }, [primaryOrgId, companionsIdsByOrgId]);
+  }, [primaryOrgId, companionsIdsByOrgId, companionsReloadToken]);
 
   const companions = useMemo(() => {
     if (!primaryOrgId) return [];
@@ -110,9 +134,20 @@ const EstimatesContent = () => {
     [companionsById]
   );
 
+  // The shared finance header stays visible on this route and already writes to
+  // the search store, so the control looked functional while doing nothing.
+  // Matching on the companion name is what a user typing there would expect.
+  const visibleEstimates = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return estimates;
+    return estimates.filter((estimate) =>
+      companionName(estimate.patientId).toLowerCase().includes(needle)
+    );
+  }, [estimates, query, companionName]);
+
   const activeEstimate = useMemo(
-    () => estimates.find((estimate) => estimate.id === activeEstimateId) ?? null,
-    [estimates, activeEstimateId]
+    () => visibleEstimates.find((estimate) => estimate.id === activeEstimateId) ?? null,
+    [visibleEstimates, activeEstimateId]
   );
 
   const handleAction = async (action: EstimateAction) => {
@@ -175,6 +210,7 @@ const EstimatesContent = () => {
           <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
             <Primary
               text="New estimate"
+              isDisabled={companions.length === 0}
               onClick={() => {
                 setCreateError(null);
                 setCreateOpen(true);
@@ -185,15 +221,40 @@ const EstimatesContent = () => {
         </div>
       </div>
 
-      <InvoiceStatusFilterPills
-        options={EstimateStatusFilters}
-        activeStatus={activeStatus}
-        setActiveStatus={(value) => {
-          setActiveStatus(value);
-          setActiveEstimateId(null);
-        }}
-        ariaLabel="Filter estimates by status"
-      />
+      {/*
+        Seven non-shrinking pills exceed a phone's width. PhoneInvoiceList wraps
+        its own filter row in a horizontal scroller for the same reason; without
+        one the page itself scrolls sideways and the later statuses are hard to
+        reach.
+      */}
+      <div className="overflow-x-auto scrollbar-hidden -mx-1 px-1">
+        <InvoiceStatusFilterPills
+          options={EstimateStatusFilters}
+          activeStatus={activeStatus}
+          setActiveStatus={(value) => {
+            setActiveStatus(value);
+            setActiveEstimateId(null);
+          }}
+          ariaLabel="Filter estimates by status"
+          className="w-max"
+        />
+      </div>
+
+      {companionsError && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3!">
+          <p role="alert" className="text-body-4 text-text-error">
+            {companionsError}
+          </p>
+          <Secondary
+            text="Retry"
+            onClick={() => {
+              setCompanionsError(null);
+              setCompanionsReloadToken((token) => token + 1);
+            }}
+            ariaLabel="Retry loading companions"
+          />
+        </div>
+      )}
 
       {loading && (
         <div className="h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />
@@ -208,21 +269,19 @@ const EstimatesContent = () => {
         </div>
       )}
 
-      {!loading && !error && estimates.length === 0 && (
+      {!loading && !error && visibleEstimates.length === 0 && (
         <div className="border border-card-border rounded-2xl px-6! py-10! text-center">
           <p className="text-body-3 text-text-primary">No estimates yet</p>
           <p className="text-body-4 text-text-secondary">
-            {activeStatus === 'all'
-              ? 'Create an estimate to quote a treatment plan before it is invoiced.'
-              : 'No estimate currently has this status.'}
+            {emptyListMessage(Boolean(query.trim()), estimates.length > 0, activeStatus)}
           </p>
         </div>
       )}
 
-      {!loading && !error && estimates.length > 0 && (
+      {!loading && !error && visibleEstimates.length > 0 && (
         <div className="flex flex-col gap-6">
           <EstimateList
-            estimates={estimates}
+            estimates={visibleEstimates}
             activeEstimateId={activeEstimateId}
             onSelect={(estimate) => {
               setActiveEstimateId(estimate.id);

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -1,0 +1,263 @@
+'use client';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
+import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
+import PageSkeleton from '@/app/ui/layout/PageSkeleton';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { useNotify } from '@/app/hooks/useNotify';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { loadCompanionsForPrimaryOrg } from '@/app/features/companions/services/companionService';
+import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
+import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
+import { useEstimates } from '@/app/features/finance/hooks/useEstimates';
+import {
+  approveEstimate,
+  convertEstimate,
+  createEstimate,
+  declineEstimate,
+  getEstimateErrorMessage,
+  markEstimateSent,
+} from '@/app/features/finance/services/estimateService';
+import {
+  EstimateStatusFilters,
+  type CreateEstimateInput,
+  type Estimate,
+  type EstimateStatus,
+} from '@/app/features/finance/types/estimate';
+import EstimateList from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
+import EstimateDetail, {
+  type EstimateAction,
+} from '@/app/features/finance/pages/Estimates/Sections/EstimateDetail';
+import CreateEstimateDialog from '@/app/features/finance/pages/Estimates/Sections/CreateEstimateDialog';
+
+const ESTIMATES_PAGE_SKELETON = <PageSkeleton variant="list" />;
+
+const ACTION_LABELS: Record<EstimateAction, { title: string; text: string }> = {
+  send: { title: 'Estimate sent', text: 'The estimate is marked as sent.' },
+  approve: { title: 'Estimate approved', text: 'The estimate can now be converted to an invoice.' },
+  decline: { title: 'Estimate declined', text: 'The estimate has been declined.' },
+  convert: { title: 'Invoice created', text: 'The estimate has been converted to an invoice.' },
+};
+
+const runAction = (
+  action: EstimateAction,
+  organisationId: string,
+  estimateId: string
+): Promise<Estimate> => {
+  switch (action) {
+    case 'send':
+      return markEstimateSent(organisationId, estimateId);
+    case 'approve':
+      return approveEstimate(organisationId, estimateId);
+    case 'decline':
+      return declineEstimate(organisationId, estimateId);
+    case 'convert':
+      return convertEstimate(organisationId, estimateId);
+  }
+};
+
+const EstimatesContent = () => {
+  const { notify } = useNotify();
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const currency = useCurrencyForPrimaryOrg();
+
+  const [activeStatus, setActiveStatus] = useState('all');
+  const statusFilter: EstimateStatus | undefined =
+    activeStatus === 'all' ? undefined : (activeStatus as EstimateStatus);
+
+  const { estimates, loading, error, upsert, reload } = useEstimates(
+    primaryOrgId ?? undefined,
+    statusFilter
+  );
+
+  const [activeEstimateId, setActiveEstimateId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<EstimateAction | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const companionsById = useCompanionStore((s) => s.companionsById);
+  const companionsIdsByOrgId = useCompanionStore((s) => s.companionsIdsByOrgId);
+
+  // Companions are needed for two things: naming a row, and populating the
+  // create picker. The estimates API returns a bare patientId, so without this
+  // every row would read as a uuid.
+  useEffect(() => {
+    if (!primaryOrgId) return;
+    if ((companionsIdsByOrgId[primaryOrgId] ?? []).length > 0) return;
+    loadCompanionsForPrimaryOrg().catch((err: unknown) => {
+      console.error('Failed to load companions for the estimates page:', err);
+    });
+  }, [primaryOrgId, companionsIdsByOrgId]);
+
+  const companions = useMemo(() => {
+    if (!primaryOrgId) return [];
+    return (companionsIdsByOrgId[primaryOrgId] ?? [])
+      .map((id) => companionsById[id])
+      .filter(Boolean)
+      .map((companion) => ({ id: companion.id, name: companion.name || 'Unnamed companion' }));
+  }, [primaryOrgId, companionsById, companionsIdsByOrgId]);
+
+  const companionName = useCallback(
+    (patientId: string) => companionsById[patientId]?.name || 'Unknown companion',
+    [companionsById]
+  );
+
+  const activeEstimate = useMemo(
+    () => estimates.find((estimate) => estimate.id === activeEstimateId) ?? null,
+    [estimates, activeEstimateId]
+  );
+
+  const handleAction = async (action: EstimateAction) => {
+    if (!primaryOrgId || !activeEstimate) return;
+    setPendingAction(action);
+    setActionError(null);
+    try {
+      const updated = await runAction(action, primaryOrgId, activeEstimate.id);
+      upsert(updated);
+      // A status change can move the estimate out of the active filter, in which
+      // case `upsert` drops it and there is no longer a row to keep selected.
+      if (statusFilter && updated.status !== statusFilter) setActiveEstimateId(null);
+      notify('success', ACTION_LABELS[action]);
+    } catch (err: unknown) {
+      const message = getEstimateErrorMessage(err, 'That action could not be completed.');
+      setActionError(message);
+      notify('error', { title: 'Estimate not updated', text: message });
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleCreate = async (input: CreateEstimateInput) => {
+    if (!primaryOrgId) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const created = await createEstimate(primaryOrgId, input);
+      upsert(created);
+      setActiveEstimateId(created.id);
+      setCreateOpen(false);
+      notify('success', {
+        title: 'Estimate created',
+        text: 'The estimate is saved as a draft.',
+      });
+    } catch (err: unknown) {
+      const message = getEstimateErrorMessage(err, 'The estimate could not be created.');
+      setCreateError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
+      <div className="flex items-center justify-between w-full flex-wrap gap-2">
+        <h1 className="text-text-primary text-heading-2">Estimates</h1>
+        <div className="flex items-center gap-2">
+          <Secondary href="/finance" text="Back to invoices" ariaLabel="Back to invoices" />
+          <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+            <Primary
+              text="New estimate"
+              onClick={() => {
+                setCreateError(null);
+                setCreateOpen(true);
+              }}
+              ariaLabel="Create a new estimate"
+            />
+          </PermissionGate>
+        </div>
+      </div>
+
+      <InvoiceStatusFilterPills
+        options={EstimateStatusFilters}
+        activeStatus={activeStatus}
+        setActiveStatus={(value) => {
+          setActiveStatus(value);
+          setActiveEstimateId(null);
+        }}
+        ariaLabel="Filter estimates by status"
+      />
+
+      {loading && (
+        <div className="h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />
+      )}
+
+      {!loading && error && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3!">
+          <p role="alert" className="text-body-4 text-text-error">
+            {error}
+          </p>
+          <Secondary text="Retry" onClick={reload} ariaLabel="Retry loading estimates" />
+        </div>
+      )}
+
+      {!loading && !error && estimates.length === 0 && (
+        <div className="border border-card-border rounded-2xl px-6! py-10! text-center">
+          <p className="text-body-3 text-text-primary">No estimates yet</p>
+          <p className="text-body-4 text-text-secondary">
+            {activeStatus === 'all'
+              ? 'Create an estimate to quote a treatment plan before it is invoiced.'
+              : 'No estimate currently has this status.'}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && estimates.length > 0 && (
+        <div className="flex flex-col gap-6">
+          <EstimateList
+            estimates={estimates}
+            activeEstimateId={activeEstimateId}
+            onSelect={(estimate) => {
+              setActiveEstimateId(estimate.id);
+              setActionError(null);
+            }}
+            companionName={companionName}
+          />
+          {activeEstimate && (
+            <EstimateDetail
+              estimate={activeEstimate}
+              companionName={companionName(activeEstimate.patientId)}
+              pendingAction={pendingAction}
+              onAction={(action) => void handleAction(action)}
+              error={actionError}
+            />
+          )}
+        </div>
+      )}
+
+      <CreateEstimateDialog
+        open={createOpen}
+        setOpen={setCreateOpen}
+        companions={companions}
+        currency={currency}
+        saving={creating}
+        error={createError}
+        onSubmit={(input) => void handleCreate(input)}
+      />
+    </div>
+  );
+};
+
+const Estimates = () => (
+  <PermissionGate allOf={[PERMISSIONS.BILLING_VIEW_ANY]} fallback={<Fallback />}>
+    <EstimatesContent />
+  </PermissionGate>
+);
+
+const ProtectedEstimates = () => (
+  <ProtectedRoute skeleton={ESTIMATES_PAGE_SKELETON}>
+    <OrgGuard skeleton={ESTIMATES_PAGE_SKELETON}>
+      <Suspense fallback={ESTIMATES_PAGE_SKELETON}>
+        <Estimates />
+      </Suspense>
+    </OrgGuard>
+  </ProtectedRoute>
+);
+
+export default ProtectedEstimates;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -186,6 +186,13 @@ const EstimatesContent = () => {
     setCreateError(null);
     try {
       const created = await createEstimate(primaryOrgId, input);
+      // A new estimate is always DRAFT. Under any other status filter `upsert`
+      // correctly refuses it, so selecting the id and reporting success would
+      // leave an unchanged list with nothing selected. Move to the filter the
+      // new estimate actually lives under first.
+      if (statusFilter && created.status !== statusFilter) {
+        setActiveStatus(created.status);
+      }
       upsert(created);
       setActiveEstimateId(created.id);
       setCreateOpen(false);

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills.tsx
@@ -11,6 +11,8 @@ type InvoiceStatusFilterPillsProps = {
   /** Kept for caller compatibility; geometry now comes from the shared StatusPill primitive. */
   size?: 'sm' | 'md';
   className?: string;
+  /** Overridden by the estimates list, which filters estimates rather than invoices. */
+  ariaLabel?: string;
 };
 
 const getStatusPillTokens = (option: StatusOption): StatusPillTokens => ({
@@ -55,11 +57,12 @@ const InvoiceStatusFilterPills = ({
   setActiveStatus,
   size = 'sm',
   className,
+  ariaLabel = 'Filter invoices by status',
 }: InvoiceStatusFilterPillsProps) => (
   <div /* NOSONAR: styled flex pill group; native <fieldset> defaults (block layout, border, required legend) break the pill design */
     className={clsx('flex items-center gap-2', className)}
     role="group"
-    aria-label="Filter invoices by status"
+    aria-label={ariaLabel}
   >
     {options.map((option) => {
       const isActive = option.key === activeStatus;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
@@ -20,6 +20,7 @@ import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
 import { getAppointmentCompanion, getAppointmentCompanionPhotoUrl } from '@/app/lib/appointments';
 import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import { useCompanionStore } from '@/app/stores/companionStore';
 
 type PhoneInvoiceListProps = {
   filteredList: Invoice[];
@@ -146,20 +147,30 @@ const PhoneInvoiceList = ({
   onViewInvoice,
 }: PhoneInvoiceListProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
+  const companionsById = useCompanionStore((state) => state.companionsById);
 
   const cards = useMemo(
     () =>
       filteredList.map((invoice) => {
         const appointment = getAppointmentByIdFromList(appointments, invoice.appointmentId);
         const parentName = getParentNameFromAppointments(appointments, invoice.appointmentId);
-        const companionName = getCompanionNameFromAppointments(appointments, invoice.appointmentId);
+        // An invoice converted from an estimate carries patientId and no
+        // appointmentId, so the appointment lookup finds nothing and the card
+        // would read "Unlinked invoice" for a perfectly well known patient.
+        const fromAppointments = getCompanionNameFromAppointments(
+          appointments,
+          invoice.appointmentId
+        );
+        const fromPatient = invoice.patientId ? companionsById[invoice.patientId]?.name : undefined;
+        const companionName =
+          fromAppointments === '-' && fromPatient ? fromPatient : fromAppointments;
         return {
           invoice,
           appointment,
           ownerAndCompanion: buildOwnerAndCompanion(parentName, companionName),
         };
       }),
-    [filteredList, appointments]
+    [filteredList, appointments, companionsById]
   );
 
   return (

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -177,6 +177,7 @@ const Finance = () => {
                   setActiveStatus={setActiveStatus}
                   className="flex-wrap justify-end"
                 />
+                <Secondary href="/finance/estimates" text="Estimates" ariaLabel="View estimates" />
                 <Secondary
                   href="/finance/discounts"
                   text="Discounts"

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -132,15 +132,37 @@ const Finance = () => {
       <MobileSearchBar placeholder="Search invoices" />
       <PermissionGate allOf={[PERMISSIONS.BILLING_VIEW_ANY]} fallback={<Fallback />}>
         {isPhone ? (
-          <PhoneInvoiceList
-            filteredList={filteredList}
-            statusOptions={InvoiceStatusFilters}
-            activeStatus={activeStatus}
-            setActiveStatus={setActiveStatus}
-            metrics={financeMetrics}
-            currency={currency}
-            onViewInvoice={openInvoice}
-          />
+          <div className="flex flex-col gap-3">
+            {/*
+              The desktop header's Estimates and Discounts links live in the
+              !isPhone branch. Without a phone equivalent there is no route to
+              /finance/estimates anywhere in the app on a phone, so the screen
+              would only be reachable by typing the URL.
+            */}
+            <div className="flex items-center justify-end gap-2">
+              <Secondary
+                href="/finance/estimates"
+                text="Estimates"
+                size="compact"
+                ariaLabel="View estimates"
+              />
+              <Secondary
+                href="/finance/discounts"
+                text="Discounts"
+                size="compact"
+                ariaLabel="Manage discounts"
+              />
+            </div>
+            <PhoneInvoiceList
+              filteredList={filteredList}
+              statusOptions={InvoiceStatusFilters}
+              activeStatus={activeStatus}
+              setActiveStatus={setActiveStatus}
+              metrics={financeMetrics}
+              currency={currency}
+              onViewInvoice={openInvoice}
+            />
+          </div>
         ) : (
           <div className={wrapperClassName}>
             <div className="flex items-center justify-between w-full flex-wrap gap-2">

--- a/apps/frontend/src/app/features/finance/services/estimateService.ts
+++ b/apps/frontend/src/app/features/finance/services/estimateService.ts
@@ -8,6 +8,33 @@ import type {
 const estimatesPath = (organisationId: string) =>
   `/v1/pms/organisation/${organisationId}/estimates`;
 
+const stringsIn = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+
+/**
+ * Render a zod `flatten()` as one readable sentence.
+ *
+ * Returns null when there is nothing to say, so the caller can fall through to
+ * its own fallback rather than showing an empty string.
+ */
+const flattenedZodMessage = (body: unknown): string | null => {
+  if (typeof body !== 'object' || body === null) return null;
+  const flatten = body as { formErrors?: unknown; fieldErrors?: Record<string, unknown> };
+  const fieldErrors = Object.entries(flatten.fieldErrors ?? {}).flatMap(([field, messages]) =>
+    stringsIn(messages).map((message) => `${field}: ${message}`)
+  );
+  const all = [...stringsIn(flatten.formErrors), ...fieldErrors];
+  return all.length > 0 ? all.join('. ') : null;
+};
+
+/** The error body the controller replied with, whatever shape it took. */
+const errorBody = (error: unknown): unknown => {
+  const data = (error as { response?: { data?: unknown } } | null)?.response?.data;
+  if (typeof data !== 'object' || data === null) return undefined;
+  const body = data as { error?: unknown; message?: unknown };
+  return body.error ?? body.message;
+};
+
 /**
  * Human-readable message from an estimate API error.
  *
@@ -19,31 +46,12 @@ const estimatesPath = (organisationId: string) =>
  * Object]" in front of the user.
  */
 export const getEstimateErrorMessage = (error: unknown, fallback: string): string => {
-  const data = (error as { response?: { data?: unknown } } | null)?.response?.data;
-  if (typeof data === 'object' && data !== null) {
-    const body =
-      (data as { error?: unknown; message?: unknown }).error ??
-      (data as { message?: unknown }).message;
+  const body = errorBody(error);
+  if (typeof body === 'string' && body.trim()) return body.trim();
 
-    if (typeof body === 'string' && body.trim()) return body.trim();
+  const flattened = flattenedZodMessage(body);
+  if (flattened) return flattened;
 
-    if (typeof body === 'object' && body !== null) {
-      const flatten = body as {
-        formErrors?: unknown;
-        fieldErrors?: Record<string, unknown>;
-      };
-      const formErrors = Array.isArray(flatten.formErrors)
-        ? flatten.formErrors.filter((m): m is string => typeof m === 'string')
-        : [];
-      const fieldErrors = Object.entries(flatten.fieldErrors ?? {}).flatMap(([field, messages]) =>
-        Array.isArray(messages)
-          ? messages.filter((m): m is string => typeof m === 'string').map((m) => `${field}: ${m}`)
-          : []
-      );
-      const all = [...formErrors, ...fieldErrors];
-      if (all.length > 0) return all.join('. ');
-    }
-  }
   if (error instanceof Error && error.message.trim()) return error.message.trim();
   return fallback;
 };

--- a/apps/frontend/src/app/features/finance/services/estimateService.ts
+++ b/apps/frontend/src/app/features/finance/services/estimateService.ts
@@ -1,0 +1,156 @@
+import { deleteData, getData, patchData, postData } from '@/app/services/axios';
+import type {
+  CreateEstimateInput,
+  Estimate,
+  EstimateStatus,
+} from '@/app/features/finance/types/estimate';
+
+const estimatesPath = (organisationId: string) =>
+  `/v1/pms/organisation/${organisationId}/estimates`;
+
+/**
+ * Human-readable message from an estimate API error.
+ *
+ * The estimate controller does not use the finance `{ data, meta, error }`
+ * envelope. It replies `{ error: string }` for service failures and
+ * `{ error: <zod flatten> }` for a 400, where the flatten is
+ * `{ formErrors: string[], fieldErrors: Record<string, string[]> }`. Both have
+ * to be handled: rendering the flatten object directly would put "[object
+ * Object]" in front of the user.
+ */
+export const getEstimateErrorMessage = (error: unknown, fallback: string): string => {
+  const data = (error as { response?: { data?: unknown } } | null)?.response?.data;
+  if (typeof data === 'object' && data !== null) {
+    const body =
+      (data as { error?: unknown; message?: unknown }).error ??
+      (data as { message?: unknown }).message;
+
+    if (typeof body === 'string' && body.trim()) return body.trim();
+
+    if (typeof body === 'object' && body !== null) {
+      const flatten = body as {
+        formErrors?: unknown;
+        fieldErrors?: Record<string, unknown>;
+      };
+      const formErrors = Array.isArray(flatten.formErrors)
+        ? flatten.formErrors.filter((m): m is string => typeof m === 'string')
+        : [];
+      const fieldErrors = Object.entries(flatten.fieldErrors ?? {}).flatMap(([field, messages]) =>
+        Array.isArray(messages)
+          ? messages.filter((m): m is string => typeof m === 'string').map((m) => `${field}: ${m}`)
+          : []
+      );
+      const all = [...formErrors, ...fieldErrors];
+      if (all.length > 0) return all.join('. ');
+    }
+  }
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  return fallback;
+};
+
+const assertOrg = (organisationId: string) => {
+  if (!organisationId) throw new Error('Organisation ID missing');
+};
+
+export const listEstimates = async (
+  organisationId: string,
+  filters?: { patientId?: string; status?: EstimateStatus }
+): Promise<Estimate[]> => {
+  assertOrg(organisationId);
+  // Passed as `params` rather than a hand-built query string so the request
+  // takes part in the shared GET de-duplication, which keys on both.
+  const params: Record<string, string> = {};
+  if (filters?.patientId) params.patientId = filters.patientId;
+  if (filters?.status) params.status = filters.status;
+  const res = await getData<Estimate[]>(estimatesPath(organisationId), params);
+  // The list endpoint returns a bare array. Guard anyway: a proxy or error page
+  // that replies with an object would otherwise crash `.map` in the table.
+  return Array.isArray(res.data) ? res.data : [];
+};
+
+export const getEstimate = async (
+  organisationId: string,
+  estimateId: string
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await getData<Estimate>(`${estimatesPath(organisationId)}/${estimateId}`);
+  return res.data;
+};
+
+export const createEstimate = async (
+  organisationId: string,
+  input: CreateEstimateInput
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await postData<Estimate>(estimatesPath(organisationId), input);
+  return res.data;
+};
+
+export const markEstimateSent = async (
+  organisationId: string,
+  estimateId: string
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await postData<Estimate>(`${estimatesPath(organisationId)}/${estimateId}/send`, {});
+  return res.data;
+};
+
+export const approveEstimate = async (
+  organisationId: string,
+  estimateId: string
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await postData<Estimate>(
+    `${estimatesPath(organisationId)}/${estimateId}/approve`,
+    {}
+  );
+  return res.data;
+};
+
+export const declineEstimate = async (
+  organisationId: string,
+  estimateId: string,
+  reason?: string
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await postData<Estimate>(
+    `${estimatesPath(organisationId)}/${estimateId}/decline`,
+    reason ? { reason } : {}
+  );
+  return res.data;
+};
+
+/**
+ * Convert an APPROVED estimate into an invoice.
+ *
+ * Safe to call twice: the backend claims the estimate with a conditional
+ * `updateMany` inside a transaction and `Invoice.estimateId` is uniquely
+ * indexed, so a second call returns the estimate already carrying the first
+ * invoice's id rather than minting a second one.
+ */
+export const convertEstimate = async (
+  organisationId: string,
+  estimateId: string
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await postData<Estimate>(
+    `${estimatesPath(organisationId)}/${estimateId}/convert`,
+    {}
+  );
+  return res.data;
+};
+
+export const updateEstimate = async (
+  organisationId: string,
+  estimateId: string,
+  input: Partial<Pick<CreateEstimateInput, 'validUntil' | 'currency' | 'notes' | 'items'>>
+): Promise<Estimate> => {
+  assertOrg(organisationId);
+  const res = await patchData<Estimate>(`${estimatesPath(organisationId)}/${estimateId}`, input);
+  return res.data;
+};
+
+export const deleteEstimate = async (organisationId: string, estimateId: string): Promise<void> => {
+  assertOrg(organisationId);
+  await deleteData(`${estimatesPath(organisationId)}/${estimateId}`);
+};

--- a/apps/frontend/src/app/features/finance/types/estimate.ts
+++ b/apps/frontend/src/app/features/finance/types/estimate.ts
@@ -1,0 +1,159 @@
+import {
+  StatusOption,
+  dropdownStatusFromToken,
+} from '@/app/features/companions/pages/Companions/types';
+
+/**
+ * Estimate shapes as the backend returns them.
+ *
+ * These live here rather than in `@yosemite-crew/types` because the estimate
+ * endpoints reply with the raw Prisma selection (`estimate.service.ts`
+ * `estimateSelect`), not a DTO, and no other workspace consumes them yet.
+ */
+
+export type EstimateStatus = 'DRAFT' | 'SENT' | 'APPROVED' | 'DECLINED' | 'EXPIRED' | 'CONVERTED';
+
+export const ESTIMATE_STATUSES: readonly EstimateStatus[] = [
+  'DRAFT',
+  'SENT',
+  'APPROVED',
+  'DECLINED',
+  'EXPIRED',
+  'CONVERTED',
+] as const;
+
+export type EstimateItem = {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxRate: number;
+  lineTotal: number;
+  notes: string | null;
+};
+
+export type Estimate = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  encounterId: string | null;
+  status: EstimateStatus;
+  validUntil: string | null;
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+  currency: string;
+  notes: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  declinedAt: string | null;
+  declineReason: string | null;
+  convertedToInvoiceId: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items: EstimateItem[];
+};
+
+/** One line as the create/update endpoints accept it. */
+export type EstimateItemInput = {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxRate?: number;
+  notes?: string;
+};
+
+export type CreateEstimateInput = {
+  patientId: string;
+  encounterId?: string;
+  validUntil?: string;
+  currency?: string;
+  notes?: string;
+  items: EstimateItemInput[];
+};
+
+/**
+ * Which lifecycle actions the backend will accept for a given status.
+ *
+ * Mirrors the guards in `EstimateService`: only a DRAFT can be sent, only a
+ * DRAFT or SENT can be approved or declined, and only an APPROVED estimate can
+ * be converted. Keeping this next to the type means the UI disables an action
+ * rather than offering it and letting the request fail.
+ */
+export const canSend = (status: EstimateStatus): boolean => status === 'DRAFT';
+export const canApprove = (status: EstimateStatus): boolean =>
+  status === 'DRAFT' || status === 'SENT';
+export const canDecline = (status: EstimateStatus): boolean =>
+  status === 'DRAFT' || status === 'SENT';
+export const canConvert = (status: EstimateStatus): boolean => status === 'APPROVED';
+
+/**
+ * The pill token prefix per status, in lifecycle order. One map feeds both the
+ * filter row and the row badge, so the two can never drift apart.
+ *
+ * Colours follow the invoice pills so the two finance lists read as one family:
+ * neutral while the estimate is still in play, success for the terminal happy
+ * path, warning for declined and expired.
+ */
+const ESTIMATE_STATUS_TOKEN: Record<EstimateStatus, string> = {
+  DRAFT: 'color-pill-neutral',
+  SENT: 'color-pill-info',
+  APPROVED: 'color-pill-progress',
+  CONVERTED: 'color-pill-success',
+  DECLINED: 'color-pill-warning',
+  EXPIRED: 'color-pill-warning',
+};
+
+const ESTIMATE_STATUS_LABEL: Record<EstimateStatus, string> = {
+  DRAFT: 'Draft',
+  SENT: 'Sent',
+  APPROVED: 'Approved',
+  CONVERTED: 'Converted',
+  DECLINED: 'Declined',
+  EXPIRED: 'Expired',
+};
+
+/**
+ * Filter order, which is deliberately not the Prisma enum order.
+ *
+ * The enum ends DECLINED, EXPIRED, CONVERTED. Reading left to right a clinic
+ * should see the estimate travel its normal path first - draft, sent, approved,
+ * converted - with the two dead ends after it, rather than converted stranded
+ * behind them.
+ */
+const ESTIMATE_FILTER_ORDER: readonly EstimateStatus[] = [
+  'DRAFT',
+  'SENT',
+  'APPROVED',
+  'CONVERTED',
+  'DECLINED',
+  'EXPIRED',
+];
+
+/** Filter pills, with "All" first. */
+export const EstimateStatusFilters: StatusOption[] = [
+  dropdownStatusFromToken('All', 'all', 'color-pill-neutral'),
+  ...ESTIMATE_FILTER_ORDER.map((status) =>
+    dropdownStatusFromToken(ESTIMATE_STATUS_LABEL[status], status, ESTIMATE_STATUS_TOKEN[status])
+  ),
+];
+
+/**
+ * The badge tokens and label for one status.
+ *
+ * Returns every field, so the badge needs no `??` fallbacks: the record is keyed
+ * by the union, and an unmapped status is a type error rather than a runtime
+ * branch nothing can reach.
+ */
+export const estimateStatusBadge = (
+  status: EstimateStatus
+): { label: string; bg: string; text: string; border: string } => {
+  const prefix = ESTIMATE_STATUS_TOKEN[status];
+  return {
+    label: ESTIMATE_STATUS_LABEL[status],
+    bg: `var(--${prefix}-bg)`,
+    text: `var(--${prefix}-text)`,
+    border: `var(--${prefix}-border)`,
+  };
+};

--- a/apps/frontend/src/app/lib/money.ts
+++ b/apps/frontend/src/app/lib/money.ts
@@ -30,10 +30,17 @@ export const currencySymbol = (currency: string): string => {
  * another figure - an estimate line against its total, or an estimate against
  * the invoice it converts into.
  */
-export const formatMoneyPrecise = (amount: number, currency: string) =>
-  new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
+export const formatMoneyPrecise = (amount: number, currency: string) => {
+  try {
+    // No explicit fraction digits: Intl already knows each currency's minor
+    // unit, so JPY prints no decimals and KWD prints three. Pinning two would
+    // display a different amount from the one stored - KWD 1.234 as 1.23.
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amount);
+  } catch {
+    // A three-character code that is not a currency (the estimate API's schema
+    // only checks length) makes the constructor throw, and this helper runs on
+    // every line and total with no error boundary above it - one such record
+    // would blank the whole screen.
+    return `${currency} ${amount.toFixed(2)}`;
+  }
+};

--- a/apps/frontend/src/app/lib/money.ts
+++ b/apps/frontend/src/app/lib/money.ts
@@ -21,3 +21,19 @@ export const currencySymbol = (currency: string): string => {
     return currency;
   }
 };
+
+/**
+ * Money with its minor units kept, e.g. 45.5 GBP -> "£45.50".
+ *
+ * `formatMoney` above rounds to whole units, which is right for the dashboard
+ * tiles it was written for but wrong anywhere a figure has to reconcile with
+ * another figure - an estimate line against its total, or an estimate against
+ * the invoice it converts into.
+ */
+export const formatMoneyPrecise = (amount: number, currency: string) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -158,10 +158,11 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     // so the appointment lookup yields nothing and the row would read "-" for a
     // patient that is perfectly well known. Fall back to the companion store.
     const companionFromPatient = item.patientId ? companionsById[item.patientId] : undefined;
+    const companionFromAppointment = getCompanionName(item.appointmentId);
     const companionName =
-      getCompanionName(item.appointmentId) === '-' && companionFromPatient?.name
+      companionFromAppointment === '-' && companionFromPatient?.name
         ? companionFromPatient.name
-        : getCompanionName(item.appointmentId);
+        : companionFromAppointment;
     const parentName = getParentName(item.appointmentId);
     let ownerAndCompanion = '-';
     if (parentName !== '-' && companionName !== '-') {

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -24,6 +24,7 @@ import { getInvoiceItemNames, getInvoiceStatusTone } from '@/app/ui/tables/table
 import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
 import { getAppointmentCompanion, getAppointmentCompanionPhotoUrl } from '@/app/lib/appointments';
 import { getAvatarPalette } from '@/app/features/companions/pages/Companions/companionsDirectory';
+import { useCompanionStore } from '@/app/stores/companionStore';
 
 const buildAppointmentSubtitle = (
   typeName: string | undefined,
@@ -137,6 +138,8 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     router.push(`/appointments?${params.toString()}`);
   };
 
+  const companionsById = useCompanionStore((state) => state.companionsById);
+
   const getCompanionName = useMemo(
     () => (appointmentId: string | undefined) =>
       getCompanionNameFromAppointments(appointments, appointmentId),
@@ -150,7 +153,15 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
   );
 
   const renderParent = (item: Invoice, foldMeta: boolean) => {
-    const companionName = getCompanionName(item.appointmentId);
+    // An invoice converted from an estimate carries patientId and no
+    // appointmentId (deliberately - the estimate service has no route to one),
+    // so the appointment lookup yields nothing and the row would read "-" for a
+    // patient that is perfectly well known. Fall back to the companion store.
+    const companionFromPatient = item.patientId ? companionsById[item.patientId] : undefined;
+    const companionName =
+      getCompanionName(item.appointmentId) === '-' && companionFromPatient?.name
+        ? companionFromPatient.name
+        : getCompanionName(item.appointmentId);
     const parentName = getParentName(item.appointmentId);
     let ownerAndCompanion = '-';
     if (parentName !== '-' && companionName !== '-') {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The estimate backend has been complete since #2429: nine routed, permission-gated endpoints under `/v1/pms/organisation/:organisationId/estimates`, a status state machine, audit events, org-scoped tenancy checks, and a race-safe convert-to-invoice. No client calls any of them.

Verified two ways before starting:

- A repository-wide search for the estimate endpoints across `apps/frontend/src`, `apps/mobileAppYC/src` and `apps/desktop/src` returns nothing. `AppointmentEstimatePanel.tsx` is a false friend: a 94-line presentational cost card with no network call and no relation to the `Estimate` model.
- The dev database holds 0 rows in `Estimate` and `EstimateItem`, against 398 invoices.

## What is the new behavior?

A new `/finance/estimates` route, reached from an Estimates button beside Discounts on the finance page.

- A list of the organisation's estimates with a status filter, showing companion, status, dates and total.
- A detail panel with the line items, subtotal, tax and total.
- The lifecycle actions the service will actually accept: send from DRAFT, approve or decline from DRAFT or SENT, convert from APPROVED. A CONVERTED estimate offers no actions and links to the invoice it became.
- Creation, because the conversion cannot be reached or tested without a way to get an estimate to APPROVED, and there were no estimates on dev to convert.

Four things worth a reviewer's attention:

**The totals arithmetic is pinned to the server's.** `computeEstimateTotals` mirrors `computeTotals` in `estimate.service.ts` exactly: a line total excludes tax, tax is applied per line as a percentage of that line, the total is the sum. A test transcribes the server loop and compares float for float rather than to a rounded penny, because a preview that disagrees with what is saved is worse than no preview at all.

**`formatMoneyPrecise` is new.** The shared `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the dashboard tiles it was written for and wrong anywhere a figure has to reconcile with another figure. An estimate of 45.50 was rendering as 46 against an invoice of 45.50. The existing `formatMoney` is untouched.

**The action row is gated on `billing:edit:any`.** Worth recording: every one of the seven roles in `ROLE_PERMISSIONS` carries that permission, so a read-only billing user cannot be produced by choosing a weaker role. The only route to one is `revokedPermissions`, which is what the read-only story exercises.

**`InvoiceStatusFilterPills` gains an optional `ariaLabel`** rather than being copied for estimates, since the Sonar duplication ceiling is 0%. Its default keeps the existing behaviour.

Out of scope, deliberately: editing an existing estimate, deleting one, and any change to `EstimateService`.

## Validation performed

Measured, not estimated:

- `npx tsc --noEmit` from `apps/frontend`: exit 0.
- `pnpm --filter frontend run lint`: exit 0. The single warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, a file this PR does not touch.
- `pnpm --filter frontend run test -- --testPathPatterns="estimate|Estimate"`: 8 suites, 199 tests, all passing.
- Coverage on every new source file: 100% statements, branches, functions and lines, except `Estimates/index.tsx` at 100/96.29/100/100 and `CreateEstimateDialog.tsx` at 100/98.27/100/100.
- Aikido SAST and secrets scan on the changed source: no issues.
- Visual QA: 34 Storybook screenshots across `EstimateDetail`, `EstimateList` and `CreateEstimateDialog`, at 1440 and 390, in both light and dark, with zero play-function or console errors.

The visual pass earned its place three times over. It caught that the action row was invisible in Storybook because the org store was unseeded; that my own story helper was querying the visible button text when an `aria-label` had replaced it as the accessible name, so two of four actions were never actually asserted and the absence assertions were passing for the wrong reason; and that the line-item row wrapped illegibly at modal width, with no labels naming the numeric fields once a value had been typed into them.

Not verified: the signed-in flow on deployed dev, since local login is blocked by SuperTokens cross-origin. That needs a pass on dev.yosemitecrew.com after merge, creating an estimate, approving it and converting it.

## Related Issue(s)

Fixes #2527
