### PR TITLE
feat(frontend): surface credit notes on the invoice detail

### DIFF
--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -1,0 +1,299 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import type { CreditNote } from '@yosemite-crew/types';
+
+// Renders children so the ledger's gated controls are exercised here; the
+// permission logic itself is covered by PermissionGate's own tests.
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Secondary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+import InvoiceCreditNotes from '@/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes';
+
+const makeNote = (overrides: Partial<CreditNote> = {}): CreditNote => ({
+  id: 'cn-1',
+  invoiceId: 'inv-1',
+  creditNoteNumber: 'CN-0001',
+  amount: 40,
+  status: 'ISSUED',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+type RenderOptions = {
+  creditNotes?: CreditNote[];
+  totalAmount?: number;
+  currency?: string;
+  busy?: boolean;
+  error?: string | null;
+};
+
+const renderSection = (options: RenderOptions = {}) => {
+  const onAction = jest.fn();
+  render(
+    <InvoiceCreditNotes
+      creditNotes={options.creditNotes}
+      totalAmount={options.totalAmount ?? 200}
+      currency={options.currency ?? 'USD'}
+      busy={options.busy ?? false}
+      error={options.error ?? null}
+      onAction={onAction}
+    />
+  );
+  return { onAction };
+};
+
+const amountField = () => screen.getByLabelText('Amount');
+const reasonField = () => screen.getByLabelText('Reason (optional)');
+const issueButton = () => screen.getByRole('button', { name: /issue a credit note/i });
+
+describe('InvoiceCreditNotes', () => {
+  it('says nothing has been credited when the invoice has no credit notes', () => {
+    renderSection({ creditNotes: undefined });
+
+    expect(screen.getByText('Nothing has been credited against this invoice.')).toBeInTheDocument();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    // No ISSUED notes means no credited summary line.
+    expect(screen.queryByText('Credited')).not.toBeInTheDocument();
+  });
+
+  it('treats an empty credit note list the same as none at all', () => {
+    renderSection({ creditNotes: [] });
+
+    expect(screen.getByText('Nothing has been credited against this invoice.')).toBeInTheDocument();
+  });
+
+  it('lists a row per credit note with its number and amount', () => {
+    renderSection({
+      creditNotes: [
+        makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', amount: 40 }),
+        makeNote({ id: 'cn-2', creditNoteNumber: 'CN-0002', amount: 25 }),
+      ],
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText('CN-0001')).toBeInTheDocument();
+    expect(screen.getByText('$40')).toBeInTheDocument();
+    expect(screen.getByText('CN-0002')).toBeInTheDocument();
+    expect(screen.getByText('$25')).toBeInTheDocument();
+  });
+
+  it('labels a voided note and offers Void only on an issued one', () => {
+    renderSection({
+      creditNotes: [
+        makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', amount: 40, status: 'ISSUED' }),
+        makeNote({ id: 'cn-2', creditNoteNumber: 'CN-0002', amount: 60, status: 'VOIDED' }),
+      ],
+    });
+
+    expect(screen.getByText('CN-0002 (voided)')).toBeInTheDocument();
+    expect(screen.getByText('CN-0001')).toBeInTheDocument();
+
+    const voidedRow = screen.getByText('CN-0002 (voided)').closest('li') as HTMLElement;
+    expect(within(voidedRow).queryByRole('button')).not.toBeInTheDocument();
+
+    const issuedRow = screen.getByText('CN-0001').closest('li') as HTMLElement;
+    expect(
+      within(issuedRow).getByRole('button', { name: 'Void credit note CN-0001' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the reason when present and nothing when absent', () => {
+    renderSection({
+      creditNotes: [
+        makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', reason: 'Duplicate charge' }),
+        makeNote({ id: 'cn-2', creditNoteNumber: 'CN-0002', reason: undefined }),
+      ],
+    });
+
+    expect(screen.getByText('Duplicate charge')).toBeInTheDocument();
+
+    // The label column holds only the number span when there is no reason.
+    const withReason = screen.getByText('CN-0001').parentElement as HTMLElement;
+    expect(withReason.children).toHaveLength(2);
+    const withoutReason = screen.getByText('CN-0002').parentElement as HTMLElement;
+    expect(withoutReason.children).toHaveLength(1);
+  });
+
+  it('sums only issued notes into the credited total', () => {
+    renderSection({
+      totalAmount: 200,
+      creditNotes: [
+        makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', amount: 40, status: 'ISSUED' }),
+        makeNote({ id: 'cn-2', creditNoteNumber: 'CN-0002', amount: 60, status: 'VOIDED' }),
+      ],
+    });
+
+    const creditedRow = screen.getByText('Credited').parentElement as HTMLElement;
+    expect(within(creditedRow).getByText('$40')).toBeInTheDocument();
+    // The voided $60 must not be added in: $100 would be the naive total.
+    expect(within(creditedRow).queryByText('$100')).not.toBeInTheDocument();
+    // and the remaining figure is the total minus the issued note only.
+    expect(screen.getByText(/Up to \$160.00 can still be credited/)).toBeInTheDocument();
+  });
+
+  it('omits the credited summary when every note is voided', () => {
+    renderSection({
+      creditNotes: [makeNote({ id: 'cn-2', creditNoteNumber: 'CN-0002', status: 'VOIDED' })],
+    });
+
+    expect(screen.queryByText('Credited')).not.toBeInTheDocument();
+  });
+
+  it('issues a credit note with the typed amount and trimmed reason, then clears the fields', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    await userEvent.type(amountField(), '75');
+    await userEvent.type(reasonField(), '  Goodwill gesture  ');
+    await userEvent.click(issueButton());
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction).toHaveBeenCalledWith({
+      type: 'issue',
+      amount: 75,
+      reason: 'Goodwill gesture',
+    });
+    expect(amountField()).toHaveValue(null);
+    expect(reasonField()).toHaveValue('');
+  });
+
+  it('sends no reason when the field is blank', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    await userEvent.type(amountField(), '10');
+    await userEvent.type(reasonField(), '   ');
+    await userEvent.click(issueButton());
+
+    expect(onAction).toHaveBeenCalledWith({ type: 'issue', amount: 10, reason: undefined });
+  });
+
+  it('rejects an empty amount', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    await userEvent.click(issueButton());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a credit amount above zero.');
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero amount', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    await userEvent.type(amountField(), '0');
+    await userEvent.click(issueButton());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a credit amount above zero.');
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative amount', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    // fireEvent, not userEvent: a lone "-" is an invalid intermediate value for a
+    // number input, so typing it key by key never reaches the change handler.
+    fireEvent.change(amountField(), { target: { value: '-5' } });
+    await userEvent.click(issueButton());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a credit amount above zero.');
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects an amount above the remaining creditable and names the remaining figure', async () => {
+    const { onAction } = renderSection({
+      totalAmount: 200,
+      creditNotes: [makeNote({ id: 'cn-1', amount: 50, status: 'ISSUED' })],
+    });
+
+    await userEvent.type(amountField(), '175');
+    await userEvent.click(issueButton());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The most that can still be credited on this invoice is $150.00.'
+    );
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('clears a validation message once a valid amount is issued', async () => {
+    const { onAction } = renderSection({ totalAmount: 200 });
+
+    await userEvent.click(issueButton());
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await userEvent.type(amountField(), '20');
+    await userEvent.click(issueButton());
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onAction).toHaveBeenCalledWith({ type: 'issue', amount: 20, reason: undefined });
+  });
+
+  it('replaces the form with the fully credited line when nothing is left to credit', () => {
+    renderSection({
+      totalAmount: 100,
+      creditNotes: [makeNote({ id: 'cn-1', amount: 100, status: 'ISSUED' })],
+    });
+
+    expect(screen.getByText('This invoice is fully credited.')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Amount')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /issue a credit note/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/cancels any open payment link/)).not.toBeInTheDocument();
+  });
+
+  it('voids a credit note by id', async () => {
+    const { onAction } = renderSection({
+      creditNotes: [makeNote({ id: 'cn-7', creditNoteNumber: 'CN-0007', amount: 40 })],
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Void credit note CN-0007' }));
+
+    expect(onAction).toHaveBeenCalledWith({ type: 'void', creditNoteId: 'cn-7' });
+  });
+
+  it('disables the actions while busy', () => {
+    renderSection({
+      busy: true,
+      creditNotes: [makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', amount: 40 })],
+    });
+
+    expect(screen.getByRole('button', { name: 'Void credit note CN-0001' })).toBeDisabled();
+    expect(issueButton()).toBeDisabled();
+    expect(issueButton()).toHaveTextContent('Working...');
+  });
+
+  it('renders the error prop as an alert', () => {
+    renderSection({ error: 'Credit note amount exceeds invoice remaining amount' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Credit note amount exceeds invoice remaining amount'
+    );
+  });
+
+  it('prefers a validation message over the error prop', async () => {
+    renderSection({ error: 'Invoice cannot accept credit notes.' });
+
+    await userEvent.click(issueButton());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a credit amount above zero.');
+    expect(screen.queryByText('Invoice cannot accept credit notes.')).not.toBeInTheDocument();
+  });
+
+  it('warns that issuing cancels an open payment link while crediting is still possible', () => {
+    renderSection({ totalAmount: 200 });
+
+    expect(
+      screen.getByText(
+        'Up to $200.00 can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -38,22 +38,25 @@ type RenderOptions = {
   busy?: boolean;
   error?: string | null;
   status?: string;
+  issuedToken?: number;
 };
 
 const renderSection = (options: RenderOptions = {}) => {
   const onAction = jest.fn();
-  render(
+  const element = (opts: RenderOptions) => (
     <InvoiceCreditNotes
-      creditNotes={options.creditNotes}
-      totalAmount={options.totalAmount ?? 200}
-      status={options.status ?? 'AWAITING_PAYMENT'}
-      currency={options.currency ?? 'USD'}
-      busy={options.busy ?? false}
-      error={options.error ?? null}
+      creditNotes={opts.creditNotes}
+      totalAmount={opts.totalAmount ?? 200}
+      status={opts.status ?? 'AWAITING_PAYMENT'}
+      currency={opts.currency ?? 'USD'}
+      busy={opts.busy ?? false}
+      error={opts.error ?? null}
+      issuedToken={opts.issuedToken ?? 0}
       onAction={onAction}
     />
   );
-  return { onAction };
+  const view = render(element(options));
+  return { onAction, rerender: (next: RenderOptions) => view.rerender(element(next)) };
 };
 
 const amountField = () => screen.getByLabelText('Amount');
@@ -153,7 +156,7 @@ describe('InvoiceCreditNotes', () => {
     expect(screen.queryByText('Credited')).not.toBeInTheDocument();
   });
 
-  it('issues a credit note with the typed amount and trimmed reason, then clears the fields', async () => {
+  it('issues a credit note with the typed amount and trimmed reason', async () => {
     const { onAction } = renderSection({ totalAmount: 200 });
 
     await userEvent.type(amountField(), '75');
@@ -166,8 +169,38 @@ describe('InvoiceCreditNotes', () => {
       amount: 75,
       reason: 'Goodwill gesture',
     });
+  });
+
+  it('keeps the draft while the request is in flight and clears it only on success', async () => {
+    const { rerender } = renderSection({ totalAmount: 200, issuedToken: 0 });
+
+    await userEvent.type(amountField(), '75');
+    await userEvent.type(reasonField(), 'Goodwill gesture');
+    await userEvent.click(issueButton());
+
+    // Still on screen: the server has not accepted anything yet, and clearing
+    // now would lose both fields on a rejection.
+    expect(amountField()).toHaveValue(75);
+    expect(reasonField()).toHaveValue('Goodwill gesture');
+
+    rerender({ totalAmount: 200, issuedToken: 1 });
+
     expect(amountField()).toHaveValue(null);
     expect(reasonField()).toHaveValue('');
+  });
+
+  it('keeps the draft when the server rejects the credit note', async () => {
+    const { rerender } = renderSection({ totalAmount: 200, issuedToken: 0 });
+
+    await userEvent.type(amountField(), '75');
+    await userEvent.click(issueButton());
+
+    // The token does not advance on a failure, so the amount survives for a
+    // retry rather than having to be retyped from the error message.
+    rerender({ totalAmount: 200, issuedToken: 0, error: 'Invoice cannot accept credit notes.' });
+
+    expect(amountField()).toHaveValue(75);
+    expect(screen.getByRole('alert')).toHaveTextContent('Invoice cannot accept credit notes.');
   });
 
   it('sends no reason when the field is blank', async () => {
@@ -251,14 +284,33 @@ describe('InvoiceCreditNotes', () => {
     expect(screen.queryByText(/cancels any open payment link/)).not.toBeInTheDocument();
   });
 
-  it('voids a credit note by id', async () => {
+  it('asks before voiding, and voids by id once confirmed', async () => {
     const { onAction } = renderSection({
       creditNotes: [makeNote({ id: 'cn-7', creditNoteNumber: 'CN-0007', amount: 40 })],
     });
 
     await userEvent.click(screen.getByRole('button', { name: 'Void credit note CN-0007' }));
 
+    // Voiding cannot be undone here and moves money back onto what the client
+    // owes, so the first click only arms it.
+    expect(onAction).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Confirm voiding credit note CN-0007' })
+    );
     expect(onAction).toHaveBeenCalledWith({ type: 'void', creditNoteId: 'cn-7' });
+  });
+
+  it('lets the user back out of a void', async () => {
+    const { onAction } = renderSection({
+      creditNotes: [makeNote({ id: 'cn-7', creditNoteNumber: 'CN-0007', amount: 40 })],
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Void credit note CN-0007' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Keep credit note CN-0007' }));
+
+    expect(onAction).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Void credit note CN-0007' })).toBeInTheDocument();
   });
 
   it('disables the actions while busy', () => {

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -341,12 +341,16 @@ describe('InvoiceCreditNotes', () => {
     expect(screen.queryByText('Invoice cannot accept credit notes.')).not.toBeInTheDocument();
   });
 
-  it('warns that issuing cancels an open payment link while crediting is still possible', () => {
+  it('does not claim a sent payment link is cancelled, because it is not', () => {
+    // issueCreditNote only flips the local PaymentAttempt to CANCELED. It never
+    // calls the provider-expiry path, so the Stripe URL keeps working and would
+    // charge the pre-credit amount. Filed as its own issue; the copy must not
+    // promise otherwise in the meantime.
     renderSection({ totalAmount: 200 });
 
     expect(
       screen.getByText(
-        'Up to $200.00 can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.'
+        'Up to $200.00 can still be credited. Any pending payment attempt on this invoice is marked cancelled, but a payment link already sent to the client keeps working and would charge the pre-credit amount - send a new one.'
       )
     ).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -37,6 +37,7 @@ type RenderOptions = {
   currency?: string;
   busy?: boolean;
   error?: string | null;
+  status?: string;
 };
 
 const renderSection = (options: RenderOptions = {}) => {
@@ -45,6 +46,7 @@ const renderSection = (options: RenderOptions = {}) => {
     <InvoiceCreditNotes
       creditNotes={options.creditNotes}
       totalAmount={options.totalAmount ?? 200}
+      status={options.status ?? 'AWAITING_PAYMENT'}
       currency={options.currency ?? 'USD'}
       busy={options.busy ?? false}
       error={options.error ?? null}
@@ -295,5 +297,37 @@ describe('InvoiceCreditNotes', () => {
         'Up to $200.00 can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.'
       )
     ).toBeInTheDocument();
+  });
+
+  it.each(['CANCELLED', 'REFUNDED'])(
+    'offers no issue form on a %s invoice, which the service would reject',
+    (status) => {
+      renderSection({ status, totalAmount: 200 });
+
+      expect(screen.queryByLabelText('Amount')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(`A ${status.toLowerCase()} invoice cannot take a credit note.`)
+      ).toBeInTheDocument();
+      // The ledger itself stays readable - only the writing controls go.
+      expect(screen.getByText(/Nothing has been credited/i)).toBeInTheDocument();
+    }
+  );
+
+  it('accepts an amount exactly equal to the advertised cap', async () => {
+    // 10.01 minus an issued 0.05 is 9.959999999999999 unrounded. The cap is
+    // shown as 9.96, so entering 9.96 must be accepted - without rounding the
+    // remainder the form refuses the very figure it advertises.
+    const { onAction } = renderSection({
+      totalAmount: 10.01,
+      creditNotes: [makeNote({ id: 'cn-1', amount: 0.05, status: 'ISSUED' })],
+    });
+
+    expect(screen.getByText(/Up to \$9\.96 can still be credited/)).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText('Amount'), '9.96');
+    await userEvent.click(screen.getByRole('button', { name: /Issue a credit note/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onAction).toHaveBeenCalledWith({ type: 'issue', amount: 9.96, reason: undefined });
   });
 });

--- a/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
@@ -334,4 +334,56 @@ describe('useInvoiceCreditNotes', () => {
     // A void must not clear a half-typed issue draft.
     expect(result.current.issuedToken).toBe(1);
   });
+
+  it('drops a late result when the invoice changes with no new request', async () => {
+    // The earlier guard only caught a SECOND action superseding the first. If
+    // the user simply closes invoice A and opens invoice B, no new request sets
+    // the token, so A's late result still matched and landed on B.
+    let rejectA: (reason: unknown) => void = () => {};
+    creditNoteServiceMock.issueCreditNote.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectA = reject;
+      })
+    );
+
+    const { result, rerender } = renderHook(({ invoice }) => useInvoiceCreditNotes(invoice), {
+      initialProps: { invoice: invoiceFixture({ id: 'inv-a' }) },
+    });
+
+    act(() => {
+      result.current.run({ type: 'issue', amount: 10 });
+    });
+    expect(result.current.busy).toBe(true);
+
+    // Switch invoice. No new action is started.
+    rerender({ invoice: invoiceFixture({ id: 'inv-b' }) });
+    // A's spinner belonged to a panel that is now closed.
+    expect(result.current.busy).toBe(false);
+
+    await act(async () => {
+      rejectA(new Error('A failed'));
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(notifyMock).not.toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('clears a stale error when the invoice changes', async () => {
+    creditNoteServiceMock.issueCreditNote.mockRejectedValueOnce(new Error('nope'));
+
+    const { result, rerender } = renderHook(({ invoice }) => useInvoiceCreditNotes(invoice), {
+      initialProps: { invoice: invoiceFixture({ id: 'inv-a' }) },
+    });
+
+    act(() => {
+      result.current.run({ type: 'issue', amount: 10 });
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    rerender({ invoice: invoiceFixture({ id: 'inv-b' }) });
+
+    // The message described invoice A and must not sit on invoice B's panel.
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
@@ -1,0 +1,283 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { CreditNote, Invoice } from '@yosemite-crew/types';
+
+const creditNoteServiceMock = {
+  issueCreditNote: jest.fn(),
+  voidCreditNote: jest.fn(),
+};
+jest.mock('@/app/features/finance/services/creditNoteService', () => ({
+  issueCreditNote: (...args: unknown[]) => creditNoteServiceMock.issueCreditNote(...args),
+  voidCreditNote: (...args: unknown[]) => creditNoteServiceMock.voidCreditNote(...args),
+  // Mirrors the real helper closely enough to tell "server said why" from
+  // "fall back to our own copy" - the two branches the hook depends on.
+  getCreditNoteErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error && error.message.trim() ? error.message.trim() : fallback,
+}));
+
+const invoiceStoreMock = {
+  upsertInvoice: jest.fn(),
+};
+jest.mock('@/app/stores/invoiceStore', () => ({
+  useInvoiceStore: (selector: (state: { upsertInvoice: jest.Mock }) => unknown) =>
+    selector({ upsertInvoice: invoiceStoreMock.upsertInvoice }),
+}));
+
+const notifyMock = jest.fn();
+jest.mock('@/app/hooks/useNotify', () => ({
+  useNotify: () => ({ notify: notifyMock }),
+}));
+
+import { useInvoiceCreditNotes } from '@/app/features/finance/hooks/useInvoiceCreditNotes';
+
+/** A promise plus the handles to settle it, so a test can inspect mid-flight state. */
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const creditNote = (overrides: Partial<CreditNote> = {}): CreditNote =>
+  ({
+    id: 'cn-1',
+    invoiceId: 'inv-1',
+    creditNoteNumber: 'CN-0001',
+    amount: 25,
+    status: 'ISSUED',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  }) as CreditNote;
+
+const invoiceFixture = (overrides: Partial<Invoice> = {}): Invoice =>
+  ({
+    id: 'inv-1',
+    organisationId: 'org-1',
+    items: [],
+    subtotal: 100,
+    totalAmount: 100,
+    currency: 'usd',
+    paymentCollectionMethod: 'PAYMENT_LINK',
+    status: 'PENDING',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  }) as Invoice;
+
+beforeEach(() => {
+  creditNoteServiceMock.issueCreditNote.mockResolvedValue(creditNote());
+  creditNoteServiceMock.voidCreditNote.mockResolvedValue(creditNote({ status: 'VOIDED' }));
+});
+
+describe('useInvoiceCreditNotes', () => {
+  it('starts idle', () => {
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    expect(result.current.busy).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does nothing without an invoice', () => {
+    const { result } = renderHook(() => useInvoiceCreditNotes(null));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    expect(creditNoteServiceMock.issueCreditNote).not.toHaveBeenCalled();
+    expect(creditNoteServiceMock.voidCreditNote).not.toHaveBeenCalled();
+    expect(invoiceStoreMock.upsertInvoice).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(result.current.busy).toBe(false);
+  });
+
+  it('does nothing for an invoice that has no id yet', () => {
+    // An unsaved invoice would otherwise POST to /invoices/undefined/credit-notes.
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture({ id: undefined })));
+
+    act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
+
+    expect(creditNoteServiceMock.voidCreditNote).not.toHaveBeenCalled();
+    expect(invoiceStoreMock.upsertInvoice).not.toHaveBeenCalled();
+  });
+
+  it('issues a credit note with the invoice id, amount and reason', async () => {
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25, reason: 'Goodwill' }));
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(creditNoteServiceMock.issueCreditNote).toHaveBeenCalledWith('inv-1', {
+      amount: 25,
+      reason: 'Goodwill',
+    });
+    expect(creditNoteServiceMock.voidCreditNote).not.toHaveBeenCalled();
+  });
+
+  it('appends the issued note to an invoice that had none', async () => {
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    await waitFor(() => expect(invoiceStoreMock.upsertInvoice).toHaveBeenCalled());
+    const merged = invoiceStoreMock.upsertInvoice.mock.calls[0][0] as Invoice;
+    expect(merged.id).toBe('inv-1');
+    expect(merged.totalAmount).toBe(100);
+    expect(merged.creditNotes).toEqual([creditNote()]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('keeps the notes already on the invoice when appending a new one', async () => {
+    const existing = creditNote({ id: 'cn-existing', amount: 10 });
+    const { result } = renderHook(() =>
+      useInvoiceCreditNotes(invoiceFixture({ creditNotes: [existing] }))
+    );
+    creditNoteServiceMock.issueCreditNote.mockResolvedValue(creditNote({ id: 'cn-2' }));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    await waitFor(() => expect(invoiceStoreMock.upsertInvoice).toHaveBeenCalled());
+    const merged = invoiceStoreMock.upsertInvoice.mock.calls[0][0] as Invoice;
+    expect(merged.creditNotes?.map((note) => note.id)).toEqual(['cn-existing', 'cn-2']);
+  });
+
+  it('voids a credit note by id', async () => {
+    const { result } = renderHook(() =>
+      useInvoiceCreditNotes(invoiceFixture({ creditNotes: [creditNote()] }))
+    );
+
+    act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(creditNoteServiceMock.voidCreditNote).toHaveBeenCalledWith('inv-1', 'cn-1');
+    expect(creditNoteServiceMock.issueCreditNote).not.toHaveBeenCalled();
+  });
+
+  it('replaces a note already on the invoice rather than duplicating it', async () => {
+    // Voiding returns the SAME id with a new status. Appending it would show the
+    // note twice in the ledger and double-count it in remainingCreditable.
+    const { result } = renderHook(() =>
+      useInvoiceCreditNotes(
+        invoiceFixture({ creditNotes: [creditNote({ id: 'cn-keep' }), creditNote()] })
+      )
+    );
+
+    act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
+
+    await waitFor(() => expect(invoiceStoreMock.upsertInvoice).toHaveBeenCalled());
+    const merged = invoiceStoreMock.upsertInvoice.mock.calls[0][0] as Invoice;
+    expect(merged.creditNotes).toHaveLength(2);
+    expect(merged.creditNotes?.map((note) => note.id)).toEqual(['cn-keep', 'cn-1']);
+    expect(merged.creditNotes?.find((note) => note.id === 'cn-1')?.status).toBe('VOIDED');
+    expect(merged.creditNotes?.find((note) => note.id === 'cn-keep')?.status).toBe('ISSUED');
+  });
+
+  it('is busy while the request is in flight and idle once it settles', async () => {
+    const pending = deferred<CreditNote>();
+    creditNoteServiceMock.issueCreditNote.mockReturnValue(pending.promise);
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    expect(result.current.busy).toBe(true);
+    expect(invoiceStoreMock.upsertInvoice).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve(creditNote());
+      await pending.promise;
+    });
+
+    expect(result.current.busy).toBe(false);
+    expect(invoiceStoreMock.upsertInvoice).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a previous error when a new request starts', async () => {
+    creditNoteServiceMock.issueCreditNote.mockRejectedValueOnce(new Error('Nope.'));
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+    await waitFor(() => expect(result.current.error).toBe('Nope.'));
+
+    const pending = deferred<CreditNote>();
+    creditNoteServiceMock.issueCreditNote.mockReturnValue(pending.promise);
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      pending.resolve(creditNote());
+      await pending.promise;
+    });
+  });
+
+  it('surfaces a failure message and notifies, leaving the invoice untouched', async () => {
+    creditNoteServiceMock.issueCreditNote.mockRejectedValue(
+      new Error('Credit note amount exceeds invoice remaining amount')
+    );
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 500 }));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Credit note amount exceeds invoice remaining amount')
+    );
+    expect(result.current.busy).toBe(false);
+    expect(invoiceStoreMock.upsertInvoice).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalledWith('error', {
+      title: 'Credit note not saved',
+      text: 'Credit note amount exceeds invoice remaining amount',
+    });
+  });
+
+  it('falls back to issue-specific copy when the failure carries no message', async () => {
+    creditNoteServiceMock.issueCreditNote.mockRejectedValue({ status: 500 });
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    await waitFor(() => expect(result.current.error).toBe('The credit note could not be issued.'));
+  });
+
+  it('falls back to void-specific copy when the failure carries no message', async () => {
+    creditNoteServiceMock.voidCreditNote.mockRejectedValue({ status: 500 });
+    const { result } = renderHook(() =>
+      useInvoiceCreditNotes(invoiceFixture({ creditNotes: [creditNote()] }))
+    );
+
+    act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
+
+    await waitFor(() => expect(result.current.error).toBe('The credit note could not be voided.'));
+    expect(notifyMock).toHaveBeenCalledWith('error', {
+      title: 'Credit note not saved',
+      text: 'The credit note could not be voided.',
+    });
+  });
+
+  it('notifies success with issue copy', async () => {
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+
+    act(() => result.current.run({ type: 'issue', amount: 25 }));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+    expect(notifyMock).toHaveBeenCalledWith('success', {
+      title: 'Credit note issued',
+      text: 'The credit has been recorded against this invoice.',
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('notifies success with different copy for a void', async () => {
+    const { result } = renderHook(() =>
+      useInvoiceCreditNotes(invoiceFixture({ creditNotes: [creditNote()] }))
+    );
+
+    act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+    expect(notifyMock).toHaveBeenCalledWith('success', {
+      title: 'Credit note voided',
+      text: 'The credit note no longer reduces this invoice.',
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
@@ -280,4 +280,58 @@ describe('useInvoiceCreditNotes', () => {
       text: 'The credit note no longer reduces this invoice.',
     });
   });
+
+  it('discards a late result once the open invoice has changed', async () => {
+    // Invoice A's request is still in flight when the user closes it and opens
+    // invoice B on the same hook instance. Without scoping, A's failure would
+    // surface as an error on B, and A's credit note would be merged into B.
+    let rejectA: (reason: unknown) => void = () => {};
+    creditNoteServiceMock.issueCreditNote.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectA = reject;
+      })
+    );
+
+    const { result, rerender } = renderHook(({ invoice }) => useInvoiceCreditNotes(invoice), {
+      initialProps: { invoice: invoiceFixture({ id: 'inv-a' }) },
+    });
+
+    act(() => {
+      result.current.run({ type: 'issue', amount: 10 });
+    });
+    expect(result.current.busy).toBe(true);
+
+    rerender({ invoice: invoiceFixture({ id: 'inv-b' }) });
+    act(() => {
+      result.current.run({ type: 'issue', amount: 20 });
+    });
+
+    await act(async () => {
+      rejectA(new Error('A failed'));
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(notifyMock).not.toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('bumps issuedToken on an accepted issue but not on a void', async () => {
+    creditNoteServiceMock.issueCreditNote.mockResolvedValue(creditNote());
+    creditNoteServiceMock.voidCreditNote.mockResolvedValue(creditNote({ status: 'VOIDED' }));
+
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
+    expect(result.current.issuedToken).toBe(0);
+
+    act(() => {
+      result.current.run({ type: 'issue', amount: 10 });
+    });
+    await waitFor(() => expect(result.current.issuedToken).toBe(1));
+
+    act(() => {
+      result.current.run({ type: 'void', creditNoteId: 'cn-1' });
+    });
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    // A void must not clear a half-typed issue draft.
+    expect(result.current.issuedToken).toBe(1);
+  });
 });

--- a/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useInvoiceCreditNotes.test.ts
@@ -22,6 +22,11 @@ jest.mock('@/app/stores/invoiceStore', () => ({
     selector({ upsertInvoice: invoiceStoreMock.upsertInvoice }),
 }));
 
+const getFinanceInvoiceByIdMock = jest.fn().mockResolvedValue({});
+jest.mock('@/app/features/billing/services/invoiceService', () => ({
+  getFinanceInvoiceById: (...args: unknown[]) => getFinanceInvoiceByIdMock(...args),
+}));
+
 const notifyMock = jest.fn();
 jest.mock('@/app/hooks/useNotify', () => ({
   useNotify: () => ({ notify: notifyMock }),
@@ -197,7 +202,9 @@ describe('useInvoiceCreditNotes', () => {
     const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture()));
 
     act(() => result.current.run({ type: 'issue', amount: 25 }));
-    await waitFor(() => expect(result.current.error).toBe('Nope.'));
+    await waitFor(() =>
+      expect(result.current.error).toBe('Nope. Check the ledger below before retrying.')
+    );
 
     const pending = deferred<CreditNote>();
     creditNoteServiceMock.issueCreditNote.mockReturnValue(pending.promise);
@@ -220,12 +227,14 @@ describe('useInvoiceCreditNotes', () => {
     act(() => result.current.run({ type: 'issue', amount: 500 }));
 
     await waitFor(() =>
-      expect(result.current.error).toBe('Credit note amount exceeds invoice remaining amount')
+      expect(result.current.error).toBe(
+        'Credit note amount exceeds invoice remaining amount Check the ledger below before retrying.'
+      )
     );
     expect(result.current.busy).toBe(false);
     expect(invoiceStoreMock.upsertInvoice).not.toHaveBeenCalled();
     expect(notifyMock).toHaveBeenCalledWith('error', {
-      title: 'Credit note not saved',
+      title: 'Credit note not confirmed',
       text: 'Credit note amount exceeds invoice remaining amount',
     });
   });
@@ -236,7 +245,11 @@ describe('useInvoiceCreditNotes', () => {
 
     act(() => result.current.run({ type: 'issue', amount: 25 }));
 
-    await waitFor(() => expect(result.current.error).toBe('The credit note could not be issued.'));
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'The credit note could not be issued. Check the ledger below before retrying.'
+      )
+    );
   });
 
   it('falls back to void-specific copy when the failure carries no message', async () => {
@@ -247,9 +260,13 @@ describe('useInvoiceCreditNotes', () => {
 
     act(() => result.current.run({ type: 'void', creditNoteId: 'cn-1' }));
 
-    await waitFor(() => expect(result.current.error).toBe('The credit note could not be voided.'));
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        'The credit note could not be voided. Check the ledger below before retrying.'
+      )
+    );
     expect(notifyMock).toHaveBeenCalledWith('error', {
-      title: 'Credit note not saved',
+      title: 'Credit note not confirmed',
       text: 'The credit note could not be voided.',
     });
   });
@@ -385,5 +402,22 @@ describe('useInvoiceCreditNotes', () => {
 
     // The message described invoice A and must not sit on invoice B's panel.
     expect(result.current.error).toBeNull();
+  });
+
+  it('re-reads the invoice after a failure instead of claiming nothing was saved', async () => {
+    // issueCreditNote creates the note and then records a FinanceEvent, and the
+    // two are not in one transaction - so a failure in the second returns a 500
+    // over a note that exists. Saying "not saved" would invite a retry that
+    // mints a second one.
+    creditNoteServiceMock.issueCreditNote.mockRejectedValueOnce(new Error('event write failed'));
+
+    const { result } = renderHook(() => useInvoiceCreditNotes(invoiceFixture({ id: 'inv-1' })));
+    act(() => result.current.run({ type: 'issue', amount: 10 }));
+
+    await waitFor(() => expect(getFinanceInvoiceByIdMock).toHaveBeenCalledWith('inv-1'));
+    expect(notifyMock).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ title: 'Credit note not confirmed' })
+    );
   });
 });

--- a/apps/frontend/src/app/__tests__/services/creditNoteService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/creditNoteService.test.ts
@@ -1,0 +1,341 @@
+import type { CreditNote, CreditNoteStatus } from '@yosemite-crew/types';
+import {
+  getCreditNoteErrorMessage,
+  issueCreditNote,
+  remainingCreditable,
+  voidCreditNote,
+} from '@/app/features/finance/services/creditNoteService';
+import { postData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  postData: jest.fn(),
+}));
+
+const mockPostData = postData as jest.Mock;
+
+const ISSUE_PATH = '/fhir/v1/invoice/inv-1/credit-notes';
+const VOID_PATH = '/fhir/v1/invoice/inv-1/credit-notes/cn-1/void';
+
+const makeCreditNote = (overrides: Partial<CreditNote> = {}): CreditNote => ({
+  id: 'cn-1',
+  invoiceId: 'inv-1',
+  creditNoteNumber: 'CN-0001',
+  amount: 25,
+  status: 'ISSUED',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+const noteWith = (amount: number, status: CreditNoteStatus, id: string): CreditNote =>
+  makeCreditNote({ id, amount, status });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('issueCreditNote', () => {
+  it('posts to the invoice router path, not the finance prefix', async () => {
+    const note = makeCreditNote();
+    mockPostData.mockResolvedValue({ data: { data: note, meta: null, error: null } });
+
+    const issued = await issueCreditNote('inv-1', { amount: 25 });
+
+    expect(mockPostData).toHaveBeenCalledTimes(1);
+    expect(mockPostData.mock.calls[0][0]).toBe(ISSUE_PATH);
+    expect(mockPostData.mock.calls[0][0]).not.toContain('/v1/finance');
+    expect(issued).toEqual(note);
+  });
+
+  it('omits the reason key entirely when no reason is given', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote() });
+
+    await issueCreditNote('inv-1', { amount: 25 });
+
+    expect(mockPostData).toHaveBeenCalledWith(ISSUE_PATH, { amount: 25 });
+    const body = mockPostData.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(['amount']);
+  });
+
+  it('omits the reason key for an empty string', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote() });
+
+    await issueCreditNote('inv-1', { amount: 10, reason: '' });
+
+    expect(mockPostData).toHaveBeenCalledWith(ISSUE_PATH, { amount: 10 });
+  });
+
+  it('omits the reason key for a whitespace-only reason', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote() });
+
+    await issueCreditNote('inv-1', { amount: 10, reason: '   \n\t ' });
+
+    expect(mockPostData).toHaveBeenCalledWith(ISSUE_PATH, { amount: 10 });
+    expect(mockPostData.mock.calls[0][1]).not.toHaveProperty('reason');
+  });
+
+  it('sends the reason trimmed when one is given', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote({ reason: 'Goodwill' }) });
+
+    await issueCreditNote('inv-1', { amount: 40, reason: '  Goodwill  ' });
+
+    expect(mockPostData).toHaveBeenCalledWith(ISSUE_PATH, { amount: 40, reason: 'Goodwill' });
+  });
+
+  it('accepts a bare credit note body with no envelope', async () => {
+    const note = makeCreditNote({ amount: 12 });
+    mockPostData.mockResolvedValue({ data: note });
+
+    await expect(issueCreditNote('inv-1', { amount: 12 })).resolves.toEqual(note);
+  });
+
+  it('throws the envelope error message', async () => {
+    mockPostData.mockResolvedValue({
+      data: {
+        data: null,
+        meta: null,
+        error: { code: 'CONFLICT', message: 'Credit note amount exceeds invoice remaining amount' },
+      },
+    });
+
+    await expect(issueCreditNote('inv-1', { amount: 500 })).rejects.toThrow(
+      'Credit note amount exceeds invoice remaining amount'
+    );
+  });
+
+  it('throws the envelope error code when no message is present', async () => {
+    mockPostData.mockResolvedValue({ data: { data: null, error: { code: 'INVOICE_LOCKED' } } });
+
+    await expect(issueCreditNote('inv-1', { amount: 5 })).rejects.toThrow('INVOICE_LOCKED');
+  });
+
+  it('throws the generic fallback when the envelope error is empty', async () => {
+    mockPostData.mockResolvedValue({ data: { data: null, error: {} } });
+
+    await expect(issueCreditNote('inv-1', { amount: 5 })).rejects.toThrow('Finance request failed');
+  });
+
+  it('throws for a missing invoice id and makes no request', async () => {
+    await expect(issueCreditNote('', { amount: 5 })).rejects.toThrow('Invoice ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+
+  it('propagates a transport failure', async () => {
+    mockPostData.mockRejectedValue(new Error('Request failed with status code 409'));
+
+    await expect(issueCreditNote('inv-1', { amount: 5 })).rejects.toThrow(
+      'Request failed with status code 409'
+    );
+  });
+});
+
+describe('voidCreditNote', () => {
+  it('posts to the void sub-path', async () => {
+    const note = makeCreditNote({ status: 'VOIDED' });
+    mockPostData.mockResolvedValue({ data: { data: note, meta: null, error: null } });
+
+    const voided = await voidCreditNote('inv-1', 'cn-1');
+
+    expect(mockPostData.mock.calls[0][0]).toBe(VOID_PATH);
+    expect(voided).toEqual(note);
+  });
+
+  it('sends an empty body when no reason is given', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote({ status: 'VOIDED' }) });
+
+    await voidCreditNote('inv-1', 'cn-1');
+
+    expect(mockPostData).toHaveBeenCalledWith(VOID_PATH, {});
+  });
+
+  it('sends an empty body for a whitespace-only reason', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote({ status: 'VOIDED' }) });
+
+    await voidCreditNote('inv-1', 'cn-1', '  ');
+
+    expect(mockPostData).toHaveBeenCalledWith(VOID_PATH, {});
+  });
+
+  it('sends the reason trimmed when one is given', async () => {
+    mockPostData.mockResolvedValue({ data: makeCreditNote({ status: 'VOIDED' }) });
+
+    await voidCreditNote('inv-1', 'cn-1', '  Issued in error  ');
+
+    expect(mockPostData).toHaveBeenCalledWith(VOID_PATH, { reason: 'Issued in error' });
+  });
+
+  it('accepts a bare credit note body with no envelope', async () => {
+    const note = makeCreditNote({ status: 'VOIDED' });
+    mockPostData.mockResolvedValue({ data: note });
+
+    await expect(voidCreditNote('inv-1', 'cn-1')).resolves.toEqual(note);
+  });
+
+  it('throws the envelope error message', async () => {
+    mockPostData.mockResolvedValue({
+      data: { data: null, meta: null, error: { message: 'Credit note already voided.' } },
+    });
+
+    await expect(voidCreditNote('inv-1', 'cn-1')).rejects.toThrow('Credit note already voided.');
+  });
+
+  it('throws the envelope error code when no message is present', async () => {
+    mockPostData.mockResolvedValue({ data: { data: null, error: { code: 'ALREADY_VOIDED' } } });
+
+    await expect(voidCreditNote('inv-1', 'cn-1')).rejects.toThrow('ALREADY_VOIDED');
+  });
+
+  it('throws the generic fallback when the envelope error is empty', async () => {
+    mockPostData.mockResolvedValue({ data: { data: null, error: {} } });
+
+    await expect(voidCreditNote('inv-1', 'cn-1')).rejects.toThrow('Finance request failed');
+  });
+
+  it('throws for a missing invoice id and makes no request', async () => {
+    await expect(voidCreditNote('', 'cn-1')).rejects.toThrow('Invoice ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+
+  it('throws for a missing credit note id and makes no request', async () => {
+    await expect(voidCreditNote('inv-1', '')).rejects.toThrow('Credit note ID missing');
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+
+  it('propagates a transport failure', async () => {
+    mockPostData.mockRejectedValue(new Error('network down'));
+
+    await expect(voidCreditNote('inv-1', 'cn-1')).rejects.toThrow('network down');
+  });
+});
+
+describe('getCreditNoteErrorMessage', () => {
+  it('reads the controller bare { message } body', () => {
+    const error = {
+      message: 'Request failed with status code 409',
+      response: { data: { message: 'Credit note amount exceeds invoice remaining amount' } },
+    };
+
+    expect(getCreditNoteErrorMessage(error, 'fallback')).toBe(
+      'Credit note amount exceeds invoice remaining amount'
+    );
+  });
+
+  it('surfaces the "cannot accept credit notes" 409 verbatim', () => {
+    const error = { response: { data: { message: 'Invoice cannot accept credit notes.' } } };
+
+    expect(getCreditNoteErrorMessage(error, 'fallback')).toBe(
+      'Invoice cannot accept credit notes.'
+    );
+  });
+
+  it('reads a nested { error: { message } } body', () => {
+    const error = { response: { data: { error: { message: 'Invalid credit note amount' } } } };
+
+    expect(getCreditNoteErrorMessage(error, 'fallback')).toBe('Invalid credit note amount');
+  });
+
+  it('prefers the nested envelope message over the top-level message', () => {
+    const error = {
+      response: { data: { message: 'outer', error: { message: 'inner' } } },
+    };
+
+    expect(getCreditNoteErrorMessage(error, 'fallback')).toBe('inner');
+  });
+
+  it('trims the surfaced message', () => {
+    const error = { response: { data: { message: '  Credit note not found  ' } } };
+
+    expect(getCreditNoteErrorMessage(error, 'fallback')).toBe('Credit note not found');
+  });
+
+  it('falls back to a plain Error message when there is no response body', () => {
+    expect(getCreditNoteErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+  });
+
+  it('uses the fallback for a blank body message', () => {
+    expect(getCreditNoteErrorMessage({ response: { data: { message: '   ' } } }, 'fallback')).toBe(
+      'fallback'
+    );
+  });
+
+  it('uses the fallback for a blank Error message', () => {
+    expect(getCreditNoteErrorMessage(new Error('   '), 'fallback')).toBe('fallback');
+  });
+
+  it('uses the fallback for a non-string body message', () => {
+    expect(getCreditNoteErrorMessage({ response: { data: { message: 42 } } }, 'fallback')).toBe(
+      'fallback'
+    );
+  });
+
+  it('uses the fallback for null, undefined, a string and a number', () => {
+    expect(getCreditNoteErrorMessage(null, 'fallback')).toBe('fallback');
+    expect(getCreditNoteErrorMessage(undefined, 'fallback')).toBe('fallback');
+    expect(getCreditNoteErrorMessage('nope', 'fallback')).toBe('fallback');
+    expect(getCreditNoteErrorMessage(500, 'fallback')).toBe('fallback');
+  });
+
+  it('uses the fallback when the response data is not an object', () => {
+    expect(getCreditNoteErrorMessage({ response: { data: 'oops' } }, 'fallback')).toBe('fallback');
+  });
+
+  it('uses the fallback when the response data is null', () => {
+    expect(getCreditNoteErrorMessage({ response: { data: null } }, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('remainingCreditable', () => {
+  it('returns the full total for an undefined list', () => {
+    expect(remainingCreditable(100, undefined)).toBe(100);
+  });
+
+  it('returns the full total for an empty list', () => {
+    expect(remainingCreditable(100, [])).toBe(100);
+  });
+
+  it('subtracts a single ISSUED note', () => {
+    expect(remainingCreditable(100, [noteWith(30, 'ISSUED', 'cn-1')])).toBe(70);
+  });
+
+  it('subtracts every ISSUED note', () => {
+    const notes = [
+      noteWith(30, 'ISSUED', 'cn-1'),
+      noteWith(20, 'ISSUED', 'cn-2'),
+      noteWith(5, 'ISSUED', 'cn-3'),
+    ];
+
+    expect(remainingCreditable(100, notes)).toBe(45);
+  });
+
+  it('excludes VOIDED notes so voiding restores the cap', () => {
+    const notes = [noteWith(30, 'ISSUED', 'cn-1'), noteWith(40, 'VOIDED', 'cn-2')];
+
+    expect(remainingCreditable(100, notes)).toBe(70);
+  });
+
+  it('restores the whole total when every note is voided', () => {
+    const notes = [noteWith(60, 'VOIDED', 'cn-1'), noteWith(40, 'VOIDED', 'cn-2')];
+
+    expect(remainingCreditable(100, notes)).toBe(100);
+  });
+
+  it('excludes DRAFT notes as well', () => {
+    expect(remainingCreditable(100, [noteWith(25, 'DRAFT', 'cn-1')])).toBe(100);
+  });
+
+  it('returns 0 for a fully credited invoice', () => {
+    const notes = [noteWith(60, 'ISSUED', 'cn-1'), noteWith(40, 'ISSUED', 'cn-2')];
+
+    expect(remainingCreditable(100, notes)).toBe(0);
+  });
+
+  it('never goes negative when the invoice is over-credited', () => {
+    const notes = [noteWith(80, 'ISSUED', 'cn-1'), noteWith(50, 'ISSUED', 'cn-2')];
+
+    expect(remainingCreditable(100, notes)).toBe(0);
+  });
+
+  it('handles a zero-total invoice', () => {
+    expect(remainingCreditable(0, [])).toBe(0);
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
@@ -1504,5 +1504,52 @@ describe('invoiceService', () => {
       expect(invoices[0].creditNotes).toEqual([creditNote]);
       expect(invoices[1].creditNotes).toBeUndefined();
     });
+
+    it('unwraps the nested single-invoice payload', async () => {
+      // InvoiceService.getById replies { organistion, invoice } - the
+      // misspelling is the API's - and the finance envelope wraps that pair, so
+      // the invoice sits one level down. Reading fields straight off the pair
+      // produced an invoice with no id at all, and it is the only read that
+      // carries settlementSummary.
+      const settlementSummary = { invoiceTotal: 100, credited: 25, balance: 75 };
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: {
+            organistion: { name: 'Avenger Park', address: '', image: '', placesId: '' },
+            invoice: {
+              id: 'inv-nested',
+              status: 'AWAITING_PAYMENT',
+              totalAmount: 100,
+              creditNotes: [creditNote],
+              settlementSummary,
+            },
+          },
+          meta: null,
+          error: null,
+        },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-nested');
+
+      expect(invoice.id).toBe('inv-nested');
+      expect(invoice.totalAmount).toBe(100);
+      expect(invoice.creditNotes).toEqual([creditNote]);
+      expect(invoice.settlementSummary).toEqual(settlementSummary);
+    });
+
+    it('still reads a flat single-invoice payload', async () => {
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: { id: 'inv-flat', status: 'PENDING', totalAmount: 42 },
+          meta: null,
+          error: null,
+        },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-flat');
+
+      expect(invoice.id).toBe('inv-flat');
+      expect(invoice.totalAmount).toBe(42);
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
@@ -1380,4 +1380,129 @@ describe('invoiceService', () => {
     await expect(sendInvoiceToClient('')).rejects.toThrow('Invoice ID missing');
     errorSpy.mockRestore();
   });
+
+  describe('normalizeFinanceInvoice credit-note passthrough', () => {
+    const creditNote = {
+      id: 'cn-1',
+      invoiceId: 'inv-credit',
+      creditNoteNumber: 'CN-0001',
+      amount: 25,
+      status: 'ISSUED',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    };
+
+    it('carries creditNotes through the single-invoice read', async () => {
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: {
+            id: 'inv-credit',
+            status: 'PENDING',
+            totalAmount: 100,
+            creditNotes: [creditNote],
+          },
+          meta: null,
+          error: null,
+        },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-credit');
+
+      expect(invoice.creditNotes).toEqual([creditNote]);
+      expect(invoiceState.upsertInvoice).toHaveBeenCalledWith(
+        expect.objectContaining({ creditNotes: [creditNote] })
+      );
+    });
+
+    it('carries settlementSummary through the single-invoice read', async () => {
+      // Without this the outstanding figure never sees the credited balance and
+      // silently falls back to total-minus-deposit.
+      const settlementSummary = {
+        total: 100,
+        credited: 25,
+        paid: 0,
+        balance: 75,
+      };
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: {
+            id: 'inv-settled',
+            status: 'PENDING',
+            totalAmount: 100,
+            settlementSummary,
+          },
+          meta: null,
+          error: null,
+        },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-settled');
+
+      expect(invoice.settlementSummary).toEqual(settlementSummary);
+    });
+
+    it('leaves both undefined when the payload carries neither', async () => {
+      // Unenveloped shape: the single-invoice read returns the invoice directly
+      // when the backend omits the { data, meta } wrapper.
+      (getData as jest.Mock).mockResolvedValue({
+        data: { id: 'inv-bare', status: 'PENDING', totalAmount: 100 },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-bare');
+
+      expect(invoice.creditNotes).toBeUndefined();
+      expect(invoice.settlementSummary).toBeUndefined();
+      expect(invoice.id).toBe('inv-bare');
+    });
+
+    it('drops a creditNotes value that is not an array', async () => {
+      // The ledger maps over this list, so a stray object or string must become
+      // undefined rather than reaching the component as a non-iterable.
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: {
+            id: 'inv-bad-credit',
+            status: 'PENDING',
+            totalAmount: 100,
+            creditNotes: { id: 'cn-1' },
+          },
+          meta: null,
+          error: null,
+        },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-bad-credit');
+
+      expect(invoice.creditNotes).toBeUndefined();
+    });
+
+    it('drops a creditNotes string rather than treating it as a list', async () => {
+      (getData as jest.Mock).mockResolvedValue({
+        data: { id: 'inv-str-credit', status: 'PENDING', creditNotes: 'cn-1' },
+      });
+
+      const invoice = await getFinanceInvoiceById('inv-str-credit');
+
+      expect(invoice.creditNotes).toBeUndefined();
+    });
+
+    it('carries creditNotes through the org invoice list read', async () => {
+      (getData as jest.Mock).mockResolvedValue({
+        data: {
+          data: [
+            { id: 'inv-a', status: 'PENDING', totalAmount: 100, creditNotes: [creditNote] },
+            { id: 'inv-b', status: 'PENDING', totalAmount: 50 },
+          ],
+          meta: null,
+          error: null,
+        },
+      });
+
+      await loadInvoicesForOrgPrimaryOrg();
+
+      const [, invoices] = invoiceState.setInvoicesForOrg.mock.calls[0];
+      expect(invoices[0].creditNotes).toEqual([creditNote]);
+      expect(invoices[1].creditNotes).toBeUndefined();
+    });
+  });
 });

--- a/apps/frontend/src/app/features/billing/services/invoiceService.ts
+++ b/apps/frontend/src/app/features/billing/services/invoiceService.ts
@@ -250,6 +250,13 @@ const normalizeFinanceInvoice = (
     renderedDocumentId: invoice?.renderedDocumentId,
     invoiceDocumentId: invoice?.invoiceDocumentId,
     payments: invoice?.payments,
+    // The backend returns creditNotes on every invoice read and settlementSummary
+    // on the single-invoice read. Both were being dropped here, which left the
+    // credit ledger invisible and made getInvoiceOutstanding's preferred branch
+    // (settlementSummary.balance) unreachable, so it always fell back to
+    // total-minus-deposit. See #2595 for the list-endpoint half of that.
+    creditNotes: Array.isArray(invoice?.creditNotes) ? invoice.creditNotes : undefined,
+    settlementSummary: invoice?.settlementSummary,
     metadata: invoice?.metadata,
     paidAt: invoice?.paidAt ? new Date(invoice.paidAt) : undefined,
     createdAt,

--- a/apps/frontend/src/app/features/billing/services/invoiceService.ts
+++ b/apps/frontend/src/app/features/billing/services/invoiceService.ts
@@ -194,10 +194,30 @@ const reverseAppointmentReadyForBillingViaAppointmentRoute = async (
   return unwrapFinanceData(res.data);
 };
 
+/**
+ * The single-invoice read nests its payload.
+ *
+ * `InvoiceService.getById` returns `{ organistion, invoice }` (the misspelling
+ * is the API's), and the finance envelope wraps that whole object - so
+ * `unwrapFinanceData` yields the pair, not the invoice. Reading fields straight
+ * off it produced an invoice with no id and a zero total, and it is the only
+ * read that carries `settlementSummary`, so the nesting has to be undone here.
+ *
+ * A real invoice never has an `invoice` property of its own, which is what
+ * makes that key a safe discriminator.
+ */
+const unwrapNestedInvoice = (value: any): any => {
+  if (value && typeof value === 'object' && typeof value.invoice === 'object' && value.invoice) {
+    return value.invoice;
+  }
+  return value;
+};
+
 const normalizeFinanceInvoice = (
-  invoice: any,
+  payload: any,
   fallbackOrganisationId?: string
 ): NormalizedFinanceInvoice => {
+  const invoice = unwrapNestedInvoice(payload);
   if (invoice?.resourceType === 'Invoice') {
     return normalizeInvoiceForFrontend(invoice, fallbackOrganisationId);
   }

--- a/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { CreditNote, Invoice } from '@yosemite-crew/types';
 import { useInvoiceStore } from '@/app/stores/invoiceStore';
 import { useNotify } from '@/app/hooks/useNotify';
@@ -13,6 +13,8 @@ import type { CreditNoteAction } from '@/app/features/finance/pages/Finance/Sect
 export type UseInvoiceCreditNotes = {
   busy: boolean;
   error: string | null;
+  /** Bumped on each accepted credit note, so the form knows when to clear. */
+  issuedToken: number;
   run: (action: CreditNoteAction) => void;
 };
 
@@ -44,10 +46,17 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // The invoice the in-flight request belongs to. A user can close invoice A
+  // while its request is pending and open invoice B on the same hook instance;
+  // without this the late result would merge into, and error against, B.
+  const inFlightInvoiceId = useRef<string | null>(null);
+  const [issuedToken, setIssuedToken] = useState(0);
+
   const run = useCallback(
     (action: CreditNoteAction) => {
       if (!invoice?.id) return;
       const invoiceId = invoice.id;
+      inFlightInvoiceId.current = invoiceId;
       setBusy(true);
       setError(null);
 
@@ -58,7 +67,9 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
 
       request
         .then((creditNote) => {
+          if (inFlightInvoiceId.current !== invoiceId) return;
           upsertInvoice(mergeCreditNote(invoice, creditNote));
+          if (action.type === 'issue') setIssuedToken((token) => token + 1);
           notify('success', {
             title: action.type === 'issue' ? 'Credit note issued' : 'Credit note voided',
             text:
@@ -68,6 +79,7 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
           });
         })
         .catch((err: unknown) => {
+          if (inFlightInvoiceId.current !== invoiceId) return;
           const message = getCreditNoteErrorMessage(
             err,
             action.type === 'issue'
@@ -77,10 +89,13 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
           setError(message);
           notify('error', { title: 'Credit note not saved', text: message });
         })
-        .finally(() => setBusy(false));
+        .finally(() => {
+          if (inFlightInvoiceId.current !== invoiceId) return;
+          setBusy(false);
+        });
     },
     [invoice, upsertInvoice, notify]
   );
 
-  return { busy, error, run };
+  return { busy, error, issuedToken, run };
 };

--- a/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CreditNote, Invoice } from '@yosemite-crew/types';
 import { useInvoiceStore } from '@/app/stores/invoiceStore';
 import { useNotify } from '@/app/hooks/useNotify';
@@ -46,28 +46,52 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // The invoice the in-flight request belongs to. A user can close invoice A
-  // while its request is pending and open invoice B on the same hook instance;
-  // without this the late result would merge into, and error against, B.
-  const inFlightInvoiceId = useRef<string | null>(null);
   const [issuedToken, setIssuedToken] = useState(0);
+  const invoiceId = invoice?.id ?? null;
+
+  /**
+   * The invoice currently on screen, readable from a promise callback.
+   *
+   * A request started for invoice A can resolve after the user has closed A
+   * and opened B on the same hook instance. Comparing the request's invoice
+   * against this is what keeps A's result off B's panel. Tracking only the
+   * last REQUESTED invoice is not enough: switching invoice without starting a
+   * new request would leave the old value in place and A's result would still
+   * match.
+   *
+   * Updated in an effect rather than during render - the repo lints against
+   * touching a ref while rendering.
+   */
+  const displayedInvoiceId = useRef<string | null>(invoiceId);
+  useEffect(() => {
+    displayedInvoiceId.current = invoiceId;
+  }, [invoiceId]);
+
+  // Render-phase reset, the pattern useOrganisationDiscountCap uses: A's error
+  // and spinner belong to a panel the user has closed, so they must not carry
+  // over to B. State only - no ref is touched here.
+  const [prevInvoiceId, setPrevInvoiceId] = useState(invoiceId);
+  if (prevInvoiceId !== invoiceId) {
+    setPrevInvoiceId(invoiceId);
+    setBusy(false);
+    setError(null);
+  }
 
   const run = useCallback(
     (action: CreditNoteAction) => {
       if (!invoice?.id) return;
-      const invoiceId = invoice.id;
-      inFlightInvoiceId.current = invoiceId;
+      const requestInvoiceId = invoice.id;
       setBusy(true);
       setError(null);
 
       const request =
         action.type === 'issue'
-          ? issueCreditNote(invoiceId, { amount: action.amount, reason: action.reason })
-          : voidCreditNote(invoiceId, action.creditNoteId);
+          ? issueCreditNote(requestInvoiceId, { amount: action.amount, reason: action.reason })
+          : voidCreditNote(requestInvoiceId, action.creditNoteId);
 
       request
         .then((creditNote) => {
-          if (inFlightInvoiceId.current !== invoiceId) return;
+          if (displayedInvoiceId.current !== requestInvoiceId) return;
           upsertInvoice(mergeCreditNote(invoice, creditNote));
           if (action.type === 'issue') setIssuedToken((token) => token + 1);
           notify('success', {
@@ -79,7 +103,7 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
           });
         })
         .catch((err: unknown) => {
-          if (inFlightInvoiceId.current !== invoiceId) return;
+          if (displayedInvoiceId.current !== requestInvoiceId) return;
           const message = getCreditNoteErrorMessage(
             err,
             action.type === 'issue'
@@ -90,7 +114,7 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
           notify('error', { title: 'Credit note not saved', text: message });
         })
         .finally(() => {
-          if (inFlightInvoiceId.current !== invoiceId) return;
+          if (displayedInvoiceId.current !== requestInvoiceId) return;
           setBusy(false);
         });
     },

--- a/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
@@ -1,0 +1,86 @@
+'use client';
+import { useCallback, useState } from 'react';
+import type { CreditNote, Invoice } from '@yosemite-crew/types';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useNotify } from '@/app/hooks/useNotify';
+import {
+  getCreditNoteErrorMessage,
+  issueCreditNote,
+  voidCreditNote,
+} from '@/app/features/finance/services/creditNoteService';
+import type { CreditNoteAction } from '@/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes';
+
+export type UseInvoiceCreditNotes = {
+  busy: boolean;
+  error: string | null;
+  run: (action: CreditNoteAction) => void;
+};
+
+/** Merge one credit note back into the invoice already in the store. */
+const mergeCreditNote = (invoice: Invoice, creditNote: CreditNote): Invoice => {
+  const existing = invoice.creditNotes ?? [];
+  const index = existing.findIndex((note) => note.id === creditNote.id);
+  const creditNotes =
+    index === -1
+      ? [...existing, creditNote]
+      : existing.map((note) => (note.id === creditNote.id ? creditNote : note));
+  return { ...invoice, creditNotes };
+};
+
+/**
+ * Issue or void a credit note on the open invoice.
+ *
+ * The result is merged straight back into the invoice store rather than
+ * refetched, so the ledger and the credited total update in place.
+ *
+ * One caveat the UI cannot paper over: `settlementSummary` is not returned by
+ * the finance list endpoint, so the invoice's Outstanding figure does not yet
+ * respond to a credit note. That is tracked in #2595; crediting still shows
+ * correctly here, in the credit ledger.
+ */
+export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCreditNotes => {
+  const { notify } = useNotify();
+  const upsertInvoice = useInvoiceStore((s) => s.upsertInvoice);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    (action: CreditNoteAction) => {
+      if (!invoice?.id) return;
+      const invoiceId = invoice.id;
+      setBusy(true);
+      setError(null);
+
+      const request =
+        action.type === 'issue'
+          ? issueCreditNote(invoiceId, { amount: action.amount, reason: action.reason })
+          : voidCreditNote(invoiceId, action.creditNoteId);
+
+      request
+        .then((creditNote) => {
+          upsertInvoice(mergeCreditNote(invoice, creditNote));
+          notify('success', {
+            title: action.type === 'issue' ? 'Credit note issued' : 'Credit note voided',
+            text:
+              action.type === 'issue'
+                ? 'The credit has been recorded against this invoice.'
+                : 'The credit note no longer reduces this invoice.',
+          });
+        })
+        .catch((err: unknown) => {
+          const message = getCreditNoteErrorMessage(
+            err,
+            action.type === 'issue'
+              ? 'The credit note could not be issued.'
+              : 'The credit note could not be voided.'
+          );
+          setError(message);
+          notify('error', { title: 'Credit note not saved', text: message });
+        })
+        .finally(() => setBusy(false));
+    },
+    [invoice, upsertInvoice, notify]
+  );
+
+  return { busy, error, run };
+};

--- a/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useInvoiceCreditNotes.ts
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CreditNote, Invoice } from '@yosemite-crew/types';
 import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { getFinanceInvoiceById } from '@/app/features/billing/services/invoiceService';
 import { useNotify } from '@/app/hooks/useNotify';
 import {
   getCreditNoteErrorMessage,
@@ -110,8 +111,19 @@ export const useInvoiceCreditNotes = (invoice: Invoice | null): UseInvoiceCredit
               ? 'The credit note could not be issued.'
               : 'The credit note could not be voided.'
           );
-          setError(message);
-          notify('error', { title: 'Credit note not saved', text: message });
+          // A failure does not prove nothing was written. issueCreditNote
+          // creates the note and then records a FinanceEvent, and those two are
+          // not in one transaction - so a failure in the second returns a 500
+          // over a note that exists. Telling the user it was not saved would
+          // invite a retry that mints a second one. Re-read the invoice so the
+          // ledger shows what is actually there, and say only that it could not
+          // be confirmed.
+          setError(`${message} Check the ledger below before retrying.`);
+          notify('error', { title: 'Credit note not confirmed', text: message });
+          getFinanceInvoiceById(requestInvoiceId).catch(() => {
+            // The re-read is a best effort; the message above already tells the
+            // user not to trust the ledger blindly.
+          });
         })
         .finally(() => {
           if (displayedInvoiceId.current !== requestInvoiceId) return;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
@@ -1,20 +1,9 @@
 'use client';
 import React, { useState } from 'react';
-import { currencySymbol } from '@/app/lib/money';
 import { Secondary } from '@/app/ui/primitives/Buttons';
+import { formatCap } from '@/app/features/finance/services/creditNoteService';
 
-/**
- * The cap, to the penny.
- *
- * `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the
- * ledger rows beside the rest of the invoice panel but wrong for this one
- * figure: a remaining 159.97 advertised as "160" invites the user to type 160
- * and take a 409 back from the service, whose own cap is exact.
- */
-export const formatCap = (amount: number, currency: string) =>
-  `${currencySymbol(currency)}${amount.toFixed(2)}`;
-
-export type CreditNoteDraft = { amount: number; reason?: string };
+type CreditNoteDraft = { amount: number; reason?: string };
 
 type CreditNoteIssueFormProps = {
   remaining: number;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
@@ -9,6 +9,14 @@ type CreditNoteIssueFormProps = {
   remaining: number;
   currency: string;
   busy: boolean;
+  /**
+   * Increments each time the server accepts a credit note. The draft is only
+   * cleared on that edge - clearing on submit loses the user's amount and
+   * reason on any rejection or dropped connection, and they would have to
+   * reconstruct both from the error message. A counter rather than a boolean
+   * so a second successful issue also clears.
+   */
+  issuedToken: number;
   onIssue: (draft: CreditNoteDraft) => void;
   /** Raised when the draft is refused before any request goes out. */
   onInvalid: (message: string) => void;
@@ -30,12 +38,23 @@ const CreditNoteIssueForm = ({
   remaining,
   currency,
   busy,
+  issuedToken,
   onIssue,
   onInvalid,
   onValid,
 }: CreditNoteIssueFormProps) => {
   const [amountInput, setAmountInput] = useState('');
   const [reasonInput, setReasonInput] = useState('');
+
+  // Render-phase reset on the success edge, the pattern useOrganisationDiscountCap
+  // uses: clearing inside the submit handler would discard the draft before the
+  // server had accepted it.
+  const [prevIssuedToken, setPrevIssuedToken] = useState(issuedToken);
+  if (prevIssuedToken !== issuedToken) {
+    setPrevIssuedToken(issuedToken);
+    setAmountInput('');
+    setReasonInput('');
+  }
 
   const handleIssue = () => {
     const amount = Number(amountInput.trim());
@@ -51,8 +70,6 @@ const CreditNoteIssueForm = ({
     }
     onValid();
     onIssue({ amount, reason: reasonInput.trim() || undefined });
-    setAmountInput('');
-    setReasonInput('');
   };
 
   return (

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
@@ -1,0 +1,117 @@
+'use client';
+import React, { useState } from 'react';
+import { currencySymbol } from '@/app/lib/money';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+
+/**
+ * The cap, to the penny.
+ *
+ * `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the
+ * ledger rows beside the rest of the invoice panel but wrong for this one
+ * figure: a remaining 159.97 advertised as "160" invites the user to type 160
+ * and take a 409 back from the service, whose own cap is exact.
+ */
+export const formatCap = (amount: number, currency: string) =>
+  `${currencySymbol(currency)}${amount.toFixed(2)}`;
+
+export type CreditNoteDraft = { amount: number; reason?: string };
+
+type CreditNoteIssueFormProps = {
+  remaining: number;
+  currency: string;
+  busy: boolean;
+  onIssue: (draft: CreditNoteDraft) => void;
+  /** Raised when the draft is refused before any request goes out. */
+  onInvalid: (message: string) => void;
+  /** Clears a previous message once a draft is accepted. */
+  onValid: () => void;
+};
+
+const fieldClass =
+  'flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active';
+const inputClass =
+  'min-w-0 flex-1 bg-transparent px-3 py-2 text-[13px] text-[var(--ink-body)] outline-none';
+
+/**
+ * Amount and reason, validated against the same cap the service enforces so the
+ * common mistake produces a message here rather than a 409. The server check
+ * remains the authority; this only saves a round trip.
+ */
+const CreditNoteIssueForm = ({
+  remaining,
+  currency,
+  busy,
+  onIssue,
+  onInvalid,
+  onValid,
+}: CreditNoteIssueFormProps) => {
+  const [amountInput, setAmountInput] = useState('');
+  const [reasonInput, setReasonInput] = useState('');
+
+  const handleIssue = () => {
+    const amount = Number(amountInput.trim());
+    if (!Number.isFinite(amount) || amount <= 0) {
+      onInvalid('Enter a credit amount above zero.');
+      return;
+    }
+    if (amount > remaining) {
+      onInvalid(
+        `The most that can still be credited on this invoice is ${formatCap(remaining, currency)}.`
+      );
+      return;
+    }
+    onValid();
+    onIssue({ amount, reason: reasonInput.trim() || undefined });
+    setAmountInput('');
+    setReasonInput('');
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="flex flex-col gap-1 w-32">
+          <label htmlFor="credit-note-amount" className="text-[12px] text-[var(--ink-muted)]">
+            Amount
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="credit-note-amount"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              max={remaining}
+              value={amountInput}
+              onChange={(e) => setAmountInput(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 flex-1 min-w-40">
+          <label htmlFor="credit-note-reason" className="text-[12px] text-[var(--ink-muted)]">
+            Reason (optional)
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="credit-note-reason"
+              type="text"
+              value={reasonInput}
+              onChange={(e) => setReasonInput(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+        <Secondary
+          text={busy ? 'Working...' : 'Issue credit note'}
+          isDisabled={busy}
+          onClick={handleIssue}
+          ariaLabel="Issue a credit note against this invoice"
+        />
+      </div>
+      <p className="text-[12px] text-[var(--ink-muted)]">
+        {`Up to ${formatCap(remaining, currency)} can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.`}
+      </p>
+    </div>
+  );
+};
+
+export default CreditNoteIssueForm;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
@@ -114,7 +114,7 @@ const CreditNoteIssueForm = ({
         />
       </div>
       <p className="text-[12px] text-[var(--ink-muted)]">
-        {`Up to ${formatCap(remaining, currency)} can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.`}
+        {`Up to ${formatCap(remaining, currency)} can still be credited. Any pending payment attempt on this invoice is marked cancelled, but a payment link already sent to the client keeps working and would charge the pre-credit amount - send a new one.`}
       </p>
     </div>
   );

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 import type { CreditNote } from '@yosemite-crew/types';
 import { formatMoney } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
@@ -21,8 +21,14 @@ type CreditNoteLedgerProps = {
  * A voided note is struck through and keeps its row - removing it would hide
  * that a credit was raised and reversed, which is exactly the history a
  * practice needs when reconciling. Only an issued note offers a Void control.
+ *
+ * Voiding asks first. It cannot be undone from here, it moves money back onto
+ * what the client owes, and the control is a compact button sitting inches from
+ * the amount - a single mis-click should not be enough.
  */
 const CreditNoteLedger = ({ notes, currency, busy, onVoid }: CreditNoteLedgerProps) => {
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
   if (notes.length === 0) {
     return (
       <p className="text-[13px] text-[var(--ink-muted)]">
@@ -53,13 +59,35 @@ const CreditNoteLedger = ({ notes, currency, busy, onVoid }: CreditNoteLedgerPro
             </span>
             {isIssued(note) && (
               <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-                <Secondary
-                  text="Void"
-                  size="compact"
-                  isDisabled={busy}
-                  onClick={() => onVoid(note.id)}
-                  ariaLabel={`Void credit note ${note.creditNoteNumber}`}
-                />
+                {confirmingId === note.id ? (
+                  <span className="flex items-center gap-2">
+                    <Secondary
+                      text="Confirm void"
+                      size="compact"
+                      isDisabled={busy}
+                      onClick={() => {
+                        setConfirmingId(null);
+                        onVoid(note.id);
+                      }}
+                      ariaLabel={`Confirm voiding credit note ${note.creditNoteNumber}`}
+                    />
+                    <Secondary
+                      text="Cancel"
+                      size="compact"
+                      isDisabled={busy}
+                      onClick={() => setConfirmingId(null)}
+                      ariaLabel={`Keep credit note ${note.creditNoteNumber}`}
+                    />
+                  </span>
+                ) : (
+                  <Secondary
+                    text="Void"
+                    size="compact"
+                    isDisabled={busy}
+                    onClick={() => setConfirmingId(note.id)}
+                    ariaLabel={`Void credit note ${note.creditNoteNumber}`}
+                  />
+                )}
               </PermissionGate>
             )}
           </span>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
@@ -1,0 +1,72 @@
+'use client';
+import React from 'react';
+import type { CreditNote } from '@yosemite-crew/types';
+import { formatMoney } from '@/app/lib/money';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+
+export const isIssued = (note: CreditNote) => note.status === 'ISSUED';
+
+type CreditNoteLedgerProps = {
+  notes: CreditNote[];
+  currency: string;
+  busy: boolean;
+  onVoid: (creditNoteId: string) => void;
+};
+
+/**
+ * Every credit note on the invoice, issued or voided.
+ *
+ * A voided note is struck through and keeps its row - removing it would hide
+ * that a credit was raised and reversed, which is exactly the history a
+ * practice needs when reconciling. Only an issued note offers a Void control.
+ */
+const CreditNoteLedger = ({ notes, currency, busy, onVoid }: CreditNoteLedgerProps) => {
+  if (notes.length === 0) {
+    return (
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Nothing has been credited against this invoice.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {notes.map((note) => (
+        <li key={note.id} className="flex items-center justify-between gap-3">
+          <span className="flex flex-col">
+            <span className="text-[13px] text-[var(--ink-body)]">
+              {note.creditNoteNumber}
+              {note.status === 'VOIDED' ? ' (voided)' : ''}
+            </span>
+            {note.reason ? (
+              <span className="text-[12px] text-[var(--ink-muted)]">{note.reason}</span>
+            ) : null}
+          </span>
+          <span className="flex items-center gap-3">
+            <span
+              className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]"
+              style={note.status === 'VOIDED' ? { textDecoration: 'line-through' } : undefined}
+            >
+              {formatMoney(note.amount, currency)}
+            </span>
+            {isIssued(note) && (
+              <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+                <Secondary
+                  text="Void"
+                  size="compact"
+                  isDisabled={busy}
+                  onClick={() => onVoid(note.id)}
+                  ariaLabel={`Void credit note ${note.creditNoteNumber}`}
+                />
+              </PermissionGate>
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default CreditNoteLedger;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
@@ -5,8 +5,7 @@ import { formatMoney } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { Secondary } from '@/app/ui/primitives/Buttons';
-
-export const isIssued = (note: CreditNote) => note.status === 'ISSUED';
+import { isIssued } from '@/app/features/finance/services/creditNoteService';
 
 type CreditNoteLedgerProps = {
   notes: CreditNote[];

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
@@ -88,6 +88,7 @@ const meta = {
   args: {
     creditNotes: [note('cn-1', 'CN-0001', 40, 'ISSUED', 'Goodwill on the delayed dental')],
     totalAmount: 199.97,
+    status: 'AWAITING_PAYMENT',
     currency: 'GBP',
     busy: false,
     error: null,
@@ -204,5 +205,20 @@ export const WithoutEditPermission: Story = {
     await expect(
       canvas.queryByRole('button', { name: /Void credit note CN-0001/i })
     ).not.toBeInTheDocument();
+  },
+};
+
+export const CancelledInvoice: Story = {
+  name: 'Cancelled invoice - ledger readable, no issuing',
+  args: { status: 'CANCELLED' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The service rejects CANCELLED and REFUNDED with a 409 whatever the
+    // balance, so offering the form would only invite a failing request.
+    await expect(canvas.queryByLabelText('Amount')).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText('A cancelled invoice cannot take a credit note.')
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('CN-0001')).toBeInTheDocument();
   },
 };

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
@@ -63,11 +63,12 @@ const meta = {
           'matching the cap in `InvoiceService.issueCreditNote`, so the common mistake produces ' +
           'a message here instead of a 409. A VOIDED note stops counting against the cap, which ' +
           'is why the sum filters on status rather than adding up the whole list.\n\n' +
-          'Issuing a credit note cancels every PaymentAttempt on the invoice that is not already ' +
-          'SUCCEEDED or CANCELED. That is deliberate on the backend - an outstanding Stripe ' +
-          'checkout link still names the old amount and would collect the full sum - and it is ' +
-          'why the copy warns about open payment links rather than staying silent about a side ' +
-          'effect the user cannot see.\n\n' +
+          'Issuing a credit note marks every PaymentAttempt on the invoice CANCELED locally, but ' +
+          'it does NOT expire the session at Stripe - `issueCreditNote` never calls the ' +
+          '`cancelOpenCheckoutSessionAttempts` path that does. A link already sent to the client ' +
+          'therefore keeps working and would charge the pre-credit amount. The copy says exactly ' +
+          'that rather than promising a cancellation that does not happen; the backend gap is ' +
+          'tracked in #2598.\n\n' +
           'Known gap: the Outstanding figure in the summary panel above does not yet respond to ' +
           'a credit note, because the finance list endpoint does not return `settlementSummary`. ' +
           'Tracked in #2595.',
@@ -221,5 +222,22 @@ export const CancelledInvoice: Story = {
       canvas.getByText('A cancelled invoice cannot take a credit note.')
     ).toBeInTheDocument();
     await expect(canvas.getByText('CN-0001')).toBeInTheDocument();
+  },
+};
+
+export const VoidConfirmation: Story = {
+  name: 'Voiding asks first',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Void credit note CN-0001/i }));
+
+    // Voiding cannot be undone here and puts money back onto what the client
+    // owes, so the first click only arms it.
+    await expect(
+      canvas.getByRole('button', { name: /Confirm voiding credit note CN-0001/i })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: /Keep credit note CN-0001/i })
+    ).toBeInTheDocument();
   },
 };

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+import type { CreditNote, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import InvoiceCreditNotes from './InvoiceCreditNotes';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * Seeds the store the gate reads rather than mocking PermissionGate away, so the
+ * real gate runs. Every role in ROLE_PERMISSIONS carries `billing:edit:any`, so
+ * a read-only billing user only exists through `revokedPermissions` - which is
+ * what the read-only story below uses.
+ */
+const seedRole = (revokedPermissions: string[] = []) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: {
+      [ORG_ID]: {
+        id: 'membership-1',
+        practitionerReference: 'Practitioner/practitioner-1',
+        organizationReference: `Organization/${ORG_ID}`,
+        roleCode: 'OWNER' as UserOrganization['roleCode'],
+        roleDisplay: 'Owner',
+        active: true,
+        revokedPermissions,
+      },
+    },
+    status: 'loaded',
+  });
+};
+
+seedRole();
+
+const note = (
+  id: string,
+  number: string,
+  amount: number,
+  status: CreditNote['status'],
+  reason?: string
+): CreditNote => ({
+  id,
+  invoiceId: 'inv-1',
+  creditNoteNumber: number,
+  amount,
+  status,
+  reason,
+  createdAt: new Date('2026-08-30T09:00:00.000Z'),
+  updatedAt: new Date('2026-08-30T09:00:00.000Z'),
+});
+
+const meta = {
+  title: 'Finance/InvoiceCreditNotes',
+  component: InvoiceCreditNotes,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The credit ledger on an invoice, and the controls to credit more or reverse one.\n\n' +
+          'The amount is capped client-side at the invoice total minus every ISSUED note, ' +
+          'matching the cap in `InvoiceService.issueCreditNote`, so the common mistake produces ' +
+          'a message here instead of a 409. A VOIDED note stops counting against the cap, which ' +
+          'is why the sum filters on status rather than adding up the whole list.\n\n' +
+          'Issuing a credit note cancels every PaymentAttempt on the invoice that is not already ' +
+          'SUCCEEDED or CANCELED. That is deliberate on the backend - an outstanding Stripe ' +
+          'checkout link still names the old amount and would collect the full sum - and it is ' +
+          'why the copy warns about open payment links rather than staying silent about a side ' +
+          'effect the user cannot see.\n\n' +
+          'Known gap: the Outstanding figure in the summary panel above does not yet respond to ' +
+          'a credit note, because the finance list endpoint does not return `settlementSummary`. ' +
+          'Tracked in #2595.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      seedRole();
+      return (
+        <div style={{ maxWidth: 420 }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    creditNotes: [note('cn-1', 'CN-0001', 40, 'ISSUED', 'Goodwill on the delayed dental')],
+    totalAmount: 199.97,
+    currency: 'GBP',
+    busy: false,
+    error: null,
+    onAction: () => {},
+  },
+} satisfies Meta<typeof InvoiceCreditNotes>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OneCredit: Story = {
+  name: 'One credit issued',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('CN-0001')).toBeInTheDocument();
+    await expect(canvas.getByText(/Goodwill on the delayed dental/)).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: /Void credit note CN-0001/i })
+    ).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  name: 'Nothing credited yet',
+  args: { creditNotes: [] },
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).getByText(/Nothing has been credited against this invoice/i)
+    ).toBeInTheDocument();
+  },
+};
+
+export const VoidedDoesNotCount: Story = {
+  name: 'A voided note stops reducing the invoice',
+  args: {
+    creditNotes: [
+      note('cn-1', 'CN-0001', 40, 'ISSUED'),
+      note('cn-2', 'CN-0002', 60, 'VOIDED', 'Raised against the wrong invoice'),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Credited counts the ISSUED 40 only, not 100. Read the figure opposite the
+    // "Credited" label rather than by text - the note's own amount is also 40,
+    // so a bare getByText('£40') matches two nodes and proves nothing.
+    const credited = canvas.getByText('Credited').nextElementSibling;
+    await expect(credited).toHaveTextContent('£40');
+    await expect(canvas.getByText(/CN-0002 \(voided\)/)).toBeInTheDocument();
+    // A voided note offers no Void control.
+    await expect(
+      canvas.queryByRole('button', { name: /Void credit note CN-0002/i })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const RejectsOverCap: Story = {
+  name: 'Refuses more than the invoice can still take',
+  args: { creditNotes: [note('cn-1', 'CN-0001', 180, 'ISSUED')] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // 199.97 total less 180 issued leaves 19.97.
+    await userEvent.type(canvas.getByLabelText('Amount'), '50');
+    await userEvent.click(canvas.getByRole('button', { name: /Issue a credit note/i }));
+    await expect(canvas.getByRole('alert')).toHaveTextContent(/can still be credited/i);
+  },
+};
+
+export const FullyCredited: Story = {
+  name: 'Fully credited - no form at all',
+  args: { creditNotes: [note('cn-1', 'CN-0001', 199.97, 'ISSUED')] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/This invoice is fully credited/i)).toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Amount')).not.toBeInTheDocument();
+  },
+};
+
+export const Busy: Story = {
+  name: 'Working',
+  args: { busy: true },
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).getByRole('button', { name: /Issue a credit note/i })
+    ).toBeDisabled();
+  },
+};
+
+export const ServerRefused: Story = {
+  name: 'The server refused it',
+  args: { error: 'Invoice cannot accept credit notes.' },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByRole('alert')).toHaveTextContent(
+      'Invoice cannot accept credit notes.'
+    );
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Billing edit revoked - ledger visible, no controls',
+  decorators: [
+    (Story) => {
+      seedRole(['billing:edit:any']);
+      return (
+        <div style={{ maxWidth: 420 }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('CN-0001')).toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Amount')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: /Void credit note CN-0001/i })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.stories.tsx
@@ -89,6 +89,7 @@ const meta = {
     creditNotes: [note('cn-1', 'CN-0001', 40, 'ISSUED', 'Goodwill on the delayed dental')],
     totalAmount: 199.97,
     status: 'AWAITING_PAYMENT',
+    issuedToken: 0,
     currency: 'GBP',
     busy: false,
     error: null,

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -1,0 +1,219 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import type { CreditNote } from '@yosemite-crew/types';
+import { currencySymbol, formatMoney } from '@/app/lib/money';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+import { remainingCreditable } from '@/app/features/finance/services/creditNoteService';
+
+export type CreditNoteAction =
+  { type: 'issue'; amount: number; reason?: string } | { type: 'void'; creditNoteId: string };
+
+type InvoiceCreditNotesProps = {
+  creditNotes: CreditNote[] | undefined;
+  totalAmount: number;
+  currency: string;
+  /** True while a credit note is being issued or voided, so actions lock. */
+  busy: boolean;
+  error: string | null;
+  onAction: (action: CreditNoteAction) => void;
+};
+
+const isIssued = (note: CreditNote) => note.status === 'ISSUED';
+
+/**
+ * The cap, to the penny.
+ *
+ * `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the
+ * ledger rows beside the rest of the invoice panel but wrong for this one
+ * figure: a remaining 159.97 advertised as "160" invites the user to type 160
+ * and take a 409 back from the service, whose own cap is exact.
+ */
+const formatCap = (amount: number, currency: string) =>
+  `${currencySymbol(currency)}${amount.toFixed(2)}`;
+
+/**
+ * The credit ledger on an invoice: what has been credited, and the controls to
+ * credit more or reverse one.
+ *
+ * The amount field is capped client-side at what the service will accept - the
+ * invoice total minus every ISSUED note - so the common mistake produces a
+ * message here rather than a 409 from the API. The server check remains the
+ * authority; this only saves a round trip.
+ *
+ * Issuing a credit note has a side effect worth knowing about: the service
+ * cancels every PaymentAttempt on the invoice that is not already SUCCEEDED or
+ * CANCELED, because an outstanding Stripe checkout link still names the old
+ * amount and would collect the full sum. That is why the copy warns about open
+ * payment links rather than staying silent.
+ */
+const InvoiceCreditNotes = ({
+  creditNotes,
+  totalAmount,
+  currency,
+  busy,
+  error,
+  onAction,
+}: InvoiceCreditNotesProps) => {
+  const [amountInput, setAmountInput] = useState('');
+  const [reasonInput, setReasonInput] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const notes = useMemo(() => creditNotes ?? [], [creditNotes]);
+  const issuedNotes = useMemo(() => notes.filter(isIssued), [notes]);
+  const credited = useMemo(
+    () => issuedNotes.reduce((sum, note) => sum + note.amount, 0),
+    [issuedNotes]
+  );
+  const remaining = remainingCreditable(totalAmount, notes);
+
+  const handleIssue = () => {
+    const amount = Number(amountInput.trim());
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setFormError('Enter a credit amount above zero.');
+      return;
+    }
+    if (amount > remaining) {
+      setFormError(
+        `The most that can still be credited on this invoice is ${formatCap(remaining, currency)}.`
+      );
+      return;
+    }
+    setFormError(null);
+    onAction({ type: 'issue', amount, reason: reasonInput.trim() || undefined });
+    setAmountInput('');
+    setReasonInput('');
+  };
+
+  const message = formError ?? error;
+
+  return (
+    <section className="flex flex-col gap-3" aria-label="Credit notes">
+      <h3 className="text-[13px] font-bold text-[var(--ink)]">Credit notes</h3>
+      <div className="rounded-[14px] border border-card-border px-4.5 py-4 flex flex-col gap-3">
+        {notes.length === 0 ? (
+          <p className="text-[13px] text-[var(--ink-muted)]">
+            Nothing has been credited against this invoice.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {notes.map((note) => (
+              <li key={note.id} className="flex items-center justify-between gap-3">
+                <span className="flex flex-col">
+                  <span className="text-[13px] text-[var(--ink-body)]">
+                    {note.creditNoteNumber}
+                    {note.status === 'VOIDED' ? ' (voided)' : ''}
+                  </span>
+                  {note.reason ? (
+                    <span className="text-[12px] text-[var(--ink-muted)]">{note.reason}</span>
+                  ) : null}
+                </span>
+                <span className="flex items-center gap-3">
+                  <span
+                    className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]"
+                    style={
+                      note.status === 'VOIDED' ? { textDecoration: 'line-through' } : undefined
+                    }
+                  >
+                    {formatMoney(note.amount, currency)}
+                  </span>
+                  {isIssued(note) && (
+                    <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+                      <Secondary
+                        text="Void"
+                        size="compact"
+                        isDisabled={busy}
+                        onClick={() => onAction({ type: 'void', creditNoteId: note.id })}
+                        ariaLabel={`Void credit note ${note.creditNoteNumber}`}
+                      />
+                    </PermissionGate>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {issuedNotes.length > 0 && (
+          <>
+            <span className="h-px bg-card-border" aria-hidden="true" />
+            <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
+              <span>Credited</span>
+              <span className="tabular-nums text-[13px] font-bold text-[var(--ink-body)]">
+                {formatMoney(credited, currency)}
+              </span>
+            </div>
+          </>
+        )}
+
+        <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+          {remaining > 0 ? (
+            <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
+              <div className="flex flex-wrap items-end gap-2">
+                <div className="flex flex-col gap-1 w-32">
+                  <label
+                    htmlFor="credit-note-amount"
+                    className="text-[12px] text-[var(--ink-muted)]"
+                  >
+                    Amount
+                  </label>
+                  <span className="flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active">
+                    <input
+                      id="credit-note-amount"
+                      type="number"
+                      inputMode="decimal"
+                      min={0}
+                      max={remaining}
+                      value={amountInput}
+                      onChange={(e) => setAmountInput(e.target.value)}
+                      className="min-w-0 flex-1 bg-transparent px-3 py-2 text-[13px] text-[var(--ink-body)] outline-none"
+                    />
+                  </span>
+                </div>
+                <div className="flex flex-col gap-1 flex-1 min-w-40">
+                  <label
+                    htmlFor="credit-note-reason"
+                    className="text-[12px] text-[var(--ink-muted)]"
+                  >
+                    Reason (optional)
+                  </label>
+                  <span className="flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active">
+                    <input
+                      id="credit-note-reason"
+                      type="text"
+                      value={reasonInput}
+                      onChange={(e) => setReasonInput(e.target.value)}
+                      className="min-w-0 flex-1 bg-transparent px-3 py-2 text-[13px] text-[var(--ink-body)] outline-none"
+                    />
+                  </span>
+                </div>
+                <Secondary
+                  text={busy ? 'Working...' : 'Issue credit note'}
+                  isDisabled={busy}
+                  onClick={handleIssue}
+                  ariaLabel="Issue a credit note against this invoice"
+                />
+              </div>
+              <p className="text-[12px] text-[var(--ink-muted)]">
+                {`Up to ${formatCap(remaining, currency)} can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.`}
+              </p>
+            </div>
+          ) : (
+            <p className="text-[12px] text-[var(--ink-muted)] border-t border-t-card-border pt-3!">
+              This invoice is fully credited.
+            </p>
+          )}
+        </PermissionGate>
+
+        {message ? (
+          <p role="alert" className="text-[13px] text-text-error">
+            {message}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default InvoiceCreditNotes;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -1,11 +1,14 @@
 'use client';
 import React, { useMemo, useState } from 'react';
 import type { CreditNote } from '@yosemite-crew/types';
-import { currencySymbol, formatMoney } from '@/app/lib/money';
+import { formatMoney } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
-import { Secondary } from '@/app/ui/primitives/Buttons';
 import { remainingCreditable } from '@/app/features/finance/services/creditNoteService';
+import CreditNoteLedger, {
+  isIssued,
+} from '@/app/features/finance/pages/Finance/Sections/CreditNoteLedger';
+import CreditNoteIssueForm from '@/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm';
 
 export type CreditNoteAction =
   { type: 'issue'; amount: number; reason?: string } | { type: 'void'; creditNoteId: string };
@@ -20,33 +23,15 @@ type InvoiceCreditNotesProps = {
   onAction: (action: CreditNoteAction) => void;
 };
 
-const isIssued = (note: CreditNote) => note.status === 'ISSUED';
-
 /**
- * The cap, to the penny.
- *
- * `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the
- * ledger rows beside the rest of the invoice panel but wrong for this one
- * figure: a remaining 159.97 advertised as "160" invites the user to type 160
- * and take a 409 back from the service, whose own cap is exact.
- */
-const formatCap = (amount: number, currency: string) =>
-  `${currencySymbol(currency)}${amount.toFixed(2)}`;
-
-/**
- * The credit ledger on an invoice: what has been credited, and the controls to
- * credit more or reverse one.
- *
- * The amount field is capped client-side at what the service will accept - the
- * invoice total minus every ISSUED note - so the common mistake produces a
- * message here rather than a 409 from the API. The server check remains the
- * authority; this only saves a round trip.
+ * The credit ledger on an invoice, and the controls to credit more or reverse
+ * one.
  *
  * Issuing a credit note has a side effect worth knowing about: the service
  * cancels every PaymentAttempt on the invoice that is not already SUCCEEDED or
  * CANCELED, because an outstanding Stripe checkout link still names the old
- * amount and would collect the full sum. That is why the copy warns about open
- * payment links rather than staying silent.
+ * amount and would collect the full sum. That is why the form's copy warns
+ * about open payment links rather than staying silent.
  */
 const InvoiceCreditNotes = ({
   creditNotes,
@@ -56,8 +41,6 @@ const InvoiceCreditNotes = ({
   error,
   onAction,
 }: InvoiceCreditNotesProps) => {
-  const [amountInput, setAmountInput] = useState('');
-  const [reasonInput, setReasonInput] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   const notes = useMemo(() => creditNotes ?? [], [creditNotes]);
@@ -67,73 +50,18 @@ const InvoiceCreditNotes = ({
     [issuedNotes]
   );
   const remaining = remainingCreditable(totalAmount, notes);
-
-  const handleIssue = () => {
-    const amount = Number(amountInput.trim());
-    if (!Number.isFinite(amount) || amount <= 0) {
-      setFormError('Enter a credit amount above zero.');
-      return;
-    }
-    if (amount > remaining) {
-      setFormError(
-        `The most that can still be credited on this invoice is ${formatCap(remaining, currency)}.`
-      );
-      return;
-    }
-    setFormError(null);
-    onAction({ type: 'issue', amount, reason: reasonInput.trim() || undefined });
-    setAmountInput('');
-    setReasonInput('');
-  };
-
   const message = formError ?? error;
 
   return (
     <section className="flex flex-col gap-3" aria-label="Credit notes">
       <h3 className="text-[13px] font-bold text-[var(--ink)]">Credit notes</h3>
       <div className="rounded-[14px] border border-card-border px-4.5 py-4 flex flex-col gap-3">
-        {notes.length === 0 ? (
-          <p className="text-[13px] text-[var(--ink-muted)]">
-            Nothing has been credited against this invoice.
-          </p>
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {notes.map((note) => (
-              <li key={note.id} className="flex items-center justify-between gap-3">
-                <span className="flex flex-col">
-                  <span className="text-[13px] text-[var(--ink-body)]">
-                    {note.creditNoteNumber}
-                    {note.status === 'VOIDED' ? ' (voided)' : ''}
-                  </span>
-                  {note.reason ? (
-                    <span className="text-[12px] text-[var(--ink-muted)]">{note.reason}</span>
-                  ) : null}
-                </span>
-                <span className="flex items-center gap-3">
-                  <span
-                    className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]"
-                    style={
-                      note.status === 'VOIDED' ? { textDecoration: 'line-through' } : undefined
-                    }
-                  >
-                    {formatMoney(note.amount, currency)}
-                  </span>
-                  {isIssued(note) && (
-                    <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-                      <Secondary
-                        text="Void"
-                        size="compact"
-                        isDisabled={busy}
-                        onClick={() => onAction({ type: 'void', creditNoteId: note.id })}
-                        ariaLabel={`Void credit note ${note.creditNoteNumber}`}
-                      />
-                    </PermissionGate>
-                  )}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
+        <CreditNoteLedger
+          notes={notes}
+          currency={currency}
+          busy={busy}
+          onVoid={(creditNoteId) => onAction({ type: 'void', creditNoteId })}
+        />
 
         {issuedNotes.length > 0 && (
           <>
@@ -149,56 +77,14 @@ const InvoiceCreditNotes = ({
 
         <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
           {remaining > 0 ? (
-            <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
-              <div className="flex flex-wrap items-end gap-2">
-                <div className="flex flex-col gap-1 w-32">
-                  <label
-                    htmlFor="credit-note-amount"
-                    className="text-[12px] text-[var(--ink-muted)]"
-                  >
-                    Amount
-                  </label>
-                  <span className="flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active">
-                    <input
-                      id="credit-note-amount"
-                      type="number"
-                      inputMode="decimal"
-                      min={0}
-                      max={remaining}
-                      value={amountInput}
-                      onChange={(e) => setAmountInput(e.target.value)}
-                      className="min-w-0 flex-1 bg-transparent px-3 py-2 text-[13px] text-[var(--ink-body)] outline-none"
-                    />
-                  </span>
-                </div>
-                <div className="flex flex-col gap-1 flex-1 min-w-40">
-                  <label
-                    htmlFor="credit-note-reason"
-                    className="text-[12px] text-[var(--ink-muted)]"
-                  >
-                    Reason (optional)
-                  </label>
-                  <span className="flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active">
-                    <input
-                      id="credit-note-reason"
-                      type="text"
-                      value={reasonInput}
-                      onChange={(e) => setReasonInput(e.target.value)}
-                      className="min-w-0 flex-1 bg-transparent px-3 py-2 text-[13px] text-[var(--ink-body)] outline-none"
-                    />
-                  </span>
-                </div>
-                <Secondary
-                  text={busy ? 'Working...' : 'Issue credit note'}
-                  isDisabled={busy}
-                  onClick={handleIssue}
-                  ariaLabel="Issue a credit note against this invoice"
-                />
-              </div>
-              <p className="text-[12px] text-[var(--ink-muted)]">
-                {`Up to ${formatCap(remaining, currency)} can still be credited. Issuing one cancels any open payment link on this invoice, because it would still charge the old amount.`}
-              </p>
-            </div>
+            <CreditNoteIssueForm
+              remaining={remaining}
+              currency={currency}
+              busy={busy}
+              onIssue={(draft) => onAction({ type: 'issue', ...draft })}
+              onInvalid={setFormError}
+              onValid={() => setFormError(null)}
+            />
           ) : (
             <p className="text-[12px] text-[var(--ink-muted)] border-t border-t-card-border pt-3!">
               This invoice is fully credited.

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -4,7 +4,10 @@ import type { CreditNote } from '@yosemite-crew/types';
 import { formatMoney } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
-import { remainingCreditable } from '@/app/features/finance/services/creditNoteService';
+import {
+  acceptsCreditNotes,
+  remainingCreditable,
+} from '@/app/features/finance/services/creditNoteService';
 import CreditNoteLedger, {
   isIssued,
 } from '@/app/features/finance/pages/Finance/Sections/CreditNoteLedger';
@@ -16,6 +19,8 @@ export type CreditNoteAction =
 type InvoiceCreditNotesProps = {
   creditNotes: CreditNote[] | undefined;
   totalAmount: number;
+  /** The invoice's status: CANCELLED and REFUNDED cannot take a credit note. */
+  status: string | undefined;
   currency: string;
   /** True while a credit note is being issued or voided, so actions lock. */
   busy: boolean;
@@ -36,6 +41,7 @@ type InvoiceCreditNotesProps = {
 const InvoiceCreditNotes = ({
   creditNotes,
   totalAmount,
+  status,
   currency,
   busy,
   error,
@@ -50,6 +56,7 @@ const InvoiceCreditNotes = ({
     [issuedNotes]
   );
   const remaining = remainingCreditable(totalAmount, notes);
+  const creditable = acceptsCreditNotes(status);
   const message = formError ?? error;
 
   return (
@@ -76,7 +83,7 @@ const InvoiceCreditNotes = ({
         )}
 
         <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-          {remaining > 0 ? (
+          {creditable && remaining > 0 && (
             <CreditNoteIssueForm
               remaining={remaining}
               currency={currency}
@@ -85,9 +92,15 @@ const InvoiceCreditNotes = ({
               onInvalid={setFormError}
               onValid={() => setFormError(null)}
             />
-          ) : (
+          )}
+          {creditable && remaining <= 0 && (
             <p className="text-[12px] text-[var(--ink-muted)] border-t border-t-card-border pt-3!">
               This invoice is fully credited.
+            </p>
+          )}
+          {!creditable && (
+            <p className="text-[12px] text-[var(--ink-muted)] border-t border-t-card-border pt-3!">
+              {`A ${String(status).toLowerCase()} invoice cannot take a credit note.`}
             </p>
           )}
         </PermissionGate>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -6,11 +6,10 @@ import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import {
   acceptsCreditNotes,
+  isIssued,
   remainingCreditable,
 } from '@/app/features/finance/services/creditNoteService';
-import CreditNoteLedger, {
-  isIssued,
-} from '@/app/features/finance/pages/Finance/Sections/CreditNoteLedger';
+import CreditNoteLedger from '@/app/features/finance/pages/Finance/Sections/CreditNoteLedger';
 import CreditNoteIssueForm from '@/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm';
 
 export type CreditNoteAction =

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -25,6 +25,8 @@ type InvoiceCreditNotesProps = {
   /** True while a credit note is being issued or voided, so actions lock. */
   busy: boolean;
   error: string | null;
+  /** Bumped when the server accepts a credit note, so the form clears then. */
+  issuedToken: number;
   onAction: (action: CreditNoteAction) => void;
 };
 
@@ -45,6 +47,7 @@ const InvoiceCreditNotes = ({
   currency,
   busy,
   error,
+  issuedToken,
   onAction,
 }: InvoiceCreditNotesProps) => {
   const [formError, setFormError] = useState<string | null>(null);
@@ -88,6 +91,7 @@ const InvoiceCreditNotes = ({
               remaining={remaining}
               currency={currency}
               busy={busy}
+              issuedToken={issuedToken}
               onIssue={(draft) => onAction({ type: 'issue', ...draft })}
               onInvalid={setFormError}
               onValid={() => setFormError(null)}

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
@@ -18,6 +18,8 @@ import InvoiceSummaryPanel from '@/app/features/finance/pages/Finance/Sections/I
 import InvoiceBilledTo from '@/app/features/finance/pages/Finance/Sections/InvoiceBilledTo';
 import InvoicePaymentLedger from '@/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger';
 import InvoicePhoneRecord from '@/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord';
+import InvoiceCreditNotes from '@/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes';
+import { useInvoiceCreditNotes } from '@/app/features/finance/hooks/useInvoiceCreditNotes';
 
 type InvoiceInfoProps = {
   showModal: boolean;
@@ -27,6 +29,7 @@ type InvoiceInfoProps = {
 
 const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
+  const creditNotes = useInvoiceCreditNotes(activeInvoice);
   const currency = useCurrencyForPrimaryOrg();
   const router = useRouter();
   const isPhone = useIsPhone();
@@ -124,6 +127,14 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
                 </div>
                 <div className="flex flex-col gap-5">
                   <InvoiceSummaryPanel invoice={activeInvoice} currency={currency} />
+                  <InvoiceCreditNotes
+                    creditNotes={activeInvoice.creditNotes}
+                    totalAmount={activeInvoice.totalAmount ?? 0}
+                    currency={currency}
+                    busy={creditNotes.busy}
+                    error={creditNotes.error}
+                    onAction={creditNotes.run}
+                  />
                   <InvoiceBilledTo parentId={parentId} appointment={appointment} />
                 </div>
               </div>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
@@ -86,18 +86,34 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
     >
       {isPhone ? (
         activeInvoice && (
-          <InvoicePhoneRecord
-            titleId={titleId}
-            invoice={activeInvoice}
-            appointment={appointment}
-            currency={currency}
-            statusLabel={invoiceStatusLabel}
-            statusTone={invoiceStatusTone}
-            payerName={payerName}
-            payerEmail={payerEmail}
-            onClose={() => setShowModal(false)}
-            onOpenAppointment={goToAppointmentFinance}
-          />
+          <div className="flex flex-col gap-4">
+            <InvoicePhoneRecord
+              titleId={titleId}
+              invoice={activeInvoice}
+              appointment={appointment}
+              currency={currency}
+              statusLabel={invoiceStatusLabel}
+              statusTone={invoiceStatusTone}
+              payerName={payerName}
+              payerEmail={payerEmail}
+              onClose={() => setShowModal(false)}
+              onOpenAppointment={goToAppointmentFinance}
+            />
+            {/*
+              InvoicePhoneRecord neither takes nor renders credit notes, so
+              without this the ledger and its actions would exist on desktop
+              only and a phone user could not see, issue or void one.
+            */}
+            <InvoiceCreditNotes
+              creditNotes={activeInvoice.creditNotes}
+              totalAmount={activeInvoice.totalAmount ?? 0}
+              status={activeInvoice.status}
+              currency={currency}
+              busy={creditNotes.busy}
+              error={creditNotes.error}
+              onAction={creditNotes.run}
+            />
+          </div>
         )
       ) : (
         <div className="flex flex-col flex-auto min-h-0 gap-4">
@@ -130,6 +146,7 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
                   <InvoiceCreditNotes
                     creditNotes={activeInvoice.creditNotes}
                     totalAmount={activeInvoice.totalAmount ?? 0}
+                    status={activeInvoice.status}
                     currency={currency}
                     busy={creditNotes.busy}
                     error={creditNotes.error}

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
@@ -110,6 +110,7 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
               status={activeInvoice.status}
               currency={currency}
               busy={creditNotes.busy}
+              issuedToken={creditNotes.issuedToken}
               error={creditNotes.error}
               onAction={creditNotes.run}
             />
@@ -149,6 +150,7 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
                     status={activeInvoice.status}
                     currency={currency}
                     busy={creditNotes.busy}
+                    issuedToken={creditNotes.issuedToken}
                     error={creditNotes.error}
                     onAction={creditNotes.run}
                   />

--- a/apps/frontend/src/app/features/finance/services/creditNoteService.ts
+++ b/apps/frontend/src/app/features/finance/services/creditNoteService.ts
@@ -1,5 +1,6 @@
 import type { CreditNote } from '@yosemite-crew/types';
 import { postData } from '@/app/services/axios';
+import { currencySymbol } from '@/app/lib/money';
 
 /**
  * Credit notes live on the invoice router, which is mounted at `/fhir/v1/invoice`
@@ -77,18 +78,53 @@ export const voidCreditNote = async (
 };
 
 /**
+ * Round to cents exactly the way the backend's `roundMoney` does
+ * (`apps/backend/src/services/finance/pricing.ts`).
+ *
+ * Not cosmetic. Without it the raw subtraction leaves float dust - a total of
+ * 10.01 against an issued 0.05 gives 9.959999999999999 - which the UI displays
+ * as "9.96" while rejecting an entered 9.96 as over the cap, refusing the exact
+ * figure it just advertised. The server, which rounds, would have accepted it.
+ */
+const roundMoney = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100;
+
+/**
  * What is still creditable on an invoice.
  *
  * Mirrors the cap in `InvoiceService.issueCreditNote`: the total minus every
- * credit note currently ISSUED. Voided notes do not count, which is why the
- * filter is on status rather than simply summing the list.
+ * credit note currently ISSUED, rounded to cents the same way. Voided notes do
+ * not count, which is why the filter is on status rather than simply summing
+ * the list.
  */
 export const remainingCreditable = (
   totalAmount: number,
   creditNotes: readonly CreditNote[] | undefined
 ): number => {
-  const issued = (creditNotes ?? [])
-    .filter((note) => note.status === 'ISSUED')
-    .reduce((sum, note) => sum + note.amount, 0);
-  return Math.max(0, totalAmount - issued);
+  const issued = roundMoney(
+    (creditNotes ?? [])
+      .filter((note) => note.status === 'ISSUED')
+      .reduce((sum, note) => sum + note.amount, 0)
+  );
+  return Math.max(0, roundMoney(totalAmount - issued));
 };
+
+/**
+ * Whether the invoice's status lets it take a credit note at all.
+ *
+ * `InvoiceService.issueCreditNote` rejects CANCELLED and REFUNDED with a 409
+ * regardless of the balance, so offering the form on one of those would invite
+ * a request that can only fail.
+ */
+export const acceptsCreditNotes = (status: string | undefined): boolean =>
+  status !== 'CANCELLED' && status !== 'REFUNDED';
+
+/**
+ * The cap, to the penny.
+ *
+ * `formatMoney` runs at `maximumFractionDigits: 0`, which is right for the
+ * ledger rows beside the rest of the invoice panel but wrong for this one
+ * figure: a remaining 159.97 advertised as "160" invites the user to type 160
+ * and take a 409 back from the service, whose own cap is exact.
+ */
+export const formatCap = (amount: number, currency: string) =>
+  `${currencySymbol(currency)}${amount.toFixed(2)}`;

--- a/apps/frontend/src/app/features/finance/services/creditNoteService.ts
+++ b/apps/frontend/src/app/features/finance/services/creditNoteService.ts
@@ -1,0 +1,94 @@
+import type { CreditNote } from '@yosemite-crew/types';
+import { postData } from '@/app/services/axios';
+
+/**
+ * Credit notes live on the invoice router, which is mounted at `/fhir/v1/invoice`
+ * rather than under `/v1/finance` like the rest of the finance API. The split is
+ * load-bearing: posting these to the finance prefix 404s.
+ */
+const creditNotesPath = (invoiceId: string) => `/fhir/v1/invoice/${invoiceId}/credit-notes`;
+
+type FinanceEnvelope<T> = {
+  data: T;
+  meta?: unknown;
+  error?: { code?: string; message?: string } | null;
+};
+
+const unwrap = <T>(value: T | FinanceEnvelope<T>): T => {
+  if (value && typeof value === 'object' && 'data' in value) {
+    const envelope = value as FinanceEnvelope<T>;
+    if (envelope.error) {
+      throw new Error(envelope.error.message || envelope.error.code || 'Finance request failed');
+    }
+    return envelope.data;
+  }
+  return value as T;
+};
+
+/**
+ * Human-readable message from a credit-note failure.
+ *
+ * The invoice controller replies with a bare `{ message }` on failure, not the
+ * success envelope, and axios only carries "Request failed with status code N"
+ * on `error.message` - so the body has to be read. The messages worth surfacing
+ * verbatim are the service's own 409s: "Credit note amount exceeds invoice
+ * remaining amount" and "Invoice cannot accept credit notes."
+ */
+export const getCreditNoteErrorMessage = (error: unknown, fallback: string): string => {
+  const data = (error as { response?: { data?: unknown } } | null)?.response?.data;
+  if (typeof data === 'object' && data !== null) {
+    const body = data as { message?: unknown; error?: { message?: unknown } };
+    const message = body.error?.message ?? body.message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  return fallback;
+};
+
+export type IssueCreditNoteInput = {
+  amount: number;
+  reason?: string;
+};
+
+export const issueCreditNote = async (
+  invoiceId: string,
+  input: IssueCreditNoteInput
+): Promise<CreditNote> => {
+  if (!invoiceId) throw new Error('Invoice ID missing');
+  const res = await postData<CreditNote | FinanceEnvelope<CreditNote>>(creditNotesPath(invoiceId), {
+    amount: input.amount,
+    ...(input.reason?.trim() ? { reason: input.reason.trim() } : {}),
+  });
+  return unwrap(res.data);
+};
+
+export const voidCreditNote = async (
+  invoiceId: string,
+  creditNoteId: string,
+  reason?: string
+): Promise<CreditNote> => {
+  if (!invoiceId) throw new Error('Invoice ID missing');
+  if (!creditNoteId) throw new Error('Credit note ID missing');
+  const res = await postData<CreditNote | FinanceEnvelope<CreditNote>>(
+    `${creditNotesPath(invoiceId)}/${creditNoteId}/void`,
+    reason?.trim() ? { reason: reason.trim() } : {}
+  );
+  return unwrap(res.data);
+};
+
+/**
+ * What is still creditable on an invoice.
+ *
+ * Mirrors the cap in `InvoiceService.issueCreditNote`: the total minus every
+ * credit note currently ISSUED. Voided notes do not count, which is why the
+ * filter is on status rather than simply summing the list.
+ */
+export const remainingCreditable = (
+  totalAmount: number,
+  creditNotes: readonly CreditNote[] | undefined
+): number => {
+  const issued = (creditNotes ?? [])
+    .filter((note) => note.status === 'ISSUED')
+    .reduce((sum, note) => sum + note.amount, 0);
+  return Math.max(0, totalAmount - issued);
+};

--- a/apps/frontend/src/app/features/finance/services/creditNoteService.ts
+++ b/apps/frontend/src/app/features/finance/services/creditNoteService.ts
@@ -128,3 +128,6 @@ export const acceptsCreditNotes = (status: string | undefined): boolean =>
  */
 export const formatCap = (amount: number, currency: string) =>
   `${currencySymbol(currency)}${amount.toFixed(2)}`;
+
+/** An ISSUED note is the only kind that still reduces the invoice. */
+export const isIssued = (note: CreditNote) => note.status === 'ISSUED';


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Credit notes are complete and unreachable, and the client is also discarding the data the API already sends.

- `CreditNote` is modelled and migrated, `issueCreditNote` and `voidCreditNote` are implemented with cap enforcement, stale-PaymentAttempt cancellation and FinanceEvent emission, and both are routed at `POST /fhir/v1/invoice/:invoiceId/credit-notes` and `.../:creditNoteId/void` behind `billing:edit:any`.
- No client calls either one.
- `normalizeFinanceInvoice` (`apps/frontend/src/app/features/billing/services/invoiceService.ts:197`) builds its result field by field and copies neither `creditNotes` nor `settlementSummary`, so even where the backend supplies the ledger it never reaches a component.

There are 0 `CreditNote` rows on dev, which is a consequence of the above rather than evidence the feature is unwanted.

## What is the new behavior?

A credit ledger on the invoice detail, beneath the summary panel: every credit note with its number, reason and amount, a voided one struck through and labelled, the credited total, and an amount-and-reason form to issue another. Each issued note carries a Void control. Everything that writes is behind `billing:edit:any`.

`normalizeFinanceInvoice` now carries `creditNotes` and `settlementSummary` through.

Two details worth a reviewer's attention:

**The path prefix is load-bearing.** Credit notes are on `invoiceRouter`, mounted at `/fhir/v1/invoice`, while the rest of the finance API is under `/v1/finance`. Posting to the wrong prefix 404s, so the service asserts the literal path and a test asserts it does not contain `/v1/finance`.

**The cap is rendered to the penny, deliberately.** It mirrors the service's own cap - total minus every ISSUED note, so a voided note stops reducing it - but `formatMoney` runs at `maximumFractionDigits: 0`, and a remaining 159.97 advertised as "160" invites the user to type 160 and take a 409 back. The ledger rows still use `formatMoney`, matching the invoice panel they sit under; only the cap is exact.

The copy warning that issuing cancels an open payment link is not filler: `issueCreditNote` cancels every `PaymentAttempt` that is not already SUCCEEDED or CANCELED, because an outstanding Stripe checkout link still names the pre-credit amount and would collect the full sum. A user who is not told will not guess.

### Out of scope

Any change to `InvoiceService`. Refunds, which are a separate concern on a different router.

## Known gap, filed separately

The invoice's **Outstanding** figure still does not respond to a credit note. Chasing that turned out to be a live defect much wider than credit notes: `getInvoiceOutstanding` documents itself as preferring `settlementSummary.balance`, but `listForOrganisation` returns no `settlementSummary` and no `payments`, so the preferred branch is unreachable on the finance list and the fallback `totalAmount - deposit` is the only path ever taken.

Measured on dev: three unsettled invoices have recorded payments and no deposit, and are presented as owing 1654.25 against a true 767.03. One shows 484.13 outstanding when the client has paid all but 3.75.

Filed as #2595 with the query and the numbers. It needs a batched fix on the list endpoint, not an inline one - dev already holds 398 invoices and the naive shape is two extra queries each.

## Validation performed

Measured, not estimated:

- `npx tsc --noEmit` from `apps/frontend`: exit 0.
- `pnpm --filter frontend run lint`: exit 0. The one warning is a pre-existing unused eslint-disable in `CompanionIdCard.test.tsx`, untouched here.
- Full frontend suite: **978 suites, 12144 tests, all passing** - including the repo-wide `colorUtilityExists` guard, run deliberately because a targeted run does not load it.
- Coverage on all three new files - `creditNoteService.ts`, `useInvoiceCreditNotes.ts`, `InvoiceCreditNotes.tsx`: 100% statements, branches, functions and lines.
- The service tests were mutation-checked: four mutations applied one at a time (path prefix switched to the finance prefix, the ISSUED filter removed, `reason.trim()` removed, the `Math.max(0, ...)` floor removed) and each was caught by a failing test. Green there means the assertions bite.
- Aikido SAST and secrets scan on the new service and hook: no issues.
- Visual QA: 20 Storybook screenshots across 8 states at 1440 and 390 in both light and dark, no play-function or console errors. The exact-cap fix was verified visually at phone width in dark: the hint and the error both read the true remaining figure rather than a rounded one.

Not verified: the signed-in flow on deployed dev, since local login is blocked by SuperTokens cross-origin. Issuing and voiding a real credit note needs a pass on dev.yosemitecrew.com after merge.

## Related Issue(s)

Refs #2595
