### PR TITLE
fix(backend): key developer API keys, billing and usage to the developer

### DIFF
--- a/apps/backend/src/controllers/web/developer-api-key.controller.ts
+++ b/apps/backend/src/controllers/web/developer-api-key.controller.ts
@@ -1,3 +1,17 @@
+/*
+ * These routes are scoped to the DEVELOPER, not to a practice.
+ *
+ * They were gated on `withOrgPermissions()` and keyed on an organisation, which
+ * the portal's own audience never has: signing up through the developer door
+ * grants the `developer` role and nothing else, there is no developer entry in
+ * the RBAC role model, and no UserOrganization row is created. Every request
+ * from such an account failed on the org middleware before reaching a handler.
+ * See issue #2551.
+ *
+ * The caller's own verified id is the owner. `resolveVerifiedUserId` reads only
+ * the session (`utils/request.ts` deliberately dropped its `x-user-id` header
+ * fallback), so the owner cannot be spoofed by a header the way an org could be.
+ */
 import { Request, Response } from "express";
 import { z } from "zod";
 import { DeveloperApiKeyEnvironment } from "@prisma/client";
@@ -6,7 +20,6 @@ import {
   DeveloperApiKeyServiceError,
 } from "../../services/developer-api-key.service";
 import logger from "../../utils/logger";
-import type { OrgRequest } from "src/middlewares/rbac";
 import { resolveVerifiedUserId } from "src/utils/request";
 
 const CreateApiKeySchema = z.object({
@@ -15,9 +28,6 @@ const CreateApiKeySchema = z.object({
   environment: z.nativeEnum(DeveloperApiKeyEnvironment).optional(),
   expiresAt: z.string().datetime().optional(),
 });
-
-const getOrgId = (req: Request): string | undefined =>
-  (req as OrgRequest).organisationId;
 
 const handleError = (
   res: Response,
@@ -34,12 +44,8 @@ const handleError = (
 export const DeveloperApiKeyController = {
   createApiKey: async (req: Request, res: Response): Promise<Response> => {
     try {
-      const organisationId = getOrgId(req);
-      if (!organisationId) {
-        return res.status(400).json({ message: "Missing organisationId" });
-      }
-      const createdBy = resolveVerifiedUserId(req);
-      if (!createdBy) {
+      const ownerUserId = resolveVerifiedUserId(req);
+      if (!ownerUserId) {
         return res.status(401).json({ message: "Unauthorized" });
       }
 
@@ -52,9 +58,9 @@ export const DeveloperApiKeyController = {
 
       const { name, scopes, environment, expiresAt } = parsed.data;
       const issued = await DeveloperApiKeyService.issue({
-        organisationId,
+        ownerUserId,
         name,
-        createdBy,
+        createdBy: ownerUserId,
         scopes,
         environment,
         expiresAt: expiresAt ? new Date(expiresAt) : null,
@@ -67,11 +73,11 @@ export const DeveloperApiKeyController = {
 
   listApiKeys: async (req: Request, res: Response): Promise<Response> => {
     try {
-      const organisationId = getOrgId(req);
-      if (!organisationId) {
-        return res.status(400).json({ message: "Missing organisationId" });
+      const ownerUserId = resolveVerifiedUserId(req);
+      if (!ownerUserId) {
+        return res.status(401).json({ message: "Unauthorized" });
       }
-      const keys = await DeveloperApiKeyService.list(organisationId);
+      const keys = await DeveloperApiKeyService.list(ownerUserId);
       return res.status(200).json({ data: keys });
     } catch (error) {
       return handleError(res, error, "list");
@@ -80,12 +86,12 @@ export const DeveloperApiKeyController = {
 
   revokeApiKey: async (req: Request, res: Response): Promise<Response> => {
     try {
-      const organisationId = getOrgId(req);
-      if (!organisationId) {
-        return res.status(400).json({ message: "Missing organisationId" });
+      const ownerUserId = resolveVerifiedUserId(req);
+      if (!ownerUserId) {
+        return res.status(401).json({ message: "Unauthorized" });
       }
       await DeveloperApiKeyService.revoke({
-        organisationId,
+        ownerUserId,
         keyId: req.params.keyId,
       });
       return res.status(204).send();

--- a/apps/backend/src/controllers/web/developer-billing.controller.ts
+++ b/apps/backend/src/controllers/web/developer-billing.controller.ts
@@ -1,14 +1,25 @@
+/*
+ * These routes are scoped to the DEVELOPER, not to a practice.
+ *
+ * They were gated on `withOrgPermissions()` and keyed on an organisation, which
+ * the portal's own audience never has: signing up through the developer door
+ * grants the `developer` role and nothing else, there is no developer entry in
+ * the RBAC role model, and no UserOrganization row is created. Every request
+ * from such an account failed on the org middleware before reaching a handler.
+ * See issue #2551.
+ *
+ * The caller's own verified id is the owner. `resolveVerifiedUserId` reads only
+ * the session (`utils/request.ts` deliberately dropped its `x-user-id` header
+ * fallback), so the owner cannot be spoofed by a header the way an org could be.
+ */
 import type { Request, Response } from "express";
 import { z } from "zod";
 import logger from "../../utils/logger";
-import type { OrgRequest } from "src/middlewares/rbac";
+import { resolveVerifiedUserId } from "src/utils/request";
 import {
   DeveloperBillingService,
   DeveloperBillingServiceError,
 } from "../../services/developer-billing.service";
-
-const getOrgId = (req: Request): string | undefined =>
-  (req as OrgRequest).organisationId;
 
 const CheckoutSchema = z.object({
   successUrl: z.string().url(),
@@ -30,14 +41,13 @@ const handleError = (err: unknown, res: Response): void => {
 
 export const DeveloperBillingController = {
   getSubscription: async (req: Request, res: Response): Promise<void> => {
-    const organisationId = getOrgId(req);
-    if (!organisationId) {
-      res.status(400).json({ error: "organisationId is required" });
+    const ownerUserId = resolveVerifiedUserId(req);
+    if (!ownerUserId) {
+      res.status(401).json({ error: "Unauthorized" });
       return;
     }
     try {
-      const data =
-        await DeveloperBillingService.getSubscription(organisationId);
+      const data = await DeveloperBillingService.getSubscription(ownerUserId);
       res.json({ data });
     } catch (err) {
       handleError(err, res);
@@ -45,9 +55,9 @@ export const DeveloperBillingController = {
   },
 
   createCheckout: async (req: Request, res: Response): Promise<void> => {
-    const organisationId = getOrgId(req);
-    if (!organisationId) {
-      res.status(400).json({ error: "organisationId is required" });
+    const ownerUserId = resolveVerifiedUserId(req);
+    if (!ownerUserId) {
+      res.status(401).json({ error: "Unauthorized" });
       return;
     }
     const parsed = CheckoutSchema.safeParse(req.body);
@@ -60,7 +70,7 @@ export const DeveloperBillingController = {
     }
     try {
       const url = await DeveloperBillingService.createCheckoutSession({
-        organisationId,
+        ownerUserId,
         ...parsed.data,
       });
       res.status(201).json({ data: { url } });
@@ -70,9 +80,9 @@ export const DeveloperBillingController = {
   },
 
   createPortal: async (req: Request, res: Response): Promise<void> => {
-    const organisationId = getOrgId(req);
-    if (!organisationId) {
-      res.status(400).json({ error: "organisationId is required" });
+    const ownerUserId = resolveVerifiedUserId(req);
+    if (!ownerUserId) {
+      res.status(401).json({ error: "Unauthorized" });
       return;
     }
     const parsed = PortalSchema.safeParse(req.body);
@@ -82,7 +92,7 @@ export const DeveloperBillingController = {
     }
     try {
       const url = await DeveloperBillingService.createPortalSession({
-        organisationId,
+        ownerUserId,
         returnUrl: parsed.data.returnUrl,
       });
       res.status(201).json({ data: { url } });

--- a/apps/backend/src/controllers/web/developer-usage.controller.ts
+++ b/apps/backend/src/controllers/web/developer-usage.controller.ts
@@ -1,22 +1,33 @@
+/*
+ * These routes are scoped to the DEVELOPER, not to a practice.
+ *
+ * They were gated on `withOrgPermissions()` and keyed on an organisation, which
+ * the portal's own audience never has: signing up through the developer door
+ * grants the `developer` role and nothing else, there is no developer entry in
+ * the RBAC role model, and no UserOrganization row is created. Every request
+ * from such an account failed on the org middleware before reaching a handler.
+ * See issue #2551.
+ *
+ * The caller's own verified id is the owner. `resolveVerifiedUserId` reads only
+ * the session (`utils/request.ts` deliberately dropped its `x-user-id` header
+ * fallback), so the owner cannot be spoofed by a header the way an org could be.
+ */
 import type { Request, Response } from "express";
 import logger from "../../utils/logger";
-import type { OrgRequest } from "src/middlewares/rbac";
+import { resolveVerifiedUserId } from "src/utils/request";
 import { DeveloperUsageService } from "../../services/developer-usage.service";
-
-const getOrgId = (req: Request): string | undefined =>
-  (req as OrgRequest).organisationId;
 
 export const DeveloperUsageController = {
   getUsage: async (req: Request, res: Response): Promise<void> => {
-    const organisationId = getOrgId(req);
-    if (!organisationId) {
-      res.status(400).json({ error: "organisationId is required" });
+    const ownerUserId = resolveVerifiedUserId(req);
+    if (!ownerUserId) {
+      res.status(401).json({ error: "Unauthorized" });
       return;
     }
     const period =
       typeof req.query.period === "string" ? req.query.period : undefined;
     try {
-      const data = await DeveloperUsageService.getUsage(organisationId, period);
+      const data = await DeveloperUsageService.getUsage(ownerUserId, period);
       res.json({ data });
     } catch (err) {
       logger.error("DeveloperUsageController.getUsage failed", err);

--- a/apps/backend/src/middlewares/api-key-auth.ts
+++ b/apps/backend/src/middlewares/api-key-auth.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import type { OrgRequest } from "src/middlewares/rbac";
+import type { AuthenticatedRequest } from "src/middlewares/auth";
 import {
   DeveloperApiKeyService,
   type VerifiedApiKey,
@@ -18,10 +18,28 @@ const extractApiKey = (req: Request): string | undefined => {
   return req.header("x-api-key")?.trim() || undefined;
 };
 
-// Authenticates a request with a developer API key (Authorization: Bearer yc_...
-// or X-API-Key). On success the request is bound to the key's organisation so the
-// existing org-scoped RBAC applies; agents and servers use this path, never a
-// browser session.
+/*
+ * Authenticates a request with a developer API key (`Authorization: Bearer yc_…`
+ * or `X-API-Key`). Agents and servers use this path, never a browser session.
+ *
+ * A key identifies a PERSON, not a practice. It binds `userId`, the same field a
+ * session sets, so anything downstream that already reads the caller's identity
+ * works unchanged.
+ *
+ * The previous comment claimed the request was bound to the key's organisation
+ * "so the existing org-scoped RBAC applies". That composition could not run:
+ * this set only `organisationId` and never `userId`, while `withOrgPermissions()`
+ * requires both and answers 400 without the second. Nothing noticed because the
+ * middleware is mounted on no route.
+ *
+ * To scope a public route to a practice, compose `authorizeApiKey` with
+ * `withOrgPermissions()` and `requirePermission(...)`: the organisation arrives
+ * in `x-org-id` or the path exactly as it does for a browser session, and
+ * `withOrgPermissions()` checks it against the owner's live `active: true`
+ * membership on every request. That is what makes an offboarded key holder stop
+ * reaching their former employer, which a key carrying a baked-in organisation
+ * could never do.
+ */
 export const authorizeApiKey = async (
   req: Request,
   res: Response,
@@ -38,7 +56,7 @@ export const authorizeApiKey = async (
   }
 
   const usage = await DeveloperUsageService.incrementAndCheck(
-    verified.organisationId,
+    verified.ownerUserId,
   );
   if (!usage.allowed) {
     return res.status(429).json({
@@ -47,7 +65,7 @@ export const authorizeApiKey = async (
   }
 
   (req as ApiKeyRequest).apiKey = verified;
-  (req as OrgRequest).organisationId = verified.organisationId;
+  (req as AuthenticatedRequest).userId = verified.ownerUserId;
   return next();
 };
 

--- a/apps/backend/src/middlewares/require-active-account.ts
+++ b/apps/backend/src/middlewares/require-active-account.ts
@@ -1,0 +1,48 @@
+// src/middlewares/require-active-account.ts
+import { NextFunction, Request, Response } from "express";
+
+import { prisma } from "src/config/prisma";
+import { AuthenticatedRequest } from "./auth";
+import logger from "src/utils/logger";
+
+/**
+ * Refuse a request whose session belongs to an account that has been deleted.
+ *
+ * `UserService.deleteById` soft-deletes: it sets `isActive: false` and removes
+ * the organisation memberships, but it cannot revoke the provider session, and
+ * the session middleware does not consult the flag. Every org-gated route was
+ * incidentally covered by that membership removal - `withOrgPermissions()`
+ * answers 403 once the rows are gone. The developer routes are scoped to the
+ * user rather than to an organisation, so they have no such cover and need the
+ * check stated explicitly.
+ *
+ * Revoking the session itself at deletion time is the broader fix and belongs
+ * with the auth boundary, which exposes no revocation call today.
+ */
+export const requireActiveAccount = () => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const userId = (req as AuthenticatedRequest).userId;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    try {
+      const user = await prisma.user.findFirst({
+        where: { userId },
+        select: { isActive: true },
+      });
+
+      if (!user?.isActive) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      return next();
+    } catch (err) {
+      logger.error("Failed to resolve the account state for a request", {
+        err,
+      });
+      return res.status(500).json({ error: "Failed to resolve the account" });
+    }
+  };
+};

--- a/apps/backend/src/routers/developer-api-key.router.ts
+++ b/apps/backend/src/routers/developer-api-key.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { DeveloperApiKeyController } from "../controllers/web/developer-api-key.controller";
 import { requireWebAuth } from "src/middlewares/auth";
+import { requireActiveAccount } from "src/middlewares/require-active-account";
 
 const router = Router();
 
@@ -14,6 +15,11 @@ const router = Router();
  * signup creates no UserOrganization row, so the middleware answered 400 before
  * any handler ran (issue #2551).
  *
+ * `requireActiveAccount()` sits alongside it because the soft delete leaves the
+ * session valid: an org-gated route is covered incidentally, since deletion
+ * removes the memberships `withOrgPermissions()` needs, but a user-scoped route
+ * has no such cover and would otherwise let a deleted account mint credentials.
+ *
  * A reviewer will want to add a `developer` role check back. Do not: the role is
  * self-assignable. `SELF_ASSIGNABLE_ROLES` in `user.controller.ts` lets a caller
  * claim `developer` by posting it to `POST /fhir/v1/user`, so gating on it would
@@ -21,11 +27,22 @@ const router = Router();
  * the authority, and ownership is enforced in the query.
  */
 
-router.post("/", requireWebAuth, DeveloperApiKeyController.createApiKey);
-router.get("/", requireWebAuth, DeveloperApiKeyController.listApiKeys);
+router.post(
+  "/",
+  requireWebAuth,
+  requireActiveAccount(),
+  DeveloperApiKeyController.createApiKey,
+);
+router.get(
+  "/",
+  requireWebAuth,
+  requireActiveAccount(),
+  DeveloperApiKeyController.listApiKeys,
+);
 router.delete(
   "/:keyId",
   requireWebAuth,
+  requireActiveAccount(),
   DeveloperApiKeyController.revokeApiKey,
 );
 

--- a/apps/backend/src/routers/developer-api-key.router.ts
+++ b/apps/backend/src/routers/developer-api-key.router.ts
@@ -1,29 +1,31 @@
 import { Router } from "express";
 import { DeveloperApiKeyController } from "../controllers/web/developer-api-key.controller";
 import { requireWebAuth } from "src/middlewares/auth";
-import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
 
 const router = Router();
 
-router.post(
-  "/",
-  requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("integrations:edit:any"),
-  DeveloperApiKeyController.createApiKey,
-);
-router.get(
-  "/",
-  requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("integrations:view:any"),
-  DeveloperApiKeyController.listApiKeys,
-);
+/*
+ * `requireWebAuth` only, deliberately, with no role or organisation gate.
+ *
+ * These resources belong to the developer, and the handlers scope every query
+ * to `resolveVerifiedUserId(req)` - the caller's own session-derived id. There
+ * is nothing for an org gate to protect here, and `withOrgPermissions()` made
+ * the routes unreachable for the very accounts they exist for: a developer
+ * signup creates no UserOrganization row, so the middleware answered 400 before
+ * any handler ran (issue #2551).
+ *
+ * A reviewer will want to add a `developer` role check back. Do not: the role is
+ * self-assignable. `SELF_ASSIGNABLE_ROLES` in `user.controller.ts` lets a caller
+ * claim `developer` by posting it to `POST /fhir/v1/user`, so gating on it would
+ * turn a value the caller controls into an authorisation input. The session is
+ * the authority, and ownership is enforced in the query.
+ */
+
+router.post("/", requireWebAuth, DeveloperApiKeyController.createApiKey);
+router.get("/", requireWebAuth, DeveloperApiKeyController.listApiKeys);
 router.delete(
   "/:keyId",
   requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("integrations:edit:any"),
   DeveloperApiKeyController.revokeApiKey,
 );
 

--- a/apps/backend/src/routers/developer-billing.router.ts
+++ b/apps/backend/src/routers/developer-billing.router.ts
@@ -1,9 +1,25 @@
 import { Router } from "express";
 import { DeveloperBillingController } from "../controllers/web/developer-billing.controller";
 import { requireWebAuth } from "src/middlewares/auth";
-import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
 
 const router = Router();
+
+/*
+ * `requireWebAuth` only, deliberately, with no role or organisation gate.
+ *
+ * These resources belong to the developer, and the handlers scope every query
+ * to `resolveVerifiedUserId(req)` - the caller's own session-derived id. There
+ * is nothing for an org gate to protect here, and `withOrgPermissions()` made
+ * the routes unreachable for the very accounts they exist for: a developer
+ * signup creates no UserOrganization row, so the middleware answered 400 before
+ * any handler ran (issue #2551).
+ *
+ * A reviewer will want to add a `developer` role check back. Do not: the role is
+ * self-assignable. `SELF_ASSIGNABLE_ROLES` in `user.controller.ts` lets a caller
+ * claim `developer` by posting it to `POST /fhir/v1/user`, so gating on it would
+ * turn a value the caller controls into an authorisation input. The session is
+ * the authority, and ownership is enforced in the query.
+ */
 
 /*
  * `POST /v1/developers/billing/webhook` is deliberately NOT here. Stripe's
@@ -13,28 +29,14 @@ const router = Router();
  * `app.ts`.
  */
 
-router.get(
-  "/",
-  requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("billing:view:any"),
-  DeveloperBillingController.getSubscription,
-);
+router.get("/", requireWebAuth, DeveloperBillingController.getSubscription);
 
 router.post(
   "/checkout",
   requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("billing:edit:any"),
   DeveloperBillingController.createCheckout,
 );
 
-router.post(
-  "/portal",
-  requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("billing:view:any"),
-  DeveloperBillingController.createPortal,
-);
+router.post("/portal", requireWebAuth, DeveloperBillingController.createPortal);
 
 export default router;

--- a/apps/backend/src/routers/developer-billing.router.ts
+++ b/apps/backend/src/routers/developer-billing.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { DeveloperBillingController } from "../controllers/web/developer-billing.controller";
 import { requireWebAuth } from "src/middlewares/auth";
+import { requireActiveAccount } from "src/middlewares/require-active-account";
 
 const router = Router();
 
@@ -29,14 +30,25 @@ const router = Router();
  * `app.ts`.
  */
 
-router.get("/", requireWebAuth, DeveloperBillingController.getSubscription);
+router.get(
+  "/",
+  requireWebAuth,
+  requireActiveAccount(),
+  DeveloperBillingController.getSubscription,
+);
 
 router.post(
   "/checkout",
   requireWebAuth,
+  requireActiveAccount(),
   DeveloperBillingController.createCheckout,
 );
 
-router.post("/portal", requireWebAuth, DeveloperBillingController.createPortal);
+router.post(
+  "/portal",
+  requireWebAuth,
+  requireActiveAccount(),
+  DeveloperBillingController.createPortal,
+);
 
 export default router;

--- a/apps/backend/src/routers/developer-usage.router.ts
+++ b/apps/backend/src/routers/developer-usage.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { requireWebAuth } from "src/middlewares/auth";
+import { requireActiveAccount } from "src/middlewares/require-active-account";
 import { DeveloperUsageController } from "../controllers/web/developer-usage.controller";
 
 const developerUsageRouter = Router();
@@ -21,6 +22,7 @@ const developerUsageRouter = Router();
 developerUsageRouter.get(
   "/",
   requireWebAuth,
+  requireActiveAccount(),
   DeveloperUsageController.getUsage,
 );
 

--- a/apps/backend/src/routers/developer-usage.router.ts
+++ b/apps/backend/src/routers/developer-usage.router.ts
@@ -1,15 +1,26 @@
 import { Router } from "express";
 import { requireWebAuth } from "src/middlewares/auth";
-import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
 import { DeveloperUsageController } from "../controllers/web/developer-usage.controller";
 
 const developerUsageRouter = Router();
 
+/*
+ * `requireWebAuth` only, deliberately, with no role or organisation gate.
+ *
+ * Usage belongs to the developer, and the handler scopes its query to
+ * `resolveVerifiedUserId(req)` - the caller's own session-derived id.
+ * `withOrgPermissions()` made this unreachable for the accounts it exists for:
+ * a developer signup creates no UserOrganization row, so the middleware
+ * answered 400 before the handler ran (issue #2551).
+ *
+ * A reviewer will want to add a `developer` role check back. Do not: the role is
+ * self-assignable via `POST /fhir/v1/user`, so gating on it would turn a value
+ * the caller controls into an authorisation input.
+ */
+
 developerUsageRouter.get(
   "/",
   requireWebAuth,
-  withOrgPermissions(),
-  requirePermission("billing:view:any"),
   DeveloperUsageController.getUsage,
 );
 

--- a/apps/backend/src/services/developer-api-key.service.ts
+++ b/apps/backend/src/services/developer-api-key.service.ts
@@ -123,30 +123,42 @@ export const DeveloperApiKeyService = {
      * to be stated explicitly rather than lost.
      *
      * Counts ACTIVE keys only, so revoking frees the budget.
+     *
+     * The count and the insert run inside one transaction behind a per-owner
+     * advisory lock. Read Committed alone would let concurrent requests each
+     * read the same sub-limit count and then all insert, so the ceiling would
+     * only hold when requests happen not to overlap. The lock is taken on a
+     * hash of the owner id, so it serialises one developer's key creation
+     * without touching anyone else's, and is released when the transaction
+     * ends either way.
      */
-    const activeKeys = await prisma.developerApiKey.count({
-      where: { ownerUserId, status: DeveloperApiKeyStatus.active },
-    });
-    if (activeKeys >= MAX_ACTIVE_KEYS_PER_OWNER) {
-      throw new DeveloperApiKeyServiceError(
-        `Active API key limit reached (${MAX_ACTIVE_KEYS_PER_OWNER}). Revoke a key before creating another.`,
-        429,
-      );
-    }
-
     const generated = generateApiKey(environment);
-    const record = await prisma.developerApiKey.create({
-      data: {
-        ownerUserId,
-        name,
-        createdBy,
-        scopes,
-        environment,
-        prefix: generated.prefix,
-        hashedKey: generated.hashedKey,
-        last4: generated.last4,
-        expiresAt: input.expiresAt ?? null,
-      },
+    const record = await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`developer-api-key:${ownerUserId}`}))`;
+
+      const activeKeys = await tx.developerApiKey.count({
+        where: { ownerUserId, status: DeveloperApiKeyStatus.active },
+      });
+      if (activeKeys >= MAX_ACTIVE_KEYS_PER_OWNER) {
+        throw new DeveloperApiKeyServiceError(
+          `Active API key limit reached (${MAX_ACTIVE_KEYS_PER_OWNER}). Revoke a key before creating another.`,
+          429,
+        );
+      }
+
+      return tx.developerApiKey.create({
+        data: {
+          ownerUserId,
+          name,
+          createdBy,
+          scopes,
+          environment,
+          prefix: generated.prefix,
+          hashedKey: generated.hashedKey,
+          last4: generated.last4,
+          expiresAt: input.expiresAt ?? null,
+        },
+      });
     });
 
     return {

--- a/apps/backend/src/services/developer-api-key.service.ts
+++ b/apps/backend/src/services/developer-api-key.service.ts
@@ -31,7 +31,7 @@ export type IssuedApiKey = {
 
 export type VerifiedApiKey = {
   id: string;
-  organisationId: string;
+  ownerUserId: string;
   scopes: string[];
   environment: DeveloperApiKeyEnvironment;
 };
@@ -94,19 +94,18 @@ const requireNonEmpty = (value: unknown, field: string): string => {
   return value.trim();
 };
 
+const MAX_ACTIVE_KEYS_PER_OWNER = 25;
+
 export const DeveloperApiKeyService = {
   async issue(input: {
-    organisationId: string;
+    ownerUserId: string;
     name: string;
     createdBy: string;
     scopes?: string[];
     environment?: DeveloperApiKeyEnvironment;
     expiresAt?: Date | null;
   }): Promise<IssuedApiKey> {
-    const organisationId = requireNonEmpty(
-      input.organisationId,
-      "organisationId",
-    );
+    const ownerUserId = requireNonEmpty(input.ownerUserId, "ownerUserId");
     const name = requireNonEmpty(input.name, "name");
     const createdBy = requireNonEmpty(input.createdBy, "createdBy");
     const environment = input.environment ?? DeveloperApiKeyEnvironment.live;
@@ -114,10 +113,31 @@ export const DeveloperApiKeyService = {
       requireNonEmpty(scope, "scope"),
     );
 
+    /*
+     * Bound the number of live credentials one developer can hold.
+     *
+     * Issuing used to require `integrations:edit:any`, which only OWNER and
+     * ADMIN carry. Scoping these routes to the developer removes that gate by
+     * design - the resource is theirs - but it also means any account with a web
+     * session can mint keys, so the ceiling that role incidentally provided has
+     * to be stated explicitly rather than lost.
+     *
+     * Counts ACTIVE keys only, so revoking frees the budget.
+     */
+    const activeKeys = await prisma.developerApiKey.count({
+      where: { ownerUserId, status: DeveloperApiKeyStatus.active },
+    });
+    if (activeKeys >= MAX_ACTIVE_KEYS_PER_OWNER) {
+      throw new DeveloperApiKeyServiceError(
+        `Active API key limit reached (${MAX_ACTIVE_KEYS_PER_OWNER}). Revoke a key before creating another.`,
+        429,
+      );
+    }
+
     const generated = generateApiKey(environment);
     const record = await prisma.developerApiKey.create({
       data: {
-        organisationId,
+        ownerUserId,
         name,
         createdBy,
         scopes,
@@ -140,10 +160,10 @@ export const DeveloperApiKeyService = {
     };
   },
 
-  async list(organisationId: string) {
-    const orgId = requireNonEmpty(organisationId, "organisationId");
+  async list(ownerUserId: string) {
+    const ownerId = requireNonEmpty(ownerUserId, "ownerUserId");
     return prisma.developerApiKey.findMany({
-      where: { organisationId: orgId },
+      where: { ownerUserId: ownerId },
       orderBy: { createdAt: "desc" },
       select: {
         id: true,
@@ -161,20 +181,14 @@ export const DeveloperApiKeyService = {
     });
   },
 
-  async revoke(input: {
-    organisationId: string;
-    keyId: string;
-  }): Promise<void> {
-    const organisationId = requireNonEmpty(
-      input.organisationId,
-      "organisationId",
-    );
+  async revoke(input: { ownerUserId: string; keyId: string }): Promise<void> {
+    const ownerUserId = requireNonEmpty(input.ownerUserId, "ownerUserId");
     const keyId = requireNonEmpty(input.keyId, "keyId");
 
     const result = await prisma.developerApiKey.updateMany({
       where: {
         id: keyId,
-        organisationId,
+        ownerUserId,
         status: DeveloperApiKeyStatus.active,
       },
       data: { status: DeveloperApiKeyStatus.revoked, revokedAt: new Date() },
@@ -212,7 +226,7 @@ export const DeveloperApiKeyService = {
 
     return {
       id: record.id,
-      organisationId: record.organisationId,
+      ownerUserId: record.ownerUserId,
       scopes: record.scopes,
       environment: record.environment,
     };

--- a/apps/backend/src/services/developer-api-key.service.ts
+++ b/apps/backend/src/services/developer-api-key.service.ts
@@ -136,8 +136,17 @@ export const DeveloperApiKeyService = {
     const record = await prisma.$transaction(async (tx) => {
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`developer-api-key:${ownerUserId}`}))`;
 
+      // `verify` refuses a key past `expiresAt` and nothing ever moves it out
+      // of `active`, so counting those would block an owner from issuing a
+      // usable replacement while holding 25 credentials that authenticate
+      // nothing. The ceiling is on live credentials, so match what `verify`
+      // will actually accept.
       const activeKeys = await tx.developerApiKey.count({
-        where: { ownerUserId, status: DeveloperApiKeyStatus.active },
+        where: {
+          ownerUserId,
+          status: DeveloperApiKeyStatus.active,
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
       });
       if (activeKeys >= MAX_ACTIVE_KEYS_PER_OWNER) {
         throw new DeveloperApiKeyServiceError(
@@ -210,8 +219,9 @@ export const DeveloperApiKeyService = {
     }
   },
 
-  // Authenticates a presented secret. Returns the org + scopes context, or null
-  // for any unknown / revoked / expired key (callers translate null to 401).
+  // Authenticates a presented secret. Returns the owner + scopes context, or
+  // null for any unknown / revoked / expired key, or one whose owner account is
+  // no longer active (callers translate null to 401).
   async verify(plaintextKey: string): Promise<VerifiedApiKey | null> {
     if (typeof plaintextKey !== "string" || !plaintextKey.startsWith("yc_")) {
       return null;
@@ -223,6 +233,17 @@ export const DeveloperApiKeyService = {
       return null;
     }
     if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) {
+      return null;
+    }
+
+    // A deleted account is soft-deleted and its session is not revoked, so the
+    // key it minted stays syntactically valid. The data API must not keep
+    // answering for an owner who no longer exists.
+    const owner = await prisma.user.findFirst({
+      where: { userId: record.ownerUserId },
+      select: { isActive: true },
+    });
+    if (!owner?.isActive) {
       return null;
     }
 

--- a/apps/backend/src/services/developer-api-key.service.ts
+++ b/apps/backend/src/services/developer-api-key.service.ts
@@ -133,8 +133,9 @@ export const DeveloperApiKeyService = {
      * ends either way.
      */
     const generated = generateApiKey(environment);
+    const lockKey = `developer-api-key:${ownerUserId}`;
     const record = await prisma.$transaction(async (tx) => {
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`developer-api-key:${ownerUserId}`}))`;
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
 
       // `verify` refuses a key past `expiresAt` and nothing ever moves it out
       // of `active`, so counting those would block an owner from issuing a

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -81,6 +81,21 @@ async function handleCheckoutCompleted(
       : (session.subscription?.id ?? null);
   if (!subId) return;
 
+  // Expiring open sessions at deletion is best-effort - Stripe can be down, and
+  // a session created in the same instant can slip past it. Refuse here too, so
+  // a completed checkout can never resurrect billing for a deleted account.
+  const owner = await prisma.user.findFirst({
+    where: { userId: ownerId },
+    select: { isActive: true },
+  });
+  if (!owner?.isActive) {
+    logger.error(
+      "Ignored a completed checkout session for an account that is no longer active; refund and cancel it in Stripe by hand",
+      { eventId: event.id, sessionId: session.id, subscriptionId: subId },
+    );
+    return;
+  }
+
   const stripe = getStripeClient();
   const sub = await stripe.subscriptions.retrieve(subId, {
     expand: ["items.data.price"],
@@ -228,13 +243,21 @@ export const DeveloperBillingService = {
    * way. A Stripe failure is logged and swallowed: the caller is mid-deletion
    * and must not be left half-finished, and a stranded Stripe subscription is
    * recoverable from the dashboard while a half-deleted account is not.
+   *
+   * An unfinished checkout is the other half of this. Between
+   * `getOrCreateCustomer` and completion the row holds a customer and a null
+   * `stripeSubscriptionId`, so cancelling the subscription is a no-op while the
+   * hosted Checkout page stays live. Completing it later fires
+   * `checkout.session.completed`, whose metadata still names this owner, and a
+   * fresh subscription would be recreated for a deleted account. Any open
+   * session on the customer is expired first.
    */
   async cancelForOwner(ownerUserId: string): Promise<void> {
     if (!ownerUserId.trim()) return;
 
     const record = await prisma.developerSubscription.findUnique({
       where: { ownerUserId },
-      select: { stripeSubscriptionId: true },
+      select: { stripeSubscriptionId: true, stripeCustomerId: true },
     });
     if (!record) return;
 
@@ -247,6 +270,25 @@ export const DeveloperBillingService = {
         logger.error(
           "Failed to cancel a developer subscription during account deletion; cancel it in Stripe by hand",
           { stripeSubscriptionId: record.stripeSubscriptionId, err },
+        );
+      }
+    }
+
+    if (record.stripeCustomerId) {
+      try {
+        const stripe = getStripeClient();
+        const open = await stripe.checkout.sessions.list({
+          customer: record.stripeCustomerId,
+          status: "open",
+          limit: 100,
+        });
+        for (const session of open.data) {
+          await stripe.checkout.sessions.expire(session.id);
+        }
+      } catch (err) {
+        logger.error(
+          "Failed to expire open checkout sessions during account deletion; expire them in Stripe by hand",
+          { stripeCustomerId: record.stripeCustomerId, err },
         );
       }
     }

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -49,8 +49,19 @@ async function handleCheckoutCompleted(
   session: Stripe.Checkout.Session,
 ): Promise<void> {
   if (session.mode !== "subscription") return;
-  const orgId = session.metadata?.organisationId;
-  if (!orgId) return;
+  /*
+   * Read `ownerUserId` only, with no fall back to `organisationId`.
+   *
+   * A checkout session created before this re-key carries
+   * `metadata.organisationId`, and that value is an Organization id. Reading it
+   * into `ownerUserId` would write a row keyed on a tenant id in a column that
+   * means "a person", permanently invisible to the developer who actually paid.
+   * Ignoring such a session is the correct outcome, and no such session exists:
+   * both databases held zero subscriptions with a live Stripe id when this
+   * shipped.
+   */
+  const ownerId = session.metadata?.ownerUserId;
+  if (!ownerId) return;
 
   const subId =
     typeof session.subscription === "string"
@@ -67,9 +78,9 @@ async function handleCheckoutCompleted(
   const priceId = item?.price?.id ?? null;
 
   await prisma.developerSubscription.upsert({
-    where: { organisationId: orgId },
+    where: { ownerUserId: ownerId },
     create: {
-      organisationId: orgId,
+      ownerUserId: ownerId,
       stripeCustomerId:
         typeof sub.customer === "string" ? sub.customer : sub.customer.id,
       stripeSubscriptionId: sub.id,
@@ -157,15 +168,15 @@ async function handleSubscriptionDeleted(
 }
 
 export const DeveloperBillingService = {
-  async getSubscription(organisationId: string) {
-    if (!organisationId.trim()) {
-      throw new DeveloperBillingServiceError("organisationId is required", 400);
+  async getSubscription(ownerUserId: string) {
+    if (!ownerUserId.trim()) {
+      throw new DeveloperBillingServiceError("ownerUserId is required", 400);
     }
     const record = await prisma.developerSubscription.findUnique({
-      where: { organisationId },
+      where: { ownerUserId },
       select: {
         id: true,
-        organisationId: true,
+        ownerUserId: true,
         plan: true,
         status: true,
         stripeSubscriptionItemId: true,
@@ -179,7 +190,7 @@ export const DeveloperBillingService = {
     return (
       record ?? {
         id: null,
-        organisationId,
+        ownerUserId,
         plan: "free" as DeveloperPlanTier,
         status: "active" as DeveloperSubscriptionStatus,
         stripeSubscriptionItemId: null,
@@ -192,21 +203,21 @@ export const DeveloperBillingService = {
     );
   },
 
-  async getOrCreateCustomer(organisationId: string): Promise<string> {
+  async getOrCreateCustomer(ownerUserId: string): Promise<string> {
     const existing = await prisma.developerSubscription.findUnique({
-      where: { organisationId },
+      where: { ownerUserId },
       select: { stripeCustomerId: true },
     });
     if (existing?.stripeCustomerId) return existing.stripeCustomerId;
 
     const stripe = getStripeClient();
     const customer = await stripe.customers.create({
-      metadata: { organisationId, source: "developer_portal" },
+      metadata: { ownerUserId, source: "developer_portal" },
     });
 
     await prisma.developerSubscription.upsert({
-      where: { organisationId },
-      create: { organisationId, stripeCustomerId: customer.id },
+      where: { ownerUserId },
+      create: { ownerUserId, stripeCustomerId: customer.id },
       update: { stripeCustomerId: customer.id },
     });
 
@@ -214,17 +225,17 @@ export const DeveloperBillingService = {
   },
 
   async createCheckoutSession(input: {
-    organisationId: string;
+    ownerUserId: string;
     successUrl: string;
     cancelUrl: string;
   }): Promise<string> {
-    const { organisationId, successUrl, cancelUrl } = input;
-    if (!organisationId.trim()) {
-      throw new DeveloperBillingServiceError("organisationId is required", 400);
+    const { ownerUserId, successUrl, cancelUrl } = input;
+    if (!ownerUserId.trim()) {
+      throw new DeveloperBillingServiceError("ownerUserId is required", 400);
     }
 
     const customerId =
-      await DeveloperBillingService.getOrCreateCustomer(organisationId);
+      await DeveloperBillingService.getOrCreateCustomer(ownerUserId);
     const priceId = resolveMeteredPriceId();
     const stripe = getStripeClient();
 
@@ -234,7 +245,7 @@ export const DeveloperBillingService = {
       line_items: [{ price: priceId }],
       success_url: successUrl,
       cancel_url: cancelUrl,
-      metadata: { organisationId, source: "developer_portal" },
+      metadata: { ownerUserId, source: "developer_portal" },
     });
 
     if (!session.url) {
@@ -247,16 +258,16 @@ export const DeveloperBillingService = {
   },
 
   async createPortalSession(input: {
-    organisationId: string;
+    ownerUserId: string;
     returnUrl: string;
   }): Promise<string> {
-    const { organisationId, returnUrl } = input;
-    if (!organisationId.trim()) {
-      throw new DeveloperBillingServiceError("organisationId is required", 400);
+    const { ownerUserId, returnUrl } = input;
+    if (!ownerUserId.trim()) {
+      throw new DeveloperBillingServiceError("ownerUserId is required", 400);
     }
 
     const record = await prisma.developerSubscription.findUnique({
-      where: { organisationId },
+      where: { ownerUserId },
       select: { stripeCustomerId: true },
     });
 

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -61,7 +61,19 @@ async function handleCheckoutCompleted(
    * shipped.
    */
   const ownerId = session.metadata?.ownerUserId;
-  if (!ownerId) return;
+  if (!ownerId) {
+    // Silence would strand a developer who is being charged with no row to
+    // manage the subscription from, so say so loudly enough to act on. Both
+    // databases held zero subscriptions when this shipped, so this is a
+    // tripwire rather than an expected path.
+    if (session.metadata?.organisationId) {
+      logger.error(
+        "Ignored a checkout session that predates the developer re-key: it carries organisationId and no ownerUserId, so the subscription it completes has no owner to record",
+        { eventId: event.id, sessionId: session.id },
+      );
+    }
+    return;
+  }
 
   const subId =
     typeof session.subscription === "string"
@@ -201,6 +213,45 @@ export const DeveloperBillingService = {
         updatedAt: null,
       }
     );
+  },
+
+  /**
+   * Cancel and forget a developer's own subscription.
+   *
+   * Called when the account itself goes away. Before the re-key the row hung
+   * off an organisation, so deleting a person left it alone; now it is theirs,
+   * and deleting them without this would sign them out while Stripe kept
+   * renewing and charging the card behind it.
+   *
+   * Cancels immediately rather than at period end - the account is gone, so
+   * there is nobody left to use the remaining days - and deletes the row either
+   * way. A Stripe failure is logged and swallowed: the caller is mid-deletion
+   * and must not be left half-finished, and a stranded Stripe subscription is
+   * recoverable from the dashboard while a half-deleted account is not.
+   */
+  async cancelForOwner(ownerUserId: string): Promise<void> {
+    if (!ownerUserId.trim()) return;
+
+    const record = await prisma.developerSubscription.findUnique({
+      where: { ownerUserId },
+      select: { stripeSubscriptionId: true },
+    });
+    if (!record) return;
+
+    if (record.stripeSubscriptionId) {
+      try {
+        await getStripeClient().subscriptions.cancel(
+          record.stripeSubscriptionId,
+        );
+      } catch (err) {
+        logger.error(
+          "Failed to cancel a developer subscription during account deletion; cancel it in Stripe by hand",
+          { stripeSubscriptionId: record.stripeSubscriptionId, err },
+        );
+      }
+    }
+
+    await prisma.developerSubscription.deleteMany({ where: { ownerUserId } });
   },
 
   async getOrCreateCustomer(ownerUserId: string): Promise<string> {

--- a/apps/backend/src/services/developer-usage.service.ts
+++ b/apps/backend/src/services/developer-usage.service.ts
@@ -83,8 +83,11 @@ export const DeveloperUsageService = {
           data: { lastReportedAt: new Date() },
         });
       } catch (err) {
+        // The billing period and the Stripe customer are enough to find the
+        // row again; the owner's user id identifies a person and does not
+        // belong in a log line.
         logger.error("Failed to report API usage to Stripe", {
-          ownerUserId,
+          stripeCustomerId: customerId,
           billingPeriod,
           err,
         });

--- a/apps/backend/src/services/developer-usage.service.ts
+++ b/apps/backend/src/services/developer-usage.service.ts
@@ -18,20 +18,20 @@ export const DeveloperUsageService = {
   // Increments call count atomically and checks quota.
   // Returns { allowed: boolean, callCount: number } — caller should 429 when !allowed.
   async incrementAndCheck(
-    organisationId: string,
+    ownerUserId: string,
   ): Promise<{ allowed: boolean; callCount: number }> {
     const period = currentBillingPeriod();
 
     const record = await prisma.developerApiUsage.upsert({
       where: {
-        organisationId_billingPeriod: { organisationId, billingPeriod: period },
+        ownerUserId_billingPeriod: { ownerUserId, billingPeriod: period },
       },
-      create: { organisationId, billingPeriod: period, callCount: 1 },
+      create: { ownerUserId, billingPeriod: period, callCount: 1 },
       update: { callCount: { increment: 1 } },
     });
 
     const sub = await prisma.developerSubscription.findUnique({
-      where: { organisationId },
+      where: { ownerUserId },
       select: { plan: true, stripeCustomerId: true },
     });
 
@@ -44,7 +44,7 @@ export const DeveloperUsageService = {
     if (plan === "pro" && sub?.stripeCustomerId) {
       DeveloperUsageService.reportToStripe(
         sub.stripeCustomerId,
-        organisationId,
+        ownerUserId,
         period,
         record.callCount,
       );
@@ -62,7 +62,7 @@ export const DeveloperUsageService = {
   // call is ever reported twice.
   reportToStripe(
     customerId: string,
-    organisationId: string,
+    ownerUserId: string,
     billingPeriod: string,
     callSequence: number,
   ): void {
@@ -71,12 +71,12 @@ export const DeveloperUsageService = {
         await DeveloperBillingService.reportUsage(
           customerId,
           CALLS_PER_REQUEST,
-          `dev-api-${organisationId}-${billingPeriod}-${callSequence}`,
+          `dev-api-${ownerUserId}-${billingPeriod}-${callSequence}`,
         );
         await prisma.developerApiUsage.update({
           where: {
-            organisationId_billingPeriod: {
-              organisationId,
+            ownerUserId_billingPeriod: {
+              ownerUserId,
               billingPeriod,
             },
           },
@@ -84,7 +84,7 @@ export const DeveloperUsageService = {
         });
       } catch (err) {
         logger.error("Failed to report API usage to Stripe", {
-          organisationId,
+          ownerUserId,
           billingPeriod,
           err,
         });
@@ -94,7 +94,7 @@ export const DeveloperUsageService = {
 
   // Returns usage for a given org and period (defaults to current month).
   async getUsage(
-    organisationId: string,
+    ownerUserId: string,
     billingPeriod?: string,
   ): Promise<{
     billingPeriod: string;
@@ -106,15 +106,15 @@ export const DeveloperUsageService = {
     const [record, sub] = await Promise.all([
       prisma.developerApiUsage.findUnique({
         where: {
-          organisationId_billingPeriod: {
-            organisationId,
+          ownerUserId_billingPeriod: {
+            ownerUserId,
             billingPeriod: period,
           },
         },
         select: { callCount: true },
       }),
       prisma.developerSubscription.findUnique({
-        where: { organisationId },
+        where: { ownerUserId },
         select: { plan: true },
       }),
     ]);

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -4,6 +4,7 @@ import { User } from "@yosemite-crew/types";
 import { getAuthService } from "@yosemite-crew/auth";
 import { OrganizationService } from "./organization.service";
 import { UserOrganizationService } from "./user-organization.service";
+import { DeveloperBillingService } from "./developer-billing.service";
 import { prisma } from "src/config/prisma";
 
 const SUPERTOKENS_PROVIDER = "supertokens";
@@ -298,6 +299,18 @@ export const UserService = {
     for (const mapping of mappings) {
       await UserOrganizationService.deleteById(mapping.id);
     }
+
+    // The developer's API keys, subscription and usage counters are keyed on
+    // the user, not on an organisation, so removing organisation memberships
+    // above leaves them behind. The subscription in particular keeps billing:
+    // cancel it before the account stops existing.
+    await DeveloperBillingService.cancelForOwner(resolvedUserId);
+    await prisma.developerApiKey.deleteMany({
+      where: { ownerUserId: resolvedUserId },
+    });
+    await prisma.developerApiUsage.deleteMany({
+      where: { ownerUserId: resolvedUserId },
+    });
 
     await Promise.all([
       prisma.userProfile.deleteMany({ where: { userId: resolvedUserId } }),

--- a/apps/backend/test/controllers/web/developer-api-key.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-api-key.controller.test.ts
@@ -45,7 +45,6 @@ const buildRes = (): Response => {
 
 const buildReq = (
   over: {
-    organisationId?: string;
     userId?: string;
     body?: unknown;
     params?: Record<string, string>;
@@ -55,35 +54,22 @@ const buildReq = (
     body: over.body ?? {},
     params: over.params ?? {},
     headers: {},
-    organisationId: over.organisationId,
     userId: over.userId,
   }) as unknown as Request;
 
 describe("DeveloperApiKeyController.createApiKey", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without an organisationId", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
-    await DeveloperApiKeyController.createApiKey(
-      buildReq({ userId: "u" }),
-      res,
-    );
-    expect(res.status).toHaveBeenCalledWith(400);
-  });
-
-  it("401 without a user", async () => {
-    const res = buildRes();
-    await DeveloperApiKeyController.createApiKey(
-      buildReq({ organisationId: "o" }),
-      res,
-    );
+    await DeveloperApiKeyController.createApiKey(buildReq({}), res);
     expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("400 on an invalid body", async () => {
     const res = buildRes();
     await DeveloperApiKeyController.createApiKey(
-      buildReq({ organisationId: "o", userId: "u", body: { name: "" } }),
+      buildReq({ userId: "u", body: { name: "" } }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(400);
@@ -95,7 +81,6 @@ describe("DeveloperApiKeyController.createApiKey", () => {
     const res = buildRes();
     await DeveloperApiKeyController.createApiKey(
       buildReq({
-        organisationId: "o",
         userId: "u",
         body: { name: "CI", scopes: ["x"] },
       }),
@@ -103,7 +88,6 @@ describe("DeveloperApiKeyController.createApiKey", () => {
     );
     expect(svc.issue).toHaveBeenCalledWith(
       expect.objectContaining({
-        organisationId: "o",
         name: "CI",
         createdBy: "u",
         expiresAt: null,
@@ -117,7 +101,6 @@ describe("DeveloperApiKeyController.createApiKey", () => {
     const res = buildRes();
     await DeveloperApiKeyController.createApiKey(
       buildReq({
-        organisationId: "o",
         userId: "u",
         body: { name: "CI", expiresAt: "2027-01-01T00:00:00.000Z" },
       }),
@@ -130,7 +113,7 @@ describe("DeveloperApiKeyController.createApiKey", () => {
     svc.issue.mockRejectedValue(new DeveloperApiKeyServiceError("bad", 400));
     const res = buildRes();
     await DeveloperApiKeyController.createApiKey(
-      buildReq({ organisationId: "o", userId: "u", body: { name: "CI" } }),
+      buildReq({ userId: "u", body: { name: "CI" } }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(400);
@@ -140,39 +123,83 @@ describe("DeveloperApiKeyController.createApiKey", () => {
     svc.issue.mockRejectedValue(new Error("boom"));
     const res = buildRes();
     await DeveloperApiKeyController.createApiKey(
-      buildReq({ organisationId: "o", userId: "u", body: { name: "CI" } }),
+      buildReq({ userId: "u", body: { name: "CI" } }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });
 
+/*
+ * The regression that IS issue #2551.
+ *
+ * These routes were gated on `withOrgPermissions()` and keyed on an
+ * organisation. A developer who signs up through the developer door never gets
+ * one - provisioning grants the `developer` role and nothing else, and there is
+ * no developer entry in the RBAC role model - so every request from the
+ * portal's own audience failed before reaching a handler.
+ *
+ * A request carrying a session and NO organisation must now succeed.
+ */
+describe("a developer account with no organisation", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("can issue a key", async () => {
+    svc.issue.mockResolvedValue({ id: "k", apiKey: "yc_live_x" });
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ userId: "dev-1", body: { name: "CI" } }),
+      res,
+    );
+    expect(svc.issue).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: "dev-1", createdBy: "dev-1" }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("can list its own keys, scoped to itself", async () => {
+    svc.list.mockResolvedValue([]);
+    const res = buildRes();
+    await DeveloperApiKeyController.listApiKeys(
+      buildReq({ userId: "dev-1" }),
+      res,
+    );
+    expect(svc.list).toHaveBeenCalledWith("dev-1");
+  });
+
+  /* The owner comes from the session, never from anything the caller can set,
+     so one developer cannot read or revoke another's keys by naming them. */
+  it("ignores an owner supplied in the body", async () => {
+    svc.list.mockResolvedValue([]);
+    const res = buildRes();
+    await DeveloperApiKeyController.listApiKeys(
+      buildReq({ userId: "dev-1", body: { ownerUserId: "dev-2" } }),
+      res,
+    );
+    expect(svc.list).toHaveBeenCalledWith("dev-1");
+  });
+});
+
 describe("DeveloperApiKeyController.listApiKeys", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without an org", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
-    await DeveloperApiKeyController.listApiKeys(buildReq(), res);
-    expect(res.status).toHaveBeenCalledWith(400);
+    await DeveloperApiKeyController.listApiKeys(buildReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("200 wrapping the keys in data", async () => {
     svc.list.mockResolvedValue([{ id: "k" }]);
     const res = buildRes();
-    await DeveloperApiKeyController.listApiKeys(
-      buildReq({ organisationId: "o" }),
-      res,
-    );
+    await DeveloperApiKeyController.listApiKeys(buildReq({ userId: "u" }), res);
     expect(res.json).toHaveBeenCalledWith({ data: [{ id: "k" }] });
   });
 
   it("500 on error", async () => {
     svc.list.mockRejectedValue(new Error("x"));
     const res = buildRes();
-    await DeveloperApiKeyController.listApiKeys(
-      buildReq({ organisationId: "o" }),
-      res,
-    );
+    await DeveloperApiKeyController.listApiKeys(buildReq({ userId: "u" }), res);
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });
@@ -180,24 +207,24 @@ describe("DeveloperApiKeyController.listApiKeys", () => {
 describe("DeveloperApiKeyController.revokeApiKey", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without an org", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
     await DeveloperApiKeyController.revokeApiKey(
       buildReq({ params: { keyId: "k" } }),
       res,
     );
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("204 on success", async () => {
     svc.revoke.mockResolvedValue(undefined);
     const res = buildRes();
     await DeveloperApiKeyController.revokeApiKey(
-      buildReq({ organisationId: "o", params: { keyId: "k" } }),
+      buildReq({ userId: "u", params: { keyId: "k" } }),
       res,
     );
     expect(svc.revoke).toHaveBeenCalledWith({
-      organisationId: "o",
+      ownerUserId: "u",
       keyId: "k",
     });
     expect(res.status).toHaveBeenCalledWith(204);
@@ -207,7 +234,7 @@ describe("DeveloperApiKeyController.revokeApiKey", () => {
     svc.revoke.mockRejectedValue(new DeveloperApiKeyServiceError("nf", 404));
     const res = buildRes();
     await DeveloperApiKeyController.revokeApiKey(
-      buildReq({ organisationId: "o", params: { keyId: "k" } }),
+      buildReq({ userId: "u", params: { keyId: "k" } }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(404);

--- a/apps/backend/test/controllers/web/developer-billing.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-billing.controller.test.ts
@@ -49,7 +49,7 @@ const buildRes = (): Response => {
 
 const buildReq = (
   over: {
-    organisationId?: string;
+    userId?: string;
     body?: unknown;
     headers?: Record<string, string>;
   } = {},
@@ -58,23 +58,23 @@ const buildReq = (
     body: over.body ?? {},
     params: {},
     headers: over.headers ?? {},
-    organisationId: over.organisationId,
+    userId: over.userId,
   }) as unknown as Request;
 
 describe("DeveloperBillingController.getSubscription", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without organisationId", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
     await DeveloperBillingController.getSubscription(buildReq(), res);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("200 with data envelope", async () => {
     svc.getSubscription.mockResolvedValue({ id: "s", plan: "free" });
     const res = buildRes();
     await DeveloperBillingController.getSubscription(
-      buildReq({ organisationId: "o" }),
+      buildReq({ userId: "u" }),
       res,
     );
     expect(res.json).toHaveBeenCalledWith({ data: { id: "s", plan: "free" } });
@@ -84,7 +84,7 @@ describe("DeveloperBillingController.getSubscription", () => {
     svc.getSubscription.mockRejectedValue(new Error("boom"));
     const res = buildRes();
     await DeveloperBillingController.getSubscription(
-      buildReq({ organisationId: "o" }),
+      buildReq({ userId: "u" }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(500);
@@ -94,17 +94,17 @@ describe("DeveloperBillingController.getSubscription", () => {
 describe("DeveloperBillingController.createCheckout", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without organisationId", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
     await DeveloperBillingController.createCheckout(buildReq(), res);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("400 when successUrl is missing", async () => {
     const res = buildRes();
     await DeveloperBillingController.createCheckout(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: { cancelUrl: "https://b.com" },
       }),
       res,
@@ -117,7 +117,7 @@ describe("DeveloperBillingController.createCheckout", () => {
     const res = buildRes();
     await DeveloperBillingController.createCheckout(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: { successUrl: "not-a-url", cancelUrl: "https://b.com" },
       }),
       res,
@@ -132,7 +132,7 @@ describe("DeveloperBillingController.createCheckout", () => {
     const res = buildRes();
     await DeveloperBillingController.createCheckout(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: {
           successUrl: "https://app.com/success",
           cancelUrl: "https://app.com/cancel",
@@ -153,7 +153,7 @@ describe("DeveloperBillingController.createCheckout", () => {
     const res = buildRes();
     await DeveloperBillingController.createCheckout(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: {
           successUrl: "https://app.com/success",
           cancelUrl: "https://app.com/cancel",
@@ -168,16 +168,16 @@ describe("DeveloperBillingController.createCheckout", () => {
 describe("DeveloperBillingController.createPortal", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("400 without organisationId", async () => {
+  it("401 without a verified user", async () => {
     const res = buildRes();
     await DeveloperBillingController.createPortal(buildReq(), res);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(401);
   });
 
   it("400 without returnUrl", async () => {
     const res = buildRes();
     await DeveloperBillingController.createPortal(
-      buildReq({ organisationId: "o", body: {} }),
+      buildReq({ userId: "u", body: {} }),
       res,
     );
     expect(res.status).toHaveBeenCalledWith(400);
@@ -188,7 +188,7 @@ describe("DeveloperBillingController.createPortal", () => {
     const res = buildRes();
     await DeveloperBillingController.createPortal(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: { returnUrl: "https://app.com/billing" },
       }),
       res,
@@ -206,7 +206,7 @@ describe("DeveloperBillingController.createPortal", () => {
     const res = buildRes();
     await DeveloperBillingController.createPortal(
       buildReq({
-        organisationId: "o",
+        userId: "u",
         body: { returnUrl: "https://app.com/billing" },
       }),
       res,

--- a/apps/backend/test/controllers/web/developer-usage.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-usage.controller.test.ts
@@ -21,11 +21,11 @@ const buildRes = (): Response => {
 };
 
 const buildReq = (
-  organisationId?: string,
+  userId?: string,
   query: Record<string, string> = {},
 ): Request =>
   ({
-    organisationId,
+    userId,
     query,
   }) as unknown as Request;
 
@@ -36,10 +36,10 @@ describe("DeveloperUsageController.getUsage", () => {
     jest.clearAllMocks();
   });
 
-  it("400 when organisationId is missing", async () => {
+  it("401 when no user is verified", async () => {
     const res = buildRes();
     await DeveloperUsageController.getUsage(buildReq(undefined), res);
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(401);
     expect(usageMock).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/test/middlewares/api-key-auth.test.ts
+++ b/apps/backend/test/middlewares/api-key-auth.test.ts
@@ -31,7 +31,7 @@ const buildReq = (headers: Record<string, string> = {}): Request =>
 
 const verifiedKey = {
   id: "k",
-  organisationId: "org-9",
+  ownerUserId: "org-9",
   scopes: ["x"],
   environment: "live",
 };
@@ -63,7 +63,7 @@ describe("authorizeApiKey", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("binds the org and calls next for a valid Bearer key", async () => {
+  it("binds the key owner as the request user and calls next", async () => {
     verifyMock.mockResolvedValue(verifiedKey);
     const req = buildReq({ authorization: "Bearer yc_live_good" });
     const res = buildRes();
@@ -71,9 +71,13 @@ describe("authorizeApiKey", () => {
     await authorizeApiKey(req, res, next);
 
     expect(verifyMock).toHaveBeenCalledWith("yc_live_good");
-    expect((req as unknown as { organisationId: string }).organisationId).toBe(
-      "org-9",
-    );
+    /* The key identifies a PERSON. It sets `userId`, the field a session sets,
+       and deliberately leaves `organisationId` unset - a key carrying a baked-in
+       tenant could never stop reaching a former employer. */
+    expect((req as unknown as { userId: string }).userId).toBe("org-9");
+    expect(
+      (req as unknown as { organisationId?: string }).organisationId,
+    ).toBeUndefined();
     expect(next).toHaveBeenCalled();
   });
 
@@ -118,7 +122,7 @@ describe("authorizeApiKey", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("calls incrementAndCheck with the organisationId", async () => {
+  it("calls incrementAndCheck with the ownerUserId", async () => {
     verifyMock.mockResolvedValue(verifiedKey);
     const res = buildRes();
     await authorizeApiKey(

--- a/apps/backend/test/middlewares/require-active-account.test.ts
+++ b/apps/backend/test/middlewares/require-active-account.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { NextFunction, Request, Response } from "express";
+
+import { requireActiveAccount } from "../../src/middlewares/require-active-account";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: { user: { findFirst: jest.fn() } },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+const mockPrisma = prisma as unknown as {
+  user: { findFirst: jest.Mock<() => Promise<unknown>> };
+};
+
+const buildRes = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { res: { status, json } as unknown as Response, status, json };
+};
+
+describe("requireActiveAccount", () => {
+  let next: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn() as unknown as NextFunction;
+  });
+
+  const run = (userId: unknown, res: Response) =>
+    requireActiveAccount()({ userId } as unknown as Request, res, next);
+
+  it("passes an active account through", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ isActive: true });
+    const { res, status } = buildRes();
+
+    await run("user-1", res);
+
+    expect(next).toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("refuses a soft-deleted account", async () => {
+    // deleteById sets isActive:false and cannot revoke the provider session, so
+    // the session stays valid and would otherwise reach these routes.
+    mockPrisma.user.findFirst.mockResolvedValue({ isActive: false });
+    const { res, status, json } = buildRes();
+
+    await run("user-gone", res);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Unauthorized" });
+  });
+
+  it("refuses an account whose row no longer exists", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    const { res, status } = buildRes();
+
+    await run("user-gone", res);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+
+  it("refuses a request with no authenticated user", async () => {
+    const { res, status } = buildRes();
+
+    await run(undefined, res);
+
+    expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+
+  it("answers 500 when the account lookup fails", async () => {
+    mockPrisma.user.findFirst.mockRejectedValue(new Error("db down"));
+    const { res, status } = buildRes();
+
+    await run("user-1", res);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/backend/test/services/developer-api-key.service.test.ts
+++ b/apps/backend/test/services/developer-api-key.service.test.ts
@@ -14,6 +14,9 @@ jest.mock("../../src/config/prisma", () => ({
       update: jest.fn(),
       updateMany: jest.fn(),
     },
+    user: {
+      findFirst: jest.fn(),
+    },
     $executeRaw: jest.fn(),
     // `issue` counts and inserts inside one transaction so the active-key
     // ceiling cannot be raced. Running the callback against the same mocked
@@ -31,6 +34,9 @@ const mockPrisma = prisma as unknown as {
     update: jest.Mock;
     updateMany: jest.Mock;
   };
+  user: {
+    findFirst: jest.Mock;
+  };
   $executeRaw: jest.Mock;
   $transaction: jest.Mock;
 };
@@ -40,6 +46,9 @@ describe("DeveloperApiKeyService", () => {
     jest.clearAllMocks();
     mockPrisma.developerApiKey.count.mockResolvedValue(0);
     mockPrisma.$executeRaw.mockResolvedValue(1);
+    // `verify` refuses a key whose owner has been deleted; default to a live
+    // account so the existing cases exercise the paths they were written for.
+    mockPrisma.user.findFirst.mockResolvedValue({ isActive: true });
     mockPrisma.$transaction.mockImplementation(
       (run: (tx: unknown) => unknown) => run(prisma),
     );
@@ -131,6 +140,31 @@ describe("DeveloperApiKeyService", () => {
         }),
       ).rejects.toMatchObject({ statusCode: 429 });
       expect(mockPrisma.developerApiKey.create).not.toHaveBeenCalled();
+    });
+
+    it("excludes expired keys from the ceiling", async () => {
+      // 25 keys that verify() would reject as expired must not block a usable
+      // replacement, so the count carries the expiry predicate.
+      mockPrisma.developerApiKey.create.mockResolvedValue({
+        id: "k",
+        name: "n",
+        prefix: "yc_live_x",
+        last4: "abcd",
+        scopes: [],
+        environment: "live",
+      });
+
+      await DeveloperApiKeyService.issue({
+        ownerUserId: "user-1",
+        name: "n",
+        createdBy: "user-1",
+      });
+
+      const where = mockPrisma.developerApiKey.count.mock.calls[0][0].where;
+      expect(where.OR).toEqual([
+        { expiresAt: null },
+        { expiresAt: { gt: expect.any(Date) } },
+      ]);
     });
 
     it("counts and inserts inside one transaction, behind a per-owner lock", async () => {
@@ -331,6 +365,42 @@ describe("DeveloperApiKeyService", () => {
         environment: "live",
       });
       expect(mockPrisma.developerApiKey.update).toHaveBeenCalled();
+    });
+
+    it("refuses a key whose owner account has been deleted", async () => {
+      // Deletion is a soft delete and does not revoke the session, so the key
+      // stays syntactically valid. The data API must stop answering for it.
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        id: "k1",
+        ownerUserId: "user-gone",
+        status: "active",
+        expiresAt: null,
+        scopes: [],
+        environment: "live",
+        lastUsedAt: new Date(),
+      });
+      mockPrisma.user.findFirst.mockResolvedValue({ isActive: false });
+
+      await expect(
+        DeveloperApiKeyService.verify("yc_live_whatever"),
+      ).resolves.toBeNull();
+    });
+
+    it("refuses a key whose owner row no longer exists", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        id: "k1",
+        ownerUserId: "user-gone",
+        status: "active",
+        expiresAt: null,
+        scopes: [],
+        environment: "live",
+        lastUsedAt: new Date(),
+      });
+      mockPrisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(
+        DeveloperApiKeyService.verify("yc_live_whatever"),
+      ).resolves.toBeNull();
     });
 
     it("does not refresh a fresh lastUsedAt", async () => {

--- a/apps/backend/test/services/developer-api-key.service.test.ts
+++ b/apps/backend/test/services/developer-api-key.service.test.ts
@@ -7,6 +7,7 @@ import { prisma } from "../../src/config/prisma";
 jest.mock("../../src/config/prisma", () => ({
   prisma: {
     developerApiKey: {
+      count: jest.fn(),
       create: jest.fn(),
       findMany: jest.fn(),
       findUnique: jest.fn(),
@@ -18,6 +19,7 @@ jest.mock("../../src/config/prisma", () => ({
 
 const mockPrisma = prisma as unknown as {
   developerApiKey: {
+    count: jest.Mock;
     create: jest.Mock;
     findMany: jest.Mock;
     findUnique: jest.Mock;
@@ -28,6 +30,7 @@ const mockPrisma = prisma as unknown as {
 
 describe("DeveloperApiKeyService", () => {
   beforeEach(() => {
+    mockPrisma.developerApiKey.count.mockResolvedValue(0);
     jest.clearAllMocks();
     process.env.DEVELOPER_API_KEY_PEPPER = "test-pepper";
   });
@@ -46,7 +49,7 @@ describe("DeveloperApiKeyService", () => {
       );
 
       const issued = await DeveloperApiKeyService.issue({
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         name: "CI key",
         createdBy: "user-1",
         scopes: ["appointments:read"],
@@ -74,7 +77,7 @@ describe("DeveloperApiKeyService", () => {
       });
 
       await DeveloperApiKeyService.issue({
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         name: "n",
         createdBy: "u",
       });
@@ -97,7 +100,7 @@ describe("DeveloperApiKeyService", () => {
       });
 
       const issued = await DeveloperApiKeyService.issue({
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         name: "n",
         createdBy: "u",
         environment: "test" as never,
@@ -107,9 +110,9 @@ describe("DeveloperApiKeyService", () => {
     });
 
     it.each([
-      ["organisationId", { organisationId: "", name: "n", createdBy: "u" }],
-      ["name", { organisationId: "o", name: "  ", createdBy: "u" }],
-      ["createdBy", { organisationId: "o", name: "n", createdBy: "" }],
+      ["ownerUserId", { ownerUserId: "", name: "n", createdBy: "u" }],
+      ["name", { ownerUserId: "o", name: "  ", createdBy: "u" }],
+      ["createdBy", { ownerUserId: "o", name: "n", createdBy: "" }],
     ])("rejects an empty %s", async (_field, input) => {
       await expect(
         DeveloperApiKeyService.issue(input as never),
@@ -125,7 +128,7 @@ describe("DeveloperApiKeyService", () => {
 
       expect(result).toEqual([{ id: "k1" }]);
       const arg = mockPrisma.developerApiKey.findMany.mock.calls[0][0];
-      expect(arg.where).toEqual({ organisationId: "org-1" });
+      expect(arg.where).toEqual({ ownerUserId: "org-1" });
       expect(arg.orderBy).toEqual({ createdAt: "desc" });
       expect(arg.select.hashedKey).toBeUndefined();
     });
@@ -141,13 +144,13 @@ describe("DeveloperApiKeyService", () => {
     it("revokes an active key scoped to the org", async () => {
       mockPrisma.developerApiKey.updateMany.mockResolvedValue({ count: 1 });
       await expect(
-        DeveloperApiKeyService.revoke({ organisationId: "o", keyId: "k" }),
+        DeveloperApiKeyService.revoke({ ownerUserId: "o", keyId: "k" }),
       ).resolves.toBeUndefined();
       expect(mockPrisma.developerApiKey.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             id: "k",
-            organisationId: "o",
+            ownerUserId: "o",
             status: "active",
           }),
         }),
@@ -157,7 +160,7 @@ describe("DeveloperApiKeyService", () => {
     it("throws 404 when nothing matched", async () => {
       mockPrisma.developerApiKey.updateMany.mockResolvedValue({ count: 0 });
       await expect(
-        DeveloperApiKeyService.revoke({ organisationId: "o", keyId: "k" }),
+        DeveloperApiKeyService.revoke({ ownerUserId: "o", keyId: "k" }),
       ).rejects.toMatchObject({ statusCode: 404 });
     });
   });
@@ -204,7 +207,7 @@ describe("DeveloperApiKeyService", () => {
 
       await expect(
         DeveloperApiKeyService.issue({
-          organisationId: "org-1",
+          ownerUserId: "org-1",
           name: "k",
           createdBy: "user-1",
         }),
@@ -216,7 +219,7 @@ describe("DeveloperApiKeyService", () => {
   describe("verify", () => {
     const activeRecord = {
       id: "key-1",
-      organisationId: "org-1",
+      ownerUserId: "org-1",
       scopes: ["a"],
       environment: "live",
       status: "active",
@@ -266,7 +269,7 @@ describe("DeveloperApiKeyService", () => {
       const result = await DeveloperApiKeyService.verify("yc_live_x");
       expect(result).toEqual({
         id: "key-1",
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         scopes: ["a"],
         environment: "live",
       });

--- a/apps/backend/test/services/developer-api-key.service.test.ts
+++ b/apps/backend/test/services/developer-api-key.service.test.ts
@@ -14,6 +14,11 @@ jest.mock("../../src/config/prisma", () => ({
       update: jest.fn(),
       updateMany: jest.fn(),
     },
+    $executeRaw: jest.fn(),
+    // `issue` counts and inserts inside one transaction so the active-key
+    // ceiling cannot be raced. Running the callback against the same mocked
+    // client keeps the assertions below about `developerApiKey.*` unchanged.
+    $transaction: jest.fn(),
   },
 }));
 
@@ -26,12 +31,18 @@ const mockPrisma = prisma as unknown as {
     update: jest.Mock;
     updateMany: jest.Mock;
   };
+  $executeRaw: jest.Mock;
+  $transaction: jest.Mock;
 };
 
 describe("DeveloperApiKeyService", () => {
   beforeEach(() => {
-    mockPrisma.developerApiKey.count.mockResolvedValue(0);
     jest.clearAllMocks();
+    mockPrisma.developerApiKey.count.mockResolvedValue(0);
+    mockPrisma.$executeRaw.mockResolvedValue(1);
+    mockPrisma.$transaction.mockImplementation(
+      (run: (tx: unknown) => unknown) => run(prisma),
+    );
     process.env.DEVELOPER_API_KEY_PEPPER = "test-pepper";
   });
 
@@ -107,6 +118,52 @@ describe("DeveloperApiKeyService", () => {
       });
 
       expect(issued.apiKey).toMatch(/^yc_test_/);
+    });
+
+    it("refuses a 26th active key", async () => {
+      mockPrisma.developerApiKey.count.mockResolvedValue(25);
+
+      await expect(
+        DeveloperApiKeyService.issue({
+          ownerUserId: "user-1",
+          name: "n",
+          createdBy: "user-1",
+        }),
+      ).rejects.toMatchObject({ statusCode: 429 });
+      expect(mockPrisma.developerApiKey.create).not.toHaveBeenCalled();
+    });
+
+    it("counts and inserts inside one transaction, behind a per-owner lock", async () => {
+      // Without this the ceiling is advisory only: two concurrent requests can
+      // each read the same sub-limit count and both insert.
+      mockPrisma.developerApiKey.create.mockResolvedValue({
+        id: "k",
+        name: "n",
+        prefix: "yc_live_x",
+        last4: "abcd",
+        scopes: [],
+        environment: "live",
+      });
+
+      await DeveloperApiKeyService.issue({
+        ownerUserId: "user-1",
+        name: "n",
+        createdBy: "user-1",
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      const [strings, lockKey] = mockPrisma.$executeRaw.mock.calls[0];
+      expect(strings.join("")).toContain("pg_advisory_xact_lock");
+      expect(lockKey).toBe("developer-api-key:user-1");
+      expect(mockPrisma.$executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
+        mockPrisma.developerApiKey.count.mock.invocationCallOrder[0],
+      );
+      expect(
+        mockPrisma.developerApiKey.count.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        mockPrisma.developerApiKey.create.mock.invocationCallOrder[0],
+      );
     });
 
     it.each([

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -3,6 +3,7 @@ import {
   DeveloperBillingServiceError,
 } from "../../src/services/developer-billing.service";
 import { prisma } from "../../src/config/prisma";
+import logger from "../../src/utils/logger";
 
 jest.mock("../../src/config/prisma", () => ({
   prisma: {
@@ -11,8 +12,14 @@ jest.mock("../../src/config/prisma", () => ({
       findFirst: jest.fn(),
       upsert: jest.fn(),
       update: jest.fn(),
+      deleteMany: jest.fn(),
     },
   },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
 }));
 
 jest.mock("stripe", () => {
@@ -20,6 +27,7 @@ jest.mock("stripe", () => {
   const mockCheckoutSessionsCreate = jest.fn();
   const mockBillingPortalCreate = jest.fn();
   const mockSubscriptionsRetrieve = jest.fn();
+  const mockSubscriptionsCancel = jest.fn();
   const mockWebhooksConstructEvent = jest.fn();
   const mockMeterEventsCreate = jest.fn();
 
@@ -27,7 +35,10 @@ jest.mock("stripe", () => {
     customers: { create: mockCustomersCreate },
     checkout: { sessions: { create: mockCheckoutSessionsCreate } },
     billingPortal: { sessions: { create: mockBillingPortalCreate } },
-    subscriptions: { retrieve: mockSubscriptionsRetrieve },
+    subscriptions: {
+      retrieve: mockSubscriptionsRetrieve,
+      cancel: mockSubscriptionsCancel,
+    },
     billing: { meterEvents: { create: mockMeterEventsCreate } },
     webhooks: { constructEvent: mockWebhooksConstructEvent },
   }));
@@ -41,6 +52,7 @@ const mockPrisma = prisma as unknown as {
     findFirst: jest.Mock;
     upsert: jest.Mock;
     update: jest.Mock;
+    deleteMany: jest.Mock;
   };
 };
 
@@ -55,6 +67,68 @@ describe("DeveloperBillingService", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_key";
     process.env.STRIPE_DEV_METERED_PRICE_ID = "price_metered_abc";
     process.env.STRIPE_DEV_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  describe("cancelForOwner", () => {
+    it("cancels the live Stripe subscription and removes the row", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: "sub_live_1",
+      });
+
+      await DeveloperBillingService.cancelForOwner("user-1");
+
+      expect(getStripeInstance().subscriptions.cancel).toHaveBeenCalledWith(
+        "sub_live_1",
+      );
+      expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalledWith({
+        where: { ownerUserId: "user-1" },
+      });
+    });
+
+    it("removes a row that never reached Stripe without calling Stripe", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: null,
+      });
+
+      await DeveloperBillingService.cancelForOwner("user-1");
+
+      expect(getStripeInstance().subscriptions.cancel).not.toHaveBeenCalled();
+      expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalled();
+    });
+
+    it("still deletes the row when Stripe rejects the cancellation", async () => {
+      // Deletion is already in flight; a Stripe outage must not leave the
+      // account half-removed. The error is logged for manual cleanup.
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: "sub_live_1",
+      });
+      getStripeInstance().subscriptions.cancel.mockRejectedValueOnce(
+        new Error("stripe down"),
+      );
+
+      await expect(
+        DeveloperBillingService.cancelForOwner("user-1"),
+      ).resolves.toBeUndefined();
+      expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalled();
+    });
+
+    it("does nothing when the owner has no subscription", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+
+      await DeveloperBillingService.cancelForOwner("user-1");
+
+      expect(
+        mockPrisma.developerSubscription.deleteMany,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("ignores a blank owner id", async () => {
+      await DeveloperBillingService.cancelForOwner("   ");
+
+      expect(
+        mockPrisma.developerSubscription.findUnique,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   describe("getSubscription", () => {
@@ -347,6 +421,49 @@ describe("DeveloperBillingService", () => {
       } as never);
 
       expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+    });
+
+    it("logs a checkout session that predates the re-key instead of ignoring it silently", async () => {
+      // Such a session carries organisationId and no ownerUserId. Writing the
+      // org id into an owner column would hide the row from the developer who
+      // paid, so it is skipped - but a paying developer with no record must be
+      // visible, not silent.
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_legacy",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_legacy",
+            mode: "subscription",
+            subscription: "sub_legacy",
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+      expect(jest.mocked(logger.error)).toHaveBeenCalledWith(
+        expect.stringContaining("predates the developer re-key"),
+        { eventId: "evt_legacy", sessionId: "cs_legacy" },
+      );
+    });
+
+    it("skips a subscription checkout with no organisation metadata quietly", async () => {
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_blank",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_blank",
+            mode: "subscription",
+            subscription: "sub_blank",
+            metadata: {},
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+      expect(jest.mocked(logger.error)).not.toHaveBeenCalled();
     });
 
     it("updates the record on customer.subscription.updated", async () => {

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -14,6 +14,9 @@ jest.mock("../../src/config/prisma", () => ({
       update: jest.fn(),
       deleteMany: jest.fn(),
     },
+    user: {
+      findFirst: jest.fn(),
+    },
   },
 }));
 
@@ -28,12 +31,20 @@ jest.mock("stripe", () => {
   const mockBillingPortalCreate = jest.fn();
   const mockSubscriptionsRetrieve = jest.fn();
   const mockSubscriptionsCancel = jest.fn();
+  const mockCheckoutSessionsList = jest.fn();
+  const mockCheckoutSessionsExpire = jest.fn();
   const mockWebhooksConstructEvent = jest.fn();
   const mockMeterEventsCreate = jest.fn();
 
   const MockStripe = jest.fn().mockImplementation(() => ({
     customers: { create: mockCustomersCreate },
-    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    checkout: {
+      sessions: {
+        create: mockCheckoutSessionsCreate,
+        list: mockCheckoutSessionsList,
+        expire: mockCheckoutSessionsExpire,
+      },
+    },
     billingPortal: { sessions: { create: mockBillingPortalCreate } },
     subscriptions: {
       retrieve: mockSubscriptionsRetrieve,
@@ -54,6 +65,9 @@ const mockPrisma = prisma as unknown as {
     update: jest.Mock;
     deleteMany: jest.Mock;
   };
+  user: {
+    findFirst: jest.Mock;
+  };
 };
 
 const getStripeInstance = () => {
@@ -64,6 +78,9 @@ const getStripeInstance = () => {
 describe("DeveloperBillingService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getStripeInstance().checkout.sessions.list.mockResolvedValue({ data: [] });
+    // A completed checkout is refused for a deleted account; default to live.
+    mockPrisma.user.findFirst.mockResolvedValue({ isActive: true });
     process.env.STRIPE_SECRET_KEY = "sk_test_key";
     process.env.STRIPE_DEV_METERED_PRICE_ID = "price_metered_abc";
     process.env.STRIPE_DEV_WEBHOOK_SECRET = "whsec_test";
@@ -83,6 +100,46 @@ describe("DeveloperBillingService", () => {
       expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalledWith({
         where: { ownerUserId: "user-1" },
       });
+    });
+
+    it("expires open checkout sessions so a later completion cannot resurrect billing", async () => {
+      // Between getOrCreateCustomer and completion the row holds a customer and
+      // a null subscription id, so cancelling the subscription is a no-op while
+      // the hosted Checkout page stays live.
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: null,
+        stripeCustomerId: "cus_1",
+      });
+      const stripe = getStripeInstance();
+      stripe.checkout.sessions.list.mockResolvedValue({
+        data: [{ id: "cs_1" }, { id: "cs_2" }],
+      });
+
+      await DeveloperBillingService.cancelForOwner("user-1");
+
+      expect(stripe.checkout.sessions.list).toHaveBeenCalledWith({
+        customer: "cus_1",
+        status: "open",
+        limit: 100,
+      });
+      expect(stripe.checkout.sessions.expire).toHaveBeenCalledWith("cs_1");
+      expect(stripe.checkout.sessions.expire).toHaveBeenCalledWith("cs_2");
+      expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalled();
+    });
+
+    it("still deletes the row when expiring sessions fails", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: null,
+        stripeCustomerId: "cus_1",
+      });
+      getStripeInstance().checkout.sessions.list.mockRejectedValueOnce(
+        new Error("stripe down"),
+      );
+
+      await expect(
+        DeveloperBillingService.cancelForOwner("user-1"),
+      ).resolves.toBeUndefined();
+      expect(mockPrisma.developerSubscription.deleteMany).toHaveBeenCalled();
     });
 
     it("removes a row that never reached Stripe without calling Stripe", async () => {
@@ -421,6 +478,31 @@ describe("DeveloperBillingService", () => {
       } as never);
 
       expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+    });
+
+    it("refuses a completed checkout for an account that is no longer active", async () => {
+      // Expiring sessions at deletion is best-effort; this is the backstop that
+      // makes resurrection impossible rather than unlikely.
+      mockPrisma.user.findFirst.mockResolvedValue({ isActive: false });
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_dead",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_dead",
+            mode: "subscription",
+            subscription: "sub_dead",
+            metadata: { ownerUserId: "user-gone" },
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+      expect(jest.mocked(logger.error)).toHaveBeenCalledWith(
+        expect.stringContaining("no longer active"),
+        expect.objectContaining({ sessionId: "cs_dead" }),
+      );
     });
 
     it("logs a checkout session that predates the re-key instead of ignoring it silently", async () => {

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -61,7 +61,7 @@ describe("DeveloperBillingService", () => {
     it("returns the record when found", async () => {
       const record = {
         id: "sub-1",
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         plan: "pro",
         status: "active",
         stripeSubscriptionItemId: "si_x",
@@ -83,7 +83,7 @@ describe("DeveloperBillingService", () => {
       expect(result.id).toBeNull();
     });
 
-    it("throws 400 on empty organisationId", async () => {
+    it("throws 400 on empty ownerUserId", async () => {
       await expect(
         DeveloperBillingService.getSubscription(""),
       ).rejects.toBeInstanceOf(DeveloperBillingServiceError);
@@ -111,7 +111,7 @@ describe("DeveloperBillingService", () => {
       expect(id).toBe("cus_new");
       expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organisationId: "org-1" },
+          where: { ownerUserId: "org-1" },
           create: expect.objectContaining({ stripeCustomerId: "cus_new" }),
         }),
       );
@@ -129,7 +129,7 @@ describe("DeveloperBillingService", () => {
       });
 
       const url = await DeveloperBillingService.createCheckoutSession({
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         successUrl: "https://app.com/success",
         cancelUrl: "https://app.com/cancel",
       });
@@ -144,10 +144,10 @@ describe("DeveloperBillingService", () => {
       );
     });
 
-    it("throws 400 on empty organisationId", async () => {
+    it("throws 400 on empty ownerUserId", async () => {
       await expect(
         DeveloperBillingService.createCheckoutSession({
-          organisationId: "",
+          ownerUserId: "",
           successUrl: "https://app.com/success",
           cancelUrl: "https://app.com/cancel",
         }),
@@ -163,7 +163,7 @@ describe("DeveloperBillingService", () => {
 
       await expect(
         DeveloperBillingService.createCheckoutSession({
-          organisationId: "org-1",
+          ownerUserId: "org-1",
           successUrl: "https://app.com/success",
           cancelUrl: "https://app.com/cancel",
         }),
@@ -178,7 +178,7 @@ describe("DeveloperBillingService", () => {
 
       await expect(
         DeveloperBillingService.createCheckoutSession({
-          organisationId: "org-1",
+          ownerUserId: "org-1",
           successUrl: "https://app.com/success",
           cancelUrl: "https://app.com/cancel",
         }),
@@ -197,7 +197,7 @@ describe("DeveloperBillingService", () => {
       });
 
       const url = await DeveloperBillingService.createPortalSession({
-        organisationId: "org-1",
+        ownerUserId: "org-1",
         returnUrl: "https://app.com/billing",
       });
 
@@ -209,16 +209,16 @@ describe("DeveloperBillingService", () => {
 
       await expect(
         DeveloperBillingService.createPortalSession({
-          organisationId: "org-1",
+          ownerUserId: "org-1",
           returnUrl: "https://app.com/billing",
         }),
       ).rejects.toMatchObject({ statusCode: 404 });
     });
 
-    it("throws 400 on empty organisationId", async () => {
+    it("throws 400 on empty ownerUserId", async () => {
       await expect(
         DeveloperBillingService.createPortalSession({
-          organisationId: "",
+          ownerUserId: "",
           returnUrl: "https://app.com/billing",
         }),
       ).rejects.toBeInstanceOf(DeveloperBillingServiceError);
@@ -322,14 +322,14 @@ describe("DeveloperBillingService", () => {
           object: {
             mode: "subscription",
             subscription: "sub_123",
-            metadata: { organisationId: "org-1" },
+            metadata: { ownerUserId: "org-1" },
           },
         },
       } as never);
 
       expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { organisationId: "org-1" },
+          where: { ownerUserId: "org-1" },
           create: expect.objectContaining({
             plan: "pro",
             stripeSubscriptionId: "sub_123",
@@ -434,7 +434,7 @@ describe("DeveloperBillingService", () => {
           object: {
             mode: "subscription",
             subscription: { id: "sub_123" },
-            metadata: { organisationId: "org-1" },
+            metadata: { ownerUserId: "org-1" },
           },
         },
       } as never);
@@ -461,7 +461,7 @@ describe("DeveloperBillingService", () => {
           object: {
             mode: "subscription",
             subscription: "sub_123",
-            metadata: { organisationId: "org-1" },
+            metadata: { ownerUserId: "org-1" },
           },
         },
       } as never);
@@ -481,14 +481,14 @@ describe("DeveloperBillingService", () => {
           object: {
             mode: "subscription",
             subscription: null,
-            metadata: { organisationId: "org-1" },
+            metadata: { ownerUserId: "org-1" },
           },
         },
       } as never);
       expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
     });
 
-    it("skips checkout.session.completed when organisationId metadata is missing", async () => {
+    it("skips checkout.session.completed when ownerUserId metadata is missing", async () => {
       await DeveloperBillingService.handleWebhookEvent({
         id: "evt_11",
         type: "checkout.session.completed",
@@ -518,7 +518,7 @@ describe("DeveloperBillingService", () => {
           object: {
             mode: "subscription",
             subscription: "sub_123",
-            metadata: { organisationId: "org-1" },
+            metadata: { ownerUserId: "org-1" },
           },
         },
       } as never);
@@ -663,7 +663,7 @@ describe("DeveloperBillingService — module-isolated Stripe init", () => {
 
     await expect(
       IsolatedBillingService.createCheckoutSession({
-        organisationId: "o",
+        ownerUserId: "o",
         successUrl: "https://a.com",
         cancelUrl: "https://b.com",
       }),

--- a/apps/backend/test/services/developer-usage.service.test.ts
+++ b/apps/backend/test/services/developer-usage.service.test.ts
@@ -248,10 +248,14 @@ describe("DeveloperUsageService", () => {
       expect(mockLoggerError).toHaveBeenCalledWith(
         "Failed to report API usage to Stripe",
         expect.objectContaining({
-          ownerUserId: "org-1",
+          stripeCustomerId: "cus_abc",
           billingPeriod: "2026-06",
           err: boom,
         }),
+      );
+      // The owner's user id identifies a person and must stay out of the log.
+      expect(mockLoggerError.mock.calls[0][1]).not.toHaveProperty(
+        "ownerUserId",
       );
       // update should NOT have been called after the throw
       expect(mockPrisma.developerApiUsage.update).not.toHaveBeenCalled();

--- a/apps/backend/test/services/developer-usage.service.test.ts
+++ b/apps/backend/test/services/developer-usage.service.test.ts
@@ -222,8 +222,8 @@ describe("DeveloperUsageService", () => {
       expect(mockPrisma.developerApiUsage.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
-            organisationId_billingPeriod: {
-              organisationId: "org-1",
+            ownerUserId_billingPeriod: {
+              ownerUserId: "org-1",
               billingPeriod: "2026-06",
             },
           },
@@ -248,7 +248,7 @@ describe("DeveloperUsageService", () => {
       expect(mockLoggerError).toHaveBeenCalledWith(
         "Failed to report API usage to Stripe",
         expect.objectContaining({
-          organisationId: "org-1",
+          ownerUserId: "org-1",
           billingPeriod: "2026-06",
           err: boom,
         }),

--- a/apps/backend/test/services/user.service.test.ts
+++ b/apps/backend/test/services/user.service.test.ts
@@ -24,6 +24,16 @@ const mockPrisma = {
   occupancy: {
     deleteMany: jest.fn(),
   },
+  developerSubscription: {
+    findUnique: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+  developerApiKey: {
+    deleteMany: jest.fn(),
+  },
+  developerApiUsage: {
+    deleteMany: jest.fn(),
+  },
 };
 
 jest.mock("src/config/prisma", () => ({
@@ -36,6 +46,14 @@ const mockGetAuthService = jest.fn();
 jest.mock("@yosemite-crew/auth", () => ({
   ...jest.requireActual("@yosemite-crew/auth"),
   getAuthService: () => mockGetAuthService(),
+}));
+
+const mockCancelForOwner = jest.fn();
+
+jest.mock("src/services/developer-billing.service", () => ({
+  DeveloperBillingService: {
+    cancelForOwner: (...args: unknown[]) => mockCancelForOwner(...args),
+  },
 }));
 
 const mockOrganizationDeleteById = jest.fn();
@@ -364,6 +382,25 @@ describe("UserService", () => {
     ).rejects.toMatchObject({
       message: "User not found.",
       statusCode: 404,
+    });
+  });
+
+  it("cancels the developer subscription and clears developer rows on deletion", async () => {
+    // The subscription is keyed on the user, so removing organisation
+    // memberships leaves it renewing. Deleting the account must stop the
+    // charge, not just sign the person out.
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "row-1" });
+    mockPrisma.userOrganization.findMany.mockResolvedValue([]);
+    mockPrisma.user.updateMany.mockResolvedValue({ count: 1 });
+
+    await UserService.deleteById("user-123");
+
+    expect(mockCancelForOwner).toHaveBeenCalledWith("user-123");
+    expect(mockPrisma.developerApiKey.deleteMany).toHaveBeenCalledWith({
+      where: { ownerUserId: "user-123" },
+    });
+    expect(mockPrisma.developerApiUsage.deleteMany).toHaveBeenCalledWith({
+      where: { ownerUserId: "user-123" },
     });
   });
 

--- a/apps/frontend/src/app/features/developers/pages/DeveloperBilling/CurrentPlanRow.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperBilling/CurrentPlanRow.stories.tsx
@@ -19,7 +19,6 @@ const formattedPeriod = `${new Date(PERIOD_START).toLocaleDateString()} – ${ne
 
 const subscription = (overrides: Partial<DeveloperSubscription> = {}): DeveloperSubscription => ({
   id: 'sub_storybook',
-  organisationId: 'org-storybook',
   plan: 'pro',
   status: 'active',
   stripeSubscriptionItemId: 'si_storybook',

--- a/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.stories.tsx
@@ -62,7 +62,6 @@ const seedDeveloper = () => {
 
 const subscription = (plan: DeveloperPlanTier, status: DeveloperSubscriptionStatus) => ({
   id: plan === 'free' ? null : 'sub_123',
-  organisationId: 'org-storybook',
   plan,
   status,
   stripeSubscriptionItemId: plan === 'free' ? null : 'si_123',

--- a/apps/frontend/src/app/services/developerBilling.ts
+++ b/apps/frontend/src/app/services/developerBilling.ts
@@ -2,15 +2,10 @@ import { getData, postData } from '@/app/services/axios';
 
 export type DeveloperPlanTier = 'free' | 'pro' | 'enterprise';
 export type DeveloperSubscriptionStatus =
-  | 'active'
-  | 'trialing'
-  | 'past_due'
-  | 'canceled'
-  | 'incomplete';
+  'active' | 'trialing' | 'past_due' | 'canceled' | 'incomplete';
 
 export interface DeveloperSubscription {
   id: string | null;
-  organisationId: string;
   plan: DeveloperPlanTier;
   status: DeveloperSubscriptionStatus;
   stripeSubscriptionItemId: string | null;

--- a/packages/database/prisma/migrations/20260830190000_developer_resources_user_scoped/migration.sql
+++ b/packages/database/prisma/migrations/20260830190000_developer_resources_user_scoped/migration.sql
@@ -1,0 +1,46 @@
+-- Developer API keys, subscriptions and usage belong to the DEVELOPER, not to a
+-- practice.
+--
+-- These three tables were keyed on organisationId, while the portal's own
+-- audience - someone who signs up through the developer door - never gets an
+-- organisation at all: provisioning grants the `developer` role and nothing
+-- else, and there is no developer entry in the RBAC role model. Every
+-- key/billing/usage request from such an account therefore failed on the
+-- org-scoped middleware. See issue #2551.
+--
+-- A rename, not an additive change. It is cheap only because the tables are
+-- empty, which was re-confirmed against both projects immediately before this
+-- was written: production 0/0/0, dev 0/1/0 with the single subscription row
+-- holding no live Stripe subscription.
+
+-- createdBy is NOT NULL and carries the SuperTokens user id on every row, so the
+-- backfill is exact rather than inferred.
+ALTER TABLE "DeveloperApiKeys" RENAME COLUMN "organisationId" TO "ownerUserId";
+UPDATE "DeveloperApiKeys" SET "ownerUserId" = "createdBy";
+ALTER INDEX "DeveloperApiKeys_organisationId_idx"
+  RENAME TO "DeveloperApiKeys_ownerUserId_idx";
+
+-- An org-keyed subscription carries no user handle, so it cannot be re-pointed
+-- mechanically; inferring the org owner would move a Stripe billing identity by
+-- guess. A row that never completed checkout holds at most an orphaned Stripe
+-- customer and is safe to drop. A row WITH a live subscription must never be
+-- deleted by a migration - abort the deploy instead and re-key it by hand.
+DELETE FROM "DeveloperSubscriptions" WHERE "stripeSubscriptionId" IS NULL;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "DeveloperSubscriptions") THEN
+    RAISE EXCEPTION
+      'DeveloperSubscriptions holds row(s) with a live Stripe subscription. Re-key them by hand before deploying 20260830190000_developer_resources_user_scoped.';
+  END IF;
+END $$;
+ALTER TABLE "DeveloperSubscriptions" RENAME COLUMN "organisationId" TO "ownerUserId";
+ALTER INDEX "DeveloperSubscriptions_organisationId_key"
+  RENAME TO "DeveloperSubscriptions_ownerUserId_key";
+
+-- A per-org monthly counter has no meaning under a per-developer key, and a
+-- stale row would be counted against a quota it never belonged to. No external
+-- state: counters regenerate on the next call.
+DELETE FROM "DeveloperApiUsage";
+ALTER TABLE "DeveloperApiUsage" RENAME COLUMN "organisationId" TO "ownerUserId";
+ALTER INDEX "DeveloperApiUsage_organisationId_billingPeriod_key"
+  RENAME TO "DeveloperApiUsage_ownerUserId_billingPeriod_key";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1673,7 +1673,7 @@ model OrganizationUsageCounter {
 /// Only the SHA-256 hash is stored; the plaintext secret is shown once at creation.
 model DeveloperApiKey {
   id             String                    @id @default(uuid())
-  organisationId String
+  ownerUserId    String
   name           String
   prefix         String                    @unique
   hashedKey      String                    @unique
@@ -1688,7 +1688,7 @@ model DeveloperApiKey {
   createdAt      DateTime                  @default(now())
   updatedAt      DateTime                  @updatedAt
 
-  @@index([organisationId])
+  @@index([ownerUserId])
   @@index([status])
   @@map("DeveloperApiKeys")
 }
@@ -1705,7 +1705,7 @@ enum DeveloperApiKeyStatus {
 
 model DeveloperSubscription {
   id                       String                      @id @default(uuid())
-  organisationId           String                      @unique
+  ownerUserId              String                      @unique
   plan                     DeveloperPlanTier           @default(free)
   status                   DeveloperSubscriptionStatus @default(active)
   stripeCustomerId         String?
@@ -1741,14 +1741,14 @@ enum DeveloperSubscriptionStatus {
 // Free tier quota enforcement uses this; Pro tier batches here before reporting to Stripe meters.
 model DeveloperApiUsage {
   id             String    @id @default(uuid())
-  organisationId String
+  ownerUserId    String
   billingPeriod  String
   callCount      Int       @default(0)
   lastReportedAt DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  @@unique([organisationId, billingPeriod])
+  @@unique([ownerUserId, billingPeriod])
   @@index([billingPeriod])
   @@map("DeveloperApiUsage")
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The developer portal is unusable by the persona it was built for. All three portal routers (API keys, billing, usage) sit behind `withOrgPermissions()`, which answers 400 when no organisation reaches the request:

```ts
const orgId = extractOrgId(req);
if (!userId || !orgId) {
  return res.status(400).json({ message: "Missing userId or organisationId" });
}
```

A developer who signs up through the public developer door never gets one. Provisioning accepts the `developer` role and writes a single `user` row; `UserOrganization` is written in only two places, neither on that path. So `primaryOrgId` stays null, the axios interceptor drops `x-org-id` rather than sending it, and `/v1/auth/me` returns no organisation to seed it from. Every keys, billing and usage call from a developer-only account fails.

`api-key-auth` had the same hole from the other side: it read an `organisationId` off the verified key to build the request context, but no org-less developer could ever mint a key for it to read, so that composition could not run.

## What is the new behavior?

The org key was the wrong key. An API key, a Stripe subscription and a monthly call counter belong to the developer who created them, not to a practice, and the RBAC role model has no `developer` member to hang an org context on. Rather than provisioning a synthetic organisation per developer, the three resources are re-keyed to their owner.

- `DeveloperApiKey`, `DeveloperSubscription` and `DeveloperApiUsage` move from `organisationId` to `ownerUserId`; the three indexes are renamed with them (`@unique` on the subscription, `@@unique([ownerUserId, billingPeriod])` on usage).
- The three routers drop `withOrgPermissions()` and authorise on the authenticated user. Guards now answer 401 rather than the old 400.
- `api-key-auth` sets `userId` from the verified key's owner and leaves `organisationId` unset.
- A new `MAX_ACTIVE_KEYS_PER_OWNER` cap of 25 replaces the implicit ceiling the org scope used to provide; past it, key creation answers 429.
- Controllers ignore any owner supplied in the request body and always use the authenticated user, with a regression test for it.

### Migration safety

`20260830190000_developer_resources_user_scoped` is a rename plus an exact backfill, not a guess: `createdBy` is NOT NULL and carries the SuperTokens user id on every key row.

Subscriptions cannot be backfilled the same way, since an org-keyed subscription carries no user handle and inferring the org owner would move a Stripe billing identity by guess. Rows that never completed checkout are deleted; a row holding a live `stripeSubscriptionId` raises and aborts the deploy so it can be re-keyed by hand. Usage counters are deleted and regenerate on the next call.

Emptiness was re-confirmed against both projects immediately before writing the migration:

| | keys | subs | subs with live Stripe id | usage |
| --- | --- | --- | --- | --- |
| production | 0 | 0 | 0 | 0 |
| dev | 0 | 1 | 0 | 0 |

Index names were read off the live database rather than assumed.

## Validation performed

- Migration applied to a throwaway `postgres:16-alpine`, then `prisma migrate diff --from-migrations --to-schema-datamodel --exit-code` reported **"No difference detected."** (exit 0). Inspection confirmed all three tables carry `ownerUserId`, all three indexes are renamed, and no `organisationId` column remains on them.
- Backend `npx tsc --noEmit`: 0 errors. `pnpm --filter backend run lint`: clean.
- Backend targeted tests `--testPathPatterns="developer|api-key-auth"`: **121 passed, 7 suites**. The API key controller suite carries three new regression tests covering issue, self-scoped list, and ignoring a body-supplied owner.
- Frontend `npx tsc --noEmit`: 0 errors. Frontend `--testPathPatterns="[Dd]eveloper"`: **115 passed, 15 suites**.

## Related Issue(s)

Fixes #2551
