### PR TITLE
feat(repo): add the ATCvet medication spine and show cross-vocabulary codes

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -14,7 +14,10 @@ Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.
 
 # THIRD-PARTY TRADEMARK NOTICE
-This repository may reference or include integrations, plugins, names, logos, or trademarks of third-party companies (including but not limited to IDEXX, MSD Veterinary Manual, and other partners). Such trademarks and logos are the property of their respective owners and are used solely for identification or interoperability purposes. Nothing in this repository grants any right or license to use any third-party trademarks, logos, or branding except as permitted by the respective owners.
+This repository may reference or include integrations, plugins, names, logos, or trademarks of third-party companies (including but not limited to IDEXX, MSD Veterinary Manual, the WHO Collaborating Centre for Drug Statistics Methodology (ATC/ATCvet), and other partners). Such trademarks and logos are the property of their respective owners and are used solely for identification or interoperability purposes. Nothing in this repository grants any right or license to use any third-party trademarks, logos, or branding except as permitted by the respective owners.
+
+# THIRD-PARTY DATA NOTICE
+Certain terminology and classification datasets included or referenced here are owned by third parties and are NOT covered by this repository's license. In particular, the ATCvet index is copyright the WHO Collaborating Centre for Drug Statistics Methodology and is included under a licence granted to DuneXploration UG for use within Yosemite Crew; it is not sublicensed to users of this repository. Anyone wishing to use ATC or ATCvet data in their own deployment must obtain their own licence from the WHO Collaborating Centre (https://atcddd.fhi.no/). The same applies to other third-party vocabularies distributed under their own terms.
 
 ## Preamble
 

--- a/apps/backend/data/atcvet_index.json
+++ b/apps/backend/data/atcvet_index.json
@@ -1,0 +1,33268 @@
+{
+  "source": "WHO Collaborating Centre for Drug Statistics Methodology",
+  "dataset": "ATCvet index",
+  "release": "2026",
+  "convertedFrom": "2026 ATCvet index_electronic.xlsx",
+  "entries": [
+    {
+      "code": "QA",
+      "name": "ALIMENTARY TRACT AND METABOLISM"
+    },
+    {
+      "code": "QA01",
+      "name": "STOMATOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QA01A",
+      "name": "STOMATOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QA01AA",
+      "name": "Caries prophylactic agents"
+    },
+    {
+      "code": "QA01AA01",
+      "name": "sodium fluoride"
+    },
+    {
+      "code": "QA01AA02",
+      "name": "sodium monofluorophosphate"
+    },
+    {
+      "code": "QA01AA03",
+      "name": "olaflur"
+    },
+    {
+      "code": "QA01AA04",
+      "name": "stannous fluoride"
+    },
+    {
+      "code": "QA01AA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA01AA51",
+      "name": "sodium fluoride, combinations"
+    },
+    {
+      "code": "QA01AB",
+      "name": "Antiinfectives and antiseptics for local oral treatment"
+    },
+    {
+      "code": "QA01AB02",
+      "name": "hydrogen peroxide"
+    },
+    {
+      "code": "QA01AB03",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QA01AB04",
+      "name": "amphotericin B"
+    },
+    {
+      "code": "QA01AB05",
+      "name": "polynoxylin"
+    },
+    {
+      "code": "QA01AB06",
+      "name": "domiphen"
+    },
+    {
+      "code": "QA01AB07",
+      "name": "oxyquinoline"
+    },
+    {
+      "code": "QA01AB08",
+      "name": "neomycin"
+    },
+    {
+      "code": "QA01AB09",
+      "name": "miconazole"
+    },
+    {
+      "code": "QA01AB10",
+      "name": "natamycin"
+    },
+    {
+      "code": "QA01AB11",
+      "name": "various"
+    },
+    {
+      "code": "QA01AB12",
+      "name": "hexetidine"
+    },
+    {
+      "code": "QA01AB13",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QA01AB14",
+      "name": "benzoxonium chloride"
+    },
+    {
+      "code": "QA01AB15",
+      "name": "tibezonium iodide"
+    },
+    {
+      "code": "QA01AB16",
+      "name": "mepartricin"
+    },
+    {
+      "code": "QA01AB17",
+      "name": "metronidazole"
+    },
+    {
+      "code": "QA01AB18",
+      "name": "clotrimazole"
+    },
+    {
+      "code": "QA01AB19",
+      "name": "sodium perborate"
+    },
+    {
+      "code": "QA01AB20",
+      "name": "antiinfectives for local oral treatment, combinations"
+    },
+    {
+      "code": "QA01AB21",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QA01AB22",
+      "name": "doxycycline"
+    },
+    {
+      "code": "QA01AB23",
+      "name": "minocycline"
+    },
+    {
+      "code": "QA01AB24",
+      "name": "octenidine"
+    },
+    {
+      "code": "QA01AB25",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QA01AB53",
+      "name": "chlorhexidine and cetylpyridinium"
+    },
+    {
+      "code": "QA01AC",
+      "name": "Corticosteroids for local oral treatment"
+    },
+    {
+      "code": "QA01AC01",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QA01AC02",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QA01AC03",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QA01AC04",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QA01AC54",
+      "name": "prednisolone, combinations"
+    },
+    {
+      "code": "QA01AD",
+      "name": "Other agents for local oral treatment"
+    },
+    {
+      "code": "QA01AD01",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QA01AD02",
+      "name": "benzydamine"
+    },
+    {
+      "code": "QA01AD05",
+      "name": "acetylsalicylic acid"
+    },
+    {
+      "code": "QA01AD06",
+      "name": "adrenalone"
+    },
+    {
+      "code": "QA01AD07",
+      "name": "amlexanox"
+    },
+    {
+      "code": "QA01AD08",
+      "name": "becaplermin"
+    },
+    {
+      "code": "QA01AD11",
+      "name": "various"
+    },
+    {
+      "code": "QA02",
+      "name": "DRUGS FOR ACID RELATED DISORDERS"
+    },
+    {
+      "code": "QA02A",
+      "name": "ANTACIDS"
+    },
+    {
+      "code": "QA02AA",
+      "name": "Magnesium compounds"
+    },
+    {
+      "code": "QA02AA01",
+      "name": "magnesium carbonate"
+    },
+    {
+      "code": "QA02AA02",
+      "name": "magnesium oxide"
+    },
+    {
+      "code": "QA02AA03",
+      "name": "magnesium peroxide"
+    },
+    {
+      "code": "QA02AA04",
+      "name": "magnesium hydroxide"
+    },
+    {
+      "code": "QA02AA05",
+      "name": "magnesium silicate"
+    },
+    {
+      "code": "QA02AA10",
+      "name": "combinations"
+    },
+    {
+      "code": "QA02AB",
+      "name": "Aluminium compounds"
+    },
+    {
+      "code": "QA02AB01",
+      "name": "aluminium hydroxide"
+    },
+    {
+      "code": "QA02AB02",
+      "name": "algeldrate"
+    },
+    {
+      "code": "QA02AB03",
+      "name": "aluminium phosphate"
+    },
+    {
+      "code": "QA02AB04",
+      "name": "dihydroxialumini sodium carbonate"
+    },
+    {
+      "code": "QA02AB05",
+      "name": "aluminium acetoacetate"
+    },
+    {
+      "code": "QA02AB06",
+      "name": "aloglutamol"
+    },
+    {
+      "code": "QA02AB07",
+      "name": "aluminium glycinate"
+    },
+    {
+      "code": "QA02AB10",
+      "name": "combinations"
+    },
+    {
+      "code": "QA02AC",
+      "name": "Calcium compounds"
+    },
+    {
+      "code": "QA02AC01",
+      "name": "calcium carbonate"
+    },
+    {
+      "code": "QA02AC02",
+      "name": "calcium silicate"
+    },
+    {
+      "code": "QA02AC10",
+      "name": "combinations"
+    },
+    {
+      "code": "QA02AD",
+      "name": "Combinations and complexes of aluminium, calcium and magnesium compounds"
+    },
+    {
+      "code": "QA02AD01",
+      "name": "ordinary salt combinations"
+    },
+    {
+      "code": "QA02AD02",
+      "name": "magaldrate"
+    },
+    {
+      "code": "QA02AD03",
+      "name": "almagate"
+    },
+    {
+      "code": "QA02AD04",
+      "name": "hydrotalcite"
+    },
+    {
+      "code": "QA02AD05",
+      "name": "almasilate"
+    },
+    {
+      "code": "QA02AF",
+      "name": "Antacids with antiflatulents"
+    },
+    {
+      "code": "QA02AF01",
+      "name": "magaldrate and antiflatulents"
+    },
+    {
+      "code": "QA02AF02",
+      "name": "ordinary salt combinations and antiflatulents"
+    },
+    {
+      "code": "QA02AG",
+      "name": "Antacids with antispasmodics"
+    },
+    {
+      "code": "QA02AH",
+      "name": "Antacids with sodium bicarbonate"
+    },
+    {
+      "code": "QA02AX",
+      "name": "Antacids, other combinations"
+    },
+    {
+      "code": "QA02B",
+      "name": "DRUGS FOR PEPTIC ULCER AND GASTRO-OESOPHAGEAL REFLUX DISEASE (GORD)"
+    },
+    {
+      "code": "QA02BA",
+      "name": "H2-receptor antagonists"
+    },
+    {
+      "code": "QA02BA01",
+      "name": "cimetidine"
+    },
+    {
+      "code": "QA02BA02",
+      "name": "ranitidine"
+    },
+    {
+      "code": "QA02BA03",
+      "name": "famotidine"
+    },
+    {
+      "code": "QA02BA04",
+      "name": "nizatidine"
+    },
+    {
+      "code": "QA02BA05",
+      "name": "niperotidine"
+    },
+    {
+      "code": "QA02BA06",
+      "name": "roxatidine"
+    },
+    {
+      "code": "QA02BA07",
+      "name": "ranitidine bismuth citrate"
+    },
+    {
+      "code": "QA02BA08",
+      "name": "lafutidine"
+    },
+    {
+      "code": "QA02BA51",
+      "name": "cimetidine, combinations"
+    },
+    {
+      "code": "QA02BA53",
+      "name": "famotidine, combinations"
+    },
+    {
+      "code": "QA02BB",
+      "name": "Prostaglandins"
+    },
+    {
+      "code": "QA02BB01",
+      "name": "misoprostol"
+    },
+    {
+      "code": "QA02BB02",
+      "name": "enprostil"
+    },
+    {
+      "code": "QA02BC",
+      "name": "Proton pump inhibitors"
+    },
+    {
+      "code": "QA02BC01",
+      "name": "omeprazole"
+    },
+    {
+      "code": "QA02BC02",
+      "name": "pantoprazole"
+    },
+    {
+      "code": "QA02BC03",
+      "name": "lansoprazole"
+    },
+    {
+      "code": "QA02BC04",
+      "name": "rabeprazole"
+    },
+    {
+      "code": "QA02BC05",
+      "name": "esomeprazole"
+    },
+    {
+      "code": "QA02BC06",
+      "name": "dexlansoprazole"
+    },
+    {
+      "code": "QA02BC07",
+      "name": "dexrabeprazole"
+    },
+    {
+      "code": "QA02BC08",
+      "name": "vonoprazan"
+    },
+    {
+      "code": "QA02BC09",
+      "name": "tegoprazan"
+    },
+    {
+      "code": "QA02BC10",
+      "name": "fexuprazan"
+    },
+    {
+      "code": "QA02BC11",
+      "name": "ilaprazole"
+    },
+    {
+      "code": "QA02BC12",
+      "name": "zastaprazan"
+    },
+    {
+      "code": "QA02BC51",
+      "name": "omeprazole, combinations"
+    },
+    {
+      "code": "QA02BC53",
+      "name": "lansoprazole, combinations"
+    },
+    {
+      "code": "QA02BC54",
+      "name": "rabeprazole, combinations"
+    },
+    {
+      "code": "QA02BD",
+      "name": "Combinations for eradication of Helicobacter pylori"
+    },
+    {
+      "code": "QA02BD01",
+      "name": "omeprazole, amoxicillin and metronidazole"
+    },
+    {
+      "code": "QA02BD02",
+      "name": "lansoprazole, tetracycline and metronidazol"
+    },
+    {
+      "code": "QA02BD03",
+      "name": "lansoprazole, amoxixillin and metronidazol"
+    },
+    {
+      "code": "QA02BD04",
+      "name": "pantoprazole, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD05",
+      "name": "omeprazole, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD06",
+      "name": "esomeprazole, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD07",
+      "name": "lansoprazole, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD08",
+      "name": "bismuth subcitrate, tetracycline and metronidazol"
+    },
+    {
+      "code": "QA02BD09",
+      "name": "lansoprazole, clarithromycin and tinidazole"
+    },
+    {
+      "code": "QA02BD10",
+      "name": "lansoprazole, amoxicillin and levofloxacin"
+    },
+    {
+      "code": "QA02BD11",
+      "name": "pantoprazole, amoxicillin, clarithromycin and metronidazole"
+    },
+    {
+      "code": "QA02BD12",
+      "name": "rabeprazole, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD13",
+      "name": "rabeprazole, amoxicillin and metronidazole"
+    },
+    {
+      "code": "QA02BD14",
+      "name": "vonoprazan, amoxicillin and clarithromycin"
+    },
+    {
+      "code": "QA02BD15",
+      "name": "vonoprazan, amoxicillin and metronidazole"
+    },
+    {
+      "code": "QA02BD16",
+      "name": "omeprazole, amoxicillin and rifabutin"
+    },
+    {
+      "code": "QA02BD17",
+      "name": "vonoprazan and amoxicillin"
+    },
+    {
+      "code": "QA02BX",
+      "name": "Other drugs for peptic ulcer and gastro-oesophageal reflux disease (GORD)"
+    },
+    {
+      "code": "QA02BX01",
+      "name": "carbenoxolone"
+    },
+    {
+      "code": "QA02BX02",
+      "name": "sucralfate"
+    },
+    {
+      "code": "QA02BX03",
+      "name": "pirenzepine"
+    },
+    {
+      "code": "QA02BX04",
+      "name": "methiosulfonium chloride"
+    },
+    {
+      "code": "QA02BX05",
+      "name": "bismuth subcitrate"
+    },
+    {
+      "code": "QA02BX06",
+      "name": "proglumide"
+    },
+    {
+      "code": "QA02BX07",
+      "name": "gefarnate"
+    },
+    {
+      "code": "QA02BX08",
+      "name": "sulglicotide"
+    },
+    {
+      "code": "QA02BX09",
+      "name": "acetoxolone"
+    },
+    {
+      "code": "QA02BX10",
+      "name": "zolimidine"
+    },
+    {
+      "code": "QA02BX11",
+      "name": "troxipide"
+    },
+    {
+      "code": "QA02BX12",
+      "name": "bismuth subnitrate"
+    },
+    {
+      "code": "QA02BX13",
+      "name": "alginic acid"
+    },
+    {
+      "code": "QA02BX14",
+      "name": "rebamipide"
+    },
+    {
+      "code": "QA02BX15",
+      "name": "teprenone"
+    },
+    {
+      "code": "QA02BX16",
+      "name": "irsogladine"
+    },
+    {
+      "code": "QA02BX51",
+      "name": "carbenoxolone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QA02BX71",
+      "name": "carbenoxolone, combinations with psycholeptics"
+    },
+    {
+      "code": "QA02BX77",
+      "name": "gefarnate, combinations with psycholeptics"
+    },
+    {
+      "code": "QA02X",
+      "name": "OTHER DRUGS FOR ACID RELATED DISORDERS"
+    },
+    {
+      "code": "QA03",
+      "name": "DRUGS FOR FUNCTIONAL GASTROINTESTINAL DISORDERS"
+    },
+    {
+      "code": "QA03A",
+      "name": "DRUGS FOR FUNCTIONAL GASTROINTESTINAL DISORDERS"
+    },
+    {
+      "code": "QA03AA",
+      "name": "Synthetic anticholinergics, esters with tertiary amino group"
+    },
+    {
+      "code": "QA03AA01",
+      "name": "oxyphencyclimine"
+    },
+    {
+      "code": "QA03AA03",
+      "name": "camylofin"
+    },
+    {
+      "code": "QA03AA04",
+      "name": "mebeverine"
+    },
+    {
+      "code": "QA03AA05",
+      "name": "trimebutine"
+    },
+    {
+      "code": "QA03AA06",
+      "name": "rociverine"
+    },
+    {
+      "code": "QA03AA07",
+      "name": "dicycloverine"
+    },
+    {
+      "code": "QA03AA08",
+      "name": "dihexyverine"
+    },
+    {
+      "code": "QA03AA09",
+      "name": "difemerine"
+    },
+    {
+      "code": "QA03AA30",
+      "name": "piperidolate"
+    },
+    {
+      "code": "QA03AB",
+      "name": "Synthetic anticholinergics, quaternary ammonium compounds"
+    },
+    {
+      "code": "QA03AB01",
+      "name": "benzilone"
+    },
+    {
+      "code": "QA03AB02",
+      "name": "glycopyrronium"
+    },
+    {
+      "code": "QA03AB03",
+      "name": "oxyphenonium"
+    },
+    {
+      "code": "QA03AB04",
+      "name": "penthienate"
+    },
+    {
+      "code": "QA03AB05",
+      "name": "propantheline"
+    },
+    {
+      "code": "QA03AB06",
+      "name": "otilonium bromide"
+    },
+    {
+      "code": "QA03AB07",
+      "name": "methantheline"
+    },
+    {
+      "code": "QA03AB08",
+      "name": "tridihexethyl"
+    },
+    {
+      "code": "QA03AB09",
+      "name": "isopropamide"
+    },
+    {
+      "code": "QA03AB10",
+      "name": "hexocyclium"
+    },
+    {
+      "code": "QA03AB11",
+      "name": "poldine"
+    },
+    {
+      "code": "QA03AB12",
+      "name": "mepenzolate"
+    },
+    {
+      "code": "QA03AB13",
+      "name": "bevonium"
+    },
+    {
+      "code": "QA03AB14",
+      "name": "pipenzolate"
+    },
+    {
+      "code": "QA03AB15",
+      "name": "diphemanil"
+    },
+    {
+      "code": "QA03AB16",
+      "name": "(2-benzhydryloxyethyl)diethyl-methylammonium iodide"
+    },
+    {
+      "code": "QA03AB17",
+      "name": "tiemonium iodide"
+    },
+    {
+      "code": "QA03AB18",
+      "name": "prifinium bromide"
+    },
+    {
+      "code": "QA03AB19",
+      "name": "timepidium bromide"
+    },
+    {
+      "code": "QA03AB21",
+      "name": "fenpiverinium"
+    },
+    {
+      "code": "QA03AB53",
+      "name": "oxyphenonium, combinations"
+    },
+    {
+      "code": "QA03AB90",
+      "name": "benzetimide"
+    },
+    {
+      "code": "QA03AB92",
+      "name": "carbachol"
+    },
+    {
+      "code": "QA03AB93",
+      "name": "neostigmin"
+    },
+    {
+      "code": "QA03AC",
+      "name": "Synthetic antispasmodics, amides with tertiary amines"
+    },
+    {
+      "code": "QA03AC02",
+      "name": "dimethylaminopropionylphenothiazine"
+    },
+    {
+      "code": "QA03AC04",
+      "name": "nicofetamide"
+    },
+    {
+      "code": "QA03AC05",
+      "name": "tiropramide"
+    },
+    {
+      "code": "QA03AD",
+      "name": "Papaverine and derivatives"
+    },
+    {
+      "code": "QA03AD01",
+      "name": "papaverine"
+    },
+    {
+      "code": "QA03AD02",
+      "name": "drotaverine"
+    },
+    {
+      "code": "QA03AD30",
+      "name": "moxaverine"
+    },
+    {
+      "code": "QA03AE",
+      "name": "Serotonin receptor antagonists"
+    },
+    {
+      "code": "QA03AE01",
+      "name": "alosetron"
+    },
+    {
+      "code": "QA03AE03",
+      "name": "cilansetron"
+    },
+    {
+      "code": "QA03AX",
+      "name": "Other drugs for functional gastrointestinal disorders"
+    },
+    {
+      "code": "QA03AX01",
+      "name": "fenpiprane"
+    },
+    {
+      "code": "QA03AX02",
+      "name": "diisopromine"
+    },
+    {
+      "code": "QA03AX03",
+      "name": "chlorbenzoxamine"
+    },
+    {
+      "code": "QA03AX04",
+      "name": "pinaverium"
+    },
+    {
+      "code": "QA03AX05",
+      "name": "fenoverine"
+    },
+    {
+      "code": "QA03AX06",
+      "name": "idanpramine"
+    },
+    {
+      "code": "QA03AX07",
+      "name": "proxazole"
+    },
+    {
+      "code": "QA03AX08",
+      "name": "alverine"
+    },
+    {
+      "code": "QA03AX09",
+      "name": "trepibutone"
+    },
+    {
+      "code": "QA03AX10",
+      "name": "isometheptene"
+    },
+    {
+      "code": "QA03AX11",
+      "name": "caroverine"
+    },
+    {
+      "code": "QA03AX12",
+      "name": "phloroglucinol"
+    },
+    {
+      "code": "QA03AX13",
+      "name": "silicones"
+    },
+    {
+      "code": "QA03AX14",
+      "name": "valethamate"
+    },
+    {
+      "code": "QA03AX15",
+      "name": "menthae piperitae aetheroleum"
+    },
+    {
+      "code": "QA03AX30",
+      "name": "trimethyldiphenylpropylamine"
+    },
+    {
+      "code": "QA03AX58",
+      "name": "alverine, combinations"
+    },
+    {
+      "code": "QA03AX63",
+      "name": "silicones, combinations"
+    },
+    {
+      "code": "QA03AX90",
+      "name": "physostigmin"
+    },
+    {
+      "code": "QA03AX91",
+      "name": "macrogol ricinoleat (NFN)"
+    },
+    {
+      "code": "QA03B",
+      "name": "BELLADONNA AND DERIVATIVES, PLAIN"
+    },
+    {
+      "code": "QA03BA",
+      "name": "Belladonna alkaloids, tertiary amines"
+    },
+    {
+      "code": "QA03BA01",
+      "name": "atropine"
+    },
+    {
+      "code": "QA03BA03",
+      "name": "hyoscyamine"
+    },
+    {
+      "code": "QA03BA04",
+      "name": "belladonna total alkaloids"
+    },
+    {
+      "code": "QA03BB",
+      "name": "Belladonna alkaloids, semisynthetic, quaternary ammonium compounds"
+    },
+    {
+      "code": "QA03BB01",
+      "name": "butylscopolamine"
+    },
+    {
+      "code": "QA03BB02",
+      "name": "methylatropine"
+    },
+    {
+      "code": "QA03BB03",
+      "name": "methylscopolamine"
+    },
+    {
+      "code": "QA03BB04",
+      "name": "fentonium"
+    },
+    {
+      "code": "QA03BB05",
+      "name": "cimetropium bromide"
+    },
+    {
+      "code": "QA03BB06",
+      "name": "homatropine methylbromide"
+    },
+    {
+      "code": "QA03C",
+      "name": "ANTISPASMODICS IN COMBINATION WITH PSYCHOLEPTICS"
+    },
+    {
+      "code": "QA03CA",
+      "name": "Synthetic anticholinergic agents in combination with psycholeptics"
+    },
+    {
+      "code": "QA03CA01",
+      "name": "isopropamide and psycholeptics"
+    },
+    {
+      "code": "QA03CA02",
+      "name": "clidinium and psycholeptics"
+    },
+    {
+      "code": "QA03CA03",
+      "name": "oxyphencyclimine and psycholeptics"
+    },
+    {
+      "code": "QA03CA04",
+      "name": "otilonium bromide and psycholeptics"
+    },
+    {
+      "code": "QA03CA05",
+      "name": "glycopyrronium and psycholeptics"
+    },
+    {
+      "code": "QA03CA06",
+      "name": "bevonium and psycholeptics"
+    },
+    {
+      "code": "QA03CA07",
+      "name": "ambutonium and psycholeptics"
+    },
+    {
+      "code": "QA03CA08",
+      "name": "diphemanil and psycholeptics"
+    },
+    {
+      "code": "QA03CA09",
+      "name": "pipenzolate and psycholeptics"
+    },
+    {
+      "code": "QA03CA30",
+      "name": "emepronium and psycholeptics"
+    },
+    {
+      "code": "QA03CA34",
+      "name": "propantheline and psycholeptics"
+    },
+    {
+      "code": "QA03CB",
+      "name": "Belladonna and derivatives in combination with psycholeptics"
+    },
+    {
+      "code": "QA03CB01",
+      "name": "methylscopolamine and psycholeptics"
+    },
+    {
+      "code": "QA03CB02",
+      "name": "belladonna total alkaloids and psycholeptics"
+    },
+    {
+      "code": "QA03CB03",
+      "name": "atropine and psycholeptics"
+    },
+    {
+      "code": "QA03CB04",
+      "name": "homatropine methylbromide and psycholeptics"
+    },
+    {
+      "code": "QA03CB31",
+      "name": "hyoscyamine and psycholeptics"
+    },
+    {
+      "code": "QA03CC",
+      "name": "Other antispasmodics in combination with psycholeptics"
+    },
+    {
+      "code": "QA03D",
+      "name": "ANTISPASMODICS IN COMBINATION WITH ANALGESICS"
+    },
+    {
+      "code": "QA03DA",
+      "name": "Synthetic anticholinergic agents in combination with analgesics"
+    },
+    {
+      "code": "QA03DA01",
+      "name": "tropenzilone and analgesics"
+    },
+    {
+      "code": "QA03DA02",
+      "name": "pitofenone and analgesics"
+    },
+    {
+      "code": "QA03DA03",
+      "name": "bevonium and analgesics"
+    },
+    {
+      "code": "QA03DA04",
+      "name": "ciclonium and analgesics"
+    },
+    {
+      "code": "QA03DA05",
+      "name": "camylofin and analgesics"
+    },
+    {
+      "code": "QA03DA06",
+      "name": "trospium and analgesics"
+    },
+    {
+      "code": "QA03DA07",
+      "name": "tiemonium iodine and analgesics"
+    },
+    {
+      "code": "QA03DB",
+      "name": "Belladonna and derivatives in combination with analgesics"
+    },
+    {
+      "code": "QA03DB04",
+      "name": "butylscopolamine and analgesics"
+    },
+    {
+      "code": "QA03DC",
+      "name": "Other antispasmodics in combination with analgesics"
+    },
+    {
+      "code": "QA03E",
+      "name": "ANTISPASMODICS AND ANTICHOLINERGICS IN COMBINATION WITH OTHER DRUGS"
+    },
+    {
+      "code": "QA03EA",
+      "name": "Antispasmodics, psycholeptics and analgesics in combination"
+    },
+    {
+      "code": "QA03ED",
+      "name": "Antispasmodics in combination with other drugs"
+    },
+    {
+      "code": "QA03F",
+      "name": "PROPULSIVES"
+    },
+    {
+      "code": "QA03FA",
+      "name": "Propulsives"
+    },
+    {
+      "code": "QA03FA01",
+      "name": "metoclopramide"
+    },
+    {
+      "code": "QA03FA02",
+      "name": "cisapride"
+    },
+    {
+      "code": "QA03FA03",
+      "name": "domperidone"
+    },
+    {
+      "code": "QA03FA04",
+      "name": "bromopride"
+    },
+    {
+      "code": "QA03FA05",
+      "name": "alizapride"
+    },
+    {
+      "code": "QA03FA06",
+      "name": "clebopride"
+    },
+    {
+      "code": "QA03FA07",
+      "name": "itopride"
+    },
+    {
+      "code": "QA03FA08",
+      "name": "cinitapride"
+    },
+    {
+      "code": "QA03FA09",
+      "name": "mosapride"
+    },
+    {
+      "code": "QA03FA10",
+      "name": "acotiamide"
+    },
+    {
+      "code": "QA03FA90",
+      "name": "physostigmine"
+    },
+    {
+      "code": "QA04",
+      "name": "ANTIEMETICS AND ANTINAUSEANTS"
+    },
+    {
+      "code": "QA04A",
+      "name": "ANTIEMETICS AND ANTINAUSEANTS"
+    },
+    {
+      "code": "QA04AA",
+      "name": "Serotonin (5HT3) antagonists"
+    },
+    {
+      "code": "QA04AA01",
+      "name": "ondansetron"
+    },
+    {
+      "code": "QA04AA02",
+      "name": "granisetron"
+    },
+    {
+      "code": "QA04AA03",
+      "name": "tropisetron"
+    },
+    {
+      "code": "QA04AA04",
+      "name": "dolasetron"
+    },
+    {
+      "code": "QA04AA05",
+      "name": "palonosetron"
+    },
+    {
+      "code": "QA04AA55",
+      "name": "palonosetron, combinations"
+    },
+    {
+      "code": "QA04AD",
+      "name": "Other antiemetics"
+    },
+    {
+      "code": "QA04AD01",
+      "name": "scopolamine"
+    },
+    {
+      "code": "QA04AD02",
+      "name": "cerium oxalate"
+    },
+    {
+      "code": "QA04AD04",
+      "name": "chlorobutanol"
+    },
+    {
+      "code": "QA04AD05",
+      "name": "metopimazine"
+    },
+    {
+      "code": "QA04AD10",
+      "name": "dronabinol"
+    },
+    {
+      "code": "QA04AD11",
+      "name": "nabilone"
+    },
+    {
+      "code": "QA04AD12",
+      "name": "aprepitant"
+    },
+    {
+      "code": "QA04AD13",
+      "name": "casopitant"
+    },
+    {
+      "code": "QA04AD14",
+      "name": "rolapitant"
+    },
+    {
+      "code": "QA04AD51",
+      "name": "scopolamine, combinations"
+    },
+    {
+      "code": "QA04AD54",
+      "name": "chlorobutanol, combinations"
+    },
+    {
+      "code": "QA04AD90",
+      "name": "maropitant"
+    },
+    {
+      "code": "QA05",
+      "name": "BILE AND LIVER THERAPY"
+    },
+    {
+      "code": "QA05A",
+      "name": "BILE THERAPY"
+    },
+    {
+      "code": "QA05AA",
+      "name": "Bile acids and derivatives"
+    },
+    {
+      "code": "QA05AA01",
+      "name": "chenodeoxycholic acid"
+    },
+    {
+      "code": "QA05AA02",
+      "name": "ursodeoxycholic acid"
+    },
+    {
+      "code": "QA05AA03",
+      "name": "cholic acid"
+    },
+    {
+      "code": "QA05AA04",
+      "name": "obeticholic acid"
+    },
+    {
+      "code": "QA05AA05",
+      "name": "ursodoxicoltaurine"
+    },
+    {
+      "code": "QA05AA06",
+      "name": "norucholic acid"
+    },
+    {
+      "code": "QA05AB",
+      "name": "Preparations for biliary tract therapy"
+    },
+    {
+      "code": "QA05AB01",
+      "name": "nicotinyl methylamide"
+    },
+    {
+      "code": "QA05AX",
+      "name": "Other drugs for bile therapy"
+    },
+    {
+      "code": "QA05AX01",
+      "name": "piprozoline"
+    },
+    {
+      "code": "QA05AX02",
+      "name": "hymecromone"
+    },
+    {
+      "code": "QA05AX03",
+      "name": "cyclobutyrol"
+    },
+    {
+      "code": "QA05AX04",
+      "name": "maralixibat chloride"
+    },
+    {
+      "code": "QA05AX05",
+      "name": "odevixibat"
+    },
+    {
+      "code": "QA05AX06",
+      "name": "elafibranor"
+    },
+    {
+      "code": "QA05AX07",
+      "name": "seladelpar"
+    },
+    {
+      "code": "QA05AX08",
+      "name": "linerixibat"
+    },
+    {
+      "code": "QA05AX90",
+      "name": "menbutone"
+    },
+    {
+      "code": "QA05B",
+      "name": "LIVER THERAPY, LIPOTROPICS"
+    },
+    {
+      "code": "QA05BA",
+      "name": "Liver therapy"
+    },
+    {
+      "code": "QA05BA01",
+      "name": "arginine glutamate"
+    },
+    {
+      "code": "QA05BA03",
+      "name": "silymarin"
+    },
+    {
+      "code": "QA05BA04",
+      "name": "citiolone"
+    },
+    {
+      "code": "QA05BA05",
+      "name": "epomediol"
+    },
+    {
+      "code": "QA05BA06",
+      "name": "ornithine oxoglurate"
+    },
+    {
+      "code": "QA05BA07",
+      "name": "tidiacic arginine"
+    },
+    {
+      "code": "QA05BA08",
+      "name": "glycyrrhizic acid"
+    },
+    {
+      "code": "QA05BA09",
+      "name": "metadoxine"
+    },
+    {
+      "code": "QA05BA10",
+      "name": "phospholipids"
+    },
+    {
+      "code": "QA05BA11",
+      "name": "resmetirom"
+    },
+    {
+      "code": "QA05BA90",
+      "name": "methionine"
+    },
+    {
+      "code": "QA05C",
+      "name": "DRUGS FOR BILE THERAPY AND LIPOTROPICS IN COMBINATION"
+    },
+    {
+      "code": "QA06",
+      "name": "DRUGS FOR CONSTIPATION"
+    },
+    {
+      "code": "QA06A",
+      "name": "DRUGS FOR CONSTIPATION"
+    },
+    {
+      "code": "QA06AA",
+      "name": "Softeners, emollients"
+    },
+    {
+      "code": "QA06AA01",
+      "name": "liquid paraffin"
+    },
+    {
+      "code": "QA06AA02",
+      "name": "docusate sodium"
+    },
+    {
+      "code": "QA06AA51",
+      "name": "liquid paraffin, combinations"
+    },
+    {
+      "code": "QA06AB",
+      "name": "Contact laxatives"
+    },
+    {
+      "code": "QA06AB01",
+      "name": "oxyphenisatine"
+    },
+    {
+      "code": "QA06AB02",
+      "name": "bisacodyl"
+    },
+    {
+      "code": "QA06AB03",
+      "name": "dantron"
+    },
+    {
+      "code": "QA06AB04",
+      "name": "phenolphthalein"
+    },
+    {
+      "code": "QA06AB05",
+      "name": "castor oil"
+    },
+    {
+      "code": "QA06AB06",
+      "name": "senna glycosides"
+    },
+    {
+      "code": "QA06AB07",
+      "name": "cascara"
+    },
+    {
+      "code": "QA06AB08",
+      "name": "sodium picosulfate"
+    },
+    {
+      "code": "QA06AB09",
+      "name": "bisoxatin"
+    },
+    {
+      "code": "QA06AB20",
+      "name": "contact laxatives in combination"
+    },
+    {
+      "code": "QA06AB30",
+      "name": "contact laxatives in combination with belladonna alkaloids"
+    },
+    {
+      "code": "QA06AB52",
+      "name": "bisacodyl, combinations"
+    },
+    {
+      "code": "QA06AB53",
+      "name": "dantron, combinations"
+    },
+    {
+      "code": "QA06AB56",
+      "name": "senna glycosides, combinations"
+    },
+    {
+      "code": "QA06AB57",
+      "name": "cascara, combinations"
+    },
+    {
+      "code": "QA06AB58",
+      "name": "sodium picosulfate, combinations"
+    },
+    {
+      "code": "QA06AC",
+      "name": "Bulk-forming laxatives"
+    },
+    {
+      "code": "QA06AC01",
+      "name": "ispaghula (psylla seeds)"
+    },
+    {
+      "code": "QA06AC02",
+      "name": "ethulose"
+    },
+    {
+      "code": "QA06AC03",
+      "name": "sterculia"
+    },
+    {
+      "code": "QA06AC05",
+      "name": "linseed"
+    },
+    {
+      "code": "QA06AC06",
+      "name": "methylcellulose"
+    },
+    {
+      "code": "QA06AC07",
+      "name": "triticum (wheat fibre)"
+    },
+    {
+      "code": "QA06AC08",
+      "name": "polycarbophil calcium"
+    },
+    {
+      "code": "QA06AC51",
+      "name": "ispaghula, combinations"
+    },
+    {
+      "code": "QA06AC53",
+      "name": "sterculia, combinations"
+    },
+    {
+      "code": "QA06AC55",
+      "name": "linseed, combinations"
+    },
+    {
+      "code": "QA06AD",
+      "name": "Osmotically acting laxatives"
+    },
+    {
+      "code": "QA06AD01",
+      "name": "magnesium carbonate"
+    },
+    {
+      "code": "QA06AD02",
+      "name": "magnesium oxide"
+    },
+    {
+      "code": "QA06AD03",
+      "name": "magnesium peroxide"
+    },
+    {
+      "code": "QA06AD04",
+      "name": "magnesium sulfate"
+    },
+    {
+      "code": "QA06AD10",
+      "name": "mineral salts in combination"
+    },
+    {
+      "code": "QA06AD11",
+      "name": "lactulose"
+    },
+    {
+      "code": "QA06AD12",
+      "name": "lactitol"
+    },
+    {
+      "code": "QA06AD13",
+      "name": "sodium sulfate"
+    },
+    {
+      "code": "QA06AD14",
+      "name": "pentaerythritol"
+    },
+    {
+      "code": "QA06AD15",
+      "name": "macrogol"
+    },
+    {
+      "code": "QA06AD16",
+      "name": "mannitol"
+    },
+    {
+      "code": "QA06AD17",
+      "name": "sodium phosphate"
+    },
+    {
+      "code": "QA06AD18",
+      "name": "sorbitol"
+    },
+    {
+      "code": "QA06AD19",
+      "name": "magnesium citrate"
+    },
+    {
+      "code": "QA06AD21",
+      "name": "sodium tartrate"
+    },
+    {
+      "code": "QA06AD61",
+      "name": "lactulose, combinations"
+    },
+    {
+      "code": "QA06AD65",
+      "name": "macrogol, combinations"
+    },
+    {
+      "code": "QA06AG",
+      "name": "Enemas"
+    },
+    {
+      "code": "QA06AG01",
+      "name": "sodium phosphate"
+    },
+    {
+      "code": "QA06AG02",
+      "name": "bisacodyl"
+    },
+    {
+      "code": "QA06AG03",
+      "name": "dantron, incl. combinations"
+    },
+    {
+      "code": "QA06AG04",
+      "name": "glycerol"
+    },
+    {
+      "code": "QA06AG06",
+      "name": "oil"
+    },
+    {
+      "code": "QA06AG07",
+      "name": "sorbitol"
+    },
+    {
+      "code": "QA06AG10",
+      "name": "docusate sodium, incl. combinations"
+    },
+    {
+      "code": "QA06AG11",
+      "name": "sodium lauryl sulfoacetate, incl. combinations"
+    },
+    {
+      "code": "QA06AG20",
+      "name": "combinations"
+    },
+    {
+      "code": "QA06AH",
+      "name": "Peripheral opioid receptor antagonists"
+    },
+    {
+      "code": "QA06AH01",
+      "name": "methylnaltrexone bromide"
+    },
+    {
+      "code": "QA06AH02",
+      "name": "alvimopan"
+    },
+    {
+      "code": "QA06AH03",
+      "name": "naloxegol"
+    },
+    {
+      "code": "QA06AH04",
+      "name": "naloxone"
+    },
+    {
+      "code": "QA06AH05",
+      "name": "naldemedine"
+    },
+    {
+      "code": "QA06AX",
+      "name": "Other drugs for constipation"
+    },
+    {
+      "code": "QA06AX01",
+      "name": "glycerol"
+    },
+    {
+      "code": "QA06AX02",
+      "name": "carbon dioxide producing drugs"
+    },
+    {
+      "code": "QA06AX03",
+      "name": "lubiprostone"
+    },
+    {
+      "code": "QA06AX04",
+      "name": "linaclotide"
+    },
+    {
+      "code": "QA06AX05",
+      "name": "prucalopride"
+    },
+    {
+      "code": "QA06AX06",
+      "name": "tegaserod"
+    },
+    {
+      "code": "QA06AX07",
+      "name": "plecanatide"
+    },
+    {
+      "code": "QA06AX08",
+      "name": "tenapanor"
+    },
+    {
+      "code": "QA06AX09",
+      "name": "elobixibat"
+    },
+    {
+      "code": "QA07",
+      "name": "ANTIDIARRHEALS, INTESTINAL ANTI-INFLAMMATORY/ANTIINFECTIVE AGENTS"
+    },
+    {
+      "code": "QA07A",
+      "name": "INTESTINAL ANTIINFECTIVES"
+    },
+    {
+      "code": "QA07AA",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QA07AA01",
+      "name": "neomycin"
+    },
+    {
+      "code": "QA07AA02",
+      "name": "nystatin"
+    },
+    {
+      "code": "QA07AA03",
+      "name": "natamycin"
+    },
+    {
+      "code": "QA07AA04",
+      "name": "streptomycin"
+    },
+    {
+      "code": "QA07AA05",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QA07AA06",
+      "name": "paromomycin"
+    },
+    {
+      "code": "QA07AA07",
+      "name": "amphotericin B"
+    },
+    {
+      "code": "QA07AA08",
+      "name": "kanamycin"
+    },
+    {
+      "code": "QA07AA09",
+      "name": "vancomycin"
+    },
+    {
+      "code": "QA07AA10",
+      "name": "colistin"
+    },
+    {
+      "code": "QA07AA11",
+      "name": "rifaximin"
+    },
+    {
+      "code": "QA07AA12",
+      "name": "fidaxomicin"
+    },
+    {
+      "code": "QA07AA13",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QA07AA51",
+      "name": "neomycin, combinations"
+    },
+    {
+      "code": "QA07AA54",
+      "name": "streptomycin, combinations"
+    },
+    {
+      "code": "QA07AA90",
+      "name": "dihydrostreptomycin"
+    },
+    {
+      "code": "QA07AA91",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QA07AA92",
+      "name": "apramycin"
+    },
+    {
+      "code": "QA07AA93",
+      "name": "bacitracin"
+    },
+    {
+      "code": "QA07AA94",
+      "name": "enramycin"
+    },
+    {
+      "code": "QA07AA95",
+      "name": "avilamycin"
+    },
+    {
+      "code": "QA07AA96",
+      "name": "bambermycin"
+    },
+    {
+      "code": "QA07AA98",
+      "name": "colistin, combinations with other antibacterials"
+    },
+    {
+      "code": "QA07AA99",
+      "name": "antibiotics, combinations"
+    },
+    {
+      "code": "QA07AB",
+      "name": "Sulfonamides"
+    },
+    {
+      "code": "QA07AB02",
+      "name": "phthalylsulfathiazole"
+    },
+    {
+      "code": "QA07AB03",
+      "name": "sulfaguanidine"
+    },
+    {
+      "code": "QA07AB04",
+      "name": "succinylsulfathiazole"
+    },
+    {
+      "code": "QA07AB20",
+      "name": "sulfonamides, combinations"
+    },
+    {
+      "code": "QA07AB90",
+      "name": "formosulfathiazole"
+    },
+    {
+      "code": "QA07AB92",
+      "name": "phthalylsulfathiazole, combinations"
+    },
+    {
+      "code": "QA07AB99",
+      "name": "combinations"
+    },
+    {
+      "code": "QA07AC",
+      "name": "Imidazole derivatives"
+    },
+    {
+      "code": "QA07AC01",
+      "name": "miconazole"
+    },
+    {
+      "code": "QA07AX",
+      "name": "Other intestinal antiinfectives"
+    },
+    {
+      "code": "QA07AX01",
+      "name": "broxyquinoline"
+    },
+    {
+      "code": "QA07AX02",
+      "name": "acetarsol"
+    },
+    {
+      "code": "QA07AX03",
+      "name": "nifuroxazide"
+    },
+    {
+      "code": "QA07AX04",
+      "name": "nifurzide"
+    },
+    {
+      "code": "QA07AX90",
+      "name": "poly (2-propenal, 2-propenoic acid)"
+    },
+    {
+      "code": "QA07AX91",
+      "name": "halquinol"
+    },
+    {
+      "code": "QA07B",
+      "name": "INTESTINAL ADSORBENTS"
+    },
+    {
+      "code": "QA07BA",
+      "name": "Charcoal preparations"
+    },
+    {
+      "code": "QA07BA01",
+      "name": "medicinal charcoal"
+    },
+    {
+      "code": "QA07BA51",
+      "name": "medicinal charcoal, combinations"
+    },
+    {
+      "code": "QA07BB",
+      "name": "Bismuth preparations"
+    },
+    {
+      "code": "QA07BC",
+      "name": "Other intestinal adsorbents"
+    },
+    {
+      "code": "QA07BC01",
+      "name": "pectin"
+    },
+    {
+      "code": "QA07BC02",
+      "name": "kaolin"
+    },
+    {
+      "code": "QA07BC03",
+      "name": "crospovidone"
+    },
+    {
+      "code": "QA07BC04",
+      "name": "attapulgite"
+    },
+    {
+      "code": "QA07BC05",
+      "name": "diosmectite"
+    },
+    {
+      "code": "QA07BC30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA07BC54",
+      "name": "attapulgite, combinations"
+    },
+    {
+      "code": "QA07C",
+      "name": "ELECTROLYTES WITH CARBOHYDRATES"
+    },
+    {
+      "code": "QA07CQ",
+      "name": "Oral rehydration formulations for veterinary use"
+    },
+    {
+      "code": "QA07CQ01",
+      "name": "oral electrolytes"
+    },
+    {
+      "code": "QA07CQ02",
+      "name": "oral electrolytes and carbohydrates"
+    },
+    {
+      "code": "QA07D",
+      "name": "ANTIPROPULSIVES"
+    },
+    {
+      "code": "QA07DA",
+      "name": "Antipropulsives"
+    },
+    {
+      "code": "QA07DA01",
+      "name": "diphenoxylate"
+    },
+    {
+      "code": "QA07DA02",
+      "name": "opium"
+    },
+    {
+      "code": "QA07DA03",
+      "name": "loperamide"
+    },
+    {
+      "code": "QA07DA04",
+      "name": "difenoxin"
+    },
+    {
+      "code": "QA07DA05",
+      "name": "loperamide oxide"
+    },
+    {
+      "code": "QA07DA06",
+      "name": "eluxadoline"
+    },
+    {
+      "code": "QA07DA52",
+      "name": "morphine, combinations"
+    },
+    {
+      "code": "QA07DA53",
+      "name": "loperamide, combinations"
+    },
+    {
+      "code": "QA07E",
+      "name": "INTESTINAL ANTIINFLAMMATORY AGENTS"
+    },
+    {
+      "code": "QA07EA",
+      "name": "Corticosteroids acting locally"
+    },
+    {
+      "code": "QA07EA01",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QA07EA02",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QA07EA03",
+      "name": "prednisone"
+    },
+    {
+      "code": "QA07EA04",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QA07EA05",
+      "name": "tixocortol"
+    },
+    {
+      "code": "QA07EA06",
+      "name": "budesonide"
+    },
+    {
+      "code": "QA07EA07",
+      "name": "beclometasone"
+    },
+    {
+      "code": "QA07EB",
+      "name": "Antiallergic agents, excl. corticosteroids"
+    },
+    {
+      "code": "QA07EB01",
+      "name": "cromoglicic acid"
+    },
+    {
+      "code": "QA07EC",
+      "name": "Aminosalicylic acid and similar agents"
+    },
+    {
+      "code": "QA07EC01",
+      "name": "sulfasalazine"
+    },
+    {
+      "code": "QA07EC02",
+      "name": "mesalazine"
+    },
+    {
+      "code": "QA07EC03",
+      "name": "olsalazine"
+    },
+    {
+      "code": "QA07EC04",
+      "name": "balsalazide"
+    },
+    {
+      "code": "QA07F",
+      "name": "ANTIDIARRHEAL MICROORGANISMS"
+    },
+    {
+      "code": "QA07FA",
+      "name": "Antidiarrheal microorganisms"
+    },
+    {
+      "code": "QA07FA01",
+      "name": "lactic acid producing organisms"
+    },
+    {
+      "code": "QA07FA02",
+      "name": "saccharomyces boulardii"
+    },
+    {
+      "code": "QA07FA03",
+      "name": "escherichia coli"
+    },
+    {
+      "code": "QA07FA51",
+      "name": "lactic acid producing organisms, combinations"
+    },
+    {
+      "code": "QA07FA90",
+      "name": "probiotics"
+    },
+    {
+      "code": "QA07X",
+      "name": "OTHER ANTIDIARRHEALS"
+    },
+    {
+      "code": "QA07XA",
+      "name": "Other antidiarrheals"
+    },
+    {
+      "code": "QA07XA01",
+      "name": "albumin tannate"
+    },
+    {
+      "code": "QA07XA02",
+      "name": "ceratonia"
+    },
+    {
+      "code": "QA07XA03",
+      "name": "calcium compounds"
+    },
+    {
+      "code": "QA07XA04",
+      "name": "racecadotril"
+    },
+    {
+      "code": "QA07XA06",
+      "name": "crofelemer"
+    },
+    {
+      "code": "QA07XA51",
+      "name": "albumin tannate, combinations"
+    },
+    {
+      "code": "QA07XA90",
+      "name": "aluminium salicylates, basic"
+    },
+    {
+      "code": "QA07XA91",
+      "name": "zinc oxide"
+    },
+    {
+      "code": "QA07XA92",
+      "name": "zinc disodium edetate"
+    },
+    {
+      "code": "QA07XA99",
+      "name": "other antidiarrheals, combinations"
+    },
+    {
+      "code": "QA08",
+      "name": "ANTIOBESITY PREPARATIONS, EXCL. DIET PRODUCTS"
+    },
+    {
+      "code": "QA08A",
+      "name": "ANTIOBESITY PREPARATIONS, EXCL. DIET PRODUCTS"
+    },
+    {
+      "code": "QA08AA",
+      "name": "Centrally acting antiobesity products"
+    },
+    {
+      "code": "QA08AA01",
+      "name": "phentermine"
+    },
+    {
+      "code": "QA08AA02",
+      "name": "fenfluramine"
+    },
+    {
+      "code": "QA08AA03",
+      "name": "amfepramone"
+    },
+    {
+      "code": "QA08AA04",
+      "name": "dexfenfluramine"
+    },
+    {
+      "code": "QA08AA05",
+      "name": "mazindol"
+    },
+    {
+      "code": "QA08AA06",
+      "name": "etilamfetamine"
+    },
+    {
+      "code": "QA08AA07",
+      "name": "cathine"
+    },
+    {
+      "code": "QA08AA08",
+      "name": "clobenzorex"
+    },
+    {
+      "code": "QA08AA09",
+      "name": "mefenorex"
+    },
+    {
+      "code": "QA08AA10",
+      "name": "sibutramine"
+    },
+    {
+      "code": "QA08AA11",
+      "name": "lorcaserin"
+    },
+    {
+      "code": "QA08AA12",
+      "name": "setmelanotide"
+    },
+    {
+      "code": "QA08AA51",
+      "name": "phentermine and topiramate"
+    },
+    {
+      "code": "QA08AA56",
+      "name": "ephedrine, combinations"
+    },
+    {
+      "code": "QA08AA62",
+      "name": "bupropion and naltrexone"
+    },
+    {
+      "code": "QA08AB",
+      "name": "Peripherally acting antiobesity products"
+    },
+    {
+      "code": "QA08AB01",
+      "name": "orlistat"
+    },
+    {
+      "code": "QA08AB90",
+      "name": "mitratapide"
+    },
+    {
+      "code": "QA08AB91",
+      "name": "dirlotapide"
+    },
+    {
+      "code": "QA08AX",
+      "name": "Other antiobesity drugs"
+    },
+    {
+      "code": "QA08AX01",
+      "name": "rimonabant"
+    },
+    {
+      "code": "QA09",
+      "name": "DIGESTIVES, INCL. ENZYMES"
+    },
+    {
+      "code": "QA09A",
+      "name": "DIGESTIVES, INCL. ENZYMES"
+    },
+    {
+      "code": "QA09AA",
+      "name": "Enzyme preparations"
+    },
+    {
+      "code": "QA09AA01",
+      "name": "diastase"
+    },
+    {
+      "code": "QA09AA02",
+      "name": "multienzymes (lipase, protease etc)"
+    },
+    {
+      "code": "QA09AA03",
+      "name": "pepsin"
+    },
+    {
+      "code": "QA09AA04",
+      "name": "tilactase"
+    },
+    {
+      "code": "QA09AB",
+      "name": "Acid preparations"
+    },
+    {
+      "code": "QA09AB01",
+      "name": "glutamic acid hydrochloride"
+    },
+    {
+      "code": "QA09AB02",
+      "name": "betaine hydrochloride"
+    },
+    {
+      "code": "QA09AB03",
+      "name": "hydrochloric acid"
+    },
+    {
+      "code": "QA09AB04",
+      "name": "citric acid"
+    },
+    {
+      "code": "QA09AC",
+      "name": "Enzyme and acid preparations, combinations"
+    },
+    {
+      "code": "QA09AC01",
+      "name": "pepsin and acid preparations"
+    },
+    {
+      "code": "QA09AC02",
+      "name": "multienzymes and acid preparations"
+    },
+    {
+      "code": "QA10",
+      "name": "DRUGS USED IN DIABETES"
+    },
+    {
+      "code": "QA10A",
+      "name": "INSULINS AND ANALOGUES"
+    },
+    {
+      "code": "QA10AB",
+      "name": "Insulins and analogues for injection, fast-acting"
+    },
+    {
+      "code": "QA10AB01",
+      "name": "insulin (human)"
+    },
+    {
+      "code": "QA10AB02",
+      "name": "insulin (beef)"
+    },
+    {
+      "code": "QA10AB03",
+      "name": "insulin (pork)"
+    },
+    {
+      "code": "QA10AB04",
+      "name": "insulin lispro"
+    },
+    {
+      "code": "QA10AB05",
+      "name": "insulin aspart"
+    },
+    {
+      "code": "QA10AB06",
+      "name": "insulin glulisine"
+    },
+    {
+      "code": "QA10AB30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA10AC",
+      "name": "Insulins and analogues for injection, intermediate-acting"
+    },
+    {
+      "code": "QA10AC01",
+      "name": "insulin (human)"
+    },
+    {
+      "code": "QA10AC02",
+      "name": "insulin (beef)"
+    },
+    {
+      "code": "QA10AC03",
+      "name": "insulin (pork)"
+    },
+    {
+      "code": "QA10AC04",
+      "name": "insulin lispro"
+    },
+    {
+      "code": "QA10AC30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA10AD",
+      "name": "Insulins and analogues for injection, intermediate- or long-acting combined with fast-acting"
+    },
+    {
+      "code": "QA10AD01",
+      "name": "insulin (human)"
+    },
+    {
+      "code": "QA10AD02",
+      "name": "insulin (beef)"
+    },
+    {
+      "code": "QA10AD03",
+      "name": "insulin (pork)"
+    },
+    {
+      "code": "QA10AD04",
+      "name": "insulin lispro"
+    },
+    {
+      "code": "QA10AD05",
+      "name": "insulin aspart"
+    },
+    {
+      "code": "QA10AD06",
+      "name": "insulin degludec and insulin aspart"
+    },
+    {
+      "code": "QA10AD30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA10AE",
+      "name": "Insulins and analogues for injection, long-acting"
+    },
+    {
+      "code": "QA10AE01",
+      "name": "insulin (human)"
+    },
+    {
+      "code": "QA10AE02",
+      "name": "insulin (beef)"
+    },
+    {
+      "code": "QA10AE03",
+      "name": "insulin (pork)"
+    },
+    {
+      "code": "QA10AE04",
+      "name": "insulin glargine"
+    },
+    {
+      "code": "QA10AE05",
+      "name": "insulin detemir"
+    },
+    {
+      "code": "QA10AE06",
+      "name": "insulin degludec"
+    },
+    {
+      "code": "QA10AE07",
+      "name": "insulin icodec"
+    },
+    {
+      "code": "QA10AE30",
+      "name": "combinations"
+    },
+    {
+      "code": "QA10AE54",
+      "name": "insulin glargine and lixisenatide"
+    },
+    {
+      "code": "QA10AE56",
+      "name": "insulin degludec and liraglutide"
+    },
+    {
+      "code": "QA10AE57",
+      "name": "insulin icodec and semaglutide"
+    },
+    {
+      "code": "QA10AF",
+      "name": "Insulins and analogues, for inhalation"
+    },
+    {
+      "code": "QA10AF01",
+      "name": "insulin (human)"
+    },
+    {
+      "code": "QA10B",
+      "name": "BLOOD GLUCOSE LOWERING DRUGS, EXCL. INSULINS"
+    },
+    {
+      "code": "QA10BA",
+      "name": "Biguanides"
+    },
+    {
+      "code": "QA10BA01",
+      "name": "phenformin"
+    },
+    {
+      "code": "QA10BA02",
+      "name": "metformin"
+    },
+    {
+      "code": "QA10BA03",
+      "name": "buformin"
+    },
+    {
+      "code": "QA10BB",
+      "name": "Sulfonylureas"
+    },
+    {
+      "code": "QA10BB01",
+      "name": "glibenclamide"
+    },
+    {
+      "code": "QA10BB02",
+      "name": "chlorpropamide"
+    },
+    {
+      "code": "QA10BB03",
+      "name": "tolbutamide"
+    },
+    {
+      "code": "QA10BB04",
+      "name": "glibornuride"
+    },
+    {
+      "code": "QA10BB05",
+      "name": "tolazamide"
+    },
+    {
+      "code": "QA10BB06",
+      "name": "carbutamide"
+    },
+    {
+      "code": "QA10BB07",
+      "name": "glipizide"
+    },
+    {
+      "code": "QA10BB08",
+      "name": "gliquidone"
+    },
+    {
+      "code": "QA10BB09",
+      "name": "gliclazide"
+    },
+    {
+      "code": "QA10BB10",
+      "name": "metahexamide"
+    },
+    {
+      "code": "QA10BB11",
+      "name": "glisoxepide"
+    },
+    {
+      "code": "QA10BB12",
+      "name": "glimepiride"
+    },
+    {
+      "code": "QA10BB31",
+      "name": "acetohexamide"
+    },
+    {
+      "code": "QA10BC",
+      "name": "Sulfonamides (heterocyclic)"
+    },
+    {
+      "code": "QA10BC01",
+      "name": "glymidine"
+    },
+    {
+      "code": "QA10BD",
+      "name": "Combinations of oral blood glucose lowering drugs"
+    },
+    {
+      "code": "QA10BD01",
+      "name": "phenformin and sulfonylureas"
+    },
+    {
+      "code": "QA10BD02",
+      "name": "metformin and sulfonylureas"
+    },
+    {
+      "code": "QA10BD03",
+      "name": "metformin and rosiglitazone"
+    },
+    {
+      "code": "QA10BD04",
+      "name": "glimepiride and rosiglitazone"
+    },
+    {
+      "code": "QA10BD05",
+      "name": "metformin and pioglitazone"
+    },
+    {
+      "code": "QA10BD06",
+      "name": "glimepiride and pioglitazone"
+    },
+    {
+      "code": "QA10BD07",
+      "name": "metformin and sitagliptin"
+    },
+    {
+      "code": "QA10BD08",
+      "name": "metformin and vildagliptin"
+    },
+    {
+      "code": "QA10BD09",
+      "name": "pioglitazone and alogliptin"
+    },
+    {
+      "code": "QA10BD10",
+      "name": "metformin and saxagliptin"
+    },
+    {
+      "code": "QA10BD11",
+      "name": "metformin and linagliptin"
+    },
+    {
+      "code": "QA10BD12",
+      "name": "pioglitazone and sitagliptin"
+    },
+    {
+      "code": "QA10BD13",
+      "name": "metformin and alogliptin"
+    },
+    {
+      "code": "QA10BD14",
+      "name": "metformin and repaglinide"
+    },
+    {
+      "code": "QA10BD15",
+      "name": "metformin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD16",
+      "name": "metformin and canagliflozin"
+    },
+    {
+      "code": "QA10BD17",
+      "name": "metformin and acarbose"
+    },
+    {
+      "code": "QA10BD18",
+      "name": "metformin and gemigliptin"
+    },
+    {
+      "code": "QA10BD19",
+      "name": "linagliptin and empagliflozin"
+    },
+    {
+      "code": "QA10BD20",
+      "name": "metformin and empagliflozin"
+    },
+    {
+      "code": "QA10BD21",
+      "name": "saxagliptin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD22",
+      "name": "metformin and evogliptin"
+    },
+    {
+      "code": "QA10BD23",
+      "name": "metformin and ertugliflozin"
+    },
+    {
+      "code": "QA10BD24",
+      "name": "sitagliptin and ertugliflozin"
+    },
+    {
+      "code": "QA10BD25",
+      "name": "metformin, saxagliptin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD26",
+      "name": "metformin and lobeglitazone"
+    },
+    {
+      "code": "QA10BD27",
+      "name": "metformin, linagliptin and empagliflozin"
+    },
+    {
+      "code": "QA10BD28",
+      "name": "metformin and teneligliptin"
+    },
+    {
+      "code": "QA10BD29",
+      "name": "sitagliptin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD30",
+      "name": "gemigliptin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD31",
+      "name": "metformin, sitagliptin and dapagliflozin"
+    },
+    {
+      "code": "QA10BD32",
+      "name": "glimepiride and dapagliflozin"
+    },
+    {
+      "code": "QA10BD33",
+      "name": "pioglitazone and dapagliflozin"
+    },
+    {
+      "code": "QA10BD34",
+      "name": "metformin and enavogliflozin"
+    },
+    {
+      "code": "QA10BF",
+      "name": "Alpha glucosidase inhibitors"
+    },
+    {
+      "code": "QA10BF01",
+      "name": "acarbose"
+    },
+    {
+      "code": "QA10BF02",
+      "name": "miglitol"
+    },
+    {
+      "code": "QA10BF03",
+      "name": "voglibose"
+    },
+    {
+      "code": "QA10BG",
+      "name": "Thiazolidinediones"
+    },
+    {
+      "code": "QA10BG01",
+      "name": "troglitazone"
+    },
+    {
+      "code": "QA10BG02",
+      "name": "rosiglitazone"
+    },
+    {
+      "code": "QA10BG03",
+      "name": "pioglitazone"
+    },
+    {
+      "code": "QA10BG04",
+      "name": "lobeglitazone"
+    },
+    {
+      "code": "QA10BH",
+      "name": "Dipeptidyl peptidase 4 (DPP-4) inhibitors"
+    },
+    {
+      "code": "QA10BH01",
+      "name": "sitagliptin"
+    },
+    {
+      "code": "QA10BH02",
+      "name": "vildagliptin"
+    },
+    {
+      "code": "QA10BH03",
+      "name": "saxagliptin"
+    },
+    {
+      "code": "QA10BH04",
+      "name": "alogliptin"
+    },
+    {
+      "code": "QA10BH05",
+      "name": "linagliptin"
+    },
+    {
+      "code": "QA10BH06",
+      "name": "gemigliptin"
+    },
+    {
+      "code": "QA10BH07",
+      "name": "evogliptin"
+    },
+    {
+      "code": "QA10BH08",
+      "name": "teneligliptin"
+    },
+    {
+      "code": "QA10BH51",
+      "name": "sitagliptin and simvastatin"
+    },
+    {
+      "code": "QA10BH52",
+      "name": "gemigliptin and rosuvastatin"
+    },
+    {
+      "code": "QA10BJ",
+      "name": "Glucagon-like peptide-1 (GLP-1) analogues"
+    },
+    {
+      "code": "QA10BJ01",
+      "name": "exenatide"
+    },
+    {
+      "code": "QA10BJ02",
+      "name": "liraglutide"
+    },
+    {
+      "code": "QA10BJ03",
+      "name": "lixisenatide"
+    },
+    {
+      "code": "QA10BJ04",
+      "name": "albiglutide"
+    },
+    {
+      "code": "QA10BJ05",
+      "name": "dulaglutide"
+    },
+    {
+      "code": "QA10BJ06",
+      "name": "semaglutide"
+    },
+    {
+      "code": "QA10BJ07",
+      "name": "beinaglutide"
+    },
+    {
+      "code": "QA10BK",
+      "name": "Sodium-glucose co-transporter 2 (SGLT2) inhibitors"
+    },
+    {
+      "code": "QA10BK01",
+      "name": "dapagliflozin"
+    },
+    {
+      "code": "QA10BK02",
+      "name": "canagliflozin"
+    },
+    {
+      "code": "QA10BK03",
+      "name": "empagliflozin"
+    },
+    {
+      "code": "QA10BK04",
+      "name": "ertugliflozin"
+    },
+    {
+      "code": "QA10BK05",
+      "name": "ipragliflozin"
+    },
+    {
+      "code": "QA10BK06",
+      "name": "sotagliflozin"
+    },
+    {
+      "code": "QA10BK07",
+      "name": "luseogliflozin"
+    },
+    {
+      "code": "QA10BK08",
+      "name": "bexagliflozin"
+    },
+    {
+      "code": "QA10BK09",
+      "name": "enavogliflozin"
+    },
+    {
+      "code": "QA10BK90",
+      "name": "velagliflozin"
+    },
+    {
+      "code": "QA10BX",
+      "name": "Other blood glucose lowering drugs, excl. insulins"
+    },
+    {
+      "code": "QA10BX01",
+      "name": "guar gum"
+    },
+    {
+      "code": "QA10BX02",
+      "name": "repaglinide"
+    },
+    {
+      "code": "QA10BX03",
+      "name": "nateglinide"
+    },
+    {
+      "code": "QA10BX05",
+      "name": "pramlintide"
+    },
+    {
+      "code": "QA10BX06",
+      "name": "benfluorex"
+    },
+    {
+      "code": "QA10BX08",
+      "name": "mitiglinide"
+    },
+    {
+      "code": "QA10BX15",
+      "name": "imeglimin"
+    },
+    {
+      "code": "QA10BX16",
+      "name": "tirzepatide"
+    },
+    {
+      "code": "QA10BX17",
+      "name": "carfloglitazar"
+    },
+    {
+      "code": "QA10BX18",
+      "name": "dorzagliatin"
+    },
+    {
+      "code": "QA10X",
+      "name": "OTHER DRUGS USED IN DIABETES"
+    },
+    {
+      "code": "QA10XA",
+      "name": "Aldose reductase inhibitors"
+    },
+    {
+      "code": "QA10XA01",
+      "name": "tolrestat"
+    },
+    {
+      "code": "QA10XX",
+      "name": "Other drugs used in diabetes"
+    },
+    {
+      "code": "QA10XX01",
+      "name": "teplizumab"
+    },
+    {
+      "code": "QA10XX02",
+      "name": "donislecel"
+    },
+    {
+      "code": "QA11",
+      "name": "VITAMINS"
+    },
+    {
+      "code": "QA11A",
+      "name": "MULTIVITAMINS, COMBINATIONS"
+    },
+    {
+      "code": "QA11AA",
+      "name": "Multivitamins with minerals"
+    },
+    {
+      "code": "QA11AA01",
+      "name": "multivitamins and iron"
+    },
+    {
+      "code": "QA11AA02",
+      "name": "multivitamins and calcium"
+    },
+    {
+      "code": "QA11AA03",
+      "name": "multivitamins and other minerals, incl. combinations"
+    },
+    {
+      "code": "QA11AA04",
+      "name": "multivitamins and trace elements"
+    },
+    {
+      "code": "QA11AB",
+      "name": "Multivitamins, other combinations"
+    },
+    {
+      "code": "QA11B",
+      "name": "MULTIVITAMINS, PLAIN"
+    },
+    {
+      "code": "QA11BA",
+      "name": "Multivitamines, plain"
+    },
+    {
+      "code": "QA11C",
+      "name": "VITAMIN A AND D, INCL. COMBINATIONS OF THE TWO"
+    },
+    {
+      "code": "QA11CA",
+      "name": "Vitamin A, plain"
+    },
+    {
+      "code": "QA11CA01",
+      "name": "retinol (vit A)"
+    },
+    {
+      "code": "QA11CA02",
+      "name": "betacarotene"
+    },
+    {
+      "code": "QA11CB",
+      "name": "Vitamin A and D in combination"
+    },
+    {
+      "code": "QA11CC",
+      "name": "Vitamin D and analogues"
+    },
+    {
+      "code": "QA11CC01",
+      "name": "ergocalciferol"
+    },
+    {
+      "code": "QA11CC02",
+      "name": "dihydrotachysterol"
+    },
+    {
+      "code": "QA11CC03",
+      "name": "alfacalcidol"
+    },
+    {
+      "code": "QA11CC04",
+      "name": "calcitriol"
+    },
+    {
+      "code": "QA11CC05",
+      "name": "colecalciferol"
+    },
+    {
+      "code": "QA11CC06",
+      "name": "calcifediol"
+    },
+    {
+      "code": "QA11CC20",
+      "name": "combinations"
+    },
+    {
+      "code": "QA11CC55",
+      "name": "colecalciferol, combinations"
+    },
+    {
+      "code": "QA11D",
+      "name": "VITAMIN B1, PLAIN AND IN COMBINATION WITH VITAMIN B6 AND B12"
+    },
+    {
+      "code": "QA11DA",
+      "name": "Vitamin B1, plain"
+    },
+    {
+      "code": "QA11DA01",
+      "name": "thiamine (vit B1)"
+    },
+    {
+      "code": "QA11DA02",
+      "name": "sulbutiamine"
+    },
+    {
+      "code": "QA11DA03",
+      "name": "benfotiamine"
+    },
+    {
+      "code": "QA11DB",
+      "name": "Vitamin B1 in combination with vitamin B6 and/or vitamin B12"
+    },
+    {
+      "code": "QA11E",
+      "name": "VITAMIN B-COMPLEX, INCL. COMBINATIONS"
+    },
+    {
+      "code": "QA11EA",
+      "name": "Vitamin B-complex, plain"
+    },
+    {
+      "code": "QA11EB",
+      "name": "Vitamin B-complex, with vitamin C"
+    },
+    {
+      "code": "QA11EC",
+      "name": "Vitamin B-complex, with minerals"
+    },
+    {
+      "code": "QA11ED",
+      "name": "Vitamin B-complex, with anabolic steroids"
+    },
+    {
+      "code": "QA11EX",
+      "name": "Vitamin B-complex, other combinations"
+    },
+    {
+      "code": "QA11G",
+      "name": "ASCORBIC ACID (VITAMIN C), INCL. COMBINATIONS"
+    },
+    {
+      "code": "QA11GA",
+      "name": "Ascorbic acid (vitamin C), plain"
+    },
+    {
+      "code": "QA11GA01",
+      "name": "ascorbic acid (vit C)"
+    },
+    {
+      "code": "QA11GB",
+      "name": "Ascorbic acid (vitamin C), combinations"
+    },
+    {
+      "code": "QA11GB01",
+      "name": "ascorbic acid (vit C) and calcium"
+    },
+    {
+      "code": "QA11H",
+      "name": "OTHER PLAIN VITAMIN PREPARATIONS"
+    },
+    {
+      "code": "QA11HA",
+      "name": "Other plain vitamin preparations"
+    },
+    {
+      "code": "QA11HA01",
+      "name": "nicotinamide"
+    },
+    {
+      "code": "QA11HA02",
+      "name": "pyridoxine (vit B6)"
+    },
+    {
+      "code": "QA11HA03",
+      "name": "tocopherol (vit E)"
+    },
+    {
+      "code": "QA11HA04",
+      "name": "riboflavin (vit B2)"
+    },
+    {
+      "code": "QA11HA05",
+      "name": "biotin"
+    },
+    {
+      "code": "QA11HA06",
+      "name": "pyridoxal phosphate"
+    },
+    {
+      "code": "QA11HA07",
+      "name": "inositol"
+    },
+    {
+      "code": "QA11HA08",
+      "name": "tocofersolan"
+    },
+    {
+      "code": "QA11HA30",
+      "name": "dexpanthenol"
+    },
+    {
+      "code": "QA11HA31",
+      "name": "calcium pantothenate"
+    },
+    {
+      "code": "QA11HA32",
+      "name": "pantethine"
+    },
+    {
+      "code": "QA11J",
+      "name": "OTHER VITAMIN PRODUCTS, COMBINATIONS"
+    },
+    {
+      "code": "QA11JA",
+      "name": "Combinations of vitamins"
+    },
+    {
+      "code": "QA11JB",
+      "name": "Vitamins with minerals"
+    },
+    {
+      "code": "QA11JC",
+      "name": "Vitamins, other combinations"
+    },
+    {
+      "code": "QA12",
+      "name": "MINERAL SUPPLEMENTS"
+    },
+    {
+      "code": "QA12A",
+      "name": "CALCIUM"
+    },
+    {
+      "code": "QA12AA",
+      "name": "Calcium"
+    },
+    {
+      "code": "QA12AA01",
+      "name": "calcium phosphate"
+    },
+    {
+      "code": "QA12AA02",
+      "name": "calcium glubionate"
+    },
+    {
+      "code": "QA12AA03",
+      "name": "calcium gluconate"
+    },
+    {
+      "code": "QA12AA04",
+      "name": "calcium carbonate"
+    },
+    {
+      "code": "QA12AA05",
+      "name": "calcium lactate"
+    },
+    {
+      "code": "QA12AA06",
+      "name": "calcium lactate gluconate"
+    },
+    {
+      "code": "QA12AA07",
+      "name": "calcium chloride"
+    },
+    {
+      "code": "QA12AA08",
+      "name": "calcium glycerophosphate"
+    },
+    {
+      "code": "QA12AA09",
+      "name": "calcium citrate lysine complex"
+    },
+    {
+      "code": "QA12AA10",
+      "name": "calcium glucoheptonate"
+    },
+    {
+      "code": "QA12AA11",
+      "name": "calcium pangamate"
+    },
+    {
+      "code": "QA12AA13",
+      "name": "calcium citrate"
+    },
+    {
+      "code": "QA12AA20",
+      "name": "calcium (different salts in combination)"
+    },
+    {
+      "code": "QA12AA30",
+      "name": "calcium laevulate"
+    },
+    {
+      "code": "QA12AX",
+      "name": "Calcium, combinations with vitamin D and/or other drugs"
+    },
+    {
+      "code": "QA12B",
+      "name": "POTASSIUM"
+    },
+    {
+      "code": "QA12BA",
+      "name": "Potassium"
+    },
+    {
+      "code": "QA12BA01",
+      "name": "potassium chloride"
+    },
+    {
+      "code": "QA12BA02",
+      "name": "potassium citrate"
+    },
+    {
+      "code": "QA12BA03",
+      "name": "potassium hydrogentartrate"
+    },
+    {
+      "code": "QA12BA04",
+      "name": "potassium hydrogencarbonate"
+    },
+    {
+      "code": "QA12BA05",
+      "name": "potassium gluconate"
+    },
+    {
+      "code": "QA12BA30",
+      "name": "potassium (different salts in combination)"
+    },
+    {
+      "code": "QA12BA51",
+      "name": "potassium, combinations"
+    },
+    {
+      "code": "QA12C",
+      "name": "OTHER MINERAL SUPPLEMENTS"
+    },
+    {
+      "code": "QA12CA",
+      "name": "Sodium"
+    },
+    {
+      "code": "QA12CA01",
+      "name": "sodium chloride"
+    },
+    {
+      "code": "QA12CA02",
+      "name": "sodium sulfate"
+    },
+    {
+      "code": "QA12CB",
+      "name": "Zinc"
+    },
+    {
+      "code": "QA12CB01",
+      "name": "zinc sulfate"
+    },
+    {
+      "code": "QA12CB02",
+      "name": "zinc gluconate"
+    },
+    {
+      "code": "QA12CB03",
+      "name": "zinc protein complex"
+    },
+    {
+      "code": "QA12CB04",
+      "name": "zinc orotate"
+    },
+    {
+      "code": "QA12CC",
+      "name": "Magnesium"
+    },
+    {
+      "code": "QA12CC01",
+      "name": "magnesium chloride"
+    },
+    {
+      "code": "QA12CC02",
+      "name": "magnesium sulfate"
+    },
+    {
+      "code": "QA12CC03",
+      "name": "magnesium gluconate"
+    },
+    {
+      "code": "QA12CC04",
+      "name": "magnesium citrate"
+    },
+    {
+      "code": "QA12CC05",
+      "name": "magnesium aspartate"
+    },
+    {
+      "code": "QA12CC06",
+      "name": "magnesium lactate"
+    },
+    {
+      "code": "QA12CC07",
+      "name": "magnesium levulinate"
+    },
+    {
+      "code": "QA12CC08",
+      "name": "magnesium pidolate"
+    },
+    {
+      "code": "QA12CC09",
+      "name": "magnesium orotate"
+    },
+    {
+      "code": "QA12CC10",
+      "name": "magnesium oxide"
+    },
+    {
+      "code": "QA12CC30",
+      "name": "magnesium (different salts in combination)"
+    },
+    {
+      "code": "QA12CD",
+      "name": "Fluoride"
+    },
+    {
+      "code": "QA12CD01",
+      "name": "sodium fluoride"
+    },
+    {
+      "code": "QA12CD02",
+      "name": "sodium monofluorophosphate"
+    },
+    {
+      "code": "QA12CD51",
+      "name": "fluoride, combinations"
+    },
+    {
+      "code": "QA12CE",
+      "name": "Selenium"
+    },
+    {
+      "code": "QA12CE01",
+      "name": "sodium selenate"
+    },
+    {
+      "code": "QA12CE02",
+      "name": "sodium selenite"
+    },
+    {
+      "code": "QA12CE99",
+      "name": "selenium, combinations"
+    },
+    {
+      "code": "QA12CX",
+      "name": "Other mineral products"
+    },
+    {
+      "code": "QA12CX90",
+      "name": "toldimfos"
+    },
+    {
+      "code": "QA12CX91",
+      "name": "butafosfan"
+    },
+    {
+      "code": "QA12CX99",
+      "name": "other mineral products, combinations"
+    },
+    {
+      "code": "QA13",
+      "name": "TONICS"
+    },
+    {
+      "code": "QA13A",
+      "name": "TONICS"
+    },
+    {
+      "code": "QA14",
+      "name": "ANABOLIC AGENTS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QA14A",
+      "name": "ANABOLIC STEROIDS"
+    },
+    {
+      "code": "QA14AA",
+      "name": "Androstan derivatives"
+    },
+    {
+      "code": "QA14AA01",
+      "name": "androstanolone"
+    },
+    {
+      "code": "QA14AA02",
+      "name": "stanozolol"
+    },
+    {
+      "code": "QA14AA03",
+      "name": "metandienone"
+    },
+    {
+      "code": "QA14AA04",
+      "name": "metenolone"
+    },
+    {
+      "code": "QA14AA05",
+      "name": "oxymetholone"
+    },
+    {
+      "code": "QA14AA06",
+      "name": "quinbolone"
+    },
+    {
+      "code": "QA14AA07",
+      "name": "prasterone"
+    },
+    {
+      "code": "QA14AA08",
+      "name": "oxandrolone"
+    },
+    {
+      "code": "QA14AA09",
+      "name": "norethandrolone"
+    },
+    {
+      "code": "QA14AB",
+      "name": "Estren derivatives"
+    },
+    {
+      "code": "QA14AB01",
+      "name": "nandrolone"
+    },
+    {
+      "code": "QA14AB02",
+      "name": "ethylestrenol"
+    },
+    {
+      "code": "QA14AB03",
+      "name": "oxabolone cipionate"
+    },
+    {
+      "code": "QA14B",
+      "name": "OTHER ANABOLIC AGENTS"
+    },
+    {
+      "code": "QA15",
+      "name": "APPETITE STIMULANTS"
+    },
+    {
+      "code": "QA16",
+      "name": "OTHER ALIMENTARY TRACT AND METABOLISM PRODUCTS"
+    },
+    {
+      "code": "QA16A",
+      "name": "OTHER ALIMENTARY TRACT AND METABOLISM PRODUCTS"
+    },
+    {
+      "code": "QA16AA",
+      "name": "Amino acids and derivatives"
+    },
+    {
+      "code": "QA16AA01",
+      "name": "levocarnitine"
+    },
+    {
+      "code": "QA16AA02",
+      "name": "ademethionine"
+    },
+    {
+      "code": "QA16AA03",
+      "name": "glutamine"
+    },
+    {
+      "code": "QA16AA04",
+      "name": "mercaptamine"
+    },
+    {
+      "code": "QA16AA05",
+      "name": "carglumic acid"
+    },
+    {
+      "code": "QA16AA06",
+      "name": "betaine"
+    },
+    {
+      "code": "QA16AA07",
+      "name": "metreleptin"
+    },
+    {
+      "code": "QA16AA51",
+      "name": "levocarnitine, combinations"
+    },
+    {
+      "code": "QA16AB",
+      "name": "Enzymes"
+    },
+    {
+      "code": "QA16AB01",
+      "name": "alglucerase"
+    },
+    {
+      "code": "QA16AB02",
+      "name": "imiglucerase"
+    },
+    {
+      "code": "QA16AB03",
+      "name": "agalsidase alfa"
+    },
+    {
+      "code": "QA16AB04",
+      "name": "agalsidase beta"
+    },
+    {
+      "code": "QA16AB05",
+      "name": "laronidase"
+    },
+    {
+      "code": "QA16AB06",
+      "name": "sacrosidase"
+    },
+    {
+      "code": "QA16AB07",
+      "name": "alglucosidase alfa"
+    },
+    {
+      "code": "QA16AB08",
+      "name": "galsulfase"
+    },
+    {
+      "code": "QA16AB09",
+      "name": "idursulfase"
+    },
+    {
+      "code": "QA16AB10",
+      "name": "velaglucerase alfa"
+    },
+    {
+      "code": "QA16AB11",
+      "name": "taliglucerase alfa"
+    },
+    {
+      "code": "QA16AB12",
+      "name": "elosulfase alfa"
+    },
+    {
+      "code": "QA16AB13",
+      "name": "asfotase alfa"
+    },
+    {
+      "code": "QA16AB14",
+      "name": "sebelipase alfa"
+    },
+    {
+      "code": "QA16AB15",
+      "name": "velmanase alfa"
+    },
+    {
+      "code": "QA16AB16",
+      "name": "idursulfase beta"
+    },
+    {
+      "code": "QA16AB17",
+      "name": "cerliponase alfa"
+    },
+    {
+      "code": "QA16AB18",
+      "name": "vestronidase alfa"
+    },
+    {
+      "code": "QA16AB19",
+      "name": "pegvaliase"
+    },
+    {
+      "code": "QA16AB20",
+      "name": "pegunigalsidase alfa"
+    },
+    {
+      "code": "QA16AB21",
+      "name": "atidarsagene autotemcel"
+    },
+    {
+      "code": "QA16AB22",
+      "name": "avalglucosidase alfa"
+    },
+    {
+      "code": "QA16AB23",
+      "name": "cipaglucosidase alfa"
+    },
+    {
+      "code": "QA16AB24",
+      "name": "pegzilarginase"
+    },
+    {
+      "code": "QA16AB25",
+      "name": "olipudase alfa"
+    },
+    {
+      "code": "QA16AB26",
+      "name": "eladocagene exuparvovec"
+    },
+    {
+      "code": "QA16AB27",
+      "name": "pabinafusp alfa"
+    },
+    {
+      "code": "QA16AB28",
+      "name": "verenafusp alfa"
+    },
+    {
+      "code": "QA16AB29",
+      "name": "rebisufligene etisparvovec"
+    },
+    {
+      "code": "QA16AX",
+      "name": "Various alimentary tract and metabolism products"
+    },
+    {
+      "code": "QA16AX01",
+      "name": "thioctic acid"
+    },
+    {
+      "code": "QA16AX02",
+      "name": "anethole trithione"
+    },
+    {
+      "code": "QA16AX03",
+      "name": "sodium phenylbutyrate"
+    },
+    {
+      "code": "QA16AX04",
+      "name": "nitisinone"
+    },
+    {
+      "code": "QA16AX05",
+      "name": "zinc acetate"
+    },
+    {
+      "code": "QA16AX06",
+      "name": "miglustat"
+    },
+    {
+      "code": "QA16AX07",
+      "name": "sapropterin"
+    },
+    {
+      "code": "QA16AX08",
+      "name": "teduglutide"
+    },
+    {
+      "code": "QA16AX09",
+      "name": "glycerol phenylbutyrate"
+    },
+    {
+      "code": "QA16AX10",
+      "name": "eliglustat"
+    },
+    {
+      "code": "QA16AX11",
+      "name": "sodium benzoate"
+    },
+    {
+      "code": "QA16AX12",
+      "name": "trientine"
+    },
+    {
+      "code": "QA16AX13",
+      "name": "uridine triacetate"
+    },
+    {
+      "code": "QA16AX14",
+      "name": "migalastat"
+    },
+    {
+      "code": "QA16AX15",
+      "name": "telotristat"
+    },
+    {
+      "code": "QA16AX16",
+      "name": "givosiran"
+    },
+    {
+      "code": "QA16AX17",
+      "name": "triheptanoin"
+    },
+    {
+      "code": "QA16AX18",
+      "name": "lumasiran"
+    },
+    {
+      "code": "QA16AX19",
+      "name": "fosdenopterin"
+    },
+    {
+      "code": "QA16AX20",
+      "name": "lonafarnib"
+    },
+    {
+      "code": "QA16AX21",
+      "name": "elivaldogene autotemcel"
+    },
+    {
+      "code": "QA16AX22",
+      "name": "tiomolibdic acid"
+    },
+    {
+      "code": "QA16AX23",
+      "name": "leriglitazone"
+    },
+    {
+      "code": "QA16AX24",
+      "name": "govorestat"
+    },
+    {
+      "code": "QA16AX25",
+      "name": "nedosiran"
+    },
+    {
+      "code": "QA16AX26",
+      "name": "glepaglutide"
+    },
+    {
+      "code": "QA16AX27",
+      "name": "apraglutide"
+    },
+    {
+      "code": "QA16AX28",
+      "name": "sepiapterin"
+    },
+    {
+      "code": "QA16AX29",
+      "name": "doxecitine and doxribtimine"
+    },
+    {
+      "code": "QA16AX30",
+      "name": "sodium benzoate and sodium phenylacetate"
+    },
+    {
+      "code": "QA16Q",
+      "name": "OTHER ALIMENTARY TRACT AND METABOLISM PRODUCTS FOR VETERINARY USE"
+    },
+    {
+      "code": "QA16QA",
+      "name": "Drugs for prevention and/or treatment of acetonemia"
+    },
+    {
+      "code": "QA16QA01",
+      "name": "propylene glycol"
+    },
+    {
+      "code": "QA16QA02",
+      "name": "sodium propionate"
+    },
+    {
+      "code": "QA16QA03",
+      "name": "glycerol"
+    },
+    {
+      "code": "QA16QA04",
+      "name": "ammonium lactate"
+    },
+    {
+      "code": "QA16QA05",
+      "name": "clanobutin"
+    },
+    {
+      "code": "QA16QA06",
+      "name": "monensin"
+    },
+    {
+      "code": "QA16QA52",
+      "name": "sodium propionate, combinations"
+    },
+    {
+      "code": "QB",
+      "name": "BLOOD AND BLOOD FORMING ORGANS"
+    },
+    {
+      "code": "QB01",
+      "name": "ANTITHROMBOTIC AGENTS"
+    },
+    {
+      "code": "QB01A",
+      "name": "ANTITHROMBOTIC AGENTS"
+    },
+    {
+      "code": "QB01AA",
+      "name": "Vitamin K antagonists"
+    },
+    {
+      "code": "QB01AA01",
+      "name": "dicoumarol"
+    },
+    {
+      "code": "QB01AA02",
+      "name": "phenindione"
+    },
+    {
+      "code": "QB01AA03",
+      "name": "warfarin"
+    },
+    {
+      "code": "QB01AA04",
+      "name": "phenprocoumon"
+    },
+    {
+      "code": "QB01AA07",
+      "name": "acenocoumarol"
+    },
+    {
+      "code": "QB01AA08",
+      "name": "ethyl biscoumacetate"
+    },
+    {
+      "code": "QB01AA09",
+      "name": "clorindione"
+    },
+    {
+      "code": "QB01AA10",
+      "name": "diphenadione"
+    },
+    {
+      "code": "QB01AA11",
+      "name": "tioclomarol"
+    },
+    {
+      "code": "QB01AA12",
+      "name": "fluindione"
+    },
+    {
+      "code": "QB01AB",
+      "name": "Heparin group"
+    },
+    {
+      "code": "QB01AB01",
+      "name": "heparin"
+    },
+    {
+      "code": "QB01AB02",
+      "name": "antithrombin III"
+    },
+    {
+      "code": "QB01AB04",
+      "name": "dalteparin"
+    },
+    {
+      "code": "QB01AB05",
+      "name": "enoxaparin"
+    },
+    {
+      "code": "QB01AB06",
+      "name": "nadroparin"
+    },
+    {
+      "code": "QB01AB07",
+      "name": "parnaparin"
+    },
+    {
+      "code": "QB01AB08",
+      "name": "reviparin"
+    },
+    {
+      "code": "QB01AB09",
+      "name": "danaparoid"
+    },
+    {
+      "code": "QB01AB10",
+      "name": "tinzaparin"
+    },
+    {
+      "code": "QB01AB11",
+      "name": "sulodexide"
+    },
+    {
+      "code": "QB01AB12",
+      "name": "bemiparin"
+    },
+    {
+      "code": "QB01AB51",
+      "name": "heparin, combinations"
+    },
+    {
+      "code": "QB01AC",
+      "name": "Platelet aggregation inhibitors, excl. heparin"
+    },
+    {
+      "code": "QB01AC01",
+      "name": "ditazole"
+    },
+    {
+      "code": "QB01AC02",
+      "name": "cloricromen"
+    },
+    {
+      "code": "QB01AC03",
+      "name": "picotamide"
+    },
+    {
+      "code": "QB01AC04",
+      "name": "clopidogrel"
+    },
+    {
+      "code": "QB01AC05",
+      "name": "ticlopidine"
+    },
+    {
+      "code": "QB01AC06",
+      "name": "acetylsalicylic acid"
+    },
+    {
+      "code": "QB01AC07",
+      "name": "dipyridamole"
+    },
+    {
+      "code": "QB01AC08",
+      "name": "carbasalate calcium"
+    },
+    {
+      "code": "QB01AC09",
+      "name": "epoprostenol"
+    },
+    {
+      "code": "QB01AC10",
+      "name": "indobufen"
+    },
+    {
+      "code": "QB01AC11",
+      "name": "iloprost"
+    },
+    {
+      "code": "QB01AC13",
+      "name": "abciximab"
+    },
+    {
+      "code": "QB01AC15",
+      "name": "aloxiprin"
+    },
+    {
+      "code": "QB01AC16",
+      "name": "eptifibatide"
+    },
+    {
+      "code": "QB01AC17",
+      "name": "tirofiban"
+    },
+    {
+      "code": "QB01AC18",
+      "name": "triflusal"
+    },
+    {
+      "code": "QB01AC19",
+      "name": "beraprost"
+    },
+    {
+      "code": "QB01AC21",
+      "name": "treprostinil"
+    },
+    {
+      "code": "QB01AC22",
+      "name": "prasugrel"
+    },
+    {
+      "code": "QB01AC23",
+      "name": "cilostazol"
+    },
+    {
+      "code": "QB01AC24",
+      "name": "ticagrelor"
+    },
+    {
+      "code": "QB01AC25",
+      "name": "cangrelor"
+    },
+    {
+      "code": "QB01AC26",
+      "name": "vorapaxar"
+    },
+    {
+      "code": "QB01AC27",
+      "name": "selexipag"
+    },
+    {
+      "code": "QB01AC28",
+      "name": "limaprost"
+    },
+    {
+      "code": "QB01AC30",
+      "name": "combinations"
+    },
+    {
+      "code": "QB01AC56",
+      "name": "acetylsalicylic acid, combinations with proton pump inhibitors"
+    },
+    {
+      "code": "QB01AD",
+      "name": "Enzymes"
+    },
+    {
+      "code": "QB01AD01",
+      "name": "streptokinase"
+    },
+    {
+      "code": "QB01AD02",
+      "name": "alteplase"
+    },
+    {
+      "code": "QB01AD03",
+      "name": "anistreplase"
+    },
+    {
+      "code": "QB01AD04",
+      "name": "urokinase"
+    },
+    {
+      "code": "QB01AD05",
+      "name": "fibrinolysin"
+    },
+    {
+      "code": "QB01AD06",
+      "name": "brinase"
+    },
+    {
+      "code": "QB01AD07",
+      "name": "reteplase"
+    },
+    {
+      "code": "QB01AD08",
+      "name": "saruplase"
+    },
+    {
+      "code": "QB01AD09",
+      "name": "ancrod"
+    },
+    {
+      "code": "QB01AD10",
+      "name": "drotrecogin alfa"
+    },
+    {
+      "code": "QB01AD11",
+      "name": "tenecteplase"
+    },
+    {
+      "code": "QB01AD12",
+      "name": "protein C"
+    },
+    {
+      "code": "QB01AD13",
+      "name": "apadamtase alfa and cinaxadamtase alfa"
+    },
+    {
+      "code": "QB01AE",
+      "name": "Direct thrombin inhibitors"
+    },
+    {
+      "code": "QB01AE01",
+      "name": "desirudin"
+    },
+    {
+      "code": "QB01AE02",
+      "name": "lepirudin"
+    },
+    {
+      "code": "QB01AE03",
+      "name": "argatroban"
+    },
+    {
+      "code": "QB01AE04",
+      "name": "melagatran"
+    },
+    {
+      "code": "QB01AE05",
+      "name": "ximelagatran"
+    },
+    {
+      "code": "QB01AE06",
+      "name": "bivalirudin"
+    },
+    {
+      "code": "QB01AE07",
+      "name": "dabigatran etexilate"
+    },
+    {
+      "code": "QB01AF",
+      "name": "Direct factor Xa inhibitors"
+    },
+    {
+      "code": "QB01AF01",
+      "name": "rivaroxaban"
+    },
+    {
+      "code": "QB01AF02",
+      "name": "apixaban"
+    },
+    {
+      "code": "QB01AF03",
+      "name": "edoxaban"
+    },
+    {
+      "code": "QB01AF04",
+      "name": "betrixaban"
+    },
+    {
+      "code": "QB01AF51",
+      "name": "rivaroxaban and acetylsalicylic acid"
+    },
+    {
+      "code": "QB01AX",
+      "name": "Other antithrombotic agents"
+    },
+    {
+      "code": "QB01AX01",
+      "name": "defibrotide"
+    },
+    {
+      "code": "QB01AX04",
+      "name": "dermatan sulfate"
+    },
+    {
+      "code": "QB01AX05",
+      "name": "fondaparinux"
+    },
+    {
+      "code": "QB01AX07",
+      "name": "caplacizumab"
+    },
+    {
+      "code": "QB02",
+      "name": "ANTIHEMORRHAGICS"
+    },
+    {
+      "code": "QB02A",
+      "name": "ANTIFIBRINOLYTICS"
+    },
+    {
+      "code": "QB02AA",
+      "name": "Amino acids"
+    },
+    {
+      "code": "QB02AA01",
+      "name": "aminocapronic acid"
+    },
+    {
+      "code": "QB02AA02",
+      "name": "tranexamic acid"
+    },
+    {
+      "code": "QB02AA03",
+      "name": "aminomethylbenzoic acid"
+    },
+    {
+      "code": "QB02AB",
+      "name": "Proteinase inhibitors"
+    },
+    {
+      "code": "QB02AB01",
+      "name": "aprotinin"
+    },
+    {
+      "code": "QB02AB02",
+      "name": "alfa1 antitrypsin"
+    },
+    {
+      "code": "QB02AB04",
+      "name": "camostat"
+    },
+    {
+      "code": "QB02AB05",
+      "name": "ulinastatin"
+    },
+    {
+      "code": "QB02B",
+      "name": "VITAMIN K AND OTHER HEMOSTATICS"
+    },
+    {
+      "code": "QB02BA",
+      "name": "Vitamin K"
+    },
+    {
+      "code": "QB02BA01",
+      "name": "phytomenadione"
+    },
+    {
+      "code": "QB02BA02",
+      "name": "menadione"
+    },
+    {
+      "code": "QB02BB",
+      "name": "Fibrinogen"
+    },
+    {
+      "code": "QB02BB01",
+      "name": "human fibrinogen"
+    },
+    {
+      "code": "QB02BC",
+      "name": "Local hemostatics"
+    },
+    {
+      "code": "QB02BC01",
+      "name": "absorbable gelatin sponge"
+    },
+    {
+      "code": "QB02BC02",
+      "name": "oxidized cellulose"
+    },
+    {
+      "code": "QB02BC03",
+      "name": "tetragalacturonic acid hydroxymethylester"
+    },
+    {
+      "code": "QB02BC05",
+      "name": "adrenalone"
+    },
+    {
+      "code": "QB02BC06",
+      "name": "thrombin"
+    },
+    {
+      "code": "QB02BC07",
+      "name": "collagen"
+    },
+    {
+      "code": "QB02BC08",
+      "name": "calcium alginate"
+    },
+    {
+      "code": "QB02BC09",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QB02BC30",
+      "name": "combinations"
+    },
+    {
+      "code": "QB02BD",
+      "name": "Blood coagulation factors"
+    },
+    {
+      "code": "QB02BD01",
+      "name": "coagulation factor IX, II, VII and X in combination"
+    },
+    {
+      "code": "QB02BD02",
+      "name": "coagulation factor VIII"
+    },
+    {
+      "code": "QB02BD03",
+      "name": "factor VIII inhibitor bypassing activity"
+    },
+    {
+      "code": "QB02BD04",
+      "name": "coagulation factor IX"
+    },
+    {
+      "code": "QB02BD05",
+      "name": "coagulation factor VII"
+    },
+    {
+      "code": "QB02BD06",
+      "name": "von Willebrand factor and coagulation factor VIII in combination"
+    },
+    {
+      "code": "QB02BD07",
+      "name": "coagulation factor XIII"
+    },
+    {
+      "code": "QB02BD08",
+      "name": "coagulation factor VIIa"
+    },
+    {
+      "code": "QB02BD10",
+      "name": "von Willebrand factor"
+    },
+    {
+      "code": "QB02BD11",
+      "name": "catridecacog"
+    },
+    {
+      "code": "QB02BD13",
+      "name": "coagulation factor X"
+    },
+    {
+      "code": "QB02BD14",
+      "name": "susoctocog alfa"
+    },
+    {
+      "code": "QB02BD15",
+      "name": "valoctocogene roxaparvovec"
+    },
+    {
+      "code": "QB02BD16",
+      "name": "etranacogene dezaparvovec"
+    },
+    {
+      "code": "QB02BD17",
+      "name": "fidanacogene elaparvovec"
+    },
+    {
+      "code": "QB02BD18",
+      "name": "arvenacogene sanparvovec"
+    },
+    {
+      "code": "QB02BD30",
+      "name": "thrombin"
+    },
+    {
+      "code": "QB02BX",
+      "name": "Other systemic hemostatics"
+    },
+    {
+      "code": "QB02BX01",
+      "name": "etamsylate"
+    },
+    {
+      "code": "QB02BX02",
+      "name": "carbazochrome"
+    },
+    {
+      "code": "QB02BX03",
+      "name": "batroxobin"
+    },
+    {
+      "code": "QB02BX04",
+      "name": "romiplostim"
+    },
+    {
+      "code": "QB02BX05",
+      "name": "eltrombopag"
+    },
+    {
+      "code": "QB02BX06",
+      "name": "emicizumab"
+    },
+    {
+      "code": "QB02BX07",
+      "name": "lusutrombopag"
+    },
+    {
+      "code": "QB02BX08",
+      "name": "avatrombopag"
+    },
+    {
+      "code": "QB02BX09",
+      "name": "fostamatinib"
+    },
+    {
+      "code": "QB02BX10",
+      "name": "concizumab"
+    },
+    {
+      "code": "QB02BX11",
+      "name": "marstacimab"
+    },
+    {
+      "code": "QB02BX12",
+      "name": "fitusiran"
+    },
+    {
+      "code": "QB03",
+      "name": "ANTIANEMIC PREPARATIONS"
+    },
+    {
+      "code": "QB03A",
+      "name": "IRON PREPARATIONS"
+    },
+    {
+      "code": "QB03AA",
+      "name": "Iron bivalent, oral preparations"
+    },
+    {
+      "code": "QB03AA01",
+      "name": "ferrous glycine sulfate"
+    },
+    {
+      "code": "QB03AA02",
+      "name": "ferrous fumarate"
+    },
+    {
+      "code": "QB03AA03",
+      "name": "ferrous gluconate"
+    },
+    {
+      "code": "QB03AA04",
+      "name": "ferrous carbonate"
+    },
+    {
+      "code": "QB03AA05",
+      "name": "ferrous chloride"
+    },
+    {
+      "code": "QB03AA06",
+      "name": "ferrous succinate"
+    },
+    {
+      "code": "QB03AA07",
+      "name": "ferrous sulfate"
+    },
+    {
+      "code": "QB03AA08",
+      "name": "ferrous tartrate"
+    },
+    {
+      "code": "QB03AA09",
+      "name": "ferrous aspartate"
+    },
+    {
+      "code": "QB03AA10",
+      "name": "ferrous ascorbate"
+    },
+    {
+      "code": "QB03AA11",
+      "name": "ferrous iodine"
+    },
+    {
+      "code": "QB03AA12",
+      "name": "ferrous sodium citrate"
+    },
+    {
+      "code": "QB03AB",
+      "name": "Iron trivalent, oral preparations"
+    },
+    {
+      "code": "QB03AB01",
+      "name": "ferric sodium citrate"
+    },
+    {
+      "code": "QB03AB02",
+      "name": "saccharated iron oxide"
+    },
+    {
+      "code": "QB03AB03",
+      "name": "sodium feredetate"
+    },
+    {
+      "code": "QB03AB04",
+      "name": "ferric hydroxide"
+    },
+    {
+      "code": "QB03AB05",
+      "name": "ferric oxide polymaltose complexes"
+    },
+    {
+      "code": "QB03AB07",
+      "name": "chondroitin sulfate-iron complex"
+    },
+    {
+      "code": "QB03AB08",
+      "name": "ferric acetyl transferrin"
+    },
+    {
+      "code": "QB03AB09",
+      "name": "ferric proteinsuccinylate"
+    },
+    {
+      "code": "QB03AB10",
+      "name": "ferric maltol"
+    },
+    {
+      "code": "QB03AB90",
+      "name": "iron dextran complexes"
+    },
+    {
+      "code": "QB03AC",
+      "name": "Iron, parenteral preparations"
+    },
+    {
+      "code": "QB03AD",
+      "name": "Iron in combination with folic acid"
+    },
+    {
+      "code": "QB03AD01",
+      "name": "ferrous amino acid complex and folic acid"
+    },
+    {
+      "code": "QB03AD02",
+      "name": "ferrous fumarate and folic acid"
+    },
+    {
+      "code": "QB03AD03",
+      "name": "ferrous sulfate and folic acid"
+    },
+    {
+      "code": "QB03AD04",
+      "name": "ferric oxide polymaltose complexes and folic acid"
+    },
+    {
+      "code": "QB03AD05",
+      "name": "ferrous gluconate and folic acid"
+    },
+    {
+      "code": "QB03AE",
+      "name": "Iron in other combinations"
+    },
+    {
+      "code": "QB03AE01",
+      "name": "iron, vitamin B12 and folic acid"
+    },
+    {
+      "code": "QB03AE02",
+      "name": "iron, multivitamins and folic acid"
+    },
+    {
+      "code": "QB03AE03",
+      "name": "iron and multivitamins"
+    },
+    {
+      "code": "QB03AE04",
+      "name": "iron, multivitamins and minerals"
+    },
+    {
+      "code": "QB03AE10",
+      "name": "various combinations"
+    },
+    {
+      "code": "QB03B",
+      "name": "VITAMIN B12 AND FOLIC ACID"
+    },
+    {
+      "code": "QB03BA",
+      "name": "Vitamin B12 (cyanocobalamin and analogues)"
+    },
+    {
+      "code": "QB03BA01",
+      "name": "cyanocobalamin"
+    },
+    {
+      "code": "QB03BA02",
+      "name": "cyanocobalamin tannin complex"
+    },
+    {
+      "code": "QB03BA03",
+      "name": "hydroxocobalamin"
+    },
+    {
+      "code": "QB03BA04",
+      "name": "cobamamide"
+    },
+    {
+      "code": "QB03BA05",
+      "name": "mecobalamin"
+    },
+    {
+      "code": "QB03BA51",
+      "name": "cyanocobalamin, combinations"
+    },
+    {
+      "code": "QB03BA53",
+      "name": "hydroxocobalamin, combinations"
+    },
+    {
+      "code": "QB03BB",
+      "name": "Folic acid and derivatives"
+    },
+    {
+      "code": "QB03BB01",
+      "name": "folic acid"
+    },
+    {
+      "code": "QB03BB51",
+      "name": "folic acid, combinations"
+    },
+    {
+      "code": "QB03X",
+      "name": "OTHER ANTIANEMIC PREPARATIONS"
+    },
+    {
+      "code": "QB03XA",
+      "name": "Other antianemic preparations"
+    },
+    {
+      "code": "QB03XA01",
+      "name": "erythropoietin"
+    },
+    {
+      "code": "QB03XA02",
+      "name": "darbepoetin alfa"
+    },
+    {
+      "code": "QB03XA03",
+      "name": "methoxy polyethylene glycol-epoetin beta"
+    },
+    {
+      "code": "QB03XA04",
+      "name": "peginesatide"
+    },
+    {
+      "code": "QB03XA05",
+      "name": "roxadustat"
+    },
+    {
+      "code": "QB03XA06",
+      "name": "luspatercept"
+    },
+    {
+      "code": "QB03XA07",
+      "name": "daprodustat"
+    },
+    {
+      "code": "QB03XA08",
+      "name": "vadadustat"
+    },
+    {
+      "code": "QB03XA09",
+      "name": "molidustat"
+    },
+    {
+      "code": "QB03XA10",
+      "name": "efepoetin alfa"
+    },
+    {
+      "code": "QB05",
+      "name": "BLOOD SUBSTITUTES AND PERFUSION SOLUTIONS"
+    },
+    {
+      "code": "QB05A",
+      "name": "BLOOD AND RELATED PRODUCTS"
+    },
+    {
+      "code": "QB05AA",
+      "name": "Blood substitutes and plasma protein fractions"
+    },
+    {
+      "code": "QB05AA01",
+      "name": "albumin"
+    },
+    {
+      "code": "QB05AA02",
+      "name": "other plasma protein fractions"
+    },
+    {
+      "code": "QB05AA03",
+      "name": "fluorocarbon blood substitutes"
+    },
+    {
+      "code": "QB05AA05",
+      "name": "dextran"
+    },
+    {
+      "code": "QB05AA06",
+      "name": "gelatin agents"
+    },
+    {
+      "code": "QB05AA07",
+      "name": "hydroxyethylstarch"
+    },
+    {
+      "code": "QB05AA08",
+      "name": "hemoglobin crosfumaril"
+    },
+    {
+      "code": "QB05AA09",
+      "name": "hemoglobin raffimer"
+    },
+    {
+      "code": "QB05AA10",
+      "name": "hemoglobin glutamer (bovine)"
+    },
+    {
+      "code": "QB05AA91",
+      "name": "hemoglobin betafumaril (bovine)"
+    },
+    {
+      "code": "QB05AX",
+      "name": "Other blood products"
+    },
+    {
+      "code": "QB05AX01",
+      "name": "erythrocytes"
+    },
+    {
+      "code": "QB05AX02",
+      "name": "thrombocytes"
+    },
+    {
+      "code": "QB05AX03",
+      "name": "blood plasma"
+    },
+    {
+      "code": "QB05AX04",
+      "name": "stem cells from umbilical cord blood"
+    },
+    {
+      "code": "QB05B",
+      "name": "I.V. SOLUTIONS"
+    },
+    {
+      "code": "QB05BA",
+      "name": "Solutions for parenteral nutrition"
+    },
+    {
+      "code": "QB05BA01",
+      "name": "amino acids"
+    },
+    {
+      "code": "QB05BA02",
+      "name": "fat emulsions"
+    },
+    {
+      "code": "QB05BA03",
+      "name": "carbohydrates"
+    },
+    {
+      "code": "QB05BA04",
+      "name": "protein hydrolysates"
+    },
+    {
+      "code": "QB05BA10",
+      "name": "combinations"
+    },
+    {
+      "code": "QB05BB",
+      "name": "Solutions affecting the electrolyte balance"
+    },
+    {
+      "code": "QB05BB01",
+      "name": "electrolytes"
+    },
+    {
+      "code": "QB05BB02",
+      "name": "electrolytes with carbohydrates"
+    },
+    {
+      "code": "QB05BB03",
+      "name": "trometamol"
+    },
+    {
+      "code": "QB05BB04",
+      "name": "electrolytes in combination with other drugs"
+    },
+    {
+      "code": "QB05BC",
+      "name": "Solutions producing osmotic diuresis"
+    },
+    {
+      "code": "QB05BC01",
+      "name": "mannitol"
+    },
+    {
+      "code": "QB05BC02",
+      "name": "carbamide"
+    },
+    {
+      "code": "QB05C",
+      "name": "IRRIGATING SOLUTIONS"
+    },
+    {
+      "code": "QB05CA",
+      "name": "Antiinfectives"
+    },
+    {
+      "code": "QB05CA01",
+      "name": "cetylpyridinium"
+    },
+    {
+      "code": "QB05CA02",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QB05CA03",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QB05CA04",
+      "name": "sulfamethizole"
+    },
+    {
+      "code": "QB05CA05",
+      "name": "taurolidine"
+    },
+    {
+      "code": "QB05CA06",
+      "name": "mandelic acid"
+    },
+    {
+      "code": "QB05CA07",
+      "name": "noxytiolin"
+    },
+    {
+      "code": "QB05CA08",
+      "name": "ethacridine lactate"
+    },
+    {
+      "code": "QB05CA09",
+      "name": "neomycin"
+    },
+    {
+      "code": "QB05CA10",
+      "name": "combinations"
+    },
+    {
+      "code": "QB05CB",
+      "name": "Salt solutions"
+    },
+    {
+      "code": "QB05CB01",
+      "name": "sodium chloride"
+    },
+    {
+      "code": "QB05CB02",
+      "name": "sodium citrate"
+    },
+    {
+      "code": "QB05CB03",
+      "name": "magnesium citrate"
+    },
+    {
+      "code": "QB05CB04",
+      "name": "sodium bicarbonate"
+    },
+    {
+      "code": "QB05CB10",
+      "name": "combinations"
+    },
+    {
+      "code": "QB05CX",
+      "name": "Other irrigating solutions"
+    },
+    {
+      "code": "QB05CX01",
+      "name": "glucose"
+    },
+    {
+      "code": "QB05CX02",
+      "name": "sorbitol"
+    },
+    {
+      "code": "QB05CX03",
+      "name": "glycine"
+    },
+    {
+      "code": "QB05CX04",
+      "name": "mannitol"
+    },
+    {
+      "code": "QB05CX10",
+      "name": "combinations"
+    },
+    {
+      "code": "QB05D",
+      "name": "PERITONEAL DIALYTICS"
+    },
+    {
+      "code": "QB05DA",
+      "name": "Isotonic solutions"
+    },
+    {
+      "code": "QB05DB",
+      "name": "Hypertonic solutions"
+    },
+    {
+      "code": "QB05X",
+      "name": "I.V. SOLUTION ADDITIVES"
+    },
+    {
+      "code": "QB05XA",
+      "name": "Electrolyte solutions"
+    },
+    {
+      "code": "QB05XA01",
+      "name": "potassium chloride"
+    },
+    {
+      "code": "QB05XA02",
+      "name": "sodium bicarbonate"
+    },
+    {
+      "code": "QB05XA03",
+      "name": "sodium chloride"
+    },
+    {
+      "code": "QB05XA04",
+      "name": "ammonium chloride"
+    },
+    {
+      "code": "QB05XA05",
+      "name": "magnesium sulfate"
+    },
+    {
+      "code": "QB05XA06",
+      "name": "potassium phosphate incl. combinations with other potassium salts"
+    },
+    {
+      "code": "QB05XA07",
+      "name": "calcium chloride"
+    },
+    {
+      "code": "QB05XA08",
+      "name": "sodium acetate"
+    },
+    {
+      "code": "QB05XA09",
+      "name": "sodium phosphate"
+    },
+    {
+      "code": "QB05XA10",
+      "name": "magnesium phosphate"
+    },
+    {
+      "code": "QB05XA11",
+      "name": "magnesium chloride"
+    },
+    {
+      "code": "QB05XA12",
+      "name": "zinc chloride"
+    },
+    {
+      "code": "QB05XA13",
+      "name": "hydrochloric acid"
+    },
+    {
+      "code": "QB05XA14",
+      "name": "sodium glycerophosphate"
+    },
+    {
+      "code": "QB05XA15",
+      "name": "potassium lactate"
+    },
+    {
+      "code": "QB05XA16",
+      "name": "cardioplegia solutions"
+    },
+    {
+      "code": "QB05XA17",
+      "name": "potassium acetate"
+    },
+    {
+      "code": "QB05XA18",
+      "name": "zinc sulfate"
+    },
+    {
+      "code": "QB05XA19",
+      "name": "calcium gluconate"
+    },
+    {
+      "code": "QB05XA20",
+      "name": "sodium selenite"
+    },
+    {
+      "code": "QB05XA30",
+      "name": "combinations of electrolytes"
+    },
+    {
+      "code": "QB05XA31",
+      "name": "electrolytes in combination with other drugs"
+    },
+    {
+      "code": "QB05XB",
+      "name": "Amino acids"
+    },
+    {
+      "code": "QB05XB01",
+      "name": "arginine hydrochloride"
+    },
+    {
+      "code": "QB05XB02",
+      "name": "alanyl glutamine"
+    },
+    {
+      "code": "QB05XB03",
+      "name": "lysine"
+    },
+    {
+      "code": "QB05XC",
+      "name": "Vitamins"
+    },
+    {
+      "code": "QB05XX",
+      "name": "Other i.v. solution additives"
+    },
+    {
+      "code": "QB05XX02",
+      "name": "trometamol"
+    },
+    {
+      "code": "QB05Z",
+      "name": "HEMODIALYTICS AND HEMOFILTRATES"
+    },
+    {
+      "code": "QB05ZA",
+      "name": "Hemodialytics, concentrates"
+    },
+    {
+      "code": "QB05ZB",
+      "name": "Hemofiltrates"
+    },
+    {
+      "code": "QB06",
+      "name": "OTHER HEMATOLOGICAL AGENTS"
+    },
+    {
+      "code": "QB06A",
+      "name": "OTHER HEMATOLOGICAL AGENTS"
+    },
+    {
+      "code": "QB06AA",
+      "name": "Enzymes"
+    },
+    {
+      "code": "QB06AA02",
+      "name": "fibrinolysin and desoxyribonuclease"
+    },
+    {
+      "code": "QB06AA03",
+      "name": "hyaluronidase"
+    },
+    {
+      "code": "QB06AA04",
+      "name": "chymotrypsin"
+    },
+    {
+      "code": "QB06AA07",
+      "name": "trypsin"
+    },
+    {
+      "code": "QB06AA10",
+      "name": "desoxyribonuclease"
+    },
+    {
+      "code": "QB06AA55",
+      "name": "streptokinase, combinations"
+    },
+    {
+      "code": "QB06AB",
+      "name": "Heme products"
+    },
+    {
+      "code": "QB06AB01",
+      "name": "hemin"
+    },
+    {
+      "code": "QB06AC",
+      "name": "Drugs used in hereditary angioedema"
+    },
+    {
+      "code": "QB06AC01",
+      "name": "c1-inhibitor, plasma derived"
+    },
+    {
+      "code": "QB06AC02",
+      "name": "icatibant"
+    },
+    {
+      "code": "QB06AC03",
+      "name": "ecallantide"
+    },
+    {
+      "code": "QB06AC04",
+      "name": "conestat alfa"
+    },
+    {
+      "code": "QB06AC05",
+      "name": "lanadelumab"
+    },
+    {
+      "code": "QB06AC06",
+      "name": "berotralstat"
+    },
+    {
+      "code": "QB06AC07",
+      "name": "garadacimab"
+    },
+    {
+      "code": "QB06AC08",
+      "name": "sebetralstat"
+    },
+    {
+      "code": "QB06AC09",
+      "name": "donidalorsen"
+    },
+    {
+      "code": "QB06AX",
+      "name": "Other hematological agents"
+    },
+    {
+      "code": "QB06AX01",
+      "name": "crizanlizumab"
+    },
+    {
+      "code": "QB06AX02",
+      "name": "betibeglogene autotemcel"
+    },
+    {
+      "code": "QB06AX03",
+      "name": "voxelotor"
+    },
+    {
+      "code": "QB06AX04",
+      "name": "mitapivat"
+    },
+    {
+      "code": "QB06AX05",
+      "name": "exagamglogene autotemcel"
+    },
+    {
+      "code": "QB06AX06",
+      "name": "lovotibeglogene autotemcel"
+    },
+    {
+      "code": "QB06AX07",
+      "name": "mozafancogene autotemcel"
+    },
+    {
+      "code": "QC",
+      "name": "CARDIOVASCULAR SYSTEM"
+    },
+    {
+      "code": "QC01",
+      "name": "CARDIAC THERAPY"
+    },
+    {
+      "code": "QC01A",
+      "name": "CARDIAC GLYCOSIDES"
+    },
+    {
+      "code": "QC01AA",
+      "name": "Digitalis glycosides"
+    },
+    {
+      "code": "QC01AA01",
+      "name": "acetyldigitoxin"
+    },
+    {
+      "code": "QC01AA02",
+      "name": "acetyldigoxin"
+    },
+    {
+      "code": "QC01AA03",
+      "name": "digitalis leaves"
+    },
+    {
+      "code": "QC01AA04",
+      "name": "digitoxin"
+    },
+    {
+      "code": "QC01AA05",
+      "name": "digoxin"
+    },
+    {
+      "code": "QC01AA06",
+      "name": "lanatoside C"
+    },
+    {
+      "code": "QC01AA07",
+      "name": "deslanoside"
+    },
+    {
+      "code": "QC01AA08",
+      "name": "metildigoxin"
+    },
+    {
+      "code": "QC01AA09",
+      "name": "gitoformate"
+    },
+    {
+      "code": "QC01AA52",
+      "name": "acetyldigoxin, combinations"
+    },
+    {
+      "code": "QC01AB",
+      "name": "Scilla glycosides"
+    },
+    {
+      "code": "QC01AB01",
+      "name": "proscillaridin"
+    },
+    {
+      "code": "QC01AB51",
+      "name": "proscillaridin, combinations"
+    },
+    {
+      "code": "QC01AC",
+      "name": "Strophanthus glycosides"
+    },
+    {
+      "code": "QC01AC01",
+      "name": "g-strophanthin"
+    },
+    {
+      "code": "QC01AC03",
+      "name": "cymarin"
+    },
+    {
+      "code": "QC01AX",
+      "name": "Other cardiac glycosides"
+    },
+    {
+      "code": "QC01AX02",
+      "name": "peruvoside"
+    },
+    {
+      "code": "QC01B",
+      "name": "ANTIARRYTHMICS, CLASS I AND III"
+    },
+    {
+      "code": "QC01BA",
+      "name": "Antiarrhythmics, class Ia"
+    },
+    {
+      "code": "QC01BA01",
+      "name": "quinidine"
+    },
+    {
+      "code": "QC01BA02",
+      "name": "procainamide"
+    },
+    {
+      "code": "QC01BA03",
+      "name": "disopyramide"
+    },
+    {
+      "code": "QC01BA04",
+      "name": "sparteine"
+    },
+    {
+      "code": "QC01BA05",
+      "name": "ajmaline"
+    },
+    {
+      "code": "QC01BA08",
+      "name": "prajmaline"
+    },
+    {
+      "code": "QC01BA12",
+      "name": "lorajmine"
+    },
+    {
+      "code": "QC01BA13",
+      "name": "hydroquinidine"
+    },
+    {
+      "code": "QC01BA51",
+      "name": "quinidine, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QC01BA71",
+      "name": "quinidine, combinations with psycholeptics"
+    },
+    {
+      "code": "QC01BB",
+      "name": "Antiarrhythmics, class Ib"
+    },
+    {
+      "code": "QC01BB01",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QC01BB02",
+      "name": "mexiletine"
+    },
+    {
+      "code": "QC01BB03",
+      "name": "tocainide"
+    },
+    {
+      "code": "QC01BB04",
+      "name": "aprindine"
+    },
+    {
+      "code": "QC01BC",
+      "name": "Antiarrhythmics, class Ic"
+    },
+    {
+      "code": "QC01BC03",
+      "name": "propafenone"
+    },
+    {
+      "code": "QC01BC04",
+      "name": "flecainide"
+    },
+    {
+      "code": "QC01BC07",
+      "name": "lorcainide"
+    },
+    {
+      "code": "QC01BC08",
+      "name": "encainide"
+    },
+    {
+      "code": "QC01BC09",
+      "name": "ethacizine"
+    },
+    {
+      "code": "QC01BD",
+      "name": "Antiarrhythmics, class III"
+    },
+    {
+      "code": "QC01BD01",
+      "name": "amiodarone"
+    },
+    {
+      "code": "QC01BD02",
+      "name": "bretylium tosilate"
+    },
+    {
+      "code": "QC01BD03",
+      "name": "bunaftine"
+    },
+    {
+      "code": "QC01BD04",
+      "name": "dofetilide"
+    },
+    {
+      "code": "QC01BD05",
+      "name": "ibutilide"
+    },
+    {
+      "code": "QC01BD07",
+      "name": "dronedarone"
+    },
+    {
+      "code": "QC01BG",
+      "name": "Other antiarrhythmics, class I and III"
+    },
+    {
+      "code": "QC01BG01",
+      "name": "moracizine"
+    },
+    {
+      "code": "QC01BG07",
+      "name": "cibenzoline"
+    },
+    {
+      "code": "QC01BG11",
+      "name": "vernakalant"
+    },
+    {
+      "code": "QC01C",
+      "name": "CARDIAC STIMULANTS EXCL. CARDIAC GLYCOSIDES"
+    },
+    {
+      "code": "QC01CA",
+      "name": "Adrenergic and dopaminergic agents"
+    },
+    {
+      "code": "QC01CA01",
+      "name": "etilefrine"
+    },
+    {
+      "code": "QC01CA02",
+      "name": "isoprenaline"
+    },
+    {
+      "code": "QC01CA03",
+      "name": "norepinephrine"
+    },
+    {
+      "code": "QC01CA04",
+      "name": "dopamine"
+    },
+    {
+      "code": "QC01CA05",
+      "name": "norfenefrine"
+    },
+    {
+      "code": "QC01CA06",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QC01CA07",
+      "name": "dobutamine"
+    },
+    {
+      "code": "QC01CA08",
+      "name": "oxedrine"
+    },
+    {
+      "code": "QC01CA09",
+      "name": "metaraminol"
+    },
+    {
+      "code": "QC01CA10",
+      "name": "methoxamine"
+    },
+    {
+      "code": "QC01CA11",
+      "name": "mephentermine"
+    },
+    {
+      "code": "QC01CA12",
+      "name": "dimetofrine"
+    },
+    {
+      "code": "QC01CA13",
+      "name": "prenalterol"
+    },
+    {
+      "code": "QC01CA14",
+      "name": "dopexamine"
+    },
+    {
+      "code": "QC01CA15",
+      "name": "gepefrine"
+    },
+    {
+      "code": "QC01CA16",
+      "name": "ibopamine"
+    },
+    {
+      "code": "QC01CA17",
+      "name": "midodrine"
+    },
+    {
+      "code": "QC01CA18",
+      "name": "octopamine"
+    },
+    {
+      "code": "QC01CA19",
+      "name": "fenoldopam"
+    },
+    {
+      "code": "QC01CA21",
+      "name": "cafedrine"
+    },
+    {
+      "code": "QC01CA22",
+      "name": "arbutamine"
+    },
+    {
+      "code": "QC01CA23",
+      "name": "theodrenaline"
+    },
+    {
+      "code": "QC01CA24",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QC01CA25",
+      "name": "amezinium metilsulfate"
+    },
+    {
+      "code": "QC01CA26",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QC01CA27",
+      "name": "droxidopa"
+    },
+    {
+      "code": "QC01CA28",
+      "name": "centhaquine"
+    },
+    {
+      "code": "QC01CA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QC01CA51",
+      "name": "etilefrine, combinations"
+    },
+    {
+      "code": "QC01CE",
+      "name": "Phosphodiesterase inhibitors"
+    },
+    {
+      "code": "QC01CE01",
+      "name": "amrinone"
+    },
+    {
+      "code": "QC01CE02",
+      "name": "milrinone"
+    },
+    {
+      "code": "QC01CE03",
+      "name": "enoximone"
+    },
+    {
+      "code": "QC01CE04",
+      "name": "bucladesine"
+    },
+    {
+      "code": "QC01CE90",
+      "name": "pimobendan"
+    },
+    {
+      "code": "QC01CX",
+      "name": "Other cardiac stimulants"
+    },
+    {
+      "code": "QC01CX06",
+      "name": "angiotensinamide"
+    },
+    {
+      "code": "QC01CX07",
+      "name": "xamoterol"
+    },
+    {
+      "code": "QC01CX08",
+      "name": "levosimendan"
+    },
+    {
+      "code": "QC01CX09",
+      "name": "angiotensin II"
+    },
+    {
+      "code": "QC01CX10",
+      "name": "omecamtiv mecarbil"
+    },
+    {
+      "code": "QC01D",
+      "name": "VASODILATORS USED IN CARDIAC DISEASES"
+    },
+    {
+      "code": "QC01DA",
+      "name": "Organic nitrates"
+    },
+    {
+      "code": "QC01DA02",
+      "name": "glyceryl trinitrate"
+    },
+    {
+      "code": "QC01DA04",
+      "name": "methylpropylpropanediol dinitrate"
+    },
+    {
+      "code": "QC01DA05",
+      "name": "pentaerithrityl tetranitrate"
+    },
+    {
+      "code": "QC01DA07",
+      "name": "propatylnitrate"
+    },
+    {
+      "code": "QC01DA08",
+      "name": "isosorbide dinitrate"
+    },
+    {
+      "code": "QC01DA09",
+      "name": "trolnitrate"
+    },
+    {
+      "code": "QC01DA13",
+      "name": "eritrityl tetranitrate"
+    },
+    {
+      "code": "QC01DA14",
+      "name": "isosorbide mononitrate"
+    },
+    {
+      "code": "QC01DA20",
+      "name": "organic nitrates in combination"
+    },
+    {
+      "code": "QC01DA38",
+      "name": "tenitramine"
+    },
+    {
+      "code": "QC01DA52",
+      "name": "glyceryl trinitrate, combinations"
+    },
+    {
+      "code": "QC01DA54",
+      "name": "methylpropylpropanediol dinitrate, combinations"
+    },
+    {
+      "code": "QC01DA55",
+      "name": "pentaerithrityl tetranitrate, combinations"
+    },
+    {
+      "code": "QC01DA57",
+      "name": "propatylnitrate, combinations"
+    },
+    {
+      "code": "QC01DA58",
+      "name": "isosorbide dinitrate, combinations"
+    },
+    {
+      "code": "QC01DA59",
+      "name": "trolnitrate, combinations"
+    },
+    {
+      "code": "QC01DA63",
+      "name": "eritrityl tetranitrate, combinations"
+    },
+    {
+      "code": "QC01DA70",
+      "name": "organic nitrates in combination with psycholeptics"
+    },
+    {
+      "code": "QC01DB",
+      "name": "Quinolone vasodilators"
+    },
+    {
+      "code": "QC01DB01",
+      "name": "flosequinan"
+    },
+    {
+      "code": "QC01DB06",
+      "name": "tedisamil"
+    },
+    {
+      "code": "QC01DX",
+      "name": "Other vasodilators used in cardiac diseases"
+    },
+    {
+      "code": "QC01DX01",
+      "name": "itramin tosilate"
+    },
+    {
+      "code": "QC01DX02",
+      "name": "prenylamine"
+    },
+    {
+      "code": "QC01DX03",
+      "name": "oxyfedrine"
+    },
+    {
+      "code": "QC01DX04",
+      "name": "benziodarone"
+    },
+    {
+      "code": "QC01DX05",
+      "name": "carbocromen"
+    },
+    {
+      "code": "QC01DX06",
+      "name": "hexobendine"
+    },
+    {
+      "code": "QC01DX07",
+      "name": "etafenone"
+    },
+    {
+      "code": "QC01DX08",
+      "name": "heptaminol"
+    },
+    {
+      "code": "QC01DX09",
+      "name": "imolamine"
+    },
+    {
+      "code": "QC01DX10",
+      "name": "dilazep"
+    },
+    {
+      "code": "QC01DX11",
+      "name": "trapidil"
+    },
+    {
+      "code": "QC01DX12",
+      "name": "molsidomine"
+    },
+    {
+      "code": "QC01DX13",
+      "name": "efloxate"
+    },
+    {
+      "code": "QC01DX14",
+      "name": "cinepazet"
+    },
+    {
+      "code": "QC01DX15",
+      "name": "cloridarol"
+    },
+    {
+      "code": "QC01DX16",
+      "name": "nicorandil"
+    },
+    {
+      "code": "QC01DX18",
+      "name": "linsidomine"
+    },
+    {
+      "code": "QC01DX19",
+      "name": "nesiritide"
+    },
+    {
+      "code": "QC01DX21",
+      "name": "serelaxin"
+    },
+    {
+      "code": "QC01DX22",
+      "name": "vericiguat"
+    },
+    {
+      "code": "QC01DX51",
+      "name": "itramin tosilate, combinations"
+    },
+    {
+      "code": "QC01DX52",
+      "name": "prenylamine, combinations"
+    },
+    {
+      "code": "QC01DX53",
+      "name": "oxyfedrine, combinations"
+    },
+    {
+      "code": "QC01DX54",
+      "name": "benziodarone, combinations"
+    },
+    {
+      "code": "QC01E",
+      "name": "OTHER CARDIAC PREPARATIONS"
+    },
+    {
+      "code": "QC01EA",
+      "name": "Prostaglandins"
+    },
+    {
+      "code": "QC01EA01",
+      "name": "alprostadil"
+    },
+    {
+      "code": "QC01EB",
+      "name": "Other cardiac preparations"
+    },
+    {
+      "code": "QC01EB02",
+      "name": "camphora"
+    },
+    {
+      "code": "QC01EB03",
+      "name": "indometacin"
+    },
+    {
+      "code": "QC01EB04",
+      "name": "crataegus glycosides"
+    },
+    {
+      "code": "QC01EB05",
+      "name": "creatinolfosfate"
+    },
+    {
+      "code": "QC01EB06",
+      "name": "fosfocreatine"
+    },
+    {
+      "code": "QC01EB07",
+      "name": "fructose 1,6-diphosphate"
+    },
+    {
+      "code": "QC01EB09",
+      "name": "ubidecarenone"
+    },
+    {
+      "code": "QC01EB10",
+      "name": "adenosine"
+    },
+    {
+      "code": "QC01EB11",
+      "name": "tiracizine"
+    },
+    {
+      "code": "QC01EB13",
+      "name": "acadesine"
+    },
+    {
+      "code": "QC01EB15",
+      "name": "trimetazidine"
+    },
+    {
+      "code": "QC01EB16",
+      "name": "ibuprofen"
+    },
+    {
+      "code": "QC01EB17",
+      "name": "ivabradine"
+    },
+    {
+      "code": "QC01EB18",
+      "name": "ranolazine"
+    },
+    {
+      "code": "QC01EB21",
+      "name": "regadenoson"
+    },
+    {
+      "code": "QC01EB22",
+      "name": "meldonium"
+    },
+    {
+      "code": "QC01EB23",
+      "name": "tiazotic acid"
+    },
+    {
+      "code": "QC01EB24",
+      "name": "mavacamten"
+    },
+    {
+      "code": "QC01EB25",
+      "name": "acoramidis"
+    },
+    {
+      "code": "QC01EB90",
+      "name": "sirolimus"
+    },
+    {
+      "code": "QC01EX",
+      "name": "Other cardiac combination products"
+    },
+    {
+      "code": "QC02",
+      "name": "ANTIHYPERTENSIVES"
+    },
+    {
+      "code": "QC02A",
+      "name": "ANTIADRENERGIC AGENTS, CENTRALLY ACTING"
+    },
+    {
+      "code": "QC02AA",
+      "name": "Rauwolfia alkaloids"
+    },
+    {
+      "code": "QC02AA01",
+      "name": "rescinnamine"
+    },
+    {
+      "code": "QC02AA02",
+      "name": "reserpine"
+    },
+    {
+      "code": "QC02AA03",
+      "name": "combinations of rauwolfia alkaloids"
+    },
+    {
+      "code": "QC02AA04",
+      "name": "rauwolfia alkaloids, whole root"
+    },
+    {
+      "code": "QC02AA05",
+      "name": "deserpidine"
+    },
+    {
+      "code": "QC02AA06",
+      "name": "methoserpidine"
+    },
+    {
+      "code": "QC02AA07",
+      "name": "bietaserpine"
+    },
+    {
+      "code": "QC02AA52",
+      "name": "reserpine, combinations"
+    },
+    {
+      "code": "QC02AA53",
+      "name": "combinations of rauwolfia alkaloids, combinations"
+    },
+    {
+      "code": "QC02AA57",
+      "name": "bietaserpine, combinations"
+    },
+    {
+      "code": "QC02AB",
+      "name": "Methyldopa"
+    },
+    {
+      "code": "QC02AB01",
+      "name": "methyldopa (levorotatory)"
+    },
+    {
+      "code": "QC02AB02",
+      "name": "methyldopa (racemic)"
+    },
+    {
+      "code": "QC02AC",
+      "name": "Imidazoline receptor agonists"
+    },
+    {
+      "code": "QC02AC01",
+      "name": "clonidine"
+    },
+    {
+      "code": "QC02AC02",
+      "name": "guanfacine"
+    },
+    {
+      "code": "QC02AC04",
+      "name": "tolonidine"
+    },
+    {
+      "code": "QC02AC05",
+      "name": "moxonidine"
+    },
+    {
+      "code": "QC02AC06",
+      "name": "rilmenidine"
+    },
+    {
+      "code": "QC02B",
+      "name": "ANTIADRENERGIC AGENTS, GANGLION-BLOCKING"
+    },
+    {
+      "code": "QC02BA",
+      "name": "Sulfonium derivatives"
+    },
+    {
+      "code": "QC02BA01",
+      "name": "trimetaphan"
+    },
+    {
+      "code": "QC02BB",
+      "name": "Secondary and tertiary amines"
+    },
+    {
+      "code": "QC02BB01",
+      "name": "mecamylamine"
+    },
+    {
+      "code": "QC02BC",
+      "name": "Bisquaternary ammonium compounds"
+    },
+    {
+      "code": "QC02C",
+      "name": "ANTIADRENERGIC AGENTS, PERIPHERALLY ACTING"
+    },
+    {
+      "code": "QC02CA",
+      "name": "Alpha-adrenoreceptor antagonists"
+    },
+    {
+      "code": "QC02CA01",
+      "name": "prazosin"
+    },
+    {
+      "code": "QC02CA02",
+      "name": "indoramin"
+    },
+    {
+      "code": "QC02CA03",
+      "name": "trimazosin"
+    },
+    {
+      "code": "QC02CA04",
+      "name": "doxazosin"
+    },
+    {
+      "code": "QC02CA06",
+      "name": "urapidil"
+    },
+    {
+      "code": "QC02CC",
+      "name": "Guanidine derivatives"
+    },
+    {
+      "code": "QC02CC01",
+      "name": "betanidine"
+    },
+    {
+      "code": "QC02CC02",
+      "name": "guanethidine"
+    },
+    {
+      "code": "QC02CC03",
+      "name": "guanoxan"
+    },
+    {
+      "code": "QC02CC04",
+      "name": "debrisoquine"
+    },
+    {
+      "code": "QC02CC05",
+      "name": "guanoclor"
+    },
+    {
+      "code": "QC02CC06",
+      "name": "guanazodine"
+    },
+    {
+      "code": "QC02CC07",
+      "name": "guanoxabenz"
+    },
+    {
+      "code": "QC02D",
+      "name": "ARTERIOLAR SMOOTH MUSCLE, AGENTS ACTING ON"
+    },
+    {
+      "code": "QC02DA",
+      "name": "Thiazide derivatives"
+    },
+    {
+      "code": "QC02DA01",
+      "name": "diazoxide"
+    },
+    {
+      "code": "QC02DB",
+      "name": "Hydrazinophtalazine derivatives"
+    },
+    {
+      "code": "QC02DB01",
+      "name": "dihydralazine"
+    },
+    {
+      "code": "QC02DB02",
+      "name": "hydralazine"
+    },
+    {
+      "code": "QC02DB03",
+      "name": "endralazine"
+    },
+    {
+      "code": "QC02DB04",
+      "name": "cadralazine"
+    },
+    {
+      "code": "QC02DC",
+      "name": "Pyrimidine derivatives"
+    },
+    {
+      "code": "QC02DC01",
+      "name": "minoxidil"
+    },
+    {
+      "code": "QC02DD",
+      "name": "Nitroferricyanide derivatives"
+    },
+    {
+      "code": "QC02DD01",
+      "name": "nitroprusside"
+    },
+    {
+      "code": "QC02DG",
+      "name": "Guanidine derivatives"
+    },
+    {
+      "code": "QC02DG01",
+      "name": "pinacidil"
+    },
+    {
+      "code": "QC02K",
+      "name": "OTHER ANTIHYPERTENSIVES"
+    },
+    {
+      "code": "QC02KA",
+      "name": "Alcaloids, excl. rauwolfia"
+    },
+    {
+      "code": "QC02KA01",
+      "name": "veratrum"
+    },
+    {
+      "code": "QC02KB",
+      "name": "Tyrosine hydroxylase inhibitors"
+    },
+    {
+      "code": "QC02KB01",
+      "name": "metirosine"
+    },
+    {
+      "code": "QC02KC",
+      "name": "MAO inhibitors"
+    },
+    {
+      "code": "QC02KC01",
+      "name": "pargyline"
+    },
+    {
+      "code": "QC02KD",
+      "name": "Serotonin antagonists"
+    },
+    {
+      "code": "QC02KD01",
+      "name": "ketanserin"
+    },
+    {
+      "code": "QC02KN",
+      "name": "Other antihypertensives"
+    },
+    {
+      "code": "QC02KN01",
+      "name": "aprocitentan"
+    },
+    {
+      "code": "QC02KN02",
+      "name": "baxdrostat"
+    },
+    {
+      "code": "QC02KX",
+      "name": "Antihypertensives for pulmonary arterial hypertension"
+    },
+    {
+      "code": "QC02KX01",
+      "name": "bosentan"
+    },
+    {
+      "code": "QC02KX02",
+      "name": "ambrisentan"
+    },
+    {
+      "code": "QC02KX03",
+      "name": "sitaxentan"
+    },
+    {
+      "code": "QC02KX04",
+      "name": "macitentan"
+    },
+    {
+      "code": "QC02KX05",
+      "name": "riociguat"
+    },
+    {
+      "code": "QC02KX06",
+      "name": "sotatercept"
+    },
+    {
+      "code": "QC02KX52",
+      "name": "ambrisentan and tadalafil"
+    },
+    {
+      "code": "QC02KX54",
+      "name": "macitentan and tadalafil"
+    },
+    {
+      "code": "QC02L",
+      "name": "ANTIHYPERTENSIVES AND DIURETICS IN COMBINATION"
+    },
+    {
+      "code": "QC02LA",
+      "name": "Rauwolfia alkaloids and diuretics in combination"
+    },
+    {
+      "code": "QC02LA01",
+      "name": "reserpine and diuretics"
+    },
+    {
+      "code": "QC02LA02",
+      "name": "rescinnamine and diuretics"
+    },
+    {
+      "code": "QC02LA03",
+      "name": "deserpidine and diuretics"
+    },
+    {
+      "code": "QC02LA04",
+      "name": "methoserpidine and diuretics"
+    },
+    {
+      "code": "QC02LA07",
+      "name": "bietaserpine and diuretics"
+    },
+    {
+      "code": "QC02LA08",
+      "name": "rauwolfia alkaloids, whole root and diuretics"
+    },
+    {
+      "code": "QC02LA09",
+      "name": "syrosingopine and diuretics"
+    },
+    {
+      "code": "QC02LA50",
+      "name": "combinations of rauwolfia alkaloids and diuretics incl. other combinations"
+    },
+    {
+      "code": "QC02LA51",
+      "name": "reserpine and diuretics, combinations with other drugs"
+    },
+    {
+      "code": "QC02LA52",
+      "name": "rescinnamine and diuretics, combinations with other drugs"
+    },
+    {
+      "code": "QC02LA71",
+      "name": "reserpine and diuretics, combinations with psycholeptics"
+    },
+    {
+      "code": "QC02LB",
+      "name": "Methyldopa and diuretics in combination"
+    },
+    {
+      "code": "QC02LB01",
+      "name": "methyldopa (levorotatory) and diuretics"
+    },
+    {
+      "code": "QC02LC",
+      "name": "Imidazoline receptor agonists in combination with diuretics"
+    },
+    {
+      "code": "QC02LC01",
+      "name": "clonidine and diuretics"
+    },
+    {
+      "code": "QC02LC05",
+      "name": "moxonidine and diuretics"
+    },
+    {
+      "code": "QC02LC51",
+      "name": "clonidine and diuretics, combinations with other drugs"
+    },
+    {
+      "code": "QC02LE",
+      "name": "Alpha-adrenoreceptor antagonists and diuretics"
+    },
+    {
+      "code": "QC02LE01",
+      "name": "prazosin and diuretics"
+    },
+    {
+      "code": "QC02LF",
+      "name": "Guanidine derivatives and diuretics"
+    },
+    {
+      "code": "QC02LF01",
+      "name": "guanethidine and diuretics"
+    },
+    {
+      "code": "QC02LG",
+      "name": "Hydrazinophthalazine derivatives and diuretics"
+    },
+    {
+      "code": "QC02LG01",
+      "name": "dihydralazine and diuretics"
+    },
+    {
+      "code": "QC02LG02",
+      "name": "hydralazine and diuretics"
+    },
+    {
+      "code": "QC02LG03",
+      "name": "picodralazine and diuretics"
+    },
+    {
+      "code": "QC02LG51",
+      "name": "dihydralazine and diuretics, combinations with other drugs"
+    },
+    {
+      "code": "QC02LG73",
+      "name": "picodralazine and diuretics, combinations with psycholeptics"
+    },
+    {
+      "code": "QC02LK",
+      "name": "Alkaloids, excl. rauwolfia, in combination with diuretics"
+    },
+    {
+      "code": "QC02LK01",
+      "name": "veratrum and diuretics"
+    },
+    {
+      "code": "QC02LL",
+      "name": "MAO inhibitors and diuretics"
+    },
+    {
+      "code": "QC02LL01",
+      "name": "pargyline and diuretics"
+    },
+    {
+      "code": "QC02LN",
+      "name": "Serotonin antagonists and diuretics"
+    },
+    {
+      "code": "QC02LX",
+      "name": "Other antihypertensives and diuretics"
+    },
+    {
+      "code": "QC02LX01",
+      "name": "pinacidil and diuretics"
+    },
+    {
+      "code": "QC02N",
+      "name": "COMBINATIONS OF ANTIHYPERTENSIVES IN ATCvet GR. QC02"
+    },
+    {
+      "code": "QC03",
+      "name": "DIURETICS"
+    },
+    {
+      "code": "QC03A",
+      "name": "LOW-CEILING DIURETICS, THIAZIDES"
+    },
+    {
+      "code": "QC03AA",
+      "name": "Thiazides, plain"
+    },
+    {
+      "code": "QC03AA01",
+      "name": "bendroflumethiazide"
+    },
+    {
+      "code": "QC03AA02",
+      "name": "hydroflumethiazide"
+    },
+    {
+      "code": "QC03AA03",
+      "name": "hydrochlorothiazide"
+    },
+    {
+      "code": "QC03AA04",
+      "name": "chlorothiazide"
+    },
+    {
+      "code": "QC03AA05",
+      "name": "polythiazide"
+    },
+    {
+      "code": "QC03AA06",
+      "name": "trichlormethiazide"
+    },
+    {
+      "code": "QC03AA07",
+      "name": "cyclopenthiazide"
+    },
+    {
+      "code": "QC03AA08",
+      "name": "methyclothiazide"
+    },
+    {
+      "code": "QC03AA09",
+      "name": "cyclothiazide"
+    },
+    {
+      "code": "QC03AA13",
+      "name": "mebutizide"
+    },
+    {
+      "code": "QC03AA56",
+      "name": "trichlormethiazide, combinations"
+    },
+    {
+      "code": "QC03AB",
+      "name": "Thiazides and potassium in combination"
+    },
+    {
+      "code": "QC03AB01",
+      "name": "bendroflumethiazide and potassium"
+    },
+    {
+      "code": "QC03AB02",
+      "name": "hydroflumethiazide and potassium"
+    },
+    {
+      "code": "QC03AB03",
+      "name": "hydrochlorothiazide and potassium"
+    },
+    {
+      "code": "QC03AB04",
+      "name": "chlorothiazide and potassium"
+    },
+    {
+      "code": "QC03AB05",
+      "name": "polythiazide and potassium"
+    },
+    {
+      "code": "QC03AB06",
+      "name": "trichlormethiazide and potassium"
+    },
+    {
+      "code": "QC03AB07",
+      "name": "cyclopenthiazide and potassium"
+    },
+    {
+      "code": "QC03AB08",
+      "name": "methyclothiazide and potassium"
+    },
+    {
+      "code": "QC03AB09",
+      "name": "cyclothiazide and potassium"
+    },
+    {
+      "code": "QC03AH",
+      "name": "Thiazides, combinations with psycholeptics and/or analgesics"
+    },
+    {
+      "code": "QC03AH01",
+      "name": "chlorothiazide, combinations"
+    },
+    {
+      "code": "QC03AH02",
+      "name": "hydroflumethiazide, combinations"
+    },
+    {
+      "code": "QC03AX",
+      "name": "Thiazides, combinations with other drugs"
+    },
+    {
+      "code": "QC03AX01",
+      "name": "hydrochlorothiazide, combinations"
+    },
+    {
+      "code": "QC03B",
+      "name": "LOW-CEILING DIURETICS, EXCL. THIAZIDES"
+    },
+    {
+      "code": "QC03BA",
+      "name": "Sulfonamides, plain"
+    },
+    {
+      "code": "QC03BA02",
+      "name": "quinethazone"
+    },
+    {
+      "code": "QC03BA03",
+      "name": "clopamide"
+    },
+    {
+      "code": "QC03BA04",
+      "name": "chlortalidone"
+    },
+    {
+      "code": "QC03BA05",
+      "name": "mefruside"
+    },
+    {
+      "code": "QC03BA07",
+      "name": "clofenamide"
+    },
+    {
+      "code": "QC03BA08",
+      "name": "metolazone"
+    },
+    {
+      "code": "QC03BA09",
+      "name": "meticrane"
+    },
+    {
+      "code": "QC03BA10",
+      "name": "xipamide"
+    },
+    {
+      "code": "QC03BA11",
+      "name": "indapamide"
+    },
+    {
+      "code": "QC03BA12",
+      "name": "clorexolone"
+    },
+    {
+      "code": "QC03BA13",
+      "name": "fenquizone"
+    },
+    {
+      "code": "QC03BA82",
+      "name": "clorexolone, combinations with psycholeptics"
+    },
+    {
+      "code": "QC03BB",
+      "name": "Sulfonamides and potassium in combination"
+    },
+    {
+      "code": "QC03BB02",
+      "name": "quinethazone and potassium"
+    },
+    {
+      "code": "QC03BB03",
+      "name": "clopamide and potassium"
+    },
+    {
+      "code": "QC03BB04",
+      "name": "chlortalidone and potassium"
+    },
+    {
+      "code": "QC03BB05",
+      "name": "mefruside and potassium"
+    },
+    {
+      "code": "QC03BB07",
+      "name": "clofenamide and potassium"
+    },
+    {
+      "code": "QC03BC",
+      "name": "Mercurial diuretics"
+    },
+    {
+      "code": "QC03BC01",
+      "name": "mersalyl"
+    },
+    {
+      "code": "QC03BD",
+      "name": "Xantine derivatives"
+    },
+    {
+      "code": "QC03BD01",
+      "name": "theobromine"
+    },
+    {
+      "code": "QC03BK",
+      "name": "Sulfonamides, combinations with other drugs"
+    },
+    {
+      "code": "QC03BX",
+      "name": "Other low-ceiling diuretics"
+    },
+    {
+      "code": "QC03BX03",
+      "name": "cicletanine"
+    },
+    {
+      "code": "QC03C",
+      "name": "HIGH-CEILING DIURETICS"
+    },
+    {
+      "code": "QC03CA",
+      "name": "Sulfonamides, plain"
+    },
+    {
+      "code": "QC03CA01",
+      "name": "furosemide"
+    },
+    {
+      "code": "QC03CA02",
+      "name": "bumetanide"
+    },
+    {
+      "code": "QC03CA03",
+      "name": "piretanide"
+    },
+    {
+      "code": "QC03CA04",
+      "name": "torasemide"
+    },
+    {
+      "code": "QC03CB",
+      "name": "Sulfonamides and potassium in combination"
+    },
+    {
+      "code": "QC03CB01",
+      "name": "furosemide and potassium"
+    },
+    {
+      "code": "QC03CB02",
+      "name": "bumetanide and potassium"
+    },
+    {
+      "code": "QC03CC",
+      "name": "Aryloxyacetic acid derivatives"
+    },
+    {
+      "code": "QC03CC01",
+      "name": "etacrynic acid"
+    },
+    {
+      "code": "QC03CC02",
+      "name": "tienilic acid"
+    },
+    {
+      "code": "QC03CD",
+      "name": "Pyrazolone derivatives"
+    },
+    {
+      "code": "QC03CD01",
+      "name": "muzolimine"
+    },
+    {
+      "code": "QC03CX",
+      "name": "Other high-ceiling diuretics"
+    },
+    {
+      "code": "QC03CX01",
+      "name": "etozolin"
+    },
+    {
+      "code": "QC03D",
+      "name": "ALDOSTERONE ANTAGONISTS AND OTHER POTASSIUM-SPARING AGENTS"
+    },
+    {
+      "code": "QC03DA",
+      "name": "Aldosterone antagonists"
+    },
+    {
+      "code": "QC03DA01",
+      "name": "spironolactone"
+    },
+    {
+      "code": "QC03DA02",
+      "name": "potassium canrenoate"
+    },
+    {
+      "code": "QC03DA03",
+      "name": "canrenone"
+    },
+    {
+      "code": "QC03DA04",
+      "name": "eplerenone"
+    },
+    {
+      "code": "QC03DA05",
+      "name": "finerenone"
+    },
+    {
+      "code": "QC03DA54",
+      "name": "eplerenone and dapagliflozin"
+    },
+    {
+      "code": "QC03DB",
+      "name": "Other potassium-sparing agents"
+    },
+    {
+      "code": "QC03DB01",
+      "name": "amiloride"
+    },
+    {
+      "code": "QC03DB02",
+      "name": "triamterene"
+    },
+    {
+      "code": "QC03E",
+      "name": "DIURETICS AND POTASSIUM-SPARING AGENTS IN COMBINATION"
+    },
+    {
+      "code": "QC03EA",
+      "name": "Low-ceiling diuretics and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA01",
+      "name": "hydrochlorothiazide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA02",
+      "name": "trichlormethiazide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA03",
+      "name": "epitizide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA04",
+      "name": "altizide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA05",
+      "name": "mebutizide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA06",
+      "name": "chlortalidone and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA07",
+      "name": "cyclopenthiazide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA12",
+      "name": "metolazone and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA13",
+      "name": "bendroflumethiazide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EA14",
+      "name": "butizide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EB",
+      "name": "High-ceiling diuretics and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EB01",
+      "name": "furosemide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EB02",
+      "name": "bumetanide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03EB03",
+      "name": "torasemide and potassium-sparing agents"
+    },
+    {
+      "code": "QC03X",
+      "name": "OTHER DIURETICS"
+    },
+    {
+      "code": "QC03XA",
+      "name": "Vasopressin antagonists"
+    },
+    {
+      "code": "QC03XA01",
+      "name": "tolvaptan"
+    },
+    {
+      "code": "QC03XA02",
+      "name": "conivaptan"
+    },
+    {
+      "code": "QC04",
+      "name": "PERIPHERAL VASODILATORS"
+    },
+    {
+      "code": "QC04A",
+      "name": "PERIPHERAL VASODILATORS"
+    },
+    {
+      "code": "QC04AA",
+      "name": "2-amino-1-phenylethanol derivatives"
+    },
+    {
+      "code": "QC04AA01",
+      "name": "isoxsuprine"
+    },
+    {
+      "code": "QC04AA02",
+      "name": "buphenine"
+    },
+    {
+      "code": "QC04AA31",
+      "name": "bamethan"
+    },
+    {
+      "code": "QC04AB",
+      "name": "Imidazoline derivatives"
+    },
+    {
+      "code": "QC04AB01",
+      "name": "phentolamine"
+    },
+    {
+      "code": "QC04AB02",
+      "name": "tolazoline"
+    },
+    {
+      "code": "QC04AC",
+      "name": "Nicotinic acid and derivatives"
+    },
+    {
+      "code": "QC04AC01",
+      "name": "nicotinic acid"
+    },
+    {
+      "code": "QC04AC02",
+      "name": "nicotinyl alcohol (pyridylcarbinol)"
+    },
+    {
+      "code": "QC04AC03",
+      "name": "inositol nicotinate"
+    },
+    {
+      "code": "QC04AC07",
+      "name": "ciclonicate"
+    },
+    {
+      "code": "QC04AD",
+      "name": "Purine derivatives"
+    },
+    {
+      "code": "QC04AD01",
+      "name": "pentifylline"
+    },
+    {
+      "code": "QC04AD02",
+      "name": "xantinol nicotinate"
+    },
+    {
+      "code": "QC04AD03",
+      "name": "pentoxifylline"
+    },
+    {
+      "code": "QC04AD04",
+      "name": "etofylline nicotinate"
+    },
+    {
+      "code": "QC04AD90",
+      "name": "propentofylline"
+    },
+    {
+      "code": "QC04AE",
+      "name": "Ergot alkaloids"
+    },
+    {
+      "code": "QC04AE01",
+      "name": "ergoloid mesylates"
+    },
+    {
+      "code": "QC04AE02",
+      "name": "nicergoline"
+    },
+    {
+      "code": "QC04AE04",
+      "name": "dihydroergocristine"
+    },
+    {
+      "code": "QC04AE51",
+      "name": "ergoloid mesylates, combinations"
+    },
+    {
+      "code": "QC04AE54",
+      "name": "dihydroergocristine, combinations"
+    },
+    {
+      "code": "QC04AF",
+      "name": "Enzymes"
+    },
+    {
+      "code": "QC04AF01",
+      "name": "kallidinogenase"
+    },
+    {
+      "code": "QC04AX",
+      "name": "Other peripheral vasodilators"
+    },
+    {
+      "code": "QC04AX01",
+      "name": "cyclandelate"
+    },
+    {
+      "code": "QC04AX02",
+      "name": "phenoxybenzamine"
+    },
+    {
+      "code": "QC04AX07",
+      "name": "vincamine"
+    },
+    {
+      "code": "QC04AX10",
+      "name": "moxisylyte"
+    },
+    {
+      "code": "QC04AX11",
+      "name": "bencyclane"
+    },
+    {
+      "code": "QC04AX17",
+      "name": "vinburnine"
+    },
+    {
+      "code": "QC04AX19",
+      "name": "suloctidil"
+    },
+    {
+      "code": "QC04AX20",
+      "name": "buflomedil"
+    },
+    {
+      "code": "QC04AX21",
+      "name": "naftidrofuryl"
+    },
+    {
+      "code": "QC04AX23",
+      "name": "butalamine"
+    },
+    {
+      "code": "QC04AX24",
+      "name": "visnadine"
+    },
+    {
+      "code": "QC04AX26",
+      "name": "cetiedil"
+    },
+    {
+      "code": "QC04AX27",
+      "name": "cinepazide"
+    },
+    {
+      "code": "QC04AX28",
+      "name": "ifenprodil"
+    },
+    {
+      "code": "QC04AX30",
+      "name": "azapetine"
+    },
+    {
+      "code": "QC04AX32",
+      "name": "fasudil"
+    },
+    {
+      "code": "QC04AX33",
+      "name": "clazosentan"
+    },
+    {
+      "code": "QC05",
+      "name": "VASOPROTECTIVES"
+    },
+    {
+      "code": "QC05A",
+      "name": "AGENTS FOR TREATMENT OF HEMORRHOIDS AND ANAL FISSURES FOR TOPICAL USE"
+    },
+    {
+      "code": "QC05AA",
+      "name": "Corticosteroids"
+    },
+    {
+      "code": "QC05AA01",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QC05AA04",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QC05AA05",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QC05AA06",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QC05AA08",
+      "name": "fluocortolone"
+    },
+    {
+      "code": "QC05AA09",
+      "name": "dexametasone"
+    },
+    {
+      "code": "QC05AA10",
+      "name": "fluocinolone acetonide"
+    },
+    {
+      "code": "QC05AA11",
+      "name": "fluocinonide"
+    },
+    {
+      "code": "QC05AA12",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QC05AB",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QC05AD",
+      "name": "Local anesthetics"
+    },
+    {
+      "code": "QC05AD01",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QC05AD02",
+      "name": "tetracaine"
+    },
+    {
+      "code": "QC05AD03",
+      "name": "benzocaine"
+    },
+    {
+      "code": "QC05AD04",
+      "name": "cinchocaine"
+    },
+    {
+      "code": "QC05AD05",
+      "name": "procaine"
+    },
+    {
+      "code": "QC05AD06",
+      "name": "oxetacaine"
+    },
+    {
+      "code": "QC05AD07",
+      "name": "pramocaine"
+    },
+    {
+      "code": "QC05AE",
+      "name": "Muscle relaxants"
+    },
+    {
+      "code": "QC05AE01",
+      "name": "glyceryl trinitrate"
+    },
+    {
+      "code": "QC05AE02",
+      "name": "isosorbide dinitrate"
+    },
+    {
+      "code": "QC05AE03",
+      "name": "diltiazem"
+    },
+    {
+      "code": "QC05AX",
+      "name": "Other agents for treatment of hemorrhoids and anal fissures for topical use"
+    },
+    {
+      "code": "QC05AX01",
+      "name": "aluminium preparations"
+    },
+    {
+      "code": "QC05AX02",
+      "name": "bismuth preparations, combinations"
+    },
+    {
+      "code": "QC05AX03",
+      "name": "other preparations, combinations"
+    },
+    {
+      "code": "QC05AX04",
+      "name": "zinc preparations"
+    },
+    {
+      "code": "QC05AX05",
+      "name": "tribenoside"
+    },
+    {
+      "code": "QC05AX06",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QC05B",
+      "name": "ANTIVARICOSE THERAPY"
+    },
+    {
+      "code": "QC05BA",
+      "name": "Heparins or heparinoids for topical use"
+    },
+    {
+      "code": "QC05BA01",
+      "name": "organo-heparinoid"
+    },
+    {
+      "code": "QC05BA02",
+      "name": "sodium apolate"
+    },
+    {
+      "code": "QC05BA03",
+      "name": "heparin"
+    },
+    {
+      "code": "QC05BA04",
+      "name": "pentosan polysulfate sodium"
+    },
+    {
+      "code": "QC05BA51",
+      "name": "heparinoid, combinations"
+    },
+    {
+      "code": "QC05BA53",
+      "name": "heparin, combinations"
+    },
+    {
+      "code": "QC05BB",
+      "name": "Sclerosing agents for local injection"
+    },
+    {
+      "code": "QC05BB01",
+      "name": "monoethanolamine oleat"
+    },
+    {
+      "code": "QC05BB02",
+      "name": "polidocanol"
+    },
+    {
+      "code": "QC05BB03",
+      "name": "invert sugar"
+    },
+    {
+      "code": "QC05BB04",
+      "name": "sodium tetradecyl sulfate"
+    },
+    {
+      "code": "QC05BB05",
+      "name": "phenol"
+    },
+    {
+      "code": "QC05BB56",
+      "name": "glucose, combinations"
+    },
+    {
+      "code": "QC05BX",
+      "name": "Other sclerosing agents"
+    },
+    {
+      "code": "QC05BX01",
+      "name": "calcium dobesilate"
+    },
+    {
+      "code": "QC05BX51",
+      "name": "calcium dobesilate, combinations"
+    },
+    {
+      "code": "QC05C",
+      "name": "CAPILLARY STABILIZING AGENTS"
+    },
+    {
+      "code": "QC05CA",
+      "name": "Bioflavonoids"
+    },
+    {
+      "code": "QC05CA01",
+      "name": "rutoside"
+    },
+    {
+      "code": "QC05CA02",
+      "name": "monoxerutin"
+    },
+    {
+      "code": "QC05CA03",
+      "name": "diosmin"
+    },
+    {
+      "code": "QC05CA04",
+      "name": "troxerutin"
+    },
+    {
+      "code": "QC05CA05",
+      "name": "hidrosmin"
+    },
+    {
+      "code": "QC05CA51",
+      "name": "rutoside, combinations"
+    },
+    {
+      "code": "QC05CA53",
+      "name": "diosmin, combinations"
+    },
+    {
+      "code": "QC05CA54",
+      "name": "troxerutin, combinations"
+    },
+    {
+      "code": "QC05CX",
+      "name": "Other capillary stabilizing agents"
+    },
+    {
+      "code": "QC05CX01",
+      "name": "tribenoside"
+    },
+    {
+      "code": "QC05CX02",
+      "name": "naftazone"
+    },
+    {
+      "code": "QC05CX03",
+      "name": "Hippocastani semen"
+    },
+    {
+      "code": "QC05X",
+      "name": "OTHER VASOPROTECTIVES"
+    },
+    {
+      "code": "QC05XX",
+      "name": "Other vasoprotectives"
+    },
+    {
+      "code": "QC05XX01",
+      "name": "beperminogene perplasmid"
+    },
+    {
+      "code": "QC05XX90",
+      "name": "beraprost"
+    },
+    {
+      "code": "QC07",
+      "name": "BETA BLOCKING AGENTS"
+    },
+    {
+      "code": "QC07A",
+      "name": "BETA BLOCKING AGENTS"
+    },
+    {
+      "code": "QC07AA",
+      "name": "Beta blocking agents, non-selective"
+    },
+    {
+      "code": "QC07AA01",
+      "name": "alprenolol"
+    },
+    {
+      "code": "QC07AA02",
+      "name": "oxprenolol"
+    },
+    {
+      "code": "QC07AA03",
+      "name": "pindolol"
+    },
+    {
+      "code": "QC07AA05",
+      "name": "propranolol"
+    },
+    {
+      "code": "QC07AA06",
+      "name": "timolol"
+    },
+    {
+      "code": "QC07AA07",
+      "name": "sotalol"
+    },
+    {
+      "code": "QC07AA12",
+      "name": "nadolol"
+    },
+    {
+      "code": "QC07AA14",
+      "name": "mepindolol"
+    },
+    {
+      "code": "QC07AA15",
+      "name": "carteolol"
+    },
+    {
+      "code": "QC07AA16",
+      "name": "tertatolol"
+    },
+    {
+      "code": "QC07AA17",
+      "name": "bopindolol"
+    },
+    {
+      "code": "QC07AA19",
+      "name": "bupranolol"
+    },
+    {
+      "code": "QC07AA23",
+      "name": "penbutolol"
+    },
+    {
+      "code": "QC07AA27",
+      "name": "cloranolol"
+    },
+    {
+      "code": "QC07AA90",
+      "name": "carazolol"
+    },
+    {
+      "code": "QC07AB",
+      "name": "Beta blocking agents, selective"
+    },
+    {
+      "code": "QC07AB01",
+      "name": "practolol"
+    },
+    {
+      "code": "QC07AB02",
+      "name": "metoprolol"
+    },
+    {
+      "code": "QC07AB03",
+      "name": "atenolol"
+    },
+    {
+      "code": "QC07AB04",
+      "name": "acebutolol"
+    },
+    {
+      "code": "QC07AB05",
+      "name": "betaxolol"
+    },
+    {
+      "code": "QC07AB06",
+      "name": "bevantolol"
+    },
+    {
+      "code": "QC07AB07",
+      "name": "bisoprolol"
+    },
+    {
+      "code": "QC07AB08",
+      "name": "celiprolol"
+    },
+    {
+      "code": "QC07AB09",
+      "name": "esmolol"
+    },
+    {
+      "code": "QC07AB10",
+      "name": "epanolol"
+    },
+    {
+      "code": "QC07AB11",
+      "name": "s-atenolol"
+    },
+    {
+      "code": "QC07AB12",
+      "name": "nebivolol"
+    },
+    {
+      "code": "QC07AB13",
+      "name": "talinolol"
+    },
+    {
+      "code": "QC07AB14",
+      "name": "landiolol"
+    },
+    {
+      "code": "QC07AG",
+      "name": "Alpha and beta blocking agents"
+    },
+    {
+      "code": "QC07AG01",
+      "name": "labetalol"
+    },
+    {
+      "code": "QC07AG02",
+      "name": "carvedilol"
+    },
+    {
+      "code": "QC07B",
+      "name": "BETA BLOCKING AGENTS AND THIAZIDES"
+    },
+    {
+      "code": "QC07BA",
+      "name": "Beta blocking agents, non-selective and thiazides"
+    },
+    {
+      "code": "QC07BA02",
+      "name": "oxprenolol and thiazides"
+    },
+    {
+      "code": "QC07BA05",
+      "name": "propranolol and thiazides"
+    },
+    {
+      "code": "QC07BA06",
+      "name": "timolol and thiazides"
+    },
+    {
+      "code": "QC07BA07",
+      "name": "sotalol and thiazides"
+    },
+    {
+      "code": "QC07BA12",
+      "name": "nadolol and thiazides"
+    },
+    {
+      "code": "QC07BA68",
+      "name": "metipranolol and thiazides, combinations"
+    },
+    {
+      "code": "QC07BB",
+      "name": "Beta blocking agents, selective, and thiazides"
+    },
+    {
+      "code": "QC07BB02",
+      "name": "metoprolol and thiazides"
+    },
+    {
+      "code": "QC07BB03",
+      "name": "atenolol and thiazides"
+    },
+    {
+      "code": "QC07BB04",
+      "name": "acetobutol and thiazides"
+    },
+    {
+      "code": "QC07BB06",
+      "name": "bevantolol and thiazides"
+    },
+    {
+      "code": "QC07BB07",
+      "name": "bisoprolol and thiazides"
+    },
+    {
+      "code": "QC07BB12",
+      "name": "nebivolol and thiazides"
+    },
+    {
+      "code": "QC07BB52",
+      "name": "metoprolol and thiazides, combinations"
+    },
+    {
+      "code": "QC07BG",
+      "name": "Alpha and beta blocking agents and thiazides"
+    },
+    {
+      "code": "QC07BG01",
+      "name": "labetalol and thiazides"
+    },
+    {
+      "code": "QC07C",
+      "name": "BETA BLOCKING AGENTS AND OTHER DIURETICS"
+    },
+    {
+      "code": "QC07CA",
+      "name": "Beta blocking agents, non-selective and other diuretics"
+    },
+    {
+      "code": "QC07CA02",
+      "name": "oxprenolol and other diuretics"
+    },
+    {
+      "code": "QC07CA03",
+      "name": "pindolol and other diuretics"
+    },
+    {
+      "code": "QC07CA17",
+      "name": "biopindolol and other diuretics"
+    },
+    {
+      "code": "QC07CA23",
+      "name": "penbutolol and other diuretics"
+    },
+    {
+      "code": "QC07CB",
+      "name": "Beta blocking agents, selective, and other diuretics"
+    },
+    {
+      "code": "QC07CB02",
+      "name": "metoprolol and other diuretics"
+    },
+    {
+      "code": "QC07CB03",
+      "name": "atenolol and other diuretics"
+    },
+    {
+      "code": "QC07CB53",
+      "name": "atenolol and other diuretics, combinations"
+    },
+    {
+      "code": "QC07CG",
+      "name": "Alpha and beta blocking agents and other diuretics"
+    },
+    {
+      "code": "QC07CG01",
+      "name": "labetalol and other diuretics"
+    },
+    {
+      "code": "QC07D",
+      "name": "BETA BLOCKING AGENTS, THIAZIDES AND OTHER DIURETICS"
+    },
+    {
+      "code": "QC07DA",
+      "name": "Beta blocking agents, non-selective, thiazides and other diuretics"
+    },
+    {
+      "code": "QC07DA06",
+      "name": "timolol, thiazides and other diuretics"
+    },
+    {
+      "code": "QC07DB",
+      "name": "Beta blocking agents, selective, thiazides and other diuretics"
+    },
+    {
+      "code": "QC07DB01",
+      "name": "atenolol, thiazides and other diuretics"
+    },
+    {
+      "code": "QC07E",
+      "name": "BETA BLOCKING AGENTS AND VASODILATORS"
+    },
+    {
+      "code": "QC07EA",
+      "name": "Beta blocking agents, non-selective, and vasodilators"
+    },
+    {
+      "code": "QC07EB",
+      "name": "Beta blocking agents, selective, and vasodilators"
+    },
+    {
+      "code": "QC07F",
+      "name": "BETA BLOCKING AGENTS, OTHER COMBINATIONS"
+    },
+    {
+      "code": "QC07FB",
+      "name": "Beta blocking agents and calcium channel blockers"
+    },
+    {
+      "code": "QC07FB02",
+      "name": "metoprolol and felodipine"
+    },
+    {
+      "code": "QC07FB03",
+      "name": "atenolol and nifedipine"
+    },
+    {
+      "code": "QC07FB07",
+      "name": "bisoprolol and amlodipine"
+    },
+    {
+      "code": "QC07FB12",
+      "name": "nebivolol and amlodipine"
+    },
+    {
+      "code": "QC07FB13",
+      "name": "metoprolol and amlodipine"
+    },
+    {
+      "code": "QC07FX",
+      "name": "Beta blocking agents, other combinations"
+    },
+    {
+      "code": "QC07FX01",
+      "name": "propranolol and other combinations"
+    },
+    {
+      "code": "QC07FX02",
+      "name": "sotalol and acetylsalicylic acid"
+    },
+    {
+      "code": "QC07FX03",
+      "name": "metoprolol and acetylsalicylic acid"
+    },
+    {
+      "code": "QC07FX04",
+      "name": "bisoprolol and acetylsalicylic acid"
+    },
+    {
+      "code": "QC07FX05",
+      "name": "metoprolol and ivabradine"
+    },
+    {
+      "code": "QC07FX06",
+      "name": "carvedilol and ivabradine"
+    },
+    {
+      "code": "QC08",
+      "name": "CALCIUM CHANNEL BLOCKERS"
+    },
+    {
+      "code": "QC08C",
+      "name": "SELECTIVE CALCIUM CHANNEL BLOCKERS WITH MAINLY VASCULAR EFFECTS"
+    },
+    {
+      "code": "QC08CA",
+      "name": "Dihydropyridine derivatives"
+    },
+    {
+      "code": "QC08CA01",
+      "name": "amlodipine"
+    },
+    {
+      "code": "QC08CA02",
+      "name": "felodipine"
+    },
+    {
+      "code": "QC08CA03",
+      "name": "isradipine"
+    },
+    {
+      "code": "QC08CA04",
+      "name": "nicardipine"
+    },
+    {
+      "code": "QC08CA05",
+      "name": "nifedipine"
+    },
+    {
+      "code": "QC08CA06",
+      "name": "nimodipine"
+    },
+    {
+      "code": "QC08CA07",
+      "name": "nisoldipine"
+    },
+    {
+      "code": "QC08CA08",
+      "name": "nitrendipine"
+    },
+    {
+      "code": "QC08CA09",
+      "name": "lacidipine"
+    },
+    {
+      "code": "QC08CA10",
+      "name": "nilvadipine"
+    },
+    {
+      "code": "QC08CA11",
+      "name": "manidipine"
+    },
+    {
+      "code": "QC08CA12",
+      "name": "barnidipine"
+    },
+    {
+      "code": "QC08CA13",
+      "name": "lercanidipine"
+    },
+    {
+      "code": "QC08CA14",
+      "name": "cilnidipine"
+    },
+    {
+      "code": "QC08CA15",
+      "name": "benidipine"
+    },
+    {
+      "code": "QC08CA16",
+      "name": "clevidipine"
+    },
+    {
+      "code": "QC08CA17",
+      "name": "levamlodipine"
+    },
+    {
+      "code": "QC08CA51",
+      "name": "amlodipine and celecoxib"
+    },
+    {
+      "code": "QC08CA55",
+      "name": "nifedipine, combinations"
+    },
+    {
+      "code": "QC08CX",
+      "name": "Other selective calcium channel blockers with mainly vascular effects"
+    },
+    {
+      "code": "QC08CX01",
+      "name": "mibefradil"
+    },
+    {
+      "code": "QC08D",
+      "name": "SELECTIVE CALCIUM CHANNEL BLOCKERS WITH DIRECT CARDIAC EFFECTS"
+    },
+    {
+      "code": "QC08DA",
+      "name": "Phenylalkylamine derivatives"
+    },
+    {
+      "code": "QC08DA01",
+      "name": "verapamil"
+    },
+    {
+      "code": "QC08DA02",
+      "name": "gallopamil"
+    },
+    {
+      "code": "QC08DA03",
+      "name": "etripamil"
+    },
+    {
+      "code": "QC08DA51",
+      "name": "verapamil, combinations"
+    },
+    {
+      "code": "QC08DB",
+      "name": "Benzothiazepine derivatives"
+    },
+    {
+      "code": "QC08DB01",
+      "name": "diltiazem"
+    },
+    {
+      "code": "QC08E",
+      "name": "NON-SELECTIVE CALCIUM CHANNEL BLOCKERS"
+    },
+    {
+      "code": "QC08EA",
+      "name": "Phenylalkylamine derivatives"
+    },
+    {
+      "code": "QC08EA01",
+      "name": "fendiline"
+    },
+    {
+      "code": "QC08EA02",
+      "name": "bepridil"
+    },
+    {
+      "code": "QC08EX",
+      "name": "Other non-selective calcium channel blockers"
+    },
+    {
+      "code": "QC08EX01",
+      "name": "lidoflazine"
+    },
+    {
+      "code": "QC08EX02",
+      "name": "perhexiline"
+    },
+    {
+      "code": "QC08G",
+      "name": "CALCIUM CHANNEL BLOCKERS AND DIURETICS"
+    },
+    {
+      "code": "QC08GA",
+      "name": "Calcium channel blockers and diuretics"
+    },
+    {
+      "code": "QC08GA01",
+      "name": "nifedipine and diuretics"
+    },
+    {
+      "code": "QC08GA02",
+      "name": "amlodipine and diuretics"
+    },
+    {
+      "code": "QC09",
+      "name": "AGENTS ACTING ON THE RENIN-ANGIOTENSIN SYSTEM"
+    },
+    {
+      "code": "QC09A",
+      "name": "ACE INHIBITORS, PLAIN"
+    },
+    {
+      "code": "QC09AA",
+      "name": "ACE inhibitors, plain"
+    },
+    {
+      "code": "QC09AA01",
+      "name": "captopril"
+    },
+    {
+      "code": "QC09AA02",
+      "name": "enalapril"
+    },
+    {
+      "code": "QC09AA03",
+      "name": "lisinopril"
+    },
+    {
+      "code": "QC09AA04",
+      "name": "perindopril"
+    },
+    {
+      "code": "QC09AA05",
+      "name": "ramipril"
+    },
+    {
+      "code": "QC09AA06",
+      "name": "quinapril"
+    },
+    {
+      "code": "QC09AA07",
+      "name": "benazepril"
+    },
+    {
+      "code": "QC09AA08",
+      "name": "cilazapril"
+    },
+    {
+      "code": "QC09AA09",
+      "name": "fosinopril"
+    },
+    {
+      "code": "QC09AA10",
+      "name": "trandolapril"
+    },
+    {
+      "code": "QC09AA11",
+      "name": "spirapril"
+    },
+    {
+      "code": "QC09AA12",
+      "name": "delapril"
+    },
+    {
+      "code": "QC09AA13",
+      "name": "moexipril"
+    },
+    {
+      "code": "QC09AA14",
+      "name": "temocapril"
+    },
+    {
+      "code": "QC09AA15",
+      "name": "zofenopril"
+    },
+    {
+      "code": "QC09AA16",
+      "name": "imidapril"
+    },
+    {
+      "code": "QC09B",
+      "name": "ACE INHIBITORS, COMBINATIONS"
+    },
+    {
+      "code": "QC09BA",
+      "name": "ACE inhibitors and diuretics"
+    },
+    {
+      "code": "QC09BA01",
+      "name": "captopril and diuretics"
+    },
+    {
+      "code": "QC09BA02",
+      "name": "enalapril and diuretics"
+    },
+    {
+      "code": "QC09BA03",
+      "name": "lisinopril and diuretics"
+    },
+    {
+      "code": "QC09BA04",
+      "name": "perindopril and diuretics"
+    },
+    {
+      "code": "QC09BA05",
+      "name": "ramipril and diuretics"
+    },
+    {
+      "code": "QC09BA06",
+      "name": "quinapril and diuretics"
+    },
+    {
+      "code": "QC09BA07",
+      "name": "benazepril and diuretics"
+    },
+    {
+      "code": "QC09BA08",
+      "name": "cilazapril and diuretics"
+    },
+    {
+      "code": "QC09BA09",
+      "name": "fosinopril and diuretics"
+    },
+    {
+      "code": "QC09BA12",
+      "name": "delapril and diuretics"
+    },
+    {
+      "code": "QC09BA13",
+      "name": "moexipril and diuretics"
+    },
+    {
+      "code": "QC09BA15",
+      "name": "zofenopril and diuretics"
+    },
+    {
+      "code": "QC09BB",
+      "name": "ACE inhibitors and calcium channel blockers"
+    },
+    {
+      "code": "QC09BB02",
+      "name": "enalapril and lercanidipine"
+    },
+    {
+      "code": "QC09BB03",
+      "name": "lisinopril and amlodipine"
+    },
+    {
+      "code": "QC09BB04",
+      "name": "perindopril and amlodipine"
+    },
+    {
+      "code": "QC09BB05",
+      "name": "ramipril and felodipine"
+    },
+    {
+      "code": "QC09BB06",
+      "name": "enalapril and nitrendipine"
+    },
+    {
+      "code": "QC09BB07",
+      "name": "ramipril and amlodipine"
+    },
+    {
+      "code": "QC09BB10",
+      "name": "trandolapril and verapamil"
+    },
+    {
+      "code": "QC09BB12",
+      "name": "delapril and manidipine"
+    },
+    {
+      "code": "QC09BB13",
+      "name": "benazepril and amlodipine"
+    },
+    {
+      "code": "QC09BB14",
+      "name": "zofenopril and amlodipine"
+    },
+    {
+      "code": "QC09BX",
+      "name": "ACE inhibitors, other combinations"
+    },
+    {
+      "code": "QC09BX01",
+      "name": "perindopril, amlodipine and indapamide"
+    },
+    {
+      "code": "QC09BX02",
+      "name": "perindopril and bisoprolol"
+    },
+    {
+      "code": "QC09BX03",
+      "name": "ramipril, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09BX04",
+      "name": "perindopril, bisoprolol and amlodipine"
+    },
+    {
+      "code": "QC09BX05",
+      "name": "ramipril and bisoprolol"
+    },
+    {
+      "code": "QC09BX06",
+      "name": "perindopril, bisoprolol, amlodipine and indapamide"
+    },
+    {
+      "code": "QC09BX07",
+      "name": "zofenopril and nebivolol"
+    },
+    {
+      "code": "QC09BX90",
+      "name": "benazepril and pimobendan"
+    },
+    {
+      "code": "QC09C",
+      "name": "ANGIOTENSIN II RECEPTOR BLOCKERS (ARBS), PLAIN"
+    },
+    {
+      "code": "QC09CA",
+      "name": "Angiotensin II receptor blockers (ARBs), plain"
+    },
+    {
+      "code": "QC09CA01",
+      "name": "losartan"
+    },
+    {
+      "code": "QC09CA02",
+      "name": "eprosartan"
+    },
+    {
+      "code": "QC09CA03",
+      "name": "valsartan"
+    },
+    {
+      "code": "QC09CA04",
+      "name": "irbesartan"
+    },
+    {
+      "code": "QC09CA05",
+      "name": "tasosartan"
+    },
+    {
+      "code": "QC09CA06",
+      "name": "candesartan"
+    },
+    {
+      "code": "QC09CA07",
+      "name": "telmisartan"
+    },
+    {
+      "code": "QC09CA08",
+      "name": "olmesartan medoxomil"
+    },
+    {
+      "code": "QC09CA09",
+      "name": "azilsartan medoxomil"
+    },
+    {
+      "code": "QC09CA10",
+      "name": "fimasartan"
+    },
+    {
+      "code": "QC09D",
+      "name": "ANGIOTENSIN II RECEPTOR BLOCKERS (ARBS), COMBINATIONS"
+    },
+    {
+      "code": "QC09DA",
+      "name": "Angiotensin II receptor blockers (ARBs) and diuretics"
+    },
+    {
+      "code": "QC09DA01",
+      "name": "losartan and diuretics"
+    },
+    {
+      "code": "QC09DA02",
+      "name": "eprosartan and diuretics"
+    },
+    {
+      "code": "QC09DA03",
+      "name": "valsartan and diuretics"
+    },
+    {
+      "code": "QC09DA04",
+      "name": "irbesartan and diuretics"
+    },
+    {
+      "code": "QC09DA06",
+      "name": "candesartan and diuretics"
+    },
+    {
+      "code": "QC09DA07",
+      "name": "telmisartan and diuretics"
+    },
+    {
+      "code": "QC09DA08",
+      "name": "olmesartan medoxomil and diuretics"
+    },
+    {
+      "code": "QC09DA09",
+      "name": "azilsartan medoxomil and diuretics"
+    },
+    {
+      "code": "QC09DA10",
+      "name": "fimasartan and diuretics"
+    },
+    {
+      "code": "QC09DB",
+      "name": "Angiotensin II receptor blockers (ARBs) and calcium channel blockers"
+    },
+    {
+      "code": "QC09DB01",
+      "name": "valsartan and amlodipine"
+    },
+    {
+      "code": "QC09DB02",
+      "name": "olmesartan medoxomil and amlodipine"
+    },
+    {
+      "code": "QC09DB04",
+      "name": "telmisartan and amlodipine"
+    },
+    {
+      "code": "QC09DB05",
+      "name": "irbesartan and amlodipine"
+    },
+    {
+      "code": "QC09DB06",
+      "name": "losartan and amlodipine"
+    },
+    {
+      "code": "QC09DB07",
+      "name": "candesartan and amlodipine"
+    },
+    {
+      "code": "QC09DB08",
+      "name": "valsartan and lercanidipine"
+    },
+    {
+      "code": "QC09DB09",
+      "name": "fimasartan and amlodipine"
+    },
+    {
+      "code": "QC09DX",
+      "name": "Angiotensin II receptor blockers (ARBs), other combinations"
+    },
+    {
+      "code": "QC09DX01",
+      "name": "valsartan, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09DX02",
+      "name": "valsartan and aliskiren"
+    },
+    {
+      "code": "QC09DX03",
+      "name": "olmesartan medoxomil, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09DX04",
+      "name": "valsartan and sacubitril"
+    },
+    {
+      "code": "QC09DX05",
+      "name": "valsartan and nebivolol"
+    },
+    {
+      "code": "QC09DX06",
+      "name": "candesartan, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09DX07",
+      "name": "irbesartan, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09DX08",
+      "name": "telmisartan, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09DX09",
+      "name": "candesartan, amlodipine and indapamide"
+    },
+    {
+      "code": "QC09X",
+      "name": "OTHER AGENTS ACTING ON THE RENIN-ANGIOTENSIN SYSTEM"
+    },
+    {
+      "code": "QC09XA",
+      "name": "Renin-inhibitors"
+    },
+    {
+      "code": "QC09XA01",
+      "name": "remikeren"
+    },
+    {
+      "code": "QC09XA02",
+      "name": "aliskiren"
+    },
+    {
+      "code": "QC09XA52",
+      "name": "aliskiren and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09XA53",
+      "name": "aliskiren and amlodipine"
+    },
+    {
+      "code": "QC09XA54",
+      "name": "aliskiren, amlodipine and hydrochlorothiazide"
+    },
+    {
+      "code": "QC09XX",
+      "name": "Other agents acting on the renin-angiotensin system"
+    },
+    {
+      "code": "QC09XX01",
+      "name": "sparsentan"
+    },
+    {
+      "code": "QC10",
+      "name": "LIPID MODIFYING AGENTS"
+    },
+    {
+      "code": "QC10A",
+      "name": "LIPID MODIFYING AGENTS, PLAIN"
+    },
+    {
+      "code": "QC10AA",
+      "name": "HMG CoA reductase inhibitors"
+    },
+    {
+      "code": "QC10AA01",
+      "name": "simvastatin"
+    },
+    {
+      "code": "QC10AA02",
+      "name": "lovastatin"
+    },
+    {
+      "code": "QC10AA03",
+      "name": "pravastatin"
+    },
+    {
+      "code": "QC10AA04",
+      "name": "fluvastatin"
+    },
+    {
+      "code": "QC10AA05",
+      "name": "atorvastatin"
+    },
+    {
+      "code": "QC10AA06",
+      "name": "cerivastatin"
+    },
+    {
+      "code": "QC10AA07",
+      "name": "rosuvastatin"
+    },
+    {
+      "code": "QC10AA08",
+      "name": "pitavastatin"
+    },
+    {
+      "code": "QC10AB",
+      "name": "Fibrates"
+    },
+    {
+      "code": "QC10AB01",
+      "name": "clofibrate"
+    },
+    {
+      "code": "QC10AB02",
+      "name": "bezafibrate"
+    },
+    {
+      "code": "QC10AB03",
+      "name": "aluminium clofibrate"
+    },
+    {
+      "code": "QC10AB04",
+      "name": "gemfibrozil"
+    },
+    {
+      "code": "QC10AB05",
+      "name": "fenofibrate"
+    },
+    {
+      "code": "QC10AB06",
+      "name": "simfibrate"
+    },
+    {
+      "code": "QC10AB07",
+      "name": "ronifibrate"
+    },
+    {
+      "code": "QC10AB08",
+      "name": "ciprofibrate"
+    },
+    {
+      "code": "QC10AB09",
+      "name": "etofibrate"
+    },
+    {
+      "code": "QC10AB10",
+      "name": "clofibride"
+    },
+    {
+      "code": "QC10AB11",
+      "name": "choline fenofibrate"
+    },
+    {
+      "code": "QC10AB12",
+      "name": "permafibrat"
+    },
+    {
+      "code": "QC10AC",
+      "name": "Bile acid sequestrants"
+    },
+    {
+      "code": "QC10AC01",
+      "name": "cholestyramine"
+    },
+    {
+      "code": "QC10AC02",
+      "name": "cholestipole"
+    },
+    {
+      "code": "QC10AC03",
+      "name": "colextran"
+    },
+    {
+      "code": "QC10AC04",
+      "name": "colesevelam"
+    },
+    {
+      "code": "QC10AD",
+      "name": "Nicotinic acid and derivatives"
+    },
+    {
+      "code": "QC10AD01",
+      "name": "niceritol"
+    },
+    {
+      "code": "QC10AD02",
+      "name": "nicotinic acid"
+    },
+    {
+      "code": "QC10AD03",
+      "name": "nicofuranose"
+    },
+    {
+      "code": "QC10AD04",
+      "name": "aluminium nicotinate"
+    },
+    {
+      "code": "QC10AD05",
+      "name": "nicotinyl alcohol (pyridylcarbinol)"
+    },
+    {
+      "code": "QC10AD06",
+      "name": "acipimox"
+    },
+    {
+      "code": "QC10AD52",
+      "name": "nicotinic acid, combinations"
+    },
+    {
+      "code": "QC10AX",
+      "name": "Other lipid modifying agents"
+    },
+    {
+      "code": "QC10AX01",
+      "name": "dextrothyroxine"
+    },
+    {
+      "code": "QC10AX02",
+      "name": "probucol"
+    },
+    {
+      "code": "QC10AX03",
+      "name": "tiadenol"
+    },
+    {
+      "code": "QC10AX05",
+      "name": "meglutol"
+    },
+    {
+      "code": "QC10AX06",
+      "name": "omega-3-triglycerides incl. other esters and acids"
+    },
+    {
+      "code": "QC10AX07",
+      "name": "magnesium pyridoxal 5-phosphate glutamate"
+    },
+    {
+      "code": "QC10AX08",
+      "name": "policosanol"
+    },
+    {
+      "code": "QC10AX09",
+      "name": "ezetimibe"
+    },
+    {
+      "code": "QC10AX10",
+      "name": "alipogene tiparvovec"
+    },
+    {
+      "code": "QC10AX11",
+      "name": "mipomersen"
+    },
+    {
+      "code": "QC10AX12",
+      "name": "lomitapide"
+    },
+    {
+      "code": "QC10AX13",
+      "name": "evolocumab"
+    },
+    {
+      "code": "QC10AX14",
+      "name": "alirocumab"
+    },
+    {
+      "code": "QC10AX15",
+      "name": "bempedoic acid"
+    },
+    {
+      "code": "QC10AX16",
+      "name": "inclisiran"
+    },
+    {
+      "code": "QC10AX17",
+      "name": "evinacumab"
+    },
+    {
+      "code": "QC10AX18",
+      "name": "volanesorsen"
+    },
+    {
+      "code": "QC10AX19",
+      "name": "lerodalcibep"
+    },
+    {
+      "code": "QC10B",
+      "name": "LIPID MODIFYING AGENTS, COMBINATIONS"
+    },
+    {
+      "code": "QC10BA",
+      "name": "Combinations of various lipid modifying agents"
+    },
+    {
+      "code": "QC10BA01",
+      "name": "lovastatin and nicotinic acid"
+    },
+    {
+      "code": "QC10BA02",
+      "name": "simvastatin and ezetimibe"
+    },
+    {
+      "code": "QC10BA03",
+      "name": "pravastatin and fenofibrate"
+    },
+    {
+      "code": "QC10BA04",
+      "name": "simvastatin and fenofibrate"
+    },
+    {
+      "code": "QC10BA05",
+      "name": "atorvastatin and ezetimibe"
+    },
+    {
+      "code": "QC10BA06",
+      "name": "rosuvastatin and ezetimibe"
+    },
+    {
+      "code": "QC10BA07",
+      "name": "rosuvastatin and omega-3 fatty acids"
+    },
+    {
+      "code": "QC10BA08",
+      "name": "atorvastatin and omega-3 fatty acids"
+    },
+    {
+      "code": "QC10BA09",
+      "name": "rosuvastatin and fenofibrate"
+    },
+    {
+      "code": "QC10BA10",
+      "name": "bempedoic acid and ezetimibe"
+    },
+    {
+      "code": "QC10BA11",
+      "name": "pravastatin and ezetimibe"
+    },
+    {
+      "code": "QC10BA12",
+      "name": "pravastatin, ezetimibe and fenofibrate"
+    },
+    {
+      "code": "QC10BA13",
+      "name": "pitavastatin and ezetimibe"
+    },
+    {
+      "code": "QC10BA14",
+      "name": "pitavastatin and fenofibrate"
+    },
+    {
+      "code": "QC10BA15",
+      "name": "rosuvastatin, ezetimibe and fenofibrate"
+    },
+    {
+      "code": "QC10BA16",
+      "name": "atorvastatin and fenofibrate"
+    },
+    {
+      "code": "QC10BX",
+      "name": "Lipid modifying agents in combination with other drugs"
+    },
+    {
+      "code": "QC10BX01",
+      "name": "simvastatin and acetylsalicylic acid"
+    },
+    {
+      "code": "QC10BX02",
+      "name": "pravastatin and acetylsalicylic acid"
+    },
+    {
+      "code": "QC10BX03",
+      "name": "atorvastatin and amlodipine"
+    },
+    {
+      "code": "QC10BX04",
+      "name": "simvastatin, acetylsalicylic acid and ramipril"
+    },
+    {
+      "code": "QC10BX05",
+      "name": "rosuvastatin and acetylsalisylic acid"
+    },
+    {
+      "code": "QC10BX06",
+      "name": "atorvastatin, acetylsalicylic acid and ramipril"
+    },
+    {
+      "code": "QC10BX07",
+      "name": "rosuvastatin, amlodipine and lisinopril"
+    },
+    {
+      "code": "QC10BX08",
+      "name": "atorvastatin and acetylsalicylic acid"
+    },
+    {
+      "code": "QC10BX09",
+      "name": "rosuvastatin and amlodipine"
+    },
+    {
+      "code": "QC10BX10",
+      "name": "rosuvastatin and valsartan"
+    },
+    {
+      "code": "QC10BX11",
+      "name": "atorvastatin, amlodipine and perindopril"
+    },
+    {
+      "code": "QC10BX12",
+      "name": "atorvastatin, acetylsalicylic acid and perindopril"
+    },
+    {
+      "code": "QC10BX13",
+      "name": "rosuvastatin, perindopril and indapamide"
+    },
+    {
+      "code": "QC10BX14",
+      "name": "rosuvastatin, amlodipine and perindopril"
+    },
+    {
+      "code": "QC10BX15",
+      "name": "atorvastatin and perindopril"
+    },
+    {
+      "code": "QC10BX16",
+      "name": "rosuvastatin and fimasartan"
+    },
+    {
+      "code": "QC10BX17",
+      "name": "rosuvastatin and ramipril"
+    },
+    {
+      "code": "QC10BX18",
+      "name": "atorvastatin, amlodipine and ramipril"
+    },
+    {
+      "code": "QC10BX19",
+      "name": "atorvastatin, amlodipine and candesartan"
+    },
+    {
+      "code": "QC10BX20",
+      "name": "rosuvastatin and telmisartan"
+    },
+    {
+      "code": "QC10BX21",
+      "name": "rosuvastatin and perindopril"
+    },
+    {
+      "code": "QC10BX22",
+      "name": "rosuvastatin and nebivolol"
+    },
+    {
+      "code": "QC10BX23",
+      "name": "rosuvastatin, amlodipine and ramipril"
+    },
+    {
+      "code": "QC10BX24",
+      "name": "rosuvastatin, amlodipine and telmisartan"
+    },
+    {
+      "code": "QD",
+      "name": "DERMATOLOGICALS"
+    },
+    {
+      "code": "QD01",
+      "name": "ANTIFUNGALS FOR DERMATOLOGICAL USE"
+    },
+    {
+      "code": "QD01A",
+      "name": "ANTIFUNGALS FOR TOPICAL USE"
+    },
+    {
+      "code": "QD01AA",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QD01AA01",
+      "name": "nystatin"
+    },
+    {
+      "code": "QD01AA02",
+      "name": "natamycin"
+    },
+    {
+      "code": "QD01AA03",
+      "name": "hachimycin"
+    },
+    {
+      "code": "QD01AA04",
+      "name": "pecilocin"
+    },
+    {
+      "code": "QD01AA06",
+      "name": "mepartricin"
+    },
+    {
+      "code": "QD01AA07",
+      "name": "pyrrolnitrin"
+    },
+    {
+      "code": "QD01AA08",
+      "name": "griseofulvin"
+    },
+    {
+      "code": "QD01AA20",
+      "name": "antibiotics in combination with corticosteroids"
+    },
+    {
+      "code": "QD01AC",
+      "name": "Imidazole and triazole derivatives"
+    },
+    {
+      "code": "QD01AC01",
+      "name": "clotrimazole"
+    },
+    {
+      "code": "QD01AC02",
+      "name": "miconazole"
+    },
+    {
+      "code": "QD01AC03",
+      "name": "econazole"
+    },
+    {
+      "code": "QD01AC04",
+      "name": "chlormidazole"
+    },
+    {
+      "code": "QD01AC05",
+      "name": "isoconazole"
+    },
+    {
+      "code": "QD01AC06",
+      "name": "tiabendazole"
+    },
+    {
+      "code": "QD01AC07",
+      "name": "tioconazole"
+    },
+    {
+      "code": "QD01AC08",
+      "name": "ketoconazole"
+    },
+    {
+      "code": "QD01AC09",
+      "name": "sulconazole"
+    },
+    {
+      "code": "QD01AC10",
+      "name": "bifonazole"
+    },
+    {
+      "code": "QD01AC11",
+      "name": "oxiconazole"
+    },
+    {
+      "code": "QD01AC12",
+      "name": "fenticonazole"
+    },
+    {
+      "code": "QD01AC13",
+      "name": "omoconazole"
+    },
+    {
+      "code": "QD01AC14",
+      "name": "sertaconazole"
+    },
+    {
+      "code": "QD01AC15",
+      "name": "fluconazole"
+    },
+    {
+      "code": "QD01AC16",
+      "name": "flutrimazole"
+    },
+    {
+      "code": "QD01AC17",
+      "name": "eberconazole"
+    },
+    {
+      "code": "QD01AC18",
+      "name": "luliconazole"
+    },
+    {
+      "code": "QD01AC19",
+      "name": "efinaconazole"
+    },
+    {
+      "code": "QD01AC20",
+      "name": "imidazoles/triazoles in combination with corticosteroids"
+    },
+    {
+      "code": "QD01AC21",
+      "name": "neticonazole"
+    },
+    {
+      "code": "QD01AC22",
+      "name": "lanoconazole"
+    },
+    {
+      "code": "QD01AC52",
+      "name": "miconazole, combinations"
+    },
+    {
+      "code": "QD01AC60",
+      "name": "bifonazole, combinations"
+    },
+    {
+      "code": "QD01AC90",
+      "name": "enilconazole"
+    },
+    {
+      "code": "QD01AE",
+      "name": "Other antifungals for topical use"
+    },
+    {
+      "code": "QD01AE01",
+      "name": "bromochlorosalicylanilide"
+    },
+    {
+      "code": "QD01AE02",
+      "name": "methylrosaniline"
+    },
+    {
+      "code": "QD01AE03",
+      "name": "tribromometacresol"
+    },
+    {
+      "code": "QD01AE04",
+      "name": "undecylenic acid"
+    },
+    {
+      "code": "QD01AE05",
+      "name": "polynoxylin"
+    },
+    {
+      "code": "QD01AE06",
+      "name": "2-(4-chlorphenoxy)-ethanol"
+    },
+    {
+      "code": "QD01AE07",
+      "name": "chlorphenesin"
+    },
+    {
+      "code": "QD01AE08",
+      "name": "ticlatone"
+    },
+    {
+      "code": "QD01AE09",
+      "name": "sulbentine"
+    },
+    {
+      "code": "QD01AE10",
+      "name": "ethyl hydroxybenzoate"
+    },
+    {
+      "code": "QD01AE11",
+      "name": "haloprogin"
+    },
+    {
+      "code": "QD01AE12",
+      "name": "salicylic acid"
+    },
+    {
+      "code": "QD01AE13",
+      "name": "selenium sulfide"
+    },
+    {
+      "code": "QD01AE14",
+      "name": "ciclopirox"
+    },
+    {
+      "code": "QD01AE15",
+      "name": "terbinafine"
+    },
+    {
+      "code": "QD01AE16",
+      "name": "amorolfine"
+    },
+    {
+      "code": "QD01AE17",
+      "name": "dimazole"
+    },
+    {
+      "code": "QD01AE18",
+      "name": "tolnaftate"
+    },
+    {
+      "code": "QD01AE19",
+      "name": "tolciclate"
+    },
+    {
+      "code": "QD01AE20",
+      "name": "combinations"
+    },
+    {
+      "code": "QD01AE21",
+      "name": "flucytosine"
+    },
+    {
+      "code": "QD01AE22",
+      "name": "naftifine"
+    },
+    {
+      "code": "QD01AE23",
+      "name": "butenafine"
+    },
+    {
+      "code": "QD01AE24",
+      "name": "tavaborole"
+    },
+    {
+      "code": "QD01AE25",
+      "name": "liranaftate"
+    },
+    {
+      "code": "QD01AE54",
+      "name": "undecylenic acid, combinations"
+    },
+    {
+      "code": "QD01AE91",
+      "name": "bronopol"
+    },
+    {
+      "code": "QD01AE92",
+      "name": "bensuldazic acid"
+    },
+    {
+      "code": "QD01B",
+      "name": "ANTIFUNGALS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QD01BA",
+      "name": "Antifungals for systemic use"
+    },
+    {
+      "code": "QD01BA01",
+      "name": "griseofulvin"
+    },
+    {
+      "code": "QD01BA02",
+      "name": "terbinafine"
+    },
+    {
+      "code": "QD01BA03",
+      "name": "fosravuconazole"
+    },
+    {
+      "code": "QD02",
+      "name": "EMOLLIENTS AND PROTECTIVES"
+    },
+    {
+      "code": "QD02A",
+      "name": "EMOLLIENTS AND PROTECTIVES"
+    },
+    {
+      "code": "QD02AA",
+      "name": "Silicone products"
+    },
+    {
+      "code": "QD02AB",
+      "name": "Zinc products"
+    },
+    {
+      "code": "QD02AC",
+      "name": "Soft paraffin and fat products"
+    },
+    {
+      "code": "QD02AD",
+      "name": "Liquid plasters"
+    },
+    {
+      "code": "QD02AE",
+      "name": "Carbamide products"
+    },
+    {
+      "code": "QD02AE01",
+      "name": "carbamide"
+    },
+    {
+      "code": "QD02AE51",
+      "name": "carbamide, combinations"
+    },
+    {
+      "code": "QD02AF",
+      "name": "Salicylic acid preparations"
+    },
+    {
+      "code": "QD02AX",
+      "name": "Other emollients and protectives"
+    },
+    {
+      "code": "QD02B",
+      "name": "PROTECTIVES AGAINST UV-RADIATION"
+    },
+    {
+      "code": "QD02BA",
+      "name": "Protectives against UV-radiation for topical use"
+    },
+    {
+      "code": "QD02BA01",
+      "name": "aminobenzoic acid"
+    },
+    {
+      "code": "QD02BA02",
+      "name": "octinoxate"
+    },
+    {
+      "code": "QD02BB",
+      "name": "Protectives against UV-radiation for systemic use"
+    },
+    {
+      "code": "QD02BB01",
+      "name": "betacarotene"
+    },
+    {
+      "code": "QD02BB02",
+      "name": "afamelanotide"
+    },
+    {
+      "code": "QD03",
+      "name": "PREPARATIONS FOR TREATMENT OF WOUNDS AND ULCERS"
+    },
+    {
+      "code": "QD03A",
+      "name": "CICATRIZANTS"
+    },
+    {
+      "code": "QD03AA",
+      "name": "Cod-liver oil ointments"
+    },
+    {
+      "code": "QD03AX",
+      "name": "Other cicatrizants"
+    },
+    {
+      "code": "QD03AX01",
+      "name": "cadexomer iodine"
+    },
+    {
+      "code": "QD03AX02",
+      "name": "dextranomer"
+    },
+    {
+      "code": "QD03AX03",
+      "name": "dexpanthenol"
+    },
+    {
+      "code": "QD03AX04",
+      "name": "calcium pantothenate"
+    },
+    {
+      "code": "QD03AX05",
+      "name": "hyaluronic acid"
+    },
+    {
+      "code": "QD03AX06",
+      "name": "becaplermin"
+    },
+    {
+      "code": "QD03AX09",
+      "name": "crilanomer"
+    },
+    {
+      "code": "QD03AX10",
+      "name": "enoxolone"
+    },
+    {
+      "code": "QD03AX11",
+      "name": "sodium chlorite"
+    },
+    {
+      "code": "QD03AX12",
+      "name": "trolamine"
+    },
+    {
+      "code": "QD03AX13",
+      "name": "Betulae cortex"
+    },
+    {
+      "code": "QD03AX14",
+      "name": "Centella asiatica herba, incl. combinations"
+    },
+    {
+      "code": "QD03AX15",
+      "name": "trafermin"
+    },
+    {
+      "code": "QD03AX16",
+      "name": "beremagene geperpavec"
+    },
+    {
+      "code": "QD03AX17",
+      "name": "diperoxochloric acid"
+    },
+    {
+      "code": "QD03AX90",
+      "name": "ketanserin"
+    },
+    {
+      "code": "QD03B",
+      "name": "ENZYMES"
+    },
+    {
+      "code": "QD03BA",
+      "name": "Proteolytic enzymes"
+    },
+    {
+      "code": "QD03BA01",
+      "name": "trypsin"
+    },
+    {
+      "code": "QD03BA02",
+      "name": "collagenase"
+    },
+    {
+      "code": "QD03BA03",
+      "name": "bromelains"
+    },
+    {
+      "code": "QD03BA52",
+      "name": "collagenase, combinations"
+    },
+    {
+      "code": "QD04",
+      "name": "ANTIPRURITICS, INCL. ANTIHISTAMINES, ANESTHETICS, ETC."
+    },
+    {
+      "code": "QD04A",
+      "name": "ANTIPRURITICS, INCL. ANTIHISTAMINES, ANESTHETICS, ETC."
+    },
+    {
+      "code": "QD04AA",
+      "name": "Antihistamines for topical use"
+    },
+    {
+      "code": "QD04AA01",
+      "name": "thonzylamine"
+    },
+    {
+      "code": "QD04AA02",
+      "name": "mepyramine"
+    },
+    {
+      "code": "QD04AA03",
+      "name": "thenalidine"
+    },
+    {
+      "code": "QD04AA04",
+      "name": "tripelennamine"
+    },
+    {
+      "code": "QD04AA09",
+      "name": "chloropyramine"
+    },
+    {
+      "code": "QD04AA10",
+      "name": "promethazine"
+    },
+    {
+      "code": "QD04AA12",
+      "name": "tolpropamine"
+    },
+    {
+      "code": "QD04AA13",
+      "name": "dimetindene"
+    },
+    {
+      "code": "QD04AA14",
+      "name": "clemastine"
+    },
+    {
+      "code": "QD04AA15",
+      "name": "bamipine"
+    },
+    {
+      "code": "QD04AA16",
+      "name": "pheniramine"
+    },
+    {
+      "code": "QD04AA22",
+      "name": "isothipendyl"
+    },
+    {
+      "code": "QD04AA32",
+      "name": "diphenhydramine"
+    },
+    {
+      "code": "QD04AA33",
+      "name": "diphenhydramine methylbromide"
+    },
+    {
+      "code": "QD04AA34",
+      "name": "chlorphenoxamine"
+    },
+    {
+      "code": "QD04AB",
+      "name": "Anesthetics for topical use"
+    },
+    {
+      "code": "QD04AB01",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QD04AB02",
+      "name": "cinchocaine"
+    },
+    {
+      "code": "QD04AB03",
+      "name": "oxybuprocaine"
+    },
+    {
+      "code": "QD04AB04",
+      "name": "benzocaine"
+    },
+    {
+      "code": "QD04AB05",
+      "name": "quinisocaine"
+    },
+    {
+      "code": "QD04AB06",
+      "name": "tetracaine"
+    },
+    {
+      "code": "QD04AB07",
+      "name": "pramocaine"
+    },
+    {
+      "code": "QD04AB51",
+      "name": "lidocaine, combinations"
+    },
+    {
+      "code": "QD04AX",
+      "name": "Other antipruritics"
+    },
+    {
+      "code": "QD04AX01",
+      "name": "doxepin"
+    },
+    {
+      "code": "QD05",
+      "name": "DRUGS FOR KERATOSEBORRHEIC DISORDERS (ATC HUMAN: ANTIPSORIATICS)"
+    },
+    {
+      "code": "QD05A",
+      "name": "DRUGS FOR KERATOSEBORRHEIC DISORDERS, TOPICAL USE (ATC HUMAN: ANTIPSORIATICS FOR TOPICAL USE)"
+    },
+    {
+      "code": "QD05AA",
+      "name": "Tars"
+    },
+    {
+      "code": "QD05AC",
+      "name": "Antracen derivatives"
+    },
+    {
+      "code": "QD05AC01",
+      "name": "dithranol"
+    },
+    {
+      "code": "QD05AC51",
+      "name": "dithranol, combinations"
+    },
+    {
+      "code": "QD05AD",
+      "name": "Psoralens for topical use"
+    },
+    {
+      "code": "QD05AD01",
+      "name": "trioxysalen"
+    },
+    {
+      "code": "QD05AD02",
+      "name": "methoxsalen"
+    },
+    {
+      "code": "QD05AX",
+      "name": "Other drugs for keratoseborrheic disorders for topical use (ATC human: Other antipsoriatics for topical use)"
+    },
+    {
+      "code": "QD05AX01",
+      "name": "fumaric acid"
+    },
+    {
+      "code": "QD05AX02",
+      "name": "calcipotriol"
+    },
+    {
+      "code": "QD05AX03",
+      "name": "calcitriol"
+    },
+    {
+      "code": "QD05AX04",
+      "name": "tacalcitol"
+    },
+    {
+      "code": "QD05AX05",
+      "name": "tazarotene"
+    },
+    {
+      "code": "QD05AX06",
+      "name": "roflumilast"
+    },
+    {
+      "code": "QD05AX07",
+      "name": "tapinarof"
+    },
+    {
+      "code": "QD05AX52",
+      "name": "calcipotriol, combinations"
+    },
+    {
+      "code": "QD05AX55",
+      "name": "tazarotene and ulobetasol"
+    },
+    {
+      "code": "QD05B",
+      "name": "DRUGS FOR KERATOSEBORRHEIC DISORDERS, SYSTEMIC USE (ATC HUMAN: ANTIPSORIATICS FOR SYSTEMIC USE)"
+    },
+    {
+      "code": "QD05BA",
+      "name": "Psoralens for systemic use"
+    },
+    {
+      "code": "QD05BA01",
+      "name": "trioxysalen"
+    },
+    {
+      "code": "QD05BA02",
+      "name": "methoxsalen"
+    },
+    {
+      "code": "QD05BA03",
+      "name": "bergapten"
+    },
+    {
+      "code": "QD05BB",
+      "name": "Retinoids for for treatment of psoriasis"
+    },
+    {
+      "code": "QD05BB01",
+      "name": "etretinate"
+    },
+    {
+      "code": "QD05BB02",
+      "name": "acitretine"
+    },
+    {
+      "code": "QD05BX",
+      "name": "Other drugs for keratoseborrheic disorders for systemic use (ATC human: Other antipsoriatics for systemic use)"
+    },
+    {
+      "code": "QD05BX51",
+      "name": "fumaric acid derivatives, combinations"
+    },
+    {
+      "code": "QD06",
+      "name": "ANTIBIOTICS AND CHEMOTHERAPEUTICS FOR DERMATOLOGICAL USE"
+    },
+    {
+      "code": "QD06A",
+      "name": "ANTIBIOTICS FOR TOPICAL USE"
+    },
+    {
+      "code": "QD06AA",
+      "name": "Tetracycline and derivatives"
+    },
+    {
+      "code": "QD06AA01",
+      "name": "demeclocycline"
+    },
+    {
+      "code": "QD06AA02",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QD06AA03",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QD06AA04",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QD06AA52",
+      "name": "chlortetracycline, combinations"
+    },
+    {
+      "code": "QD06AA53",
+      "name": "oxytetracycline, combinations"
+    },
+    {
+      "code": "QD06AA54",
+      "name": "tetracycline, combinations"
+    },
+    {
+      "code": "QD06AX",
+      "name": "Other antibiotics for topical use"
+    },
+    {
+      "code": "QD06AX01",
+      "name": "fusidic acid"
+    },
+    {
+      "code": "QD06AX02",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QD06AX04",
+      "name": "neomycin"
+    },
+    {
+      "code": "QD06AX05",
+      "name": "bacitracin"
+    },
+    {
+      "code": "QD06AX07",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QD06AX08",
+      "name": "tyrothricin"
+    },
+    {
+      "code": "QD06AX09",
+      "name": "mupirocin"
+    },
+    {
+      "code": "QD06AX10",
+      "name": "virginiamycin"
+    },
+    {
+      "code": "QD06AX11",
+      "name": "rifaximin"
+    },
+    {
+      "code": "QD06AX12",
+      "name": "amikacin"
+    },
+    {
+      "code": "QD06AX13",
+      "name": "retapamulin"
+    },
+    {
+      "code": "QD06AX14",
+      "name": "ozenoxacin"
+    },
+    {
+      "code": "QD06AX15",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QD06AX99",
+      "name": "other antibiotics for topical use, combinations"
+    },
+    {
+      "code": "QD06B",
+      "name": "CHEMOTHERAPEUTICS FOR TOPICAL USE"
+    },
+    {
+      "code": "QD06BA",
+      "name": "Sulfonamides"
+    },
+    {
+      "code": "QD06BA01",
+      "name": "silver sulfadiazine"
+    },
+    {
+      "code": "QD06BA02",
+      "name": "sulfathiazole"
+    },
+    {
+      "code": "QD06BA03",
+      "name": "mafenide"
+    },
+    {
+      "code": "QD06BA04",
+      "name": "sulfamethizole"
+    },
+    {
+      "code": "QD06BA05",
+      "name": "sulfanilamide"
+    },
+    {
+      "code": "QD06BA06",
+      "name": "sulfamerazine"
+    },
+    {
+      "code": "QD06BA30",
+      "name": "combinations of chemotherapeutics for topical use"
+    },
+    {
+      "code": "QD06BA51",
+      "name": "silver sulfadiazine, combinations"
+    },
+    {
+      "code": "QD06BA53",
+      "name": "mafenide, combinations"
+    },
+    {
+      "code": "QD06BA90",
+      "name": "formosulfathiazole"
+    },
+    {
+      "code": "QD06BA99",
+      "name": "sulfonamides, combinations"
+    },
+    {
+      "code": "QD06BB",
+      "name": "Antivirals"
+    },
+    {
+      "code": "QD06BB01",
+      "name": "idoxuridine"
+    },
+    {
+      "code": "QD06BB02",
+      "name": "tromantadine"
+    },
+    {
+      "code": "QD06BB03",
+      "name": "aciclovir"
+    },
+    {
+      "code": "QD06BB04",
+      "name": "podophyllotoxin"
+    },
+    {
+      "code": "QD06BB05",
+      "name": "inosine"
+    },
+    {
+      "code": "QD06BB06",
+      "name": "penciclovir"
+    },
+    {
+      "code": "QD06BB07",
+      "name": "lysozyme"
+    },
+    {
+      "code": "QD06BB08",
+      "name": "ibacitabine"
+    },
+    {
+      "code": "QD06BB09",
+      "name": "edoxudine"
+    },
+    {
+      "code": "QD06BB10",
+      "name": "imiquimod"
+    },
+    {
+      "code": "QD06BB11",
+      "name": "docosanol"
+    },
+    {
+      "code": "QD06BB12",
+      "name": "sinecatechins"
+    },
+    {
+      "code": "QD06BB13",
+      "name": "berdazimer sodium"
+    },
+    {
+      "code": "QD06BB53",
+      "name": "aciclovir, combinations"
+    },
+    {
+      "code": "QD06BX",
+      "name": "Other chemotherapeutics"
+    },
+    {
+      "code": "QD06BX01",
+      "name": "metronidazole"
+    },
+    {
+      "code": "QD06BX02",
+      "name": "ingenol mebutate"
+    },
+    {
+      "code": "QD06BX03",
+      "name": "tirbanibulin"
+    },
+    {
+      "code": "QD06C",
+      "name": "ANTIBIOTICS AND CHEMOTERAPEUTICS, COMBINATIONS"
+    },
+    {
+      "code": "QD07",
+      "name": "CORTICOSTEROIDS, DERMATOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QD07A",
+      "name": "CORTICOSTEROIDS, PLAIN"
+    },
+    {
+      "code": "QD07AA",
+      "name": "Corticosteroids, weak (group I)"
+    },
+    {
+      "code": "QD07AA01",
+      "name": "methylprednisolone"
+    },
+    {
+      "code": "QD07AA02",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QD07AA03",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QD07AB",
+      "name": "Corticosteroids, moderately potent (group II)"
+    },
+    {
+      "code": "QD07AB01",
+      "name": "clobetasone"
+    },
+    {
+      "code": "QD07AB02",
+      "name": "hydrocortisone butyrate"
+    },
+    {
+      "code": "QD07AB03",
+      "name": "flumetasone"
+    },
+    {
+      "code": "QD07AB04",
+      "name": "fluocortin"
+    },
+    {
+      "code": "QD07AB05",
+      "name": "fluperolone"
+    },
+    {
+      "code": "QD07AB06",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QD07AB07",
+      "name": "fluprednidene"
+    },
+    {
+      "code": "QD07AB08",
+      "name": "desonide"
+    },
+    {
+      "code": "QD07AB09",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QD07AB10",
+      "name": "alclometasone"
+    },
+    {
+      "code": "QD07AB11",
+      "name": "hydrocortisone buteprate"
+    },
+    {
+      "code": "QD07AB19",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QD07AB21",
+      "name": "clocortolone"
+    },
+    {
+      "code": "QD07AB30",
+      "name": "combinations of corticosteroids"
+    },
+    {
+      "code": "QD07AC",
+      "name": "Corticosteroids, potent (group III)"
+    },
+    {
+      "code": "QD07AC01",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QD07AC02",
+      "name": "fluclorolone"
+    },
+    {
+      "code": "QD07AC03",
+      "name": "desoximetasone"
+    },
+    {
+      "code": "QD07AC04",
+      "name": "fluocinolone acetonide"
+    },
+    {
+      "code": "QD07AC05",
+      "name": "fluocortolone"
+    },
+    {
+      "code": "QD07AC06",
+      "name": "diflucortolone"
+    },
+    {
+      "code": "QD07AC07",
+      "name": "fludroxycortide"
+    },
+    {
+      "code": "QD07AC08",
+      "name": "fluocinonide"
+    },
+    {
+      "code": "QD07AC09",
+      "name": "budesonide"
+    },
+    {
+      "code": "QD07AC10",
+      "name": "diflorasone"
+    },
+    {
+      "code": "QD07AC11",
+      "name": "amcinonide"
+    },
+    {
+      "code": "QD07AC12",
+      "name": "halometasone"
+    },
+    {
+      "code": "QD07AC13",
+      "name": "mometasone"
+    },
+    {
+      "code": "QD07AC14",
+      "name": "methylprednisolone aceponate"
+    },
+    {
+      "code": "QD07AC15",
+      "name": "beclometasone"
+    },
+    {
+      "code": "QD07AC16",
+      "name": "hydrocortisone aceponate"
+    },
+    {
+      "code": "QD07AC17",
+      "name": "fluticasone"
+    },
+    {
+      "code": "QD07AC18",
+      "name": "prednicarbate"
+    },
+    {
+      "code": "QD07AC19",
+      "name": "difluprednate"
+    },
+    {
+      "code": "QD07AC21",
+      "name": "ulobetasol"
+    },
+    {
+      "code": "QD07AC90",
+      "name": "resocortol butyrate"
+    },
+    {
+      "code": "QD07AD",
+      "name": "Corticosteroids, very potent (group IV)"
+    },
+    {
+      "code": "QD07AD01",
+      "name": "clobetasol"
+    },
+    {
+      "code": "QD07AD02",
+      "name": "halcinonide"
+    },
+    {
+      "code": "QD07B",
+      "name": "CORTICOSTEROIDS, COMBINATIONS WITH ANTISEPTICS"
+    },
+    {
+      "code": "QD07BA",
+      "name": "Corticosteroids, weak, combinations with antiseptics"
+    },
+    {
+      "code": "QD07BA01",
+      "name": "prednisolone and antiseptics"
+    },
+    {
+      "code": "QD07BA04",
+      "name": "hydrocortisone and antiseptics"
+    },
+    {
+      "code": "QD07BB",
+      "name": "Corticosteroids, moderately potent, combinations with antiseptics"
+    },
+    {
+      "code": "QD07BB01",
+      "name": "flumetasone and antiseptics"
+    },
+    {
+      "code": "QD07BB02",
+      "name": "desonide and antiseptics"
+    },
+    {
+      "code": "QD07BB03",
+      "name": "triamcinolone and antiseptics"
+    },
+    {
+      "code": "QD07BB04",
+      "name": "hydrocortisone butyrate and antiseptics"
+    },
+    {
+      "code": "QD07BC",
+      "name": "Corticosteroids, potent, combinations with antiseptics"
+    },
+    {
+      "code": "QD07BC01",
+      "name": "betamethasone and antiseptics"
+    },
+    {
+      "code": "QD07BC02",
+      "name": "fluocinolone acetonide and antiseptics"
+    },
+    {
+      "code": "QD07BC03",
+      "name": "fluocortolone and antiseptics"
+    },
+    {
+      "code": "QD07BC04",
+      "name": "diflucortolone and antiseptics"
+    },
+    {
+      "code": "QD07BD",
+      "name": "Corticosteroids, very potent, combinations with antiseptics"
+    },
+    {
+      "code": "QD07C",
+      "name": "CORTICOSTEROIDS, COMBINATIONS WITH ANTIBIOTICS"
+    },
+    {
+      "code": "QD07CA",
+      "name": "Corticosteroids, weak, combinations with antibiotics"
+    },
+    {
+      "code": "QD07CA01",
+      "name": "hydrocortisone and antibiotics"
+    },
+    {
+      "code": "QD07CA02",
+      "name": "methylprednisolone and antibiotics"
+    },
+    {
+      "code": "QD07CA03",
+      "name": "prednisolone and antibiotics"
+    },
+    {
+      "code": "QD07CB",
+      "name": "Corticosteroids, moderately potent, combinations with antibiotics"
+    },
+    {
+      "code": "QD07CB01",
+      "name": "triamcinolone and antibiotics"
+    },
+    {
+      "code": "QD07CB02",
+      "name": "fluprednidene and antibiotics"
+    },
+    {
+      "code": "QD07CB03",
+      "name": "fluorometholone and antibiotics"
+    },
+    {
+      "code": "QD07CB04",
+      "name": "dexamethasone and antibiotics"
+    },
+    {
+      "code": "QD07CB05",
+      "name": "flumetasone and antibiotics"
+    },
+    {
+      "code": "QD07CC",
+      "name": "Corticosteroids, potent, combinations with antibiotics"
+    },
+    {
+      "code": "QD07CC01",
+      "name": "betamethasone and antibiotics"
+    },
+    {
+      "code": "QD07CC02",
+      "name": "fluocinolone acetonide and antibiotics"
+    },
+    {
+      "code": "QD07CC03",
+      "name": "fludroxycortide and antibiotics"
+    },
+    {
+      "code": "QD07CC04",
+      "name": "beclometasone and antibiotics"
+    },
+    {
+      "code": "QD07CC05",
+      "name": "fluocinonide and antibiotics"
+    },
+    {
+      "code": "QD07CC06",
+      "name": "fluocortolone and antibiotics"
+    },
+    {
+      "code": "QD07CD",
+      "name": "Corticosteroids, very potent, combinations with antibiotics"
+    },
+    {
+      "code": "QD07CD01",
+      "name": "clobetasol and antibiotics"
+    },
+    {
+      "code": "QD07X",
+      "name": "CORTICOSTEROIDS, OTHER COMBINATIONS"
+    },
+    {
+      "code": "QD07XA",
+      "name": "Corticosteroids, weak, other combinations"
+    },
+    {
+      "code": "QD07XA01",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QD07XA02",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QD07XB",
+      "name": "Corticosteroids, moderately potent, other combinations"
+    },
+    {
+      "code": "QD07XB01",
+      "name": "flumetasone"
+    },
+    {
+      "code": "QD07XB02",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QD07XB03",
+      "name": "fluprednidene"
+    },
+    {
+      "code": "QD07XB04",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QD07XB05",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QD07XB30",
+      "name": "combinations of corticosteroids"
+    },
+    {
+      "code": "QD07XC",
+      "name": "Corticosteroids, potent, other combinations"
+    },
+    {
+      "code": "QD07XC01",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QD07XC02",
+      "name": "desoximetasone"
+    },
+    {
+      "code": "QD07XC03",
+      "name": "mometasone"
+    },
+    {
+      "code": "QD07XC04",
+      "name": "diflucortolone"
+    },
+    {
+      "code": "QD07XC05",
+      "name": "fluocortolone"
+    },
+    {
+      "code": "QD07XD",
+      "name": "Corticosteroids, very potent, other combinations"
+    },
+    {
+      "code": "QD08",
+      "name": "ANTISEPTICS AND DISINFECTANTS"
+    },
+    {
+      "code": "QD08A",
+      "name": "ANTISEPTICS AND DISINFECTANTS"
+    },
+    {
+      "code": "QD08AA",
+      "name": "Acridine derivatives"
+    },
+    {
+      "code": "QD08AA01",
+      "name": "ethacridine lactate"
+    },
+    {
+      "code": "QD08AA02",
+      "name": "aminoacridine"
+    },
+    {
+      "code": "QD08AA03",
+      "name": "euflavine"
+    },
+    {
+      "code": "QD08AA99",
+      "name": "acridine derivatives, combinations"
+    },
+    {
+      "code": "QD08AB",
+      "name": "Aluminium agents"
+    },
+    {
+      "code": "QD08AC",
+      "name": "Biguanides and amidines"
+    },
+    {
+      "code": "QD08AC01",
+      "name": "dibromopropamidine"
+    },
+    {
+      "code": "QD08AC02",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QD08AC03",
+      "name": "propamidine"
+    },
+    {
+      "code": "QD08AC04",
+      "name": "hexamidine"
+    },
+    {
+      "code": "QD08AC05",
+      "name": "polihexanide"
+    },
+    {
+      "code": "QD08AC52",
+      "name": "chlorhexidine, combinations"
+    },
+    {
+      "code": "QD08AC54",
+      "name": "hexamidine, combinations"
+    },
+    {
+      "code": "QD08AD",
+      "name": "Boric acid products"
+    },
+    {
+      "code": "QD08AE",
+      "name": "Phenol and derivatives"
+    },
+    {
+      "code": "QD08AE01",
+      "name": "hexachlorophene"
+    },
+    {
+      "code": "QD08AE02",
+      "name": "policresulen"
+    },
+    {
+      "code": "QD08AE03",
+      "name": "phenol"
+    },
+    {
+      "code": "QD08AE04",
+      "name": "triclosan"
+    },
+    {
+      "code": "QD08AE05",
+      "name": "chloroxylenol"
+    },
+    {
+      "code": "QD08AE06",
+      "name": "biphenylol"
+    },
+    {
+      "code": "QD08AE99",
+      "name": "phenol and derivatives, combinations"
+    },
+    {
+      "code": "QD08AF",
+      "name": "Nitrofuran derivatives"
+    },
+    {
+      "code": "QD08AF01",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QD08AG",
+      "name": "Iodine products"
+    },
+    {
+      "code": "QD08AG01",
+      "name": "iodine/octylphenoxypolyglycolether"
+    },
+    {
+      "code": "QD08AG02",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QD08AG03",
+      "name": "iodine"
+    },
+    {
+      "code": "QD08AG04",
+      "name": "diiodohydroxypropane"
+    },
+    {
+      "code": "QD08AG53",
+      "name": "iodine, combinations"
+    },
+    {
+      "code": "QD08AH",
+      "name": "Quinoline derivatives"
+    },
+    {
+      "code": "QD08AH01",
+      "name": "dequalinium"
+    },
+    {
+      "code": "QD08AH02",
+      "name": "chlorquinaldol"
+    },
+    {
+      "code": "QD08AH03",
+      "name": "oxyquinoline"
+    },
+    {
+      "code": "QD08AH30",
+      "name": "clioquinol"
+    },
+    {
+      "code": "QD08AJ",
+      "name": "Quaternary ammonium compounds"
+    },
+    {
+      "code": "QD08AJ01",
+      "name": "benzalkonium"
+    },
+    {
+      "code": "QD08AJ02",
+      "name": "cetrimonium"
+    },
+    {
+      "code": "QD08AJ03",
+      "name": "cetylpyridinium"
+    },
+    {
+      "code": "QD08AJ04",
+      "name": "cetrimide"
+    },
+    {
+      "code": "QD08AJ05",
+      "name": "benzoxonium chloride"
+    },
+    {
+      "code": "QD08AJ06",
+      "name": "didecyldimethylammonium chloride"
+    },
+    {
+      "code": "QD08AJ08",
+      "name": "benzethonium chloride"
+    },
+    {
+      "code": "QD08AJ10",
+      "name": "decamethoxine"
+    },
+    {
+      "code": "QD08AJ57",
+      "name": "octenidine, combinations"
+    },
+    {
+      "code": "QD08AJ58",
+      "name": "benzethonium chloride, combinations"
+    },
+    {
+      "code": "QD08AJ59",
+      "name": "dodeclonium bromide, combinations"
+    },
+    {
+      "code": "QD08AK",
+      "name": "Mercurial products"
+    },
+    {
+      "code": "QD08AK01",
+      "name": "mercuric amidochloride"
+    },
+    {
+      "code": "QD08AK02",
+      "name": "phenylmercuric borate"
+    },
+    {
+      "code": "QD08AK03",
+      "name": "mercuric chloride"
+    },
+    {
+      "code": "QD08AK04",
+      "name": "merbromin"
+    },
+    {
+      "code": "QD08AK05",
+      "name": "mercury, metallic"
+    },
+    {
+      "code": "QD08AK06",
+      "name": "thiomersal"
+    },
+    {
+      "code": "QD08AK30",
+      "name": "mercuric iodide"
+    },
+    {
+      "code": "QD08AK52",
+      "name": "phenylmercuric borate, combinations"
+    },
+    {
+      "code": "QD08AL",
+      "name": "Silver compounds"
+    },
+    {
+      "code": "QD08AL01",
+      "name": "silver nitrate"
+    },
+    {
+      "code": "QD08AL30",
+      "name": "silver"
+    },
+    {
+      "code": "QD08AX",
+      "name": "Other antiseptics and disinfectants"
+    },
+    {
+      "code": "QD08AX01",
+      "name": "hydrogen peroxide"
+    },
+    {
+      "code": "QD08AX02",
+      "name": "eosin"
+    },
+    {
+      "code": "QD08AX03",
+      "name": "propanol"
+    },
+    {
+      "code": "QD08AX04",
+      "name": "tosylchloramide sodium"
+    },
+    {
+      "code": "QD08AX05",
+      "name": "isopropanol"
+    },
+    {
+      "code": "QD08AX06",
+      "name": "potassium permanganate"
+    },
+    {
+      "code": "QD08AX07",
+      "name": "sodium hypochlorite"
+    },
+    {
+      "code": "QD08AX08",
+      "name": "ethanol"
+    },
+    {
+      "code": "QD08AX53",
+      "name": "propanol, combinations"
+    },
+    {
+      "code": "QD09",
+      "name": "MEDICATED DRESSINGS"
+    },
+    {
+      "code": "QD09A",
+      "name": "MEDICATED DRESSINGS"
+    },
+    {
+      "code": "QD09AA",
+      "name": "Medicated dressings with antiinfectives"
+    },
+    {
+      "code": "QD09AA01",
+      "name": "framycetin"
+    },
+    {
+      "code": "QD09AA02",
+      "name": "fusidic acid"
+    },
+    {
+      "code": "QD09AA03",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QD09AA04",
+      "name": "phenylmercuric nitrate"
+    },
+    {
+      "code": "QD09AA05",
+      "name": "benzododecinium"
+    },
+    {
+      "code": "QD09AA06",
+      "name": "triclosan"
+    },
+    {
+      "code": "QD09AA07",
+      "name": "cetylpyridinium"
+    },
+    {
+      "code": "QD09AA08",
+      "name": "aluminium chlorohydrate"
+    },
+    {
+      "code": "QD09AA09",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QD09AA10",
+      "name": "clioquinol"
+    },
+    {
+      "code": "QD09AA11",
+      "name": "benzalkonium"
+    },
+    {
+      "code": "QD09AA12",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QD09AA13",
+      "name": "iodoform"
+    },
+    {
+      "code": "QD09AB",
+      "name": "Zinc bandages"
+    },
+    {
+      "code": "QD09AB01",
+      "name": "zinc bandage without supplements"
+    },
+    {
+      "code": "QD09AB02",
+      "name": "zinc bandage with supplements"
+    },
+    {
+      "code": "QD09AX",
+      "name": "Soft paraffin dressings"
+    },
+    {
+      "code": "QD10",
+      "name": "ANTI-ACNE PREPARATIONS"
+    },
+    {
+      "code": "QD10A",
+      "name": "ANTI-ACNE PREPARATIONS FOR TOPICAL USE"
+    },
+    {
+      "code": "QD10AA",
+      "name": "Corticosteroides, combinations for treatment of acne"
+    },
+    {
+      "code": "QD10AA01",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QD10AA02",
+      "name": "methylprednisolone"
+    },
+    {
+      "code": "QD10AA03",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QD10AB",
+      "name": "Preparations containing sulfur"
+    },
+    {
+      "code": "QD10AB01",
+      "name": "bithionol"
+    },
+    {
+      "code": "QD10AB02",
+      "name": "sulfur"
+    },
+    {
+      "code": "QD10AB03",
+      "name": "tioxolone"
+    },
+    {
+      "code": "QD10AB05",
+      "name": "mesulfen"
+    },
+    {
+      "code": "QD10AD",
+      "name": "Retinoids for topical use in acne"
+    },
+    {
+      "code": "QD10AD01",
+      "name": "tretinoin"
+    },
+    {
+      "code": "QD10AD02",
+      "name": "retinol"
+    },
+    {
+      "code": "QD10AD03",
+      "name": "adapalene"
+    },
+    {
+      "code": "QD10AD04",
+      "name": "isotretinoin"
+    },
+    {
+      "code": "QD10AD05",
+      "name": "motretinide"
+    },
+    {
+      "code": "QD10AD06",
+      "name": "trifarotene"
+    },
+    {
+      "code": "QD10AD51",
+      "name": "tretinoin, combinations"
+    },
+    {
+      "code": "QD10AD53",
+      "name": "adapalene, combinations"
+    },
+    {
+      "code": "QD10AD54",
+      "name": "isotretinoin, combinations"
+    },
+    {
+      "code": "QD10AE",
+      "name": "Peroxides"
+    },
+    {
+      "code": "QD10AE01",
+      "name": "benzoyl peroxide"
+    },
+    {
+      "code": "QD10AE51",
+      "name": "benzoyl peroxide, combinations"
+    },
+    {
+      "code": "QD10AF",
+      "name": "Antiinfectives for treatment of acne"
+    },
+    {
+      "code": "QD10AF01",
+      "name": "clindamycin"
+    },
+    {
+      "code": "QD10AF02",
+      "name": "erythromycin"
+    },
+    {
+      "code": "QD10AF03",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QD10AF04",
+      "name": "meclocycline"
+    },
+    {
+      "code": "QD10AF05",
+      "name": "nadifloxacin"
+    },
+    {
+      "code": "QD10AF06",
+      "name": "sulfacetamide"
+    },
+    {
+      "code": "QD10AF07",
+      "name": "minocycline"
+    },
+    {
+      "code": "QD10AF51",
+      "name": "clindamycin, combinations"
+    },
+    {
+      "code": "QD10AF52",
+      "name": "erythromycin, combinations"
+    },
+    {
+      "code": "QD10AX",
+      "name": "Other anti-acne preparations for topical use"
+    },
+    {
+      "code": "QD10AX01",
+      "name": "aluminium chloride"
+    },
+    {
+      "code": "QD10AX02",
+      "name": "resorcinol"
+    },
+    {
+      "code": "QD10AX03",
+      "name": "azelaic acid"
+    },
+    {
+      "code": "QD10AX04",
+      "name": "aluminium oxide"
+    },
+    {
+      "code": "QD10AX05",
+      "name": "dapsone"
+    },
+    {
+      "code": "QD10AX06",
+      "name": "clascoterone"
+    },
+    {
+      "code": "QD10AX30",
+      "name": "various combinations"
+    },
+    {
+      "code": "QD10B",
+      "name": "ANTI-ACNE PREPARATIONS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QD10BA",
+      "name": "Retinoids for treatment of acne"
+    },
+    {
+      "code": "QD10BA01",
+      "name": "isotretinoin"
+    },
+    {
+      "code": "QD10BX",
+      "name": "Other anti-acne preparations for systemic use"
+    },
+    {
+      "code": "QD10BX01",
+      "name": "ichtasol"
+    },
+    {
+      "code": "QD11",
+      "name": "OTHER DERMATOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QD11A",
+      "name": "OTHER DERMATOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QD11AA",
+      "name": "Antihidrotics"
+    },
+    {
+      "code": "QD11AA01",
+      "name": "glycopyrronium"
+    },
+    {
+      "code": "QD11AA02",
+      "name": "sofpironium bromide"
+    },
+    {
+      "code": "QD11AC",
+      "name": "Medicated shampoos"
+    },
+    {
+      "code": "QD11AC01",
+      "name": "cetrimide"
+    },
+    {
+      "code": "QD11AC02",
+      "name": "cadmium compounds"
+    },
+    {
+      "code": "QD11AC03",
+      "name": "selenium compounds"
+    },
+    {
+      "code": "QD11AC06",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QD11AC08",
+      "name": "sulfur compounds"
+    },
+    {
+      "code": "QD11AC09",
+      "name": "xenysalate"
+    },
+    {
+      "code": "QD11AC30",
+      "name": "others"
+    },
+    {
+      "code": "QD11AE",
+      "name": "Androgens for topical use"
+    },
+    {
+      "code": "QD11AE01",
+      "name": "metandienone"
+    },
+    {
+      "code": "QD11AF",
+      "name": "Wart and anti-corn preparations"
+    },
+    {
+      "code": "QD11AH",
+      "name": "Agents for dermatitis, excluding corticosteroids"
+    },
+    {
+      "code": "QD11AH01",
+      "name": "tacrolimus"
+    },
+    {
+      "code": "QD11AH02",
+      "name": "pimecrolimus"
+    },
+    {
+      "code": "QD11AH03",
+      "name": "cromoglicic acid"
+    },
+    {
+      "code": "QD11AH04",
+      "name": "alitretinoin"
+    },
+    {
+      "code": "QD11AH05",
+      "name": "dupilumab"
+    },
+    {
+      "code": "QD11AH06",
+      "name": "crisaborole"
+    },
+    {
+      "code": "QD11AH07",
+      "name": "tralokinumab"
+    },
+    {
+      "code": "QD11AH08",
+      "name": "abrocitinib"
+    },
+    {
+      "code": "QD11AH09",
+      "name": "ruxolitinib"
+    },
+    {
+      "code": "QD11AH10",
+      "name": "lebrikizumab"
+    },
+    {
+      "code": "QD11AH11",
+      "name": "delgocitinib"
+    },
+    {
+      "code": "QD11AH12",
+      "name": "nemolizumab"
+    },
+    {
+      "code": "QD11AH90",
+      "name": "oclacitinib"
+    },
+    {
+      "code": "QD11AH91",
+      "name": "lokivetmab"
+    },
+    {
+      "code": "QD11AH92",
+      "name": "ilunocitinib"
+    },
+    {
+      "code": "QD11AH93",
+      "name": "atinvicitinib"
+    },
+    {
+      "code": "QD11AX",
+      "name": "Other dermatologicals"
+    },
+    {
+      "code": "QD11AX01",
+      "name": "minoxidil, topical"
+    },
+    {
+      "code": "QD11AX02",
+      "name": "gamolenic acid"
+    },
+    {
+      "code": "QD11AX03",
+      "name": "calcium gluconate"
+    },
+    {
+      "code": "QD11AX04",
+      "name": "lithium succinate"
+    },
+    {
+      "code": "QD11AX05",
+      "name": "magnesium sulphate"
+    },
+    {
+      "code": "QD11AX06",
+      "name": "mequinol"
+    },
+    {
+      "code": "QD11AX08",
+      "name": "tiratricol"
+    },
+    {
+      "code": "QD11AX09",
+      "name": "oxaceprol"
+    },
+    {
+      "code": "QD11AX10",
+      "name": "finasteride"
+    },
+    {
+      "code": "QD11AX11",
+      "name": "hydroquinone"
+    },
+    {
+      "code": "QD11AX12",
+      "name": "pyrithione zinc"
+    },
+    {
+      "code": "QD11AX13",
+      "name": "monobenzone"
+    },
+    {
+      "code": "QD11AX16",
+      "name": "eflornithine"
+    },
+    {
+      "code": "QD11AX18",
+      "name": "diclofenac"
+    },
+    {
+      "code": "QD11AX21",
+      "name": "brimonidine"
+    },
+    {
+      "code": "QD11AX22",
+      "name": "ivermectin"
+    },
+    {
+      "code": "QD11AX23",
+      "name": "aminobenzoate potassium"
+    },
+    {
+      "code": "QD11AX24",
+      "name": "deoxycholic acid"
+    },
+    {
+      "code": "QD11AX25",
+      "name": "hydrogen peroxide"
+    },
+    {
+      "code": "QD11AX26",
+      "name": "caffeine"
+    },
+    {
+      "code": "QD11AX27",
+      "name": "oxymetazoline"
+    },
+    {
+      "code": "QD11AX52",
+      "name": "gamolenic acid, combinations"
+    },
+    {
+      "code": "QD11AX57",
+      "name": "collagen, combinations"
+    },
+    {
+      "code": "QD11AX90",
+      "name": "benzoylperoxide"
+    },
+    {
+      "code": "QD51",
+      "name": "PRODUCTS FOR THE TREATMENT OF CLAWS AND HOOFS"
+    },
+    {
+      "code": "QG",
+      "name": "GENITO URINARY SYSTEM AND SEX HORMONES"
+    },
+    {
+      "code": "QG01",
+      "name": "GYNECOLOGICAL ANTIINFECTIVES AND ANTISEPTICS"
+    },
+    {
+      "code": "QG01A",
+      "name": "ANTIINFECTIVES AND ANTISEPTICS, EXCL. COMBINATIONS WITH CORTICOSTEROIDS"
+    },
+    {
+      "code": "QG01AA",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QG01AA01",
+      "name": "nystatin"
+    },
+    {
+      "code": "QG01AA02",
+      "name": "natamycin"
+    },
+    {
+      "code": "QG01AA03",
+      "name": "amphotericin B"
+    },
+    {
+      "code": "QG01AA04",
+      "name": "candicidin"
+    },
+    {
+      "code": "QG01AA05",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QG01AA06",
+      "name": "hachimycin"
+    },
+    {
+      "code": "QG01AA07",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QG01AA08",
+      "name": "carfecillin"
+    },
+    {
+      "code": "QG01AA09",
+      "name": "mepartricin"
+    },
+    {
+      "code": "QG01AA10",
+      "name": "clindamycin"
+    },
+    {
+      "code": "QG01AA11",
+      "name": "pentamycin"
+    },
+    {
+      "code": "QG01AA51",
+      "name": "nystatin, combinations"
+    },
+    {
+      "code": "QG01AA55",
+      "name": "chloramphenicol, combinations"
+    },
+    {
+      "code": "QG01AA90",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QG01AA91",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QG01AA99",
+      "name": "antibiotics, combinations"
+    },
+    {
+      "code": "QG01AB",
+      "name": "Arsenic compounds"
+    },
+    {
+      "code": "QG01AB01",
+      "name": "acetarsol"
+    },
+    {
+      "code": "QG01AC",
+      "name": "Quinoline derivatives"
+    },
+    {
+      "code": "QG01AC01",
+      "name": "diiodohydroxyquinoline"
+    },
+    {
+      "code": "QG01AC02",
+      "name": "clioquinol"
+    },
+    {
+      "code": "QG01AC03",
+      "name": "chlorquinaldol"
+    },
+    {
+      "code": "QG01AC05",
+      "name": "dequalinium"
+    },
+    {
+      "code": "QG01AC06",
+      "name": "broxyquinoline"
+    },
+    {
+      "code": "QG01AC30",
+      "name": "oxyquinoline"
+    },
+    {
+      "code": "QG01AC90",
+      "name": "acriflavinium chloride"
+    },
+    {
+      "code": "QG01AC99",
+      "name": "combinations"
+    },
+    {
+      "code": "QG01AD",
+      "name": "Organic acids"
+    },
+    {
+      "code": "QG01AD01",
+      "name": "lactic acid"
+    },
+    {
+      "code": "QG01AD02",
+      "name": "acetic acid"
+    },
+    {
+      "code": "QG01AD03",
+      "name": "ascorbic acid"
+    },
+    {
+      "code": "QG01AE",
+      "name": "Sulfonamides"
+    },
+    {
+      "code": "QG01AE01",
+      "name": "sulfatolamide"
+    },
+    {
+      "code": "QG01AE10",
+      "name": "combinations of sulfonamides"
+    },
+    {
+      "code": "QG01AF",
+      "name": "Imidazole derivatives"
+    },
+    {
+      "code": "QG01AF01",
+      "name": "metronidazole"
+    },
+    {
+      "code": "QG01AF02",
+      "name": "clotrimazole"
+    },
+    {
+      "code": "QG01AF04",
+      "name": "miconazole"
+    },
+    {
+      "code": "QG01AF05",
+      "name": "econazole"
+    },
+    {
+      "code": "QG01AF06",
+      "name": "ornidazole"
+    },
+    {
+      "code": "QG01AF07",
+      "name": "isoconazole"
+    },
+    {
+      "code": "QG01AF08",
+      "name": "tioconazole"
+    },
+    {
+      "code": "QG01AF11",
+      "name": "ketoconazole"
+    },
+    {
+      "code": "QG01AF12",
+      "name": "fenticonazole"
+    },
+    {
+      "code": "QG01AF13",
+      "name": "azanidazole"
+    },
+    {
+      "code": "QG01AF14",
+      "name": "propenidazole"
+    },
+    {
+      "code": "QG01AF15",
+      "name": "butoconazole"
+    },
+    {
+      "code": "QG01AF16",
+      "name": "omoconazole"
+    },
+    {
+      "code": "QG01AF17",
+      "name": "oxiconazole"
+    },
+    {
+      "code": "QG01AF18",
+      "name": "flutrimazole"
+    },
+    {
+      "code": "QG01AF19",
+      "name": "sertaconazole"
+    },
+    {
+      "code": "QG01AF20",
+      "name": "combinations of imidazole derivatives"
+    },
+    {
+      "code": "QG01AF21",
+      "name": "tinidazole"
+    },
+    {
+      "code": "QG01AF55",
+      "name": "econazole, combinations"
+    },
+    {
+      "code": "QG01AG",
+      "name": "Triazole derivatives"
+    },
+    {
+      "code": "QG01AG02",
+      "name": "terconazole"
+    },
+    {
+      "code": "QG01AX",
+      "name": "Other antiinfectives and antiseptics"
+    },
+    {
+      "code": "QG01AX01",
+      "name": "clodantoin"
+    },
+    {
+      "code": "QG01AX02",
+      "name": "inosine"
+    },
+    {
+      "code": "QG01AX03",
+      "name": "policresulen"
+    },
+    {
+      "code": "QG01AX05",
+      "name": "nifuratel"
+    },
+    {
+      "code": "QG01AX06",
+      "name": "furazolidone"
+    },
+    {
+      "code": "QG01AX09",
+      "name": "methylrosaniline"
+    },
+    {
+      "code": "QG01AX11",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QG01AX12",
+      "name": "ciclopirox"
+    },
+    {
+      "code": "QG01AX13",
+      "name": "protiofate"
+    },
+    {
+      "code": "QG01AX14",
+      "name": "lactobacillus"
+    },
+    {
+      "code": "QG01AX15",
+      "name": "copper usnate"
+    },
+    {
+      "code": "QG01AX16",
+      "name": "hexetidine"
+    },
+    {
+      "code": "QG01AX17",
+      "name": "dapivirine"
+    },
+    {
+      "code": "QG01AX66",
+      "name": "octenidine, combinations"
+    },
+    {
+      "code": "QG01AX90",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QG01AX99",
+      "name": "other antiinfectives and antiseptics, combinations"
+    },
+    {
+      "code": "QG01B",
+      "name": "ANTIINFECTIVES/ANTISEPTICS IN COMBINATION WITH CORTICOSTEROIDS"
+    },
+    {
+      "code": "QG01BA",
+      "name": "Antibiotics and corticosteroids"
+    },
+    {
+      "code": "QG01BC",
+      "name": "Quinoline derivatives and corticosteroids"
+    },
+    {
+      "code": "QG01BD",
+      "name": "Antiseptics and corticosteroids"
+    },
+    {
+      "code": "QG01BE",
+      "name": "Sulfonamides and corticosteroids"
+    },
+    {
+      "code": "QG01BF",
+      "name": "Imidazole derivatives and corticosteroids"
+    },
+    {
+      "code": "QG02",
+      "name": "OTHER GYNECOLOGICALS"
+    },
+    {
+      "code": "QG02A",
+      "name": "UTEROTONICS"
+    },
+    {
+      "code": "QG02AB",
+      "name": "Ergot alkaloids"
+    },
+    {
+      "code": "QG02AB01",
+      "name": "methylergometrine"
+    },
+    {
+      "code": "QG02AB02",
+      "name": "ergot alkaloids"
+    },
+    {
+      "code": "QG02AB03",
+      "name": "ergometrine"
+    },
+    {
+      "code": "QG02AB53",
+      "name": "ergometrine, combinations"
+    },
+    {
+      "code": "QG02AC",
+      "name": "Ergot alkaloids and oxytocin incl. analogues, in combination"
+    },
+    {
+      "code": "QG02AC01",
+      "name": "methylergometrine and oxytocin"
+    },
+    {
+      "code": "QG02AC90",
+      "name": "ergometrine and oxytocin"
+    },
+    {
+      "code": "QG02AD",
+      "name": "Prostaglandins"
+    },
+    {
+      "code": "QG02AD01",
+      "name": "dinoprost"
+    },
+    {
+      "code": "QG02AD02",
+      "name": "dinoprostone"
+    },
+    {
+      "code": "QG02AD03",
+      "name": "gemeprost"
+    },
+    {
+      "code": "QG02AD04",
+      "name": "carboprost"
+    },
+    {
+      "code": "QG02AD05",
+      "name": "sulprostone"
+    },
+    {
+      "code": "QG02AD06",
+      "name": "misoprostol"
+    },
+    {
+      "code": "QG02AD90",
+      "name": "cloprostenol"
+    },
+    {
+      "code": "QG02AD91",
+      "name": "luprostiol"
+    },
+    {
+      "code": "QG02AD92",
+      "name": "fenprostalene"
+    },
+    {
+      "code": "QG02AD93",
+      "name": "tiaprost"
+    },
+    {
+      "code": "QG02AD94",
+      "name": "alfaprostol"
+    },
+    {
+      "code": "QG02AD95",
+      "name": "etiproston"
+    },
+    {
+      "code": "QG02AX",
+      "name": "Other uterotonics"
+    },
+    {
+      "code": "QG02B",
+      "name": "CONTRACEPTIVES FOR TOPICAL USE"
+    },
+    {
+      "code": "QG02BA",
+      "name": "Intrauterine contraceptives"
+    },
+    {
+      "code": "QG02BA01",
+      "name": "plastic IUD"
+    },
+    {
+      "code": "QG02BA02",
+      "name": "plastic IUD with copper"
+    },
+    {
+      "code": "QG02BA03",
+      "name": "plastic IUD with progestogens"
+    },
+    {
+      "code": "QG02BB",
+      "name": "Intravaginal contraceptives"
+    },
+    {
+      "code": "QG02BB01",
+      "name": "vaginal ring with progestogen and estrogen"
+    },
+    {
+      "code": "QG02BB02",
+      "name": "vaginal ring with progestogen"
+    },
+    {
+      "code": "QG02C",
+      "name": "OTHER GYNECOLOGICALS"
+    },
+    {
+      "code": "QG02CA",
+      "name": "Sympathomimetics, labour repressants"
+    },
+    {
+      "code": "QG02CA01",
+      "name": "ritodrine"
+    },
+    {
+      "code": "QG02CA02",
+      "name": "buphenine"
+    },
+    {
+      "code": "QG02CA03",
+      "name": "fenoterol"
+    },
+    {
+      "code": "QG02CA90",
+      "name": "vetrabutin"
+    },
+    {
+      "code": "QG02CA91",
+      "name": "clenbuterol"
+    },
+    {
+      "code": "QG02CB",
+      "name": "Prolactine inhibitors"
+    },
+    {
+      "code": "QG02CB01",
+      "name": "bromocriptine"
+    },
+    {
+      "code": "QG02CB02",
+      "name": "lisuride"
+    },
+    {
+      "code": "QG02CB03",
+      "name": "cabergoline"
+    },
+    {
+      "code": "QG02CB04",
+      "name": "quinagolide"
+    },
+    {
+      "code": "QG02CB05",
+      "name": "metergoline"
+    },
+    {
+      "code": "QG02CB06",
+      "name": "terguride"
+    },
+    {
+      "code": "QG02CC",
+      "name": "Antiinflammatory products for vaginal administration"
+    },
+    {
+      "code": "QG02CC01",
+      "name": "ibuprofen"
+    },
+    {
+      "code": "QG02CC02",
+      "name": "naproxen"
+    },
+    {
+      "code": "QG02CC03",
+      "name": "benzydamine"
+    },
+    {
+      "code": "QG02CC04",
+      "name": "flunoxaprofen"
+    },
+    {
+      "code": "QG02CX",
+      "name": "Other gynecologicals"
+    },
+    {
+      "code": "QG02CX01",
+      "name": "atosiban"
+    },
+    {
+      "code": "QG02CX02",
+      "name": "flibanserin"
+    },
+    {
+      "code": "QG02CX03",
+      "name": "Agni casti fructus"
+    },
+    {
+      "code": "QG02CX04",
+      "name": "Cimicifugae rhizoma"
+    },
+    {
+      "code": "QG02CX05",
+      "name": "bremelanotide"
+    },
+    {
+      "code": "QG02CX06",
+      "name": "fezolinetant"
+    },
+    {
+      "code": "QG02CX07",
+      "name": "elinzanetant"
+    },
+    {
+      "code": "QG02CX90",
+      "name": "denaverine"
+    },
+    {
+      "code": "QG02CX91",
+      "name": "lotrifen"
+    },
+    {
+      "code": "QG03",
+      "name": "SEX HORMONES AND MODULATORS OF THE GENITAL SYSTEM"
+    },
+    {
+      "code": "QG03A",
+      "name": "HORMONAL CONTRACEPTIVES FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QG03AA",
+      "name": "Progestogens and estrogens, fixed combinations"
+    },
+    {
+      "code": "QG03AA01",
+      "name": "etynodiol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA02",
+      "name": "quingestanol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA03",
+      "name": "lynestrenol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA04",
+      "name": "megestrol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA05",
+      "name": "norethisterone and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA06",
+      "name": "norgestrel and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA07",
+      "name": "levonorgestrel and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA08",
+      "name": "medroxyprogesterone and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA09",
+      "name": "desogestrel and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA10",
+      "name": "gestodene and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA11",
+      "name": "norgestimate and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA12",
+      "name": "drospirenone and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA13",
+      "name": "norelgestromin and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA14",
+      "name": "nomegestrol and estradiol"
+    },
+    {
+      "code": "QG03AA15",
+      "name": "chlormadinone and and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA16",
+      "name": "dienogest and ethinylestradiol"
+    },
+    {
+      "code": "QG03AA17",
+      "name": "medroxyprogesterone and estradiol"
+    },
+    {
+      "code": "QG03AA18",
+      "name": "drospirenone and estetrol"
+    },
+    {
+      "code": "QG03AB",
+      "name": "Progestogens and estrogens, sequential preparations"
+    },
+    {
+      "code": "QG03AB01",
+      "name": "megestrol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB02",
+      "name": "lynestrenol and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB03",
+      "name": "levonorgestrel and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB04",
+      "name": "norethisterone and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB05",
+      "name": "desogestrel and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB06",
+      "name": "gestodene and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB07",
+      "name": "chlormadinone and ethinylestradiol"
+    },
+    {
+      "code": "QG03AB08",
+      "name": "dienogest and estradiol"
+    },
+    {
+      "code": "QG03AB09",
+      "name": "norgestimate and ethinylestradiol"
+    },
+    {
+      "code": "QG03AC",
+      "name": "Progestogens"
+    },
+    {
+      "code": "QG03AC01",
+      "name": "norethisterone"
+    },
+    {
+      "code": "QG03AC02",
+      "name": "lynestrenol"
+    },
+    {
+      "code": "QG03AC03",
+      "name": "levonorgestrel"
+    },
+    {
+      "code": "QG03AC04",
+      "name": "quingestanol"
+    },
+    {
+      "code": "QG03AC05",
+      "name": "megestrol"
+    },
+    {
+      "code": "QG03AC06",
+      "name": "medroxyprogesterone"
+    },
+    {
+      "code": "QG03AC07",
+      "name": "norgestrienone"
+    },
+    {
+      "code": "QG03AC08",
+      "name": "etonogestrel"
+    },
+    {
+      "code": "QG03AC09",
+      "name": "desogestrel"
+    },
+    {
+      "code": "QG03AC10",
+      "name": "drospirenone"
+    },
+    {
+      "code": "QG03AD",
+      "name": "Emergency contraceptives"
+    },
+    {
+      "code": "QG03AD01",
+      "name": "levonorgestrel"
+    },
+    {
+      "code": "QG03AD02",
+      "name": "ulipristal"
+    },
+    {
+      "code": "QG03B",
+      "name": "ANDROGENS"
+    },
+    {
+      "code": "QG03BA",
+      "name": "3-oxoandrosten (4) derivatives"
+    },
+    {
+      "code": "QG03BA01",
+      "name": "fluoxymesterone"
+    },
+    {
+      "code": "QG03BA02",
+      "name": "methyltestosterone"
+    },
+    {
+      "code": "QG03BA03",
+      "name": "testosterone"
+    },
+    {
+      "code": "QG03BB",
+      "name": "5-androstanon (3) derivatives"
+    },
+    {
+      "code": "QG03BB01",
+      "name": "mesterolone"
+    },
+    {
+      "code": "QG03BB02",
+      "name": "androstanolone"
+    },
+    {
+      "code": "QG03C",
+      "name": "ESTROGENS"
+    },
+    {
+      "code": "QG03CA",
+      "name": "Natural and semisynthetic estrogens, plain"
+    },
+    {
+      "code": "QG03CA01",
+      "name": "ethinylestradiol"
+    },
+    {
+      "code": "QG03CA03",
+      "name": "estradiol"
+    },
+    {
+      "code": "QG03CA04",
+      "name": "estriol"
+    },
+    {
+      "code": "QG03CA06",
+      "name": "chlorotrianisene"
+    },
+    {
+      "code": "QG03CA07",
+      "name": "estrone"
+    },
+    {
+      "code": "QG03CA09",
+      "name": "promestriene"
+    },
+    {
+      "code": "QG03CA10",
+      "name": "estetrol"
+    },
+    {
+      "code": "QG03CA53",
+      "name": "estradiol, combinations"
+    },
+    {
+      "code": "QG03CA57",
+      "name": "conjugated estrogens"
+    },
+    {
+      "code": "QG03CB",
+      "name": "Synthetic estrogens, plain"
+    },
+    {
+      "code": "QG03CB01",
+      "name": "dienestrol"
+    },
+    {
+      "code": "QG03CB02",
+      "name": "diethylstilbestrol"
+    },
+    {
+      "code": "QG03CB03",
+      "name": "methallenestril"
+    },
+    {
+      "code": "QG03CB04",
+      "name": "moxestrol"
+    },
+    {
+      "code": "QG03CC",
+      "name": "Estrogens, combinations with other drugs"
+    },
+    {
+      "code": "QG03CC02",
+      "name": "dienestrol"
+    },
+    {
+      "code": "QG03CC03",
+      "name": "methallenestril"
+    },
+    {
+      "code": "QG03CC04",
+      "name": "estrone"
+    },
+    {
+      "code": "QG03CC05",
+      "name": "diethylstilbestrol"
+    },
+    {
+      "code": "QG03CC06",
+      "name": "estriol"
+    },
+    {
+      "code": "QG03CC07",
+      "name": "conjugated estrogens and bazedoxifene"
+    },
+    {
+      "code": "QG03CX",
+      "name": "Other estrogens"
+    },
+    {
+      "code": "QG03CX01",
+      "name": "tibolone"
+    },
+    {
+      "code": "QG03D",
+      "name": "PROGESTOGENS"
+    },
+    {
+      "code": "QG03DA",
+      "name": "Pregnen (4) derivatives"
+    },
+    {
+      "code": "QG03DA01",
+      "name": "gestonorone"
+    },
+    {
+      "code": "QG03DA02",
+      "name": "medroxyprogesterone"
+    },
+    {
+      "code": "QG03DA03",
+      "name": "hydroxyprogesterone"
+    },
+    {
+      "code": "QG03DA04",
+      "name": "progesterone"
+    },
+    {
+      "code": "QG03DA90",
+      "name": "proligeston"
+    },
+    {
+      "code": "QG03DB",
+      "name": "Pregnadien derivatives"
+    },
+    {
+      "code": "QG03DB01",
+      "name": "dydrogesterone"
+    },
+    {
+      "code": "QG03DB02",
+      "name": "megestrol"
+    },
+    {
+      "code": "QG03DB03",
+      "name": "medrogestone"
+    },
+    {
+      "code": "QG03DB04",
+      "name": "nomegestrol"
+    },
+    {
+      "code": "QG03DB05",
+      "name": "demegestone"
+    },
+    {
+      "code": "QG03DB06",
+      "name": "chlormadinone"
+    },
+    {
+      "code": "QG03DB07",
+      "name": "promegestone"
+    },
+    {
+      "code": "QG03DB08",
+      "name": "dienogest"
+    },
+    {
+      "code": "QG03DB91",
+      "name": "melengestrol"
+    },
+    {
+      "code": "QG03DC",
+      "name": "Estren derivatives"
+    },
+    {
+      "code": "QG03DC01",
+      "name": "allylestrenol"
+    },
+    {
+      "code": "QG03DC02",
+      "name": "norethisterone"
+    },
+    {
+      "code": "QG03DC03",
+      "name": "lynestrenol"
+    },
+    {
+      "code": "QG03DC04",
+      "name": "ethisterone"
+    },
+    {
+      "code": "QG03DC06",
+      "name": "etynodiol"
+    },
+    {
+      "code": "QG03DC31",
+      "name": "methylestrenolone"
+    },
+    {
+      "code": "QG03DX",
+      "name": "Other progestogens"
+    },
+    {
+      "code": "QG03DX90",
+      "name": "altrenogest"
+    },
+    {
+      "code": "QG03DX91",
+      "name": "delmadinone"
+    },
+    {
+      "code": "QG03E",
+      "name": "ANDROGENS AND FEMALE SEX HORMONES IN COMBINATION"
+    },
+    {
+      "code": "QG03EA",
+      "name": "Androgens and estrogens"
+    },
+    {
+      "code": "QG03EA01",
+      "name": "methyltestosterone and estrogen"
+    },
+    {
+      "code": "QG03EA02",
+      "name": "testosterone and estrogen"
+    },
+    {
+      "code": "QG03EA03",
+      "name": "prasterone and estrogen"
+    },
+    {
+      "code": "QG03EB",
+      "name": "Androgen, progestogen and estrogen in combination"
+    },
+    {
+      "code": "QG03EK",
+      "name": "Androgens and female sex hormones in combination with other drugs"
+    },
+    {
+      "code": "QG03EK01",
+      "name": "methyltestosterone"
+    },
+    {
+      "code": "QG03F",
+      "name": "PROGESTOGENS AND ESTROGENS IN COMBINATION"
+    },
+    {
+      "code": "QG03FA",
+      "name": "Progestogens and estrogens, combinations"
+    },
+    {
+      "code": "QG03FA01",
+      "name": "norethisterone and estrogen"
+    },
+    {
+      "code": "QG03FA02",
+      "name": "hydroxyprogesterone and estrogen"
+    },
+    {
+      "code": "QG03FA03",
+      "name": "ethisterone and estrogen"
+    },
+    {
+      "code": "QG03FA04",
+      "name": "progesterone and estrogen"
+    },
+    {
+      "code": "QG03FA05",
+      "name": "methylnortestosterone and estrogen"
+    },
+    {
+      "code": "QG03FA06",
+      "name": "etynodiol and estrogen"
+    },
+    {
+      "code": "QG03FA07",
+      "name": "lynestrenol and estrogen"
+    },
+    {
+      "code": "QG03FA08",
+      "name": "megestrol and estrogen"
+    },
+    {
+      "code": "QG03FA09",
+      "name": "noretynodrel and estrogen"
+    },
+    {
+      "code": "QG03FA10",
+      "name": "norgestrel and estrogen"
+    },
+    {
+      "code": "QG03FA11",
+      "name": "levonorgestrel and estrogen"
+    },
+    {
+      "code": "QG03FA12",
+      "name": "medroxyprogesterone and estrogen"
+    },
+    {
+      "code": "QG03FA13",
+      "name": "norgestimate and estrogen"
+    },
+    {
+      "code": "QG03FA14",
+      "name": "dydrogesterone and estrogen"
+    },
+    {
+      "code": "QG03FA15",
+      "name": "dienogest and estrogen"
+    },
+    {
+      "code": "QG03FA16",
+      "name": "trimegestone and estrogen"
+    },
+    {
+      "code": "QG03FA17",
+      "name": "drospirenone and estrogen"
+    },
+    {
+      "code": "QG03FB",
+      "name": "Progestogens and estrogens, sequential preparations"
+    },
+    {
+      "code": "QG03FB01",
+      "name": "norgestrel and estrogen"
+    },
+    {
+      "code": "QG03FB02",
+      "name": "lynestrenol and estrogen"
+    },
+    {
+      "code": "QG03FB03",
+      "name": "chlormadinone and estrogen"
+    },
+    {
+      "code": "QG03FB04",
+      "name": "megestrol and estrogen"
+    },
+    {
+      "code": "QG03FB05",
+      "name": "norethisterone and estrogen"
+    },
+    {
+      "code": "QG03FB06",
+      "name": "medroxyprogesterone and estrogen"
+    },
+    {
+      "code": "QG03FB07",
+      "name": "medrogestone and estrogen"
+    },
+    {
+      "code": "QG03FB08",
+      "name": "dydrogesterone and estrogen"
+    },
+    {
+      "code": "QG03FB09",
+      "name": "levonorgestrel and estrogen"
+    },
+    {
+      "code": "QG03FB10",
+      "name": "desogestrel and estrogen"
+    },
+    {
+      "code": "QG03FB11",
+      "name": "trimegestone and estrogen"
+    },
+    {
+      "code": "QG03FB12",
+      "name": "nomegestrol and estrogen"
+    },
+    {
+      "code": "QG03G",
+      "name": "GONADOTROPINS AND OTHER OVULATION STIMULANTS"
+    },
+    {
+      "code": "QG03GA",
+      "name": "Gonadotropins"
+    },
+    {
+      "code": "QG03GA01",
+      "name": "chorionic gonadotrophin"
+    },
+    {
+      "code": "QG03GA02",
+      "name": "human menopausal gonadotrophin"
+    },
+    {
+      "code": "QG03GA03",
+      "name": "serum gonadotrophin"
+    },
+    {
+      "code": "QG03GA04",
+      "name": "urofollitropin"
+    },
+    {
+      "code": "QG03GA05",
+      "name": "follitropin alfa"
+    },
+    {
+      "code": "QG03GA06",
+      "name": "follitropin beta"
+    },
+    {
+      "code": "QG03GA07",
+      "name": "lutropin alfa"
+    },
+    {
+      "code": "QG03GA08",
+      "name": "choriogonadotropin alfa"
+    },
+    {
+      "code": "QG03GA09",
+      "name": "corifollitropin alfa"
+    },
+    {
+      "code": "QG03GA10",
+      "name": "follitropin delta"
+    },
+    {
+      "code": "QG03GA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QG03GA90",
+      "name": "follicle stimulating hormone-pituitary"
+    },
+    {
+      "code": "QG03GA99",
+      "name": "gonadotropins, combinations"
+    },
+    {
+      "code": "QG03GB",
+      "name": "Ovulation stimulants, synthetic"
+    },
+    {
+      "code": "QG03GB01",
+      "name": "cyclofenil"
+    },
+    {
+      "code": "QG03GB02",
+      "name": "clomifene"
+    },
+    {
+      "code": "QG03GB03",
+      "name": "epimestrol"
+    },
+    {
+      "code": "QG03H",
+      "name": "ANTIANDROGENS"
+    },
+    {
+      "code": "QG03HA",
+      "name": "Antiandrogens, plain"
+    },
+    {
+      "code": "QG03HA01",
+      "name": "cyproterone"
+    },
+    {
+      "code": "QG03HB",
+      "name": "Antiandrogens and estrogens"
+    },
+    {
+      "code": "QG03HB01",
+      "name": "cyproterone and estrogen"
+    },
+    {
+      "code": "QG03X",
+      "name": "OTHER SEX HORMONES AND MODULATORS OF THE GENITAL SYSTEM"
+    },
+    {
+      "code": "QG03XA",
+      "name": "Antigonadotropins and similar agents"
+    },
+    {
+      "code": "QG03XA01",
+      "name": "danazol"
+    },
+    {
+      "code": "QG03XA02",
+      "name": "gestrinone"
+    },
+    {
+      "code": "QG03XA90",
+      "name": "anti-Pmsg"
+    },
+    {
+      "code": "QG03XA91",
+      "name": "gonadotropin releasing factor analogue, conjugated"
+    },
+    {
+      "code": "QG03XB",
+      "name": "Progesterone receptor modulators"
+    },
+    {
+      "code": "QG03XB01",
+      "name": "mifepristone"
+    },
+    {
+      "code": "QG03XB02",
+      "name": "ulipristal"
+    },
+    {
+      "code": "QG03XB51",
+      "name": "mifepristone, combinations"
+    },
+    {
+      "code": "QG03XB90",
+      "name": "aglepristone"
+    },
+    {
+      "code": "QG03XC",
+      "name": "Selective estrogen receptor modulators"
+    },
+    {
+      "code": "QG03XC01",
+      "name": "raloxifene"
+    },
+    {
+      "code": "QG03XC02",
+      "name": "bazedoxifene"
+    },
+    {
+      "code": "QG03XC03",
+      "name": "lasofoxifene"
+    },
+    {
+      "code": "QG03XC04",
+      "name": "ormeloxifene"
+    },
+    {
+      "code": "QG03XC05",
+      "name": "ospemifene"
+    },
+    {
+      "code": "QG03XX",
+      "name": "Other sex hormones and modulators of the genital system"
+    },
+    {
+      "code": "QG03XX01",
+      "name": "prasterone"
+    },
+    {
+      "code": "QG03XX90",
+      "name": "finrozole"
+    },
+    {
+      "code": "QG04",
+      "name": "UROLOGICALS"
+    },
+    {
+      "code": "QG04B",
+      "name": "UROLOGICALS"
+    },
+    {
+      "code": "QG04BA",
+      "name": "Acidifiers"
+    },
+    {
+      "code": "QG04BA01",
+      "name": "ammonium chloride"
+    },
+    {
+      "code": "QG04BA03",
+      "name": "calcium chloride"
+    },
+    {
+      "code": "QG04BA90",
+      "name": "methionine"
+    },
+    {
+      "code": "QG04BC",
+      "name": "Urinary concrement solvents"
+    },
+    {
+      "code": "QG04BD",
+      "name": "Drugs for urinary frequency and incontinence"
+    },
+    {
+      "code": "QG04BD01",
+      "name": "emepronium"
+    },
+    {
+      "code": "QG04BD02",
+      "name": "flavoxate"
+    },
+    {
+      "code": "QG04BD03",
+      "name": "meladrazine"
+    },
+    {
+      "code": "QG04BD04",
+      "name": "oxybutynin"
+    },
+    {
+      "code": "QG04BD05",
+      "name": "terodiline"
+    },
+    {
+      "code": "QG04BD06",
+      "name": "propiverine"
+    },
+    {
+      "code": "QG04BD07",
+      "name": "tolterodine"
+    },
+    {
+      "code": "QG04BD08",
+      "name": "solifenacin"
+    },
+    {
+      "code": "QG04BD09",
+      "name": "trospium"
+    },
+    {
+      "code": "QG04BD10",
+      "name": "darifenacin"
+    },
+    {
+      "code": "QG04BD11",
+      "name": "fesoterodine"
+    },
+    {
+      "code": "QG04BD12",
+      "name": "mirabegron"
+    },
+    {
+      "code": "QG04BD13",
+      "name": "desfesoterodine"
+    },
+    {
+      "code": "QG04BD14",
+      "name": "imidafenacin"
+    },
+    {
+      "code": "QG04BD15",
+      "name": "vibegron"
+    },
+    {
+      "code": "QG04BE",
+      "name": "Drugs used in erectile dysfunction"
+    },
+    {
+      "code": "QG04BE01",
+      "name": "alprostadil"
+    },
+    {
+      "code": "QG04BE02",
+      "name": "papaverine"
+    },
+    {
+      "code": "QG04BE03",
+      "name": "sildenafil"
+    },
+    {
+      "code": "QG04BE04",
+      "name": "yohimbine"
+    },
+    {
+      "code": "QG04BE06",
+      "name": "moxisylyte"
+    },
+    {
+      "code": "QG04BE07",
+      "name": "apomorphine"
+    },
+    {
+      "code": "QG04BE08",
+      "name": "tadalafil"
+    },
+    {
+      "code": "QG04BE09",
+      "name": "vardenafil"
+    },
+    {
+      "code": "QG04BE10",
+      "name": "avanafil"
+    },
+    {
+      "code": "QG04BE11",
+      "name": "udenafil"
+    },
+    {
+      "code": "QG04BE30",
+      "name": "combinations"
+    },
+    {
+      "code": "QG04BE52",
+      "name": "papaverine, combinations"
+    },
+    {
+      "code": "QG04BQ",
+      "name": "Urinary alkalizers"
+    },
+    {
+      "code": "QG04BQ01",
+      "name": "sodium bicarbonate"
+    },
+    {
+      "code": "QG04BX",
+      "name": "Other urologicals"
+    },
+    {
+      "code": "QG04BX01",
+      "name": "magnesium hydroxide"
+    },
+    {
+      "code": "QG04BX03",
+      "name": "acetohydroxamic acid"
+    },
+    {
+      "code": "QG04BX06",
+      "name": "phenazopyridine"
+    },
+    {
+      "code": "QG04BX10",
+      "name": "succinimide"
+    },
+    {
+      "code": "QG04BX11",
+      "name": "collagen"
+    },
+    {
+      "code": "QG04BX12",
+      "name": "phenyl salicylate"
+    },
+    {
+      "code": "QG04BX13",
+      "name": "dimethyl sulfoxide"
+    },
+    {
+      "code": "QG04BX14",
+      "name": "dapoxetine"
+    },
+    {
+      "code": "QG04BX15",
+      "name": "pentosan polysulfate sodium"
+    },
+    {
+      "code": "QG04BX16",
+      "name": "tiopronin"
+    },
+    {
+      "code": "QG04BX17",
+      "name": "sodium salicylate and methenamine"
+    },
+    {
+      "code": "QG04BX56",
+      "name": "phenazopyridine, combinations"
+    },
+    {
+      "code": "QG04BX90",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QG04BX91",
+      "name": "phenylpropanolamin"
+    },
+    {
+      "code": "QG04C",
+      "name": "DRUGS USED IN BENIGN PROSTATIC HYPERTROPHY"
+    },
+    {
+      "code": "QG04CA",
+      "name": "Alpha-adrenoreceptor antagonists"
+    },
+    {
+      "code": "QG04CA01",
+      "name": "alfuzosin"
+    },
+    {
+      "code": "QG04CA02",
+      "name": "tamsulosin"
+    },
+    {
+      "code": "QG04CA03",
+      "name": "terazocin"
+    },
+    {
+      "code": "QG04CA04",
+      "name": "silodosin"
+    },
+    {
+      "code": "QG04CA51",
+      "name": "alfuzosin and finasteride"
+    },
+    {
+      "code": "QG04CA52",
+      "name": "tamsulosin and dutasteride"
+    },
+    {
+      "code": "QG04CA53",
+      "name": "tamsulosin and solifenacin"
+    },
+    {
+      "code": "QG04CA54",
+      "name": "tamsulosin and tadalafil"
+    },
+    {
+      "code": "QG04CA55",
+      "name": "doxazosin and finasteride"
+    },
+    {
+      "code": "QG04CB",
+      "name": "Testosterone-5-alpha reductase inhibitors"
+    },
+    {
+      "code": "QG04CB01",
+      "name": "finasteride"
+    },
+    {
+      "code": "QG04CB02",
+      "name": "dutasteride"
+    },
+    {
+      "code": "QG04CB51",
+      "name": "finasteride and tadalafil"
+    },
+    {
+      "code": "QG04CX",
+      "name": "Other drugs used in benign prostatic hypertrophy"
+    },
+    {
+      "code": "QG04CX01",
+      "name": "Prunus africanae cortex"
+    },
+    {
+      "code": "QG04CX02",
+      "name": "Sabalis serrulatae fructus"
+    },
+    {
+      "code": "QG04CX03",
+      "name": "mepartricin"
+    },
+    {
+      "code": "QG04CX04",
+      "name": "fexapotide"
+    },
+    {
+      "code": "QG04CX90",
+      "name": "osaterone"
+    },
+    {
+      "code": "QG51",
+      "name": "ANTIINFECTIVES AND ANTISEPTICS FOR INTRAUTERINE USE"
+    },
+    {
+      "code": "QG51A",
+      "name": "ANTIINFECTIVES AND ANTISEPTICS FOR INTRAUTERINE USE"
+    },
+    {
+      "code": "QG51AA",
+      "name": "Antibacterials"
+    },
+    {
+      "code": "QG51AA01",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QG51AA02",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QG51AA03",
+      "name": "amoxicillin"
+    },
+    {
+      "code": "QG51AA04",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QG51AA05",
+      "name": "cefapirin"
+    },
+    {
+      "code": "QG51AA06",
+      "name": "rifaximin"
+    },
+    {
+      "code": "QG51AA07",
+      "name": "cefquinome"
+    },
+    {
+      "code": "QG51AA08",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QG51AA09",
+      "name": "formosulfathiazole"
+    },
+    {
+      "code": "QG51AD",
+      "name": "Antiseptics"
+    },
+    {
+      "code": "QG51AD01",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QG51AD02",
+      "name": "policresulen"
+    },
+    {
+      "code": "QG51AD03",
+      "name": "peroxy-acetic acid"
+    },
+    {
+      "code": "QG51AD30",
+      "name": "combinations of antiseptics"
+    },
+    {
+      "code": "QG51AG",
+      "name": "Antiinfectives and/or antiseptics, combinations for intrauterine use"
+    },
+    {
+      "code": "QG51AG01",
+      "name": "procaine benzylpenicillin, dihydrostreptomycin, and sulfadimidine"
+    },
+    {
+      "code": "QG51AG02",
+      "name": "benzylpenicillin, dihydrostreptomycin, and sulfadimidine"
+    },
+    {
+      "code": "QG51AG03",
+      "name": "tetracycline, neomycin and sulfadimidine"
+    },
+    {
+      "code": "QG51AG04",
+      "name": "ampicillin and oxacillin"
+    },
+    {
+      "code": "QG51AG05",
+      "name": "ampicillin and cloxacillin"
+    },
+    {
+      "code": "QG51AG06",
+      "name": "oxytetracycline and neomycin"
+    },
+    {
+      "code": "QG51AG07",
+      "name": "ampicillin and colistin"
+    },
+    {
+      "code": "QG52",
+      "name": "PRODUCTS FOR TEATS AND UDDER"
+    },
+    {
+      "code": "QG52A",
+      "name": "DISINFECTANTS"
+    },
+    {
+      "code": "QG52B",
+      "name": "TEAT CANAL DEVICES"
+    },
+    {
+      "code": "QG52C",
+      "name": "EMOLLIENTS"
+    },
+    {
+      "code": "QG52X",
+      "name": "VARIOUS PRODUCTS FOR TEATS AND UDDER"
+    },
+    {
+      "code": "QH",
+      "name": "SYSTEMIC HORMONAL PREPARATIONS, EXCL. SEX HORMONES AND INSULIN"
+    },
+    {
+      "code": "QH01",
+      "name": "PITUITARY AND HYPOTHALAMIC HORMONES AND ANALOGUES"
+    },
+    {
+      "code": "QH01A",
+      "name": "ANTERIOR PITUITARY LOBE HORMONES AND ANALOGUES"
+    },
+    {
+      "code": "QH01AA",
+      "name": "ACTH"
+    },
+    {
+      "code": "QH01AA01",
+      "name": "corticotropin"
+    },
+    {
+      "code": "QH01AA02",
+      "name": "tetracosactide"
+    },
+    {
+      "code": "QH01AB",
+      "name": "Thyrotropin"
+    },
+    {
+      "code": "QH01AB01",
+      "name": "thyrotropin alfa"
+    },
+    {
+      "code": "QH01AC",
+      "name": "Somatropin and somatropin agonists"
+    },
+    {
+      "code": "QH01AC01",
+      "name": "somatropin"
+    },
+    {
+      "code": "QH01AC02",
+      "name": "somatrem"
+    },
+    {
+      "code": "QH01AC03",
+      "name": "mecasermin"
+    },
+    {
+      "code": "QH01AC04",
+      "name": "sermorelin"
+    },
+    {
+      "code": "QH01AC05",
+      "name": "mecasermin rinfabate"
+    },
+    {
+      "code": "QH01AC06",
+      "name": "tesamorelin"
+    },
+    {
+      "code": "QH01AC07",
+      "name": "somapacitan"
+    },
+    {
+      "code": "QH01AC08",
+      "name": "somatrogon"
+    },
+    {
+      "code": "QH01AC09",
+      "name": "lonapegsomatropin"
+    },
+    {
+      "code": "QH01AX",
+      "name": "Other anterior pituitary lobe hormones and analogues"
+    },
+    {
+      "code": "QH01AX01",
+      "name": "pegvisomant"
+    },
+    {
+      "code": "QH01AX90",
+      "name": "capromorelin"
+    },
+    {
+      "code": "QH01B",
+      "name": "POSTERIOR PITUITARY LOBE HORMONES"
+    },
+    {
+      "code": "QH01BA",
+      "name": "Vasopressin and analogues"
+    },
+    {
+      "code": "QH01BA01",
+      "name": "vasopressin (argipressin)"
+    },
+    {
+      "code": "QH01BA02",
+      "name": "desmopressin"
+    },
+    {
+      "code": "QH01BA03",
+      "name": "lypressin"
+    },
+    {
+      "code": "QH01BA04",
+      "name": "terlipressin"
+    },
+    {
+      "code": "QH01BA05",
+      "name": "ornipressin"
+    },
+    {
+      "code": "QH01BB",
+      "name": "Oxytocin and analogues"
+    },
+    {
+      "code": "QH01BB01",
+      "name": "demoxytocin"
+    },
+    {
+      "code": "QH01BB02",
+      "name": "oxytocin"
+    },
+    {
+      "code": "QH01BB03",
+      "name": "carbetocin"
+    },
+    {
+      "code": "QH01C",
+      "name": "HYPOTHALAMIC HORMONES"
+    },
+    {
+      "code": "QH01CA",
+      "name": "Gonadotropin-releasing hormones"
+    },
+    {
+      "code": "QH01CA01",
+      "name": "gonadorelin"
+    },
+    {
+      "code": "QH01CA02",
+      "name": "nafarelin"
+    },
+    {
+      "code": "QH01CA90",
+      "name": "buserelin"
+    },
+    {
+      "code": "QH01CA91",
+      "name": "fertirelin"
+    },
+    {
+      "code": "QH01CA92",
+      "name": "lecirelin"
+    },
+    {
+      "code": "QH01CA93",
+      "name": "deslorelin"
+    },
+    {
+      "code": "QH01CA94",
+      "name": "azagly-nafarelin"
+    },
+    {
+      "code": "QH01CA95",
+      "name": "peforelin"
+    },
+    {
+      "code": "QH01CA96",
+      "name": "salmon gonadotropin releasing hormone analogue"
+    },
+    {
+      "code": "QH01CA97",
+      "name": "triptorelin"
+    },
+    {
+      "code": "QH01CA98",
+      "name": "alarelin"
+    },
+    {
+      "code": "QH01CB",
+      "name": "Somatostatin and analogues"
+    },
+    {
+      "code": "QH01CB01",
+      "name": "somatostatin"
+    },
+    {
+      "code": "QH01CB02",
+      "name": "octreotide"
+    },
+    {
+      "code": "QH01CB03",
+      "name": "lanreotide"
+    },
+    {
+      "code": "QH01CB04",
+      "name": "vapreotide"
+    },
+    {
+      "code": "QH01CB05",
+      "name": "pasireotide"
+    },
+    {
+      "code": "QH01CB06",
+      "name": "paltusotine"
+    },
+    {
+      "code": "QH01CC",
+      "name": "Anti-gonadrotropin-releasing hormones"
+    },
+    {
+      "code": "QH01CC01",
+      "name": "ganirelix"
+    },
+    {
+      "code": "QH01CC02",
+      "name": "cetrorelix"
+    },
+    {
+      "code": "QH01CC03",
+      "name": "elagolix"
+    },
+    {
+      "code": "QH01CC04",
+      "name": "linzagolix"
+    },
+    {
+      "code": "QH01CC53",
+      "name": "elagolix, estradiol and norethisterone"
+    },
+    {
+      "code": "QH01CC54",
+      "name": "relugolix, estradiol and norethisterone"
+    },
+    {
+      "code": "QH02",
+      "name": "CORTICOSTEROIDS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QH02A",
+      "name": "CORTICOSTEROIDS FOR SYSTEMIC USE, PLAIN"
+    },
+    {
+      "code": "QH02AA",
+      "name": "Mineralocorticoids"
+    },
+    {
+      "code": "QH02AA01",
+      "name": "aldosterone"
+    },
+    {
+      "code": "QH02AA02",
+      "name": "fludrocortisone"
+    },
+    {
+      "code": "QH02AA03",
+      "name": "desoxycortone"
+    },
+    {
+      "code": "QH02AB",
+      "name": "Glucocorticoids"
+    },
+    {
+      "code": "QH02AB01",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QH02AB02",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QH02AB03",
+      "name": "fluocortolone"
+    },
+    {
+      "code": "QH02AB04",
+      "name": "methylprednisolone"
+    },
+    {
+      "code": "QH02AB05",
+      "name": "paramethasone"
+    },
+    {
+      "code": "QH02AB06",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QH02AB07",
+      "name": "prednisone"
+    },
+    {
+      "code": "QH02AB08",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QH02AB09",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QH02AB10",
+      "name": "cortisone"
+    },
+    {
+      "code": "QH02AB11",
+      "name": "prednylidene"
+    },
+    {
+      "code": "QH02AB12",
+      "name": "rimexolone"
+    },
+    {
+      "code": "QH02AB13",
+      "name": "deflazacort"
+    },
+    {
+      "code": "QH02AB14",
+      "name": "cloprednol"
+    },
+    {
+      "code": "QH02AB15",
+      "name": "meprednisone"
+    },
+    {
+      "code": "QH02AB17",
+      "name": "cortivazol"
+    },
+    {
+      "code": "QH02AB18",
+      "name": "vamorolone"
+    },
+    {
+      "code": "QH02AB30",
+      "name": "combinations of glucocorticoids"
+    },
+    {
+      "code": "QH02AB56",
+      "name": "prednisolone, combinations"
+    },
+    {
+      "code": "QH02AB57",
+      "name": "prednisone, combinations"
+    },
+    {
+      "code": "QH02AB90",
+      "name": "flumetasone"
+    },
+    {
+      "code": "QH02B",
+      "name": "CORTICOSTEROIDS FOR SYSTEMIC USE, COMBINATIONS"
+    },
+    {
+      "code": "QH02BX",
+      "name": "Corticosteroids for systemic use, combinations"
+    },
+    {
+      "code": "QH02BX01",
+      "name": "methylprednisolone, combinations"
+    },
+    {
+      "code": "QH02BX90",
+      "name": "dexamethasone, combinations"
+    },
+    {
+      "code": "QH02C",
+      "name": "ANTIADRENAL PREPARATIONS"
+    },
+    {
+      "code": "QH02CA",
+      "name": "Anticorticosteroids"
+    },
+    {
+      "code": "QH02CA01",
+      "name": "trilostane"
+    },
+    {
+      "code": "QH02CA02",
+      "name": "osilodrostat"
+    },
+    {
+      "code": "QH02CA03",
+      "name": "ketoconazole"
+    },
+    {
+      "code": "QH02CA04",
+      "name": "levoketoconazole"
+    },
+    {
+      "code": "QH03",
+      "name": "THYROID THERAPY"
+    },
+    {
+      "code": "QH03A",
+      "name": "THYROID PREPARATIONS"
+    },
+    {
+      "code": "QH03AA",
+      "name": "Thyroid hormones"
+    },
+    {
+      "code": "QH03AA01",
+      "name": "levothyroxine sodium"
+    },
+    {
+      "code": "QH03AA02",
+      "name": "liothyronine sodium"
+    },
+    {
+      "code": "QH03AA03",
+      "name": "combinations of levothyroxine and liothyronine"
+    },
+    {
+      "code": "QH03AA04",
+      "name": "tiratricol"
+    },
+    {
+      "code": "QH03AA05",
+      "name": "thyroid gland preparations"
+    },
+    {
+      "code": "QH03AA51",
+      "name": "levothyroxine sodium and iodine compounds"
+    },
+    {
+      "code": "QH03B",
+      "name": "ANTITHYROID PREPARATIONS"
+    },
+    {
+      "code": "QH03BA",
+      "name": "Thiouracils"
+    },
+    {
+      "code": "QH03BA01",
+      "name": "methylthiouracil"
+    },
+    {
+      "code": "QH03BA02",
+      "name": "propylthiouracil"
+    },
+    {
+      "code": "QH03BA03",
+      "name": "benzylthiouracil"
+    },
+    {
+      "code": "QH03BB",
+      "name": "Sulfur-containing imidazole derivatives"
+    },
+    {
+      "code": "QH03BB01",
+      "name": "carbimazole"
+    },
+    {
+      "code": "QH03BB02",
+      "name": "thiamazole"
+    },
+    {
+      "code": "QH03BB52",
+      "name": "thiamazole, combinations"
+    },
+    {
+      "code": "QH03BC",
+      "name": "Perchlorates"
+    },
+    {
+      "code": "QH03BC01",
+      "name": "potassium perchlorate"
+    },
+    {
+      "code": "QH03BX",
+      "name": "Other antithyroid preparations"
+    },
+    {
+      "code": "QH03BX01",
+      "name": "diiodotyrosine"
+    },
+    {
+      "code": "QH03BX02",
+      "name": "dibromotyrosine"
+    },
+    {
+      "code": "QH03C",
+      "name": "IODINE THERAPY"
+    },
+    {
+      "code": "QH03CA",
+      "name": "Iodine therapy"
+    },
+    {
+      "code": "QH04",
+      "name": "PANCREATIC HORMONES"
+    },
+    {
+      "code": "QH04A",
+      "name": "GLYCOGENOLYTIC HORMONES"
+    },
+    {
+      "code": "QH04AA",
+      "name": "Glycogenolytic hormones"
+    },
+    {
+      "code": "QH04AA01",
+      "name": "glucagon"
+    },
+    {
+      "code": "QH04AA02",
+      "name": "dasiglucagon"
+    },
+    {
+      "code": "QH05",
+      "name": "CALCIUM HOMEOSTASIS"
+    },
+    {
+      "code": "QH05A",
+      "name": "PARATHYROID HORMONES AND ANALOGUES"
+    },
+    {
+      "code": "QH05AA",
+      "name": "Parathyroid hormones and analogues"
+    },
+    {
+      "code": "QH05AA01",
+      "name": "parathyroid gland extract"
+    },
+    {
+      "code": "QH05AA02",
+      "name": "teriparatide"
+    },
+    {
+      "code": "QH05AA03",
+      "name": "parathyroid hormone"
+    },
+    {
+      "code": "QH05AA04",
+      "name": "abaloparatide"
+    },
+    {
+      "code": "QH05AA05",
+      "name": "palopegteriparatide"
+    },
+    {
+      "code": "QH05B",
+      "name": "ANTI-PARATHYROID AGENTS"
+    },
+    {
+      "code": "QH05BA",
+      "name": "Calcitonin preparations"
+    },
+    {
+      "code": "QH05BA01",
+      "name": "calcitonin (salmon synthetic)"
+    },
+    {
+      "code": "QH05BA02",
+      "name": "calcitonin (pork natural)"
+    },
+    {
+      "code": "QH05BA03",
+      "name": "calcitonin (human synthetic)"
+    },
+    {
+      "code": "QH05BA04",
+      "name": "elcatonin"
+    },
+    {
+      "code": "QH05BX",
+      "name": "Other anti-parathyroid agents"
+    },
+    {
+      "code": "QH05BX01",
+      "name": "cinacalcet"
+    },
+    {
+      "code": "QH05BX02",
+      "name": "paricalcitol"
+    },
+    {
+      "code": "QH05BX03",
+      "name": "doxercalciferol"
+    },
+    {
+      "code": "QH05BX04",
+      "name": "etelcalcetide"
+    },
+    {
+      "code": "QH05BX05",
+      "name": "calcifediol"
+    },
+    {
+      "code": "QH05BX06",
+      "name": "evocalcet"
+    },
+    {
+      "code": "QI",
+      "name": "IMMUNOLOGICALS"
+    },
+    {
+      "code": "QI01",
+      "name": "IMMUNOLOGICALS FOR AVES"
+    },
+    {
+      "code": "QI01A",
+      "name": "DOMESTIC FOWL"
+    },
+    {
+      "code": "QI01AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01AA01",
+      "name": "avian infectious bursal (gumboro) disease virus"
+    },
+    {
+      "code": "QI01AA02",
+      "name": "newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AA03",
+      "name": "avian infectious bronchitis virus"
+    },
+    {
+      "code": "QI01AA04",
+      "name": "avian reovirus"
+    },
+    {
+      "code": "QI01AA05",
+      "name": "avian adenovirus"
+    },
+    {
+      "code": "QI01AA06",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA07",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian rhinotracheitis virus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA08",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus"
+    },
+    {
+      "code": "QI01AA09",
+      "name": "newcastle disease virus / paramyxovirus + avian infectious bursal (gumboro) disease virus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA10",
+      "name": "avian infectious bronchitis virus + newcastle disease virus / paramyxovirus"
+    },
+    {
+      "code": "QI01AA11",
+      "name": "avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus"
+    },
+    {
+      "code": "QI01AA12",
+      "name": "newcastle disease virus / paramyxovirus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA13",
+      "name": "newcastle disease virus / paramyxovirus + avian infectious bronchitis virus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA14",
+      "name": "avian infectious bronchitis virus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA15",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus"
+    },
+    {
+      "code": "QI01AA16",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian reovirus"
+    },
+    {
+      "code": "QI01AA17",
+      "name": "avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA18",
+      "name": "avian infectious bronchitis virus + newcastle disease virus / paramyxovirus + avian adenovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA19",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA20",
+      "name": "newcastle disease virus / paramyxovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA21",
+      "name": "avian infectious bronchitis virus + newcastle disease virus / paramyxovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA22",
+      "name": "avian infectious bursal (gumboro) disease virus + avian reovirus"
+    },
+    {
+      "code": "QI01AA23",
+      "name": "avian influenza virus"
+    },
+    {
+      "code": "QI01AA24",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian reovirus + avian adenovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AA25",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian reovirus + avian adenovirus"
+    },
+    {
+      "code": "QI01AA26",
+      "name": "avian infectious bronchitis virus + avian infectious bursal (gumboro) disease virus + newcastle disease virus / paramyxovirus + avian reovirus + avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01AB01",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI01AB02",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI01AB03",
+      "name": "mycoplasma"
+    },
+    {
+      "code": "QI01AB04",
+      "name": "haemophilus"
+    },
+    {
+      "code": "QI01AB05",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI01AB06",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI01AB07",
+      "name": "ornithobacterium"
+    },
+    {
+      "code": "QI01AB08",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI01AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01AD01",
+      "name": "avian rhinotracheitis virus"
+    },
+    {
+      "code": "QI01AD02",
+      "name": "avian encephalomyelitis virus"
+    },
+    {
+      "code": "QI01AD03",
+      "name": "avian herpes virus (marek's disease)"
+    },
+    {
+      "code": "QI01AD04",
+      "name": "chicken anaemia virus"
+    },
+    {
+      "code": "QI01AD05",
+      "name": "avian adenovirus"
+    },
+    {
+      "code": "QI01AD06",
+      "name": "newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AD07",
+      "name": "avian infectious bronchitis virus"
+    },
+    {
+      "code": "QI01AD08",
+      "name": "avian infectious laryngotracheitis virus"
+    },
+    {
+      "code": "QI01AD09",
+      "name": "avian infectious bursal disease virus (gumboro disease)"
+    },
+    {
+      "code": "QI01AD10",
+      "name": "avian reovirus"
+    },
+    {
+      "code": "QI01AD11",
+      "name": "newcastle disease virus/paramyxovirus + avian infectious bronchitis virus"
+    },
+    {
+      "code": "QI01AD12",
+      "name": "avian pox virus"
+    },
+    {
+      "code": "QI01AD13",
+      "name": "avian leucosis virus"
+    },
+    {
+      "code": "QI01AD14",
+      "name": "avian reticuloendotheliosis"
+    },
+    {
+      "code": "QI01AD15",
+      "name": "avian infectious bursal disease virus (gumboro disease) + avian herpes virus (marek's disease)"
+    },
+    {
+      "code": "QI01AD16",
+      "name": "avian herpes virus (marek's disease) + avian infectious bursal disease virus (gumboro disease) + newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AD17",
+      "name": "avian herpes virus (marek's disease) + avian infectious laryngotracheitis virus + newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AD18",
+      "name": "avian herpes virus (marek's disease) + avian infectious laryngotracheitis virus + avian infectious bursal disease virus (gumboro) disease"
+    },
+    {
+      "code": "QI01AD19",
+      "name": "avian herpes virus (marek's disease) + avian infectious laryngotracheitis virus"
+    },
+    {
+      "code": "QI01AD20",
+      "name": "avian herpes virus (marek's disease) + avian infectious laryngotracheitis virus + avian infectious bursal disease virus (gumboro) disease + newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AD21",
+      "name": "avian herpes virus (marek's disease) + newcastle disease virus/paramyxovirus"
+    },
+    {
+      "code": "QI01AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01AE01",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI01AE02",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI01AE03",
+      "name": "mycoplasma"
+    },
+    {
+      "code": "QI01AE04",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI01AE05",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI01AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01AJ",
+      "name": "Live and inactivated viral and bacterial vacciness"
+    },
+    {
+      "code": "QI01AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01AL01",
+      "name": "newcastle disease virus / paramyxovirus + escherichia + pasteurella"
+    },
+    {
+      "code": "QI01AL02",
+      "name": "newcastle disease virus / paramyxovirus + avian infectious bronchitis virus + haemophilus"
+    },
+    {
+      "code": "QI01AL03",
+      "name": "newcastle disease virus / paramyxovirus + haemophilus"
+    },
+    {
+      "code": "QI01AL04",
+      "name": "newcastle disease virus / paramyxovirus + pasteurella"
+    },
+    {
+      "code": "QI01AL05",
+      "name": "newcastle disease virus / paramyxovirus + avian infectious bronchitis virus + avian adenovirus + haemophilus"
+    },
+    {
+      "code": "QI01AL06",
+      "name": "newcastle disease virus / paramyxovirus + avian infectious bronchitis virus + escherichia + pasteurella"
+    },
+    {
+      "code": "QI01AL07",
+      "name": "newcastle disease virus/paramyxovirus + salmonella + pasteurella"
+    },
+    {
+      "code": "QI01AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01AN01",
+      "name": "coccidia"
+    },
+    {
+      "code": "QI01AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01AO01",
+      "name": "coccidia"
+    },
+    {
+      "code": "QI01AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01B",
+      "name": "DUCK"
+    },
+    {
+      "code": "QI01BA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01BA01",
+      "name": "duck parvovirus + goose parvovirus"
+    },
+    {
+      "code": "QI01BB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01BB01",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI01BC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01BD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01BD01",
+      "name": "duck enteritis virus"
+    },
+    {
+      "code": "QI01BD02",
+      "name": "duck hepatitis virus"
+    },
+    {
+      "code": "QI01BD03",
+      "name": "duck parvovirus"
+    },
+    {
+      "code": "QI01BE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01BF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01BG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01BH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01BH01",
+      "name": "live goose parvovirus + inactivated duck parvovirus"
+    },
+    {
+      "code": "QI01BI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01BJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI01BK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01BL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01BM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01BN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01BO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01BP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01BQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01BR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01BS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01BU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01BV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01BX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01C",
+      "name": "TURKEY"
+    },
+    {
+      "code": "QI01CA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01CA01",
+      "name": "turkey paramyxovirus"
+    },
+    {
+      "code": "QI01CA02",
+      "name": "turkey paramyxovirus + turkey rhinotracheitis virus"
+    },
+    {
+      "code": "QI01CA03",
+      "name": "newcastle disease virus / paramyxovirus + avian adenovirus"
+    },
+    {
+      "code": "QI01CB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01CB01",
+      "name": "pasteurella + erysipelothrix"
+    },
+    {
+      "code": "QI01CB02",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI01CC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01CD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01CD01",
+      "name": "turkey rhinotracheitis virus"
+    },
+    {
+      "code": "QI01CD02",
+      "name": "turkey herpes virus"
+    },
+    {
+      "code": "QI01CE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01CF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01CG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01CH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01CI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01CJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI01CK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01CL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01CL01",
+      "name": "newcastle disease virus / paramyxovirus + avian adenovirus + avian influenza virus + pasteurella"
+    },
+    {
+      "code": "QI01CM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01CN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01CO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01CP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01CQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01CR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01CS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01CU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01CV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01CX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01D",
+      "name": "GOOSE"
+    },
+    {
+      "code": "QI01DA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01DB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01DC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01DD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01DD01",
+      "name": "goose parvovirus"
+    },
+    {
+      "code": "QI01DE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01DF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01DG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01DH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01DI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01DJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI01DK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01DL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01DM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01DM01",
+      "name": "goose parvovirus antiserum"
+    },
+    {
+      "code": "QI01DN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01DO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01DP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01DQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01DR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01DS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01DU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01DV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01DX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01E",
+      "name": "PIGEON"
+    },
+    {
+      "code": "QI01EA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01EA01",
+      "name": "pigeon paramyxovirus"
+    },
+    {
+      "code": "QI01EB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01EC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01ED",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01ED01",
+      "name": "pigeon pox virus"
+    },
+    {
+      "code": "QI01EE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01EE01",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI01EF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01EG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01EH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01EH01",
+      "name": "live pigeon pox virus + inactivated pigeon paramyxovirus"
+    },
+    {
+      "code": "QI01EI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01EJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI01EK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01EL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01EM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01EN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01EO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01EP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01EQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01ER",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01ES",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01EU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01EV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01EX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01F",
+      "name": "PHEASANT"
+    },
+    {
+      "code": "QI01G",
+      "name": "QUAIL"
+    },
+    {
+      "code": "QI01H",
+      "name": "PARTRIDGE"
+    },
+    {
+      "code": "QI01I",
+      "name": "OSTRICH"
+    },
+    {
+      "code": "QI01K",
+      "name": "PET BIRDS"
+    },
+    {
+      "code": "QI01KA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI01KA01",
+      "name": "pacheco‘s virus / herpesvirus"
+    },
+    {
+      "code": "QI01KB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI01KC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI01KD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI01KD01",
+      "name": "canary pox virus"
+    },
+    {
+      "code": "QI01KD02",
+      "name": "pacheco‘s virus / herpesvirus"
+    },
+    {
+      "code": "QI01KE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI01KF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI01KG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01KH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI01KI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01KJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI01KK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI01KL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI01KM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI01KN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI01KO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI01KP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI01KQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI01KR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI01KS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI01KU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI01KV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI01KX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI01X",
+      "name": "AVES, OTHERS"
+    },
+    {
+      "code": "QI02",
+      "name": "IMMUNOLOGICALS FOR BOVIDAE"
+    },
+    {
+      "code": "QI02A",
+      "name": "CATTLE"
+    },
+    {
+      "code": "QI02AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI02AA01",
+      "name": "bovine viral diarrhea (BVD)"
+    },
+    {
+      "code": "QI02AA02",
+      "name": "bovine respiratory syncytial virus (BRSV)"
+    },
+    {
+      "code": "QI02AA03",
+      "name": "bovine rhinotracheitis virus (IBR)"
+    },
+    {
+      "code": "QI02AA04",
+      "name": "foot and mouth disease virus"
+    },
+    {
+      "code": "QI02AA05",
+      "name": "bovine parainfluenza virus + bovine adenovirus + bovine reovirus"
+    },
+    {
+      "code": "QI02AA06",
+      "name": "bovine parainfluenza virus + bovine adenovirus + bovine reovirus + bovine rhinotracheitis virus"
+    },
+    {
+      "code": "QI02AA07",
+      "name": "bovine parainfluenza virus + bovine adenovirus + bovine reovirus + bovine respiratory syncytial virus"
+    },
+    {
+      "code": "QI02AA08",
+      "name": "bluetongue virus"
+    },
+    {
+      "code": "QI02AA09",
+      "name": "bluetongue virus + lumpy skin disease virus"
+    },
+    {
+      "code": "QI02AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI02AB01",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI02AB02",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI02AB03",
+      "name": "leptospira"
+    },
+    {
+      "code": "QI02AB04",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI02AB05",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI02AB06",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI02AB07",
+      "name": "coxiella + chlamydia"
+    },
+    {
+      "code": "QI02AB08",
+      "name": "escherichia + salmonella + pasteurella + streptococcus"
+    },
+    {
+      "code": "QI02AB09",
+      "name": "escherichia + salmonella"
+    },
+    {
+      "code": "QI02AB10",
+      "name": "escherichia + salmonella + pasteurella"
+    },
+    {
+      "code": "QI02AB11",
+      "name": "clostridium + pasteurella"
+    },
+    {
+      "code": "QI02AB12",
+      "name": "clostridium + salmonella"
+    },
+    {
+      "code": "QI02AB13",
+      "name": "escherichia + streptococcus"
+    },
+    {
+      "code": "QI02AB14",
+      "name": "pasteurella + streptococcus + corynebacterium"
+    },
+    {
+      "code": "QI02AB15",
+      "name": "chlamydia"
+    },
+    {
+      "code": "QI02AB16",
+      "name": "streptococcus + staphylococcus + pseudomona + corynebacterium"
+    },
+    {
+      "code": "QI02AB17",
+      "name": "escherichia + staphylococcus"
+    },
+    {
+      "code": "QI02AB18",
+      "name": "streptococcus"
+    },
+    {
+      "code": "QI02AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI02AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI02AD01",
+      "name": "bovine rhinotracheitis virus (IBR)"
+    },
+    {
+      "code": "QI02AD02",
+      "name": "bovine viral diarrhea (BVD)"
+    },
+    {
+      "code": "QI02AD03",
+      "name": "bovine viral diarrhea + bovine respiratory syncytial virus"
+    },
+    {
+      "code": "QI02AD04",
+      "name": "bovine respiratory syncytial virus (BRSV)"
+    },
+    {
+      "code": "QI02AD05",
+      "name": "bovine parainfluenza virus"
+    },
+    {
+      "code": "QI02AD06",
+      "name": "bovine rhinotracheitis virus + bovine parainfluenza virus"
+    },
+    {
+      "code": "QI02AD07",
+      "name": "bovine respiratory syncytial virus + bovine parainfluenza virus"
+    },
+    {
+      "code": "QI02AD08",
+      "name": "bovine rotavirus + bovine coronavirus"
+    },
+    {
+      "code": "QI02AD09",
+      "name": "bovine rotavirus"
+    },
+    {
+      "code": "QI02AD10",
+      "name": "bovine coronavirus"
+    },
+    {
+      "code": "QI02AD11",
+      "name": "lumpy skin disease virus (LSDV)"
+    },
+    {
+      "code": "QI02AD12",
+      "name": "bovine respiratory syncytial virus + bovine parainfluenza virus + bovine coronavirus"
+    },
+    {
+      "code": "QI02AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI02AE01",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI02AE02",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI02AE03",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI02AE04",
+      "name": "bacillus anthracis"
+    },
+    {
+      "code": "QI02AE05",
+      "name": "mycoplasma"
+    },
+    {
+      "code": "QI02AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI02AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI02AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI02AH01",
+      "name": "live bovine rhinotracheitis virus (IBR) + live bovine respiratory syncytial virus (BRSV) + inactivated bovine viral diarrhea (BVD) + inactivated bovine parainfluenza virus"
+    },
+    {
+      "code": "QI02AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI02AI01",
+      "name": "live bovine rotavirus + live bovine coronavirus + inactivated escherichia"
+    },
+    {
+      "code": "QI02AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI02AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI02AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI02AL01",
+      "name": "bovine rotavirus + bovine coronavirus + escherichia"
+    },
+    {
+      "code": "QI02AL02",
+      "name": "bovine rotavirus + bovine coronavirus + parvovirus + escherichia"
+    },
+    {
+      "code": "QI02AL03",
+      "name": "bovine rotavirus + escherichia"
+    },
+    {
+      "code": "QI02AL04",
+      "name": "bovine parainfluenza virus + bovine  respiratory syncytial virus + pasteurella"
+    },
+    {
+      "code": "QI02AL05",
+      "name": "bovine rotavirus + bovine coronavirus + clostridium + escherichia"
+    },
+    {
+      "code": "QI02AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI02AM01",
+      "name": "escherichia antiserum"
+    },
+    {
+      "code": "QI02AM02",
+      "name": "salmonella antiserum"
+    },
+    {
+      "code": "QI02AM03",
+      "name": "pasteurella antiserum + salmonella antiserum + streptococcus antiserum + escherichia antiserum"
+    },
+    {
+      "code": "QI02AM04",
+      "name": "escherichia antiserum + pneumococci antiserum"
+    },
+    {
+      "code": "QI02AM05",
+      "name": "bovine rotavirus antiserum + bovine coronavirus antiserum + escherichia antiserum"
+    },
+    {
+      "code": "QI02AM06",
+      "name": "salmonella antiserum + pasteurella antiserum + escherichia antiserum"
+    },
+    {
+      "code": "QI02AM07",
+      "name": "salmonella antiserum + escherichia antiserum"
+    },
+    {
+      "code": "QI02AM08",
+      "name": "pasteurella antiserum"
+    },
+    {
+      "code": "QI02AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI02AN01",
+      "name": "dictyocaulus"
+    },
+    {
+      "code": "QI02AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI02AO01",
+      "name": "dictyocaulus"
+    },
+    {
+      "code": "QI02AO02",
+      "name": "cryptosporidium"
+    },
+    {
+      "code": "QI02AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI02AP01",
+      "name": "trichophyton"
+    },
+    {
+      "code": "QI02AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI02AQ01",
+      "name": "trichophyton"
+    },
+    {
+      "code": "QI02AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI02AR01",
+      "name": "bovine tuberculin PPD"
+    },
+    {
+      "code": "QI02AR02",
+      "name": "avian tuberculin PPD"
+    },
+    {
+      "code": "QI02AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI02AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI02AT01",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI02AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI02AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI02AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI02B",
+      "name": "BUFFALO"
+    },
+    {
+      "code": "QI02X",
+      "name": "BOVIDAE, OTHERS"
+    },
+    {
+      "code": "QI03",
+      "name": "IMMUNOLOGICALS FOR CAPRIDAE"
+    },
+    {
+      "code": "QI03A",
+      "name": "GOAT"
+    },
+    {
+      "code": "QI03AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI03AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI03AB01",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI03AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI03AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI03AD01",
+      "name": "peste de petits ruminants (PPR)"
+    },
+    {
+      "code": "QI03AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI03AE01",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI03AF",
+      "name": "Live bacterial and viral"
+    },
+    {
+      "code": "QI03AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI03AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI03AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI03AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI03AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI03AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI03AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI03AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI03AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI03AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI03AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI03AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI03AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI03AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI03AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI03AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI03AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI03X",
+      "name": "CAPRIDAE, OTHERS"
+    },
+    {
+      "code": "QI04",
+      "name": "IMMUNOLOGICALS FOR OVIDAE"
+    },
+    {
+      "code": "QI04A",
+      "name": "SHEEP"
+    },
+    {
+      "code": "QI04AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI04AA01",
+      "name": "louping ill virus"
+    },
+    {
+      "code": "QI04AA02",
+      "name": "bluetongue virus"
+    },
+    {
+      "code": "QI04AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI04AB01",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI04AB02",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI04AB03",
+      "name": "bacteroides"
+    },
+    {
+      "code": "QI04AB04",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI04AB05",
+      "name": "clostridium + pasteurella"
+    },
+    {
+      "code": "QI04AB06",
+      "name": "chlamydia"
+    },
+    {
+      "code": "QI04AB08",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI04AB09",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI04AB10",
+      "name": "staphylococcus"
+    },
+    {
+      "code": "QI04AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI04AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI04AD01",
+      "name": "orf virus / contagious pustular dermatitis"
+    },
+    {
+      "code": "QI04AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI04AE01",
+      "name": "chlamydia"
+    },
+    {
+      "code": "QI04AE02",
+      "name": "listeria"
+    },
+    {
+      "code": "QI04AE03",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QI04AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI04AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI04AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI04AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI04AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI04AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI04AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI04AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI04AM01",
+      "name": "pasteurella antiserum"
+    },
+    {
+      "code": "QI04AM02",
+      "name": "clostridium antiserum"
+    },
+    {
+      "code": "QI04AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI04AN01",
+      "name": "toxoplasma"
+    },
+    {
+      "code": "QI04AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI04AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI04AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI04AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI04AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI04AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI04AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI04AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI04AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI04X",
+      "name": "OVIDAE, OTHERS"
+    },
+    {
+      "code": "QI05",
+      "name": "IMMUNOLOGICALS FOR EQUIDAE"
+    },
+    {
+      "code": "QI05A",
+      "name": "HORSE"
+    },
+    {
+      "code": "QI05AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI05AA01",
+      "name": "equine influenza virus"
+    },
+    {
+      "code": "QI05AA03",
+      "name": "equine rhinopneumonitis virus + equine reovirus + equine influenza virus"
+    },
+    {
+      "code": "QI05AA04",
+      "name": "equine rhinopneumonitis virus + equine influenza virus"
+    },
+    {
+      "code": "QI05AA05",
+      "name": "equine rhinopneumonitis virus"
+    },
+    {
+      "code": "QI05AA06",
+      "name": "equine reovirus"
+    },
+    {
+      "code": "QI05AA07",
+      "name": "equine arteritis virus"
+    },
+    {
+      "code": "QI05AA08",
+      "name": "equine parapox virus"
+    },
+    {
+      "code": "QI05AA09",
+      "name": "equine rotavirus"
+    },
+    {
+      "code": "QI05AA10",
+      "name": "west nile virus"
+    },
+    {
+      "code": "QI05AA11",
+      "name": "equine rhinopneumonitis virus + equine abortion virus"
+    },
+    {
+      "code": "QI05AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI05AB01",
+      "name": "streptococcus"
+    },
+    {
+      "code": "QI05AB02",
+      "name": "actinobacillus + escherichia + salmonella + streptococcus"
+    },
+    {
+      "code": "QI05AB03",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI05AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI05AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI05AD01",
+      "name": "equine rhinopneumonitis virus"
+    },
+    {
+      "code": "QI05AD02",
+      "name": "equine influenza virus"
+    },
+    {
+      "code": "QI05AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI05AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI05AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI05AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI05AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI05AI01",
+      "name": "equine influenza virus + clostridium"
+    },
+    {
+      "code": "QI05AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI05AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI05AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI05AL01",
+      "name": "equine influenza virus + clostridium"
+    },
+    {
+      "code": "QI05AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI05AM01",
+      "name": "clostridium antiserum"
+    },
+    {
+      "code": "QI05AM02",
+      "name": "antilipopolysacharide antiserum"
+    },
+    {
+      "code": "QI05AM03",
+      "name": "actinobacillus antiserum + escherichia antiserum + salmonella antiserum + streptococcus antiserum"
+    },
+    {
+      "code": "QI05AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI05AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI05AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI05AP01",
+      "name": "trichophyton"
+    },
+    {
+      "code": "QI05AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI05AQ01",
+      "name": "trichophyton"
+    },
+    {
+      "code": "QI05AQ02",
+      "name": "trichophyton + microsporum"
+    },
+    {
+      "code": "QI05AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI05AR01",
+      "name": "mallein"
+    },
+    {
+      "code": "QI05AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI05AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI05AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI05AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI05AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI05AX01",
+      "name": "parapox ovis virus, inactivated"
+    },
+    {
+      "code": "QI05AX02",
+      "name": "propionibacterium acnes, inactivated"
+    },
+    {
+      "code": "QI05B",
+      "name": "ASININE/DONKEY"
+    },
+    {
+      "code": "QI05C",
+      "name": "HYBRIDE"
+    },
+    {
+      "code": "QI05X",
+      "name": "EQUIDAE, OTHERS"
+    },
+    {
+      "code": "QI06",
+      "name": "IMMUNOLOGICALS FOR FELIDAE"
+    },
+    {
+      "code": "QI06A",
+      "name": "CAT"
+    },
+    {
+      "code": "QI06AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI06AA01",
+      "name": "feline leukaemia virus"
+    },
+    {
+      "code": "QI06AA02",
+      "name": "feline panleucopenia virus / parvovirus"
+    },
+    {
+      "code": "QI06AA03",
+      "name": "rabies virus + feline rhinotracheitis virus + feline calicivirus"
+    },
+    {
+      "code": "QI06AA04",
+      "name": "feline rhinotracheitis virus + feline calicivirus + feline panleucopenia virus / parvovirus"
+    },
+    {
+      "code": "QI06AA05",
+      "name": "feline rhinotracheitis virus + feline calicivirus"
+    },
+    {
+      "code": "QI06AA06",
+      "name": "feline infectious peritonitis virus"
+    },
+    {
+      "code": "QI06AA07",
+      "name": "feline calicivirus"
+    },
+    {
+      "code": "QI06AA08",
+      "name": "feline rhinotracheitis virus"
+    },
+    {
+      "code": "QI06AA09",
+      "name": "feline panleucopenia virus + feline calcivirus + feline rhinotracheitis virus + rabies virus"
+    },
+    {
+      "code": "QI06AA10",
+      "name": "feline immunodeficiency virus"
+    },
+    {
+      "code": "QI06AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI06AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI06AC01",
+      "name": "chlamydia vaccine"
+    },
+    {
+      "code": "QI06AC02",
+      "name": "bordetella vaccine"
+    },
+    {
+      "code": "QI06AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI06AD01",
+      "name": "feline panleucopenia virus / parvovirus"
+    },
+    {
+      "code": "QI06AD02",
+      "name": "feline infectious peritonitis virus"
+    },
+    {
+      "code": "QI06AD03",
+      "name": "feline rhinotracheitis virus + feline calicivirus"
+    },
+    {
+      "code": "QI06AD04",
+      "name": "feline panleucopenia virus / parvovirus + feline rhinotracheitis virus + feline calicivirus"
+    },
+    {
+      "code": "QI06AD05",
+      "name": "feline panleucopenia virus / parvovirus + feline rhinotracheitis virus"
+    },
+    {
+      "code": "QI06AD06",
+      "name": "feline parapox virus"
+    },
+    {
+      "code": "QI06AD07",
+      "name": "feline leukaemia, recombinant live canarypox virus"
+    },
+    {
+      "code": "QI06AD08",
+      "name": "rabies, recombinant live canarypox virus"
+    },
+    {
+      "code": "QI06AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI06AE01",
+      "name": "chlamydia"
+    },
+    {
+      "code": "QI06AE02",
+      "name": "bordetella"
+    },
+    {
+      "code": "QI06AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI06AF01",
+      "name": "feline panleucopenia virus / parvovirus + feline rhinotracheitis virus + feline calicivirus + chlamydia"
+    },
+    {
+      "code": "QI06AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI06AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI06AH01",
+      "name": "live feline rhinotracheitis virus + live feline calicivirus + inactivated feline panleucopenia virus / parvovirus"
+    },
+    {
+      "code": "QI06AH02",
+      "name": "live feline panleucopenia virus / parvovirus + inactivated rabies virus"
+    },
+    {
+      "code": "QI06AH03",
+      "name": "live feline rhinotracheitis virus + inactivated feline panleucopenia virus / parvovirus"
+    },
+    {
+      "code": "QI06AH04",
+      "name": "live feline panleucopenia virus / parvovirus + inactivated rabies virus + inactivated feline rhinotracheitis virus + inactivated feline calicivirus"
+    },
+    {
+      "code": "QI06AH05",
+      "name": "live feline panleucopenia virus / parvovirus + live feline rhinotracheitis virus + live feline calicivirus + inactivated rabies virus"
+    },
+    {
+      "code": "QI06AH06",
+      "name": "live feline panleucopenia virus / parvovirus + inactivated feline rhinotracheitis virus + inactivated feline calicivirus"
+    },
+    {
+      "code": "QI06AH07",
+      "name": "live feline panleucopenia virus / parvovirus + live feline rhinotracheitis virus + live feline calicivirus + inactivated feline leukaemia virus"
+    },
+    {
+      "code": "QI06AH08",
+      "name": "live feline rhinotracheitis virus + inactivated feline calicivirus antigen"
+    },
+    {
+      "code": "QI06AH09",
+      "name": "live feline rhinotracheitis virus + live feline panleucopenia virus / parvovirus + inactivated feline calicivirus antigen"
+    },
+    {
+      "code": "QI06AH10",
+      "name": "live feline rhinotracheitis virus + live feline panleucopenia virus / parvovirus + inactivated feline calicivirus + feline leukaemia, recombinant live canarypox virus"
+    },
+    {
+      "code": "QI06AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI06AI01",
+      "name": "live feline panleucopenia virus / parvovirus + live feline rhinotracheitis virus + live feline calicivirus + inactivated chlamydia"
+    },
+    {
+      "code": "QI06AI02",
+      "name": "live feline rhinotracheitis virus + live feline calicivirus + inactivated chlamydia"
+    },
+    {
+      "code": "QI06AI03",
+      "name": "live feline panleucopenia virus / parvovirus + live feline rhinotracheitis virus + live feline calicivirus + live feline leukaemia virus + inactivated chlamydia"
+    },
+    {
+      "code": "QI06AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI06AJ01",
+      "name": "live feline rhinotracheitis virus + live feline calicivirus + inactivated feline panleucopenia virus / parvovirus + live chlamydia"
+    },
+    {
+      "code": "QI06AJ02",
+      "name": "live feline rhinotracheitis virus + inactivated feline calicivirus antigen + live chlamydia"
+    },
+    {
+      "code": "QI06AJ03",
+      "name": "live feline rhinotracheitis virus + inactivated feline calicivirus antigen + live feline panleucopenia virus / parvovirus + live chlamydia"
+    },
+    {
+      "code": "QI06AJ04",
+      "name": "live feline rhinotracheitis virus + live feline calicivirus + live chlamydia + inactivated feline panleucopenia virus / inactivated feline leukaemia virus"
+    },
+    {
+      "code": "QI06AJ05",
+      "name": "live feline rhinotracheitis virus + inactivated feline calicivirus antigen + live feline panleucopenia virus / parvovirus + live chlamydia + feline leukaemia recombinant live canarypox virus"
+    },
+    {
+      "code": "QI06AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI06AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI06AL01",
+      "name": "feline panleucopenia virus / parvovirus + feline rhinotracheitis virus + feline calicivirus + feline infectious leukaemia virus + chlamydia"
+    },
+    {
+      "code": "QI06AL02",
+      "name": "feline panleucopenia virus / parvovirus + feline rhinotracheitis virus + feline calicivirus + inactivated chlamydia"
+    },
+    {
+      "code": "QI06AL03",
+      "name": "feline rhinotracheitis virus + feline calicivirus + chlamydia"
+    },
+    {
+      "code": "QI06AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI06AM01",
+      "name": "feline panleucopenia virus / parvovirus antiserum + feline rhinotracheitis virus antiserum + feline calicivirus antiserum"
+    },
+    {
+      "code": "QI06AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI06AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI06AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI06AP01",
+      "name": "trichophyton"
+    },
+    {
+      "code": "QI06AP02",
+      "name": "trichophyton + microsporum"
+    },
+    {
+      "code": "QI06AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI06AQ01",
+      "name": "trichophyton + microsporum"
+    },
+    {
+      "code": "QI06AQ02",
+      "name": "microsporum"
+    },
+    {
+      "code": "QI06AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI06AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI06AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI06AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI06AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI06AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI06X",
+      "name": "FELIDAE, OTHERS"
+    },
+    {
+      "code": "QI07",
+      "name": "IMMUNOLOGICALS FOR CANIDAE"
+    },
+    {
+      "code": "QI07A",
+      "name": "DOG"
+    },
+    {
+      "code": "QI07AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI07AA01",
+      "name": "canine parvovirus"
+    },
+    {
+      "code": "QI07AA02",
+      "name": "rabies virus"
+    },
+    {
+      "code": "QI07AA03",
+      "name": "canine parainfluenza virus + canine reovirus + canine influenza virus"
+    },
+    {
+      "code": "QI07AA04",
+      "name": "canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AA05",
+      "name": "canine adenovirus"
+    },
+    {
+      "code": "QI07AA06",
+      "name": "canine herpesvirus"
+    },
+    {
+      "code": "QI07AA07",
+      "name": "canine influenza virus"
+    },
+    {
+      "code": "QI07AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI07AB01",
+      "name": "leptospira"
+    },
+    {
+      "code": "QI07AB02",
+      "name": "staphylococcus"
+    },
+    {
+      "code": "QI07AB03",
+      "name": "bordetella"
+    },
+    {
+      "code": "QI07AB04",
+      "name": "borrelia"
+    },
+    {
+      "code": "QI07AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI07AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI07AD01",
+      "name": "canine parvovirus"
+    },
+    {
+      "code": "QI07AD02",
+      "name": "canine distemper virus + canine adenovirus + canine parvovirus"
+    },
+    {
+      "code": "QI07AD03",
+      "name": "canine distemper virus + canine parvovirus"
+    },
+    {
+      "code": "QI07AD04",
+      "name": "canine distemper virus + canine adenovirus + canine parvovirus + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AD05",
+      "name": "canine distemper virus"
+    },
+    {
+      "code": "QI07AD06",
+      "name": "canine distemper virus + canine adenovirus"
+    },
+    {
+      "code": "QI07AD07",
+      "name": "canine distemper virus + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AD08",
+      "name": "canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AD09",
+      "name": "canine parvovirus + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AD10",
+      "name": "canine distemper virus + canine adenovirus + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AD11",
+      "name": "canine coronavirus"
+    },
+    {
+      "code": "QI07AD12",
+      "name": "canine coronavirus + canine parvovirus"
+    },
+    {
+      "code": "QI07AD13",
+      "name": "canine parapox virus"
+    },
+    {
+      "code": "QI07AD14",
+      "name": "canine distemper virus based on measles virus"
+    },
+    {
+      "code": "QI07AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI07AE01",
+      "name": "bordetella"
+    },
+    {
+      "code": "QI07AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI07AF01",
+      "name": "bordetella + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AF02",
+      "name": "bordetella + canine adenovirus + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI07AH01",
+      "name": "live canine distemper virus + inactivated canine adenovirus + inactivated canine parvovirus"
+    },
+    {
+      "code": "QI07AH02",
+      "name": "live canine parainfluenza virus + inactivated canine parvovirus"
+    },
+    {
+      "code": "QI07AH03",
+      "name": "live canine distemper virus + live canine parainfluenza virus + inactivated canine adenovirus + inactivated canine parvovirus"
+    },
+    {
+      "code": "QI07AH04",
+      "name": "live canine distemper virus + live canine parvovirus + inactivated canine coronavirus"
+    },
+    {
+      "code": "QI07AH05",
+      "name": "live canine distemper virus + live canine adenovirus + live canine parvovirus + live canine parainfluenza virus + inactivated feline coronavirus"
+    },
+    {
+      "code": "QI07AH06",
+      "name": "live canine parainfluenza virus + inactivated feline coronavirus"
+    },
+    {
+      "code": "QI07AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07AI01",
+      "name": "live canine distemper virus + live canine adenovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI02",
+      "name": "live canine distemper virus + live canine adenovirus + live canine parainfluenza virus + live canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI03",
+      "name": "live canine distemper virus + live canine adenovirus + live canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI04",
+      "name": "live canine distemper virus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI05",
+      "name": "live canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI06",
+      "name": "live canine distemper virus + live canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI07",
+      "name": "live canine parvovirus + live canine parainfluenza virus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AI08",
+      "name": "live canine parainfluenza virus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI07AJ01",
+      "name": "live canine distemper virus + inactivated canine adenovirus + inactivated rabies + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ02",
+      "name": "live canine distemper virus + inactivated canine adenovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ03",
+      "name": "live canine distemper virus + inactivated canine adenovirus + inactivated canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ04",
+      "name": "live canine distemper virus + inactivated canine adenovirus + inactivated canine parvovirus + inactivated rabies + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ05",
+      "name": "live canine distemper virus + live canine adenovirus + live canine parvovirus + inactivated rabies + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ06",
+      "name": "live canine distemper virus + live canine adenovirus + live parainfluenza virus + live canine parvovirus + inactivated rabies + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ07",
+      "name": "live canine distemper virus + live canine adenovirus + inactivated rabies + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ08",
+      "name": "live canine distemper virus + live canine adenovirus + inactivated canine parvovirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ10",
+      "name": "live canine distemper virus + live canine adenovirus + live parainfluenza virus + live canine parvovirus + inactivated canine coronavirus + inactivated leptospira"
+    },
+    {
+      "code": "QI07AJ11",
+      "name": "live canine parvovirus + live canine parainfluenza virus + inactivated leptospira + inactivated canine coronavirus"
+    },
+    {
+      "code": "QI07AJ12",
+      "name": "live canine parainfluenza virus + inactivated leptospira + inactivated canine coronavirus"
+    },
+    {
+      "code": "QI07AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI07AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07AL01",
+      "name": "rabies virus + leptospira"
+    },
+    {
+      "code": "QI07AL02",
+      "name": "rabies virus + canine parvovirus + leptospira"
+    },
+    {
+      "code": "QI07AL03",
+      "name": "canine distemper virus + canine adenovirus + canine parvovirus + rabies virus + leptospira"
+    },
+    {
+      "code": "QI07AL04",
+      "name": "canine parvovirus + leptospira"
+    },
+    {
+      "code": "QI07AL05",
+      "name": "bordetella + canine parainfluenza virus"
+    },
+    {
+      "code": "QI07AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI07AM01",
+      "name": "canine distemper antiserum + canine adenovirus antiserum + canine parvovirus antiserum + leptospira antiserum"
+    },
+    {
+      "code": "QI07AM02",
+      "name": "anti lipopolysacharide antiserum"
+    },
+    {
+      "code": "QI07AM03",
+      "name": "canine distemper antiserum + canine adenovirus antiserum + canine parvovirus antiserum"
+    },
+    {
+      "code": "QI07AM04",
+      "name": "snake venom antiserum"
+    },
+    {
+      "code": "QI07AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI07AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI07AO01",
+      "name": "leishmania"
+    },
+    {
+      "code": "QI07AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI07AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI07AQ01",
+      "name": "trichophyton + microsporum"
+    },
+    {
+      "code": "QI07AQ02",
+      "name": "microsporum vaccine"
+    },
+    {
+      "code": "QI07AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI07AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI07AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI07AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI07AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI07AV01",
+      "name": "staphylococcus + bacteriophage"
+    },
+    {
+      "code": "QI07AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI07B",
+      "name": "FOX"
+    },
+    {
+      "code": "QI07BA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI07BB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI07BC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI07BD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI07BE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI07BF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI07BG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07BH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI07BI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07BJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI07BK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI07BL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07BM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI07BN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI07BO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI07BP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI07BQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI07BR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI07BS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI07BT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI07BU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI07BV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI07BX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI07X",
+      "name": "CANIDAE, OTHERS"
+    },
+    {
+      "code": "QI07XA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI07XB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI07XC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI07XD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI07XE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI07XF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI07XG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07XH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI07XI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07XJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI07XK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI07XL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI07XM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI07XN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI07XO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI07XP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI07XQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI07XR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI07XS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI07XT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI07XU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI07XV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI07XX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI08",
+      "name": "IMMUNOLOGICALS FOR LEPORIDAE"
+    },
+    {
+      "code": "QI08A",
+      "name": "RABBIT"
+    },
+    {
+      "code": "QI08AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI08AA01",
+      "name": "rabbit haemorrhagic disease virus"
+    },
+    {
+      "code": "QI08AA02",
+      "name": "rabbit distemper virus"
+    },
+    {
+      "code": "QI08AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI08AB01",
+      "name": "pasteurella + bordetella"
+    },
+    {
+      "code": "QI08AB02",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI08AB03",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI08AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI08AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI08AD01",
+      "name": "shope fibroma virus"
+    },
+    {
+      "code": "QI08AD02",
+      "name": "myxomatosis virus"
+    },
+    {
+      "code": "QI08AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI08AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI08AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI08AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI08AH01",
+      "name": "live myxomatosis virus + inactivated rabbit haemorrhagic disease virus"
+    },
+    {
+      "code": "QI08AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI08AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI08AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI08AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI08AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI08AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI08AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI08AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI08AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI08AQ01",
+      "name": "trichophyton + microsporum"
+    },
+    {
+      "code": "QI08AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI08AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI08AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI08AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI08AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI08AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI08B",
+      "name": "HARE"
+    },
+    {
+      "code": "QI08X",
+      "name": "LEPORIDAE, OTHERS"
+    },
+    {
+      "code": "QI09",
+      "name": "IMMUNOLOGICALS FOR SUIDAE"
+    },
+    {
+      "code": "QI09A",
+      "name": "PIG"
+    },
+    {
+      "code": "QI09AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI09AA01",
+      "name": "aujeszky‘s disease virus"
+    },
+    {
+      "code": "QI09AA02",
+      "name": "porcine parvovirus"
+    },
+    {
+      "code": "QI09AA03",
+      "name": "porcine influenza virus"
+    },
+    {
+      "code": "QI09AA04",
+      "name": "aujeszky´s disease virus + porcine influenza virus"
+    },
+    {
+      "code": "QI09AA05",
+      "name": "porcine reproductive and respiratory syndrome (PRRS) virus"
+    },
+    {
+      "code": "QI09AA06",
+      "name": "classical swine fever virus"
+    },
+    {
+      "code": "QI09AA07",
+      "name": "porcine circovirus"
+    },
+    {
+      "code": "QI09AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI09AB01",
+      "name": "treponema"
+    },
+    {
+      "code": "QI09AB02",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI09AB03",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI09AB04",
+      "name": "bordetella + pasteurella"
+    },
+    {
+      "code": "QI09AB05",
+      "name": "pasteurella"
+    },
+    {
+      "code": "QI09AB06",
+      "name": "actinobacillus/haemophilus + pasteurella"
+    },
+    {
+      "code": "QI09AB07",
+      "name": "actinobacillus/haemophilus vaccine"
+    },
+    {
+      "code": "QI09AB08",
+      "name": "escherichia + clostridium"
+    },
+    {
+      "code": "QI09AB09",
+      "name": "escherichia + erysipelothrix"
+    },
+    {
+      "code": "QI09AB10",
+      "name": "pasteurella + staphylococcus + corynebacterium"
+    },
+    {
+      "code": "QI09AB11",
+      "name": "escherichia + pasteurella + salmonella + streptococcus"
+    },
+    {
+      "code": "QI09AB12",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI09AB13",
+      "name": "mycoplasma"
+    },
+    {
+      "code": "QI09AB14",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI09AB15",
+      "name": "escherichia + erysipelothrix + clostridium"
+    },
+    {
+      "code": "QI09AB16",
+      "name": "bordetella + pasteurella + mycoplasma"
+    },
+    {
+      "code": "QI09AB17",
+      "name": "mycoplasma + haemophilus"
+    },
+    {
+      "code": "QI09AB18",
+      "name": "lawsonia"
+    },
+    {
+      "code": "QI09AB19",
+      "name": "brachyspira"
+    },
+    {
+      "code": "QI09AB20",
+      "name": "streptococcus"
+    },
+    {
+      "code": "QI09AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI09AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI09AD01",
+      "name": "aujeszky‘s disease virus"
+    },
+    {
+      "code": "QI09AD02",
+      "name": "porcine transmissable gastro-enteritis (TGE) virus"
+    },
+    {
+      "code": "QI09AD03",
+      "name": "porcine reproductive and respiratory syndrome (PRRS) virus"
+    },
+    {
+      "code": "QI09AD04",
+      "name": "classical swine fever virus"
+    },
+    {
+      "code": "QI09AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI09AE01",
+      "name": "erysipelothrix"
+    },
+    {
+      "code": "QI09AE02",
+      "name": "salmonella"
+    },
+    {
+      "code": "QI09AE03",
+      "name": "escherichia"
+    },
+    {
+      "code": "QI09AE04",
+      "name": "lawsonia"
+    },
+    {
+      "code": "QI09AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI09AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI09AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI09AH01",
+      "name": "live aujeszky‘s disease virus + inactivated porcine influenza virus"
+    },
+    {
+      "code": "QI09AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI09AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI09AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI09AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI09AL01",
+      "name": "porcine parvovirus + erysipelothrix"
+    },
+    {
+      "code": "QI09AL02",
+      "name": "porcine rotavirus + escherichia"
+    },
+    {
+      "code": "QI09AL03",
+      "name": "porcine parvovirus + escherichia + erysipelothrix"
+    },
+    {
+      "code": "QI09AL04",
+      "name": "porcine influenza virus + erysipelothrix"
+    },
+    {
+      "code": "QI09AL05",
+      "name": "porcine transmissable gastro-enteritis virus (TGE) + escherichia + clostridium"
+    },
+    {
+      "code": "QI09AL06",
+      "name": "porcine parvovirus + porcine influenza virus + erysipelothrix"
+    },
+    {
+      "code": "QI09AL07",
+      "name": "porcine parvovirus + erysipelothrix + leptospira"
+    },
+    {
+      "code": "QI09AL08",
+      "name": "porcine circovirus + mycoplasma"
+    },
+    {
+      "code": "QI09AL09",
+      "name": "porcine rotavirus + escherichia + clostridium"
+    },
+    {
+      "code": "QI09AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI09AM01",
+      "name": "escherichia antiserum and monoclonal antibodies"
+    },
+    {
+      "code": "QI09AM02",
+      "name": "pasteurella antiserum"
+    },
+    {
+      "code": "QI09AM03",
+      "name": "erysipelothrix antiserum"
+    },
+    {
+      "code": "QI09AM04",
+      "name": "clostridium antiserum"
+    },
+    {
+      "code": "QI09AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI09AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI09AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI09AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI09AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI09AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI09AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI09AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI09AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI09AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI09X",
+      "name": "SUIDAE, OTHERS"
+    },
+    {
+      "code": "QI10",
+      "name": "IMMUNOLOGICALS FOR PISCES"
+    },
+    {
+      "code": "QI10A",
+      "name": "ATLANTIC SALMON"
+    },
+    {
+      "code": "QI10AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI10AA01",
+      "name": "salmon pancreas disease (SPD) virus"
+    },
+    {
+      "code": "QI10AA02",
+      "name": "salmon pancreas disease (SPD), protein coding plasmid"
+    },
+    {
+      "code": "QI10AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI10AB01",
+      "name": "aeromonas"
+    },
+    {
+      "code": "QI10AB02",
+      "name": "aeromonas + vibrio"
+    },
+    {
+      "code": "QI10AB03",
+      "name": "aeromonas + moritella + vibrio"
+    },
+    {
+      "code": "QI10AB04",
+      "name": "yersinia"
+    },
+    {
+      "code": "QI10AB05",
+      "name": "moritella"
+    },
+    {
+      "code": "QI10AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI10AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI10AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI10AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI10AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI10AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI10AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI10AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10AL01",
+      "name": "infectious pancreatic necrosis (IPN) virus + aeromonas + vibrio"
+    },
+    {
+      "code": "QI10AL02",
+      "name": "infectious pancreatic necrosis (IPN) virus + aeromonas + moritella + vibrio"
+    },
+    {
+      "code": "QI10AL03",
+      "name": "infectious pancreatic necrosis (IPN) virus + aeromonas"
+    },
+    {
+      "code": "QI10AL04",
+      "name": "infectious pancreatic necrosis (IPN) virus + infectious salmon anaemia (ISA) virus + aeromonas + moritella + vibrio"
+    },
+    {
+      "code": "QI10AL05",
+      "name": "infectious pancreatic necrosis (IPN) virus + salmon pancreatic disease (SPD) virus + aeromonas + moritella + vibrio"
+    },
+    {
+      "code": "QI10AL06",
+      "name": "infectious pancreatic necrosis (IPN) virus + aeromonas + moritella + vibrio + yersinia"
+    },
+    {
+      "code": "QI10AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI10AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI10AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI10AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI10AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI10AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI10AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI10AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI10AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI10AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI10B",
+      "name": "RAINBOW TROUT"
+    },
+    {
+      "code": "QI10BA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI10BB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI10BB01",
+      "name": "vibrio"
+    },
+    {
+      "code": "QI10BB02",
+      "name": "aeromonas + vibrio"
+    },
+    {
+      "code": "QI10BB03",
+      "name": "yersinia"
+    },
+    {
+      "code": "QI10BB04",
+      "name": "aeromonas + moritella + vibrio + flavobacterium"
+    },
+    {
+      "code": "QI10BC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI10BD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI10BE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI10BF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI10BG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10BH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI10BI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10BJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI10BK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI10BL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI10BM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI10BN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI10BO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI10BP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI10BQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI10BR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI10BS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI10BU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI10BV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI10BX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI10C",
+      "name": "CARP"
+    },
+    {
+      "code": "QI10D",
+      "name": "TURBOT"
+    },
+    {
+      "code": "QI10E",
+      "name": "ORNAMENTAL FISH"
+    },
+    {
+      "code": "QI10F",
+      "name": "ATLANTIC COD"
+    },
+    {
+      "code": "QI10FB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI10FB01",
+      "name": "vibrio"
+    },
+    {
+      "code": "QI10FB02",
+      "name": "aeromonas + vibrio"
+    },
+    {
+      "code": "QI10G",
+      "name": "SEA BASS"
+    },
+    {
+      "code": "QI10GA",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI10GA01",
+      "name": "vibrio"
+    },
+    {
+      "code": "QI10X",
+      "name": "PISCES, OTHERS"
+    },
+    {
+      "code": "QI11",
+      "name": "IMMUNOLOGICALS FOR RODENTS"
+    },
+    {
+      "code": "QI11A",
+      "name": "RAT"
+    },
+    {
+      "code": "QI11B",
+      "name": "MOUSE"
+    },
+    {
+      "code": "QI11C",
+      "name": "GUINEA-PIG"
+    },
+    {
+      "code": "QI11X",
+      "name": "RODENTS, OTHERS"
+    },
+    {
+      "code": "QI20",
+      "name": "IMMUNOLOGICALS FOR OTHER SPECIES"
+    },
+    {
+      "code": "QI20A",
+      "name": "RED DEER"
+    },
+    {
+      "code": "QI20AA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI20AB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI20AB01",
+      "name": "mycobacteria"
+    },
+    {
+      "code": "QI20AC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI20AD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI20AE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI20AF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI20AG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20AH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI20AI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20AJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI20AK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI20AL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20AM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI20AN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI20AO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI20AP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI20AQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI20AR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI20AS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI20AT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI20AU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI20AV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI20AX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI20B",
+      "name": "REINDEER"
+    },
+    {
+      "code": "QI20C",
+      "name": "MINK"
+    },
+    {
+      "code": "QI20CA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI20CA01",
+      "name": "mink enteritis virus"
+    },
+    {
+      "code": "QI20CB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI20CB01",
+      "name": "clostridium"
+    },
+    {
+      "code": "QI20CC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI20CD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI20CD01",
+      "name": "mink distemper virus"
+    },
+    {
+      "code": "QI20CE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI20CF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI20CG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20CH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI20CH01",
+      "name": "live mink distemper virus + inactivated mink enteritis virus"
+    },
+    {
+      "code": "QI20CI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20CJ",
+      "name": "Live viral and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI20CJ01",
+      "name": "live mink distemper virus + inactivated mink enteritisvirus / parvovirus + inactivated clostridium + inactivated pseudomonas"
+    },
+    {
+      "code": "QI20CK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI20CL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20CL01",
+      "name": "mink enteritisvirus /parvovirus + inactivated clostridium + inactivated pseudomonas"
+    },
+    {
+      "code": "QI20CL02",
+      "name": "mink enteritisvirus /parvovirus + inactivated clostridium"
+    },
+    {
+      "code": "QI20CM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI20CN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI20CO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI20CP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI20CQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI20CR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI20CS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI20CT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI20CU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI20CV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI20CX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI20D",
+      "name": "FERRET"
+    },
+    {
+      "code": "QI20DA",
+      "name": "Inactivated viral vaccines"
+    },
+    {
+      "code": "QI20DB",
+      "name": "Inactivated bacterial vaccines (including mycoplasma, toxoid and chlamydia)"
+    },
+    {
+      "code": "QI20DC",
+      "name": "Inactivated bacterial vaccines and antisera"
+    },
+    {
+      "code": "QI20DD",
+      "name": "Live viral vaccines"
+    },
+    {
+      "code": "QI20DD01",
+      "name": "ferret distemper virus"
+    },
+    {
+      "code": "QI20DE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI20DF",
+      "name": "Live bacterial and viral vaccines"
+    },
+    {
+      "code": "QI20DG",
+      "name": "Live and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20DH",
+      "name": "Live and inactivated viral vaccines"
+    },
+    {
+      "code": "QI20DI",
+      "name": "Live viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20DJ",
+      "name": "Live and inactivated viral and bacterial vaccines"
+    },
+    {
+      "code": "QI20DK",
+      "name": "Inactivated viral and live bacterial vaccines"
+    },
+    {
+      "code": "QI20DL",
+      "name": "Inactivated viral and inactivated bacterial vaccines"
+    },
+    {
+      "code": "QI20DM",
+      "name": "Antisera, immunoglobulin preparations, and antitoxins"
+    },
+    {
+      "code": "QI20DN",
+      "name": "Live parasitic vaccines"
+    },
+    {
+      "code": "QI20DO",
+      "name": "Inactivated parasitic vaccines"
+    },
+    {
+      "code": "QI20DP",
+      "name": "Live fungal vaccines"
+    },
+    {
+      "code": "QI20DQ",
+      "name": "Inactivated fungal vaccines"
+    },
+    {
+      "code": "QI20DR",
+      "name": "In vivo diagnostic preparations"
+    },
+    {
+      "code": "QI20DS",
+      "name": "Allergens"
+    },
+    {
+      "code": "QI20DT",
+      "name": "Colostrum preparations and substitutes"
+    },
+    {
+      "code": "QI20DU",
+      "name": "Other live vaccines"
+    },
+    {
+      "code": "QI20DV",
+      "name": "Other inactivated vaccines"
+    },
+    {
+      "code": "QI20DX",
+      "name": "Other immunologicals"
+    },
+    {
+      "code": "QI20E",
+      "name": "SNAKE"
+    },
+    {
+      "code": "QI20F",
+      "name": "BEE"
+    },
+    {
+      "code": "QI20X",
+      "name": "OTHERS"
+    },
+    {
+      "code": "QI20XE",
+      "name": "Live bacterial vaccines"
+    },
+    {
+      "code": "QI20XE01",
+      "name": "mycobacterium"
+    },
+    {
+      "code": "QJ",
+      "name": "ANTIINFECTIVES FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QJ01",
+      "name": "ANTIBACTERIALS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QJ01A",
+      "name": "TETRACYCLINES"
+    },
+    {
+      "code": "QJ01AA",
+      "name": "Tetracyclines"
+    },
+    {
+      "code": "QJ01AA01",
+      "name": "demeclocycline"
+    },
+    {
+      "code": "QJ01AA02",
+      "name": "doxycycline"
+    },
+    {
+      "code": "QJ01AA03",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QJ01AA04",
+      "name": "lymecycline"
+    },
+    {
+      "code": "QJ01AA05",
+      "name": "metacycline"
+    },
+    {
+      "code": "QJ01AA06",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QJ01AA07",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QJ01AA08",
+      "name": "minocycline"
+    },
+    {
+      "code": "QJ01AA09",
+      "name": "rolitetracycline"
+    },
+    {
+      "code": "QJ01AA10",
+      "name": "penimepicycline"
+    },
+    {
+      "code": "QJ01AA11",
+      "name": "clomocycline"
+    },
+    {
+      "code": "QJ01AA12",
+      "name": "tigecycline"
+    },
+    {
+      "code": "QJ01AA13",
+      "name": "eravacycline"
+    },
+    {
+      "code": "QJ01AA14",
+      "name": "sarecycline"
+    },
+    {
+      "code": "QJ01AA15",
+      "name": "omadacycline"
+    },
+    {
+      "code": "QJ01AA20",
+      "name": "combinations of tetracyclines"
+    },
+    {
+      "code": "QJ01AA53",
+      "name": "chlortetracycline, combinations"
+    },
+    {
+      "code": "QJ01AA56",
+      "name": "oxytetracycline, combinations"
+    },
+    {
+      "code": "QJ01B",
+      "name": "AMPHENICOLS"
+    },
+    {
+      "code": "QJ01BA",
+      "name": "Amphenicols"
+    },
+    {
+      "code": "QJ01BA01",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QJ01BA02",
+      "name": "thiamphenicol"
+    },
+    {
+      "code": "QJ01BA52",
+      "name": "thiamphenicol, combinations"
+    },
+    {
+      "code": "QJ01BA90",
+      "name": "florfenicol"
+    },
+    {
+      "code": "QJ01BA99",
+      "name": "amphenicols, combinations"
+    },
+    {
+      "code": "QJ01C",
+      "name": "BETA-LACTAM ANTIBACTERIALS, PENICILLINS"
+    },
+    {
+      "code": "QJ01CA",
+      "name": "Penicillins with extended spectrum"
+    },
+    {
+      "code": "QJ01CA01",
+      "name": "ampicillin"
+    },
+    {
+      "code": "QJ01CA02",
+      "name": "pivampicillin"
+    },
+    {
+      "code": "QJ01CA03",
+      "name": "carbenicillin"
+    },
+    {
+      "code": "QJ01CA04",
+      "name": "amoxicillin"
+    },
+    {
+      "code": "QJ01CA05",
+      "name": "carindacillin"
+    },
+    {
+      "code": "QJ01CA06",
+      "name": "bacampicillin"
+    },
+    {
+      "code": "QJ01CA07",
+      "name": "epicillin"
+    },
+    {
+      "code": "QJ01CA08",
+      "name": "pivmecillinam"
+    },
+    {
+      "code": "QJ01CA09",
+      "name": "azlocillin"
+    },
+    {
+      "code": "QJ01CA10",
+      "name": "mezlocillin"
+    },
+    {
+      "code": "QJ01CA11",
+      "name": "mecillinam"
+    },
+    {
+      "code": "QJ01CA12",
+      "name": "piperacillin"
+    },
+    {
+      "code": "QJ01CA13",
+      "name": "ticarcillin"
+    },
+    {
+      "code": "QJ01CA14",
+      "name": "metampicillin"
+    },
+    {
+      "code": "QJ01CA15",
+      "name": "talampicillin"
+    },
+    {
+      "code": "QJ01CA16",
+      "name": "sulbenicillin"
+    },
+    {
+      "code": "QJ01CA17",
+      "name": "temocillin"
+    },
+    {
+      "code": "QJ01CA18",
+      "name": "hetacillin"
+    },
+    {
+      "code": "QJ01CA19",
+      "name": "aspoxicillin"
+    },
+    {
+      "code": "QJ01CA20",
+      "name": "combinations"
+    },
+    {
+      "code": "QJ01CA51",
+      "name": "ampicillin, combinations"
+    },
+    {
+      "code": "QJ01CE",
+      "name": "Beta-lactamase sensitive penicillins"
+    },
+    {
+      "code": "QJ01CE01",
+      "name": "benzylpenicillin"
+    },
+    {
+      "code": "QJ01CE02",
+      "name": "phenoxymethylpenicillin"
+    },
+    {
+      "code": "QJ01CE03",
+      "name": "propicillin"
+    },
+    {
+      "code": "QJ01CE04",
+      "name": "azidocillin"
+    },
+    {
+      "code": "QJ01CE05",
+      "name": "pheneticillin"
+    },
+    {
+      "code": "QJ01CE06",
+      "name": "penamecillin"
+    },
+    {
+      "code": "QJ01CE07",
+      "name": "clometocillin"
+    },
+    {
+      "code": "QJ01CE08",
+      "name": "benzathine benzylpenicillin"
+    },
+    {
+      "code": "QJ01CE09",
+      "name": "procaine benzylpenicillin"
+    },
+    {
+      "code": "QJ01CE10",
+      "name": "benzathine phenoxymethylpenicillin"
+    },
+    {
+      "code": "QJ01CE30",
+      "name": "combinations"
+    },
+    {
+      "code": "QJ01CE90",
+      "name": "penethamate hydriodide"
+    },
+    {
+      "code": "QJ01CE91",
+      "name": "benethamine penicillin"
+    },
+    {
+      "code": "QJ01CF",
+      "name": "Beta-lactamase resistant penicillins"
+    },
+    {
+      "code": "QJ01CF01",
+      "name": "dicloxacillin"
+    },
+    {
+      "code": "QJ01CF02",
+      "name": "cloxacillin"
+    },
+    {
+      "code": "QJ01CF03",
+      "name": "meticillin"
+    },
+    {
+      "code": "QJ01CF04",
+      "name": "oxacillin"
+    },
+    {
+      "code": "QJ01CF05",
+      "name": "flucloxacillin"
+    },
+    {
+      "code": "QJ01CF06",
+      "name": "nafcillin"
+    },
+    {
+      "code": "QJ01CG",
+      "name": "Beta-lactamase inhibitors"
+    },
+    {
+      "code": "QJ01CG01",
+      "name": "sulbactam"
+    },
+    {
+      "code": "QJ01CG02",
+      "name": "tazobactam"
+    },
+    {
+      "code": "QJ01CG30",
+      "name": "sulbactam and durlobactam"
+    },
+    {
+      "code": "QJ01CR",
+      "name": "Combinations of penicillins, incl. beta-lactamase inhibitors"
+    },
+    {
+      "code": "QJ01CR01",
+      "name": "ampicillin and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01CR02",
+      "name": "amoxicillin and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01CR03",
+      "name": "ticarcillin and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01CR04",
+      "name": "sultamicillin"
+    },
+    {
+      "code": "QJ01CR05",
+      "name": "piperacillin and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01CR50",
+      "name": "combinations of penicillins"
+    },
+    {
+      "code": "QJ01D",
+      "name": "OTHER BETA-LACTAM ANTIBACTERIALS"
+    },
+    {
+      "code": "QJ01DB",
+      "name": "First-generation cephalosporins"
+    },
+    {
+      "code": "QJ01DB01",
+      "name": "cefalexin"
+    },
+    {
+      "code": "QJ01DB02",
+      "name": "cefaloridine"
+    },
+    {
+      "code": "QJ01DB03",
+      "name": "cefalotin"
+    },
+    {
+      "code": "QJ01DB04",
+      "name": "cefazolin"
+    },
+    {
+      "code": "QJ01DB05",
+      "name": "cefadroxil"
+    },
+    {
+      "code": "QJ01DB06",
+      "name": "cefazedone"
+    },
+    {
+      "code": "QJ01DB07",
+      "name": "cefatrizine"
+    },
+    {
+      "code": "QJ01DB08",
+      "name": "cefapirin"
+    },
+    {
+      "code": "QJ01DB09",
+      "name": "cefradine"
+    },
+    {
+      "code": "QJ01DB10",
+      "name": "cefacetrile"
+    },
+    {
+      "code": "QJ01DB11",
+      "name": "cefroxadine"
+    },
+    {
+      "code": "QJ01DB12",
+      "name": "ceftezole"
+    },
+    {
+      "code": "QJ01DC",
+      "name": "Second-generation cephalosporins"
+    },
+    {
+      "code": "QJ01DC01",
+      "name": "cefoxitin"
+    },
+    {
+      "code": "QJ01DC02",
+      "name": "cefuroxime"
+    },
+    {
+      "code": "QJ01DC03",
+      "name": "cefamandole"
+    },
+    {
+      "code": "QJ01DC04",
+      "name": "cefaclor"
+    },
+    {
+      "code": "QJ01DC05",
+      "name": "cefotetan"
+    },
+    {
+      "code": "QJ01DC06",
+      "name": "cefonicid"
+    },
+    {
+      "code": "QJ01DC07",
+      "name": "cefotiam"
+    },
+    {
+      "code": "QJ01DC08",
+      "name": "loracarbef"
+    },
+    {
+      "code": "QJ01DC09",
+      "name": "cefmetazole"
+    },
+    {
+      "code": "QJ01DC10",
+      "name": "cefprozil"
+    },
+    {
+      "code": "QJ01DC11",
+      "name": "ceforanide"
+    },
+    {
+      "code": "QJ01DC12",
+      "name": "cefminox"
+    },
+    {
+      "code": "QJ01DC13",
+      "name": "cefbuperazone"
+    },
+    {
+      "code": "QJ01DC14",
+      "name": "flomoxef"
+    },
+    {
+      "code": "QJ01DC52",
+      "name": "cefuroxime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD",
+      "name": "Third-generation cephalosporins"
+    },
+    {
+      "code": "QJ01DD01",
+      "name": "cefotaxime"
+    },
+    {
+      "code": "QJ01DD02",
+      "name": "ceftazidime"
+    },
+    {
+      "code": "QJ01DD03",
+      "name": "cefsulodin"
+    },
+    {
+      "code": "QJ01DD04",
+      "name": "ceftriaxone"
+    },
+    {
+      "code": "QJ01DD05",
+      "name": "cefmenoxime"
+    },
+    {
+      "code": "QJ01DD06",
+      "name": "latamoxef"
+    },
+    {
+      "code": "QJ01DD07",
+      "name": "ceftizoxime"
+    },
+    {
+      "code": "QJ01DD08",
+      "name": "cefixime"
+    },
+    {
+      "code": "QJ01DD09",
+      "name": "cefodizime"
+    },
+    {
+      "code": "QJ01DD10",
+      "name": "cefetamet"
+    },
+    {
+      "code": "QJ01DD11",
+      "name": "cefpiramide"
+    },
+    {
+      "code": "QJ01DD12",
+      "name": "cefoperazone"
+    },
+    {
+      "code": "QJ01DD13",
+      "name": "cefpodoxime"
+    },
+    {
+      "code": "QJ01DD14",
+      "name": "ceftibuten"
+    },
+    {
+      "code": "QJ01DD15",
+      "name": "cefdinir"
+    },
+    {
+      "code": "QJ01DD16",
+      "name": "cefditoren"
+    },
+    {
+      "code": "QJ01DD17",
+      "name": "cefcapene"
+    },
+    {
+      "code": "QJ01DD18",
+      "name": "cefteram"
+    },
+    {
+      "code": "QJ01DD51",
+      "name": "cefotaxime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD52",
+      "name": "ceftazidime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD54",
+      "name": "ceftriaxone, combinations"
+    },
+    {
+      "code": "QJ01DD58",
+      "name": "cefixime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD62",
+      "name": "cefoperazone and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD63",
+      "name": "ceftriaxone and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD64",
+      "name": "cefpodoxime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DD90",
+      "name": "ceftiofur"
+    },
+    {
+      "code": "QJ01DD91",
+      "name": "cefovecin"
+    },
+    {
+      "code": "QJ01DD99",
+      "name": "ceftiofur, combinations"
+    },
+    {
+      "code": "QJ01DE",
+      "name": "Fourth-generation cephalosporins"
+    },
+    {
+      "code": "QJ01DE01",
+      "name": "cefepime"
+    },
+    {
+      "code": "QJ01DE02",
+      "name": "cefpirome"
+    },
+    {
+      "code": "QJ01DE03",
+      "name": "cefozopran"
+    },
+    {
+      "code": "QJ01DE51",
+      "name": "cefepime and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DE90",
+      "name": "cefquinome"
+    },
+    {
+      "code": "QJ01DF",
+      "name": "Monobactams"
+    },
+    {
+      "code": "QJ01DF01",
+      "name": "aztreonam"
+    },
+    {
+      "code": "QJ01DF02",
+      "name": "carumonam"
+    },
+    {
+      "code": "QJ01DF51",
+      "name": "aztreonam and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DH",
+      "name": "Carbapenems"
+    },
+    {
+      "code": "QJ01DH02",
+      "name": "meropenem"
+    },
+    {
+      "code": "QJ01DH03",
+      "name": "ertapenem"
+    },
+    {
+      "code": "QJ01DH04",
+      "name": "doripenem"
+    },
+    {
+      "code": "QJ01DH05",
+      "name": "biapenem"
+    },
+    {
+      "code": "QJ01DH06",
+      "name": "tebipenem pivoxil"
+    },
+    {
+      "code": "QJ01DH51",
+      "name": "imipenem and cilastatin"
+    },
+    {
+      "code": "QJ01DH52",
+      "name": "meropenem and vaborbactam"
+    },
+    {
+      "code": "QJ01DH55",
+      "name": "panipenem and betamipron"
+    },
+    {
+      "code": "QJ01DH56",
+      "name": "imipenem, cilastatin and relebactam"
+    },
+    {
+      "code": "QJ01DI",
+      "name": "Other cephalosporins and penems"
+    },
+    {
+      "code": "QJ01DI01",
+      "name": "ceftobiprole medocaril"
+    },
+    {
+      "code": "QJ01DI02",
+      "name": "ceftaroline fosamil"
+    },
+    {
+      "code": "QJ01DI03",
+      "name": "faropenem"
+    },
+    {
+      "code": "QJ01DI04",
+      "name": "cefiderocol"
+    },
+    {
+      "code": "QJ01DI54",
+      "name": "ceftolozane and beta-lactamase inhibitor"
+    },
+    {
+      "code": "QJ01DI55",
+      "name": "sulopenem and probenecid"
+    },
+    {
+      "code": "QJ01E",
+      "name": "SULFONAMIDES AND TRIMETHOPRIM"
+    },
+    {
+      "code": "QJ01EA",
+      "name": "Trimethoprim and derivatives"
+    },
+    {
+      "code": "QJ01EA01",
+      "name": "trimethoprim"
+    },
+    {
+      "code": "QJ01EA02",
+      "name": "brodimoprim"
+    },
+    {
+      "code": "QJ01EA03",
+      "name": "iclaprim"
+    },
+    {
+      "code": "QJ01EQ",
+      "name": "Sulfonamides (ATC human differently classified, see guidelines)"
+    },
+    {
+      "code": "QJ01EQ01",
+      "name": "sulfapyrazole"
+    },
+    {
+      "code": "QJ01EQ02",
+      "name": "sulfamethizole"
+    },
+    {
+      "code": "QJ01EQ03",
+      "name": "sulfadimidine"
+    },
+    {
+      "code": "QJ01EQ04",
+      "name": "sulfapyridine"
+    },
+    {
+      "code": "QJ01EQ05",
+      "name": "sulfafurazole"
+    },
+    {
+      "code": "QJ01EQ06",
+      "name": "sulfanilamide"
+    },
+    {
+      "code": "QJ01EQ07",
+      "name": "sulfathiazole"
+    },
+    {
+      "code": "QJ01EQ08",
+      "name": "sulfaphenazole"
+    },
+    {
+      "code": "QJ01EQ09",
+      "name": "sulfadimethoxine"
+    },
+    {
+      "code": "QJ01EQ10",
+      "name": "sulfadiazine"
+    },
+    {
+      "code": "QJ01EQ11",
+      "name": "sulfamethoxazole"
+    },
+    {
+      "code": "QJ01EQ12",
+      "name": "sulfachlorpyridazine"
+    },
+    {
+      "code": "QJ01EQ13",
+      "name": "sulfadoxine"
+    },
+    {
+      "code": "QJ01EQ14",
+      "name": "sulfatroxazol"
+    },
+    {
+      "code": "QJ01EQ15",
+      "name": "sulfamethoxypyridazine"
+    },
+    {
+      "code": "QJ01EQ16",
+      "name": "sulfaquinoxaline"
+    },
+    {
+      "code": "QJ01EQ17",
+      "name": "sulfamerazine"
+    },
+    {
+      "code": "QJ01EQ18",
+      "name": "sulfamonomethoxine"
+    },
+    {
+      "code": "QJ01EQ19",
+      "name": "sulfalene"
+    },
+    {
+      "code": "QJ01EQ21",
+      "name": "sulfacetamide"
+    },
+    {
+      "code": "QJ01EQ30",
+      "name": "combinations of sulfonamides"
+    },
+    {
+      "code": "QJ01EQ59",
+      "name": "sulfadimethoxine, combinations"
+    },
+    {
+      "code": "QJ01EW",
+      "name": "Combinations of sulfonamides and trimethoprim, incl. derivatives"
+    },
+    {
+      "code": "QJ01EW03",
+      "name": "sulfadimidine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW09",
+      "name": "sulfadimethoxine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW10",
+      "name": "sulfadiazine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW11",
+      "name": "sulfamethoxazole and trimethoprime"
+    },
+    {
+      "code": "QJ01EW12",
+      "name": "sulfachlorpyridazine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW13",
+      "name": "sulfadoxine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW14",
+      "name": "sulfatroxazol and trimethoprim"
+    },
+    {
+      "code": "QJ01EW15",
+      "name": "sulfamethoxypyridazine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW16",
+      "name": "sulfaquinoxaline and trimethoprim"
+    },
+    {
+      "code": "QJ01EW17",
+      "name": "sulfamonomethoxine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW18",
+      "name": "sulfamerazine and trimethoprim"
+    },
+    {
+      "code": "QJ01EW19",
+      "name": "sulfadimethoxine and ormetoprim"
+    },
+    {
+      "code": "QJ01EW30",
+      "name": "combinations of sulfonamides and trimethoprim"
+    },
+    {
+      "code": "QJ01F",
+      "name": "MACROLIDES, LINCOSAMIDES AND STREPTOGRAMINS"
+    },
+    {
+      "code": "QJ01FA",
+      "name": "Macrolides"
+    },
+    {
+      "code": "QJ01FA01",
+      "name": "erythromycin"
+    },
+    {
+      "code": "QJ01FA02",
+      "name": "spiramycin"
+    },
+    {
+      "code": "QJ01FA03",
+      "name": "midecamycin"
+    },
+    {
+      "code": "QJ01FA05",
+      "name": "oleandomycin"
+    },
+    {
+      "code": "QJ01FA06",
+      "name": "roxithromycin"
+    },
+    {
+      "code": "QJ01FA07",
+      "name": "josamycin"
+    },
+    {
+      "code": "QJ01FA08",
+      "name": "troleandomycin"
+    },
+    {
+      "code": "QJ01FA09",
+      "name": "clarithromycin"
+    },
+    {
+      "code": "QJ01FA10",
+      "name": "azithromycin"
+    },
+    {
+      "code": "QJ01FA11",
+      "name": "miocamycin"
+    },
+    {
+      "code": "QJ01FA12",
+      "name": "rokitamycin"
+    },
+    {
+      "code": "QJ01FA13",
+      "name": "dirithromycin"
+    },
+    {
+      "code": "QJ01FA14",
+      "name": "flurithromycin"
+    },
+    {
+      "code": "QJ01FA15",
+      "name": "telithromycin"
+    },
+    {
+      "code": "QJ01FA16",
+      "name": "solithromycin"
+    },
+    {
+      "code": "QJ01FA17",
+      "name": "nafithromycin"
+    },
+    {
+      "code": "QJ01FA90",
+      "name": "tylosin"
+    },
+    {
+      "code": "QJ01FA91",
+      "name": "tilmicosin"
+    },
+    {
+      "code": "QJ01FA92",
+      "name": "tylvalosin"
+    },
+    {
+      "code": "QJ01FA93",
+      "name": "kitasamycin"
+    },
+    {
+      "code": "QJ01FA94",
+      "name": "tulathromycin"
+    },
+    {
+      "code": "QJ01FA95",
+      "name": "gamithromycin"
+    },
+    {
+      "code": "QJ01FA96",
+      "name": "tildipirosin"
+    },
+    {
+      "code": "QJ01FA99",
+      "name": "macrolides, combinations with other substances"
+    },
+    {
+      "code": "QJ01FF",
+      "name": "Lincosamides"
+    },
+    {
+      "code": "QJ01FF01",
+      "name": "clindamycin"
+    },
+    {
+      "code": "QJ01FF02",
+      "name": "lincomycin"
+    },
+    {
+      "code": "QJ01FF52",
+      "name": "lincomycin, combinations"
+    },
+    {
+      "code": "QJ01FG",
+      "name": "Streptogramins"
+    },
+    {
+      "code": "QJ01FG01",
+      "name": "pristinamycin"
+    },
+    {
+      "code": "QJ01FG02",
+      "name": "quinupristin and dalfopristin"
+    },
+    {
+      "code": "QJ01FG90",
+      "name": "virginiamycin"
+    },
+    {
+      "code": "QJ01G",
+      "name": "AMINOGLYCOSIDE ANTIBACTERIALS"
+    },
+    {
+      "code": "QJ01GA",
+      "name": "Streptomycins"
+    },
+    {
+      "code": "QJ01GA01",
+      "name": "streptomycin"
+    },
+    {
+      "code": "QJ01GA02",
+      "name": "streptoduocin"
+    },
+    {
+      "code": "QJ01GA90",
+      "name": "dihydrostreptomycin"
+    },
+    {
+      "code": "QJ01GA99",
+      "name": "combinations of streptomycins"
+    },
+    {
+      "code": "QJ01GB",
+      "name": "Other aminoglycosides"
+    },
+    {
+      "code": "QJ01GB01",
+      "name": "tobramycin"
+    },
+    {
+      "code": "QJ01GB03",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QJ01GB04",
+      "name": "kanamycin"
+    },
+    {
+      "code": "QJ01GB05",
+      "name": "neomycin"
+    },
+    {
+      "code": "QJ01GB06",
+      "name": "amikacin"
+    },
+    {
+      "code": "QJ01GB07",
+      "name": "netilmicin"
+    },
+    {
+      "code": "QJ01GB08",
+      "name": "sisomicin"
+    },
+    {
+      "code": "QJ01GB09",
+      "name": "dibekacin"
+    },
+    {
+      "code": "QJ01GB10",
+      "name": "ribostamycin"
+    },
+    {
+      "code": "QJ01GB11",
+      "name": "isepamicin"
+    },
+    {
+      "code": "QJ01GB12",
+      "name": "arbekacin"
+    },
+    {
+      "code": "QJ01GB13",
+      "name": "bekanamycin"
+    },
+    {
+      "code": "QJ01GB14",
+      "name": "plazomicin"
+    },
+    {
+      "code": "QJ01GB90",
+      "name": "apramycin"
+    },
+    {
+      "code": "QJ01GB91",
+      "name": "framycetin"
+    },
+    {
+      "code": "QJ01GB92",
+      "name": "paromomycin"
+    },
+    {
+      "code": "QJ01M",
+      "name": "QUINOLONE AND QUINOXALINE ANTIBACTERIALS"
+    },
+    {
+      "code": "QJ01MA",
+      "name": "Fluoroquinolones"
+    },
+    {
+      "code": "QJ01MA01",
+      "name": "ofloxacin"
+    },
+    {
+      "code": "QJ01MA02",
+      "name": "ciprofloxacin"
+    },
+    {
+      "code": "QJ01MA03",
+      "name": "pefloxacin"
+    },
+    {
+      "code": "QJ01MA04",
+      "name": "enoxacin"
+    },
+    {
+      "code": "QJ01MA05",
+      "name": "temafloxacin"
+    },
+    {
+      "code": "QJ01MA06",
+      "name": "norfloxacin"
+    },
+    {
+      "code": "QJ01MA07",
+      "name": "lomefloxacin"
+    },
+    {
+      "code": "QJ01MA08",
+      "name": "fleroxacin"
+    },
+    {
+      "code": "QJ01MA09",
+      "name": "sparfloxacin"
+    },
+    {
+      "code": "QJ01MA10",
+      "name": "rufloxacin"
+    },
+    {
+      "code": "QJ01MA11",
+      "name": "grepafloxacin"
+    },
+    {
+      "code": "QJ01MA12",
+      "name": "levofloxacin"
+    },
+    {
+      "code": "QJ01MA13",
+      "name": "trovafloxacin"
+    },
+    {
+      "code": "QJ01MA14",
+      "name": "moxifloxacin"
+    },
+    {
+      "code": "QJ01MA15",
+      "name": "gemifloxacin"
+    },
+    {
+      "code": "QJ01MA16",
+      "name": "gatifloxacin"
+    },
+    {
+      "code": "QJ01MA17",
+      "name": "prulifloxacin"
+    },
+    {
+      "code": "QJ01MA18",
+      "name": "pazufloxacin"
+    },
+    {
+      "code": "QJ01MA19",
+      "name": "garenoxacin"
+    },
+    {
+      "code": "QJ01MA21",
+      "name": "sitafloxacin"
+    },
+    {
+      "code": "QJ01MA22",
+      "name": "tosufloxacin"
+    },
+    {
+      "code": "QJ01MA23",
+      "name": "delafloxacin"
+    },
+    {
+      "code": "QJ01MA24",
+      "name": "levonadifloxacin"
+    },
+    {
+      "code": "QJ01MA25",
+      "name": "lascufloxacin"
+    },
+    {
+      "code": "QJ01MA90",
+      "name": "enrofloxacin"
+    },
+    {
+      "code": "QJ01MA92",
+      "name": "danofloxacin"
+    },
+    {
+      "code": "QJ01MA93",
+      "name": "marbofloxacin"
+    },
+    {
+      "code": "QJ01MA94",
+      "name": "difloxacin"
+    },
+    {
+      "code": "QJ01MA95",
+      "name": "orbifloxacin"
+    },
+    {
+      "code": "QJ01MA96",
+      "name": "ibafloxacin"
+    },
+    {
+      "code": "QJ01MA97",
+      "name": "pradofloxacin"
+    },
+    {
+      "code": "QJ01MA98",
+      "name": "sarafloxacin"
+    },
+    {
+      "code": "QJ01MB",
+      "name": "Other quinolones"
+    },
+    {
+      "code": "QJ01MB01",
+      "name": "rosoxacin"
+    },
+    {
+      "code": "QJ01MB02",
+      "name": "nalidixic acid"
+    },
+    {
+      "code": "QJ01MB03",
+      "name": "piromidic acid"
+    },
+    {
+      "code": "QJ01MB04",
+      "name": "pipemidic acid"
+    },
+    {
+      "code": "QJ01MB05",
+      "name": "oxolinic acid"
+    },
+    {
+      "code": "QJ01MB06",
+      "name": "cinoxacin"
+    },
+    {
+      "code": "QJ01MB07",
+      "name": "flumequine"
+    },
+    {
+      "code": "QJ01MB08",
+      "name": "nemonoxacin"
+    },
+    {
+      "code": "QJ01MQ",
+      "name": "Quinoxalines"
+    },
+    {
+      "code": "QJ01MQ01",
+      "name": "olaquindox"
+    },
+    {
+      "code": "QJ01R",
+      "name": "COMBINATIONS OF ANTIBACTERIALS"
+    },
+    {
+      "code": "QJ01RA",
+      "name": "Combinations of antibacterials"
+    },
+    {
+      "code": "QJ01RA01",
+      "name": "penicillins, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA02",
+      "name": "sulfonamides, combinations with other antibacterials excl. trimethoprim"
+    },
+    {
+      "code": "QJ01RA03",
+      "name": "cefuroxime and metronidazole"
+    },
+    {
+      "code": "QJ01RA04",
+      "name": "spiramycin and metronidazole"
+    },
+    {
+      "code": "QJ01RA05",
+      "name": "levofloxacin and ornidazole"
+    },
+    {
+      "code": "QJ01RA06",
+      "name": "cefepime and amikacin"
+    },
+    {
+      "code": "QJ01RA07",
+      "name": "azithromycin, fluconazole and secnidazole"
+    },
+    {
+      "code": "QJ01RA08",
+      "name": "tetracycline and oleandomycin"
+    },
+    {
+      "code": "QJ01RA09",
+      "name": "ofloxacin and ornidazole"
+    },
+    {
+      "code": "QJ01RA10",
+      "name": "ciprofloxacin and metronidazole"
+    },
+    {
+      "code": "QJ01RA11",
+      "name": "ciprofloxacin and tinidazole"
+    },
+    {
+      "code": "QJ01RA12",
+      "name": "ciprofloxacin and ornidazole"
+    },
+    {
+      "code": "QJ01RA13",
+      "name": "norfloxacin and tinidazole"
+    },
+    {
+      "code": "QJ01RA14",
+      "name": "norfloxacin and metronidazole"
+    },
+    {
+      "code": "QJ01RA15",
+      "name": "cefixime and ornidazole"
+    },
+    {
+      "code": "QJ01RA16",
+      "name": "cefixime and azithromycin"
+    },
+    {
+      "code": "QJ01RA17",
+      "name": "ofloxacin and nitazoxanide"
+    },
+    {
+      "code": "QJ01RA18",
+      "name": "ofloxacin and tinidazole"
+    },
+    {
+      "code": "QJ01RA19",
+      "name": "tetracycline and nystatin"
+    },
+    {
+      "code": "QJ01RA80",
+      "name": "nitrofuran derivatives, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA90",
+      "name": "tetracyclines, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA91",
+      "name": "macrolides, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA92",
+      "name": "amphenicols, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA94",
+      "name": "lincosamides, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA95",
+      "name": "polymyxins, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA96",
+      "name": "quinolones, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RA97",
+      "name": "aminoglycosides, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ01RV",
+      "name": "Combinations of antibacterials and other substances"
+    },
+    {
+      "code": "QJ01RV01",
+      "name": "antibacterials and corticosteroids"
+    },
+    {
+      "code": "QJ01X",
+      "name": "OTHER ANTIBACTERIALS"
+    },
+    {
+      "code": "QJ01XA",
+      "name": "Glycopeptide antibacterials"
+    },
+    {
+      "code": "QJ01XA01",
+      "name": "vancomycin"
+    },
+    {
+      "code": "QJ01XA02",
+      "name": "teicoplanin"
+    },
+    {
+      "code": "QJ01XA03",
+      "name": "telavancin"
+    },
+    {
+      "code": "QJ01XA04",
+      "name": "dalbavancin"
+    },
+    {
+      "code": "QJ01XA05",
+      "name": "oritavancin"
+    },
+    {
+      "code": "QJ01XB",
+      "name": "Polymyxins"
+    },
+    {
+      "code": "QJ01XB01",
+      "name": "colistin"
+    },
+    {
+      "code": "QJ01XB02",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QJ01XC",
+      "name": "Steroid antibacterials"
+    },
+    {
+      "code": "QJ01XC01",
+      "name": "fusidic acid"
+    },
+    {
+      "code": "QJ01XD",
+      "name": "Imidazole derivatives"
+    },
+    {
+      "code": "QJ01XD01",
+      "name": "metronidazole"
+    },
+    {
+      "code": "QJ01XD02",
+      "name": "tinidazole"
+    },
+    {
+      "code": "QJ01XD03",
+      "name": "ornidazole"
+    },
+    {
+      "code": "QJ01XE",
+      "name": "Nitrofuran derivatives"
+    },
+    {
+      "code": "QJ01XE01",
+      "name": "nitrofurantoin"
+    },
+    {
+      "code": "QJ01XE02",
+      "name": "nifurtoinol"
+    },
+    {
+      "code": "QJ01XE03",
+      "name": "furazidin"
+    },
+    {
+      "code": "QJ01XE51",
+      "name": "nitrofurantoin, combinations"
+    },
+    {
+      "code": "QJ01XE90",
+      "name": "furazolidone"
+    },
+    {
+      "code": "QJ01XE91",
+      "name": "nifurpirinol"
+    },
+    {
+      "code": "QJ01XQ",
+      "name": "Pleuromutilins"
+    },
+    {
+      "code": "QJ01XQ01",
+      "name": "tiamulin"
+    },
+    {
+      "code": "QJ01XQ02",
+      "name": "valnemulin"
+    },
+    {
+      "code": "QJ01XX",
+      "name": "Other antibacterials"
+    },
+    {
+      "code": "QJ01XX01",
+      "name": "fosfomycin"
+    },
+    {
+      "code": "QJ01XX02",
+      "name": "xibornol"
+    },
+    {
+      "code": "QJ01XX03",
+      "name": "clofoctol"
+    },
+    {
+      "code": "QJ01XX04",
+      "name": "spectinomycin"
+    },
+    {
+      "code": "QJ01XX05",
+      "name": "methenamine"
+    },
+    {
+      "code": "QJ01XX06",
+      "name": "mandelic acid"
+    },
+    {
+      "code": "QJ01XX07",
+      "name": "nitroxoline"
+    },
+    {
+      "code": "QJ01XX08",
+      "name": "linezolid"
+    },
+    {
+      "code": "QJ01XX09",
+      "name": "daptomycin"
+    },
+    {
+      "code": "QJ01XX10",
+      "name": "bacitracin"
+    },
+    {
+      "code": "QJ01XX11",
+      "name": "tedizolid"
+    },
+    {
+      "code": "QJ01XX12",
+      "name": "lefamulin"
+    },
+    {
+      "code": "QJ01XX13",
+      "name": "gepotidacin"
+    },
+    {
+      "code": "QJ01XX55",
+      "name": "methenamine, combinations"
+    },
+    {
+      "code": "QJ01XX93",
+      "name": "furaltadone"
+    },
+    {
+      "code": "QJ01XX95",
+      "name": "novobiocin"
+    },
+    {
+      "code": "QJ02",
+      "name": "ANTIMYCOTICS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QJ02A",
+      "name": "ANTIMYCOTICS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QJ02AA",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QJ02AA01",
+      "name": "amphotericin B"
+    },
+    {
+      "code": "QJ02AA02",
+      "name": "hachimycin"
+    },
+    {
+      "code": "QJ02AB",
+      "name": "Imidazole derivatives"
+    },
+    {
+      "code": "QJ02AB01",
+      "name": "miconazole"
+    },
+    {
+      "code": "QJ02AB02",
+      "name": "ketoconazole"
+    },
+    {
+      "code": "QJ02AB90",
+      "name": "clotrimazole"
+    },
+    {
+      "code": "QJ02AC",
+      "name": "Triazole and tetrazole derivatives"
+    },
+    {
+      "code": "QJ02AC01",
+      "name": "fluconazole"
+    },
+    {
+      "code": "QJ02AC02",
+      "name": "itraconazole"
+    },
+    {
+      "code": "QJ02AC03",
+      "name": "voriconazole"
+    },
+    {
+      "code": "QJ02AC04",
+      "name": "posaconazole"
+    },
+    {
+      "code": "QJ02AC05",
+      "name": "isavuconazole"
+    },
+    {
+      "code": "QJ02AC06",
+      "name": "oteseconazole"
+    },
+    {
+      "code": "QJ02AX",
+      "name": "Other antimycotics for systemic use"
+    },
+    {
+      "code": "QJ02AX01",
+      "name": "flucytosine"
+    },
+    {
+      "code": "QJ02AX04",
+      "name": "caspofungin"
+    },
+    {
+      "code": "QJ02AX05",
+      "name": "micafungin"
+    },
+    {
+      "code": "QJ02AX06",
+      "name": "anidulafungin"
+    },
+    {
+      "code": "QJ02AX07",
+      "name": "ibrexafungerp"
+    },
+    {
+      "code": "QJ02AX08",
+      "name": "rezafungin acetate"
+    },
+    {
+      "code": "QJ04",
+      "name": "ANTIMYCOBACTERIALS"
+    },
+    {
+      "code": "QJ04A",
+      "name": "DRUGS FOR TREATMENT OF TUBERCULOSIS"
+    },
+    {
+      "code": "QJ04AA",
+      "name": "Aminosalicylic acid and derivatives"
+    },
+    {
+      "code": "QJ04AA01",
+      "name": "aminosalicylic acid"
+    },
+    {
+      "code": "QJ04AA02",
+      "name": "sodium aminosalicylate"
+    },
+    {
+      "code": "QJ04AA03",
+      "name": "calcium aminosalicylate"
+    },
+    {
+      "code": "QJ04AB",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QJ04AB01",
+      "name": "cycloserine"
+    },
+    {
+      "code": "QJ04AB02",
+      "name": "rifampicin"
+    },
+    {
+      "code": "QJ04AB03",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QJ04AB04",
+      "name": "rifabutin"
+    },
+    {
+      "code": "QJ04AB05",
+      "name": "rifapentine"
+    },
+    {
+      "code": "QJ04AB06",
+      "name": "enviomycin"
+    },
+    {
+      "code": "QJ04AB30",
+      "name": "capreomycin"
+    },
+    {
+      "code": "QJ04AC",
+      "name": "Hydrazides"
+    },
+    {
+      "code": "QJ04AC01",
+      "name": "isoniazid"
+    },
+    {
+      "code": "QJ04AC02",
+      "name": "ftivazide"
+    },
+    {
+      "code": "QJ04AC51",
+      "name": "isoniazid, combinations"
+    },
+    {
+      "code": "QJ04AD",
+      "name": "Thiocarbamide derivatives"
+    },
+    {
+      "code": "QJ04AD01",
+      "name": "protionamide"
+    },
+    {
+      "code": "QJ04AD02",
+      "name": "tiocarlide"
+    },
+    {
+      "code": "QJ04AD03",
+      "name": "ethionamide"
+    },
+    {
+      "code": "QJ04AK",
+      "name": "Other drugs for the treatment of tuberculosis"
+    },
+    {
+      "code": "QJ04AK01",
+      "name": "pyrazinamide"
+    },
+    {
+      "code": "QJ04AK02",
+      "name": "ethambutol"
+    },
+    {
+      "code": "QJ04AK03",
+      "name": "terizidone"
+    },
+    {
+      "code": "QJ04AK04",
+      "name": "morinamide"
+    },
+    {
+      "code": "QJ04AK05",
+      "name": "bedaquiline"
+    },
+    {
+      "code": "QJ04AK06",
+      "name": "delamanid"
+    },
+    {
+      "code": "QJ04AK07",
+      "name": "thioacetazone"
+    },
+    {
+      "code": "QJ04AK08",
+      "name": "pretomanid"
+    },
+    {
+      "code": "QJ04AM",
+      "name": "Combinations of drugs for the treatment of tuberculosis"
+    },
+    {
+      "code": "QJ04AM01",
+      "name": "streptomycin and isoniazid"
+    },
+    {
+      "code": "QJ04AM02",
+      "name": "rifampicin and isoniazid"
+    },
+    {
+      "code": "QJ04AM03",
+      "name": "ethambutol and isoniazid"
+    },
+    {
+      "code": "QJ04AM04",
+      "name": "thioacetazone and isoniazid"
+    },
+    {
+      "code": "QJ04AM05",
+      "name": "rifampicin, pyrazinamide and isoniazid"
+    },
+    {
+      "code": "QJ04AM06",
+      "name": "rifampicin, pyrazinamide, ethambutol and isoniazid"
+    },
+    {
+      "code": "QJ04AM07",
+      "name": "rifampicin, ethambutol and isoniazid"
+    },
+    {
+      "code": "QJ04AM08",
+      "name": "isoniazid, sulfamethoxazole and trimethoprim"
+    },
+    {
+      "code": "QJ04AM09",
+      "name": "pyrazinamide, ethambutol, isoniazid and lomefloxacin"
+    },
+    {
+      "code": "QJ04AM10",
+      "name": "pyrazinamide, ethambutol, protionamide and lomefloxacin"
+    },
+    {
+      "code": "QJ04AM11",
+      "name": "rifabutin, pyrazinamide and protionamide"
+    },
+    {
+      "code": "QJ04AM12",
+      "name": "rifampicin, pyrazinamide, isoniazid and levofloxacin"
+    },
+    {
+      "code": "QJ04B",
+      "name": "DRUGS FOR TREATMENT OF LEPRA"
+    },
+    {
+      "code": "QJ04BA",
+      "name": "Drugs for treatment of lepra"
+    },
+    {
+      "code": "QJ04BA01",
+      "name": "clofazimine"
+    },
+    {
+      "code": "QJ04BA02",
+      "name": "dapsone"
+    },
+    {
+      "code": "QJ04BA03",
+      "name": "adesulfone sodium"
+    },
+    {
+      "code": "QJ04BA50",
+      "name": "dapsone and rifampicin"
+    },
+    {
+      "code": "QJ04BA51",
+      "name": "dapsone, rifampicin and clofazimine"
+    },
+    {
+      "code": "QJ05",
+      "name": "ANTIVIRALS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QJ05A",
+      "name": "DIRECT ACTING ANTIVIRALS"
+    },
+    {
+      "code": "QJ05AA",
+      "name": "Thiosemicarbazones"
+    },
+    {
+      "code": "QJ05AA01",
+      "name": "metisazone"
+    },
+    {
+      "code": "QJ05AB",
+      "name": "Nucleosides and nucleotides excl. reverse transcriptase inhibitors"
+    },
+    {
+      "code": "QJ05AB01",
+      "name": "aciclovir"
+    },
+    {
+      "code": "QJ05AB02",
+      "name": "idoxuridine"
+    },
+    {
+      "code": "QJ05AB03",
+      "name": "vidarabine"
+    },
+    {
+      "code": "QJ05AB06",
+      "name": "ganciclovir"
+    },
+    {
+      "code": "QJ05AB09",
+      "name": "famciclovir"
+    },
+    {
+      "code": "QJ05AB11",
+      "name": "valaciclovir"
+    },
+    {
+      "code": "QJ05AB12",
+      "name": "cidofovir"
+    },
+    {
+      "code": "QJ05AB13",
+      "name": "penciclovir"
+    },
+    {
+      "code": "QJ05AB14",
+      "name": "valganciclovir"
+    },
+    {
+      "code": "QJ05AB15",
+      "name": "brivudine"
+    },
+    {
+      "code": "QJ05AB16",
+      "name": "remdesivir"
+    },
+    {
+      "code": "QJ05AB17",
+      "name": "brincidofovir"
+    },
+    {
+      "code": "QJ05AB18",
+      "name": "molnupiravir"
+    },
+    {
+      "code": "QJ05AC",
+      "name": "Cyclic amines"
+    },
+    {
+      "code": "QJ05AC02",
+      "name": "rimantadine"
+    },
+    {
+      "code": "QJ05AC03",
+      "name": "tromantadine"
+    },
+    {
+      "code": "QJ05AD",
+      "name": "Phosphonic acid derivatives"
+    },
+    {
+      "code": "QJ05AD01",
+      "name": "foscarnet"
+    },
+    {
+      "code": "QJ05AD02",
+      "name": "fosfonet"
+    },
+    {
+      "code": "QJ05AE",
+      "name": "Protease inhibitors"
+    },
+    {
+      "code": "QJ05AE01",
+      "name": "saquinavir"
+    },
+    {
+      "code": "QJ05AE02",
+      "name": "indinavir"
+    },
+    {
+      "code": "QJ05AE03",
+      "name": "ritonavir"
+    },
+    {
+      "code": "QJ05AE04",
+      "name": "nelfinavir"
+    },
+    {
+      "code": "QJ05AE05",
+      "name": "amprenavir"
+    },
+    {
+      "code": "QJ05AE07",
+      "name": "fosamprenavir"
+    },
+    {
+      "code": "QJ05AE08",
+      "name": "atazanavir"
+    },
+    {
+      "code": "QJ05AE09",
+      "name": "tipranavir"
+    },
+    {
+      "code": "QJ05AE10",
+      "name": "darunavir"
+    },
+    {
+      "code": "QJ05AE16",
+      "name": "ensitrelvir"
+    },
+    {
+      "code": "QJ05AE30",
+      "name": "nirmatrelvir and ritonavir"
+    },
+    {
+      "code": "QJ05AF",
+      "name": "Nucleoside and nucleotide reverse transcriptase inhibitors"
+    },
+    {
+      "code": "QJ05AF01",
+      "name": "zidovudine"
+    },
+    {
+      "code": "QJ05AF02",
+      "name": "didanosine"
+    },
+    {
+      "code": "QJ05AF03",
+      "name": "zalcitabine"
+    },
+    {
+      "code": "QJ05AF04",
+      "name": "stavudine"
+    },
+    {
+      "code": "QJ05AF05",
+      "name": "lamivudine"
+    },
+    {
+      "code": "QJ05AF06",
+      "name": "abacavir"
+    },
+    {
+      "code": "QJ05AF07",
+      "name": "tenofovir disoproxil"
+    },
+    {
+      "code": "QJ05AF08",
+      "name": "adefovir dipivoxil"
+    },
+    {
+      "code": "QJ05AF09",
+      "name": "emtricitabine"
+    },
+    {
+      "code": "QJ05AF10",
+      "name": "entecavir"
+    },
+    {
+      "code": "QJ05AF11",
+      "name": "telbivudine"
+    },
+    {
+      "code": "QJ05AF12",
+      "name": "clevudine"
+    },
+    {
+      "code": "QJ05AF13",
+      "name": "tenofovir alafenamide"
+    },
+    {
+      "code": "QJ05AG",
+      "name": "Non-nucleoside reverse transcriptase inhibitors"
+    },
+    {
+      "code": "QJ05AG01",
+      "name": "nevirapine"
+    },
+    {
+      "code": "QJ05AG02",
+      "name": "delavirdine"
+    },
+    {
+      "code": "QJ05AG03",
+      "name": "efavirenz"
+    },
+    {
+      "code": "QJ05AG04",
+      "name": "etravirine"
+    },
+    {
+      "code": "QJ05AG05",
+      "name": "rilpivirine"
+    },
+    {
+      "code": "QJ05AG06",
+      "name": "doravirine"
+    },
+    {
+      "code": "QJ05AG07",
+      "name": "elsulfavirine"
+    },
+    {
+      "code": "QJ05AH",
+      "name": "Neuraminidase inhibitors"
+    },
+    {
+      "code": "QJ05AH01",
+      "name": "zanamivir"
+    },
+    {
+      "code": "QJ05AH02",
+      "name": "oseltamivir"
+    },
+    {
+      "code": "QJ05AH03",
+      "name": "peramivir"
+    },
+    {
+      "code": "QJ05AH04",
+      "name": "laninamivir"
+    },
+    {
+      "code": "QJ05AJ",
+      "name": "Integrase inhibitors"
+    },
+    {
+      "code": "QJ05AJ01",
+      "name": "raltegravir"
+    },
+    {
+      "code": "QJ05AJ02",
+      "name": "elvitegravir"
+    },
+    {
+      "code": "QJ05AJ03",
+      "name": "dolutegravir"
+    },
+    {
+      "code": "QJ05AJ04",
+      "name": "cabotegravir"
+    },
+    {
+      "code": "QJ05AP",
+      "name": "Antivirals for treatment of HCV infections"
+    },
+    {
+      "code": "QJ05AP01",
+      "name": "ribavirin"
+    },
+    {
+      "code": "QJ05AP02",
+      "name": "telaprevir"
+    },
+    {
+      "code": "QJ05AP03",
+      "name": "boceprevir"
+    },
+    {
+      "code": "QJ05AP04",
+      "name": "faldaprevir"
+    },
+    {
+      "code": "QJ05AP05",
+      "name": "simeprevir"
+    },
+    {
+      "code": "QJ05AP06",
+      "name": "asunaprevir"
+    },
+    {
+      "code": "QJ05AP07",
+      "name": "daclatasvir"
+    },
+    {
+      "code": "QJ05AP08",
+      "name": "sofosbuvir"
+    },
+    {
+      "code": "QJ05AP09",
+      "name": "dasabuvir"
+    },
+    {
+      "code": "QJ05AP10",
+      "name": "elbasvir"
+    },
+    {
+      "code": "QJ05AP11",
+      "name": "grazoprevir"
+    },
+    {
+      "code": "QJ05AP12",
+      "name": "coblopasvir"
+    },
+    {
+      "code": "QJ05AP13",
+      "name": "ravidasvir"
+    },
+    {
+      "code": "QJ05AP14",
+      "name": "narlaprevir"
+    },
+    {
+      "code": "QJ05AP51",
+      "name": "sofosbuvir and ledipasvir"
+    },
+    {
+      "code": "QJ05AP52",
+      "name": "dasabuvir, ombitasvir, paritaprevir and ritonavir"
+    },
+    {
+      "code": "QJ05AP53",
+      "name": "ombitasvir, paritaprevir and ritonavir"
+    },
+    {
+      "code": "QJ05AP54",
+      "name": "elbasvir and grazoprevir"
+    },
+    {
+      "code": "QJ05AP55",
+      "name": "sofosbuvir and velpatasvir"
+    },
+    {
+      "code": "QJ05AP56",
+      "name": "sofosbuvir, velpatasvir and voxilaprevir"
+    },
+    {
+      "code": "QJ05AP57",
+      "name": "glecaprevir and pibrentasvir"
+    },
+    {
+      "code": "QJ05AP58",
+      "name": "daclatasvir, asunaprevir and beclabuvir"
+    },
+    {
+      "code": "QJ05AR",
+      "name": "Antivirals for treatment of HIV infections, combinations"
+    },
+    {
+      "code": "QJ05AR01",
+      "name": "zidovudine and lamivudine"
+    },
+    {
+      "code": "QJ05AR02",
+      "name": "lamivudine and abacavir"
+    },
+    {
+      "code": "QJ05AR03",
+      "name": "tenofovir disoproxil and emtricitabine"
+    },
+    {
+      "code": "QJ05AR04",
+      "name": "zidovudine, lamivudine and abacavir"
+    },
+    {
+      "code": "QJ05AR05",
+      "name": "zidovudine, lamivudine and nevirapine"
+    },
+    {
+      "code": "QJ05AR06",
+      "name": "emtricitabine, tenofovir disoproxil and efavirenz"
+    },
+    {
+      "code": "QJ05AR07",
+      "name": "stavudine, lamivudine and nevirapine"
+    },
+    {
+      "code": "QJ05AR08",
+      "name": "emtricitabine, tenofovir disoproxil and rilpivirine"
+    },
+    {
+      "code": "QJ05AR09",
+      "name": "emtricitabine, tenofovir disoproxil, elvitegravir and cobicistat"
+    },
+    {
+      "code": "QJ05AR10",
+      "name": "lopinavir and ritonavir"
+    },
+    {
+      "code": "QJ05AR11",
+      "name": "lamivudine, tenofovir disoproxil and efavirenz"
+    },
+    {
+      "code": "QJ05AR12",
+      "name": "lamivudine and tenofovir disoproxil"
+    },
+    {
+      "code": "QJ05AR13",
+      "name": "lamivudine, abacavir and dolutegravir"
+    },
+    {
+      "code": "QJ05AR14",
+      "name": "darunavir and cobicistat"
+    },
+    {
+      "code": "QJ05AR15",
+      "name": "atazanavir and cobicistat"
+    },
+    {
+      "code": "QJ05AR16",
+      "name": "lamivudine and raltegravir"
+    },
+    {
+      "code": "QJ05AR17",
+      "name": "emtricitabine and tenofovir alafenamide"
+    },
+    {
+      "code": "QJ05AR18",
+      "name": "emtricitabine, tenofovir alafenamide, elvitegravir and cobicistat"
+    },
+    {
+      "code": "QJ05AR19",
+      "name": "emtricitabine, tenofovir alafenamide and rilpivirine"
+    },
+    {
+      "code": "QJ05AR20",
+      "name": "emtricitabine, tenofovir alafenamide and bictegravir"
+    },
+    {
+      "code": "QJ05AR21",
+      "name": "dolutegravir and rilpivirine"
+    },
+    {
+      "code": "QJ05AR22",
+      "name": "emtricitabine, tenofovir alafenamide, darunavir and cobicistat"
+    },
+    {
+      "code": "QJ05AR23",
+      "name": "atazanavir and ritonavir"
+    },
+    {
+      "code": "QJ05AR24",
+      "name": "lamivudine, tenofovir disoproxil and doravirine"
+    },
+    {
+      "code": "QJ05AR25",
+      "name": "lamivudine and dolutegravir"
+    },
+    {
+      "code": "QJ05AR26",
+      "name": "darunavir and ritonavir"
+    },
+    {
+      "code": "QJ05AR27",
+      "name": "lamivudine, tenofovir disoproxil and dolutegravir"
+    },
+    {
+      "code": "QJ05AR28",
+      "name": "stavudine and lamivudine"
+    },
+    {
+      "code": "QJ05AR29",
+      "name": "emtricitabine, tenofovir alafenamide and dolutegravir"
+    },
+    {
+      "code": "QJ05AX",
+      "name": "Other antivirals"
+    },
+    {
+      "code": "QJ05AX01",
+      "name": "moroxydine"
+    },
+    {
+      "code": "QJ05AX02",
+      "name": "lysozyme"
+    },
+    {
+      "code": "QJ05AX05",
+      "name": "inosine pranobex"
+    },
+    {
+      "code": "QJ05AX06",
+      "name": "pleconaril"
+    },
+    {
+      "code": "QJ05AX07",
+      "name": "enfuvirtide"
+    },
+    {
+      "code": "QJ05AX09",
+      "name": "maraviroc"
+    },
+    {
+      "code": "QJ05AX10",
+      "name": "maribavir"
+    },
+    {
+      "code": "QJ05AX13",
+      "name": "umifenovir"
+    },
+    {
+      "code": "QJ05AX17",
+      "name": "enisamium iodide"
+    },
+    {
+      "code": "QJ05AX18",
+      "name": "letermovir"
+    },
+    {
+      "code": "QJ05AX19",
+      "name": "tilorone"
+    },
+    {
+      "code": "QJ05AX21",
+      "name": "pentanedioic acid imidazolyl ethanamide"
+    },
+    {
+      "code": "QJ05AX23",
+      "name": "ibalizumab"
+    },
+    {
+      "code": "QJ05AX24",
+      "name": "tecovirimat"
+    },
+    {
+      "code": "QJ05AX25",
+      "name": "baloxavir marboxil"
+    },
+    {
+      "code": "QJ05AX26",
+      "name": "amenamevir"
+    },
+    {
+      "code": "QJ05AX27",
+      "name": "favipiravir"
+    },
+    {
+      "code": "QJ05AX28",
+      "name": "bulevirtide"
+    },
+    {
+      "code": "QJ05AX29",
+      "name": "fostemsavir"
+    },
+    {
+      "code": "QJ05AX31",
+      "name": "lenacapavir"
+    },
+    {
+      "code": "QJ05AX32",
+      "name": "riamilovir"
+    },
+    {
+      "code": "QJ05AX33",
+      "name": "labuvirtide"
+    },
+    {
+      "code": "QJ51",
+      "name": "ANTIBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51A",
+      "name": "TETRACYCLINES FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51AA",
+      "name": "Tetracyclines"
+    },
+    {
+      "code": "QJ51AA03",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QJ51AA06",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QJ51AA07",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QJ51AA53",
+      "name": "chlortetracycline, combinations"
+    },
+    {
+      "code": "QJ51B",
+      "name": "AMPHENICOLS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51BA",
+      "name": "Amphenicols"
+    },
+    {
+      "code": "QJ51BA01",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QJ51BA02",
+      "name": "thiamphenicol"
+    },
+    {
+      "code": "QJ51BA90",
+      "name": "florfenicol"
+    },
+    {
+      "code": "QJ51C",
+      "name": "BETA-LACTAM ANTIBACTERIALS, PENICILLINS, FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51CA",
+      "name": "Pencillins with extended spectrum"
+    },
+    {
+      "code": "QJ51CA01",
+      "name": "ampicillin"
+    },
+    {
+      "code": "QJ51CA51",
+      "name": "ampicillin, combinations"
+    },
+    {
+      "code": "QJ51CE",
+      "name": "Beta-lactamase sensitive penicillins"
+    },
+    {
+      "code": "QJ51CE01",
+      "name": "benzylpenicillin"
+    },
+    {
+      "code": "QJ51CE09",
+      "name": "procaine benzylpenicillin"
+    },
+    {
+      "code": "QJ51CE59",
+      "name": "procaine benzylpenicillin, combinations"
+    },
+    {
+      "code": "QJ51CE90",
+      "name": "penethamate hydriodide"
+    },
+    {
+      "code": "QJ51CF",
+      "name": "Beta-lactamase resistant penicillins"
+    },
+    {
+      "code": "QJ51CF01",
+      "name": "dicloxacillin"
+    },
+    {
+      "code": "QJ51CF02",
+      "name": "cloxacillin"
+    },
+    {
+      "code": "QJ51CF03",
+      "name": "meticillin"
+    },
+    {
+      "code": "QJ51CF04",
+      "name": "oxacillin"
+    },
+    {
+      "code": "QJ51CF05",
+      "name": "flucloxacillin"
+    },
+    {
+      "code": "QJ51CR",
+      "name": "Combinations of pencillins and/or beta-lactamase inhibitors"
+    },
+    {
+      "code": "QJ51CR01",
+      "name": "ampicillin and enzyme inhibitor"
+    },
+    {
+      "code": "QJ51CR02",
+      "name": "amoxicillin and enzyme inhibitor"
+    },
+    {
+      "code": "QJ51CR50",
+      "name": "combinations of penicillins"
+    },
+    {
+      "code": "QJ51D",
+      "name": "OTHER BETA-LACTAM ANTIBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51DB",
+      "name": "First-generation cephalosporins"
+    },
+    {
+      "code": "QJ51DB01",
+      "name": "cefalexin"
+    },
+    {
+      "code": "QJ51DB04",
+      "name": "cefazolin"
+    },
+    {
+      "code": "QJ51DB08",
+      "name": "cefapirin"
+    },
+    {
+      "code": "QJ51DB10",
+      "name": "cefacetrile"
+    },
+    {
+      "code": "QJ51DB90",
+      "name": "cefalonium"
+    },
+    {
+      "code": "QJ51DC",
+      "name": "Second-generation cephalosporins"
+    },
+    {
+      "code": "QJ51DC02",
+      "name": "cefuroxime"
+    },
+    {
+      "code": "QJ51DD",
+      "name": "Third-generation cephalosporins"
+    },
+    {
+      "code": "QJ51DD12",
+      "name": "cefoperazone"
+    },
+    {
+      "code": "QJ51DD90",
+      "name": "ceftiofur"
+    },
+    {
+      "code": "QJ51DE",
+      "name": "Fourth-generation cephalosporins"
+    },
+    {
+      "code": "QJ51DE90",
+      "name": "cefquinome"
+    },
+    {
+      "code": "QJ51E",
+      "name": "SULFONAMIDES AND TRIMETHOPRIM FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51EA",
+      "name": "Trimethoprim and derivatives"
+    },
+    {
+      "code": "QJ51EA01",
+      "name": "trimethoprim"
+    },
+    {
+      "code": "QJ51F",
+      "name": "MACROLIDES AND LINCOSAMIDES FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51FA",
+      "name": "Macrolides"
+    },
+    {
+      "code": "QJ51FA01",
+      "name": "erythromycin"
+    },
+    {
+      "code": "QJ51FA02",
+      "name": "spiramycin"
+    },
+    {
+      "code": "QJ51FA90",
+      "name": "tylosin"
+    },
+    {
+      "code": "QJ51FF",
+      "name": "Lincosamides"
+    },
+    {
+      "code": "QJ51FF02",
+      "name": "lincomycin"
+    },
+    {
+      "code": "QJ51FF90",
+      "name": "pirlimycin"
+    },
+    {
+      "code": "QJ51G",
+      "name": "AMINOGLYCOSIDE ANTIBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51GA",
+      "name": "Streptomycins"
+    },
+    {
+      "code": "QJ51GA90",
+      "name": "dihydrostreptomycin"
+    },
+    {
+      "code": "QJ51GB",
+      "name": "Other aminoglycosides"
+    },
+    {
+      "code": "QJ51GB03",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QJ51GB90",
+      "name": "apramycin"
+    },
+    {
+      "code": "QJ51R",
+      "name": "COMBINATIONS OF ANTIBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51RA",
+      "name": "Tetracyclines, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RA01",
+      "name": "chlortetracycline, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RB",
+      "name": "Amphenicols, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RB01",
+      "name": "chloramphenicol, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC",
+      "name": "Beta-lactam antibacterials, penicillins, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC04",
+      "name": "procaine benzylpenicillin, dihydrostreptomycin, sulfadimidin"
+    },
+    {
+      "code": "QJ51RC20",
+      "name": "ampicillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC21",
+      "name": "pivampicillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC22",
+      "name": "benzylpenicillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC23",
+      "name": "procaine benzylpenicillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC24",
+      "name": "benzathine benzylpenicillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC25",
+      "name": "penethamate hydroiodide, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RC26",
+      "name": "cloxacillin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RD",
+      "name": "Other beta-lactam antibacterials, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RD01",
+      "name": "cefalexin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RD34",
+      "name": "cefacetrile, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RE",
+      "name": "Sulfonamides and trimethoprim incl. derivatives"
+    },
+    {
+      "code": "QJ51RE01",
+      "name": "sulfadiazine and trimethoprim"
+    },
+    {
+      "code": "QJ51RF",
+      "name": "Macrolides and lincosamides, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RF01",
+      "name": "spiramycin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RF02",
+      "name": "erythromycin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RF03",
+      "name": "lincomycin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RG",
+      "name": "Aminoglycoside antibacterials, combinations"
+    },
+    {
+      "code": "QJ51RG01",
+      "name": "neomycin, combinations with other antibacterials"
+    },
+    {
+      "code": "QJ51RV",
+      "name": "Combinations of antibacterials and other substances"
+    },
+    {
+      "code": "QJ51RV01",
+      "name": "antibacterials and corticosteroids"
+    },
+    {
+      "code": "QJ51RV02",
+      "name": "antibacterials, antimycotics and corticosteroids"
+    },
+    {
+      "code": "QJ51X",
+      "name": "OTHER ANTIBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ51XB",
+      "name": "Polymyxins"
+    },
+    {
+      "code": "QJ51XB01",
+      "name": "colistin"
+    },
+    {
+      "code": "QJ51XB02",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QJ51XX",
+      "name": "Other antibacterials for intramammary use"
+    },
+    {
+      "code": "QJ51XX01",
+      "name": "rifaximin"
+    },
+    {
+      "code": "QJ54",
+      "name": "ANTIMYCOBACTERIALS FOR INTRAMAMMARY USE"
+    },
+    {
+      "code": "QJ54A",
+      "name": "DRUGS FOR MYCOBACTERIAL INFECTIONS"
+    },
+    {
+      "code": "QJ54AB",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QJ54AB02",
+      "name": "rifampicin"
+    },
+    {
+      "code": "QJ54AB03",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QL",
+      "name": "ANTINEOPLASTIC AND IMMUNOMODULATING AGENTS"
+    },
+    {
+      "code": "QL01",
+      "name": "ANTINEOPLASTIC AGENTS"
+    },
+    {
+      "code": "QL01A",
+      "name": "ALKYLATING AGENTS"
+    },
+    {
+      "code": "QL01AA",
+      "name": "Nitrogen mustard analogues"
+    },
+    {
+      "code": "QL01AA01",
+      "name": "cyclophosphamide"
+    },
+    {
+      "code": "QL01AA02",
+      "name": "chlorambucil"
+    },
+    {
+      "code": "QL01AA03",
+      "name": "melphalan"
+    },
+    {
+      "code": "QL01AA05",
+      "name": "chlormethine"
+    },
+    {
+      "code": "QL01AA06",
+      "name": "ifosfamide"
+    },
+    {
+      "code": "QL01AA07",
+      "name": "trofosfamide"
+    },
+    {
+      "code": "QL01AA08",
+      "name": "prednimustine"
+    },
+    {
+      "code": "QL01AA09",
+      "name": "bendamustine"
+    },
+    {
+      "code": "QL01AA10",
+      "name": "melphalan flufenamide"
+    },
+    {
+      "code": "QL01AB",
+      "name": "Alkyl sulfonates"
+    },
+    {
+      "code": "QL01AB01",
+      "name": "busulfan"
+    },
+    {
+      "code": "QL01AB02",
+      "name": "treosulfan"
+    },
+    {
+      "code": "QL01AB03",
+      "name": "mannosulfan"
+    },
+    {
+      "code": "QL01AC",
+      "name": "Ethylene imines"
+    },
+    {
+      "code": "QL01AC01",
+      "name": "thiotepa"
+    },
+    {
+      "code": "QL01AC02",
+      "name": "triaziquone"
+    },
+    {
+      "code": "QL01AC03",
+      "name": "carboquone"
+    },
+    {
+      "code": "QL01AD",
+      "name": "Nitrosoureas"
+    },
+    {
+      "code": "QL01AD01",
+      "name": "carmustine"
+    },
+    {
+      "code": "QL01AD02",
+      "name": "lomustine"
+    },
+    {
+      "code": "QL01AD03",
+      "name": "semustine"
+    },
+    {
+      "code": "QL01AD04",
+      "name": "streptozocin"
+    },
+    {
+      "code": "QL01AD05",
+      "name": "fotemustine"
+    },
+    {
+      "code": "QL01AD06",
+      "name": "nimustine"
+    },
+    {
+      "code": "QL01AD07",
+      "name": "ranimustine"
+    },
+    {
+      "code": "QL01AD08",
+      "name": "uramustine"
+    },
+    {
+      "code": "QL01AG",
+      "name": "Epoxides"
+    },
+    {
+      "code": "QL01AG01",
+      "name": "etoglucid"
+    },
+    {
+      "code": "QL01AX",
+      "name": "Other alkylating agents"
+    },
+    {
+      "code": "QL01AX01",
+      "name": "mitobronitol"
+    },
+    {
+      "code": "QL01AX02",
+      "name": "pipobroman"
+    },
+    {
+      "code": "QL01AX03",
+      "name": "temozolomide"
+    },
+    {
+      "code": "QL01AX04",
+      "name": "dacarbazine"
+    },
+    {
+      "code": "QL01B",
+      "name": "ANTIMETABOLITES"
+    },
+    {
+      "code": "QL01BA",
+      "name": "Folic acid analogues"
+    },
+    {
+      "code": "QL01BA01",
+      "name": "methotrexate"
+    },
+    {
+      "code": "QL01BA03",
+      "name": "raltitrexed"
+    },
+    {
+      "code": "QL01BA04",
+      "name": "pemetrexed"
+    },
+    {
+      "code": "QL01BA05",
+      "name": "pralatrexate"
+    },
+    {
+      "code": "QL01BB",
+      "name": "Purine analogues"
+    },
+    {
+      "code": "QL01BB02",
+      "name": "mercaptopurine"
+    },
+    {
+      "code": "QL01BB03",
+      "name": "tioguanine"
+    },
+    {
+      "code": "QL01BB04",
+      "name": "cladribine"
+    },
+    {
+      "code": "QL01BB05",
+      "name": "fudarabine"
+    },
+    {
+      "code": "QL01BB06",
+      "name": "clofarabine"
+    },
+    {
+      "code": "QL01BB07",
+      "name": "nelarabine"
+    },
+    {
+      "code": "QL01BB90",
+      "name": "rabacfosadine"
+    },
+    {
+      "code": "QL01BC",
+      "name": "Pyrimidine analogues"
+    },
+    {
+      "code": "QL01BC01",
+      "name": "cytarabine"
+    },
+    {
+      "code": "QL01BC02",
+      "name": "fluorouracil"
+    },
+    {
+      "code": "QL01BC03",
+      "name": "tegafur"
+    },
+    {
+      "code": "QL01BC04",
+      "name": "carmofur"
+    },
+    {
+      "code": "QL01BC05",
+      "name": "gemcitabine"
+    },
+    {
+      "code": "QL01BC06",
+      "name": "capecitabine"
+    },
+    {
+      "code": "QL01BC07",
+      "name": "azacitidine"
+    },
+    {
+      "code": "QL01BC08",
+      "name": "decitabine"
+    },
+    {
+      "code": "QL01BC09",
+      "name": "floxuridine"
+    },
+    {
+      "code": "QL01BC52",
+      "name": "fluorouracil, combinations"
+    },
+    {
+      "code": "QL01BC53",
+      "name": "tegafur, combinations"
+    },
+    {
+      "code": "QL01BC58",
+      "name": "decitabine, combinations"
+    },
+    {
+      "code": "QL01BC59",
+      "name": "trifluridine, combinations"
+    },
+    {
+      "code": "QL01C",
+      "name": "PLANT ALKALOIDS AND OTHER NATURAL PRODUCTS"
+    },
+    {
+      "code": "QL01CA",
+      "name": "Vinca alkaloids and analogues"
+    },
+    {
+      "code": "QL01CA01",
+      "name": "vinblastine"
+    },
+    {
+      "code": "QL01CA02",
+      "name": "vincristine"
+    },
+    {
+      "code": "QL01CA03",
+      "name": "vindesine"
+    },
+    {
+      "code": "QL01CA04",
+      "name": "vinorelbine"
+    },
+    {
+      "code": "QL01CA05",
+      "name": "vinflunine"
+    },
+    {
+      "code": "QL01CA06",
+      "name": "vintafolide"
+    },
+    {
+      "code": "QL01CB",
+      "name": "Podophyllotoxin derivatives"
+    },
+    {
+      "code": "QL01CB01",
+      "name": "etoposide"
+    },
+    {
+      "code": "QL01CB02",
+      "name": "teniposide"
+    },
+    {
+      "code": "QL01CC",
+      "name": "Colchicine derivatives"
+    },
+    {
+      "code": "QL01CC01",
+      "name": "demecolcine"
+    },
+    {
+      "code": "QL01CD",
+      "name": "Taxanes"
+    },
+    {
+      "code": "QL01CD01",
+      "name": "paclitaxel"
+    },
+    {
+      "code": "QL01CD02",
+      "name": "docetaxel"
+    },
+    {
+      "code": "QL01CD03",
+      "name": "paclitaxel poliglumex"
+    },
+    {
+      "code": "QL01CD04",
+      "name": "cabazitaxel"
+    },
+    {
+      "code": "QL01CD51",
+      "name": "paclitaxel and encequidar"
+    },
+    {
+      "code": "QL01CE",
+      "name": "Topoisomerase 1 (TOP1) inhibitors"
+    },
+    {
+      "code": "QL01CE01",
+      "name": "topotecan"
+    },
+    {
+      "code": "QL01CE02",
+      "name": "irinotecan"
+    },
+    {
+      "code": "QL01CE03",
+      "name": "etirinotecan pegol"
+    },
+    {
+      "code": "QL01CE04",
+      "name": "belotecan"
+    },
+    {
+      "code": "QL01CX",
+      "name": "Other plant alkaloids and natural products"
+    },
+    {
+      "code": "QL01CX01",
+      "name": "trabectedin"
+    },
+    {
+      "code": "QL01D",
+      "name": "CYTOTOXIC ANTIBIOTICS AND RELATED SUBSTANCES"
+    },
+    {
+      "code": "QL01DA",
+      "name": "Actinomycines"
+    },
+    {
+      "code": "QL01DA01",
+      "name": "dactinomycin"
+    },
+    {
+      "code": "QL01DB",
+      "name": "Anthracyclines and related substances"
+    },
+    {
+      "code": "QL01DB01",
+      "name": "doxorubicin"
+    },
+    {
+      "code": "QL01DB02",
+      "name": "daunorubicin"
+    },
+    {
+      "code": "QL01DB03",
+      "name": "epirubicin"
+    },
+    {
+      "code": "QL01DB04",
+      "name": "aclarubicin"
+    },
+    {
+      "code": "QL01DB05",
+      "name": "zorubicin"
+    },
+    {
+      "code": "QL01DB06",
+      "name": "idarubicin"
+    },
+    {
+      "code": "QL01DB07",
+      "name": "mitoxantrone"
+    },
+    {
+      "code": "QL01DB08",
+      "name": "pirarubicin"
+    },
+    {
+      "code": "QL01DB09",
+      "name": "valrubicin"
+    },
+    {
+      "code": "QL01DB10",
+      "name": "amrubicin"
+    },
+    {
+      "code": "QL01DB11",
+      "name": "pixantrone"
+    },
+    {
+      "code": "QL01DC",
+      "name": "Other cytotoxic antibiotics"
+    },
+    {
+      "code": "QL01DC01",
+      "name": "bleomycin"
+    },
+    {
+      "code": "QL01DC02",
+      "name": "plicamycin"
+    },
+    {
+      "code": "QL01DC03",
+      "name": "mitomycin"
+    },
+    {
+      "code": "QL01DC04",
+      "name": "ixabepilone"
+    },
+    {
+      "code": "QL01DC05",
+      "name": "utidelone"
+    },
+    {
+      "code": "QL01E",
+      "name": "PROTEIN KINASE INHIBITORS"
+    },
+    {
+      "code": "QL01EA",
+      "name": "BCR-ABL tyrosine kinase inhibitors"
+    },
+    {
+      "code": "QL01EA01",
+      "name": "imatinib"
+    },
+    {
+      "code": "QL01EA02",
+      "name": "dasatinib"
+    },
+    {
+      "code": "QL01EA03",
+      "name": "nilotinib"
+    },
+    {
+      "code": "QL01EA04",
+      "name": "bosutinib"
+    },
+    {
+      "code": "QL01EA05",
+      "name": "ponatinib"
+    },
+    {
+      "code": "QL01EA06",
+      "name": "asciminib"
+    },
+    {
+      "code": "QL01EB",
+      "name": "Epidermal growth factor receptor (EGFR) tyrosine kinase inhibitors"
+    },
+    {
+      "code": "QL01EB01",
+      "name": "gefitinib"
+    },
+    {
+      "code": "QL01EB02",
+      "name": "erlotinib"
+    },
+    {
+      "code": "QL01EB03",
+      "name": "afatinib"
+    },
+    {
+      "code": "QL01EB04",
+      "name": "osimertinib"
+    },
+    {
+      "code": "QL01EB05",
+      "name": "rociletinib"
+    },
+    {
+      "code": "QL01EB06",
+      "name": "olmutinib"
+    },
+    {
+      "code": "QL01EB07",
+      "name": "dacomitinib"
+    },
+    {
+      "code": "QL01EB08",
+      "name": "icotinib"
+    },
+    {
+      "code": "QL01EB09",
+      "name": "lazertinib"
+    },
+    {
+      "code": "QL01EB10",
+      "name": "mobocertinib"
+    },
+    {
+      "code": "QL01EB11",
+      "name": "aumolertinib"
+    },
+    {
+      "code": "QL01EB12",
+      "name": "firmonertinib"
+    },
+    {
+      "code": "QL01EC",
+      "name": "B-Raf serine-threonine kinase (BRAF) inhibitors"
+    },
+    {
+      "code": "QL01EC01",
+      "name": "vemurafenib"
+    },
+    {
+      "code": "QL01EC02",
+      "name": "dabrafenib"
+    },
+    {
+      "code": "QL01EC03",
+      "name": "encorafenib"
+    },
+    {
+      "code": "QL01EC04",
+      "name": "tovorafenib"
+    },
+    {
+      "code": "QL01ED",
+      "name": "Anaplastic lymphoma kinase (ALK) inhibitors"
+    },
+    {
+      "code": "QL01ED01",
+      "name": "crizotinib"
+    },
+    {
+      "code": "QL01ED02",
+      "name": "ceritinib"
+    },
+    {
+      "code": "QL01ED03",
+      "name": "alectinib"
+    },
+    {
+      "code": "QL01ED04",
+      "name": "brigatinib"
+    },
+    {
+      "code": "QL01ED05",
+      "name": "lorlatinib"
+    },
+    {
+      "code": "QL01EE",
+      "name": "Mitogen-activated protein kinase (MEK) inhibitors"
+    },
+    {
+      "code": "QL01EE01",
+      "name": "trametinib"
+    },
+    {
+      "code": "QL01EE02",
+      "name": "cobimetinib"
+    },
+    {
+      "code": "QL01EE03",
+      "name": "binimetinib"
+    },
+    {
+      "code": "QL01EE04",
+      "name": "selumetinib"
+    },
+    {
+      "code": "QL01EE05",
+      "name": "mirdametinib"
+    },
+    {
+      "code": "QL01EE06",
+      "name": "tunlametinib"
+    },
+    {
+      "code": "QL01EF",
+      "name": "Cyclin-dependent kinase (CDK) inhibitors"
+    },
+    {
+      "code": "QL01EF01",
+      "name": "palbociclib"
+    },
+    {
+      "code": "QL01EF02",
+      "name": "ribociclib"
+    },
+    {
+      "code": "QL01EF03",
+      "name": "abemaciclib"
+    },
+    {
+      "code": "QL01EG",
+      "name": "Mammalian target of rapamycin (mTOR) kinase inhibitors"
+    },
+    {
+      "code": "QL01EG01",
+      "name": "temsirolimus"
+    },
+    {
+      "code": "QL01EG02",
+      "name": "everolimus"
+    },
+    {
+      "code": "QL01EG03",
+      "name": "ridaforolimus"
+    },
+    {
+      "code": "QL01EG04",
+      "name": "sirolimus"
+    },
+    {
+      "code": "QL01EH",
+      "name": "Human epidermal growth factor receptor 2 (HER2) tyrosine kinase inhibitors"
+    },
+    {
+      "code": "QL01EH01",
+      "name": "lapatinib"
+    },
+    {
+      "code": "QL01EH02",
+      "name": "neratinib"
+    },
+    {
+      "code": "QL01EH03",
+      "name": "tucatinib"
+    },
+    {
+      "code": "QL01EH04",
+      "name": "zongertinib"
+    },
+    {
+      "code": "QL01EH05",
+      "name": "mifanertinib"
+    },
+    {
+      "code": "QL01EH06",
+      "name": "sevabertinib"
+    },
+    {
+      "code": "QL01EJ",
+      "name": "Janus-associated kinase (JAK) inhibitors"
+    },
+    {
+      "code": "QL01EJ01",
+      "name": "ruxolitinib"
+    },
+    {
+      "code": "QL01EJ02",
+      "name": "fedratinib"
+    },
+    {
+      "code": "QL01EJ03",
+      "name": "pacritinib"
+    },
+    {
+      "code": "QL01EJ04",
+      "name": "momelotinib"
+    },
+    {
+      "code": "QL01EK",
+      "name": "Vascular endothelial growth factor receptor (VEGFR) tyrosine kinase inhibitors"
+    },
+    {
+      "code": "QL01EK01",
+      "name": "axitinib"
+    },
+    {
+      "code": "QL01EK02",
+      "name": "cediranib"
+    },
+    {
+      "code": "QL01EK03",
+      "name": "tivozanib"
+    },
+    {
+      "code": "QL01EK04",
+      "name": "fruquintinib"
+    },
+    {
+      "code": "QL01EK05",
+      "name": "rivoceranib"
+    },
+    {
+      "code": "QL01EL",
+      "name": "Bruton's tyrosine kinase (BTK) inhibitors"
+    },
+    {
+      "code": "QL01EL01",
+      "name": "ibrutinib"
+    },
+    {
+      "code": "QL01EL02",
+      "name": "acalabrutinib"
+    },
+    {
+      "code": "QL01EL03",
+      "name": "zanubrutinib"
+    },
+    {
+      "code": "QL01EL04",
+      "name": "orelabrutinib"
+    },
+    {
+      "code": "QL01EL05",
+      "name": "pirtobrutinib"
+    },
+    {
+      "code": "QL01EL06",
+      "name": "tirabrutinib"
+    },
+    {
+      "code": "QL01EM",
+      "name": "Phosphatidylinositol-3-kinase (Pi3K) inhibitors"
+    },
+    {
+      "code": "QL01EM01",
+      "name": "idelalisib"
+    },
+    {
+      "code": "QL01EM02",
+      "name": "copanlisib"
+    },
+    {
+      "code": "QL01EM03",
+      "name": "alpelisib"
+    },
+    {
+      "code": "QL01EM04",
+      "name": "duvelisib"
+    },
+    {
+      "code": "QL01EM05",
+      "name": "parsaclisib"
+    },
+    {
+      "code": "QL01EM06",
+      "name": "inavolisib"
+    },
+    {
+      "code": "QL01EN",
+      "name": "Fibroblast growth factor receptor (FGFR) tyrosine kinase inhibitors"
+    },
+    {
+      "code": "QL01EN01",
+      "name": "erdafitinib"
+    },
+    {
+      "code": "QL01EN02",
+      "name": "pemigatinib"
+    },
+    {
+      "code": "QL01EN03",
+      "name": "infigratinib"
+    },
+    {
+      "code": "QL01EN04",
+      "name": "futibatinib"
+    },
+    {
+      "code": "QL01EP",
+      "name": "Cellular-mesenchymal-epithelial transition factor (c-MET) kinase inhibitors"
+    },
+    {
+      "code": "QL01EP01",
+      "name": "capmatinib"
+    },
+    {
+      "code": "QL01EP02",
+      "name": "tepotinib"
+    },
+    {
+      "code": "QL01EP03",
+      "name": "savolitinib"
+    },
+    {
+      "code": "QL01EX",
+      "name": "Other protein kinase inhibitors"
+    },
+    {
+      "code": "QL01EX01",
+      "name": "sunitinib"
+    },
+    {
+      "code": "QL01EX02",
+      "name": "sorafenib"
+    },
+    {
+      "code": "QL01EX03",
+      "name": "pazopanib"
+    },
+    {
+      "code": "QL01EX04",
+      "name": "vandetanib"
+    },
+    {
+      "code": "QL01EX05",
+      "name": "regorafenib"
+    },
+    {
+      "code": "QL01EX06",
+      "name": "masitinib"
+    },
+    {
+      "code": "QL01EX07",
+      "name": "cabozantinib"
+    },
+    {
+      "code": "QL01EX08",
+      "name": "lenvatinib"
+    },
+    {
+      "code": "QL01EX09",
+      "name": "nintedanib"
+    },
+    {
+      "code": "QL01EX10",
+      "name": "midostaurin"
+    },
+    {
+      "code": "QL01EX11",
+      "name": "quizartinib"
+    },
+    {
+      "code": "QL01EX12",
+      "name": "larotrectinib"
+    },
+    {
+      "code": "QL01EX13",
+      "name": "gilteritinib"
+    },
+    {
+      "code": "QL01EX14",
+      "name": "entrectinib"
+    },
+    {
+      "code": "QL01EX15",
+      "name": "pexidartinib"
+    },
+    {
+      "code": "QL01EX18",
+      "name": "avapritinib"
+    },
+    {
+      "code": "QL01EX19",
+      "name": "ripretinib"
+    },
+    {
+      "code": "QL01EX22",
+      "name": "selpercatinib"
+    },
+    {
+      "code": "QL01EX23",
+      "name": "pralsetinib"
+    },
+    {
+      "code": "QL01EX24",
+      "name": "surufatinib"
+    },
+    {
+      "code": "QL01EX25",
+      "name": "umbralisib"
+    },
+    {
+      "code": "QL01EX26",
+      "name": "sitravatinib"
+    },
+    {
+      "code": "QL01EX27",
+      "name": "capivasertib"
+    },
+    {
+      "code": "QL01EX28",
+      "name": "repotrectinib"
+    },
+    {
+      "code": "QL01EX29",
+      "name": "vimseltinib"
+    },
+    {
+      "code": "QL01EX90",
+      "name": "toceranib"
+    },
+    {
+      "code": "QL01F",
+      "name": "MONOCLONAL ANTIBODIES AND ANTIBODY DRUG CONJUGATES"
+    },
+    {
+      "code": "QL01FA",
+      "name": "CD20 (Clusters of Differentiation 20) inhibitors"
+    },
+    {
+      "code": "QL01FA01",
+      "name": "rituximab"
+    },
+    {
+      "code": "QL01FA02",
+      "name": "ofatumumab"
+    },
+    {
+      "code": "QL01FA03",
+      "name": "obinutuzumab"
+    },
+    {
+      "code": "QL01FB",
+      "name": "CD22 (Clusters of Differentiation 22) inhibitors"
+    },
+    {
+      "code": "QL01FB01",
+      "name": "inotuzumab ozogamicin"
+    },
+    {
+      "code": "QL01FB02",
+      "name": "moxetumomab pasudotox"
+    },
+    {
+      "code": "QL01FC",
+      "name": "CD38 (Clusters of Differentiation 38) inhibitors"
+    },
+    {
+      "code": "QL01FC01",
+      "name": "daratumumab"
+    },
+    {
+      "code": "QL01FC02",
+      "name": "isatuximab"
+    },
+    {
+      "code": "QL01FD",
+      "name": "HER2 (Human Epidermal Growth Factor Receptor 2) inhibitors"
+    },
+    {
+      "code": "QL01FD01",
+      "name": "trastuzumab"
+    },
+    {
+      "code": "QL01FD02",
+      "name": "pertuzumab"
+    },
+    {
+      "code": "QL01FD03",
+      "name": "trastuzumab emtansine"
+    },
+    {
+      "code": "QL01FD04",
+      "name": "trastuzumab deruxtecan"
+    },
+    {
+      "code": "QL01FD05",
+      "name": "trastuzumab duocarmazine"
+    },
+    {
+      "code": "QL01FD06",
+      "name": "margetuximab"
+    },
+    {
+      "code": "QL01FD07",
+      "name": "zanidatamab"
+    },
+    {
+      "code": "QL01FE",
+      "name": "EGFR (Epidermal Growth Factor Receptor) inhibitors"
+    },
+    {
+      "code": "QL01FE01",
+      "name": "cetuximab"
+    },
+    {
+      "code": "QL01FE02",
+      "name": "panitumumab"
+    },
+    {
+      "code": "QL01FE03",
+      "name": "necitumumab"
+    },
+    {
+      "code": "QL01FF",
+      "name": "PD-1/PD-L1 (Programmed cell death protein 1/death ligand 1) inhibitors"
+    },
+    {
+      "code": "QL01FF01",
+      "name": "nivolumab"
+    },
+    {
+      "code": "QL01FF02",
+      "name": "pembrolizumab"
+    },
+    {
+      "code": "QL01FF03",
+      "name": "durvalumab"
+    },
+    {
+      "code": "QL01FF04",
+      "name": "avelumab"
+    },
+    {
+      "code": "QL01FF05",
+      "name": "atezolizumab"
+    },
+    {
+      "code": "QL01FF06",
+      "name": "cemiplimab"
+    },
+    {
+      "code": "QL01FF07",
+      "name": "dostarlimab"
+    },
+    {
+      "code": "QL01FF08",
+      "name": "prolgolimab"
+    },
+    {
+      "code": "QL01FF09",
+      "name": "tislelizumab"
+    },
+    {
+      "code": "QL01FF10",
+      "name": "retifanlimab"
+    },
+    {
+      "code": "QL01FF11",
+      "name": "sugemalimab"
+    },
+    {
+      "code": "QL01FF12",
+      "name": "serplulimab"
+    },
+    {
+      "code": "QL01FF13",
+      "name": "toripalimab"
+    },
+    {
+      "code": "QL01FF14",
+      "name": "camrelizumab"
+    },
+    {
+      "code": "QL01FF15",
+      "name": "envafolimab"
+    },
+    {
+      "code": "QL01FF16",
+      "name": "sasanlimab"
+    },
+    {
+      "code": "QL01FG",
+      "name": "VEGF/VEGFR (Vascular Endothelial Growth Factor/ -Receptor) inhibitors"
+    },
+    {
+      "code": "QL01FG01",
+      "name": "bevacizumab"
+    },
+    {
+      "code": "QL01FG02",
+      "name": "ramucirumab"
+    },
+    {
+      "code": "QL01FX",
+      "name": "Other monoclonal antibodies and antibody drug conjugates"
+    },
+    {
+      "code": "QL01FX01",
+      "name": "edrecolomab"
+    },
+    {
+      "code": "QL01FX02",
+      "name": "gemtuzumab ozogamicin"
+    },
+    {
+      "code": "QL01FX03",
+      "name": "catumaxomab"
+    },
+    {
+      "code": "QL01FX04",
+      "name": "ipilimumab"
+    },
+    {
+      "code": "QL01FX05",
+      "name": "brentuximab vedotin"
+    },
+    {
+      "code": "QL01FX06",
+      "name": "dinutuximab beta"
+    },
+    {
+      "code": "QL01FX07",
+      "name": "blinatumomab"
+    },
+    {
+      "code": "QL01FX08",
+      "name": "elotuzumab"
+    },
+    {
+      "code": "QL01FX09",
+      "name": "mogamulizumab"
+    },
+    {
+      "code": "QL01FX10",
+      "name": "olaratumab"
+    },
+    {
+      "code": "QL01FX11",
+      "name": "bermekimab"
+    },
+    {
+      "code": "QL01FX12",
+      "name": "tafasitamab"
+    },
+    {
+      "code": "QL01FX13",
+      "name": "enfortumab vedotin"
+    },
+    {
+      "code": "QL01FX14",
+      "name": "polatuzumab vedotin"
+    },
+    {
+      "code": "QL01FX15",
+      "name": "belantamab mafodotin"
+    },
+    {
+      "code": "QL01FX16",
+      "name": "oportuzumab monatox"
+    },
+    {
+      "code": "QL01FX17",
+      "name": "sacituzumab govitecan"
+    },
+    {
+      "code": "QL01FX18",
+      "name": "amivantamab"
+    },
+    {
+      "code": "QL01FX19",
+      "name": "sabatolimab"
+    },
+    {
+      "code": "QL01FX20",
+      "name": "tremelimumab"
+    },
+    {
+      "code": "QL01FX21",
+      "name": "naxitamab"
+    },
+    {
+      "code": "QL01FX22",
+      "name": "loncastuximab tesirine"
+    },
+    {
+      "code": "QL01FX23",
+      "name": "tisotumab vedotin"
+    },
+    {
+      "code": "QL01FX24",
+      "name": "teclistamab"
+    },
+    {
+      "code": "QL01FX25",
+      "name": "mosunetuzumab"
+    },
+    {
+      "code": "QL01FX26",
+      "name": "mirvetuximab soravtansine"
+    },
+    {
+      "code": "QL01FX27",
+      "name": "epcoritamab"
+    },
+    {
+      "code": "QL01FX28",
+      "name": "glofitamab"
+    },
+    {
+      "code": "QL01FX29",
+      "name": "talquetamab"
+    },
+    {
+      "code": "QL01FX31",
+      "name": "zolbetuximab"
+    },
+    {
+      "code": "QL01FX32",
+      "name": "elranatamab"
+    },
+    {
+      "code": "QL01FX33",
+      "name": "tarlatamab"
+    },
+    {
+      "code": "QL01FX34",
+      "name": "odronextamab"
+    },
+    {
+      "code": "QL01FX35",
+      "name": "datopotamab deruxtecan"
+    },
+    {
+      "code": "QL01FX36",
+      "name": "patritumab deruxtecan"
+    },
+    {
+      "code": "QL01FX37",
+      "name": "linvoseltamab"
+    },
+    {
+      "code": "QL01FX38",
+      "name": "ifinatamab deruxtecan"
+    },
+    {
+      "code": "QL01FX39",
+      "name": "bemarituzumab"
+    },
+    {
+      "code": "QL01FY",
+      "name": "Combinations of monoclonal antibodies and antibody drug conjugates"
+    },
+    {
+      "code": "QL01FY01",
+      "name": "pertuzumab and trastuzumab"
+    },
+    {
+      "code": "QL01FY02",
+      "name": "nivolumab and relatlimab"
+    },
+    {
+      "code": "QL01FY03",
+      "name": "prolgolimab and nurulimab"
+    },
+    {
+      "code": "QL01X",
+      "name": "OTHER ANTINEOPLASTIC AGENTS"
+    },
+    {
+      "code": "QL01XA",
+      "name": "Platinum compounds"
+    },
+    {
+      "code": "QL01XA01",
+      "name": "cisplatin"
+    },
+    {
+      "code": "QL01XA02",
+      "name": "carboplatin"
+    },
+    {
+      "code": "QL01XA03",
+      "name": "oxaliplatin"
+    },
+    {
+      "code": "QL01XA04",
+      "name": "satraplatin"
+    },
+    {
+      "code": "QL01XA05",
+      "name": "polyplatillen"
+    },
+    {
+      "code": "QL01XB",
+      "name": "Methylhydrazines"
+    },
+    {
+      "code": "QL01XB01",
+      "name": "procarbazine"
+    },
+    {
+      "code": "QL01XD",
+      "name": "Sensitizers used in photodynamic/radiation therapy"
+    },
+    {
+      "code": "QL01XD01",
+      "name": "porfimer sodium"
+    },
+    {
+      "code": "QL01XD03",
+      "name": "methyl aminolevulinate"
+    },
+    {
+      "code": "QL01XD04",
+      "name": "aminolevulinic acid"
+    },
+    {
+      "code": "QL01XD05",
+      "name": "temoporfin"
+    },
+    {
+      "code": "QL01XD06",
+      "name": "efaproxiral"
+    },
+    {
+      "code": "QL01XD07",
+      "name": "padeliporfin"
+    },
+    {
+      "code": "QL01XF",
+      "name": "Retinoids for cancer treatment"
+    },
+    {
+      "code": "QL01XF01",
+      "name": "tretinoin"
+    },
+    {
+      "code": "QL01XF02",
+      "name": "alitretinoin"
+    },
+    {
+      "code": "QL01XF03",
+      "name": "bexarotene"
+    },
+    {
+      "code": "QL01XG",
+      "name": "Proteasome inhibitors"
+    },
+    {
+      "code": "QL01XG01",
+      "name": "bortezomib"
+    },
+    {
+      "code": "QL01XG02",
+      "name": "carfilzomib"
+    },
+    {
+      "code": "QL01XG03",
+      "name": "ixazomib"
+    },
+    {
+      "code": "QL01XH",
+      "name": "Histone deacetylase (HDAC) inhibitors"
+    },
+    {
+      "code": "QL01XH01",
+      "name": "vorinostat"
+    },
+    {
+      "code": "QL01XH02",
+      "name": "romidepsin"
+    },
+    {
+      "code": "QL01XH03",
+      "name": "panobinostat"
+    },
+    {
+      "code": "QL01XH04",
+      "name": "belinostat"
+    },
+    {
+      "code": "QL01XH05",
+      "name": "entinostat"
+    },
+    {
+      "code": "QL01XH06",
+      "name": "tucidinostat"
+    },
+    {
+      "code": "QL01XH07",
+      "name": "resminostat"
+    },
+    {
+      "code": "QL01XJ",
+      "name": "Hedgehog pathway inhibitors"
+    },
+    {
+      "code": "QL01XJ01",
+      "name": "vismodegib"
+    },
+    {
+      "code": "QL01XJ02",
+      "name": "sonidegib"
+    },
+    {
+      "code": "QL01XJ03",
+      "name": "glasdegib"
+    },
+    {
+      "code": "QL01XK",
+      "name": "Poly (ADP-ribose) polymerase (PARP) inhibitors"
+    },
+    {
+      "code": "QL01XK01",
+      "name": "olaparib"
+    },
+    {
+      "code": "QL01XK02",
+      "name": "niraparib"
+    },
+    {
+      "code": "QL01XK03",
+      "name": "rucaparib"
+    },
+    {
+      "code": "QL01XK04",
+      "name": "talazoparib"
+    },
+    {
+      "code": "QL01XK05",
+      "name": "veliparib"
+    },
+    {
+      "code": "QL01XK06",
+      "name": "pamiparib"
+    },
+    {
+      "code": "QL01XK07",
+      "name": "senaparib"
+    },
+    {
+      "code": "QL01XK52",
+      "name": "niraparib and abiraterone"
+    },
+    {
+      "code": "QL01XL",
+      "name": "Antineoplastic cell and gene therapy"
+    },
+    {
+      "code": "QL01XL01",
+      "name": "sitimagene ceradenovec"
+    },
+    {
+      "code": "QL01XL02",
+      "name": "talimogene laherparepvec"
+    },
+    {
+      "code": "QL01XL03",
+      "name": "axicabtagene ciloleucel"
+    },
+    {
+      "code": "QL01XL04",
+      "name": "tisagenlecleucel"
+    },
+    {
+      "code": "QL01XL05",
+      "name": "ciltacabtagene autoleucel"
+    },
+    {
+      "code": "QL01XL06",
+      "name": "brexucabtagene autoleucel"
+    },
+    {
+      "code": "QL01XL07",
+      "name": "idecabtagene vicleucel"
+    },
+    {
+      "code": "QL01XL08",
+      "name": "lisocabtagene maraleucel"
+    },
+    {
+      "code": "QL01XL09",
+      "name": "tabelecleucel"
+    },
+    {
+      "code": "QL01XL10",
+      "name": "nadofaragene firadenovec"
+    },
+    {
+      "code": "QL01XL11",
+      "name": "lifileucel"
+    },
+    {
+      "code": "QL01XL12",
+      "name": "obecabtagene autoleucel"
+    },
+    {
+      "code": "QL01XM",
+      "name": "Isocitrate dehydrogenase (IDH) inhibitors"
+    },
+    {
+      "code": "QL01XM01",
+      "name": "enasidenib"
+    },
+    {
+      "code": "QL01XM02",
+      "name": "ivosidenib"
+    },
+    {
+      "code": "QL01XM03",
+      "name": "olutasidenib"
+    },
+    {
+      "code": "QL01XM04",
+      "name": "vorasidenib"
+    },
+    {
+      "code": "QL01XU",
+      "name": "Other antineoplastic agents (cont.)"
+    },
+    {
+      "code": "QL01XX",
+      "name": "Other antineoplastic agents"
+    },
+    {
+      "code": "QL01XX01",
+      "name": "amsacrine"
+    },
+    {
+      "code": "QL01XX02",
+      "name": "asparaginase"
+    },
+    {
+      "code": "QL01XX03",
+      "name": "altretamine"
+    },
+    {
+      "code": "QL01XX05",
+      "name": "hydroxycarbamide"
+    },
+    {
+      "code": "QL01XX07",
+      "name": "lonidamine"
+    },
+    {
+      "code": "QL01XX08",
+      "name": "pentostatin"
+    },
+    {
+      "code": "QL01XX10",
+      "name": "masoprocol"
+    },
+    {
+      "code": "QL01XX11",
+      "name": "estramustine"
+    },
+    {
+      "code": "QL01XX16",
+      "name": "mitoguazone"
+    },
+    {
+      "code": "QL01XX18",
+      "name": "tiazofurin"
+    },
+    {
+      "code": "QL01XX23",
+      "name": "mitotane"
+    },
+    {
+      "code": "QL01XX24",
+      "name": "pegaspargase"
+    },
+    {
+      "code": "QL01XX27",
+      "name": "arsenic trioxide"
+    },
+    {
+      "code": "QL01XX29",
+      "name": "denileukin diftitox"
+    },
+    {
+      "code": "QL01XX33",
+      "name": "celecoxib"
+    },
+    {
+      "code": "QL01XX35",
+      "name": "anagrelide"
+    },
+    {
+      "code": "QL01XX36",
+      "name": "oblimersen"
+    },
+    {
+      "code": "QL01XX40",
+      "name": "omacetaxine mepesuccinate"
+    },
+    {
+      "code": "QL01XX41",
+      "name": "eribulin"
+    },
+    {
+      "code": "QL01XX44",
+      "name": "aflibercept"
+    },
+    {
+      "code": "QL01XX52",
+      "name": "venetoclax"
+    },
+    {
+      "code": "QL01XX53",
+      "name": "vosaroxin"
+    },
+    {
+      "code": "QL01XX57",
+      "name": "plitidepsin"
+    },
+    {
+      "code": "QL01XX58",
+      "name": "epacadostat"
+    },
+    {
+      "code": "QL01XX66",
+      "name": "selinexor"
+    },
+    {
+      "code": "QL01XX67",
+      "name": "tagraxofusp"
+    },
+    {
+      "code": "QL01XX69",
+      "name": "lurbinectedin"
+    },
+    {
+      "code": "QL01XX71",
+      "name": "tisagenlecleucel"
+    },
+    {
+      "code": "QL01XX72",
+      "name": "tazemetostat"
+    },
+    {
+      "code": "QL01XX73",
+      "name": "sotorasib"
+    },
+    {
+      "code": "QL01XX74",
+      "name": "belzutifan"
+    },
+    {
+      "code": "QL01XX75",
+      "name": "tebentafusp"
+    },
+    {
+      "code": "QL01XX77",
+      "name": "adagrasib"
+    },
+    {
+      "code": "QL01XX78",
+      "name": "navitoclax"
+    },
+    {
+      "code": "QL01XX79",
+      "name": "eflornithine"
+    },
+    {
+      "code": "QL01XX80",
+      "name": "imetelstat"
+    },
+    {
+      "code": "QL01XX81",
+      "name": "nirogacestat"
+    },
+    {
+      "code": "QL01XX82",
+      "name": "darinaparsin"
+    },
+    {
+      "code": "QL01XX83",
+      "name": "para-toluenesulfonamide"
+    },
+    {
+      "code": "QL01XX84",
+      "name": "pelabresib"
+    },
+    {
+      "code": "QL01XX85",
+      "name": "idroxioleic acid"
+    },
+    {
+      "code": "QL01XX86",
+      "name": "calaspargase pegol"
+    },
+    {
+      "code": "QL01XX87",
+      "name": "revumenib"
+    },
+    {
+      "code": "QL01XX91",
+      "name": "tigilanol tiglate"
+    },
+    {
+      "code": "QL01XX92",
+      "name": "verdinexor"
+    },
+    {
+      "code": "QL01XY",
+      "name": "Combinations of antineoplastic agents"
+    },
+    {
+      "code": "QL01XY01",
+      "name": "cytarabine and daunorubicin"
+    },
+    {
+      "code": "QL01XY04",
+      "name": "bifikafusp alfa and onfekafusp alfa"
+    },
+    {
+      "code": "QL02",
+      "name": "ENDOCRINE THERAPY"
+    },
+    {
+      "code": "QL02A",
+      "name": "HORMONES AND RELATED AGENTS"
+    },
+    {
+      "code": "QL02AA",
+      "name": "Estrogens"
+    },
+    {
+      "code": "QL02AA01",
+      "name": "diethylstilbestrol"
+    },
+    {
+      "code": "QL02AA02",
+      "name": "polyestradiol phosphate"
+    },
+    {
+      "code": "QL02AA03",
+      "name": "ethinylestradiol"
+    },
+    {
+      "code": "QL02AA04",
+      "name": "fosfestrol"
+    },
+    {
+      "code": "QL02AB",
+      "name": "Progestogens"
+    },
+    {
+      "code": "QL02AB01",
+      "name": "megestrol"
+    },
+    {
+      "code": "QL02AB02",
+      "name": "medroxyprogesterone"
+    },
+    {
+      "code": "QL02AB03",
+      "name": "gestonorone"
+    },
+    {
+      "code": "QL02AE",
+      "name": "Gonadotropin releasing hormone analogues"
+    },
+    {
+      "code": "QL02AE01",
+      "name": "buserelin"
+    },
+    {
+      "code": "QL02AE02",
+      "name": "leuprorelin"
+    },
+    {
+      "code": "QL02AE03",
+      "name": "goserelin"
+    },
+    {
+      "code": "QL02AE04",
+      "name": "triptorelin"
+    },
+    {
+      "code": "QL02AE05",
+      "name": "histrelin"
+    },
+    {
+      "code": "QL02AE51",
+      "name": "leuprorelin and bicalutamide"
+    },
+    {
+      "code": "QL02AX",
+      "name": "Other hormones"
+    },
+    {
+      "code": "QL02B",
+      "name": "HORMONE ANTAGONISTS AND RELATED AGENTS"
+    },
+    {
+      "code": "QL02BA",
+      "name": "Anti-estrogens"
+    },
+    {
+      "code": "QL02BA01",
+      "name": "tamoxifen"
+    },
+    {
+      "code": "QL02BA02",
+      "name": "toremifene"
+    },
+    {
+      "code": "QL02BA03",
+      "name": "fulvestrant"
+    },
+    {
+      "code": "QL02BA04",
+      "name": "elacestrant"
+    },
+    {
+      "code": "QL02BA05",
+      "name": "camizestrant"
+    },
+    {
+      "code": "QL02BB",
+      "name": "Anti-androgens"
+    },
+    {
+      "code": "QL02BB01",
+      "name": "flutamide"
+    },
+    {
+      "code": "QL02BB02",
+      "name": "nilutamide"
+    },
+    {
+      "code": "QL02BB03",
+      "name": "bicalutamide"
+    },
+    {
+      "code": "QL02BB04",
+      "name": "enzalutamide"
+    },
+    {
+      "code": "QL02BB05",
+      "name": "apalutamide"
+    },
+    {
+      "code": "QL02BB06",
+      "name": "darolutamide"
+    },
+    {
+      "code": "QL02BG",
+      "name": "Aromatase inhibitors"
+    },
+    {
+      "code": "QL02BG01",
+      "name": "aminoglutethimide"
+    },
+    {
+      "code": "QL02BG02",
+      "name": "formestane"
+    },
+    {
+      "code": "QL02BG03",
+      "name": "anastrozole"
+    },
+    {
+      "code": "QL02BG04",
+      "name": "letrozole"
+    },
+    {
+      "code": "QL02BG05",
+      "name": "vorozole"
+    },
+    {
+      "code": "QL02BG06",
+      "name": "exemestane"
+    },
+    {
+      "code": "QL02BX",
+      "name": "Other hormone antagonists and related agents"
+    },
+    {
+      "code": "QL02BX01",
+      "name": "abarelix"
+    },
+    {
+      "code": "QL02BX02",
+      "name": "degarelix"
+    },
+    {
+      "code": "QL02BX03",
+      "name": "abiraterone"
+    },
+    {
+      "code": "QL02BX04",
+      "name": "relugolix"
+    },
+    {
+      "code": "QL02BX53",
+      "name": "abiraterone and corticosteroids"
+    },
+    {
+      "code": "QL03",
+      "name": "IMMUNOSTIMULANTS"
+    },
+    {
+      "code": "QL03A",
+      "name": "IMMUNOSTIMULANTS"
+    },
+    {
+      "code": "QL03AA",
+      "name": "Colony stimulating factors"
+    },
+    {
+      "code": "QL03AA02",
+      "name": "filgrastim"
+    },
+    {
+      "code": "QL03AA03",
+      "name": "molgramostim"
+    },
+    {
+      "code": "QL03AA09",
+      "name": "sargramostim"
+    },
+    {
+      "code": "QL03AA10",
+      "name": "lenograstim"
+    },
+    {
+      "code": "QL03AA12",
+      "name": "ancestim"
+    },
+    {
+      "code": "QL03AA13",
+      "name": "pegfilgrastim"
+    },
+    {
+      "code": "QL03AA14",
+      "name": "lipegfilgrastim"
+    },
+    {
+      "code": "QL03AA15",
+      "name": "balugrastim"
+    },
+    {
+      "code": "QL03AA16",
+      "name": "empegfilgrastim"
+    },
+    {
+      "code": "QL03AA17",
+      "name": "pegteograstim"
+    },
+    {
+      "code": "QL03AA18",
+      "name": "efbemalenograstim alfa"
+    },
+    {
+      "code": "QL03AA19",
+      "name": "eflapegrastim"
+    },
+    {
+      "code": "QL03AA90",
+      "name": "pegbovigrastim"
+    },
+    {
+      "code": "QL03AB",
+      "name": "Interferons"
+    },
+    {
+      "code": "QL03AB01",
+      "name": "interferon alfa natural"
+    },
+    {
+      "code": "QL03AB02",
+      "name": "interferon beta natural"
+    },
+    {
+      "code": "QL03AB03",
+      "name": "interferon gamma"
+    },
+    {
+      "code": "QL03AB04",
+      "name": "interferon alfa-2a"
+    },
+    {
+      "code": "QL03AB05",
+      "name": "interferon alfa-2b"
+    },
+    {
+      "code": "QL03AB06",
+      "name": "interferon alfa-n1"
+    },
+    {
+      "code": "QL03AB07",
+      "name": "interferon beta-1a"
+    },
+    {
+      "code": "QL03AB08",
+      "name": "interferon beta-1b"
+    },
+    {
+      "code": "QL03AB09",
+      "name": "interferon alfacon-1"
+    },
+    {
+      "code": "QL03AB10",
+      "name": "peginterferon alfa-2b"
+    },
+    {
+      "code": "QL03AB11",
+      "name": "peginterferon alfa-2a"
+    },
+    {
+      "code": "QL03AB12",
+      "name": "albinterferon alfa-2b"
+    },
+    {
+      "code": "QL03AB13",
+      "name": "peginterferon beta-1a"
+    },
+    {
+      "code": "QL03AB14",
+      "name": "cepeginterferon alfa-2b"
+    },
+    {
+      "code": "QL03AB15",
+      "name": "ropeginterferon alfa-2b"
+    },
+    {
+      "code": "QL03AB16",
+      "name": "peginterferon alfacon-2"
+    },
+    {
+      "code": "QL03AB17",
+      "name": "sampeginterferon beta-1a"
+    },
+    {
+      "code": "QL03AB60",
+      "name": "peginterferon alfa-2b, combinations"
+    },
+    {
+      "code": "QL03AB61",
+      "name": "peginterferon alfa-2a, combinations"
+    },
+    {
+      "code": "QL03AB90",
+      "name": "interferon omega, feline origin"
+    },
+    {
+      "code": "QL03AC",
+      "name": "Interleukins"
+    },
+    {
+      "code": "QL03AC01",
+      "name": "aldesleukin"
+    },
+    {
+      "code": "QL03AC02",
+      "name": "oprelvekin"
+    },
+    {
+      "code": "QL03AC03",
+      "name": "nogapendekin alfa and inbakicept"
+    },
+    {
+      "code": "QL03AX",
+      "name": "Other immunostimulants"
+    },
+    {
+      "code": "QL03AX01",
+      "name": "lentinan"
+    },
+    {
+      "code": "QL03AX02",
+      "name": "roquinimex"
+    },
+    {
+      "code": "QL03AX03",
+      "name": "BCG vaccine"
+    },
+    {
+      "code": "QL03AX04",
+      "name": "pegademase"
+    },
+    {
+      "code": "QL03AX05",
+      "name": "pidotimod"
+    },
+    {
+      "code": "QL03AX07",
+      "name": "poly I:C"
+    },
+    {
+      "code": "QL03AX08",
+      "name": "poly ICLC"
+    },
+    {
+      "code": "QL03AX09",
+      "name": "thymopentin"
+    },
+    {
+      "code": "QL03AX10",
+      "name": "immunocyanin"
+    },
+    {
+      "code": "QL03AX11",
+      "name": "tasonermin"
+    },
+    {
+      "code": "QL03AX12",
+      "name": "melanoma vaccine"
+    },
+    {
+      "code": "QL03AX13",
+      "name": "glatiramer acetate"
+    },
+    {
+      "code": "QL03AX14",
+      "name": "histamine dihydrochloride"
+    },
+    {
+      "code": "QL03AX15",
+      "name": "mifamurtide"
+    },
+    {
+      "code": "QL03AX16",
+      "name": "plerixafor"
+    },
+    {
+      "code": "QL03AX17",
+      "name": "sipuleucel-T"
+    },
+    {
+      "code": "QL03AX18",
+      "name": "cridanimod"
+    },
+    {
+      "code": "QL03AX19",
+      "name": "dasiprotimut-T"
+    },
+    {
+      "code": "QL03AX21",
+      "name": "elapegademase"
+    },
+    {
+      "code": "QL03AX22",
+      "name": "leniolisib"
+    },
+    {
+      "code": "QL03AX23",
+      "name": "motixafortide"
+    },
+    {
+      "code": "QL03AX24",
+      "name": "mavorixafor"
+    },
+    {
+      "code": "QL03AX25",
+      "name": "thymalfasin"
+    },
+    {
+      "code": "QL03AX90",
+      "name": "feline interleukin-2 recombinant canarypox virus"
+    },
+    {
+      "code": "QL04",
+      "name": "IMMUNOSUPPRESSANTS"
+    },
+    {
+      "code": "QL04A",
+      "name": "IMMUNOSUPPRESSANTS"
+    },
+    {
+      "code": "QL04AA",
+      "name": "Selective immunosuppressants"
+    },
+    {
+      "code": "QL04AA03",
+      "name": "antilymphocyte immunoglobulin (horse)"
+    },
+    {
+      "code": "QL04AA04",
+      "name": "antithymocyte immunoglobulin (rabbit)"
+    },
+    {
+      "code": "QL04AA06",
+      "name": "mycophenolic acid"
+    },
+    {
+      "code": "QL04AA15",
+      "name": "alefacept"
+    },
+    {
+      "code": "QL04AA19",
+      "name": "gusperimus"
+    },
+    {
+      "code": "QL04AA22",
+      "name": "abetimus"
+    },
+    {
+      "code": "QL04AA24",
+      "name": "abatacept"
+    },
+    {
+      "code": "QL04AA28",
+      "name": "belatacept"
+    },
+    {
+      "code": "QL04AA32",
+      "name": "apremilast"
+    },
+    {
+      "code": "QL04AA40",
+      "name": "cladribine"
+    },
+    {
+      "code": "QL04AA41",
+      "name": "imlifidase"
+    },
+    {
+      "code": "QL04AA48",
+      "name": "belumosudil"
+    },
+    {
+      "code": "QL04AA60",
+      "name": "remibrutinib"
+    },
+    {
+      "code": "QL04AA61",
+      "name": "nerandomilast"
+    },
+    {
+      "code": "QL04AA62",
+      "name": "tolebrutinib"
+    },
+    {
+      "code": "QL04AA90",
+      "name": "fuzapladib"
+    },
+    {
+      "code": "QL04AB",
+      "name": "Tumor necrosis factor alpha (TNF-alpha) inhibitors"
+    },
+    {
+      "code": "QL04AB01",
+      "name": "etanercept"
+    },
+    {
+      "code": "QL04AB02",
+      "name": "infliximab"
+    },
+    {
+      "code": "QL04AB03",
+      "name": "afelimomab"
+    },
+    {
+      "code": "QL04AB04",
+      "name": "adalimumab"
+    },
+    {
+      "code": "QL04AB05",
+      "name": "certolizumab pegol"
+    },
+    {
+      "code": "QL04AB06",
+      "name": "golimumab"
+    },
+    {
+      "code": "QL04AB07",
+      "name": "opinercept"
+    },
+    {
+      "code": "QL04AC",
+      "name": "Interleukin inhibitors"
+    },
+    {
+      "code": "QL04AC01",
+      "name": "daclizumab"
+    },
+    {
+      "code": "QL04AC02",
+      "name": "basiliximab"
+    },
+    {
+      "code": "QL04AC03",
+      "name": "anakinra"
+    },
+    {
+      "code": "QL04AC04",
+      "name": "rilonacept"
+    },
+    {
+      "code": "QL04AC05",
+      "name": "ustekinumab"
+    },
+    {
+      "code": "QL04AC07",
+      "name": "tocilizumab"
+    },
+    {
+      "code": "QL04AC08",
+      "name": "canakinumab"
+    },
+    {
+      "code": "QL04AC09",
+      "name": "briakinumab"
+    },
+    {
+      "code": "QL04AC10",
+      "name": "secukinumab"
+    },
+    {
+      "code": "QL04AC11",
+      "name": "siltuximab"
+    },
+    {
+      "code": "QL04AC12",
+      "name": "brodalumab"
+    },
+    {
+      "code": "QL04AC13",
+      "name": "ixekizumab"
+    },
+    {
+      "code": "QL04AC14",
+      "name": "sarilumab"
+    },
+    {
+      "code": "QL04AC15",
+      "name": "sirukumab"
+    },
+    {
+      "code": "QL04AC16",
+      "name": "guselkumab"
+    },
+    {
+      "code": "QL04AC17",
+      "name": "tildrakizumab"
+    },
+    {
+      "code": "QL04AC18",
+      "name": "risankizumab"
+    },
+    {
+      "code": "QL04AC19",
+      "name": "satralizumab"
+    },
+    {
+      "code": "QL04AC20",
+      "name": "netakimab"
+    },
+    {
+      "code": "QL04AC21",
+      "name": "bimekizumab"
+    },
+    {
+      "code": "QL04AC22",
+      "name": "spesolimab"
+    },
+    {
+      "code": "QL04AC23",
+      "name": "olokizumab"
+    },
+    {
+      "code": "QL04AC24",
+      "name": "mirikizumab"
+    },
+    {
+      "code": "QL04AC25",
+      "name": "levilimab"
+    },
+    {
+      "code": "QL04AC26",
+      "name": "goflikicept"
+    },
+    {
+      "code": "QL04AC27",
+      "name": "cendakimab"
+    },
+    {
+      "code": "QL04AD",
+      "name": "Calcineurin inhibitors"
+    },
+    {
+      "code": "QL04AD01",
+      "name": "ciclosporin"
+    },
+    {
+      "code": "QL04AD02",
+      "name": "tacrolimus"
+    },
+    {
+      "code": "QL04AD03",
+      "name": "voclosporin"
+    },
+    {
+      "code": "QL04AE",
+      "name": "Sphingosine-1-phosphate (S1P) receptor modulators"
+    },
+    {
+      "code": "QL04AE01",
+      "name": "fingolimod"
+    },
+    {
+      "code": "QL04AE02",
+      "name": "ozanimod"
+    },
+    {
+      "code": "QL04AE03",
+      "name": "siponimod"
+    },
+    {
+      "code": "QL04AE04",
+      "name": "ponesimod"
+    },
+    {
+      "code": "QL04AE05",
+      "name": "etrasimod"
+    },
+    {
+      "code": "QL04AF",
+      "name": "Janus-associated kinase (JAK) inhibitors"
+    },
+    {
+      "code": "QL04AF01",
+      "name": "tofacitinib"
+    },
+    {
+      "code": "QL04AF02",
+      "name": "baricitinib"
+    },
+    {
+      "code": "QL04AF03",
+      "name": "upadacitinib"
+    },
+    {
+      "code": "QL04AF04",
+      "name": "filgotinib"
+    },
+    {
+      "code": "QL04AF05",
+      "name": "itacitinib"
+    },
+    {
+      "code": "QL04AF06",
+      "name": "peficitinib"
+    },
+    {
+      "code": "QL04AF07",
+      "name": "deucravacitinib"
+    },
+    {
+      "code": "QL04AF08",
+      "name": "ritlecitinib"
+    },
+    {
+      "code": "QL04AF09",
+      "name": "deuruxolitinib"
+    },
+    {
+      "code": "QL04AG",
+      "name": "Monoclonal antibodies"
+    },
+    {
+      "code": "QL04AG01",
+      "name": "muromonab-CD3"
+    },
+    {
+      "code": "QL04AG02",
+      "name": "efalizumab"
+    },
+    {
+      "code": "QL04AG03",
+      "name": "natalizumab"
+    },
+    {
+      "code": "QL04AG04",
+      "name": "belimumab"
+    },
+    {
+      "code": "QL04AG05",
+      "name": "vedolizumab"
+    },
+    {
+      "code": "QL04AG06",
+      "name": "alemtuzumab"
+    },
+    {
+      "code": "QL04AG07",
+      "name": "begelomab"
+    },
+    {
+      "code": "QL04AG08",
+      "name": "ocrelizumab"
+    },
+    {
+      "code": "QL04AG09",
+      "name": "emapalumab"
+    },
+    {
+      "code": "QL04AG10",
+      "name": "inebilizumab"
+    },
+    {
+      "code": "QL04AG11",
+      "name": "anifrolumab"
+    },
+    {
+      "code": "QL04AG12",
+      "name": "ofatumumab"
+    },
+    {
+      "code": "QL04AG13",
+      "name": "teprotumumab"
+    },
+    {
+      "code": "QL04AG14",
+      "name": "ublituximab"
+    },
+    {
+      "code": "QL04AG15",
+      "name": "divozilimab"
+    },
+    {
+      "code": "QL04AG17",
+      "name": "seniprutug"
+    },
+    {
+      "code": "QL04AG18",
+      "name": "sibeprenlimab"
+    },
+    {
+      "code": "QL04AG19",
+      "name": "axatilimab"
+    },
+    {
+      "code": "QL04AG90",
+      "name": "cirevetmab"
+    },
+    {
+      "code": "QL04AH",
+      "name": "Mammalian target of rapamycin (mTOR) kinase inhibitors"
+    },
+    {
+      "code": "QL04AH01",
+      "name": "sirolimus"
+    },
+    {
+      "code": "QL04AH02",
+      "name": "everolimus"
+    },
+    {
+      "code": "QL04AJ",
+      "name": "Complement inhibitors"
+    },
+    {
+      "code": "QL04AJ01",
+      "name": "eculizumab"
+    },
+    {
+      "code": "QL04AJ02",
+      "name": "ravulizumab"
+    },
+    {
+      "code": "QL04AJ03",
+      "name": "pegcetacoplan"
+    },
+    {
+      "code": "QL04AJ04",
+      "name": "sutimlimab"
+    },
+    {
+      "code": "QL04AJ05",
+      "name": "avacopan"
+    },
+    {
+      "code": "QL04AJ06",
+      "name": "zilucoplan"
+    },
+    {
+      "code": "QL04AJ07",
+      "name": "crovalimab"
+    },
+    {
+      "code": "QL04AJ08",
+      "name": "iptacopan"
+    },
+    {
+      "code": "QL04AJ09",
+      "name": "danicopan"
+    },
+    {
+      "code": "QL04AJ10",
+      "name": "vilobelimab"
+    },
+    {
+      "code": "QL04AJ11",
+      "name": "pozelimab"
+    },
+    {
+      "code": "QL04AK",
+      "name": "Dihydroorotate dehydrogenase (DHODH) inhibitors"
+    },
+    {
+      "code": "QL04AK01",
+      "name": "leflunomide"
+    },
+    {
+      "code": "QL04AK02",
+      "name": "teriflunomide"
+    },
+    {
+      "code": "QL04AL",
+      "name": "Neonatal fragment crystallizable receptor (FcRn) inhibitors"
+    },
+    {
+      "code": "QL04AL01",
+      "name": "efgartigimod alfa"
+    },
+    {
+      "code": "QL04AL02",
+      "name": "rozanolixizumab"
+    },
+    {
+      "code": "QL04AL03",
+      "name": "nipocalimab"
+    },
+    {
+      "code": "QL04AX",
+      "name": "Other immunosuppressants"
+    },
+    {
+      "code": "QL04AX01",
+      "name": "azathioprine"
+    },
+    {
+      "code": "QL04AX02",
+      "name": "thalidomide"
+    },
+    {
+      "code": "QL04AX03",
+      "name": "methotrexate"
+    },
+    {
+      "code": "QL04AX04",
+      "name": "lenalidomide"
+    },
+    {
+      "code": "QL04AX05",
+      "name": "pirfenidone"
+    },
+    {
+      "code": "QL04AX06",
+      "name": "pomalidomide"
+    },
+    {
+      "code": "QL04AX07",
+      "name": "dimethyl fumarate"
+    },
+    {
+      "code": "QL04AX08",
+      "name": "darvadstrocel"
+    },
+    {
+      "code": "QL04AX09",
+      "name": "diroximel fumarate"
+    },
+    {
+      "code": "QL04AX10",
+      "name": "tegomil fumarate"
+    },
+    {
+      "code": "QL04AX11",
+      "name": "monomethyl fumarate"
+    },
+    {
+      "code": "QM",
+      "name": "MUSCULO-SKELETAL SYSTEM"
+    },
+    {
+      "code": "QM01",
+      "name": "ANTIINFLAMMATORY AND ANTIRHEUMATIC PRODUCTS"
+    },
+    {
+      "code": "QM01A",
+      "name": "ANTIINFLAMMATORY AND ANTIRHEUMATIC PRODUCTS, NON-STEROIDS"
+    },
+    {
+      "code": "QM01AA",
+      "name": "Butylpyrazolidines"
+    },
+    {
+      "code": "QM01AA01",
+      "name": "phenylbutazone"
+    },
+    {
+      "code": "QM01AA02",
+      "name": "mofebutazone"
+    },
+    {
+      "code": "QM01AA03",
+      "name": "oxyphenbutazone"
+    },
+    {
+      "code": "QM01AA05",
+      "name": "clofezone"
+    },
+    {
+      "code": "QM01AA06",
+      "name": "kebuzone"
+    },
+    {
+      "code": "QM01AA90",
+      "name": "suxibuzone"
+    },
+    {
+      "code": "QM01AA99",
+      "name": "combinations"
+    },
+    {
+      "code": "QM01AB",
+      "name": "Acetic acid derivatives and related substances"
+    },
+    {
+      "code": "QM01AB01",
+      "name": "indometacin"
+    },
+    {
+      "code": "QM01AB02",
+      "name": "sulindac"
+    },
+    {
+      "code": "QM01AB03",
+      "name": "tolmetin"
+    },
+    {
+      "code": "QM01AB04",
+      "name": "zomepirac"
+    },
+    {
+      "code": "QM01AB05",
+      "name": "diclofenac"
+    },
+    {
+      "code": "QM01AB06",
+      "name": "alclofenac"
+    },
+    {
+      "code": "QM01AB07",
+      "name": "bumadizone"
+    },
+    {
+      "code": "QM01AB08",
+      "name": "etodolac"
+    },
+    {
+      "code": "QM01AB09",
+      "name": "lonazolac"
+    },
+    {
+      "code": "QM01AB10",
+      "name": "fentiazac"
+    },
+    {
+      "code": "QM01AB11",
+      "name": "acemetacin"
+    },
+    {
+      "code": "QM01AB12",
+      "name": "difenpiramide"
+    },
+    {
+      "code": "QM01AB13",
+      "name": "oxametacin"
+    },
+    {
+      "code": "QM01AB14",
+      "name": "proglumetacin"
+    },
+    {
+      "code": "QM01AB15",
+      "name": "ketorolac"
+    },
+    {
+      "code": "QM01AB16",
+      "name": "aceclofenac"
+    },
+    {
+      "code": "QM01AB17",
+      "name": "bufexamac"
+    },
+    {
+      "code": "QM01AB51",
+      "name": "indometacin, combinations"
+    },
+    {
+      "code": "QM01AB55",
+      "name": "diclofenac, combinations"
+    },
+    {
+      "code": "QM01AC",
+      "name": "Oxicams"
+    },
+    {
+      "code": "QM01AC01",
+      "name": "piroxicam"
+    },
+    {
+      "code": "QM01AC02",
+      "name": "tenoxicam"
+    },
+    {
+      "code": "QM01AC04",
+      "name": "droxicam"
+    },
+    {
+      "code": "QM01AC05",
+      "name": "lornoxicam"
+    },
+    {
+      "code": "QM01AC06",
+      "name": "meloxicam"
+    },
+    {
+      "code": "QM01AC56",
+      "name": "meloxicam, combinations"
+    },
+    {
+      "code": "QM01AE",
+      "name": "Propionic acid derivatives"
+    },
+    {
+      "code": "QM01AE01",
+      "name": "ibuprofen"
+    },
+    {
+      "code": "QM01AE02",
+      "name": "naproxen"
+    },
+    {
+      "code": "QM01AE03",
+      "name": "ketoprofen"
+    },
+    {
+      "code": "QM01AE04",
+      "name": "fenoprofen"
+    },
+    {
+      "code": "QM01AE05",
+      "name": "fenbufen"
+    },
+    {
+      "code": "QM01AE06",
+      "name": "benoxaprofen"
+    },
+    {
+      "code": "QM01AE07",
+      "name": "suprofen"
+    },
+    {
+      "code": "QM01AE08",
+      "name": "pirprofen"
+    },
+    {
+      "code": "QM01AE09",
+      "name": "flurbiprofen"
+    },
+    {
+      "code": "QM01AE10",
+      "name": "indoprofen"
+    },
+    {
+      "code": "QM01AE11",
+      "name": "tiaprofenic acid"
+    },
+    {
+      "code": "QM01AE12",
+      "name": "oxaprozin"
+    },
+    {
+      "code": "QM01AE13",
+      "name": "ibuproxam"
+    },
+    {
+      "code": "QM01AE14",
+      "name": "dexibuprofen"
+    },
+    {
+      "code": "QM01AE15",
+      "name": "flunoxaprofen"
+    },
+    {
+      "code": "QM01AE16",
+      "name": "alminoprofen"
+    },
+    {
+      "code": "QM01AE17",
+      "name": "dexketoprofen"
+    },
+    {
+      "code": "QM01AE18",
+      "name": "naproxcinod"
+    },
+    {
+      "code": "QM01AE19",
+      "name": "loxoprofen"
+    },
+    {
+      "code": "QM01AE20",
+      "name": "pelubiprofen"
+    },
+    {
+      "code": "QM01AE51",
+      "name": "ibuprofen, combinations"
+    },
+    {
+      "code": "QM01AE52",
+      "name": "naproxen and esomeprazole"
+    },
+    {
+      "code": "QM01AE53",
+      "name": "ketoprofen, combinations"
+    },
+    {
+      "code": "QM01AE56",
+      "name": "naproxen and misoprostol"
+    },
+    {
+      "code": "QM01AE57",
+      "name": "naproxen and diphenhydramine"
+    },
+    {
+      "code": "QM01AE90",
+      "name": "vedaprofen"
+    },
+    {
+      "code": "QM01AE91",
+      "name": "carprofen"
+    },
+    {
+      "code": "QM01AE92",
+      "name": "tepoxalin"
+    },
+    {
+      "code": "QM01AG",
+      "name": "Fenamates"
+    },
+    {
+      "code": "QM01AG01",
+      "name": "mefenamic acid"
+    },
+    {
+      "code": "QM01AG02",
+      "name": "tolfenamic acid"
+    },
+    {
+      "code": "QM01AG03",
+      "name": "flufenamic acid"
+    },
+    {
+      "code": "QM01AG04",
+      "name": "meclofenamic acid"
+    },
+    {
+      "code": "QM01AG90",
+      "name": "flunixin"
+    },
+    {
+      "code": "QM01AH",
+      "name": "Coxibs"
+    },
+    {
+      "code": "QM01AH01",
+      "name": "celecoxib"
+    },
+    {
+      "code": "QM01AH02",
+      "name": "rofecoxib"
+    },
+    {
+      "code": "QM01AH03",
+      "name": "valdecoxib"
+    },
+    {
+      "code": "QM01AH04",
+      "name": "parecoxib"
+    },
+    {
+      "code": "QM01AH05",
+      "name": "etoricoxib"
+    },
+    {
+      "code": "QM01AH06",
+      "name": "lumiracoxib"
+    },
+    {
+      "code": "QM01AH07",
+      "name": "polmacoxib"
+    },
+    {
+      "code": "QM01AH90",
+      "name": "firocoxib"
+    },
+    {
+      "code": "QM01AH91",
+      "name": "robenacoxib"
+    },
+    {
+      "code": "QM01AH92",
+      "name": "mavacoxib"
+    },
+    {
+      "code": "QM01AH93",
+      "name": "cimicoxib"
+    },
+    {
+      "code": "QM01AH94",
+      "name": "deracoxib"
+    },
+    {
+      "code": "QM01AH95",
+      "name": "enflicoxib"
+    },
+    {
+      "code": "QM01AX",
+      "name": "Other antiinflammatory and antirheumatic agents, non-steroids"
+    },
+    {
+      "code": "QM01AX01",
+      "name": "nabumetone"
+    },
+    {
+      "code": "QM01AX02",
+      "name": "niflumic acid"
+    },
+    {
+      "code": "QM01AX04",
+      "name": "azapropazone"
+    },
+    {
+      "code": "QM01AX05",
+      "name": "glucosamine"
+    },
+    {
+      "code": "QM01AX07",
+      "name": "benzydamine"
+    },
+    {
+      "code": "QM01AX12",
+      "name": "glucosaminoglycan polysulfate"
+    },
+    {
+      "code": "QM01AX13",
+      "name": "proquazone"
+    },
+    {
+      "code": "QM01AX14",
+      "name": "orgotein"
+    },
+    {
+      "code": "QM01AX17",
+      "name": "nimesulide"
+    },
+    {
+      "code": "QM01AX18",
+      "name": "feprazone"
+    },
+    {
+      "code": "QM01AX21",
+      "name": "diacerein"
+    },
+    {
+      "code": "QM01AX22",
+      "name": "morniflumate"
+    },
+    {
+      "code": "QM01AX23",
+      "name": "tenidap"
+    },
+    {
+      "code": "QM01AX24",
+      "name": "oxaceprol"
+    },
+    {
+      "code": "QM01AX25",
+      "name": "chondroitin sulfate"
+    },
+    {
+      "code": "QM01AX26",
+      "name": "avocado and soyabean oil, unsaponifiables"
+    },
+    {
+      "code": "QM01AX52",
+      "name": "niflumic acid, combinations"
+    },
+    {
+      "code": "QM01AX68",
+      "name": "feprazone, combinations"
+    },
+    {
+      "code": "QM01AX90",
+      "name": "pentosan polysulfate sodium"
+    },
+    {
+      "code": "QM01AX91",
+      "name": "aminopropionitrile"
+    },
+    {
+      "code": "QM01AX92",
+      "name": "grapiprant"
+    },
+    {
+      "code": "QM01AX99",
+      "name": "combinations"
+    },
+    {
+      "code": "QM01B",
+      "name": "ANTIINFLAMMATORY/ANTIRHEUMATIC AGENTS IN COMBINATION"
+    },
+    {
+      "code": "QM01BA",
+      "name": "Antiinflammatory/antirheumatic agents in combination with corticosteroids"
+    },
+    {
+      "code": "QM01BA01",
+      "name": "phenylbutazone and corticosteroids"
+    },
+    {
+      "code": "QM01BA02",
+      "name": "dipyrocetyl and corticosteroids"
+    },
+    {
+      "code": "QM01BA03",
+      "name": "acetylsalicylic acid and corticosteroids"
+    },
+    {
+      "code": "QM01BA99",
+      "name": "combinations"
+    },
+    {
+      "code": "QM01BX",
+      "name": "Other antiinflammatory/antirheumatic agents in combination with other drugs"
+    },
+    {
+      "code": "QM01C",
+      "name": "SPECIFIC ANTIRHEUMATIC AGENTS"
+    },
+    {
+      "code": "QM01CA",
+      "name": "Quinolines"
+    },
+    {
+      "code": "QM01CA03",
+      "name": "oxycinchopen"
+    },
+    {
+      "code": "QM01CB",
+      "name": "Gold preparations"
+    },
+    {
+      "code": "QM01CB01",
+      "name": "sodium aurothiomalate"
+    },
+    {
+      "code": "QM01CB02",
+      "name": "sodium aurothiosulfate"
+    },
+    {
+      "code": "QM01CB03",
+      "name": "auranofin"
+    },
+    {
+      "code": "QM01CB04",
+      "name": "aurothioglucose"
+    },
+    {
+      "code": "QM01CB05",
+      "name": "aurotioprol"
+    },
+    {
+      "code": "QM01CC",
+      "name": "Penicillamine and similar agents"
+    },
+    {
+      "code": "QM01CC01",
+      "name": "penicillamine"
+    },
+    {
+      "code": "QM01CC02",
+      "name": "bucillamine"
+    },
+    {
+      "code": "QM01CX",
+      "name": "Other specific antirheumatic agents"
+    },
+    {
+      "code": "QM02",
+      "name": "TOPICAL PRODUCTS FOR JOINT AND MUSCULAR PAIN"
+    },
+    {
+      "code": "QM02A",
+      "name": "TOPICAL PRODUCTS FOR JOINT AND MUSCULAR PAIN"
+    },
+    {
+      "code": "QM02AA",
+      "name": "Antiinflammatory preparations, non-steroids for topical use"
+    },
+    {
+      "code": "QM02AA01",
+      "name": "phenylbutazone"
+    },
+    {
+      "code": "QM02AA02",
+      "name": "mofebutazone"
+    },
+    {
+      "code": "QM02AA03",
+      "name": "clofezone"
+    },
+    {
+      "code": "QM02AA04",
+      "name": "oxyphenbutazone"
+    },
+    {
+      "code": "QM02AA05",
+      "name": "benzydamine"
+    },
+    {
+      "code": "QM02AA06",
+      "name": "etofenamate"
+    },
+    {
+      "code": "QM02AA07",
+      "name": "piroxicam"
+    },
+    {
+      "code": "QM02AA08",
+      "name": "felbinac"
+    },
+    {
+      "code": "QM02AA09",
+      "name": "bufexamac"
+    },
+    {
+      "code": "QM02AA10",
+      "name": "ketoprofen"
+    },
+    {
+      "code": "QM02AA11",
+      "name": "bendazac"
+    },
+    {
+      "code": "QM02AA12",
+      "name": "naproxen"
+    },
+    {
+      "code": "QM02AA13",
+      "name": "ibuprofen"
+    },
+    {
+      "code": "QM02AA14",
+      "name": "fentiazac"
+    },
+    {
+      "code": "QM02AA15",
+      "name": "diclofenac"
+    },
+    {
+      "code": "QM02AA16",
+      "name": "feprazone"
+    },
+    {
+      "code": "QM02AA17",
+      "name": "niflumic acid"
+    },
+    {
+      "code": "QM02AA18",
+      "name": "meclofenamic acid"
+    },
+    {
+      "code": "QM02AA19",
+      "name": "flurbiprofen"
+    },
+    {
+      "code": "QM02AA21",
+      "name": "tolmetin"
+    },
+    {
+      "code": "QM02AA22",
+      "name": "suxibuzone"
+    },
+    {
+      "code": "QM02AA23",
+      "name": "indometacin"
+    },
+    {
+      "code": "QM02AA24",
+      "name": "nifenazone"
+    },
+    {
+      "code": "QM02AA25",
+      "name": "aceclofenac"
+    },
+    {
+      "code": "QM02AA26",
+      "name": "nimesulide"
+    },
+    {
+      "code": "QM02AA27",
+      "name": "dexketoprofen"
+    },
+    {
+      "code": "QM02AA28",
+      "name": "piketoprofen"
+    },
+    {
+      "code": "QM02AA29",
+      "name": "esflurbiprofen"
+    },
+    {
+      "code": "QM02AA31",
+      "name": "loxoprofen"
+    },
+    {
+      "code": "QM02AA99",
+      "name": "antiinflammatory preparations, non-steroids for topical use, combinations"
+    },
+    {
+      "code": "QM02AB",
+      "name": "Capsaicin and similar agents"
+    },
+    {
+      "code": "QM02AB01",
+      "name": "capsaicin"
+    },
+    {
+      "code": "QM02AB02",
+      "name": "zucapsaicin"
+    },
+    {
+      "code": "QM02AC",
+      "name": "Preparations with salicylic acid derivatives"
+    },
+    {
+      "code": "QM02AC99",
+      "name": "preparations with salicylic acid derivatives, combinations"
+    },
+    {
+      "code": "QM02AQ",
+      "name": "Blistering agents"
+    },
+    {
+      "code": "QM02AX",
+      "name": "Other topical products for joint and muscular pain"
+    },
+    {
+      "code": "QM02AX02",
+      "name": "tolazoline"
+    },
+    {
+      "code": "QM02AX03",
+      "name": "dimethyl sulfoxide"
+    },
+    {
+      "code": "QM02AX05",
+      "name": "idrocilamide"
+    },
+    {
+      "code": "QM02AX06",
+      "name": "tolperisone"
+    },
+    {
+      "code": "QM02AX10",
+      "name": "various"
+    },
+    {
+      "code": "QM02AX99",
+      "name": "combinations"
+    },
+    {
+      "code": "QM03",
+      "name": "MUSCLE RELAXANTS"
+    },
+    {
+      "code": "QM03A",
+      "name": "MUSCLE RELAXANTS, PERIPHERALLY ACTING AGENTS"
+    },
+    {
+      "code": "QM03AA",
+      "name": "Curare alkaloids"
+    },
+    {
+      "code": "QM03AA01",
+      "name": "alcuronium"
+    },
+    {
+      "code": "QM03AA02",
+      "name": "tubocurarine"
+    },
+    {
+      "code": "QM03AA04",
+      "name": "dimethyltubocurarine"
+    },
+    {
+      "code": "QM03AB",
+      "name": "Choline derivatives"
+    },
+    {
+      "code": "QM03AB01",
+      "name": "suxamethonium"
+    },
+    {
+      "code": "QM03AC",
+      "name": "Other quaternary ammonium compounds"
+    },
+    {
+      "code": "QM03AC01",
+      "name": "pancuronium"
+    },
+    {
+      "code": "QM03AC02",
+      "name": "gallamine"
+    },
+    {
+      "code": "QM03AC03",
+      "name": "vecuronium"
+    },
+    {
+      "code": "QM03AC04",
+      "name": "atracurium"
+    },
+    {
+      "code": "QM03AC05",
+      "name": "hexafluronium"
+    },
+    {
+      "code": "QM03AC06",
+      "name": "pipecuronium bromide"
+    },
+    {
+      "code": "QM03AC07",
+      "name": "doxacurium chloride"
+    },
+    {
+      "code": "QM03AC08",
+      "name": "fazadinium bromide"
+    },
+    {
+      "code": "QM03AC09",
+      "name": "rocuronium bromide"
+    },
+    {
+      "code": "QM03AC10",
+      "name": "mivacurium chloride"
+    },
+    {
+      "code": "QM03AC11",
+      "name": "cisatracuricum"
+    },
+    {
+      "code": "QM03AX",
+      "name": "Other muscle relaxants, peripherally acting agents"
+    },
+    {
+      "code": "QM03AX01",
+      "name": "botulinum toxin"
+    },
+    {
+      "code": "QM03B",
+      "name": "MUSCLE RELAXANTS, CENTRALLY ACTING AGENTS"
+    },
+    {
+      "code": "QM03BA",
+      "name": "Carbamic acid esters"
+    },
+    {
+      "code": "QM03BA01",
+      "name": "phenprobamate"
+    },
+    {
+      "code": "QM03BA02",
+      "name": "carisoprodol"
+    },
+    {
+      "code": "QM03BA03",
+      "name": "methocarbamol"
+    },
+    {
+      "code": "QM03BA04",
+      "name": "styramate"
+    },
+    {
+      "code": "QM03BA05",
+      "name": "febarbamate"
+    },
+    {
+      "code": "QM03BA51",
+      "name": "phenprobamate, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QM03BA52",
+      "name": "carisoprodol, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QM03BA53",
+      "name": "methocarbamol, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QM03BA71",
+      "name": "phenprobamate, combinations with psycholeptics"
+    },
+    {
+      "code": "QM03BA72",
+      "name": "carisoprodol, combinations with psycholeptics"
+    },
+    {
+      "code": "QM03BA73",
+      "name": "methocarbamol, combinations with psycholeptics"
+    },
+    {
+      "code": "QM03BA99",
+      "name": "combinations"
+    },
+    {
+      "code": "QM03BB",
+      "name": "Oxazol, thiazine, and triazine derivatives"
+    },
+    {
+      "code": "QM03BB02",
+      "name": "chlormezanone"
+    },
+    {
+      "code": "QM03BB03",
+      "name": "chlorzoxazone"
+    },
+    {
+      "code": "QM03BB52",
+      "name": "chlormezanone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QM03BB53",
+      "name": "chlorzoxazone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QM03BB72",
+      "name": "chlormezanone, combinations with psycholeptics"
+    },
+    {
+      "code": "QM03BB73",
+      "name": "chlorzoxazone, combinations with psycholeptics"
+    },
+    {
+      "code": "QM03BC",
+      "name": "Ethers, chemically close to antihistamines"
+    },
+    {
+      "code": "QM03BC01",
+      "name": "orphenadrine (citrate)"
+    },
+    {
+      "code": "QM03BC51",
+      "name": "orphenadrine, combinations"
+    },
+    {
+      "code": "QM03BX",
+      "name": "Other centrally acting agents"
+    },
+    {
+      "code": "QM03BX01",
+      "name": "baclofen"
+    },
+    {
+      "code": "QM03BX02",
+      "name": "tizanidine"
+    },
+    {
+      "code": "QM03BX03",
+      "name": "pridinol"
+    },
+    {
+      "code": "QM03BX04",
+      "name": "tolperisone"
+    },
+    {
+      "code": "QM03BX05",
+      "name": "thiocolchicoside"
+    },
+    {
+      "code": "QM03BX06",
+      "name": "mephenesin"
+    },
+    {
+      "code": "QM03BX07",
+      "name": "tetrazepam"
+    },
+    {
+      "code": "QM03BX08",
+      "name": "cyclobenzaprine"
+    },
+    {
+      "code": "QM03BX09",
+      "name": "eperisone"
+    },
+    {
+      "code": "QM03BX30",
+      "name": "fenyramidol"
+    },
+    {
+      "code": "QM03BX53",
+      "name": "pridinol, combinations"
+    },
+    {
+      "code": "QM03BX55",
+      "name": "thiocolchicoside, combinations"
+    },
+    {
+      "code": "QM03BX90",
+      "name": "guaifenesin"
+    },
+    {
+      "code": "QM03C",
+      "name": "MUSCLE RELAXANTS, DIRECTLY ACTING AGENTS"
+    },
+    {
+      "code": "QM03CA",
+      "name": "Dantrolene and derivatives"
+    },
+    {
+      "code": "QM03CA01",
+      "name": "dantrolene"
+    },
+    {
+      "code": "QM04",
+      "name": "ANTIGOUT PREPARATIONS"
+    },
+    {
+      "code": "QM04A",
+      "name": "ANTIGOUT PREPARATIONS"
+    },
+    {
+      "code": "QM04AA",
+      "name": "Preparations inhibiting uric acid production"
+    },
+    {
+      "code": "QM04AA01",
+      "name": "allopurinol"
+    },
+    {
+      "code": "QM04AA02",
+      "name": "tisopurine"
+    },
+    {
+      "code": "QM04AA03",
+      "name": "febuxostat"
+    },
+    {
+      "code": "QM04AA51",
+      "name": "allopurinol, combinations"
+    },
+    {
+      "code": "QM04AB",
+      "name": "Preparations increasing uric acid excretion"
+    },
+    {
+      "code": "QM04AB01",
+      "name": "probenecid"
+    },
+    {
+      "code": "QM04AB02",
+      "name": "sulfinpyrazone"
+    },
+    {
+      "code": "QM04AB03",
+      "name": "benzpromarone"
+    },
+    {
+      "code": "QM04AB04",
+      "name": "isobromindione"
+    },
+    {
+      "code": "QM04AB05",
+      "name": "lesinurad"
+    },
+    {
+      "code": "QM04AB06",
+      "name": "dotinurad"
+    },
+    {
+      "code": "QM04AC",
+      "name": "Preparations with no effect on uric acid metabolism"
+    },
+    {
+      "code": "QM04AC01",
+      "name": "colchicine"
+    },
+    {
+      "code": "QM04AC02",
+      "name": "cinchophen"
+    },
+    {
+      "code": "QM04AC51",
+      "name": "colchicine and probenecid"
+    },
+    {
+      "code": "QM04AX",
+      "name": "Other antigout preparations"
+    },
+    {
+      "code": "QM04AX01",
+      "name": "urate oxidase"
+    },
+    {
+      "code": "QM04AX02",
+      "name": "pegloticase"
+    },
+    {
+      "code": "QM05",
+      "name": "DRUGS FOR TREATMENT OF BONE DISEASES"
+    },
+    {
+      "code": "QM05B",
+      "name": "DRUGS AFFECTING BONE STRUCTURE AND MINERALIZATION"
+    },
+    {
+      "code": "QM05BA",
+      "name": "Bisphosphonates"
+    },
+    {
+      "code": "QM05BA01",
+      "name": "etidronic acid"
+    },
+    {
+      "code": "QM05BA02",
+      "name": "clodronic acid"
+    },
+    {
+      "code": "QM05BA03",
+      "name": "pamidronic acid"
+    },
+    {
+      "code": "QM05BA04",
+      "name": "alendronic acid"
+    },
+    {
+      "code": "QM05BA05",
+      "name": "tiludronic acid"
+    },
+    {
+      "code": "QM05BA06",
+      "name": "ibandronic acid"
+    },
+    {
+      "code": "QM05BA07",
+      "name": "risedronic acid"
+    },
+    {
+      "code": "QM05BA08",
+      "name": "zoledronic acid"
+    },
+    {
+      "code": "QM05BB",
+      "name": "Bisphosphonates, combinations"
+    },
+    {
+      "code": "QM05BB01",
+      "name": "etidronic acid and calcium, sequential"
+    },
+    {
+      "code": "QM05BB02",
+      "name": "risedronic acid and calcium, sequential"
+    },
+    {
+      "code": "QM05BB03",
+      "name": "alendronic acid and colecalciferol"
+    },
+    {
+      "code": "QM05BB04",
+      "name": "risedronic acid, calcium and colecalciferol, sequential"
+    },
+    {
+      "code": "QM05BB05",
+      "name": "alendronic acid, calcium and colecalciferol, sequential"
+    },
+    {
+      "code": "QM05BB06",
+      "name": "alendronic acid and alfacalcidol, sequential"
+    },
+    {
+      "code": "QM05BB07",
+      "name": "risedronic acid and colecalciferol"
+    },
+    {
+      "code": "QM05BB08",
+      "name": "zoledronic acid, calcium and colecalciferol, sequential"
+    },
+    {
+      "code": "QM05BB09",
+      "name": "ibandronic acid and colecalciferol"
+    },
+    {
+      "code": "QM05BC",
+      "name": "Bone morphogenetic proteins"
+    },
+    {
+      "code": "QM05BC01",
+      "name": "dibotermin alfa"
+    },
+    {
+      "code": "QM05BC02",
+      "name": "eptotermin alfa"
+    },
+    {
+      "code": "QM05BX",
+      "name": "Other drugs affecting bone structure and mineralization"
+    },
+    {
+      "code": "QM05BX01",
+      "name": "ipriflavone"
+    },
+    {
+      "code": "QM05BX02",
+      "name": "aluminium chlorohydrate"
+    },
+    {
+      "code": "QM05BX03",
+      "name": "strontium ranelate"
+    },
+    {
+      "code": "QM05BX04",
+      "name": "denosumab"
+    },
+    {
+      "code": "QM05BX05",
+      "name": "burosumab"
+    },
+    {
+      "code": "QM05BX06",
+      "name": "romosozumab"
+    },
+    {
+      "code": "QM05BX07",
+      "name": "vosoritide"
+    },
+    {
+      "code": "QM05BX08",
+      "name": "menatetrenone"
+    },
+    {
+      "code": "QM05BX53",
+      "name": "strontium ranelate and colecalciferol"
+    },
+    {
+      "code": "QM09",
+      "name": "OTHER DRUGS FOR DISORDERS OF THE MUSCULO-SKELETAL SYSTEM"
+    },
+    {
+      "code": "QM09A",
+      "name": "OTHER DRUGS FOR DISORDERS OF THE MUSCULO-SKELETAL SYSTEM"
+    },
+    {
+      "code": "QM09AA",
+      "name": "Quinine and derivatives"
+    },
+    {
+      "code": "QM09AA01",
+      "name": "hydroquinine"
+    },
+    {
+      "code": "QM09AA72",
+      "name": "quinine, combinations with psycholeptics"
+    },
+    {
+      "code": "QM09AB",
+      "name": "Enzymes"
+    },
+    {
+      "code": "QM09AB01",
+      "name": "chymopapain"
+    },
+    {
+      "code": "QM09AB02",
+      "name": "collagenase clostridium histolyticum"
+    },
+    {
+      "code": "QM09AB03",
+      "name": "bromelains"
+    },
+    {
+      "code": "QM09AB52",
+      "name": "trypsin, combinations"
+    },
+    {
+      "code": "QM09AX",
+      "name": "Other drugs for disorders of the musculo-skeletal system"
+    },
+    {
+      "code": "QM09AX01",
+      "name": "hyaluronic acid"
+    },
+    {
+      "code": "QM09AX02",
+      "name": "chondrocytes, autologous"
+    },
+    {
+      "code": "QM09AX03",
+      "name": "ataluren"
+    },
+    {
+      "code": "QM09AX04",
+      "name": "drisapersen"
+    },
+    {
+      "code": "QM09AX05",
+      "name": "aceneuramic acid"
+    },
+    {
+      "code": "QM09AX06",
+      "name": "eteplirsen"
+    },
+    {
+      "code": "QM09AX07",
+      "name": "nusinersen"
+    },
+    {
+      "code": "QM09AX08",
+      "name": "golodirsen"
+    },
+    {
+      "code": "QM09AX09",
+      "name": "onasemnogene abeparvovec"
+    },
+    {
+      "code": "QM09AX10",
+      "name": "risdiplam"
+    },
+    {
+      "code": "QM09AX11",
+      "name": "palovarotene"
+    },
+    {
+      "code": "QM09AX12",
+      "name": "viltolarsen"
+    },
+    {
+      "code": "QM09AX13",
+      "name": "casimersen"
+    },
+    {
+      "code": "QM09AX14",
+      "name": "givinostat"
+    },
+    {
+      "code": "QM09AX15",
+      "name": "delandistrogene moxeparvovec"
+    },
+    {
+      "code": "QM09AX16",
+      "name": "apitegromab"
+    },
+    {
+      "code": "QM09AX90",
+      "name": "equine stem cells"
+    },
+    {
+      "code": "QM09AX91",
+      "name": "polyacrylamide"
+    },
+    {
+      "code": "QM09AX92",
+      "name": "canine stem cells"
+    },
+    {
+      "code": "QM09AX99",
+      "name": "combinations"
+    },
+    {
+      "code": "QN",
+      "name": "NERVOUS SYSTEM"
+    },
+    {
+      "code": "QN01",
+      "name": "ANESTHETICS"
+    },
+    {
+      "code": "QN01A",
+      "name": "ANESTHETICS, GENERAL"
+    },
+    {
+      "code": "QN01AA",
+      "name": "Ethers"
+    },
+    {
+      "code": "QN01AA01",
+      "name": "diethyl ether"
+    },
+    {
+      "code": "QN01AA02",
+      "name": "vinyl ether"
+    },
+    {
+      "code": "QN01AB",
+      "name": "Halogenated hydrocarbons"
+    },
+    {
+      "code": "QN01AB01",
+      "name": "halothane"
+    },
+    {
+      "code": "QN01AB02",
+      "name": "chloroform"
+    },
+    {
+      "code": "QN01AB04",
+      "name": "enflurane"
+    },
+    {
+      "code": "QN01AB05",
+      "name": "trichloroethylene"
+    },
+    {
+      "code": "QN01AB06",
+      "name": "isoflurane"
+    },
+    {
+      "code": "QN01AB07",
+      "name": "desflurane"
+    },
+    {
+      "code": "QN01AB08",
+      "name": "sevoflurane"
+    },
+    {
+      "code": "QN01AF",
+      "name": "Barbiturates, plain"
+    },
+    {
+      "code": "QN01AF01",
+      "name": "methohexital"
+    },
+    {
+      "code": "QN01AF02",
+      "name": "hexobarbital"
+    },
+    {
+      "code": "QN01AF03",
+      "name": "thiopental"
+    },
+    {
+      "code": "QN01AF90",
+      "name": "thiamylal"
+    },
+    {
+      "code": "QN01AG",
+      "name": "Barbiturates in combination with other drugs"
+    },
+    {
+      "code": "QN01AG01",
+      "name": "narcobarbital"
+    },
+    {
+      "code": "QN01AH",
+      "name": "Opioid anesthetics"
+    },
+    {
+      "code": "QN01AH01",
+      "name": "fentanyl"
+    },
+    {
+      "code": "QN01AH02",
+      "name": "alfentanil"
+    },
+    {
+      "code": "QN01AH03",
+      "name": "sufentanil"
+    },
+    {
+      "code": "QN01AH04",
+      "name": "phenoperidine"
+    },
+    {
+      "code": "QN01AH05",
+      "name": "anileridine"
+    },
+    {
+      "code": "QN01AH06",
+      "name": "remifentanil"
+    },
+    {
+      "code": "QN01AH51",
+      "name": "fentanyl, combinations"
+    },
+    {
+      "code": "QN01AX",
+      "name": "Other general anesthetics"
+    },
+    {
+      "code": "QN01AX03",
+      "name": "ketamine"
+    },
+    {
+      "code": "QN01AX04",
+      "name": "propanidid"
+    },
+    {
+      "code": "QN01AX05",
+      "name": "alfaxalone"
+    },
+    {
+      "code": "QN01AX07",
+      "name": "etomidate"
+    },
+    {
+      "code": "QN01AX10",
+      "name": "propofol"
+    },
+    {
+      "code": "QN01AX11",
+      "name": "sodium oxybate"
+    },
+    {
+      "code": "QN01AX13",
+      "name": "nitrous oxide"
+    },
+    {
+      "code": "QN01AX14",
+      "name": "esketamine"
+    },
+    {
+      "code": "QN01AX15",
+      "name": "xenon"
+    },
+    {
+      "code": "QN01AX63",
+      "name": "nitrous oxide, combinations"
+    },
+    {
+      "code": "QN01AX91",
+      "name": "azaperone"
+    },
+    {
+      "code": "QN01AX92",
+      "name": "benzocaine"
+    },
+    {
+      "code": "QN01AX93",
+      "name": "tricaine mesilate"
+    },
+    {
+      "code": "QN01AX94",
+      "name": "isoeugenol"
+    },
+    {
+      "code": "QN01AX95",
+      "name": "levomenthol"
+    },
+    {
+      "code": "QN01AX99",
+      "name": "other general anesthetics, combinations"
+    },
+    {
+      "code": "QN01B",
+      "name": "ANESTHETICS, LOCAL"
+    },
+    {
+      "code": "QN01BA",
+      "name": "Esters of aminobenzoic acid"
+    },
+    {
+      "code": "QN01BA01",
+      "name": "metabutethamine"
+    },
+    {
+      "code": "QN01BA02",
+      "name": "procaine"
+    },
+    {
+      "code": "QN01BA03",
+      "name": "tetracaine"
+    },
+    {
+      "code": "QN01BA04",
+      "name": "chloroprocaine"
+    },
+    {
+      "code": "QN01BA05",
+      "name": "benzocaine"
+    },
+    {
+      "code": "QN01BA52",
+      "name": "procaine, combinations"
+    },
+    {
+      "code": "QN01BA53",
+      "name": "tetracaine, combinations"
+    },
+    {
+      "code": "QN01BB",
+      "name": "Amides"
+    },
+    {
+      "code": "QN01BB01",
+      "name": "bupivacaine"
+    },
+    {
+      "code": "QN01BB02",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QN01BB03",
+      "name": "mepivacaine"
+    },
+    {
+      "code": "QN01BB04",
+      "name": "prilocaine"
+    },
+    {
+      "code": "QN01BB05",
+      "name": "butanilicaine"
+    },
+    {
+      "code": "QN01BB06",
+      "name": "cinchocaine"
+    },
+    {
+      "code": "QN01BB07",
+      "name": "etidocaine"
+    },
+    {
+      "code": "QN01BB08",
+      "name": "articaine"
+    },
+    {
+      "code": "QN01BB09",
+      "name": "ropivacaine"
+    },
+    {
+      "code": "QN01BB10",
+      "name": "levobupivacaine"
+    },
+    {
+      "code": "QN01BB20",
+      "name": "combinations"
+    },
+    {
+      "code": "QN01BB51",
+      "name": "bupivacaine, combinations"
+    },
+    {
+      "code": "QN01BB52",
+      "name": "lidocaine, combinations"
+    },
+    {
+      "code": "QN01BB53",
+      "name": "mepivacaine, combinations"
+    },
+    {
+      "code": "QN01BB54",
+      "name": "prilocaine, combinations"
+    },
+    {
+      "code": "QN01BB57",
+      "name": "etidocaine, combinations"
+    },
+    {
+      "code": "QN01BB58",
+      "name": "articaine, combinations"
+    },
+    {
+      "code": "QN01BB59",
+      "name": "bupivacaine and meloxicam"
+    },
+    {
+      "code": "QN01BC",
+      "name": "Esters of benzoic acid"
+    },
+    {
+      "code": "QN01BC01",
+      "name": "cocaine"
+    },
+    {
+      "code": "QN01BX",
+      "name": "Other local anesthetics"
+    },
+    {
+      "code": "QN01BX01",
+      "name": "ethyl chloride"
+    },
+    {
+      "code": "QN01BX02",
+      "name": "dyclonine"
+    },
+    {
+      "code": "QN01BX03",
+      "name": "phenol"
+    },
+    {
+      "code": "QN01BX04",
+      "name": "capsaicin"
+    },
+    {
+      "code": "QN02",
+      "name": "ANALGESICS"
+    },
+    {
+      "code": "QN02A",
+      "name": "OPIOIDS"
+    },
+    {
+      "code": "QN02AA",
+      "name": "Natural opium alkaloids"
+    },
+    {
+      "code": "QN02AA01",
+      "name": "morphine"
+    },
+    {
+      "code": "QN02AA02",
+      "name": "opium"
+    },
+    {
+      "code": "QN02AA03",
+      "name": "hydromorphone"
+    },
+    {
+      "code": "QN02AA04",
+      "name": "nicomorphine"
+    },
+    {
+      "code": "QN02AA05",
+      "name": "oxycodone"
+    },
+    {
+      "code": "QN02AA08",
+      "name": "dihydrocodeine"
+    },
+    {
+      "code": "QN02AA10",
+      "name": "papaveretum"
+    },
+    {
+      "code": "QN02AA11",
+      "name": "oxymorphone"
+    },
+    {
+      "code": "QN02AA51",
+      "name": "morphine, combinations"
+    },
+    {
+      "code": "QN02AA53",
+      "name": "hydromorphone and naloxone"
+    },
+    {
+      "code": "QN02AA55",
+      "name": "oxycodone and naloxone"
+    },
+    {
+      "code": "QN02AA56",
+      "name": "oxycodone and naltrexone"
+    },
+    {
+      "code": "QN02AA58",
+      "name": "dihydrocodeine, combinations"
+    },
+    {
+      "code": "QN02AA59",
+      "name": "codeine, combinations"
+    },
+    {
+      "code": "QN02AA79",
+      "name": "codeine, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02AB",
+      "name": "Phenylpiperidine derivatives"
+    },
+    {
+      "code": "QN02AB01",
+      "name": "ketobemidone"
+    },
+    {
+      "code": "QN02AB02",
+      "name": "pethidine"
+    },
+    {
+      "code": "QN02AB03",
+      "name": "fentanyl"
+    },
+    {
+      "code": "QN02AB52",
+      "name": "pethidine, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02AB53",
+      "name": "fentanyl, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02AB72",
+      "name": "pethidine, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02AB73",
+      "name": "fentanyl, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02AC",
+      "name": "Diphenylpropylamine derivatives"
+    },
+    {
+      "code": "QN02AC01",
+      "name": "dextromoramide"
+    },
+    {
+      "code": "QN02AC03",
+      "name": "piritramide"
+    },
+    {
+      "code": "QN02AC04",
+      "name": "dextropropoxyphene"
+    },
+    {
+      "code": "QN02AC05",
+      "name": "bezitramide"
+    },
+    {
+      "code": "QN02AC52",
+      "name": "methadone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02AC54",
+      "name": "dextropropoxyphene, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02AC74",
+      "name": "dextropropoxyphene, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02AC90",
+      "name": "methadone"
+    },
+    {
+      "code": "QN02AD",
+      "name": "Benzomorphan derivatives"
+    },
+    {
+      "code": "QN02AD01",
+      "name": "pentazocine"
+    },
+    {
+      "code": "QN02AD02",
+      "name": "phenazocine"
+    },
+    {
+      "code": "QN02AD51",
+      "name": "pentazocine and naloxone"
+    },
+    {
+      "code": "QN02AE",
+      "name": "Oripavine derivatives"
+    },
+    {
+      "code": "QN02AE01",
+      "name": "buprenorphine"
+    },
+    {
+      "code": "QN02AE90",
+      "name": "etorphine"
+    },
+    {
+      "code": "QN02AE99",
+      "name": "oripavine derivatives, combinations"
+    },
+    {
+      "code": "QN02AF",
+      "name": "Morphinan derivatives"
+    },
+    {
+      "code": "QN02AF01",
+      "name": "butorphanol"
+    },
+    {
+      "code": "QN02AF02",
+      "name": "nalbuphine"
+    },
+    {
+      "code": "QN02AG",
+      "name": "Opioids in combination with antispasmodics"
+    },
+    {
+      "code": "QN02AG01",
+      "name": "morphine and antispasmodics"
+    },
+    {
+      "code": "QN02AG02",
+      "name": "ketobemidone and antispasmodics"
+    },
+    {
+      "code": "QN02AG03",
+      "name": "pethidine and antispasmodics"
+    },
+    {
+      "code": "QN02AG04",
+      "name": "hydromorphone and antispasmodics"
+    },
+    {
+      "code": "QN02AJ",
+      "name": "Opioids in combination with non-opioid analgesics"
+    },
+    {
+      "code": "QN02AJ01",
+      "name": "dihydrocodeine and paracetamol"
+    },
+    {
+      "code": "QN02AJ02",
+      "name": "dihydrocodeine and acetylsalicylic acid"
+    },
+    {
+      "code": "QN02AJ03",
+      "name": "dihydrocodeine and other non-opioid analgesics"
+    },
+    {
+      "code": "QN02AJ06",
+      "name": "codeine and paracetamol"
+    },
+    {
+      "code": "QN02AJ07",
+      "name": "codeine and acetylsalicylic acid"
+    },
+    {
+      "code": "QN02AJ08",
+      "name": "codeine and ibuprofen"
+    },
+    {
+      "code": "QN02AJ09",
+      "name": "codeine and other non-opioid analgesics"
+    },
+    {
+      "code": "QN02AJ13",
+      "name": "tramadol and paracetamol"
+    },
+    {
+      "code": "QN02AJ14",
+      "name": "tramadol and dexketoprofen"
+    },
+    {
+      "code": "QN02AJ15",
+      "name": "tramadol and other non-opioid analgesics"
+    },
+    {
+      "code": "QN02AJ16",
+      "name": "tramadol and celecoxib"
+    },
+    {
+      "code": "QN02AJ17",
+      "name": "oxycodone and paracetamol"
+    },
+    {
+      "code": "QN02AJ18",
+      "name": "oxycodone and acetylsalicylic acid"
+    },
+    {
+      "code": "QN02AJ19",
+      "name": "oxycodone and ibuprofen"
+    },
+    {
+      "code": "QN02AJ22",
+      "name": "hydrocodone and paracetamol"
+    },
+    {
+      "code": "QN02AJ23",
+      "name": "hydrocodone and ibuprofen"
+    },
+    {
+      "code": "QN02AX",
+      "name": "Other opioids"
+    },
+    {
+      "code": "QN02AX01",
+      "name": "tilidine"
+    },
+    {
+      "code": "QN02AX02",
+      "name": "tramadol"
+    },
+    {
+      "code": "QN02AX03",
+      "name": "dezocine"
+    },
+    {
+      "code": "QN02AX05",
+      "name": "meptazinol"
+    },
+    {
+      "code": "QN02AX06",
+      "name": "tapentadol"
+    },
+    {
+      "code": "QN02AX07",
+      "name": "oliceridine"
+    },
+    {
+      "code": "QN02AX51",
+      "name": "tilidine and naloxone"
+    },
+    {
+      "code": "QN02B",
+      "name": "OTHER ANALGESICS AND ANTIPYRETICS"
+    },
+    {
+      "code": "QN02BA",
+      "name": "Salicylic acid and derivatives"
+    },
+    {
+      "code": "QN02BA01",
+      "name": "acetylsalicylic acid"
+    },
+    {
+      "code": "QN02BA02",
+      "name": "aloxiprin"
+    },
+    {
+      "code": "QN02BA03",
+      "name": "choline salicylate"
+    },
+    {
+      "code": "QN02BA04",
+      "name": "sodium salicylate"
+    },
+    {
+      "code": "QN02BA05",
+      "name": "salicylamide"
+    },
+    {
+      "code": "QN02BA06",
+      "name": "salsalate"
+    },
+    {
+      "code": "QN02BA07",
+      "name": "ethenzamide"
+    },
+    {
+      "code": "QN02BA08",
+      "name": "morpholine salicylate"
+    },
+    {
+      "code": "QN02BA09",
+      "name": "dipyrocetyl"
+    },
+    {
+      "code": "QN02BA10",
+      "name": "benorilate"
+    },
+    {
+      "code": "QN02BA11",
+      "name": "diflunisal"
+    },
+    {
+      "code": "QN02BA12",
+      "name": "potassium salicylate"
+    },
+    {
+      "code": "QN02BA14",
+      "name": "guacetisal"
+    },
+    {
+      "code": "QN02BA15",
+      "name": "carbasalate calcium"
+    },
+    {
+      "code": "QN02BA16",
+      "name": "imidazole salicylate"
+    },
+    {
+      "code": "QN02BA51",
+      "name": "acetylsalicylic acid, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA55",
+      "name": "salicylamide, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA57",
+      "name": "ethenzamide, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA59",
+      "name": "dipyrocetyl, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA65",
+      "name": "carbasalate calcium, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA67",
+      "name": "magnesium salicylate, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BA71",
+      "name": "acetylsalicylic acid, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BA75",
+      "name": "salicylamide, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BA77",
+      "name": "ethenzamide, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BA79",
+      "name": "dipyrocetyl, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BB",
+      "name": "Pyrazolones"
+    },
+    {
+      "code": "QN02BB01",
+      "name": "phenazone"
+    },
+    {
+      "code": "QN02BB02",
+      "name": "metamizole sodium"
+    },
+    {
+      "code": "QN02BB03",
+      "name": "aminophenazone"
+    },
+    {
+      "code": "QN02BB04",
+      "name": "propyphenazone"
+    },
+    {
+      "code": "QN02BB05",
+      "name": "nifenazone"
+    },
+    {
+      "code": "QN02BB51",
+      "name": "phenazone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BB52",
+      "name": "metamizole sodium, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BB53",
+      "name": "aminophenazone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BB54",
+      "name": "propyphenazone, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BB71",
+      "name": "phenazone, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BB72",
+      "name": "metamizole sodium, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BB73",
+      "name": "aminophenazone, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BB74",
+      "name": "propyphenazone, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BE",
+      "name": "Anilides"
+    },
+    {
+      "code": "QN02BE01",
+      "name": "paracetamol"
+    },
+    {
+      "code": "QN02BE03",
+      "name": "phenacetin"
+    },
+    {
+      "code": "QN02BE04",
+      "name": "bucetin"
+    },
+    {
+      "code": "QN02BE05",
+      "name": "propacetamol"
+    },
+    {
+      "code": "QN02BE51",
+      "name": "paracetamol, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BE53",
+      "name": "phenacetin, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BE54",
+      "name": "bucetin, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02BE71",
+      "name": "paracetamol, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BE73",
+      "name": "phenacetin, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BE74",
+      "name": "bucetin, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02BF",
+      "name": "Gabapentinoids"
+    },
+    {
+      "code": "QN02BF01",
+      "name": "gabapentin"
+    },
+    {
+      "code": "QN02BF02",
+      "name": "pregabalin"
+    },
+    {
+      "code": "QN02BF03",
+      "name": "mirogabalin"
+    },
+    {
+      "code": "QN02BG",
+      "name": "Other analgesics and antipyretics"
+    },
+    {
+      "code": "QN02BG02",
+      "name": "rimazolium"
+    },
+    {
+      "code": "QN02BG03",
+      "name": "glafenine"
+    },
+    {
+      "code": "QN02BG04",
+      "name": "floctafenine"
+    },
+    {
+      "code": "QN02BG05",
+      "name": "viminol"
+    },
+    {
+      "code": "QN02BG06",
+      "name": "nefopam"
+    },
+    {
+      "code": "QN02BG07",
+      "name": "flupirtine"
+    },
+    {
+      "code": "QN02BG08",
+      "name": "ziconotide"
+    },
+    {
+      "code": "QN02BG09",
+      "name": "methoxyflurane"
+    },
+    {
+      "code": "QN02BG10",
+      "name": "cannabinoids"
+    },
+    {
+      "code": "QN02BG12",
+      "name": "tanezumab"
+    },
+    {
+      "code": "QN02BG90",
+      "name": "frunevetmab"
+    },
+    {
+      "code": "QN02BG91",
+      "name": "bedinvetmab"
+    },
+    {
+      "code": "QN02BG92",
+      "name": "relfovetmab"
+    },
+    {
+      "code": "QN02BG93",
+      "name": "izenivetmab"
+    },
+    {
+      "code": "QN02C",
+      "name": "ANTIMIGRAINE PREPARATIONS"
+    },
+    {
+      "code": "QN02CA",
+      "name": "Ergot alkaloids"
+    },
+    {
+      "code": "QN02CA01",
+      "name": "dihydroergotamine"
+    },
+    {
+      "code": "QN02CA02",
+      "name": "ergotamine"
+    },
+    {
+      "code": "QN02CA04",
+      "name": "methysergide"
+    },
+    {
+      "code": "QN02CA07",
+      "name": "lisuride"
+    },
+    {
+      "code": "QN02CA51",
+      "name": "dihydroergotamine, combinations"
+    },
+    {
+      "code": "QN02CA52",
+      "name": "ergotamine, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QN02CA72",
+      "name": "ergotamine, combinations with psycholeptics"
+    },
+    {
+      "code": "QN02CB",
+      "name": "Corticosteroid derivatives"
+    },
+    {
+      "code": "QN02CB01",
+      "name": "flumedroxone"
+    },
+    {
+      "code": "QN02CC",
+      "name": "Selective serotonin (5HT1) agonists"
+    },
+    {
+      "code": "QN02CC01",
+      "name": "sumatriptan"
+    },
+    {
+      "code": "QN02CC02",
+      "name": "naratriptan"
+    },
+    {
+      "code": "QN02CC03",
+      "name": "zolmitriptan"
+    },
+    {
+      "code": "QN02CC04",
+      "name": "rizatriptan"
+    },
+    {
+      "code": "QN02CC05",
+      "name": "almotriptan"
+    },
+    {
+      "code": "QN02CC06",
+      "name": "eletriptan"
+    },
+    {
+      "code": "QN02CC07",
+      "name": "frovatriptan"
+    },
+    {
+      "code": "QN02CC08",
+      "name": "lasmiditan"
+    },
+    {
+      "code": "QN02CC51",
+      "name": "sumatriptan and naproxen"
+    },
+    {
+      "code": "QN02CD",
+      "name": "Calcitonin gene-related peptide (CGRP) antagonists"
+    },
+    {
+      "code": "QN02CD01",
+      "name": "erenumab"
+    },
+    {
+      "code": "QN02CD02",
+      "name": "galcanezumab"
+    },
+    {
+      "code": "QN02CD03",
+      "name": "fremanezumab"
+    },
+    {
+      "code": "QN02CD04",
+      "name": "ubrogepant"
+    },
+    {
+      "code": "QN02CD05",
+      "name": "eptinezumab"
+    },
+    {
+      "code": "QN02CD06",
+      "name": "rimegepant"
+    },
+    {
+      "code": "QN02CD07",
+      "name": "atogepant"
+    },
+    {
+      "code": "QN02CD08",
+      "name": "zavegepant"
+    },
+    {
+      "code": "QN02CX",
+      "name": "Other antimigraine preparations"
+    },
+    {
+      "code": "QN02CX01",
+      "name": "pizotifen"
+    },
+    {
+      "code": "QN02CX02",
+      "name": "clonidine"
+    },
+    {
+      "code": "QN02CX03",
+      "name": "iprazochrome"
+    },
+    {
+      "code": "QN02CX05",
+      "name": "dimetotiazine"
+    },
+    {
+      "code": "QN02CX06",
+      "name": "oxetorone"
+    },
+    {
+      "code": "QN03",
+      "name": "ANTIEPILEPTICS"
+    },
+    {
+      "code": "QN03A",
+      "name": "ANTIEPILEPTICS"
+    },
+    {
+      "code": "QN03AA",
+      "name": "Barbiturates and derivatives"
+    },
+    {
+      "code": "QN03AA01",
+      "name": "methylphenobarbital"
+    },
+    {
+      "code": "QN03AA02",
+      "name": "phenobarbital"
+    },
+    {
+      "code": "QN03AA03",
+      "name": "primidone"
+    },
+    {
+      "code": "QN03AA04",
+      "name": "barbexaclone"
+    },
+    {
+      "code": "QN03AA30",
+      "name": "metharbital"
+    },
+    {
+      "code": "QN03AB",
+      "name": "Hydantoin derivatives"
+    },
+    {
+      "code": "QN03AB01",
+      "name": "ethotoin"
+    },
+    {
+      "code": "QN03AB02",
+      "name": "phenytoin"
+    },
+    {
+      "code": "QN03AB03",
+      "name": "amino(diphenylhydantoin) valeric acid"
+    },
+    {
+      "code": "QN03AB04",
+      "name": "mephenytoin"
+    },
+    {
+      "code": "QN03AB05",
+      "name": "fosphenytoin"
+    },
+    {
+      "code": "QN03AB52",
+      "name": "phenytoin, combinations"
+    },
+    {
+      "code": "QN03AB54",
+      "name": "mephenytoin, combinations"
+    },
+    {
+      "code": "QN03AC",
+      "name": "Oxazolidine derivatives"
+    },
+    {
+      "code": "QN03AC01",
+      "name": "paramethadione"
+    },
+    {
+      "code": "QN03AC02",
+      "name": "trimethadione"
+    },
+    {
+      "code": "QN03AC03",
+      "name": "ethadione"
+    },
+    {
+      "code": "QN03AD",
+      "name": "Succinimide derivatives"
+    },
+    {
+      "code": "QN03AD01",
+      "name": "ethosuximide"
+    },
+    {
+      "code": "QN03AD02",
+      "name": "phensuximide"
+    },
+    {
+      "code": "QN03AD03",
+      "name": "mesuximide"
+    },
+    {
+      "code": "QN03AD51",
+      "name": "ethosuximide, combinations"
+    },
+    {
+      "code": "QN03AE",
+      "name": "Benzodiazepine derivatives"
+    },
+    {
+      "code": "QN03AE01",
+      "name": "clonazepam"
+    },
+    {
+      "code": "QN03AF",
+      "name": "Carboxamide derivatives"
+    },
+    {
+      "code": "QN03AF01",
+      "name": "carbamazepine"
+    },
+    {
+      "code": "QN03AF02",
+      "name": "oxcarbazepine"
+    },
+    {
+      "code": "QN03AF03",
+      "name": "rufinamide"
+    },
+    {
+      "code": "QN03AF04",
+      "name": "eslicarbazepine"
+    },
+    {
+      "code": "QN03AG",
+      "name": "Fatty acid derivatives"
+    },
+    {
+      "code": "QN03AG01",
+      "name": "valproic acid"
+    },
+    {
+      "code": "QN03AG02",
+      "name": "valpromide"
+    },
+    {
+      "code": "QN03AG03",
+      "name": "aminobutyric acid"
+    },
+    {
+      "code": "QN03AG04",
+      "name": "vigabatrin"
+    },
+    {
+      "code": "QN03AG05",
+      "name": "progabide"
+    },
+    {
+      "code": "QN03AG06",
+      "name": "tiagabine"
+    },
+    {
+      "code": "QN03AX",
+      "name": "Other antiepileptics"
+    },
+    {
+      "code": "QN03AX03",
+      "name": "sultiame"
+    },
+    {
+      "code": "QN03AX07",
+      "name": "phenacemide"
+    },
+    {
+      "code": "QN03AX09",
+      "name": "lamotrigine"
+    },
+    {
+      "code": "QN03AX10",
+      "name": "felbamate"
+    },
+    {
+      "code": "QN03AX11",
+      "name": "topiramate"
+    },
+    {
+      "code": "QN03AX13",
+      "name": "pheneturide"
+    },
+    {
+      "code": "QN03AX14",
+      "name": "levetiracetam"
+    },
+    {
+      "code": "QN03AX15",
+      "name": "zonisamide"
+    },
+    {
+      "code": "QN03AX17",
+      "name": "stiripentol"
+    },
+    {
+      "code": "QN03AX18",
+      "name": "lacosamide"
+    },
+    {
+      "code": "QN03AX19",
+      "name": "carisbamate"
+    },
+    {
+      "code": "QN03AX21",
+      "name": "retigabine"
+    },
+    {
+      "code": "QN03AX22",
+      "name": "perampanel"
+    },
+    {
+      "code": "QN03AX23",
+      "name": "brivaracetam"
+    },
+    {
+      "code": "QN03AX24",
+      "name": "cannabidiol"
+    },
+    {
+      "code": "QN03AX25",
+      "name": "cenobamate"
+    },
+    {
+      "code": "QN03AX26",
+      "name": "fenfluramine"
+    },
+    {
+      "code": "QN03AX27",
+      "name": "ganaxolone"
+    },
+    {
+      "code": "QN03AX30",
+      "name": "beclamide"
+    },
+    {
+      "code": "QN03AX90",
+      "name": "imepitoin"
+    },
+    {
+      "code": "QN03AX91",
+      "name": "potassium bromide"
+    },
+    {
+      "code": "QN04",
+      "name": "ANTI-PARKINSON DRUGS"
+    },
+    {
+      "code": "QN04A",
+      "name": "ANTICHOLINERGIC AGENTS"
+    },
+    {
+      "code": "QN04AA",
+      "name": "Tertiary amines"
+    },
+    {
+      "code": "QN04AA01",
+      "name": "trihexyphenidyl"
+    },
+    {
+      "code": "QN04AA02",
+      "name": "biperiden"
+    },
+    {
+      "code": "QN04AA03",
+      "name": "metixene"
+    },
+    {
+      "code": "QN04AA04",
+      "name": "procyclidine"
+    },
+    {
+      "code": "QN04AA05",
+      "name": "profenamine"
+    },
+    {
+      "code": "QN04AA08",
+      "name": "dexetimide"
+    },
+    {
+      "code": "QN04AA09",
+      "name": "phenglutarimide"
+    },
+    {
+      "code": "QN04AA10",
+      "name": "mazaticol"
+    },
+    {
+      "code": "QN04AA11",
+      "name": "bornaprine"
+    },
+    {
+      "code": "QN04AA12",
+      "name": "tropatepine"
+    },
+    {
+      "code": "QN04AB",
+      "name": "Ethers, chemically close to antihistamines"
+    },
+    {
+      "code": "QN04AB01",
+      "name": "etanautine"
+    },
+    {
+      "code": "QN04AB02",
+      "name": "orphenadrine (chloride)"
+    },
+    {
+      "code": "QN04AC",
+      "name": "Ethers of tropine or tropine derivatives"
+    },
+    {
+      "code": "QN04AC01",
+      "name": "benzatropine"
+    },
+    {
+      "code": "QN04AC30",
+      "name": "etybenzatropine"
+    },
+    {
+      "code": "QN04B",
+      "name": "DOPAMINERGIC AGENTS"
+    },
+    {
+      "code": "QN04BA",
+      "name": "Dopa and dopa derivatives"
+    },
+    {
+      "code": "QN04BA01",
+      "name": "levodopa"
+    },
+    {
+      "code": "QN04BA02",
+      "name": "levodopa and decarboxylase inhibitor"
+    },
+    {
+      "code": "QN04BA03",
+      "name": "levodopa, decarboxylase inhibitor and COMT inhibitor"
+    },
+    {
+      "code": "QN04BA04",
+      "name": "melevodopa"
+    },
+    {
+      "code": "QN04BA05",
+      "name": "melevodopa and decarboxylase inhibitor"
+    },
+    {
+      "code": "QN04BA06",
+      "name": "etilevodopa and decarboxylase inhibitor"
+    },
+    {
+      "code": "QN04BA07",
+      "name": "foslevodopa and decarboxylase inhibitor"
+    },
+    {
+      "code": "QN04BB",
+      "name": "Adamantane derivatives"
+    },
+    {
+      "code": "QN04BB01",
+      "name": "amantadine"
+    },
+    {
+      "code": "QN04BC",
+      "name": "Dopamine agonists"
+    },
+    {
+      "code": "QN04BC01",
+      "name": "bromochriptine"
+    },
+    {
+      "code": "QN04BC02",
+      "name": "pergolide"
+    },
+    {
+      "code": "QN04BC03",
+      "name": "dihydroergocryptine mesylate"
+    },
+    {
+      "code": "QN04BC04",
+      "name": "ropinirole"
+    },
+    {
+      "code": "QN04BC05",
+      "name": "pramipexole"
+    },
+    {
+      "code": "QN04BC06",
+      "name": "cabergoline"
+    },
+    {
+      "code": "QN04BC07",
+      "name": "apomorphine"
+    },
+    {
+      "code": "QN04BC08",
+      "name": "piribedil"
+    },
+    {
+      "code": "QN04BC09",
+      "name": "rotigotine"
+    },
+    {
+      "code": "QN04BD",
+      "name": "Monoamine oxidase B inhibitors"
+    },
+    {
+      "code": "QN04BD01",
+      "name": "selegiline"
+    },
+    {
+      "code": "QN04BD02",
+      "name": "rasagiline"
+    },
+    {
+      "code": "QN04BD03",
+      "name": "safinamide"
+    },
+    {
+      "code": "QN04BX",
+      "name": "Other dopaminergic agents"
+    },
+    {
+      "code": "QN04BX01",
+      "name": "tolcapone"
+    },
+    {
+      "code": "QN04BX02",
+      "name": "entacapone"
+    },
+    {
+      "code": "QN04BX03",
+      "name": "budipine"
+    },
+    {
+      "code": "QN04BX04",
+      "name": "opicapone"
+    },
+    {
+      "code": "QN04C",
+      "name": "OTHER ANTIPARKINSON DRUGS"
+    },
+    {
+      "code": "QN04CX",
+      "name": "Other antiparkinson drugs"
+    },
+    {
+      "code": "QN04CX01",
+      "name": "istradefylline"
+    },
+    {
+      "code": "QN05",
+      "name": "PSYCHOLEPTICS"
+    },
+    {
+      "code": "QN05A",
+      "name": "ANTIPSYCHOTICS"
+    },
+    {
+      "code": "QN05AA",
+      "name": "Phenothiazines with aliphatic side-chain"
+    },
+    {
+      "code": "QN05AA01",
+      "name": "chlorpromazine"
+    },
+    {
+      "code": "QN05AA02",
+      "name": "levopromazine"
+    },
+    {
+      "code": "QN05AA03",
+      "name": "promazine"
+    },
+    {
+      "code": "QN05AA04",
+      "name": "acepromazine"
+    },
+    {
+      "code": "QN05AA05",
+      "name": "triflupromazine"
+    },
+    {
+      "code": "QN05AA06",
+      "name": "cyamemazine"
+    },
+    {
+      "code": "QN05AA07",
+      "name": "chlorproethazine"
+    },
+    {
+      "code": "QN05AB",
+      "name": "Phenothiazines with piperazine structure"
+    },
+    {
+      "code": "QN05AB01",
+      "name": "dixyrazine"
+    },
+    {
+      "code": "QN05AB02",
+      "name": "fluphenazine"
+    },
+    {
+      "code": "QN05AB03",
+      "name": "perphenazine"
+    },
+    {
+      "code": "QN05AB04",
+      "name": "prochlorperazine"
+    },
+    {
+      "code": "QN05AB05",
+      "name": "thiopropazate"
+    },
+    {
+      "code": "QN05AB06",
+      "name": "trifluoperazine"
+    },
+    {
+      "code": "QN05AB07",
+      "name": "acetophenazine"
+    },
+    {
+      "code": "QN05AB08",
+      "name": "thioproperazine"
+    },
+    {
+      "code": "QN05AB09",
+      "name": "butaperazine"
+    },
+    {
+      "code": "QN05AB10",
+      "name": "perazine"
+    },
+    {
+      "code": "QN05AC",
+      "name": "Phenothiazines with piperidine structure"
+    },
+    {
+      "code": "QN05AC01",
+      "name": "periciazine"
+    },
+    {
+      "code": "QN05AC02",
+      "name": "thioridazine"
+    },
+    {
+      "code": "QN05AC03",
+      "name": "mesoridazine"
+    },
+    {
+      "code": "QN05AC04",
+      "name": "pipotiazine"
+    },
+    {
+      "code": "QN05AD",
+      "name": "Butyrophenone derivatives"
+    },
+    {
+      "code": "QN05AD01",
+      "name": "haloperidol"
+    },
+    {
+      "code": "QN05AD02",
+      "name": "trifluperidol"
+    },
+    {
+      "code": "QN05AD03",
+      "name": "melperone"
+    },
+    {
+      "code": "QN05AD04",
+      "name": "moperone"
+    },
+    {
+      "code": "QN05AD05",
+      "name": "pipamperone"
+    },
+    {
+      "code": "QN05AD06",
+      "name": "bromperidol"
+    },
+    {
+      "code": "QN05AD07",
+      "name": "benperidol"
+    },
+    {
+      "code": "QN05AD08",
+      "name": "droperidol"
+    },
+    {
+      "code": "QN05AD09",
+      "name": "fluanisone"
+    },
+    {
+      "code": "QN05AD10",
+      "name": "lumateperone"
+    },
+    {
+      "code": "QN05AD90",
+      "name": "azaperone"
+    },
+    {
+      "code": "QN05AE",
+      "name": "Indole derivatives"
+    },
+    {
+      "code": "QN05AE01",
+      "name": "oxypertine"
+    },
+    {
+      "code": "QN05AE02",
+      "name": "molindone"
+    },
+    {
+      "code": "QN05AE03",
+      "name": "sertindole"
+    },
+    {
+      "code": "QN05AE04",
+      "name": "ziprasidone"
+    },
+    {
+      "code": "QN05AE05",
+      "name": "lurasidone"
+    },
+    {
+      "code": "QN05AF",
+      "name": "Thioxanthene derivatives"
+    },
+    {
+      "code": "QN05AF01",
+      "name": "flupentixol"
+    },
+    {
+      "code": "QN05AF02",
+      "name": "clopenthixol"
+    },
+    {
+      "code": "QN05AF03",
+      "name": "chlorprothixene"
+    },
+    {
+      "code": "QN05AF04",
+      "name": "tiotixene"
+    },
+    {
+      "code": "QN05AF05",
+      "name": "zuclopenthixol"
+    },
+    {
+      "code": "QN05AG",
+      "name": "Diphenylbutylpiperidine derivatives"
+    },
+    {
+      "code": "QN05AG01",
+      "name": "fluspirilene"
+    },
+    {
+      "code": "QN05AG02",
+      "name": "pimozide"
+    },
+    {
+      "code": "QN05AG03",
+      "name": "penfluridol"
+    },
+    {
+      "code": "QN05AH",
+      "name": "Diazepines, oxazepines, thiazepines and oxepines"
+    },
+    {
+      "code": "QN05AH01",
+      "name": "loxapine"
+    },
+    {
+      "code": "QN05AH02",
+      "name": "clozapine"
+    },
+    {
+      "code": "QN05AH03",
+      "name": "olanzapine"
+    },
+    {
+      "code": "QN05AH04",
+      "name": "quetiapine"
+    },
+    {
+      "code": "QN05AH05",
+      "name": "asenapine"
+    },
+    {
+      "code": "QN05AH06",
+      "name": "clotiapine"
+    },
+    {
+      "code": "QN05AH53",
+      "name": "olanzapine and samidorphan"
+    },
+    {
+      "code": "QN05AK",
+      "name": "Neuroleptics, in tardive dyskinesia"
+    },
+    {
+      "code": "QN05AL",
+      "name": "Benzamides"
+    },
+    {
+      "code": "QN05AL01",
+      "name": "sulpiride"
+    },
+    {
+      "code": "QN05AL02",
+      "name": "sultopride"
+    },
+    {
+      "code": "QN05AL03",
+      "name": "tiapride"
+    },
+    {
+      "code": "QN05AL04",
+      "name": "remoxipride"
+    },
+    {
+      "code": "QN05AL05",
+      "name": "amisulpride"
+    },
+    {
+      "code": "QN05AL06",
+      "name": "veralaprid"
+    },
+    {
+      "code": "QN05AL07",
+      "name": "levosulpiride"
+    },
+    {
+      "code": "QN05AN",
+      "name": "Lithium"
+    },
+    {
+      "code": "QN05AN01",
+      "name": "lithium"
+    },
+    {
+      "code": "QN05AX",
+      "name": "Other antipsychotics"
+    },
+    {
+      "code": "QN05AX07",
+      "name": "prothipendyl"
+    },
+    {
+      "code": "QN05AX08",
+      "name": "risperidone"
+    },
+    {
+      "code": "QN05AX10",
+      "name": "mosapramine"
+    },
+    {
+      "code": "QN05AX11",
+      "name": "zotepine"
+    },
+    {
+      "code": "QN05AX12",
+      "name": "aripiprazole"
+    },
+    {
+      "code": "QN05AX13",
+      "name": "paliperidone"
+    },
+    {
+      "code": "QN05AX14",
+      "name": "iloperidone"
+    },
+    {
+      "code": "QN05AX15",
+      "name": "cariprazine"
+    },
+    {
+      "code": "QN05AX16",
+      "name": "brexpiprazole"
+    },
+    {
+      "code": "QN05AX17",
+      "name": "pimavanserin"
+    },
+    {
+      "code": "QN05AX50",
+      "name": "xanomeline and trospium"
+    },
+    {
+      "code": "QN05AX90",
+      "name": "amperozide"
+    },
+    {
+      "code": "QN05B",
+      "name": "ANXIOLYTICS"
+    },
+    {
+      "code": "QN05BA",
+      "name": "Benzodiazepine derivatives"
+    },
+    {
+      "code": "QN05BA01",
+      "name": "diazepam"
+    },
+    {
+      "code": "QN05BA02",
+      "name": "chlordiazepoxide"
+    },
+    {
+      "code": "QN05BA03",
+      "name": "medazepam"
+    },
+    {
+      "code": "QN05BA04",
+      "name": "oxazepam"
+    },
+    {
+      "code": "QN05BA05",
+      "name": "potassium clorazepate"
+    },
+    {
+      "code": "QN05BA06",
+      "name": "lorazepam"
+    },
+    {
+      "code": "QN05BA07",
+      "name": "adinazolam"
+    },
+    {
+      "code": "QN05BA08",
+      "name": "bromazepam"
+    },
+    {
+      "code": "QN05BA09",
+      "name": "clobazam"
+    },
+    {
+      "code": "QN05BA10",
+      "name": "ketazolam"
+    },
+    {
+      "code": "QN05BA11",
+      "name": "prazepam"
+    },
+    {
+      "code": "QN05BA12",
+      "name": "alprazolam"
+    },
+    {
+      "code": "QN05BA13",
+      "name": "halazepam"
+    },
+    {
+      "code": "QN05BA14",
+      "name": "pinazepam"
+    },
+    {
+      "code": "QN05BA15",
+      "name": "camazepam"
+    },
+    {
+      "code": "QN05BA16",
+      "name": "nordazepam"
+    },
+    {
+      "code": "QN05BA17",
+      "name": "fludiazepam"
+    },
+    {
+      "code": "QN05BA18",
+      "name": "ethyl loflazepate"
+    },
+    {
+      "code": "QN05BA19",
+      "name": "etizolam"
+    },
+    {
+      "code": "QN05BA21",
+      "name": "clotiazepam"
+    },
+    {
+      "code": "QN05BA22",
+      "name": "cloxazolam"
+    },
+    {
+      "code": "QN05BA23",
+      "name": "tofisopam"
+    },
+    {
+      "code": "QN05BA24",
+      "name": "bentazepam"
+    },
+    {
+      "code": "QN05BA25",
+      "name": "mexazolam"
+    },
+    {
+      "code": "QN05BA56",
+      "name": "lorazepam, combinations"
+    },
+    {
+      "code": "QN05BB",
+      "name": "Diphenylmethane derivatives"
+    },
+    {
+      "code": "QN05BB01",
+      "name": "hydroxyzine"
+    },
+    {
+      "code": "QN05BB02",
+      "name": "captodiame"
+    },
+    {
+      "code": "QN05BB51",
+      "name": "hydroxyzine, combinations"
+    },
+    {
+      "code": "QN05BC",
+      "name": "Carbamates"
+    },
+    {
+      "code": "QN05BC01",
+      "name": "meprobamate"
+    },
+    {
+      "code": "QN05BC03",
+      "name": "emylcamate"
+    },
+    {
+      "code": "QN05BC04",
+      "name": "mebutamate"
+    },
+    {
+      "code": "QN05BC51",
+      "name": "meprobamate, combinations"
+    },
+    {
+      "code": "QN05BD",
+      "name": "Dibenzo-bicyclo-octadiene derivatives"
+    },
+    {
+      "code": "QN05BD01",
+      "name": "benzoctamine"
+    },
+    {
+      "code": "QN05BE",
+      "name": "Azaspirodecanedione derivatives"
+    },
+    {
+      "code": "QN05BE01",
+      "name": "buspirone"
+    },
+    {
+      "code": "QN05BX",
+      "name": "Other anxiolytics"
+    },
+    {
+      "code": "QN05BX01",
+      "name": "mefenoxalone"
+    },
+    {
+      "code": "QN05BX02",
+      "name": "gedocarnil"
+    },
+    {
+      "code": "QN05BX03",
+      "name": "etifoxine"
+    },
+    {
+      "code": "QN05BX04",
+      "name": "fabomotizole"
+    },
+    {
+      "code": "QN05BX05",
+      "name": "Lavandulae aetheroleum"
+    },
+    {
+      "code": "QN05C",
+      "name": "HYPNOTICS AND SEDATIVES"
+    },
+    {
+      "code": "QN05CA",
+      "name": "Barbiturates, plain"
+    },
+    {
+      "code": "QN05CA01",
+      "name": "pentobarbital"
+    },
+    {
+      "code": "QN05CA02",
+      "name": "amobarbital"
+    },
+    {
+      "code": "QN05CA03",
+      "name": "butobarbital"
+    },
+    {
+      "code": "QN05CA04",
+      "name": "barbital"
+    },
+    {
+      "code": "QN05CA05",
+      "name": "aprobarbital"
+    },
+    {
+      "code": "QN05CA06",
+      "name": "secobarbital"
+    },
+    {
+      "code": "QN05CA07",
+      "name": "talbutal"
+    },
+    {
+      "code": "QN05CA08",
+      "name": "vinylbital"
+    },
+    {
+      "code": "QN05CA09",
+      "name": "vinbarbital"
+    },
+    {
+      "code": "QN05CA10",
+      "name": "cyclobarbital"
+    },
+    {
+      "code": "QN05CA11",
+      "name": "heptabarbital"
+    },
+    {
+      "code": "QN05CA12",
+      "name": "reposal"
+    },
+    {
+      "code": "QN05CA15",
+      "name": "methohexital"
+    },
+    {
+      "code": "QN05CA16",
+      "name": "hexobarbital"
+    },
+    {
+      "code": "QN05CA19",
+      "name": "thiopental"
+    },
+    {
+      "code": "QN05CA20",
+      "name": "etallobarbital"
+    },
+    {
+      "code": "QN05CA21",
+      "name": "allobarbital"
+    },
+    {
+      "code": "QN05CA22",
+      "name": "proxibarbal"
+    },
+    {
+      "code": "QN05CB",
+      "name": "Barbiturates, combinations"
+    },
+    {
+      "code": "QN05CB01",
+      "name": "combinations of barbiturates"
+    },
+    {
+      "code": "QN05CB02",
+      "name": "barbiturates in combination with other drugs"
+    },
+    {
+      "code": "QN05CC",
+      "name": "Aldehydes and derivatives"
+    },
+    {
+      "code": "QN05CC01",
+      "name": "chloral hydrate"
+    },
+    {
+      "code": "QN05CC02",
+      "name": "chloralodol"
+    },
+    {
+      "code": "QN05CC03",
+      "name": "acetylglycinamide chloral hydrate"
+    },
+    {
+      "code": "QN05CC04",
+      "name": "dichloralphenazone"
+    },
+    {
+      "code": "QN05CC05",
+      "name": "paraldehyde"
+    },
+    {
+      "code": "QN05CD",
+      "name": "Benzodiazepine derivatives"
+    },
+    {
+      "code": "QN05CD01",
+      "name": "flurazepam"
+    },
+    {
+      "code": "QN05CD02",
+      "name": "nitrazepam"
+    },
+    {
+      "code": "QN05CD03",
+      "name": "flunitrazepam"
+    },
+    {
+      "code": "QN05CD04",
+      "name": "estazolam"
+    },
+    {
+      "code": "QN05CD05",
+      "name": "triazolam"
+    },
+    {
+      "code": "QN05CD06",
+      "name": "lormetazepam"
+    },
+    {
+      "code": "QN05CD07",
+      "name": "temazepam"
+    },
+    {
+      "code": "QN05CD08",
+      "name": "midazolam"
+    },
+    {
+      "code": "QN05CD09",
+      "name": "brotizolam"
+    },
+    {
+      "code": "QN05CD10",
+      "name": "quazepam"
+    },
+    {
+      "code": "QN05CD11",
+      "name": "loprazolam"
+    },
+    {
+      "code": "QN05CD12",
+      "name": "doxefazepam"
+    },
+    {
+      "code": "QN05CD13",
+      "name": "cinolazepam"
+    },
+    {
+      "code": "QN05CD14",
+      "name": "remimazolam"
+    },
+    {
+      "code": "QN05CD15",
+      "name": "nimetazepam"
+    },
+    {
+      "code": "QN05CD16",
+      "name": "dimdazenil"
+    },
+    {
+      "code": "QN05CD90",
+      "name": "climazolam"
+    },
+    {
+      "code": "QN05CE",
+      "name": "Piperidinedione derivatives"
+    },
+    {
+      "code": "QN05CE01",
+      "name": "glutethimide"
+    },
+    {
+      "code": "QN05CE02",
+      "name": "methyprylon"
+    },
+    {
+      "code": "QN05CE03",
+      "name": "pyrithyldione"
+    },
+    {
+      "code": "QN05CF",
+      "name": "Benzodiazepine related drugs"
+    },
+    {
+      "code": "QN05CF01",
+      "name": "zopiclone"
+    },
+    {
+      "code": "QN05CF02",
+      "name": "zolpidem"
+    },
+    {
+      "code": "QN05CF03",
+      "name": "zaleplon"
+    },
+    {
+      "code": "QN05CF04",
+      "name": "eszopiclone"
+    },
+    {
+      "code": "QN05CH",
+      "name": "Melatonin receptor agonists"
+    },
+    {
+      "code": "QN05CH01",
+      "name": "melatonin"
+    },
+    {
+      "code": "QN05CH02",
+      "name": "ramelteon"
+    },
+    {
+      "code": "QN05CH03",
+      "name": "tasimelteon"
+    },
+    {
+      "code": "QN05CJ",
+      "name": "Orexin receptor antagonists"
+    },
+    {
+      "code": "QN05CJ01",
+      "name": "suvorexant"
+    },
+    {
+      "code": "QN05CJ02",
+      "name": "lemborexant"
+    },
+    {
+      "code": "QN05CJ03",
+      "name": "daridorexant"
+    },
+    {
+      "code": "QN05CM",
+      "name": "Other hypnotics and sedatives"
+    },
+    {
+      "code": "QN05CM01",
+      "name": "methaqualone"
+    },
+    {
+      "code": "QN05CM02",
+      "name": "clomethiazole"
+    },
+    {
+      "code": "QN05CM03",
+      "name": "bromisoval"
+    },
+    {
+      "code": "QN05CM04",
+      "name": "carbromal"
+    },
+    {
+      "code": "QN05CM05",
+      "name": "scopolamine"
+    },
+    {
+      "code": "QN05CM06",
+      "name": "propiomazine"
+    },
+    {
+      "code": "QN05CM07",
+      "name": "triclofos"
+    },
+    {
+      "code": "QN05CM08",
+      "name": "ethchlorvynol"
+    },
+    {
+      "code": "QN05CM09",
+      "name": "Valerianae radix"
+    },
+    {
+      "code": "QN05CM10",
+      "name": "hexapropymate"
+    },
+    {
+      "code": "QN05CM11",
+      "name": "bromides"
+    },
+    {
+      "code": "QN05CM12",
+      "name": "apronal"
+    },
+    {
+      "code": "QN05CM13",
+      "name": "valnoctamide"
+    },
+    {
+      "code": "QN05CM15",
+      "name": "methylpentynol"
+    },
+    {
+      "code": "QN05CM16",
+      "name": "niaprazine"
+    },
+    {
+      "code": "QN05CM18",
+      "name": "dexmedetomidine"
+    },
+    {
+      "code": "QN05CM90",
+      "name": "detomidine"
+    },
+    {
+      "code": "QN05CM91",
+      "name": "medetomidine"
+    },
+    {
+      "code": "QN05CM92",
+      "name": "xylazine"
+    },
+    {
+      "code": "QN05CM93",
+      "name": "romifidine"
+    },
+    {
+      "code": "QN05CM94",
+      "name": "metomidate"
+    },
+    {
+      "code": "QN05CM96",
+      "name": "tasipimidine"
+    },
+    {
+      "code": "QN05CM99",
+      "name": "combinations"
+    },
+    {
+      "code": "QN05CX",
+      "name": "Hypnotics and sedatives in combination, excl. barbiturates"
+    },
+    {
+      "code": "QN05CX01",
+      "name": "meprobamate, combinations"
+    },
+    {
+      "code": "QN05CX02",
+      "name": "methaqualone, combinations"
+    },
+    {
+      "code": "QN05CX03",
+      "name": "methylpentynol, combinations"
+    },
+    {
+      "code": "QN05CX04",
+      "name": "clomethiazole, combinations"
+    },
+    {
+      "code": "QN05CX05",
+      "name": "emepronium, combinations"
+    },
+    {
+      "code": "QN05CX06",
+      "name": "dipiperonylaminoethanol, combinations"
+    },
+    {
+      "code": "QN06",
+      "name": "PSYCHOANALEPTICS"
+    },
+    {
+      "code": "QN06A",
+      "name": "ANTIDEPRESSANTS"
+    },
+    {
+      "code": "QN06AA",
+      "name": "Non-selective monoamine reuptake inhibitors"
+    },
+    {
+      "code": "QN06AA01",
+      "name": "desipramine"
+    },
+    {
+      "code": "QN06AA02",
+      "name": "imipramine"
+    },
+    {
+      "code": "QN06AA03",
+      "name": "imipramine oxide"
+    },
+    {
+      "code": "QN06AA04",
+      "name": "clomipramine"
+    },
+    {
+      "code": "QN06AA05",
+      "name": "opipramol"
+    },
+    {
+      "code": "QN06AA06",
+      "name": "trimipramine"
+    },
+    {
+      "code": "QN06AA07",
+      "name": "lofepramine"
+    },
+    {
+      "code": "QN06AA08",
+      "name": "dibenzepin"
+    },
+    {
+      "code": "QN06AA09",
+      "name": "amitriptyline"
+    },
+    {
+      "code": "QN06AA10",
+      "name": "nortriptyline"
+    },
+    {
+      "code": "QN06AA11",
+      "name": "protriptyline"
+    },
+    {
+      "code": "QN06AA12",
+      "name": "doxepine"
+    },
+    {
+      "code": "QN06AA13",
+      "name": "iprindole"
+    },
+    {
+      "code": "QN06AA14",
+      "name": "melitracen"
+    },
+    {
+      "code": "QN06AA15",
+      "name": "butriptyline"
+    },
+    {
+      "code": "QN06AA16",
+      "name": "dosulepin"
+    },
+    {
+      "code": "QN06AA17",
+      "name": "amoxapine"
+    },
+    {
+      "code": "QN06AA18",
+      "name": "dimetacrine"
+    },
+    {
+      "code": "QN06AA19",
+      "name": "amineptine"
+    },
+    {
+      "code": "QN06AA21",
+      "name": "maprotiline"
+    },
+    {
+      "code": "QN06AA23",
+      "name": "quinupramine"
+    },
+    {
+      "code": "QN06AB",
+      "name": "Selective serotonin reuptake inhibitors"
+    },
+    {
+      "code": "QN06AB02",
+      "name": "zimeldine"
+    },
+    {
+      "code": "QN06AB03",
+      "name": "fluoxetine"
+    },
+    {
+      "code": "QN06AB04",
+      "name": "citalopram"
+    },
+    {
+      "code": "QN06AB05",
+      "name": "paroxetine"
+    },
+    {
+      "code": "QN06AB06",
+      "name": "sertraline"
+    },
+    {
+      "code": "QN06AB07",
+      "name": "alaproclate"
+    },
+    {
+      "code": "QN06AB08",
+      "name": "fluvoxamine"
+    },
+    {
+      "code": "QN06AB09",
+      "name": "etoperidone"
+    },
+    {
+      "code": "QN06AB10",
+      "name": "escitalopram"
+    },
+    {
+      "code": "QN06AF",
+      "name": "Monoamine oxidase inhibitors, non-selective"
+    },
+    {
+      "code": "QN06AF01",
+      "name": "isocarboxazide"
+    },
+    {
+      "code": "QN06AF02",
+      "name": "nialamide"
+    },
+    {
+      "code": "QN06AF03",
+      "name": "phenelzine"
+    },
+    {
+      "code": "QN06AF04",
+      "name": "tranylcypromine"
+    },
+    {
+      "code": "QN06AF05",
+      "name": "iproniazide"
+    },
+    {
+      "code": "QN06AF06",
+      "name": "iproclozide"
+    },
+    {
+      "code": "QN06AG",
+      "name": "Monoamine oxidase A inhibitors"
+    },
+    {
+      "code": "QN06AG02",
+      "name": "moclobemide"
+    },
+    {
+      "code": "QN06AG03",
+      "name": "toloxatone"
+    },
+    {
+      "code": "QN06AX",
+      "name": "Other antidepressants"
+    },
+    {
+      "code": "QN06AX01",
+      "name": "oxitriptan"
+    },
+    {
+      "code": "QN06AX02",
+      "name": "tryptophan"
+    },
+    {
+      "code": "QN06AX03",
+      "name": "mianserin"
+    },
+    {
+      "code": "QN06AX04",
+      "name": "nomifensine"
+    },
+    {
+      "code": "QN06AX05",
+      "name": "trazodone"
+    },
+    {
+      "code": "QN06AX06",
+      "name": "nefazodone"
+    },
+    {
+      "code": "QN06AX07",
+      "name": "minaprine"
+    },
+    {
+      "code": "QN06AX08",
+      "name": "bifemelane"
+    },
+    {
+      "code": "QN06AX09",
+      "name": "viloxazine"
+    },
+    {
+      "code": "QN06AX10",
+      "name": "oxaflozane"
+    },
+    {
+      "code": "QN06AX11",
+      "name": "mirtazapine"
+    },
+    {
+      "code": "QN06AX12",
+      "name": "bupropion"
+    },
+    {
+      "code": "QN06AX13",
+      "name": "medifoxamine"
+    },
+    {
+      "code": "QN06AX14",
+      "name": "tianeptine"
+    },
+    {
+      "code": "QN06AX15",
+      "name": "pivagabine"
+    },
+    {
+      "code": "QN06AX16",
+      "name": "venlafaxine"
+    },
+    {
+      "code": "QN06AX17",
+      "name": "milnacipran"
+    },
+    {
+      "code": "QN06AX18",
+      "name": "reboxetine"
+    },
+    {
+      "code": "QN06AX19",
+      "name": "gepirone"
+    },
+    {
+      "code": "QN06AX21",
+      "name": "duloxetine"
+    },
+    {
+      "code": "QN06AX22",
+      "name": "agomelatine"
+    },
+    {
+      "code": "QN06AX23",
+      "name": "desvenlafaxine"
+    },
+    {
+      "code": "QN06AX24",
+      "name": "vilazodone"
+    },
+    {
+      "code": "QN06AX25",
+      "name": "Hyperici herba"
+    },
+    {
+      "code": "QN06AX26",
+      "name": "vortioxetine"
+    },
+    {
+      "code": "QN06AX27",
+      "name": "esketamine"
+    },
+    {
+      "code": "QN06AX28",
+      "name": "levomilnacipran"
+    },
+    {
+      "code": "QN06AX29",
+      "name": "brexanolone"
+    },
+    {
+      "code": "QN06AX31",
+      "name": "zuranolone"
+    },
+    {
+      "code": "QN06AX62",
+      "name": "bupropion and dextromethorphan"
+    },
+    {
+      "code": "QN06AX90",
+      "name": "selegiline"
+    },
+    {
+      "code": "QN06B",
+      "name": "PSYCHOSTIMULANTS, AGENTS USED FOR ADHD AND NOOTROPICS"
+    },
+    {
+      "code": "QN06BA",
+      "name": "Centrally acting sympathomimetics"
+    },
+    {
+      "code": "QN06BA01",
+      "name": "amfetamine"
+    },
+    {
+      "code": "QN06BA02",
+      "name": "dexamfetamine"
+    },
+    {
+      "code": "QN06BA03",
+      "name": "metamfetamine"
+    },
+    {
+      "code": "QN06BA04",
+      "name": "methylphenidate"
+    },
+    {
+      "code": "QN06BA05",
+      "name": "pemoline"
+    },
+    {
+      "code": "QN06BA06",
+      "name": "fencamfamin"
+    },
+    {
+      "code": "QN06BA07",
+      "name": "modafinil"
+    },
+    {
+      "code": "QN06BA08",
+      "name": "fenozolone"
+    },
+    {
+      "code": "QN06BA09",
+      "name": "atomoxetine"
+    },
+    {
+      "code": "QN06BA10",
+      "name": "fenetylline"
+    },
+    {
+      "code": "QN06BA11",
+      "name": "dexmethylphenidate"
+    },
+    {
+      "code": "QN06BA12",
+      "name": "lisdexamfetamine"
+    },
+    {
+      "code": "QN06BA13",
+      "name": "armodafinil"
+    },
+    {
+      "code": "QN06BA14",
+      "name": "solriamfetol"
+    },
+    {
+      "code": "QN06BA15",
+      "name": "dexmethylphenidate and serdexmethylphenidate"
+    },
+    {
+      "code": "QN06BC",
+      "name": "Xanthine derivatives"
+    },
+    {
+      "code": "QN06BC01",
+      "name": "caffeine"
+    },
+    {
+      "code": "QN06BC02",
+      "name": "propentofylline"
+    },
+    {
+      "code": "QN06BX",
+      "name": "Other psychostimulants and nootropics"
+    },
+    {
+      "code": "QN06BX01",
+      "name": "meclofenoxate"
+    },
+    {
+      "code": "QN06BX02",
+      "name": "pyritinol"
+    },
+    {
+      "code": "QN06BX03",
+      "name": "piracetam"
+    },
+    {
+      "code": "QN06BX04",
+      "name": "deanol"
+    },
+    {
+      "code": "QN06BX05",
+      "name": "fipexide"
+    },
+    {
+      "code": "QN06BX06",
+      "name": "citicoline"
+    },
+    {
+      "code": "QN06BX07",
+      "name": "oxiracetam"
+    },
+    {
+      "code": "QN06BX08",
+      "name": "pirisudanol"
+    },
+    {
+      "code": "QN06BX09",
+      "name": "linopirdine"
+    },
+    {
+      "code": "QN06BX10",
+      "name": "nizofenone"
+    },
+    {
+      "code": "QN06BX11",
+      "name": "aniracetam"
+    },
+    {
+      "code": "QN06BX12",
+      "name": "acetylcarnitine"
+    },
+    {
+      "code": "QN06BX13",
+      "name": "idebenone"
+    },
+    {
+      "code": "QN06BX14",
+      "name": "prolintane"
+    },
+    {
+      "code": "QN06BX15",
+      "name": "pipradrol"
+    },
+    {
+      "code": "QN06BX16",
+      "name": "pramiracetam"
+    },
+    {
+      "code": "QN06BX17",
+      "name": "adrafinil"
+    },
+    {
+      "code": "QN06BX18",
+      "name": "vinpocetine"
+    },
+    {
+      "code": "QN06BX21",
+      "name": "temgicoluril"
+    },
+    {
+      "code": "QN06BX22",
+      "name": "phenibut"
+    },
+    {
+      "code": "QN06BX53",
+      "name": "piracetam and cinnarizine"
+    },
+    {
+      "code": "QN06C",
+      "name": "PSYCHOLEPTICS AND PSYCHOANALEPTICS IN COMBINATION"
+    },
+    {
+      "code": "QN06CA",
+      "name": "Antidepressants in combination with psycholeptics"
+    },
+    {
+      "code": "QN06CA01",
+      "name": "amitriptyline and psycholeptics"
+    },
+    {
+      "code": "QN06CA02",
+      "name": "melitracen and psycholeptics"
+    },
+    {
+      "code": "QN06CA03",
+      "name": "fluoxetine and psycholeptics"
+    },
+    {
+      "code": "QN06CB",
+      "name": "Psychostimulants in combination with psycholeptics"
+    },
+    {
+      "code": "QN06D",
+      "name": "ANTI-DEMENTIA DRUGS"
+    },
+    {
+      "code": "QN06DA",
+      "name": "Anticholinesterases"
+    },
+    {
+      "code": "QN06DA01",
+      "name": "tacrine"
+    },
+    {
+      "code": "QN06DA02",
+      "name": "donepezil"
+    },
+    {
+      "code": "QN06DA03",
+      "name": "rivastigmine"
+    },
+    {
+      "code": "QN06DA04",
+      "name": "galantamine"
+    },
+    {
+      "code": "QN06DA05",
+      "name": "ipidacrine"
+    },
+    {
+      "code": "QN06DA06",
+      "name": "benzgalantamine"
+    },
+    {
+      "code": "QN06DA52",
+      "name": "donepezil and memantine"
+    },
+    {
+      "code": "QN06DA53",
+      "name": "donepezil, memantine and Ginkgo folium"
+    },
+    {
+      "code": "QN06DX",
+      "name": "Other anti-dementia drugs"
+    },
+    {
+      "code": "QN06DX01",
+      "name": "memantine"
+    },
+    {
+      "code": "QN06DX02",
+      "name": "Ginkgo folium"
+    },
+    {
+      "code": "QN06DX03",
+      "name": "aducanumab"
+    },
+    {
+      "code": "QN06DX04",
+      "name": "lecanemab"
+    },
+    {
+      "code": "QN06DX05",
+      "name": "donanemab"
+    },
+    {
+      "code": "QN06DX06",
+      "name": "blarcamesine"
+    },
+    {
+      "code": "QN06DX07",
+      "name": "hydromethylthionine"
+    },
+    {
+      "code": "QN06DX30",
+      "name": "combinations"
+    },
+    {
+      "code": "QN07",
+      "name": "OTHER NERVOUS SYSTEM DRUGS"
+    },
+    {
+      "code": "QN07A",
+      "name": "PARASYMPATHOMIMETICS"
+    },
+    {
+      "code": "QN07AA",
+      "name": "Anticholinesterases"
+    },
+    {
+      "code": "QN07AA01",
+      "name": "neostigmine"
+    },
+    {
+      "code": "QN07AA02",
+      "name": "pyridostigmine"
+    },
+    {
+      "code": "QN07AA03",
+      "name": "distigmine"
+    },
+    {
+      "code": "QN07AA30",
+      "name": "ambenonium"
+    },
+    {
+      "code": "QN07AA51",
+      "name": "neostigmine, combinations"
+    },
+    {
+      "code": "QN07AB",
+      "name": "Choline esters"
+    },
+    {
+      "code": "QN07AB01",
+      "name": "charbachol"
+    },
+    {
+      "code": "QN07AB02",
+      "name": "bethanechol"
+    },
+    {
+      "code": "QN07AX",
+      "name": "Other parasympatomimetics"
+    },
+    {
+      "code": "QN07AX01",
+      "name": "pilocarpine"
+    },
+    {
+      "code": "QN07AX02",
+      "name": "choline alfoscerate"
+    },
+    {
+      "code": "QN07AX03",
+      "name": "cevimeline"
+    },
+    {
+      "code": "QN07B",
+      "name": "DRUGS USED IN ADDICTIVE DISORDERS"
+    },
+    {
+      "code": "QN07BA",
+      "name": "Drugs used in nicotine dependence"
+    },
+    {
+      "code": "QN07BA01",
+      "name": "nicotine"
+    },
+    {
+      "code": "QN07BA03",
+      "name": "varenicline"
+    },
+    {
+      "code": "QN07BA04",
+      "name": "cytisinicline"
+    },
+    {
+      "code": "QN07BB",
+      "name": "Drugs used in alcohol dependence"
+    },
+    {
+      "code": "QN07BB01",
+      "name": "disulfiram"
+    },
+    {
+      "code": "QN07BB02",
+      "name": "calcium carbimide"
+    },
+    {
+      "code": "QN07BB03",
+      "name": "acamprosate"
+    },
+    {
+      "code": "QN07BB04",
+      "name": "naltrexone"
+    },
+    {
+      "code": "QN07BB05",
+      "name": "nalmefene"
+    },
+    {
+      "code": "QN07BB06",
+      "name": "ondelopran"
+    },
+    {
+      "code": "QN07BC",
+      "name": "Drugs used in opioid dependence"
+    },
+    {
+      "code": "QN07BC01",
+      "name": "buprenorphine"
+    },
+    {
+      "code": "QN07BC02",
+      "name": "methadone"
+    },
+    {
+      "code": "QN07BC03",
+      "name": "levacetylmethadol"
+    },
+    {
+      "code": "QN07BC04",
+      "name": "lofexidine"
+    },
+    {
+      "code": "QN07BC05",
+      "name": "levomethadone"
+    },
+    {
+      "code": "QN07BC06",
+      "name": "diamorphine"
+    },
+    {
+      "code": "QN07BC51",
+      "name": "buprenorphine, combinations"
+    },
+    {
+      "code": "QN07C",
+      "name": "ANTIVERTIGO PREPARATIONS"
+    },
+    {
+      "code": "QN07CA",
+      "name": "Antivertigo preparations"
+    },
+    {
+      "code": "QN07CA01",
+      "name": "betahistine"
+    },
+    {
+      "code": "QN07CA02",
+      "name": "cinnarizine"
+    },
+    {
+      "code": "QN07CA03",
+      "name": "flunarizine"
+    },
+    {
+      "code": "QN07CA04",
+      "name": "acetylleucine"
+    },
+    {
+      "code": "QN07CA52",
+      "name": "cinnarizine, combinations"
+    },
+    {
+      "code": "QN07X",
+      "name": "OTHER NERVOUS SYSTEM DRUGS"
+    },
+    {
+      "code": "QN07XA",
+      "name": "Gangliosides and ganglioside derivatives"
+    },
+    {
+      "code": "QN07XX",
+      "name": "Other nervous system drugs"
+    },
+    {
+      "code": "QN07XX01",
+      "name": "tirilazad"
+    },
+    {
+      "code": "QN07XX02",
+      "name": "riluzole"
+    },
+    {
+      "code": "QN07XX03",
+      "name": "xaliproden"
+    },
+    {
+      "code": "QN07XX04",
+      "name": "sodium oxybate"
+    },
+    {
+      "code": "QN07XX05",
+      "name": "amifampridine"
+    },
+    {
+      "code": "QN07XX06",
+      "name": "tetrabenazine"
+    },
+    {
+      "code": "QN07XX07",
+      "name": "fampridine"
+    },
+    {
+      "code": "QN07XX08",
+      "name": "tafamidis"
+    },
+    {
+      "code": "QN07XX10",
+      "name": "laquinimod"
+    },
+    {
+      "code": "QN07XX11",
+      "name": "pitolisant"
+    },
+    {
+      "code": "QN07XX12",
+      "name": "patisiran"
+    },
+    {
+      "code": "QN07XX13",
+      "name": "valbenazine"
+    },
+    {
+      "code": "QN07XX14",
+      "name": "edaravone"
+    },
+    {
+      "code": "QN07XX15",
+      "name": "inotersen"
+    },
+    {
+      "code": "QN07XX16",
+      "name": "deutetrabenazine"
+    },
+    {
+      "code": "QN07XX17",
+      "name": "arimoclomol"
+    },
+    {
+      "code": "QN07XX18",
+      "name": "vutrisiran"
+    },
+    {
+      "code": "QN07XX19",
+      "name": "sodium phenylbutyrate and ursodoxicoltaurine"
+    },
+    {
+      "code": "QN07XX21",
+      "name": "eplontersen"
+    },
+    {
+      "code": "QN07XX22",
+      "name": "tofersen"
+    },
+    {
+      "code": "QN07XX23",
+      "name": "troriluzole"
+    },
+    {
+      "code": "QN07XX24",
+      "name": "trofinetide"
+    },
+    {
+      "code": "QN07XX25",
+      "name": "omaveloxolone"
+    },
+    {
+      "code": "QN07XX26",
+      "name": "pridopidine"
+    },
+    {
+      "code": "QN07XX27",
+      "name": "levacetylleucine"
+    },
+    {
+      "code": "QN07XX59",
+      "name": "dextromethorphan, combinations"
+    },
+    {
+      "code": "QN51",
+      "name": "PRODUCTS FOR ANIMAL EUTHANASIA"
+    },
+    {
+      "code": "QN51A",
+      "name": "PRODUCTS FOR ANIMAL EUTHANASIA"
+    },
+    {
+      "code": "QN51AA",
+      "name": "Barbiturates"
+    },
+    {
+      "code": "QN51AA01",
+      "name": "pentobarbital"
+    },
+    {
+      "code": "QN51AA02",
+      "name": "secobarbital"
+    },
+    {
+      "code": "QN51AA30",
+      "name": "combinations of barbiturates"
+    },
+    {
+      "code": "QN51AA51",
+      "name": "pentobarbital, combinations"
+    },
+    {
+      "code": "QN51AA52",
+      "name": "secobarbital, combinations"
+    },
+    {
+      "code": "QN51AX",
+      "name": "Other products for animal euthanasia"
+    },
+    {
+      "code": "QN51AX50",
+      "name": "combinations"
+    },
+    {
+      "code": "QP",
+      "name": "ANTIPARASITIC PRODUCTS, INSECTICIDES AND REPELLENTS"
+    },
+    {
+      "code": "QP51",
+      "name": "ANTIPROTOZOALS"
+    },
+    {
+      "code": "QP51A",
+      "name": "AGENTS AGAINST PROTOZOAL DISEASES"
+    },
+    {
+      "code": "QP51AA",
+      "name": "Nitroimidazole derivatives"
+    },
+    {
+      "code": "QP51AA02",
+      "name": "tinidazole"
+    },
+    {
+      "code": "QP51AA03",
+      "name": "ornidazole"
+    },
+    {
+      "code": "QP51AA04",
+      "name": "azanidazole"
+    },
+    {
+      "code": "QP51AA05",
+      "name": "propenidazole"
+    },
+    {
+      "code": "QP51AA06",
+      "name": "nimorazole"
+    },
+    {
+      "code": "QP51AA07",
+      "name": "dimetridazole"
+    },
+    {
+      "code": "QP51AA10",
+      "name": "ipronidazole"
+    },
+    {
+      "code": "QP51AB",
+      "name": "Antimony compounds"
+    },
+    {
+      "code": "QP51AB02",
+      "name": "sodium stibogluconate"
+    },
+    {
+      "code": "QP51AC",
+      "name": "Nitrofuran derivatives"
+    },
+    {
+      "code": "QP51AC01",
+      "name": "nifurtimox"
+    },
+    {
+      "code": "QP51AC02",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QP51AD",
+      "name": "Arsenic compounds"
+    },
+    {
+      "code": "QP51AD01",
+      "name": "arsthinol"
+    },
+    {
+      "code": "QP51AD02",
+      "name": "difetarsone"
+    },
+    {
+      "code": "QP51AD03",
+      "name": "glycobiarsol"
+    },
+    {
+      "code": "QP51AD04",
+      "name": "melarsoprol"
+    },
+    {
+      "code": "QP51AD05",
+      "name": "acetarsol"
+    },
+    {
+      "code": "QP51AD53",
+      "name": "glycobiarsol, combinations"
+    },
+    {
+      "code": "QP51AE",
+      "name": "Carbanilides"
+    },
+    {
+      "code": "QP51AE02",
+      "name": "suramin sodium"
+    },
+    {
+      "code": "QP51AE03",
+      "name": "nicarbazine"
+    },
+    {
+      "code": "QP51AF",
+      "name": "Aromatic diamidines"
+    },
+    {
+      "code": "QP51AF03",
+      "name": "phenamidine"
+    },
+    {
+      "code": "QP51AG",
+      "name": "Sulfonamides, plain and in combinations"
+    },
+    {
+      "code": "QP51AG01",
+      "name": "sulfadimidine"
+    },
+    {
+      "code": "QP51AG30",
+      "name": "combinations of sulfonamides"
+    },
+    {
+      "code": "QP51AG51",
+      "name": "sulfadimidine, combinations"
+    },
+    {
+      "code": "QP51AG53",
+      "name": "sulfaquinoxaline, combinations"
+    },
+    {
+      "code": "QP51AX",
+      "name": "Other antiprotozoal agents"
+    },
+    {
+      "code": "QP51AX01",
+      "name": "chiniofon"
+    },
+    {
+      "code": "QP51AX02",
+      "name": "emetine"
+    },
+    {
+      "code": "QP51AX03",
+      "name": "phanquinone"
+    },
+    {
+      "code": "QP51AX04",
+      "name": "mepacrine"
+    },
+    {
+      "code": "QP51AX05",
+      "name": "nifursol"
+    },
+    {
+      "code": "QP51AX11",
+      "name": "arprinocid"
+    },
+    {
+      "code": "QP51AX17",
+      "name": "ethopabate"
+    },
+    {
+      "code": "QP51AX18",
+      "name": "diaveridine"
+    },
+    {
+      "code": "QP51AX23",
+      "name": "fumagillin"
+    },
+    {
+      "code": "QP51AX26",
+      "name": "clopidol"
+    },
+    {
+      "code": "QP51AX30",
+      "name": "combinations of other protozoal agents"
+    },
+    {
+      "code": "QP51B",
+      "name": "AGENTS AGAINST COCCIDIOSIS"
+    },
+    {
+      "code": "QP51BA",
+      "name": "Sulfonamides, plain and in combinations against coccidiosis"
+    },
+    {
+      "code": "QP51BA01",
+      "name": "sulfadimethoxine"
+    },
+    {
+      "code": "QP51BA02",
+      "name": "sulfaquinoxaline"
+    },
+    {
+      "code": "QP51BA03",
+      "name": "sulfaclozine"
+    },
+    {
+      "code": "QP51BB",
+      "name": "Ionophores against coccidiosis"
+    },
+    {
+      "code": "QP51BB01",
+      "name": "salinomycin"
+    },
+    {
+      "code": "QP51BB02",
+      "name": "lasalocid"
+    },
+    {
+      "code": "QP51BB03",
+      "name": "monensin"
+    },
+    {
+      "code": "QP51BB04",
+      "name": "narasin"
+    },
+    {
+      "code": "QP51BB05",
+      "name": "maduramicin"
+    },
+    {
+      "code": "QP51BB54",
+      "name": "narasin, combinations"
+    },
+    {
+      "code": "QP51BC",
+      "name": "Triazines against coccidiosis"
+    },
+    {
+      "code": "QP51BC01",
+      "name": "toltrazuril"
+    },
+    {
+      "code": "QP51BC02",
+      "name": "clazuril"
+    },
+    {
+      "code": "QP51BC03",
+      "name": "diclazuril"
+    },
+    {
+      "code": "QP51BC04",
+      "name": "ponazuril"
+    },
+    {
+      "code": "QP51BC51",
+      "name": "toltrazuril, combinations"
+    },
+    {
+      "code": "QP51BX",
+      "name": "Other agents against coccidiosis"
+    },
+    {
+      "code": "QP51BX01",
+      "name": "halofuginone"
+    },
+    {
+      "code": "QP51BX02",
+      "name": "amprolium"
+    },
+    {
+      "code": "QP51BX03",
+      "name": "robenidine"
+    },
+    {
+      "code": "QP51BX04",
+      "name": "decoquinate"
+    },
+    {
+      "code": "QP51BX05",
+      "name": "clopidol"
+    },
+    {
+      "code": "QP51BX06",
+      "name": "dinitolmide"
+    },
+    {
+      "code": "QP51BX07",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QP51BX52",
+      "name": "amprolium, combinations"
+    },
+    {
+      "code": "QP51BX56",
+      "name": "pyrimethamine, combinations"
+    },
+    {
+      "code": "QP51C",
+      "name": "AGENTS AGAINST AMOEBIOSIS AND HISTOMONOSIS"
+    },
+    {
+      "code": "QP51CA",
+      "name": "Nitroimidazole derivatives against amoebiosis and histomonosis"
+    },
+    {
+      "code": "QP51CA01",
+      "name": "metronidazole"
+    },
+    {
+      "code": "QP51CA02",
+      "name": "ronidazole"
+    },
+    {
+      "code": "QP51CA03",
+      "name": "carnidazole"
+    },
+    {
+      "code": "QP51CX",
+      "name": "Other agents against amoebiosis and histomonosis"
+    },
+    {
+      "code": "QP51CX01",
+      "name": "aminonitrothiazol"
+    },
+    {
+      "code": "QP51D",
+      "name": "AGENTS AGAINST LEISHMANIOSIS AND TRYPANOSOMOSIS"
+    },
+    {
+      "code": "QP51DF",
+      "name": "Aromatic diamidines against leishmaniosis and trypanosomosis"
+    },
+    {
+      "code": "QP51DF01",
+      "name": "diminazen"
+    },
+    {
+      "code": "QP51DF02",
+      "name": "pentamidine"
+    },
+    {
+      "code": "QP51DX",
+      "name": "Other agents against leishmaniosis and trypanosomosis"
+    },
+    {
+      "code": "QP51DX01",
+      "name": "meglumine antimonate"
+    },
+    {
+      "code": "QP51DX02",
+      "name": "melarsamin"
+    },
+    {
+      "code": "QP51DX03",
+      "name": "homidium"
+    },
+    {
+      "code": "QP51DX04",
+      "name": "isometamidium"
+    },
+    {
+      "code": "QP51DX05",
+      "name": "quinapyramine"
+    },
+    {
+      "code": "QP51DX06",
+      "name": "domperidone"
+    },
+    {
+      "code": "QP51DX07",
+      "name": "miltefosine"
+    },
+    {
+      "code": "QP51E",
+      "name": "AGENTS AGAINST BABESIOSIS AND THEILERIOSIS"
+    },
+    {
+      "code": "QP51EX",
+      "name": "Other agents against babesiosis and theileriosis"
+    },
+    {
+      "code": "QP51EX01",
+      "name": "imidocarb"
+    },
+    {
+      "code": "QP51EX02",
+      "name": "parvaquone"
+    },
+    {
+      "code": "QP51EX03",
+      "name": "buparvaquone"
+    },
+    {
+      "code": "QP51X",
+      "name": "OTHER ANTIPROTOZOAL AGENTS"
+    },
+    {
+      "code": "QP52",
+      "name": "ANTHELMINTICS"
+    },
+    {
+      "code": "QP52A",
+      "name": "ANTHELMINTICS"
+    },
+    {
+      "code": "QP52AA",
+      "name": "Quinoline derivatives and related substances"
+    },
+    {
+      "code": "QP52AA01",
+      "name": "praziquantel"
+    },
+    {
+      "code": "QP52AA02",
+      "name": "oxamniquine"
+    },
+    {
+      "code": "QP52AA04",
+      "name": "epsiprantel"
+    },
+    {
+      "code": "QP52AA30",
+      "name": "combinations of quinoline derivatives and related substances"
+    },
+    {
+      "code": "QP52AA51",
+      "name": "praziquantel, combinations"
+    },
+    {
+      "code": "QP52AA54",
+      "name": "epsiprantel, combinations"
+    },
+    {
+      "code": "QP52AB",
+      "name": "Organophosphorous compounds"
+    },
+    {
+      "code": "QP52AB01",
+      "name": "metrifonate"
+    },
+    {
+      "code": "QP52AB02",
+      "name": "bromfenofos"
+    },
+    {
+      "code": "QP52AB03",
+      "name": "dichlorvos"
+    },
+    {
+      "code": "QP52AB04",
+      "name": "haloxon"
+    },
+    {
+      "code": "QP52AB06",
+      "name": "naftalofos"
+    },
+    {
+      "code": "QP52AB51",
+      "name": "metrifonate, combinations"
+    },
+    {
+      "code": "QP52AC",
+      "name": "Benzimidazoles and related substances"
+    },
+    {
+      "code": "QP52AC01",
+      "name": "triclabendazole"
+    },
+    {
+      "code": "QP52AC02",
+      "name": "oxfendazole"
+    },
+    {
+      "code": "QP52AC03",
+      "name": "parbendazole"
+    },
+    {
+      "code": "QP52AC04",
+      "name": "thiophanate"
+    },
+    {
+      "code": "QP52AC05",
+      "name": "febantel"
+    },
+    {
+      "code": "QP52AC06",
+      "name": "netobimine"
+    },
+    {
+      "code": "QP52AC07",
+      "name": "oxibendazole"
+    },
+    {
+      "code": "QP52AC08",
+      "name": "cambendazole"
+    },
+    {
+      "code": "QP52AC09",
+      "name": "mebendazole"
+    },
+    {
+      "code": "QP52AC10",
+      "name": "tiabendazole"
+    },
+    {
+      "code": "QP52AC11",
+      "name": "albendazole"
+    },
+    {
+      "code": "QP52AC12",
+      "name": "flubendazole"
+    },
+    {
+      "code": "QP52AC13",
+      "name": "fenbendazole"
+    },
+    {
+      "code": "QP52AC30",
+      "name": "combinations of benzimidazoles and related substances"
+    },
+    {
+      "code": "QP52AC52",
+      "name": "oxfendazole, combinations"
+    },
+    {
+      "code": "QP52AC55",
+      "name": "febantel, combinations"
+    },
+    {
+      "code": "QP52AC57",
+      "name": "oxibendazole, combinations"
+    },
+    {
+      "code": "QP52AC59",
+      "name": "mebendazole, combinations"
+    },
+    {
+      "code": "QP52AE",
+      "name": "Imidazothiazoles"
+    },
+    {
+      "code": "QP52AE01",
+      "name": "levamisole"
+    },
+    {
+      "code": "QP52AE02",
+      "name": "tetramisole"
+    },
+    {
+      "code": "QP52AE30",
+      "name": "combinations of imidazothiazoles"
+    },
+    {
+      "code": "QP52AE51",
+      "name": "levamisole, combinations"
+    },
+    {
+      "code": "QP52AE52",
+      "name": "tetramisole, combinations"
+    },
+    {
+      "code": "QP52AF",
+      "name": "Tetrahydropyrimidines"
+    },
+    {
+      "code": "QP52AF01",
+      "name": "morantel"
+    },
+    {
+      "code": "QP52AF02",
+      "name": "pyrantel"
+    },
+    {
+      "code": "QP52AF03",
+      "name": "oxantel"
+    },
+    {
+      "code": "QP52AF30",
+      "name": "combinations of tetrahydropyrimidines"
+    },
+    {
+      "code": "QP52AG",
+      "name": "Phenol derivatives, incl. salicylanilides"
+    },
+    {
+      "code": "QP52AG01",
+      "name": "dichlorophene"
+    },
+    {
+      "code": "QP52AG02",
+      "name": "hexachlorophene"
+    },
+    {
+      "code": "QP52AG03",
+      "name": "niclosamide"
+    },
+    {
+      "code": "QP52AG04",
+      "name": "resorantel"
+    },
+    {
+      "code": "QP52AG05",
+      "name": "rafoxanide"
+    },
+    {
+      "code": "QP52AG06",
+      "name": "oxyclozanide"
+    },
+    {
+      "code": "QP52AG07",
+      "name": "bithionol"
+    },
+    {
+      "code": "QP52AG08",
+      "name": "nitroxinil"
+    },
+    {
+      "code": "QP52AG09",
+      "name": "closantel"
+    },
+    {
+      "code": "QP52AH",
+      "name": "Piperazine and derivatives"
+    },
+    {
+      "code": "QP52AH01",
+      "name": "piperazine"
+    },
+    {
+      "code": "QP52AH02",
+      "name": "diethylcarbamazine"
+    },
+    {
+      "code": "QP52AX",
+      "name": "Other anthelmintic agents"
+    },
+    {
+      "code": "QP52AX01",
+      "name": "nitroscanate"
+    },
+    {
+      "code": "QP52AX02",
+      "name": "bunamidine hydrochloride"
+    },
+    {
+      "code": "QP52AX03",
+      "name": "phenotiazine"
+    },
+    {
+      "code": "QP52AX04",
+      "name": "dibutyltindilaurate"
+    },
+    {
+      "code": "QP52AX05",
+      "name": "destomycin A"
+    },
+    {
+      "code": "QP52AX06",
+      "name": "halodone"
+    },
+    {
+      "code": "QP52AX07",
+      "name": "butylchloride"
+    },
+    {
+      "code": "QP52AX08",
+      "name": "thiacetarsamide"
+    },
+    {
+      "code": "QP52AX09",
+      "name": "monepantel"
+    },
+    {
+      "code": "QP52AX60",
+      "name": "emodepside and toltrazuril"
+    },
+    {
+      "code": "QP52B",
+      "name": "AGENTS AGAINST TREMATODOSIS, OPTIONAL CLASSIFICATION"
+    },
+    {
+      "code": "QP52C",
+      "name": "AGENTS AGAINST NEMATODOSIS, OPTIONAL CLASSIFICATION"
+    },
+    {
+      "code": "QP52D",
+      "name": "AGENTS AGAINST CESTODOSIS, OPTIONAL CLASSIFICATION"
+    },
+    {
+      "code": "QP52X",
+      "name": "OTHER ANTHELMINTIC AGENTS, OPTIONAL CLASSIFICATION"
+    },
+    {
+      "code": "QP53",
+      "name": "ECTOPARASITICIDES, INSECTICIDES AND REPELLENTS"
+    },
+    {
+      "code": "QP53A",
+      "name": "ECTOPARASITICIDES FOR TOPICAL USE, INCL. INSECTICIDES"
+    },
+    {
+      "code": "QP53AA",
+      "name": "Sulfur-containing products"
+    },
+    {
+      "code": "QP53AA01",
+      "name": "mesulfen"
+    },
+    {
+      "code": "QP53AA02",
+      "name": "cymiazol"
+    },
+    {
+      "code": "QP53AB",
+      "name": "Chlorine-containing products"
+    },
+    {
+      "code": "QP53AB01",
+      "name": "clofenotane"
+    },
+    {
+      "code": "QP53AB02",
+      "name": "lindane"
+    },
+    {
+      "code": "QP53AB03",
+      "name": "bromociclen"
+    },
+    {
+      "code": "QP53AB04",
+      "name": "tosylchloramide"
+    },
+    {
+      "code": "QP53AB51",
+      "name": "clofenotane, combinations"
+    },
+    {
+      "code": "QP53AB52",
+      "name": "lindane, combinations"
+    },
+    {
+      "code": "QP53AC",
+      "name": "Pyrethrins and pyrethroids"
+    },
+    {
+      "code": "QP53AC01",
+      "name": "pyrethrum"
+    },
+    {
+      "code": "QP53AC02",
+      "name": "bioallethrin"
+    },
+    {
+      "code": "QP53AC03",
+      "name": "phenothrin"
+    },
+    {
+      "code": "QP53AC04",
+      "name": "permethrin"
+    },
+    {
+      "code": "QP53AC05",
+      "name": "flumethrin"
+    },
+    {
+      "code": "QP53AC06",
+      "name": "cyhalothrin"
+    },
+    {
+      "code": "QP53AC07",
+      "name": "flucythrinate"
+    },
+    {
+      "code": "QP53AC08",
+      "name": "cypermethrin"
+    },
+    {
+      "code": "QP53AC10",
+      "name": "fluvalinate"
+    },
+    {
+      "code": "QP53AC11",
+      "name": "deltamethrin"
+    },
+    {
+      "code": "QP53AC12",
+      "name": "cyfluthrin"
+    },
+    {
+      "code": "QP53AC13",
+      "name": "tetramethrin"
+    },
+    {
+      "code": "QP53AC14",
+      "name": "fenvalerate"
+    },
+    {
+      "code": "QP53AC15",
+      "name": "acrinathrin"
+    },
+    {
+      "code": "QP53AC30",
+      "name": "combinations of pyrethrines"
+    },
+    {
+      "code": "QP53AC51",
+      "name": "pyrethrum, combinations"
+    },
+    {
+      "code": "QP53AC54",
+      "name": "permethrin, combinations"
+    },
+    {
+      "code": "QP53AC55",
+      "name": "flumethrin, combinations"
+    },
+    {
+      "code": "QP53AD",
+      "name": "Amidines"
+    },
+    {
+      "code": "QP53AD01",
+      "name": "amitraz"
+    },
+    {
+      "code": "QP53AD51",
+      "name": "amitraz, combinations"
+    },
+    {
+      "code": "QP53AE",
+      "name": "Carbamates"
+    },
+    {
+      "code": "QP53AE01",
+      "name": "carbaril"
+    },
+    {
+      "code": "QP53AE02",
+      "name": "propoxur"
+    },
+    {
+      "code": "QP53AE03",
+      "name": "bendiocarb"
+    },
+    {
+      "code": "QP53AF",
+      "name": "Organophosphorous compounds"
+    },
+    {
+      "code": "QP53AF01",
+      "name": "phoxime"
+    },
+    {
+      "code": "QP53AF02",
+      "name": "metrifonate"
+    },
+    {
+      "code": "QP53AF03",
+      "name": "dimpylate"
+    },
+    {
+      "code": "QP53AF04",
+      "name": "dichlorvos"
+    },
+    {
+      "code": "QP53AF05",
+      "name": "heptenofos"
+    },
+    {
+      "code": "QP53AF06",
+      "name": "phosmet"
+    },
+    {
+      "code": "QP53AF07",
+      "name": "fention"
+    },
+    {
+      "code": "QP53AF08",
+      "name": "coumafos"
+    },
+    {
+      "code": "QP53AF09",
+      "name": "propetamphos"
+    },
+    {
+      "code": "QP53AF10",
+      "name": "cythioate"
+    },
+    {
+      "code": "QP53AF11",
+      "name": "bromophos"
+    },
+    {
+      "code": "QP53AF12",
+      "name": "malathion"
+    },
+    {
+      "code": "QP53AF13",
+      "name": "quintiophos"
+    },
+    {
+      "code": "QP53AF14",
+      "name": "tetrachlorvinphos"
+    },
+    {
+      "code": "QP53AF16",
+      "name": "bromfenvinphos"
+    },
+    {
+      "code": "QP53AF17",
+      "name": "azamethiphos"
+    },
+    {
+      "code": "QP53AF54",
+      "name": "dichlorvos, combinations"
+    },
+    {
+      "code": "QP53AG",
+      "name": "Organic acids"
+    },
+    {
+      "code": "QP53AG01",
+      "name": "formic acid"
+    },
+    {
+      "code": "QP53AG02",
+      "name": "lactic acid"
+    },
+    {
+      "code": "QP53AG03",
+      "name": "oxalic acid"
+    },
+    {
+      "code": "QP53AG30",
+      "name": "combinations"
+    },
+    {
+      "code": "QP53AX",
+      "name": "Other ectoparasiticides for topical use"
+    },
+    {
+      "code": "QP53AX02",
+      "name": "fenvalerate"
+    },
+    {
+      "code": "QP53AX03",
+      "name": "quassia"
+    },
+    {
+      "code": "QP53AX04",
+      "name": "crotamiton"
+    },
+    {
+      "code": "QP53AX11",
+      "name": "benzylbenzoate"
+    },
+    {
+      "code": "QP53AX13",
+      "name": "nicotine"
+    },
+    {
+      "code": "QP53AX14",
+      "name": "bromoprofylat"
+    },
+    {
+      "code": "QP53AX15",
+      "name": "fipronil"
+    },
+    {
+      "code": "QP53AX16",
+      "name": "malachite green"
+    },
+    {
+      "code": "QP53AX17",
+      "name": "imidacloprid"
+    },
+    {
+      "code": "QP53AX18",
+      "name": "calcium oxide"
+    },
+    {
+      "code": "QP53AX19",
+      "name": "formaldehyde"
+    },
+    {
+      "code": "QP53AX22",
+      "name": "thymol"
+    },
+    {
+      "code": "QP53AX23",
+      "name": "pyriproxyfen"
+    },
+    {
+      "code": "QP53AX24",
+      "name": "dicyclanil"
+    },
+    {
+      "code": "QP53AX25",
+      "name": "metaflumizone"
+    },
+    {
+      "code": "QP53AX26",
+      "name": "pyriprole"
+    },
+    {
+      "code": "QP53AX27",
+      "name": "indoxacarb"
+    },
+    {
+      "code": "QP53AX28",
+      "name": "methoprene"
+    },
+    {
+      "code": "QP53AX29",
+      "name": "hexaflumuron"
+    },
+    {
+      "code": "QP53AX30",
+      "name": "combinations of other ectoparasiticides for topical use"
+    },
+    {
+      "code": "QP53AX31",
+      "name": "spinetoram"
+    },
+    {
+      "code": "QP53AX65",
+      "name": "fipronil, combinations"
+    },
+    {
+      "code": "QP53AX73",
+      "name": "pyriproxyfen, combinations"
+    },
+    {
+      "code": "QP53AX78",
+      "name": "methoprene, combinations"
+    },
+    {
+      "code": "QP53B",
+      "name": "ECTOPARASITICIDES FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QP53BB",
+      "name": "Organophosphorous compounds"
+    },
+    {
+      "code": "QP53BB01",
+      "name": "cythioate"
+    },
+    {
+      "code": "QP53BB02",
+      "name": "fenthion"
+    },
+    {
+      "code": "QP53BB03",
+      "name": "phosmet"
+    },
+    {
+      "code": "QP53BB04",
+      "name": "stirofos"
+    },
+    {
+      "code": "QP53BC",
+      "name": "Chitin synthesis inhibitors"
+    },
+    {
+      "code": "QP53BC01",
+      "name": "lufenuron"
+    },
+    {
+      "code": "QP53BC02",
+      "name": "diflubenzuron"
+    },
+    {
+      "code": "QP53BC03",
+      "name": "teflubenzuron"
+    },
+    {
+      "code": "QP53BC51",
+      "name": "lufenuron, combinations"
+    },
+    {
+      "code": "QP53BE",
+      "name": "Isoxazolines"
+    },
+    {
+      "code": "QP53BE01",
+      "name": "afoxolaner"
+    },
+    {
+      "code": "QP53BE02",
+      "name": "fluralaner"
+    },
+    {
+      "code": "QP53BE03",
+      "name": "sarolaner"
+    },
+    {
+      "code": "QP53BE04",
+      "name": "lotilaner"
+    },
+    {
+      "code": "QP53BX",
+      "name": "Other ectoparasiticides for systemic use"
+    },
+    {
+      "code": "QP53BX02",
+      "name": "nitenpyram"
+    },
+    {
+      "code": "QP53BX03",
+      "name": "spinosad"
+    },
+    {
+      "code": "QP53G",
+      "name": "REPELLENTS"
+    },
+    {
+      "code": "QP53GX",
+      "name": "Various repellents"
+    },
+    {
+      "code": "QP53GX01",
+      "name": "diethyltoluamide"
+    },
+    {
+      "code": "QP53GX02",
+      "name": "dimethylphtalate"
+    },
+    {
+      "code": "QP53GX03",
+      "name": "dibutylsuccinate"
+    },
+    {
+      "code": "QP53GX04",
+      "name": "ethohexadiol"
+    },
+    {
+      "code": "QP54",
+      "name": "ENDECTOCIDES"
+    },
+    {
+      "code": "QP54A",
+      "name": "MACROCYCLIC LACTONES"
+    },
+    {
+      "code": "QP54AA",
+      "name": "Avermectins"
+    },
+    {
+      "code": "QP54AA01",
+      "name": "ivermectin"
+    },
+    {
+      "code": "QP54AA02",
+      "name": "abamectin"
+    },
+    {
+      "code": "QP54AA03",
+      "name": "doramectin"
+    },
+    {
+      "code": "QP54AA04",
+      "name": "eprinomectin"
+    },
+    {
+      "code": "QP54AA05",
+      "name": "selamectin"
+    },
+    {
+      "code": "QP54AA06",
+      "name": "emamectin"
+    },
+    {
+      "code": "QP54AA51",
+      "name": "ivermectin, combinations"
+    },
+    {
+      "code": "QP54AA52",
+      "name": "abamectin, combinations"
+    },
+    {
+      "code": "QP54AA54",
+      "name": "eprinomectin, combinations"
+    },
+    {
+      "code": "QP54AA55",
+      "name": "selamectin, combinations"
+    },
+    {
+      "code": "QP54AB",
+      "name": "Milbemycins"
+    },
+    {
+      "code": "QP54AB01",
+      "name": "milbemycin oxime"
+    },
+    {
+      "code": "QP54AB02",
+      "name": "moxidectin"
+    },
+    {
+      "code": "QP54AB51",
+      "name": "milbemycin oxime, combinations"
+    },
+    {
+      "code": "QP54AB52",
+      "name": "moxidectin, combinations"
+    },
+    {
+      "code": "QP54AX",
+      "name": "Other macrocyclic lactones"
+    },
+    {
+      "code": "QR",
+      "name": "RESPIRATORY SYSTEM"
+    },
+    {
+      "code": "QR01",
+      "name": "NASAL PREPARATIONS"
+    },
+    {
+      "code": "QR01A",
+      "name": "DECONGESTANTS AND OTHER NASAL PREPARATIONS FOR TOPICAL USE"
+    },
+    {
+      "code": "QR01AA",
+      "name": "Sympathomimetics, plain"
+    },
+    {
+      "code": "QR01AA02",
+      "name": "cyclopentamine"
+    },
+    {
+      "code": "QR01AA03",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QR01AA04",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QR01AA05",
+      "name": "oxymetazoline"
+    },
+    {
+      "code": "QR01AA06",
+      "name": "tetryzoline"
+    },
+    {
+      "code": "QR01AA07",
+      "name": "xylometazoline"
+    },
+    {
+      "code": "QR01AA08",
+      "name": "naphazoline"
+    },
+    {
+      "code": "QR01AA09",
+      "name": "tramazoline"
+    },
+    {
+      "code": "QR01AA10",
+      "name": "metizoline"
+    },
+    {
+      "code": "QR01AA11",
+      "name": "tuaminoheptane"
+    },
+    {
+      "code": "QR01AA12",
+      "name": "fenoxazoline"
+    },
+    {
+      "code": "QR01AA13",
+      "name": "tymazoline"
+    },
+    {
+      "code": "QR01AA14",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QR01AA15",
+      "name": "indanazoline"
+    },
+    {
+      "code": "QR01AB",
+      "name": "Sympathomimetics, combinations excl. corticosteroids"
+    },
+    {
+      "code": "QR01AB01",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QR01AB02",
+      "name": "naphazoline"
+    },
+    {
+      "code": "QR01AB03",
+      "name": "tetryzoline"
+    },
+    {
+      "code": "QR01AB05",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QR01AB06",
+      "name": "xylometazoline"
+    },
+    {
+      "code": "QR01AB07",
+      "name": "oxymetazoline"
+    },
+    {
+      "code": "QR01AB08",
+      "name": "tuaminoheptane"
+    },
+    {
+      "code": "QR01AC",
+      "name": "Antiallergic agents, excl. corticosteroids"
+    },
+    {
+      "code": "QR01AC01",
+      "name": "cromoglicic acid"
+    },
+    {
+      "code": "QR01AC02",
+      "name": "levocabastine"
+    },
+    {
+      "code": "QR01AC03",
+      "name": "azelastine"
+    },
+    {
+      "code": "QR01AC04",
+      "name": "antazoline"
+    },
+    {
+      "code": "QR01AC05",
+      "name": "spaglumic acid"
+    },
+    {
+      "code": "QR01AC06",
+      "name": "thonzylamine"
+    },
+    {
+      "code": "QR01AC07",
+      "name": "nedocromil"
+    },
+    {
+      "code": "QR01AC08",
+      "name": "olopatadine"
+    },
+    {
+      "code": "QR01AC51",
+      "name": "cromoglicic acid, combinations"
+    },
+    {
+      "code": "QR01AD",
+      "name": "Corticosteroids"
+    },
+    {
+      "code": "QR01AD01",
+      "name": "beclometasone"
+    },
+    {
+      "code": "QR01AD02",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QR01AD03",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QR01AD04",
+      "name": "flunisolide"
+    },
+    {
+      "code": "QR01AD05",
+      "name": "budesonide"
+    },
+    {
+      "code": "QR01AD06",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QR01AD07",
+      "name": "tixocortol"
+    },
+    {
+      "code": "QR01AD08",
+      "name": "fluticasone"
+    },
+    {
+      "code": "QR01AD09",
+      "name": "mometasone"
+    },
+    {
+      "code": "QR01AD11",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QR01AD12",
+      "name": "fluticasone furoate"
+    },
+    {
+      "code": "QR01AD13",
+      "name": "ciclesonide"
+    },
+    {
+      "code": "QR01AD52",
+      "name": "prednisolone, combinations"
+    },
+    {
+      "code": "QR01AD53",
+      "name": "dexamethasone, combinations"
+    },
+    {
+      "code": "QR01AD57",
+      "name": "tixocortol, combinations"
+    },
+    {
+      "code": "QR01AD58",
+      "name": "fluticasone, combinations"
+    },
+    {
+      "code": "QR01AD59",
+      "name": "mometasone, combinations"
+    },
+    {
+      "code": "QR01AD60",
+      "name": "hydrocortisone, combinations"
+    },
+    {
+      "code": "QR01AX",
+      "name": "Other nasal preparations"
+    },
+    {
+      "code": "QR01AX01",
+      "name": "calcium hexamine thiocyanate"
+    },
+    {
+      "code": "QR01AX02",
+      "name": "retinol"
+    },
+    {
+      "code": "QR01AX03",
+      "name": "ipratropium bromide"
+    },
+    {
+      "code": "QR01AX05",
+      "name": "ritiometan"
+    },
+    {
+      "code": "QR01AX06",
+      "name": "mupirocin"
+    },
+    {
+      "code": "QR01AX07",
+      "name": "hexamidine"
+    },
+    {
+      "code": "QR01AX08",
+      "name": "framycetin"
+    },
+    {
+      "code": "QR01AX09",
+      "name": "hyaluronic acid"
+    },
+    {
+      "code": "QR01AX10",
+      "name": "various"
+    },
+    {
+      "code": "QR01AX30",
+      "name": "combinations"
+    },
+    {
+      "code": "QR01B",
+      "name": "NASAL DECONGESTANTS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QR01BA",
+      "name": "Sympathomimetics"
+    },
+    {
+      "code": "QR01BA01",
+      "name": "phenylpropanolamine"
+    },
+    {
+      "code": "QR01BA02",
+      "name": "pseudoephedrine"
+    },
+    {
+      "code": "QR01BA03",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QR01BA51",
+      "name": "phenylpropanolamine, combinations"
+    },
+    {
+      "code": "QR01BA52",
+      "name": "pseudoephedrine, combinations"
+    },
+    {
+      "code": "QR01BA53",
+      "name": "phenylephrine, combinations"
+    },
+    {
+      "code": "QR02",
+      "name": "THROAT PREPARATIONS"
+    },
+    {
+      "code": "QR02A",
+      "name": "THROAT PREPARATIONS"
+    },
+    {
+      "code": "QR02AA",
+      "name": "Antiseptics"
+    },
+    {
+      "code": "QR02AA01",
+      "name": "ambazone"
+    },
+    {
+      "code": "QR02AA02",
+      "name": "dequalinium"
+    },
+    {
+      "code": "QR02AA03",
+      "name": "dichlorobenzyl alcohol"
+    },
+    {
+      "code": "QR02AA05",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QR02AA06",
+      "name": "cetylpyridinum"
+    },
+    {
+      "code": "QR02AA09",
+      "name": "benzethonium"
+    },
+    {
+      "code": "QR02AA10",
+      "name": "myristyl-benzalkonium"
+    },
+    {
+      "code": "QR02AA11",
+      "name": "chlorquinaldol"
+    },
+    {
+      "code": "QR02AA12",
+      "name": "hexylresorcinol"
+    },
+    {
+      "code": "QR02AA13",
+      "name": "acriflavinium chloride"
+    },
+    {
+      "code": "QR02AA14",
+      "name": "oxyquinoline"
+    },
+    {
+      "code": "QR02AA15",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QR02AA16",
+      "name": "benzalkonium"
+    },
+    {
+      "code": "QR02AA17",
+      "name": "cetrimonium"
+    },
+    {
+      "code": "QR02AA18",
+      "name": "hexamidine"
+    },
+    {
+      "code": "QR02AA19",
+      "name": "phenol"
+    },
+    {
+      "code": "QR02AA20",
+      "name": "various"
+    },
+    {
+      "code": "QR02AA21",
+      "name": "octenidine"
+    },
+    {
+      "code": "QR02AB",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QR02AB01",
+      "name": "neomycin"
+    },
+    {
+      "code": "QR02AB02",
+      "name": "tyrothricin"
+    },
+    {
+      "code": "QR02AB03",
+      "name": "fusafungine"
+    },
+    {
+      "code": "QR02AB04",
+      "name": "bacitracin"
+    },
+    {
+      "code": "QR02AB30",
+      "name": "gramicidin"
+    },
+    {
+      "code": "QR02AD",
+      "name": "Anesthetics, local"
+    },
+    {
+      "code": "QR02AD01",
+      "name": "benzocaine"
+    },
+    {
+      "code": "QR02AD02",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QR02AD03",
+      "name": "cocaine"
+    },
+    {
+      "code": "QR02AD04",
+      "name": "dyclonine"
+    },
+    {
+      "code": "QR02AD05",
+      "name": "ambroxol"
+    },
+    {
+      "code": "QR02AX",
+      "name": "Other throat preparations"
+    },
+    {
+      "code": "QR02AX01",
+      "name": "flurbiprofen"
+    },
+    {
+      "code": "QR02AX02",
+      "name": "ibuprofen"
+    },
+    {
+      "code": "QR02AX03",
+      "name": "benzydamine"
+    },
+    {
+      "code": "QR03",
+      "name": "DRUGS FOR OBSTRUCTIVE AIRWAY DISEASES"
+    },
+    {
+      "code": "QR03A",
+      "name": "ADRENERGICS, INHALANTS"
+    },
+    {
+      "code": "QR03AA",
+      "name": "Alpha- and beta-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03AA01",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QR03AB",
+      "name": "Non-selective beta-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03AB02",
+      "name": "isoprenaline"
+    },
+    {
+      "code": "QR03AB03",
+      "name": "orciprenaline"
+    },
+    {
+      "code": "QR03AC",
+      "name": "Selective beta-2-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03AC02",
+      "name": "salbutamol"
+    },
+    {
+      "code": "QR03AC03",
+      "name": "terbutaline"
+    },
+    {
+      "code": "QR03AC04",
+      "name": "fenoterol"
+    },
+    {
+      "code": "QR03AC05",
+      "name": "rimiterol"
+    },
+    {
+      "code": "QR03AC06",
+      "name": "hexoprenaline"
+    },
+    {
+      "code": "QR03AC07",
+      "name": "isoetarine"
+    },
+    {
+      "code": "QR03AC08",
+      "name": "pirbuterol"
+    },
+    {
+      "code": "QR03AC09",
+      "name": "tretoquinol"
+    },
+    {
+      "code": "QR03AC10",
+      "name": "carbuterol"
+    },
+    {
+      "code": "QR03AC11",
+      "name": "tulobuterol"
+    },
+    {
+      "code": "QR03AC12",
+      "name": "salmeterol"
+    },
+    {
+      "code": "QR03AC13",
+      "name": "formoterol"
+    },
+    {
+      "code": "QR03AC14",
+      "name": "clenbuterol"
+    },
+    {
+      "code": "QR03AC15",
+      "name": "reproterol"
+    },
+    {
+      "code": "QR03AC16",
+      "name": "procaterol"
+    },
+    {
+      "code": "QR03AC17",
+      "name": "bitolterol"
+    },
+    {
+      "code": "QR03AC18",
+      "name": "indacaterol"
+    },
+    {
+      "code": "QR03AC19",
+      "name": "olodaterol"
+    },
+    {
+      "code": "QR03AH",
+      "name": "Combinations of adrenergics"
+    },
+    {
+      "code": "QR03AK",
+      "name": "Adrenergics in combination with corticosteroids or other drugs, excl. anticholinergics"
+    },
+    {
+      "code": "QR03AK01",
+      "name": "epinephrine and other drugs for obstructive airway diseases"
+    },
+    {
+      "code": "QR03AK02",
+      "name": "isoprenaline and other drugs for obstructive airway diseases"
+    },
+    {
+      "code": "QR03AK04",
+      "name": "salbutamol and sodium cromoglicate"
+    },
+    {
+      "code": "QR03AK05",
+      "name": "reproterol and sodium cromoglicate"
+    },
+    {
+      "code": "QR03AK06",
+      "name": "salmeterol and fluticasone"
+    },
+    {
+      "code": "QR03AK07",
+      "name": "formoterol and budesonide"
+    },
+    {
+      "code": "QR03AK08",
+      "name": "formoterol and beclometasone"
+    },
+    {
+      "code": "QR03AK09",
+      "name": "formoterol and mometasone"
+    },
+    {
+      "code": "QR03AK10",
+      "name": "vilanterol and fluticasone furoate"
+    },
+    {
+      "code": "QR03AK11",
+      "name": "formoterol and fluticasone"
+    },
+    {
+      "code": "QR03AK12",
+      "name": "salmeterol and budesonide"
+    },
+    {
+      "code": "QR03AK13",
+      "name": "salbutamol and beclometasone"
+    },
+    {
+      "code": "QR03AK14",
+      "name": "indacaterol and mometasone"
+    },
+    {
+      "code": "QR03AK15",
+      "name": "salbutamol and budesonide"
+    },
+    {
+      "code": "QR03AL",
+      "name": "Adrenergics in combinations with anticholinergics incl. triple combinations with corticosteroids"
+    },
+    {
+      "code": "QR03AL01",
+      "name": "fenoterol and ipratropium bromide"
+    },
+    {
+      "code": "QR03AL02",
+      "name": "salbutamol and ipratropium bromide"
+    },
+    {
+      "code": "QR03AL03",
+      "name": "vilanterol and umeclidinium bromide"
+    },
+    {
+      "code": "QR03AL04",
+      "name": "indacaterol and glycopyrronium bromide"
+    },
+    {
+      "code": "QR03AL05",
+      "name": "formoterol and aclidinium bromide"
+    },
+    {
+      "code": "QR03AL06",
+      "name": "olodaterol and tiotropium bromide"
+    },
+    {
+      "code": "QR03AL07",
+      "name": "formoterol and glycopyrronium bromide"
+    },
+    {
+      "code": "QR03AL08",
+      "name": "vilanterol, umeclidinium bromide and fluticasone furoate"
+    },
+    {
+      "code": "QR03AL09",
+      "name": "formoterol, glycopyrronium bromide and beclometasone"
+    },
+    {
+      "code": "QR03AL10",
+      "name": "formoterol and tiotropium bromide"
+    },
+    {
+      "code": "QR03AL11",
+      "name": "formoterol, glycopyrronium bromide and budesonide"
+    },
+    {
+      "code": "QR03AL12",
+      "name": "indacaterol, glycopyrronium bromide and mometasone"
+    },
+    {
+      "code": "QR03B",
+      "name": "OTHER DRUGS FOR OBSTRUCTIVE AIRWAY DISEASES, INHALANTS"
+    },
+    {
+      "code": "QR03BA",
+      "name": "Glucocorticoids"
+    },
+    {
+      "code": "QR03BA01",
+      "name": "beclometasone"
+    },
+    {
+      "code": "QR03BA02",
+      "name": "budesonide"
+    },
+    {
+      "code": "QR03BA03",
+      "name": "flunisolide"
+    },
+    {
+      "code": "QR03BA04",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QR03BA05",
+      "name": "fluticasone"
+    },
+    {
+      "code": "QR03BA06",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QR03BA07",
+      "name": "mometasone"
+    },
+    {
+      "code": "QR03BA08",
+      "name": "ciclesonide"
+    },
+    {
+      "code": "QR03BA09",
+      "name": "fluticasone furoate"
+    },
+    {
+      "code": "QR03BB",
+      "name": "Anticholinergics"
+    },
+    {
+      "code": "QR03BB01",
+      "name": "ipratropium bromide"
+    },
+    {
+      "code": "QR03BB02",
+      "name": "oxitropium bromide"
+    },
+    {
+      "code": "QR03BB03",
+      "name": "stramoni preparations"
+    },
+    {
+      "code": "QR03BB04",
+      "name": "tiotropium bromide"
+    },
+    {
+      "code": "QR03BB05",
+      "name": "aclidinium bromide"
+    },
+    {
+      "code": "QR03BB06",
+      "name": "glycopyrronium bromide"
+    },
+    {
+      "code": "QR03BB07",
+      "name": "umeclidinium bromide"
+    },
+    {
+      "code": "QR03BB08",
+      "name": "revefenacin"
+    },
+    {
+      "code": "QR03BB54",
+      "name": "tiotropium bromide, combinations"
+    },
+    {
+      "code": "QR03BC",
+      "name": "Antiallergic agents, excl. corticosteroids"
+    },
+    {
+      "code": "QR03BC01",
+      "name": "cromoglicic acid"
+    },
+    {
+      "code": "QR03BC03",
+      "name": "nedocromil"
+    },
+    {
+      "code": "QR03BX",
+      "name": "Other drugs for obstructive airway diseases, inhalants"
+    },
+    {
+      "code": "QR03BX01",
+      "name": "fenspiride"
+    },
+    {
+      "code": "QR03BX02",
+      "name": "ensifentrine"
+    },
+    {
+      "code": "QR03C",
+      "name": "ADRENERGICS FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QR03CA",
+      "name": "Alpha- and beta-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03CA02",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QR03CB",
+      "name": "Non-selective beta-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03CB01",
+      "name": "isoprenaline"
+    },
+    {
+      "code": "QR03CB02",
+      "name": "methoxyphenamine"
+    },
+    {
+      "code": "QR03CB03",
+      "name": "orciprenaline"
+    },
+    {
+      "code": "QR03CB51",
+      "name": "isoprenaline, combinations"
+    },
+    {
+      "code": "QR03CB53",
+      "name": "orciprenaline, combinations"
+    },
+    {
+      "code": "QR03CC",
+      "name": "Selective beta-2-adrenoreceptor agonists"
+    },
+    {
+      "code": "QR03CC02",
+      "name": "salbutamol"
+    },
+    {
+      "code": "QR03CC03",
+      "name": "terbutaline"
+    },
+    {
+      "code": "QR03CC04",
+      "name": "fenoterol"
+    },
+    {
+      "code": "QR03CC05",
+      "name": "hexoprenaline"
+    },
+    {
+      "code": "QR03CC06",
+      "name": "isoetarine"
+    },
+    {
+      "code": "QR03CC07",
+      "name": "pirbuterol"
+    },
+    {
+      "code": "QR03CC08",
+      "name": "procaterol"
+    },
+    {
+      "code": "QR03CC09",
+      "name": "tretoquinol"
+    },
+    {
+      "code": "QR03CC10",
+      "name": "carbuterol"
+    },
+    {
+      "code": "QR03CC11",
+      "name": "tulobuterol"
+    },
+    {
+      "code": "QR03CC12",
+      "name": "bambuterol"
+    },
+    {
+      "code": "QR03CC13",
+      "name": "clenbuterol"
+    },
+    {
+      "code": "QR03CC14",
+      "name": "reproterol"
+    },
+    {
+      "code": "QR03CC15",
+      "name": "formoterol"
+    },
+    {
+      "code": "QR03CC53",
+      "name": "terbutaline, combinations"
+    },
+    {
+      "code": "QR03CC63",
+      "name": "clenbuterol and ambroxol"
+    },
+    {
+      "code": "QR03CC90",
+      "name": "clenbuterol, combinations"
+    },
+    {
+      "code": "QR03CK",
+      "name": "Adrenergics and other drugs for obstructive airway diseases"
+    },
+    {
+      "code": "QR03D",
+      "name": "OTHER SYSTEMIC DRUGS FOR OBSTRUCTIVE AIRWAY DISEASES"
+    },
+    {
+      "code": "QR03DA",
+      "name": "Xanthines"
+    },
+    {
+      "code": "QR03DA01",
+      "name": "diprophylline"
+    },
+    {
+      "code": "QR03DA02",
+      "name": "choline theophyllinate"
+    },
+    {
+      "code": "QR03DA03",
+      "name": "proxyphylline"
+    },
+    {
+      "code": "QR03DA04",
+      "name": "theophylline"
+    },
+    {
+      "code": "QR03DA05",
+      "name": "aminophylline"
+    },
+    {
+      "code": "QR03DA06",
+      "name": "etamiphylline"
+    },
+    {
+      "code": "QR03DA07",
+      "name": "theobromine"
+    },
+    {
+      "code": "QR03DA08",
+      "name": "bamifylline"
+    },
+    {
+      "code": "QR03DA09",
+      "name": "acefylline piperazine"
+    },
+    {
+      "code": "QR03DA10",
+      "name": "bufylline"
+    },
+    {
+      "code": "QR03DA11",
+      "name": "doxofylline"
+    },
+    {
+      "code": "QR03DA12",
+      "name": "mepyramine theophyllinacetate"
+    },
+    {
+      "code": "QR03DA20",
+      "name": "combinations"
+    },
+    {
+      "code": "QR03DA51",
+      "name": "diprophylline, combinations"
+    },
+    {
+      "code": "QR03DA54",
+      "name": "theophylline, combinations excl. psycholeptics"
+    },
+    {
+      "code": "QR03DA55",
+      "name": "aminophylline, combinations"
+    },
+    {
+      "code": "QR03DA57",
+      "name": "theobromine, combinations"
+    },
+    {
+      "code": "QR03DA74",
+      "name": "theophylline, combinations with psycholeptics"
+    },
+    {
+      "code": "QR03DB",
+      "name": "Xanthines and adrenergics"
+    },
+    {
+      "code": "QR03DB01",
+      "name": "diprophylline and adrenergics"
+    },
+    {
+      "code": "QR03DB02",
+      "name": "choline theophyllinate and adrenergics"
+    },
+    {
+      "code": "QR03DB03",
+      "name": "proxyphylline and adrenergics"
+    },
+    {
+      "code": "QR03DB04",
+      "name": "theophylline and adrenergics"
+    },
+    {
+      "code": "QR03DB05",
+      "name": "aminophylline and adrenergics"
+    },
+    {
+      "code": "QR03DB06",
+      "name": "etamiphylline and adrenergics"
+    },
+    {
+      "code": "QR03DC",
+      "name": "Leukotriene receptor antagonists"
+    },
+    {
+      "code": "QR03DC01",
+      "name": "zafirlukast"
+    },
+    {
+      "code": "QR03DC02",
+      "name": "pranlukast"
+    },
+    {
+      "code": "QR03DC03",
+      "name": "montelukast"
+    },
+    {
+      "code": "QR03DC04",
+      "name": "ibudilast"
+    },
+    {
+      "code": "QR03DC53",
+      "name": "montelukast, combinations"
+    },
+    {
+      "code": "QR03DX",
+      "name": "Other systemic drugs for obstructive airway diseases"
+    },
+    {
+      "code": "QR03DX01",
+      "name": "amlexanox"
+    },
+    {
+      "code": "QR03DX02",
+      "name": "eprozinol"
+    },
+    {
+      "code": "QR03DX03",
+      "name": "fenspiride"
+    },
+    {
+      "code": "QR03DX05",
+      "name": "omalizumab"
+    },
+    {
+      "code": "QR03DX06",
+      "name": "seratrodast"
+    },
+    {
+      "code": "QR03DX07",
+      "name": "roflumilast"
+    },
+    {
+      "code": "QR03DX08",
+      "name": "reslizumab"
+    },
+    {
+      "code": "QR03DX09",
+      "name": "mepolizumab"
+    },
+    {
+      "code": "QR03DX10",
+      "name": "benralizumab"
+    },
+    {
+      "code": "QR03DX11",
+      "name": "tezepelumab"
+    },
+    {
+      "code": "QR03DX12",
+      "name": "depemokimab"
+    },
+    {
+      "code": "QR05",
+      "name": "COUGH AND COLD PREPARATIONS"
+    },
+    {
+      "code": "QR05C",
+      "name": "EXPECTORANTS, EXCL. COMBINATIONS WITH COUGH SUPPRESSANTS"
+    },
+    {
+      "code": "QR05CA",
+      "name": "Expectorants"
+    },
+    {
+      "code": "QR05CA01",
+      "name": "tyloxapol"
+    },
+    {
+      "code": "QR05CA02",
+      "name": "potassium iodide"
+    },
+    {
+      "code": "QR05CA03",
+      "name": "guaifenesin"
+    },
+    {
+      "code": "QR05CA04",
+      "name": "ipecacuanha"
+    },
+    {
+      "code": "QR05CA05",
+      "name": "altheae radix"
+    },
+    {
+      "code": "QR05CA06",
+      "name": "senega"
+    },
+    {
+      "code": "QR05CA07",
+      "name": "antimony pentasulfide"
+    },
+    {
+      "code": "QR05CA08",
+      "name": "creosote"
+    },
+    {
+      "code": "QR05CA09",
+      "name": "guaiacolsulfonate"
+    },
+    {
+      "code": "QR05CA10",
+      "name": "combinations of expectorants"
+    },
+    {
+      "code": "QR05CA11",
+      "name": "levoverbenone"
+    },
+    {
+      "code": "QR05CA12",
+      "name": "Hederae helicis folium"
+    },
+    {
+      "code": "QR05CA13",
+      "name": "cineole"
+    },
+    {
+      "code": "QR05CB",
+      "name": "Mucolytics"
+    },
+    {
+      "code": "QR05CB01",
+      "name": "acetylcysteine"
+    },
+    {
+      "code": "QR05CB02",
+      "name": "bromhexine"
+    },
+    {
+      "code": "QR05CB03",
+      "name": "carbocisteine"
+    },
+    {
+      "code": "QR05CB04",
+      "name": "eprazinone"
+    },
+    {
+      "code": "QR05CB05",
+      "name": "mesna"
+    },
+    {
+      "code": "QR05CB06",
+      "name": "ambroxol"
+    },
+    {
+      "code": "QR05CB07",
+      "name": "sobrerol"
+    },
+    {
+      "code": "QR05CB08",
+      "name": "domiodol"
+    },
+    {
+      "code": "QR05CB09",
+      "name": "letosteine"
+    },
+    {
+      "code": "QR05CB10",
+      "name": "combinations of mycolytics"
+    },
+    {
+      "code": "QR05CB11",
+      "name": "stepronin"
+    },
+    {
+      "code": "QR05CB13",
+      "name": "dornase alfa (desoxyribonuclease)"
+    },
+    {
+      "code": "QR05CB14",
+      "name": "neltenexine"
+    },
+    {
+      "code": "QR05CB15",
+      "name": "erdosteine"
+    },
+    {
+      "code": "QR05CB16",
+      "name": "mannitol"
+    },
+    {
+      "code": "QR05CB90",
+      "name": "dembrexine"
+    },
+    {
+      "code": "QR05D",
+      "name": "COUGH SUPPRESSANTS, EXCL. COMBINATIONS WITH EXPECTORANTS"
+    },
+    {
+      "code": "QR05DA",
+      "name": "Opium alkaloids and derivatives"
+    },
+    {
+      "code": "QR05DA01",
+      "name": "ethylmorphine"
+    },
+    {
+      "code": "QR05DA03",
+      "name": "hydrocodone"
+    },
+    {
+      "code": "QR05DA04",
+      "name": "codeine"
+    },
+    {
+      "code": "QR05DA05",
+      "name": "opium alkaloids with morphine"
+    },
+    {
+      "code": "QR05DA06",
+      "name": "normethadone"
+    },
+    {
+      "code": "QR05DA07",
+      "name": "noscapine"
+    },
+    {
+      "code": "QR05DA08",
+      "name": "pholcodine"
+    },
+    {
+      "code": "QR05DA09",
+      "name": "dextromethorphan"
+    },
+    {
+      "code": "QR05DA10",
+      "name": "thebacon"
+    },
+    {
+      "code": "QR05DA11",
+      "name": "dimemorfan"
+    },
+    {
+      "code": "QR05DA12",
+      "name": "acetyldihydrocodeine"
+    },
+    {
+      "code": "QR05DA20",
+      "name": "combinations of opium alkaloids and derivatives"
+    },
+    {
+      "code": "QR05DA90",
+      "name": "butorphanol"
+    },
+    {
+      "code": "QR05DB",
+      "name": "Other cough suppressants"
+    },
+    {
+      "code": "QR05DB01",
+      "name": "benzonatate"
+    },
+    {
+      "code": "QR05DB02",
+      "name": "benproperine"
+    },
+    {
+      "code": "QR05DB03",
+      "name": "clobutinol"
+    },
+    {
+      "code": "QR05DB04",
+      "name": "isoaminile"
+    },
+    {
+      "code": "QR05DB05",
+      "name": "pentoxyverine"
+    },
+    {
+      "code": "QR05DB07",
+      "name": "oxolamine"
+    },
+    {
+      "code": "QR05DB09",
+      "name": "oxeladin"
+    },
+    {
+      "code": "QR05DB10",
+      "name": "clofedanol"
+    },
+    {
+      "code": "QR05DB11",
+      "name": "pipazetate"
+    },
+    {
+      "code": "QR05DB12",
+      "name": "bibenzonium bromide"
+    },
+    {
+      "code": "QR05DB13",
+      "name": "butamirate"
+    },
+    {
+      "code": "QR05DB14",
+      "name": "fedrilate"
+    },
+    {
+      "code": "QR05DB15",
+      "name": "zipeprol"
+    },
+    {
+      "code": "QR05DB16",
+      "name": "dibunate"
+    },
+    {
+      "code": "QR05DB17",
+      "name": "droxypropine"
+    },
+    {
+      "code": "QR05DB18",
+      "name": "prenoxdiazine"
+    },
+    {
+      "code": "QR05DB19",
+      "name": "dropropizine"
+    },
+    {
+      "code": "QR05DB20",
+      "name": "combinations"
+    },
+    {
+      "code": "QR05DB21",
+      "name": "cloperastine"
+    },
+    {
+      "code": "QR05DB22",
+      "name": "meprotixol"
+    },
+    {
+      "code": "QR05DB23",
+      "name": "piperidione"
+    },
+    {
+      "code": "QR05DB24",
+      "name": "tipepidine"
+    },
+    {
+      "code": "QR05DB25",
+      "name": "morclofone"
+    },
+    {
+      "code": "QR05DB26",
+      "name": "nepinalone"
+    },
+    {
+      "code": "QR05DB27",
+      "name": "levodropropizine"
+    },
+    {
+      "code": "QR05DB28",
+      "name": "dimethoxanate"
+    },
+    {
+      "code": "QR05DB29",
+      "name": "gefapixant"
+    },
+    {
+      "code": "QR05F",
+      "name": "COUGH SUPPRESSANTS AND EXPECTORANTS, COMBINATIONS"
+    },
+    {
+      "code": "QR05FA",
+      "name": "Opium derivatives and expectorants"
+    },
+    {
+      "code": "QR05FA01",
+      "name": "opium derivatives and mucolytics"
+    },
+    {
+      "code": "QR05FA02",
+      "name": "opium derivatives and expectorants"
+    },
+    {
+      "code": "QR05FB",
+      "name": "Other cough suppressants and expectorants"
+    },
+    {
+      "code": "QR05FB01",
+      "name": "cough suppressants and mucolytics"
+    },
+    {
+      "code": "QR05FB02",
+      "name": "cough suppressants and expectorants"
+    },
+    {
+      "code": "QR05X",
+      "name": "OTHER COLD PREPARATIONS"
+    },
+    {
+      "code": "QR06",
+      "name": "ANTIHISTAMINES FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QR06A",
+      "name": "ANTIHISTAMINES FOR SYSTEMIC USE"
+    },
+    {
+      "code": "QR06AA",
+      "name": "Aminoalkyl ethers"
+    },
+    {
+      "code": "QR06AA01",
+      "name": "bromazine"
+    },
+    {
+      "code": "QR06AA02",
+      "name": "diphenhydramine"
+    },
+    {
+      "code": "QR06AA04",
+      "name": "clemastine"
+    },
+    {
+      "code": "QR06AA06",
+      "name": "chlorphenoxamine"
+    },
+    {
+      "code": "QR06AA07",
+      "name": "diphenylpyraline"
+    },
+    {
+      "code": "QR06AA08",
+      "name": "carbinoxamine"
+    },
+    {
+      "code": "QR06AA09",
+      "name": "doxylamine"
+    },
+    {
+      "code": "QR06AA10",
+      "name": "trimethobenzamide"
+    },
+    {
+      "code": "QR06AA11",
+      "name": "dimenhydrinate"
+    },
+    {
+      "code": "QR06AA52",
+      "name": "diphenhydramine, combinations"
+    },
+    {
+      "code": "QR06AA54",
+      "name": "clemastine, combinations"
+    },
+    {
+      "code": "QR06AA56",
+      "name": "chlorphenoxamine, combinations"
+    },
+    {
+      "code": "QR06AA57",
+      "name": "diphenylpyraline, combinations"
+    },
+    {
+      "code": "QR06AA59",
+      "name": "doxylamine, combinations"
+    },
+    {
+      "code": "QR06AA61",
+      "name": "dimenhydrinate, combinations"
+    },
+    {
+      "code": "QR06AB",
+      "name": "Substituted alkylamines"
+    },
+    {
+      "code": "QR06AB01",
+      "name": "brompheniramine"
+    },
+    {
+      "code": "QR06AB02",
+      "name": "dexchlorpheniramine"
+    },
+    {
+      "code": "QR06AB03",
+      "name": "dimetindene"
+    },
+    {
+      "code": "QR06AB04",
+      "name": "chlorpheniramine"
+    },
+    {
+      "code": "QR06AB05",
+      "name": "pheniramine"
+    },
+    {
+      "code": "QR06AB06",
+      "name": "dexbrompheniramine"
+    },
+    {
+      "code": "QR06AB07",
+      "name": "talastine"
+    },
+    {
+      "code": "QR06AB51",
+      "name": "brompheniramine, combinations"
+    },
+    {
+      "code": "QR06AB52",
+      "name": "dexchlorpheniramine, combinations"
+    },
+    {
+      "code": "QR06AB54",
+      "name": "chlorpheniramine, combinations"
+    },
+    {
+      "code": "QR06AB56",
+      "name": "dexbrompheniramine, combinations"
+    },
+    {
+      "code": "QR06AC",
+      "name": "Substituted ethylene diamines"
+    },
+    {
+      "code": "QR06AC01",
+      "name": "mepyramine"
+    },
+    {
+      "code": "QR06AC02",
+      "name": "histapyrrodine"
+    },
+    {
+      "code": "QR06AC03",
+      "name": "chloropyramine"
+    },
+    {
+      "code": "QR06AC04",
+      "name": "tripelennamine"
+    },
+    {
+      "code": "QR06AC05",
+      "name": "methapyrilene"
+    },
+    {
+      "code": "QR06AC06",
+      "name": "thonzylamine"
+    },
+    {
+      "code": "QR06AC52",
+      "name": "histapyrrodine, combinations"
+    },
+    {
+      "code": "QR06AC53",
+      "name": "chloropyramine, combinations"
+    },
+    {
+      "code": "QR06AD",
+      "name": "Phenothiazine derivatives"
+    },
+    {
+      "code": "QR06AD01",
+      "name": "alimemazine"
+    },
+    {
+      "code": "QR06AD02",
+      "name": "promethazine"
+    },
+    {
+      "code": "QR06AD03",
+      "name": "thiethylperazine"
+    },
+    {
+      "code": "QR06AD04",
+      "name": "methdilazine"
+    },
+    {
+      "code": "QR06AD05",
+      "name": "hydroxyethylpromethazine"
+    },
+    {
+      "code": "QR06AD06",
+      "name": "thiazinam"
+    },
+    {
+      "code": "QR06AD07",
+      "name": "mequitazine"
+    },
+    {
+      "code": "QR06AD08",
+      "name": "oxomemazine"
+    },
+    {
+      "code": "QR06AD09",
+      "name": "isothipendyl"
+    },
+    {
+      "code": "QR06AD52",
+      "name": "promethazine, combinations"
+    },
+    {
+      "code": "QR06AD55",
+      "name": "hydroxyethylpromethazine, combinations"
+    },
+    {
+      "code": "QR06AE",
+      "name": "Piperazine derivatives"
+    },
+    {
+      "code": "QR06AE01",
+      "name": "buclizine"
+    },
+    {
+      "code": "QR06AE03",
+      "name": "cyclizine"
+    },
+    {
+      "code": "QR06AE04",
+      "name": "chlorcyclizine"
+    },
+    {
+      "code": "QR06AE05",
+      "name": "meclozine"
+    },
+    {
+      "code": "QR06AE06",
+      "name": "oxatomide"
+    },
+    {
+      "code": "QR06AE07",
+      "name": "cetirizine"
+    },
+    {
+      "code": "QR06AE09",
+      "name": "levocetirizine"
+    },
+    {
+      "code": "QR06AE51",
+      "name": "buclizine, combinations"
+    },
+    {
+      "code": "QR06AE53",
+      "name": "cyclizine, combinations"
+    },
+    {
+      "code": "QR06AE55",
+      "name": "meclozine, combinations"
+    },
+    {
+      "code": "QR06AK",
+      "name": "Combinations of antihistamines"
+    },
+    {
+      "code": "QR06AX",
+      "name": "Other antihistamines for systemic use"
+    },
+    {
+      "code": "QR06AX01",
+      "name": "bamipine"
+    },
+    {
+      "code": "QR06AX02",
+      "name": "cyproheptadine"
+    },
+    {
+      "code": "QR06AX03",
+      "name": "thenalidine"
+    },
+    {
+      "code": "QR06AX04",
+      "name": "phenindamine"
+    },
+    {
+      "code": "QR06AX05",
+      "name": "antazoline"
+    },
+    {
+      "code": "QR06AX07",
+      "name": "triprolidine"
+    },
+    {
+      "code": "QR06AX08",
+      "name": "pyrrobutamine"
+    },
+    {
+      "code": "QR06AX09",
+      "name": "azatadine"
+    },
+    {
+      "code": "QR06AX11",
+      "name": "astemizole"
+    },
+    {
+      "code": "QR06AX12",
+      "name": "terfenadine"
+    },
+    {
+      "code": "QR06AX13",
+      "name": "loratadine"
+    },
+    {
+      "code": "QR06AX15",
+      "name": "mebhydrolin"
+    },
+    {
+      "code": "QR06AX16",
+      "name": "deptropine"
+    },
+    {
+      "code": "QR06AX17",
+      "name": "ketotifen"
+    },
+    {
+      "code": "QR06AX18",
+      "name": "acrivastine"
+    },
+    {
+      "code": "QR06AX19",
+      "name": "azelastine"
+    },
+    {
+      "code": "QR06AX21",
+      "name": "tritoqualine"
+    },
+    {
+      "code": "QR06AX22",
+      "name": "ebastine"
+    },
+    {
+      "code": "QR06AX23",
+      "name": "pimethixene"
+    },
+    {
+      "code": "QR06AX24",
+      "name": "epinastine"
+    },
+    {
+      "code": "QR06AX25",
+      "name": "mizolastine"
+    },
+    {
+      "code": "QR06AX26",
+      "name": "fexofenadine"
+    },
+    {
+      "code": "QR06AX27",
+      "name": "desloratadine"
+    },
+    {
+      "code": "QR06AX28",
+      "name": "rupatadine"
+    },
+    {
+      "code": "QR06AX29",
+      "name": "bilastine"
+    },
+    {
+      "code": "QR06AX31",
+      "name": "quifenadine"
+    },
+    {
+      "code": "QR06AX32",
+      "name": "sequifenadine"
+    },
+    {
+      "code": "QR06AX53",
+      "name": "thenalidine, combinations"
+    },
+    {
+      "code": "QR06AX58",
+      "name": "pyrrobutamine, combinations"
+    },
+    {
+      "code": "QR07",
+      "name": "OTHER RESPIRATORY SYSTEM PRODUCTS"
+    },
+    {
+      "code": "QR07A",
+      "name": "OTHER RESPIRATORY SYSTEM PRODUCTS"
+    },
+    {
+      "code": "QR07AA",
+      "name": "Lung surfactants"
+    },
+    {
+      "code": "QR07AA01",
+      "name": "colfosceril palmitate"
+    },
+    {
+      "code": "QR07AA02",
+      "name": "natural phospholipids"
+    },
+    {
+      "code": "QR07AA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QR07AB",
+      "name": "Respiratory stimulants"
+    },
+    {
+      "code": "QR07AB01",
+      "name": "doxapram"
+    },
+    {
+      "code": "QR07AB02",
+      "name": "nikethamide"
+    },
+    {
+      "code": "QR07AB03",
+      "name": "pentetrazol"
+    },
+    {
+      "code": "QR07AB04",
+      "name": "etamivan"
+    },
+    {
+      "code": "QR07AB05",
+      "name": "bemegride"
+    },
+    {
+      "code": "QR07AB06",
+      "name": "prethcamide"
+    },
+    {
+      "code": "QR07AB07",
+      "name": "almitrine"
+    },
+    {
+      "code": "QR07AB08",
+      "name": "dimefline"
+    },
+    {
+      "code": "QR07AB09",
+      "name": "mepixanox"
+    },
+    {
+      "code": "QR07AB52",
+      "name": "nikethamide, combinations"
+    },
+    {
+      "code": "QR07AB53",
+      "name": "pentetrazol, combinations"
+    },
+    {
+      "code": "QR07AB99",
+      "name": "respiratory stimulants, combinations"
+    },
+    {
+      "code": "QR07AX",
+      "name": "Other respiratory system products"
+    },
+    {
+      "code": "QR07AX01",
+      "name": "nitric oxide"
+    },
+    {
+      "code": "QR07AX02",
+      "name": "ivacaftor"
+    },
+    {
+      "code": "QR07AX30",
+      "name": "ivacaftor and lumacaftor"
+    },
+    {
+      "code": "QR07AX31",
+      "name": "ivacaftor and tezacaftor"
+    },
+    {
+      "code": "QR07AX32",
+      "name": "ivacaftor, tezacaftor and elexacaftor"
+    },
+    {
+      "code": "QR07AX33",
+      "name": "deutivacaftor, tezacaftor and vanzacaftor"
+    },
+    {
+      "code": "QS",
+      "name": "SENSORY ORGANS"
+    },
+    {
+      "code": "QS01",
+      "name": "OPHTHALMOLOGICALS"
+    },
+    {
+      "code": "QS01A",
+      "name": "ANTIINFECTIVES"
+    },
+    {
+      "code": "QS01AA",
+      "name": "Antibiotics"
+    },
+    {
+      "code": "QS01AA01",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QS01AA02",
+      "name": "chlortetracycline"
+    },
+    {
+      "code": "QS01AA03",
+      "name": "neomycin"
+    },
+    {
+      "code": "QS01AA04",
+      "name": "oxytetracycline"
+    },
+    {
+      "code": "QS01AA05",
+      "name": "tyrothricin"
+    },
+    {
+      "code": "QS01AA07",
+      "name": "framycetin"
+    },
+    {
+      "code": "QS01AA09",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QS01AA10",
+      "name": "natamycin"
+    },
+    {
+      "code": "QS01AA11",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QS01AA12",
+      "name": "tobramycin"
+    },
+    {
+      "code": "QS01AA13",
+      "name": "fusidic acid"
+    },
+    {
+      "code": "QS01AA14",
+      "name": "benzylpenicillin"
+    },
+    {
+      "code": "QS01AA15",
+      "name": "dihydrostreptomycin"
+    },
+    {
+      "code": "QS01AA16",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QS01AA17",
+      "name": "erythromycin"
+    },
+    {
+      "code": "QS01AA18",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QS01AA19",
+      "name": "ampicillin"
+    },
+    {
+      "code": "QS01AA20",
+      "name": "antibiotics in combination with other drugs"
+    },
+    {
+      "code": "QS01AA21",
+      "name": "amikacin"
+    },
+    {
+      "code": "QS01AA22",
+      "name": "micronomicin"
+    },
+    {
+      "code": "QS01AA23",
+      "name": "netilmicin"
+    },
+    {
+      "code": "QS01AA24",
+      "name": "kanamycin"
+    },
+    {
+      "code": "QS01AA25",
+      "name": "azidamfenikol"
+    },
+    {
+      "code": "QS01AA26",
+      "name": "azithromycin"
+    },
+    {
+      "code": "QS01AA27",
+      "name": "cefuroxime"
+    },
+    {
+      "code": "QS01AA28",
+      "name": "vancomycin"
+    },
+    {
+      "code": "QS01AA29",
+      "name": "dibekacin"
+    },
+    {
+      "code": "QS01AA30",
+      "name": "combinations of different antibiotics"
+    },
+    {
+      "code": "QS01AA31",
+      "name": "cefmenoxime"
+    },
+    {
+      "code": "QS01AA32",
+      "name": "bacitracin"
+    },
+    {
+      "code": "QS01AA90",
+      "name": "cloxacillin"
+    },
+    {
+      "code": "QS01AB",
+      "name": "Sulfonamides"
+    },
+    {
+      "code": "QS01AB01",
+      "name": "sulfamethizole"
+    },
+    {
+      "code": "QS01AB02",
+      "name": "sulfafurazole"
+    },
+    {
+      "code": "QS01AB03",
+      "name": "sulfadicramide"
+    },
+    {
+      "code": "QS01AB04",
+      "name": "sulfacetamide"
+    },
+    {
+      "code": "QS01AB05",
+      "name": "sulfafenazol"
+    },
+    {
+      "code": "QS01AD",
+      "name": "Antivirals"
+    },
+    {
+      "code": "QS01AD01",
+      "name": "idoxuridine"
+    },
+    {
+      "code": "QS01AD02",
+      "name": "trifluridine"
+    },
+    {
+      "code": "QS01AD03",
+      "name": "aciclovir"
+    },
+    {
+      "code": "QS01AD05",
+      "name": "interferon"
+    },
+    {
+      "code": "QS01AD06",
+      "name": "vidarabine"
+    },
+    {
+      "code": "QS01AD07",
+      "name": "famciclovir"
+    },
+    {
+      "code": "QS01AD08",
+      "name": "fomivirsen"
+    },
+    {
+      "code": "QS01AD09",
+      "name": "ganciclovir"
+    },
+    {
+      "code": "QS01AE",
+      "name": "Fluoroquinolones"
+    },
+    {
+      "code": "QS01AE01",
+      "name": "ofloxacin"
+    },
+    {
+      "code": "QS01AE02",
+      "name": "norfloxacin"
+    },
+    {
+      "code": "QS01AE03",
+      "name": "ciprofloxacin"
+    },
+    {
+      "code": "QS01AE04",
+      "name": "lomefloxacin"
+    },
+    {
+      "code": "QS01AE05",
+      "name": "levofloxacin"
+    },
+    {
+      "code": "QS01AE06",
+      "name": "gatifloxacin"
+    },
+    {
+      "code": "QS01AE07",
+      "name": "moxifloxacin"
+    },
+    {
+      "code": "QS01AE08",
+      "name": "besifloxacin"
+    },
+    {
+      "code": "QS01AE09",
+      "name": "tosufloxacin"
+    },
+    {
+      "code": "QS01AX",
+      "name": "Other antiinfectives"
+    },
+    {
+      "code": "QS01AX01",
+      "name": "mercury compounds"
+    },
+    {
+      "code": "QS01AX02",
+      "name": "silver compounds"
+    },
+    {
+      "code": "QS01AX03",
+      "name": "zinc compounds"
+    },
+    {
+      "code": "QS01AX04",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QS01AX05",
+      "name": "bibrocathol"
+    },
+    {
+      "code": "QS01AX06",
+      "name": "resorcinol"
+    },
+    {
+      "code": "QS01AX07",
+      "name": "sodium borate"
+    },
+    {
+      "code": "QS01AX08",
+      "name": "hexamidine"
+    },
+    {
+      "code": "QS01AX09",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QS01AX10",
+      "name": "sodium propionate"
+    },
+    {
+      "code": "QS01AX14",
+      "name": "dibrompropamidine"
+    },
+    {
+      "code": "QS01AX15",
+      "name": "propamidine"
+    },
+    {
+      "code": "QS01AX16",
+      "name": "picloxydine"
+    },
+    {
+      "code": "QS01AX18",
+      "name": "povidone-iodine"
+    },
+    {
+      "code": "QS01AX24",
+      "name": "polihexanide"
+    },
+    {
+      "code": "QS01AX25",
+      "name": "lotilaner"
+    },
+    {
+      "code": "QS01AX26",
+      "name": "cethexonium"
+    },
+    {
+      "code": "QS01B",
+      "name": "ANTIINFLAMMATORY AGENTS"
+    },
+    {
+      "code": "QS01BA",
+      "name": "Corticosteroids, plain"
+    },
+    {
+      "code": "QS01BA01",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QS01BA02",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QS01BA03",
+      "name": "cortisone"
+    },
+    {
+      "code": "QS01BA04",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QS01BA05",
+      "name": "triamcinolone"
+    },
+    {
+      "code": "QS01BA06",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QS01BA07",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QS01BA08",
+      "name": "medrysone"
+    },
+    {
+      "code": "QS01BA09",
+      "name": "clobetasone"
+    },
+    {
+      "code": "QS01BA10",
+      "name": "alclometasone"
+    },
+    {
+      "code": "QS01BA11",
+      "name": "desonide"
+    },
+    {
+      "code": "QS01BA12",
+      "name": "formocortal"
+    },
+    {
+      "code": "QS01BA13",
+      "name": "rimexolone"
+    },
+    {
+      "code": "QS01BA14",
+      "name": "loteprednol"
+    },
+    {
+      "code": "QS01BA15",
+      "name": "fluocinolone acetonide"
+    },
+    {
+      "code": "QS01BA16",
+      "name": "difluprednate"
+    },
+    {
+      "code": "QS01BA17",
+      "name": "clobetasol"
+    },
+    {
+      "code": "QS01BB",
+      "name": "Corticosteroids and mydriatics in combination"
+    },
+    {
+      "code": "QS01BB01",
+      "name": "hydrocortisone and mydriatics"
+    },
+    {
+      "code": "QS01BB02",
+      "name": "prednisolone and mydriatics"
+    },
+    {
+      "code": "QS01BB03",
+      "name": "fluorometholone and mydriatics"
+    },
+    {
+      "code": "QS01BB04",
+      "name": "betamethasone and mydriatics"
+    },
+    {
+      "code": "QS01BC",
+      "name": "Antiinflammatory agents, non-steroids"
+    },
+    {
+      "code": "QS01BC01",
+      "name": "indometacin"
+    },
+    {
+      "code": "QS01BC02",
+      "name": "oxyphenbutazone"
+    },
+    {
+      "code": "QS01BC03",
+      "name": "diclofenac"
+    },
+    {
+      "code": "QS01BC04",
+      "name": "flurbiprofen"
+    },
+    {
+      "code": "QS01BC05",
+      "name": "ketorolac"
+    },
+    {
+      "code": "QS01BC06",
+      "name": "piroxicam"
+    },
+    {
+      "code": "QS01BC07",
+      "name": "bendazac"
+    },
+    {
+      "code": "QS01BC08",
+      "name": "salicylic acid"
+    },
+    {
+      "code": "QS01BC09",
+      "name": "pranoprofen"
+    },
+    {
+      "code": "QS01BC10",
+      "name": "nepafenac"
+    },
+    {
+      "code": "QS01BC11",
+      "name": "bromfenac"
+    },
+    {
+      "code": "QS01C",
+      "name": "ANTIINFLAMMATORY AGENTS AND ANTIINFECTIVES IN COMBINATION"
+    },
+    {
+      "code": "QS01CA",
+      "name": "Corticosteroids and antiinfectives in combination"
+    },
+    {
+      "code": "QS01CA01",
+      "name": "dexamethasone and antiinfectives"
+    },
+    {
+      "code": "QS01CA02",
+      "name": "prednisolone and antiinfectives"
+    },
+    {
+      "code": "QS01CA03",
+      "name": "hydrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS01CA04",
+      "name": "fluocortolone and antiinfectives"
+    },
+    {
+      "code": "QS01CA05",
+      "name": "betamethasone and antiinfectives"
+    },
+    {
+      "code": "QS01CA06",
+      "name": "fludrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS01CA07",
+      "name": "fluorometholone and antiinfectives"
+    },
+    {
+      "code": "QS01CA08",
+      "name": "methylprednisolone and antiinfectives"
+    },
+    {
+      "code": "QS01CA09",
+      "name": "chloroprednisone and antiinfectives"
+    },
+    {
+      "code": "QS01CA10",
+      "name": "fluocinolone acetonide and antiinfectives"
+    },
+    {
+      "code": "QS01CA11",
+      "name": "clobetasone and antiinfectives"
+    },
+    {
+      "code": "QS01CA12",
+      "name": "loteprednol and antiinfectives"
+    },
+    {
+      "code": "QS01CB",
+      "name": "Corticosteroids/antiinfectives/mydriatics in combination"
+    },
+    {
+      "code": "QS01CB01",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QS01CB02",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QS01CB03",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QS01CB04",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QS01CB05",
+      "name": "fluorometholone"
+    },
+    {
+      "code": "QS01CC",
+      "name": "Antiinflammatory agents, non-steroids and antiinfectives in combination"
+    },
+    {
+      "code": "QS01CC01",
+      "name": "diclofenac and antiinfectives"
+    },
+    {
+      "code": "QS01CC02",
+      "name": "indometacin and antiinfectives"
+    },
+    {
+      "code": "QS01E",
+      "name": "ANTIGLAUCOMA PREPARATIONS AND MIOTICS"
+    },
+    {
+      "code": "QS01EA",
+      "name": "Sympathomimetics in glaucoma therapy"
+    },
+    {
+      "code": "QS01EA01",
+      "name": "epinephrine"
+    },
+    {
+      "code": "QS01EA02",
+      "name": "dipivefrine"
+    },
+    {
+      "code": "QS01EA03",
+      "name": "apraclonidine"
+    },
+    {
+      "code": "QS01EA04",
+      "name": "clonidine"
+    },
+    {
+      "code": "QS01EA05",
+      "name": "brimonidine"
+    },
+    {
+      "code": "QS01EA51",
+      "name": "epinephrine, combinations"
+    },
+    {
+      "code": "QS01EA55",
+      "name": "brimonidine and ripasudil"
+    },
+    {
+      "code": "QS01EB",
+      "name": "Parasympathomimetics"
+    },
+    {
+      "code": "QS01EB01",
+      "name": "pilocarpine"
+    },
+    {
+      "code": "QS01EB02",
+      "name": "carbachol"
+    },
+    {
+      "code": "QS01EB03",
+      "name": "ecothiopate"
+    },
+    {
+      "code": "QS01EB04",
+      "name": "demecarium"
+    },
+    {
+      "code": "QS01EB05",
+      "name": "physostigmine"
+    },
+    {
+      "code": "QS01EB06",
+      "name": "neostigmine"
+    },
+    {
+      "code": "QS01EB07",
+      "name": "fluostigmine"
+    },
+    {
+      "code": "QS01EB08",
+      "name": "aceclidine"
+    },
+    {
+      "code": "QS01EB09",
+      "name": "acetylcholine"
+    },
+    {
+      "code": "QS01EB10",
+      "name": "paraoxon"
+    },
+    {
+      "code": "QS01EB51",
+      "name": "pilocarpine, combinations"
+    },
+    {
+      "code": "QS01EB58",
+      "name": "aceclidine, combinations"
+    },
+    {
+      "code": "QS01EC",
+      "name": "Carbonic anhydrase inhibitors"
+    },
+    {
+      "code": "QS01EC01",
+      "name": "acetazolamide"
+    },
+    {
+      "code": "QS01EC02",
+      "name": "diclofenamide"
+    },
+    {
+      "code": "QS01EC03",
+      "name": "dorzolamide"
+    },
+    {
+      "code": "QS01EC04",
+      "name": "brinzolamide"
+    },
+    {
+      "code": "QS01EC05",
+      "name": "methazolamide"
+    },
+    {
+      "code": "QS01EC54",
+      "name": "brinzolamide, combinations"
+    },
+    {
+      "code": "QS01ED",
+      "name": "Beta blocking agents"
+    },
+    {
+      "code": "QS01ED01",
+      "name": "timolol"
+    },
+    {
+      "code": "QS01ED02",
+      "name": "betaxolol"
+    },
+    {
+      "code": "QS01ED03",
+      "name": "levobunolol"
+    },
+    {
+      "code": "QS01ED04",
+      "name": "metipranolol"
+    },
+    {
+      "code": "QS01ED05",
+      "name": "carteolol"
+    },
+    {
+      "code": "QS01ED06",
+      "name": "befunolol"
+    },
+    {
+      "code": "QS01ED51",
+      "name": "timolol, combinations"
+    },
+    {
+      "code": "QS01ED52",
+      "name": "betaxolol, combinations"
+    },
+    {
+      "code": "QS01ED54",
+      "name": "metipranolol, combinations"
+    },
+    {
+      "code": "QS01ED55",
+      "name": "carteolol, combinations"
+    },
+    {
+      "code": "QS01EE",
+      "name": "Prostaglandin analogues"
+    },
+    {
+      "code": "QS01EE01",
+      "name": "latanoprost"
+    },
+    {
+      "code": "QS01EE02",
+      "name": "unoprostone"
+    },
+    {
+      "code": "QS01EE03",
+      "name": "bimatoprost"
+    },
+    {
+      "code": "QS01EE04",
+      "name": "travoprost"
+    },
+    {
+      "code": "QS01EE05",
+      "name": "tafluprost"
+    },
+    {
+      "code": "QS01EE06",
+      "name": "latanoprostene bunod"
+    },
+    {
+      "code": "QS01EE51",
+      "name": "latanoprost and netarsudil"
+    },
+    {
+      "code": "QS01EE52",
+      "name": "latanoprost and dorzolamide"
+    },
+    {
+      "code": "QS01EX",
+      "name": "Other antiglaucoma preparations"
+    },
+    {
+      "code": "QS01EX01",
+      "name": "guanethidine"
+    },
+    {
+      "code": "QS01EX02",
+      "name": "dapiprazole"
+    },
+    {
+      "code": "QS01EX05",
+      "name": "netarsudil"
+    },
+    {
+      "code": "QS01EX06",
+      "name": "omidenepag"
+    },
+    {
+      "code": "QS01EX07",
+      "name": "ripasudil"
+    },
+    {
+      "code": "QS01F",
+      "name": "MYDRIATICS AND CYCLOPLEGICS"
+    },
+    {
+      "code": "QS01FA",
+      "name": "Anticholinergics"
+    },
+    {
+      "code": "QS01FA01",
+      "name": "atropine"
+    },
+    {
+      "code": "QS01FA02",
+      "name": "scopolamine"
+    },
+    {
+      "code": "QS01FA03",
+      "name": "methylscopolamine"
+    },
+    {
+      "code": "QS01FA04",
+      "name": "cyclopentolate"
+    },
+    {
+      "code": "QS01FA05",
+      "name": "homatropine"
+    },
+    {
+      "code": "QS01FA06",
+      "name": "tropicamide"
+    },
+    {
+      "code": "QS01FA54",
+      "name": "cyclopentolate, combinations"
+    },
+    {
+      "code": "QS01FA56",
+      "name": "tropicamide, combinations"
+    },
+    {
+      "code": "QS01FB",
+      "name": "Sympathomimetics, excl. antiglaucoma preparations"
+    },
+    {
+      "code": "QS01FB01",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QS01FB02",
+      "name": "ephedrine"
+    },
+    {
+      "code": "QS01FB03",
+      "name": "ibopamine"
+    },
+    {
+      "code": "QS01FB51",
+      "name": "phenylephrine and ketorolac"
+    },
+    {
+      "code": "QS01FB90",
+      "name": "oxedrine"
+    },
+    {
+      "code": "QS01FB99",
+      "name": "sympathomimetics, combinations"
+    },
+    {
+      "code": "QS01G",
+      "name": "DECONGESTANTS AND ANTIALLERGICS"
+    },
+    {
+      "code": "QS01GA",
+      "name": "Sympathomimetics used as decongestants"
+    },
+    {
+      "code": "QS01GA01",
+      "name": "naphazoline"
+    },
+    {
+      "code": "QS01GA02",
+      "name": "tetryzoline"
+    },
+    {
+      "code": "QS01GA03",
+      "name": "xylometazoline"
+    },
+    {
+      "code": "QS01GA04",
+      "name": "oxymetazoline"
+    },
+    {
+      "code": "QS01GA05",
+      "name": "phenylephrine"
+    },
+    {
+      "code": "QS01GA06",
+      "name": "oxedrine"
+    },
+    {
+      "code": "QS01GA07",
+      "name": "brimonidine"
+    },
+    {
+      "code": "QS01GA51",
+      "name": "naphazoline, combinations"
+    },
+    {
+      "code": "QS01GA52",
+      "name": "tetryzoline, combinations"
+    },
+    {
+      "code": "QS01GA53",
+      "name": "xylometazoline, combinations"
+    },
+    {
+      "code": "QS01GA55",
+      "name": "phenylephrine combinations"
+    },
+    {
+      "code": "QS01GA56",
+      "name": "oxedrine, combinations"
+    },
+    {
+      "code": "QS01GX",
+      "name": "Other antiallergics"
+    },
+    {
+      "code": "QS01GX01",
+      "name": "cromoglicic acid"
+    },
+    {
+      "code": "QS01GX02",
+      "name": "levocabastine"
+    },
+    {
+      "code": "QS01GX03",
+      "name": "spaglumic acid"
+    },
+    {
+      "code": "QS01GX04",
+      "name": "nedocromil"
+    },
+    {
+      "code": "QS01GX05",
+      "name": "lodoxamide"
+    },
+    {
+      "code": "QS01GX06",
+      "name": "emedastine"
+    },
+    {
+      "code": "QS01GX07",
+      "name": "azelastine"
+    },
+    {
+      "code": "QS01GX08",
+      "name": "ketotifen"
+    },
+    {
+      "code": "QS01GX09",
+      "name": "olopatadine"
+    },
+    {
+      "code": "QS01GX10",
+      "name": "epinastine"
+    },
+    {
+      "code": "QS01GX11",
+      "name": "alcaftadine"
+    },
+    {
+      "code": "QS01GX12",
+      "name": "cetirizine"
+    },
+    {
+      "code": "QS01GX13",
+      "name": "bilastine"
+    },
+    {
+      "code": "QS01GX51",
+      "name": "cromoglicic acid, combinations"
+    },
+    {
+      "code": "QS01H",
+      "name": "LOCAL ANESTHETICS"
+    },
+    {
+      "code": "QS01HA",
+      "name": "Local anesthetics"
+    },
+    {
+      "code": "QS01HA01",
+      "name": "cocaine"
+    },
+    {
+      "code": "QS01HA02",
+      "name": "oxybuprocaine"
+    },
+    {
+      "code": "QS01HA03",
+      "name": "tetracaine"
+    },
+    {
+      "code": "QS01HA04",
+      "name": "proxymetacaine"
+    },
+    {
+      "code": "QS01HA05",
+      "name": "procaine"
+    },
+    {
+      "code": "QS01HA06",
+      "name": "cinchocaine"
+    },
+    {
+      "code": "QS01HA07",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QS01HA08",
+      "name": "chloroprocaine"
+    },
+    {
+      "code": "QS01HA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QS01J",
+      "name": "DIAGNOSTIC AGENTS"
+    },
+    {
+      "code": "QS01JA",
+      "name": "Colouring agents"
+    },
+    {
+      "code": "QS01JA01",
+      "name": "fluorescein"
+    },
+    {
+      "code": "QS01JA02",
+      "name": "rose bengal sodium"
+    },
+    {
+      "code": "QS01JA51",
+      "name": "fluorescein, combinations"
+    },
+    {
+      "code": "QS01JX",
+      "name": "Other ophthalmological diagnostic agents"
+    },
+    {
+      "code": "QS01K",
+      "name": "SURGICAL AIDS"
+    },
+    {
+      "code": "QS01KA",
+      "name": "Viscoelastic substances"
+    },
+    {
+      "code": "QS01KA01",
+      "name": "hyaluronic acid"
+    },
+    {
+      "code": "QS01KA02",
+      "name": "hypromellose"
+    },
+    {
+      "code": "QS01KA51",
+      "name": "hyaluronic acid, combinations"
+    },
+    {
+      "code": "QS01KX",
+      "name": "Other surgical aids"
+    },
+    {
+      "code": "QS01KX01",
+      "name": "chymotrypsin"
+    },
+    {
+      "code": "QS01KX02",
+      "name": "trypan blue"
+    },
+    {
+      "code": "QS01L",
+      "name": "OCULAR VASCULAR DISORDER AGENTS"
+    },
+    {
+      "code": "QS01LA",
+      "name": "Antineovascularisation agents"
+    },
+    {
+      "code": "QS01LA01",
+      "name": "verteporfin"
+    },
+    {
+      "code": "QS01LA02",
+      "name": "anecortave"
+    },
+    {
+      "code": "QS01LA03",
+      "name": "pegaptanib"
+    },
+    {
+      "code": "QS01LA04",
+      "name": "ranibizumab"
+    },
+    {
+      "code": "QS01LA05",
+      "name": "aflibercept"
+    },
+    {
+      "code": "QS01LA06",
+      "name": "brolucizumab"
+    },
+    {
+      "code": "QS01LA07",
+      "name": "abicipar pegol"
+    },
+    {
+      "code": "QS01LA08",
+      "name": "bevacizumab"
+    },
+    {
+      "code": "QS01LA09",
+      "name": "faricimab"
+    },
+    {
+      "code": "QS01X",
+      "name": "OTHER OPHTHALMOLOGICALS"
+    },
+    {
+      "code": "QS01XA",
+      "name": "Other ophthalmologicals"
+    },
+    {
+      "code": "QS01XA01",
+      "name": "guaiazulen"
+    },
+    {
+      "code": "QS01XA02",
+      "name": "retinol"
+    },
+    {
+      "code": "QS01XA03",
+      "name": "sodium chloride, hypertonic"
+    },
+    {
+      "code": "QS01XA04",
+      "name": "potassium iodide"
+    },
+    {
+      "code": "QS01XA05",
+      "name": "sodium edetate"
+    },
+    {
+      "code": "QS01XA06",
+      "name": "ethylmorphine"
+    },
+    {
+      "code": "QS01XA07",
+      "name": "alum"
+    },
+    {
+      "code": "QS01XA08",
+      "name": "acetylcysteine"
+    },
+    {
+      "code": "QS01XA09",
+      "name": "iodoheparinate"
+    },
+    {
+      "code": "QS01XA10",
+      "name": "inosine"
+    },
+    {
+      "code": "QS01XA11",
+      "name": "nandrolone"
+    },
+    {
+      "code": "QS01XA12",
+      "name": "dexpanthenol"
+    },
+    {
+      "code": "QS01XA13",
+      "name": "alteplase"
+    },
+    {
+      "code": "QS01XA14",
+      "name": "heparin"
+    },
+    {
+      "code": "QS01XA15",
+      "name": "ascorbic acid"
+    },
+    {
+      "code": "QS01XA18",
+      "name": "ciclosporin"
+    },
+    {
+      "code": "QS01XA19",
+      "name": "limbal stems cells, autologous"
+    },
+    {
+      "code": "QS01XA20",
+      "name": "artificial tears and other indifferent preparations"
+    },
+    {
+      "code": "QS01XA21",
+      "name": "mercaptamine"
+    },
+    {
+      "code": "QS01XA22",
+      "name": "ocriplasmin"
+    },
+    {
+      "code": "QS01XA23",
+      "name": "sirolimus"
+    },
+    {
+      "code": "QS01XA24",
+      "name": "cenegermin"
+    },
+    {
+      "code": "QS01XA25",
+      "name": "lifitegrast"
+    },
+    {
+      "code": "QS01XA26",
+      "name": "riboflavin"
+    },
+    {
+      "code": "QS01XA27",
+      "name": "voretigene neparvovec"
+    },
+    {
+      "code": "QS01XA28",
+      "name": "varenicline"
+    },
+    {
+      "code": "QS01XA29",
+      "name": "sepofarsen"
+    },
+    {
+      "code": "QS01XA31",
+      "name": "pegcetacoplan"
+    },
+    {
+      "code": "QS01XA32",
+      "name": "avacincaptad pegol"
+    },
+    {
+      "code": "QS01XA33",
+      "name": "diquafosol"
+    },
+    {
+      "code": "QS01XA91",
+      "name": "pirenoxin"
+    },
+    {
+      "code": "QS02",
+      "name": "OTOLOGICALS"
+    },
+    {
+      "code": "QS02A",
+      "name": "ANTIINFECTIVES"
+    },
+    {
+      "code": "QS02AA",
+      "name": "Antiinfectives"
+    },
+    {
+      "code": "QS02AA01",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QS02AA02",
+      "name": "nitrofural"
+    },
+    {
+      "code": "QS02AA03",
+      "name": "boric acid"
+    },
+    {
+      "code": "QS02AA04",
+      "name": "aluminium acetotartrate"
+    },
+    {
+      "code": "QS02AA05",
+      "name": "clioquinol"
+    },
+    {
+      "code": "QS02AA06",
+      "name": "hydrogen peroxide"
+    },
+    {
+      "code": "QS02AA07",
+      "name": "neomycin"
+    },
+    {
+      "code": "QS02AA08",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QS02AA09",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QS02AA10",
+      "name": "acetic acid"
+    },
+    {
+      "code": "QS02AA11",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QS02AA12",
+      "name": "rifamycin"
+    },
+    {
+      "code": "QS02AA13",
+      "name": "miconazole"
+    },
+    {
+      "code": "QS02AA14",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QS02AA15",
+      "name": "ciprofloxacin"
+    },
+    {
+      "code": "QS02AA16",
+      "name": "ofloxacin"
+    },
+    {
+      "code": "QS02AA17",
+      "name": "fosfomycin"
+    },
+    {
+      "code": "QS02AA18",
+      "name": "cefmenoxime"
+    },
+    {
+      "code": "QS02AA30",
+      "name": "antiinfectives, combinations"
+    },
+    {
+      "code": "QS02AA57",
+      "name": "neomycin, combinations"
+    },
+    {
+      "code": "QS02B",
+      "name": "CORTICOSTEROIDS"
+    },
+    {
+      "code": "QS02BA",
+      "name": "Corticosteroids"
+    },
+    {
+      "code": "QS02BA01",
+      "name": "hydrocortisone"
+    },
+    {
+      "code": "QS02BA03",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QS02BA06",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QS02BA07",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QS02BA08",
+      "name": "fluocinolone acetonide"
+    },
+    {
+      "code": "QS02BA99",
+      "name": "corticosteroids, combinations"
+    },
+    {
+      "code": "QS02C",
+      "name": "CORTICOSTEROIDS AND ANTIINFECTIVES IN COMBINATION"
+    },
+    {
+      "code": "QS02CA",
+      "name": "Corticosteroids and antiinfectives in combination"
+    },
+    {
+      "code": "QS02CA01",
+      "name": "prednisolone and antiinfectives"
+    },
+    {
+      "code": "QS02CA02",
+      "name": "flumetasone and antiinfectives"
+    },
+    {
+      "code": "QS02CA03",
+      "name": "hydrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS02CA04",
+      "name": "triamcinolone and antiinfectives"
+    },
+    {
+      "code": "QS02CA05",
+      "name": "fluocinolone acetonide and antiinfectives"
+    },
+    {
+      "code": "QS02CA06",
+      "name": "dexamethasone and antiinfectives"
+    },
+    {
+      "code": "QS02CA07",
+      "name": "fludrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS02CA90",
+      "name": "betamethasone and antiinfectives"
+    },
+    {
+      "code": "QS02CA91",
+      "name": "mometasone and antiinfectives"
+    },
+    {
+      "code": "QS02D",
+      "name": "OTHER OTOLOGICALS"
+    },
+    {
+      "code": "QS02DA",
+      "name": "Analgesics and anesthetics"
+    },
+    {
+      "code": "QS02DA01",
+      "name": "lidocaine"
+    },
+    {
+      "code": "QS02DA02",
+      "name": "cocaine"
+    },
+    {
+      "code": "QS02DA03",
+      "name": "phenazone"
+    },
+    {
+      "code": "QS02DA04",
+      "name": "cinchocaine"
+    },
+    {
+      "code": "QS02DA30",
+      "name": "combinations"
+    },
+    {
+      "code": "QS02DC",
+      "name": "Indifferent preparations"
+    },
+    {
+      "code": "QS02Q",
+      "name": "ANTIPARASITICS"
+    },
+    {
+      "code": "QS02QA",
+      "name": "Antiparasitics"
+    },
+    {
+      "code": "QS02QA01",
+      "name": "lindane"
+    },
+    {
+      "code": "QS02QA02",
+      "name": "sulfiram"
+    },
+    {
+      "code": "QS02QA03",
+      "name": "ivermectin"
+    },
+    {
+      "code": "QS02QA51",
+      "name": "lindane, combinations"
+    },
+    {
+      "code": "QS03",
+      "name": "OPHTHALMOLOGICAL AND OTOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QS03A",
+      "name": "ANTIINFECTIVES"
+    },
+    {
+      "code": "QS03AA",
+      "name": "Antiinfectives"
+    },
+    {
+      "code": "QS03AA01",
+      "name": "neomycin"
+    },
+    {
+      "code": "QS03AA02",
+      "name": "tetracycline"
+    },
+    {
+      "code": "QS03AA03",
+      "name": "polymyxin B"
+    },
+    {
+      "code": "QS03AA04",
+      "name": "chlorhexidine"
+    },
+    {
+      "code": "QS03AA05",
+      "name": "hexamidine"
+    },
+    {
+      "code": "QS03AA06",
+      "name": "gentamicin"
+    },
+    {
+      "code": "QS03AA07",
+      "name": "ciprofloxacin"
+    },
+    {
+      "code": "QS03AA08",
+      "name": "chloramphenicol"
+    },
+    {
+      "code": "QS03AA30",
+      "name": "antiinfectives, combinations"
+    },
+    {
+      "code": "QS03B",
+      "name": "CORTICOSTEROIDS"
+    },
+    {
+      "code": "QS03BA",
+      "name": "Corticosteroids"
+    },
+    {
+      "code": "QS03BA01",
+      "name": "dexamethasone"
+    },
+    {
+      "code": "QS03BA02",
+      "name": "prednisolone"
+    },
+    {
+      "code": "QS03BA03",
+      "name": "betamethasone"
+    },
+    {
+      "code": "QS03C",
+      "name": "CORTICOSTEROIDS AND ANTIINFECTIVES IN COMBINATION"
+    },
+    {
+      "code": "QS03CA",
+      "name": "Corticosteroids and antiinfectives in combination"
+    },
+    {
+      "code": "QS03CA01",
+      "name": "dexamethasone and antiinfectives"
+    },
+    {
+      "code": "QS03CA02",
+      "name": "prednisolone and antiinfectives"
+    },
+    {
+      "code": "QS03CA04",
+      "name": "hydrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS03CA05",
+      "name": "fludrocortisone and antiinfectives"
+    },
+    {
+      "code": "QS03CA06",
+      "name": "betamethasone and antiinfectives"
+    },
+    {
+      "code": "QS03CA07",
+      "name": "methylprednisolone and antiinfectives"
+    },
+    {
+      "code": "QS03D",
+      "name": "OTHER OPHTHALMOLOGICAL AND OTOLOGICAL PREPARATIONS"
+    },
+    {
+      "code": "QV",
+      "name": "VARIOUS"
+    },
+    {
+      "code": "QV01",
+      "name": "ALLERGENS"
+    },
+    {
+      "code": "QV01A",
+      "name": "ALLERGENS"
+    },
+    {
+      "code": "QV01AA",
+      "name": "Allergen extracts"
+    },
+    {
+      "code": "QV01AA01",
+      "name": "feather"
+    },
+    {
+      "code": "QV01AA02",
+      "name": "grass pollen"
+    },
+    {
+      "code": "QV01AA03",
+      "name": "house dust mites"
+    },
+    {
+      "code": "QV01AA04",
+      "name": "mould fungus and yeast fungus"
+    },
+    {
+      "code": "QV01AA05",
+      "name": "tree pollen"
+    },
+    {
+      "code": "QV01AA07",
+      "name": "insects"
+    },
+    {
+      "code": "QV01AA08",
+      "name": "foods"
+    },
+    {
+      "code": "QV01AA09",
+      "name": "textiles"
+    },
+    {
+      "code": "QV01AA10",
+      "name": "flowers"
+    },
+    {
+      "code": "QV01AA11",
+      "name": "animals"
+    },
+    {
+      "code": "QV01AA20",
+      "name": "various"
+    },
+    {
+      "code": "QV03",
+      "name": "ALL OTHER THERAPEUTIC PRODUCTS"
+    },
+    {
+      "code": "QV03A",
+      "name": "ALL OTHER THERAPEUTIC PRODUCTS"
+    },
+    {
+      "code": "QV03AB",
+      "name": "Antidotes"
+    },
+    {
+      "code": "QV03AB01",
+      "name": "ipecacuanha"
+    },
+    {
+      "code": "QV03AB02",
+      "name": "nalorphine"
+    },
+    {
+      "code": "QV03AB03",
+      "name": "edetates"
+    },
+    {
+      "code": "QV03AB04",
+      "name": "pralidoxime"
+    },
+    {
+      "code": "QV03AB05",
+      "name": "prednisolone and promethazine"
+    },
+    {
+      "code": "QV03AB06",
+      "name": "thiosulfate"
+    },
+    {
+      "code": "QV03AB08",
+      "name": "sodium nitrite"
+    },
+    {
+      "code": "QV03AB09",
+      "name": "dimercaprol"
+    },
+    {
+      "code": "QV03AB13",
+      "name": "obidoxime"
+    },
+    {
+      "code": "QV03AB14",
+      "name": "protamine"
+    },
+    {
+      "code": "QV03AB15",
+      "name": "naloxone"
+    },
+    {
+      "code": "QV03AB16",
+      "name": "ethanol"
+    },
+    {
+      "code": "QV03AB17",
+      "name": "methylthioninium chloride"
+    },
+    {
+      "code": "QV03AB18",
+      "name": "potassium permanganate"
+    },
+    {
+      "code": "QV03AB19",
+      "name": "physostigmine"
+    },
+    {
+      "code": "QV03AB20",
+      "name": "copper sulfate"
+    },
+    {
+      "code": "QV03AB21",
+      "name": "potassium iodide"
+    },
+    {
+      "code": "QV03AB22",
+      "name": "amyl nitrite"
+    },
+    {
+      "code": "QV03AB23",
+      "name": "acetylcysteine"
+    },
+    {
+      "code": "QV03AB24",
+      "name": "digitalis antitoxin"
+    },
+    {
+      "code": "QV03AB25",
+      "name": "flumazenil"
+    },
+    {
+      "code": "QV03AB26",
+      "name": "methionine"
+    },
+    {
+      "code": "QV03AB27",
+      "name": "4-dimethylaminophenol"
+    },
+    {
+      "code": "QV03AB29",
+      "name": "cholinesterase"
+    },
+    {
+      "code": "QV03AB31",
+      "name": "prussian blue"
+    },
+    {
+      "code": "QV03AB32",
+      "name": "glutathione"
+    },
+    {
+      "code": "QV03AB33",
+      "name": "hydroxocobalamine"
+    },
+    {
+      "code": "QV03AB34",
+      "name": "fomepizole"
+    },
+    {
+      "code": "QV03AB35",
+      "name": "sugammadeks"
+    },
+    {
+      "code": "QV03AB36",
+      "name": "phentolamin"
+    },
+    {
+      "code": "QV03AB37",
+      "name": "idarucizumab"
+    },
+    {
+      "code": "QV03AB38",
+      "name": "andexanet alfa"
+    },
+    {
+      "code": "QV03AB54",
+      "name": "pralidoxime and atropine"
+    },
+    {
+      "code": "QV03AB90",
+      "name": "atipamezole"
+    },
+    {
+      "code": "QV03AB91",
+      "name": "sarmazenil"
+    },
+    {
+      "code": "QV03AB92",
+      "name": "diprenorfin"
+    },
+    {
+      "code": "QV03AB93",
+      "name": "yohimbine"
+    },
+    {
+      "code": "QV03AB94",
+      "name": "tolazoline"
+    },
+    {
+      "code": "QV03AB95",
+      "name": "apomorphine"
+    },
+    {
+      "code": "QV03AB96",
+      "name": "ropinirole"
+    },
+    {
+      "code": "QV03AC",
+      "name": "Iron-chelating agents"
+    },
+    {
+      "code": "QV03AC01",
+      "name": "deferoxamine"
+    },
+    {
+      "code": "QV03AC02",
+      "name": "deferiprone"
+    },
+    {
+      "code": "QV03AC03",
+      "name": "deferasirox"
+    },
+    {
+      "code": "QV03AE",
+      "name": "Drugs for treatment of hyperkalemia and hyperphosphatemia"
+    },
+    {
+      "code": "QV03AE01",
+      "name": "polystyrene sulfonate"
+    },
+    {
+      "code": "QV03AE02",
+      "name": "sevelamer"
+    },
+    {
+      "code": "QV03AE03",
+      "name": "lanthanum carbonate"
+    },
+    {
+      "code": "QV03AE04",
+      "name": "calcium acetate and magnesium carbonate"
+    },
+    {
+      "code": "QV03AE05",
+      "name": "sucroferric oxyhydroxide"
+    },
+    {
+      "code": "QV03AE06",
+      "name": "colestilan"
+    },
+    {
+      "code": "QV03AE07",
+      "name": "calcium acetate"
+    },
+    {
+      "code": "QV03AE08",
+      "name": "ferric citrate"
+    },
+    {
+      "code": "QV03AE09",
+      "name": "patiromer calcium"
+    },
+    {
+      "code": "QV03AE10",
+      "name": "sodium zirconium cyclosilicate"
+    },
+    {
+      "code": "QV03AF",
+      "name": "Detoxifying agents for antineoplastic treatment"
+    },
+    {
+      "code": "QV03AF01",
+      "name": "mesna"
+    },
+    {
+      "code": "QV03AF02",
+      "name": "dexrazoxane"
+    },
+    {
+      "code": "QV03AF03",
+      "name": "calcium folinate"
+    },
+    {
+      "code": "QV03AF04",
+      "name": "calcium levofolinate"
+    },
+    {
+      "code": "QV03AF05",
+      "name": "amifostine"
+    },
+    {
+      "code": "QV03AF06",
+      "name": "sodium folinate"
+    },
+    {
+      "code": "QV03AF07",
+      "name": "rasburicase"
+    },
+    {
+      "code": "QV03AF08",
+      "name": "palifermin"
+    },
+    {
+      "code": "QV03AF09",
+      "name": "glucarpidase"
+    },
+    {
+      "code": "QV03AF10",
+      "name": "sodium levofolinate"
+    },
+    {
+      "code": "QV03AF11",
+      "name": "arginine and lysine"
+    },
+    {
+      "code": "QV03AF12",
+      "name": "trilaciclib"
+    },
+    {
+      "code": "QV03AG",
+      "name": "Drugs for treatment of hypercalcemia"
+    },
+    {
+      "code": "QV03AG01",
+      "name": "sodium cellulose phosphate"
+    },
+    {
+      "code": "QV03AG05",
+      "name": "sodium phosphate"
+    },
+    {
+      "code": "QV03AH",
+      "name": "Drugs for treatment of hypoglycemia"
+    },
+    {
+      "code": "QV03AH01",
+      "name": "diazoxide"
+    },
+    {
+      "code": "QV03AK",
+      "name": "Tissue adhesives"
+    },
+    {
+      "code": "QV03AM",
+      "name": "Drugs for embolisation"
+    },
+    {
+      "code": "QV03AN",
+      "name": "Medical gases"
+    },
+    {
+      "code": "QV03AN01",
+      "name": "oxygen"
+    },
+    {
+      "code": "QV03AN02",
+      "name": "carbon dioxide"
+    },
+    {
+      "code": "QV03AN03",
+      "name": "helium"
+    },
+    {
+      "code": "QV03AN04",
+      "name": "nitrogen"
+    },
+    {
+      "code": "QV03AN05",
+      "name": "medical air"
+    },
+    {
+      "code": "QV03AX",
+      "name": "Other therapeutic products"
+    },
+    {
+      "code": "QV03AX02",
+      "name": "nalfurafine"
+    },
+    {
+      "code": "QV03AX03",
+      "name": "cobicistat"
+    },
+    {
+      "code": "QV03AX04",
+      "name": "difelikefalin"
+    },
+    {
+      "code": "QV03AZ",
+      "name": "Nerve depressants"
+    },
+    {
+      "code": "QV03AZ01",
+      "name": "ethanol"
+    },
+    {
+      "code": "QV04",
+      "name": "DIAGNOSTIC AGENTS"
+    },
+    {
+      "code": "QV04B",
+      "name": "URINE TESTS"
+    },
+    {
+      "code": "QV04C",
+      "name": "OTHER DIAGNOSTIC AGENTS"
+    },
+    {
+      "code": "QV04CA",
+      "name": "Tests for diabetes"
+    },
+    {
+      "code": "QV04CA01",
+      "name": "tolbutamide"
+    },
+    {
+      "code": "QV04CA02",
+      "name": "glucose"
+    },
+    {
+      "code": "QV04CB",
+      "name": "Tests for fat absorption"
+    },
+    {
+      "code": "QV04CB01",
+      "name": "vitamin A concentrates"
+    },
+    {
+      "code": "QV04CC",
+      "name": "Tests for bile duct patency"
+    },
+    {
+      "code": "QV04CC01",
+      "name": "sorbitol"
+    },
+    {
+      "code": "QV04CC02",
+      "name": "magnesium sulfate"
+    },
+    {
+      "code": "QV04CC03",
+      "name": "sincalide"
+    },
+    {
+      "code": "QV04CC04",
+      "name": "ceruletide"
+    },
+    {
+      "code": "QV04CD",
+      "name": "Tests for pituitary function"
+    },
+    {
+      "code": "QV04CD01",
+      "name": "metyrapone"
+    },
+    {
+      "code": "QV04CD03",
+      "name": "sermorelin"
+    },
+    {
+      "code": "QV04CD04",
+      "name": "corticorelin"
+    },
+    {
+      "code": "QV04CD05",
+      "name": "somatorelin"
+    },
+    {
+      "code": "QV04CD06",
+      "name": "macimorelin"
+    },
+    {
+      "code": "QV04CE",
+      "name": "Tests for liver functional capacity"
+    },
+    {
+      "code": "QV04CE01",
+      "name": "galactose"
+    },
+    {
+      "code": "QV04CE02",
+      "name": "sulfobromophtalein"
+    },
+    {
+      "code": "QV04CE03",
+      "name": "methacetin (13C)"
+    },
+    {
+      "code": "QV04CF",
+      "name": "Tuberculosis diagnostics"
+    },
+    {
+      "code": "QV04CF01",
+      "name": "tuberculin"
+    },
+    {
+      "code": "QV04CF02",
+      "name": "mycobacterium tuberculosis, recombinant antigens"
+    },
+    {
+      "code": "QV04CG",
+      "name": "Tests for gastric secretion"
+    },
+    {
+      "code": "QV04CG01",
+      "name": "cation exchange resins"
+    },
+    {
+      "code": "QV04CG02",
+      "name": "betazole"
+    },
+    {
+      "code": "QV04CG03",
+      "name": "histamine phosphate"
+    },
+    {
+      "code": "QV04CG04",
+      "name": "pentagastrin"
+    },
+    {
+      "code": "QV04CG05",
+      "name": "methylthioninium chloride"
+    },
+    {
+      "code": "QV04CG30",
+      "name": "caffeine and sodium benzoate"
+    },
+    {
+      "code": "QV04CH",
+      "name": "Tests for renal function and ureteral injuries"
+    },
+    {
+      "code": "QV04CH01",
+      "name": "inulin and other polyfructosans"
+    },
+    {
+      "code": "QV04CH02",
+      "name": "indigo carmine"
+    },
+    {
+      "code": "QV04CH03",
+      "name": "phenolsulfonphthalein"
+    },
+    {
+      "code": "QV04CH04",
+      "name": "alsactide"
+    },
+    {
+      "code": "QV04CH05",
+      "name": "relmapirazin"
+    },
+    {
+      "code": "QV04CH30",
+      "name": "aminohippuric acid"
+    },
+    {
+      "code": "QV04CJ",
+      "name": "Tests for thyreoidea function"
+    },
+    {
+      "code": "QV04CJ01",
+      "name": "thyrotrophin"
+    },
+    {
+      "code": "QV04CJ02",
+      "name": "protirelin"
+    },
+    {
+      "code": "QV04CK",
+      "name": "Tests for pancreatic function"
+    },
+    {
+      "code": "QV04CK01",
+      "name": "secretin"
+    },
+    {
+      "code": "QV04CK02",
+      "name": "pancreozymin (cholecystokinin)"
+    },
+    {
+      "code": "QV04CK03",
+      "name": "bentiromide"
+    },
+    {
+      "code": "QV04CL",
+      "name": "Tests for allergic diseases"
+    },
+    {
+      "code": "QV04CM",
+      "name": "Tests for fertility disturbances"
+    },
+    {
+      "code": "QV04CM01",
+      "name": "gonadorelin"
+    },
+    {
+      "code": "QV04CQ",
+      "name": "Tests for mastitis"
+    },
+    {
+      "code": "QV04CV",
+      "name": "Tests for respiratory function"
+    },
+    {
+      "code": "QV04CV01",
+      "name": "lobeline"
+    },
+    {
+      "code": "QV04CX",
+      "name": "Other diagnostic agents"
+    },
+    {
+      "code": "QV04CX01",
+      "name": "indocyanine green"
+    },
+    {
+      "code": "QV04CX02",
+      "name": "folic acid"
+    },
+    {
+      "code": "QV04CX03",
+      "name": "methacholine"
+    },
+    {
+      "code": "QV04CX04",
+      "name": "mannitol"
+    },
+    {
+      "code": "QV04CX05",
+      "name": "13C-urea"
+    },
+    {
+      "code": "QV04CX06",
+      "name": "hexaminolevulinate"
+    },
+    {
+      "code": "QV04CX07",
+      "name": "edrophonium"
+    },
+    {
+      "code": "QV04CX08",
+      "name": "carbon monoxide"
+    },
+    {
+      "code": "QV04CX09",
+      "name": "patent blue"
+    },
+    {
+      "code": "QV04CX10",
+      "name": "pafolacianine"
+    },
+    {
+      "code": "QV04CX11",
+      "name": "lithium chloride"
+    },
+    {
+      "code": "QV04CX12",
+      "name": "xenon"
+    },
+    {
+      "code": "QV04CX13",
+      "name": "pegulicianine"
+    },
+    {
+      "code": "QV06",
+      "name": "GENERAL NUTRIENTS"
+    },
+    {
+      "code": "QV06A",
+      "name": "DIET FORMULATIONS FOR TREATMENT OF OBESITY"
+    },
+    {
+      "code": "QV06AA",
+      "name": "Low-energy diets"
+    },
+    {
+      "code": "QV06B",
+      "name": "PROTEIN SUPPLEMENTS"
+    },
+    {
+      "code": "QV06C",
+      "name": "INFANT FORMULAS"
+    },
+    {
+      "code": "QV06CA",
+      "name": "Nutrients without phenylalanine"
+    },
+    {
+      "code": "QV06D",
+      "name": "OTHER NUTRIENTS"
+    },
+    {
+      "code": "QV06DA",
+      "name": "Carbohydrates/proteins/minerals/vitamins, combinations"
+    },
+    {
+      "code": "QV06DB",
+      "name": "Fat/carbohydrates/proteins/minerals/vitamins, combinations"
+    },
+    {
+      "code": "QV06DC",
+      "name": "Carbohydrates"
+    },
+    {
+      "code": "QV06DC01",
+      "name": "glucose"
+    },
+    {
+      "code": "QV06DC02",
+      "name": "fructose"
+    },
+    {
+      "code": "QV06DD",
+      "name": "Amino acids, incl. combinations with polypeptides"
+    },
+    {
+      "code": "QV06DE",
+      "name": "Amino acids/carbohydrates/minerals/vitamins, combinations"
+    },
+    {
+      "code": "QV06DF",
+      "name": "Milk substitutes"
+    },
+    {
+      "code": "QV06DX",
+      "name": "Other combinations of nutrients"
+    },
+    {
+      "code": "QV07",
+      "name": "ALL OTHER NON-THERAPEUTIC PRODUCTS"
+    },
+    {
+      "code": "QV07A",
+      "name": "ALL OTHER NON-THERAPEUTIC PRODUCTS"
+    },
+    {
+      "code": "QV07AA",
+      "name": "Plasters"
+    },
+    {
+      "code": "QV07AB",
+      "name": "Solvents and diluting agents, incl. irrigating solutions"
+    },
+    {
+      "code": "QV07AC",
+      "name": "Blood transfusion, auxiliary products"
+    },
+    {
+      "code": "QV07AD",
+      "name": "Blood tests, auxiliary products"
+    },
+    {
+      "code": "QV07AN",
+      "name": "Incontinence equipment"
+    },
+    {
+      "code": "QV07AQ",
+      "name": "Other non-therapeutic veterinary products"
+    },
+    {
+      "code": "QV07AQ01",
+      "name": "lubabegron"
+    },
+    {
+      "code": "QV07AQ02",
+      "name": "ractopamin"
+    },
+    {
+      "code": "QV07AR",
+      "name": "Sensitivity tests, discs and tablets"
+    },
+    {
+      "code": "QV07AS",
+      "name": "Stomi equipment"
+    },
+    {
+      "code": "QV07AT",
+      "name": "Cosmetics"
+    },
+    {
+      "code": "QV07AV",
+      "name": "Technical disinfectants"
+    },
+    {
+      "code": "QV07AX",
+      "name": "Washing agents etc."
+    },
+    {
+      "code": "QV07AY",
+      "name": "Other non-therapeutic auxiliary products"
+    },
+    {
+      "code": "QV07AZ",
+      "name": "Chemicals and reagents for analysis"
+    },
+    {
+      "code": "QV08",
+      "name": "CONTRAST MEDIA"
+    },
+    {
+      "code": "QV08A",
+      "name": "X-RAY CONTRAST MEDIA, IODINATED"
+    },
+    {
+      "code": "QV08AA",
+      "name": "Watersoluble, nephrotropic, high osmolar X-ray contrast media"
+    },
+    {
+      "code": "QV08AA01",
+      "name": "diatrizoic acid"
+    },
+    {
+      "code": "QV08AA02",
+      "name": "metrizoic acid"
+    },
+    {
+      "code": "QV08AA03",
+      "name": "iodamide"
+    },
+    {
+      "code": "QV08AA04",
+      "name": "iotalamic acid"
+    },
+    {
+      "code": "QV08AA05",
+      "name": "ioxitalamic acid"
+    },
+    {
+      "code": "QV08AA06",
+      "name": "ioglicic acid"
+    },
+    {
+      "code": "QV08AA07",
+      "name": "acetrizoic acid"
+    },
+    {
+      "code": "QV08AA08",
+      "name": "iocarmic acid"
+    },
+    {
+      "code": "QV08AA09",
+      "name": "methiodal"
+    },
+    {
+      "code": "QV08AA10",
+      "name": "diodone"
+    },
+    {
+      "code": "QV08AB",
+      "name": "Watersoluble, nephrotropic, low osmolar X-ray contrast media"
+    },
+    {
+      "code": "QV08AB01",
+      "name": "metrizamide"
+    },
+    {
+      "code": "QV08AB02",
+      "name": "iohexol"
+    },
+    {
+      "code": "QV08AB03",
+      "name": "ioxaglic acid"
+    },
+    {
+      "code": "QV08AB04",
+      "name": "iopamidol"
+    },
+    {
+      "code": "QV08AB05",
+      "name": "iopromide"
+    },
+    {
+      "code": "QV08AB06",
+      "name": "iotrolan"
+    },
+    {
+      "code": "QV08AB07",
+      "name": "ioversol"
+    },
+    {
+      "code": "QV08AB08",
+      "name": "iopentol"
+    },
+    {
+      "code": "QV08AB09",
+      "name": "iodixanol"
+    },
+    {
+      "code": "QV08AB10",
+      "name": "iomeprol"
+    },
+    {
+      "code": "QV08AB11",
+      "name": "iobitridol"
+    },
+    {
+      "code": "QV08AB12",
+      "name": "ioxilan"
+    },
+    {
+      "code": "QV08AC",
+      "name": "Watersoluble, hepatotropic X-ray contrast media"
+    },
+    {
+      "code": "QV08AC01",
+      "name": "iodoxamic acid"
+    },
+    {
+      "code": "QV08AC02",
+      "name": "iotroxic acid"
+    },
+    {
+      "code": "QV08AC03",
+      "name": "ioglycamic acid"
+    },
+    {
+      "code": "QV08AC04",
+      "name": "adipiodone"
+    },
+    {
+      "code": "QV08AC05",
+      "name": "iobenzamic acid"
+    },
+    {
+      "code": "QV08AC06",
+      "name": "iopanoic acid"
+    },
+    {
+      "code": "QV08AC07",
+      "name": "iocetamic acid"
+    },
+    {
+      "code": "QV08AC08",
+      "name": "sodium iopodate"
+    },
+    {
+      "code": "QV08AC09",
+      "name": "tyropanoic acid"
+    },
+    {
+      "code": "QV08AC10",
+      "name": "calcium iopodate"
+    },
+    {
+      "code": "QV08AD",
+      "name": "Non-watersoluble X-ray contrast media"
+    },
+    {
+      "code": "QV08AD01",
+      "name": "ethyl esters of iodised fatty acids"
+    },
+    {
+      "code": "QV08AD02",
+      "name": "iopydol"
+    },
+    {
+      "code": "QV08AD03",
+      "name": "propyliodone"
+    },
+    {
+      "code": "QV08AD04",
+      "name": "iofendylate"
+    },
+    {
+      "code": "QV08B",
+      "name": "X-RAY CONTRAST MEDIA, NON-IODINATED"
+    },
+    {
+      "code": "QV08BA",
+      "name": "Barium sulfate containing X-ray contrast media"
+    },
+    {
+      "code": "QV08BA01",
+      "name": "barium sulfate with suspending agents"
+    },
+    {
+      "code": "QV08BA02",
+      "name": "barium sulfate without suspending agents"
+    },
+    {
+      "code": "QV08C",
+      "name": "MAGNETIC RESONANCE IMAGING CONTRAST MEDIA"
+    },
+    {
+      "code": "QV08CA",
+      "name": "Paramagnetic contrast media"
+    },
+    {
+      "code": "QV08CA01",
+      "name": "gadopentetic acid"
+    },
+    {
+      "code": "QV08CA02",
+      "name": "gadoteric acid"
+    },
+    {
+      "code": "QV08CA03",
+      "name": "gadodiamide"
+    },
+    {
+      "code": "QV08CA04",
+      "name": "gadoteridol"
+    },
+    {
+      "code": "QV08CA05",
+      "name": "mangafodipir"
+    },
+    {
+      "code": "QV08CA06",
+      "name": "gadoversetamide"
+    },
+    {
+      "code": "QV08CA07",
+      "name": "ferric ammonium citrate"
+    },
+    {
+      "code": "QV08CA08",
+      "name": "gadobenic acid"
+    },
+    {
+      "code": "QV08CA09",
+      "name": "gadobutrol"
+    },
+    {
+      "code": "QV08CA10",
+      "name": "gadoxetic acid"
+    },
+    {
+      "code": "QV08CA11",
+      "name": "gadofosveset"
+    },
+    {
+      "code": "QV08CA12",
+      "name": "gadopiclenol"
+    },
+    {
+      "code": "QV08CA13",
+      "name": "gadoquatrane"
+    },
+    {
+      "code": "QV08CB",
+      "name": "Superparamagnetic contrast media"
+    },
+    {
+      "code": "QV08CB01",
+      "name": "ferumoxsil"
+    },
+    {
+      "code": "QV08CB02",
+      "name": "ferristene"
+    },
+    {
+      "code": "QV08CB03",
+      "name": "iron oxide, nanoparticles"
+    },
+    {
+      "code": "QV08CX",
+      "name": "Other magnetic resonance imaging contrast media"
+    },
+    {
+      "code": "QV08CX01",
+      "name": "perflubron"
+    },
+    {
+      "code": "QV08D",
+      "name": "ULTRASOUND CONTRAST MEDIA"
+    },
+    {
+      "code": "QV08DA",
+      "name": "Ultrasound contrast media"
+    },
+    {
+      "code": "QV08DA01",
+      "name": "perflutren, human albumin microspheres"
+    },
+    {
+      "code": "QV08DA02",
+      "name": "microparticles of galactose"
+    },
+    {
+      "code": "QV08DA03",
+      "name": "perflenapent"
+    },
+    {
+      "code": "QV08DA04",
+      "name": "perflutren, phospholipid microspheres"
+    },
+    {
+      "code": "QV08DA05",
+      "name": "sulfur hexafluoride, phospholipid microspheres"
+    },
+    {
+      "code": "QV08DA06",
+      "name": "perflubutane, phospholipid microspheres"
+    },
+    {
+      "code": "QV09",
+      "name": "DIAGNOSTIC RADIOPHARMACEUTICALS"
+    },
+    {
+      "code": "QV09A",
+      "name": "CENTRAL NERVOUS SYSTEM"
+    },
+    {
+      "code": "QV09AA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09AA01",
+      "name": "technetium (99mTc) exametazime"
+    },
+    {
+      "code": "QV09AA02",
+      "name": "technetium (99mTc) bicisate"
+    },
+    {
+      "code": "QV09AB",
+      "name": "Iodine (123I) compounds"
+    },
+    {
+      "code": "QV09AB01",
+      "name": "iodine iofetamine (123I)"
+    },
+    {
+      "code": "QV09AB02",
+      "name": "iodine iolopride (123I)"
+    },
+    {
+      "code": "QV09AB03",
+      "name": "iodine ioflupane (123I)"
+    },
+    {
+      "code": "QV09AX",
+      "name": "Other central nervous system diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09AX01",
+      "name": "indium (111In) pentetic acid"
+    },
+    {
+      "code": "QV09AX03",
+      "name": "iodine (124I) 2beta-carbomethoxy-3beta-(4 iodophenyl)-tropane"
+    },
+    {
+      "code": "QV09AX04",
+      "name": "flutemetamol (18F)"
+    },
+    {
+      "code": "QV09AX05",
+      "name": "florbetapir (18F)"
+    },
+    {
+      "code": "QV09AX06",
+      "name": "florbetaben (18F)"
+    },
+    {
+      "code": "QV09AX07",
+      "name": "flortaucipir (18F)"
+    },
+    {
+      "code": "QV09B",
+      "name": "SKELETON"
+    },
+    {
+      "code": "QV09BA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09BA01",
+      "name": "technetium (99mTc) oxidronic acid"
+    },
+    {
+      "code": "QV09BA02",
+      "name": "technetium (99mTc) medronic acid"
+    },
+    {
+      "code": "QV09BA03",
+      "name": "technetium (99mTc) pyrophosphate"
+    },
+    {
+      "code": "QV09BA04",
+      "name": "technetium (99mTc) butedronic acid"
+    },
+    {
+      "code": "QV09C",
+      "name": "RENAL SYSTEM"
+    },
+    {
+      "code": "QV09CA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09CA01",
+      "name": "technetium (99mTc) pentetic acid"
+    },
+    {
+      "code": "QV09CA02",
+      "name": "technetium (99mTc) succimer"
+    },
+    {
+      "code": "QV09CA03",
+      "name": "technetium (99mTc) mertiatide"
+    },
+    {
+      "code": "QV09CA04",
+      "name": "technetium (99mTc) gluceptate"
+    },
+    {
+      "code": "QV09CA05",
+      "name": "technetium (99mTc) gluconate"
+    },
+    {
+      "code": "QV09CA06",
+      "name": "technetium (99mTc) ethylenedicysteine"
+    },
+    {
+      "code": "QV09CX",
+      "name": "Other renal system diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09CX01",
+      "name": "sodium iodohippurate (123I)"
+    },
+    {
+      "code": "QV09CX02",
+      "name": "sodium iodohippurate (131I)"
+    },
+    {
+      "code": "QV09CX03",
+      "name": "sodium iothalamate (125I)"
+    },
+    {
+      "code": "QV09CX04",
+      "name": "chromium (51Cr) edetate"
+    },
+    {
+      "code": "QV09D",
+      "name": "HEPATIC AND RETICULO ENDOTHELIAL SYSTEM"
+    },
+    {
+      "code": "QV09DA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09DA01",
+      "name": "technetium (99mTc) disofenin"
+    },
+    {
+      "code": "QV09DA02",
+      "name": "technetium (99mTc) etifenin"
+    },
+    {
+      "code": "QV09DA03",
+      "name": "technetium (99mTc) lidofenin"
+    },
+    {
+      "code": "QV09DA04",
+      "name": "technetium (99mTc) mebrofenin"
+    },
+    {
+      "code": "QV09DA05",
+      "name": "technetium (99mTc) galtifenin"
+    },
+    {
+      "code": "QV09DB",
+      "name": "Technetium (99mTc), particles and colloids"
+    },
+    {
+      "code": "QV09DB01",
+      "name": "technetium (99mTc) nanocolloid"
+    },
+    {
+      "code": "QV09DB02",
+      "name": "technetium (99mTc) microcolloid"
+    },
+    {
+      "code": "QV09DB03",
+      "name": "technetium (99mTc) millimicrospheres"
+    },
+    {
+      "code": "QV09DB04",
+      "name": "technetium (99mTc) tin colloid"
+    },
+    {
+      "code": "QV09DB05",
+      "name": "technetium (99mTc) sulfur colloid"
+    },
+    {
+      "code": "QV09DB06",
+      "name": "technetium (99mTc) rheniumsulfide colloid"
+    },
+    {
+      "code": "QV09DB07",
+      "name": "technetium (99mTc) phytate"
+    },
+    {
+      "code": "QV09DX",
+      "name": "Other hepatic and reticulo endothelial system diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09DX01",
+      "name": "selenium (75Se) tauroselcholic acid"
+    },
+    {
+      "code": "QV09E",
+      "name": "RESPIRATORY SYSTEM"
+    },
+    {
+      "code": "QV09EA",
+      "name": "Technetium (99mTc), inhalants"
+    },
+    {
+      "code": "QV09EA01",
+      "name": "technetium (99mTc) pentetic acid"
+    },
+    {
+      "code": "QV09EA02",
+      "name": "technetium (99mTc) technegas"
+    },
+    {
+      "code": "QV09EA03",
+      "name": "technetium (99mTc) nanocolloid"
+    },
+    {
+      "code": "QV09EB",
+      "name": "Technetium (99mTc), particles for injection"
+    },
+    {
+      "code": "QV09EB01",
+      "name": "technetium (99mTc) macrosalb"
+    },
+    {
+      "code": "QV09EB02",
+      "name": "technetium (99mTc) microspheres"
+    },
+    {
+      "code": "QV09EX",
+      "name": "Other respiratory system diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09EX01",
+      "name": "krypton (81mKr) gas"
+    },
+    {
+      "code": "QV09EX02",
+      "name": "xenon (127Xe) gas"
+    },
+    {
+      "code": "QV09EX03",
+      "name": "xenon (133Xe) gas"
+    },
+    {
+      "code": "QV09F",
+      "name": "THYROID"
+    },
+    {
+      "code": "QV09FX",
+      "name": "Various thyroid diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09FX01",
+      "name": "technetium (99mTc) pertechnetate"
+    },
+    {
+      "code": "QV09FX02",
+      "name": "sodium iodide (123I)"
+    },
+    {
+      "code": "QV09FX03",
+      "name": "sodium iodide (131I)"
+    },
+    {
+      "code": "QV09FX04",
+      "name": "sodium iodide (124I)"
+    },
+    {
+      "code": "QV09G",
+      "name": "CARDIOVASCULAR SYSTEM"
+    },
+    {
+      "code": "QV09GA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09GA01",
+      "name": "technetium (99mTc) sestamibi"
+    },
+    {
+      "code": "QV09GA02",
+      "name": "technetium (99mTc) tetrofosmin"
+    },
+    {
+      "code": "QV09GA03",
+      "name": "technetium (99mTc) teboroxime"
+    },
+    {
+      "code": "QV09GA04",
+      "name": "technetium (99mTc) human albumin"
+    },
+    {
+      "code": "QV09GA05",
+      "name": "technetium (99mTc) furifosmin"
+    },
+    {
+      "code": "QV09GA06",
+      "name": "technetium (99mTc) stannous agent labelled cells"
+    },
+    {
+      "code": "QV09GA07",
+      "name": "technetium (99mTc) apcitide"
+    },
+    {
+      "code": "QV09GB",
+      "name": "Iodine (125I) compounds"
+    },
+    {
+      "code": "QV09GB01",
+      "name": "fibrinogen (125I)"
+    },
+    {
+      "code": "QV09GB02",
+      "name": "iodine (125I) human albumin"
+    },
+    {
+      "code": "QV09GX",
+      "name": "Other cardiovascular system diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09GX01",
+      "name": "thallium (201Tl) chloride"
+    },
+    {
+      "code": "QV09GX02",
+      "name": "indium (111In) imciromab"
+    },
+    {
+      "code": "QV09GX03",
+      "name": "chromium (51Cr) chromate labelled cells"
+    },
+    {
+      "code": "QV09GX04",
+      "name": "rubidium (82Rb) chloride"
+    },
+    {
+      "code": "QV09GX05",
+      "name": "ammonia (13N)"
+    },
+    {
+      "code": "QV09GX06",
+      "name": "flurpiridaz (18F)"
+    },
+    {
+      "code": "QV09H",
+      "name": "INFLAMMATION AND INFECTION DETECTION"
+    },
+    {
+      "code": "QV09HA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09HA01",
+      "name": "technetium (99mTc) human immunoglobulin"
+    },
+    {
+      "code": "QV09HA02",
+      "name": "technetium (99mTc) exametazime labelled cells"
+    },
+    {
+      "code": "QV09HA03",
+      "name": "technetium (99mTc) antigranulocyte antibody"
+    },
+    {
+      "code": "QV09HA04",
+      "name": "technetium (99mTc) sulesomab"
+    },
+    {
+      "code": "QV09HB",
+      "name": "Indium (111In) compounds"
+    },
+    {
+      "code": "QV09HB01",
+      "name": "indium (111In) oxinate labelled cells"
+    },
+    {
+      "code": "QV09HB02",
+      "name": "indium (111In) tropolonate labelled cells"
+    },
+    {
+      "code": "QV09HX",
+      "name": "Other diagnostic radiopharmaceuticals for inflammation and infection detection"
+    },
+    {
+      "code": "QV09HX01",
+      "name": "gallium (67Ga) citrate"
+    },
+    {
+      "code": "QV09I",
+      "name": "TUMOUR DETECTION"
+    },
+    {
+      "code": "QV09IA",
+      "name": "Technetium (99mTc) compounds"
+    },
+    {
+      "code": "QV09IA01",
+      "name": "technetium (99mTc) antiCarcinoEmbryonicAntigen antibody"
+    },
+    {
+      "code": "QV09IA02",
+      "name": "technetium (99mTc) antimelanoma antibody"
+    },
+    {
+      "code": "QV09IA03",
+      "name": "technetium (99mTc) pentavalent succimer"
+    },
+    {
+      "code": "QV09IA04",
+      "name": "technetium (99mTc) votumumab"
+    },
+    {
+      "code": "QV09IA05",
+      "name": "technetium (99mTc) depreotide"
+    },
+    {
+      "code": "QV09IA06",
+      "name": "technetium (99mTc) arcitumomab"
+    },
+    {
+      "code": "QV09IA07",
+      "name": "technetium (99mTc) hynic-octreotide"
+    },
+    {
+      "code": "QV09IA08",
+      "name": "technetium (99mTc) etarfolatide"
+    },
+    {
+      "code": "QV09IA09",
+      "name": "technetium (99mTc) tilmanocept"
+    },
+    {
+      "code": "QV09IA10",
+      "name": "technetium (99mTc) trofolastat chloride"
+    },
+    {
+      "code": "QV09IB",
+      "name": "Indium (111In) compounds"
+    },
+    {
+      "code": "QV09IB01",
+      "name": "indium (111In) pentetreotide"
+    },
+    {
+      "code": "QV09IB02",
+      "name": "indium (111In) satumomab pendetide"
+    },
+    {
+      "code": "QV09IB03",
+      "name": "indium (111In) antiovariumcarcinoma antibody"
+    },
+    {
+      "code": "QV09IB04",
+      "name": "indium (111In) capromab pendetide"
+    },
+    {
+      "code": "QV09IX",
+      "name": "Other diagnostic radiopharmaceuticals for tumour detection"
+    },
+    {
+      "code": "QV09IX01",
+      "name": "iobenguane (123I)"
+    },
+    {
+      "code": "QV09IX02",
+      "name": "iobenguane (131I)"
+    },
+    {
+      "code": "QV09IX03",
+      "name": "iodine (125I) CC49-monoclonal antibody"
+    },
+    {
+      "code": "QV09IX04",
+      "name": "fludeoxyglucose (18F)"
+    },
+    {
+      "code": "QV09IX05",
+      "name": "fluorodopa (18F)"
+    },
+    {
+      "code": "QV09IX06",
+      "name": "sodium fluoride (18F)"
+    },
+    {
+      "code": "QV09IX07",
+      "name": "fluorocholine (18F)"
+    },
+    {
+      "code": "QV09IX08",
+      "name": "fluoroethylcholine (18F)"
+    },
+    {
+      "code": "QV09IX09",
+      "name": "gallium (68Ga) edotreotide"
+    },
+    {
+      "code": "QV09IX10",
+      "name": "fluoroethyl-L-tyrosine (18F)"
+    },
+    {
+      "code": "QV09IX11",
+      "name": "fluoroestradiol (18F)"
+    },
+    {
+      "code": "QV09IX12",
+      "name": "fluciclovine (18F)"
+    },
+    {
+      "code": "QV09IX13",
+      "name": "methionine (11C)"
+    },
+    {
+      "code": "QV09IX14",
+      "name": "gallium (68Ga) gozetotide"
+    },
+    {
+      "code": "QV09IX15",
+      "name": "copper (64Cu) oxodotreotide"
+    },
+    {
+      "code": "QV09IX16",
+      "name": "piflufolastat (18F)"
+    },
+    {
+      "code": "QV09IX17",
+      "name": "PSMA-1007 (18F)"
+    },
+    {
+      "code": "QV09IX18",
+      "name": "flotufolastat (18F)"
+    },
+    {
+      "code": "QV09IX19",
+      "name": "vidoflufolastat (18F)"
+    },
+    {
+      "code": "QV09X",
+      "name": "OTHER DIAGNOSTIC RADIOPHARMACEUTICALS"
+    },
+    {
+      "code": "QV09XA",
+      "name": "Iodine (131I) compounds"
+    },
+    {
+      "code": "QV09XA01",
+      "name": "iodine (131I) norcholesterol"
+    },
+    {
+      "code": "QV09XA02",
+      "name": "iodocholesterol (131I)"
+    },
+    {
+      "code": "QV09XA03",
+      "name": "iodine (131I) human albumin"
+    },
+    {
+      "code": "QV09XX",
+      "name": "Various diagnostic radiopharmaceuticals"
+    },
+    {
+      "code": "QV09XX01",
+      "name": "cobalt (57Co) cyanocobalamine"
+    },
+    {
+      "code": "QV09XX02",
+      "name": "cobalt (58Co) cyanocobalamine"
+    },
+    {
+      "code": "QV09XX03",
+      "name": "selenium (75Se) norcholesterol"
+    },
+    {
+      "code": "QV09XX04",
+      "name": "ferric (59Fe) citrate"
+    },
+    {
+      "code": "QV10",
+      "name": "THERAPEUTIC RADIOPHARMACEUTICALS"
+    },
+    {
+      "code": "QV10A",
+      "name": "ANTIINFLAMMATORY AGENTS"
+    },
+    {
+      "code": "QV10AA",
+      "name": "Yttrium (90Y) compounds"
+    },
+    {
+      "code": "QV10AA01",
+      "name": "yttrium (90Y) citrate colloid"
+    },
+    {
+      "code": "QV10AA02",
+      "name": "yttrium (90Y) ferrihydroxide colloid"
+    },
+    {
+      "code": "QV10AA03",
+      "name": "yttrium (90Y) silicate colloid"
+    },
+    {
+      "code": "QV10AX",
+      "name": "Other antiinflammatory therapeutic radiopharmaceuticals"
+    },
+    {
+      "code": "QV10AX01",
+      "name": "phosphorous (32P) chromicphosphate colloid"
+    },
+    {
+      "code": "QV10AX02",
+      "name": "samarium (153Sm) hydroxyapatite colloid"
+    },
+    {
+      "code": "QV10AX03",
+      "name": "dysprosium (165Dy) colloid"
+    },
+    {
+      "code": "QV10AX04",
+      "name": "erbium (169Er) citrate colloid"
+    },
+    {
+      "code": "QV10AX05",
+      "name": "rhenium (186Re) sulfide colloid"
+    },
+    {
+      "code": "QV10AX06",
+      "name": "gold (198Au) colloidal"
+    },
+    {
+      "code": "QV10B",
+      "name": "PAIN PALLIATION (BONE SEEKING AGENTS)"
+    },
+    {
+      "code": "QV10BX",
+      "name": "Various pain palliation radiopharmaceuticals"
+    },
+    {
+      "code": "QV10BX01",
+      "name": "strontium (89Sr) chloride"
+    },
+    {
+      "code": "QV10BX02",
+      "name": "samarium (153Sm) lexidronam"
+    },
+    {
+      "code": "QV10BX03",
+      "name": "rhenium (186Re) etidronic acid"
+    },
+    {
+      "code": "QV10X",
+      "name": "OTHER THERAPEUTIC RADIOPHARMACEUTICALS"
+    },
+    {
+      "code": "QV10XA",
+      "name": "Iodine (131I) compounds"
+    },
+    {
+      "code": "QV10XA01",
+      "name": "sodium iodide (131I)"
+    },
+    {
+      "code": "QV10XA02",
+      "name": "iobenguane (131I)"
+    },
+    {
+      "code": "QV10XA03",
+      "name": "iodine (131I) omburtamab"
+    },
+    {
+      "code": "QV10XA04",
+      "name": "iodine (131I) apamistamab"
+    },
+    {
+      "code": "QV10XA53",
+      "name": "tositumomab/iodine (131I) tositumomab"
+    },
+    {
+      "code": "QV10XX",
+      "name": "Various therapeutic radiopharmaceuticals"
+    },
+    {
+      "code": "QV10XX01",
+      "name": "sodium phosphate (32P)"
+    },
+    {
+      "code": "QV10XX02",
+      "name": "ibritumomab tiuxetan (90Y)"
+    },
+    {
+      "code": "QV10XX03",
+      "name": "radium (223Ra) dichloride"
+    },
+    {
+      "code": "QV10XX04",
+      "name": "lutetium (177Lu) oxodotreotide"
+    },
+    {
+      "code": "QV10XX05",
+      "name": "lutetium (177Lu) vipivotide tetraxetan"
+    },
+    {
+      "code": "QV20",
+      "name": "SURGICAL DRESSINGS"
+    },
+    {
+      "code": "QV50",
+      "name": "Other veterinary products"
+    },
+    {
+      "code": "QV50Q",
+      "name": "Other veterinary products"
+    }
+  ]
+}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "seed:template-library": "tsx src/scripts/seed-template-library.ts",
     "check:wallet": "tsx src/scripts/check-wallet-config.ts",
     "import:venom-designations": "tsx src/scripts/import-venom-designations.ts",
+    "backfill:atc-codes": "tsx src/scripts/backfill-atc-codes.ts",
     "import:atcvet-index": "tsx src/scripts/import-atcvet-index.ts",
     "import:venom-hierarchy": "tsx src/scripts/import-venom-hierarchy.ts"
   },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "seed:template-library": "tsx src/scripts/seed-template-library.ts",
     "check:wallet": "tsx src/scripts/check-wallet-config.ts",
     "import:venom-designations": "tsx src/scripts/import-venom-designations.ts",
+    "import:atcvet-index": "tsx src/scripts/import-atcvet-index.ts",
     "import:venom-hierarchy": "tsx src/scripts/import-venom-hierarchy.ts"
   },
   "dependencies": {

--- a/apps/backend/scripts/convert-atcvet-xlsx.mjs
+++ b/apps/backend/scripts/convert-atcvet-xlsx.mjs
@@ -1,0 +1,67 @@
+/**
+ * Converts the WHO CC "ATCvet index" workbook into the JSON the importer reads.
+ *
+ * The workbook is copyright the WHO Collaborating Centre for Drug Statistics
+ * Methodology (see the third-party data notice in License.txt). Run this once per
+ * yearly release against your own copy of the workbook:
+ *
+ *   node apps/backend/scripts/convert-atcvet-xlsx.mjs "<path to xlsx>" apps/backend/data/atcvet_index.json
+ *
+ * Reads the sheet with the zip/XML that .xlsx already is, so no dependency is
+ * added for a conversion that runs once per yearly release.
+ */
+import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const [, , source, destination] = process.argv;
+if (!source || !destination) {
+  console.error(
+    'usage: node convert-atcvet-xlsx.mjs "<index.xlsx>" <out.json>',
+  );
+  process.exit(1);
+}
+
+// The XML plumbing is short enough to inline, but python3's zipfile+ElementTree
+// is already present on every machine that runs this and avoids a node XML dep.
+const python = `
+import json, sys, zipfile, xml.etree.ElementTree as ET
+NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+z = zipfile.ZipFile(sys.argv[1])
+shared = ["".join(t.text or "" for t in si.iter(f"{NS}t"))
+          for si in ET.fromstring(z.read("xl/sharedStrings.xml")).iter(f"{NS}si")]
+sheet_part = next(n for n in z.namelist() if n.startswith("xl/worksheets/sheet"))
+rows = []
+for row in ET.fromstring(z.read(sheet_part)).iter(f"{NS}row"):
+    cells = {}
+    for c in row.iter(f"{NS}c"):
+        col = "".join(ch for ch in c.get("r") if ch.isalpha())
+        v = c.find(f"{NS}v")
+        cells[col] = shared[int(v.text)] if (c.get("t") == "s" and v is not None) else (v.text if v is not None else "")
+    rows.append((cells.get("A", "").strip(), cells.get("B", "").strip()))
+# Drop the header row and any trailing blanks.
+entries = [{"code": c, "name": n} for c, n in rows[1:] if c and n]
+json.dump(entries, sys.stdout)
+`;
+
+const raw = execFileSync("python3", ["-c", python, source], {
+  maxBuffer: 64 * 1024 * 1024,
+});
+const entries = JSON.parse(raw.toString());
+
+fs.writeFileSync(
+  destination,
+  JSON.stringify(
+    {
+      source: "WHO Collaborating Centre for Drug Statistics Methodology",
+      dataset: "ATCvet index",
+      // Stamped from the filename rather than invented, so provenance on every
+      // imported row names the release it actually came from.
+      release: /(\d{4})/.exec(source)?.[1] ?? "unknown",
+      convertedFrom: source.split("/").pop(),
+      entries,
+    },
+    null,
+    2,
+  ),
+);
+console.log(`wrote ${entries.length} entries to ${destination}`);

--- a/apps/backend/scripts/convert-atcvet-xlsx.mjs
+++ b/apps/backend/scripts/convert-atcvet-xlsx.mjs
@@ -56,7 +56,9 @@ fs.writeFileSync(
       dataset: "ATCvet index",
       // Stamped from the filename rather than invented, so provenance on every
       // imported row names the release it actually came from.
-      release: /(\d{4})/.exec(source)?.[1] ?? "unknown",
+      // From the FILENAME only: a path like ~/archive/2019/2026 index.xlsx would
+      // otherwise be stamped with the directory's year.
+      release: /(\d{4})/.exec(source.split("/").pop() ?? "")?.[1] ?? "unknown",
       convertedFrom: source.split("/").pop(),
       entries,
     },

--- a/apps/backend/src/controllers/web/code.controller.ts
+++ b/apps/backend/src/controllers/web/code.controller.ts
@@ -7,6 +7,7 @@ import {
   type ClinicalSpecies,
 } from "src/services/clinical-terms.service";
 import { z } from "zod";
+import { AtcvetService } from "src/services/atcvet.service";
 
 const parseBoolean = (value: unknown): boolean | undefined => {
   if (value === undefined) return undefined;
@@ -23,6 +24,27 @@ const ClinicalSpeciesSchema = z.enum([
   "EQUINE",
   "AVIAN",
 ]);
+
+const MedicationsSuggestQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => value || undefined),
+  // The anatomical main group, e.g. QJ. Two characters, Q plus a letter.
+  group: z
+    .string()
+    .trim()
+    .regex(/^[Qq][A-Za-z]$/, "Invalid ATCvet group.")
+    .optional()
+    .transform((value) => value?.toUpperCase()),
+  species: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => value || undefined),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
 
 const TermsSuggestQuerySchema = z.object({
   q: z
@@ -112,6 +134,31 @@ export const CodeController = {
       }
       logger.error("Failed to list code mappings", error);
       return res.status(500).json({ message: "Failed to list code mappings." });
+    }
+  },
+
+  async suggestMedications(req: Request, res: Response) {
+    try {
+      const queryResult = MedicationsSuggestQuerySchema.safeParse(req.query);
+
+      if (!queryResult.success) {
+        return res.status(400).json({
+          message: "Invalid medication suggestion query.",
+          error: queryResult.error.flatten(),
+        });
+      }
+
+      const items = await AtcvetService.suggestMedications(queryResult.data);
+
+      return res.status(200).json({ items });
+    } catch (error) {
+      if (error instanceof CodeServiceError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      logger.error("Failed to suggest medications", error);
+      return res
+        .status(500)
+        .json({ message: "Failed to suggest medications." });
     }
   },
 

--- a/apps/backend/src/models/code-entry.ts
+++ b/apps/backend/src/models/code-entry.ts
@@ -1,4 +1,5 @@
-export type CodeSystem = "YOSEMITECODE" | "IDEXX" | "SNOMED" | "VENOM";
+export type CodeSystem =
+  "YOSEMITECODE" | "IDEXX" | "SNOMED" | "VENOM" | "ATCVET";
 export type CodeType =
   | "SPECIES"
   | "BREED"

--- a/apps/backend/src/models/code-entry.ts
+++ b/apps/backend/src/models/code-entry.ts
@@ -7,6 +7,8 @@ export type CodeType =
   | "TEST"
   | "CLINICAL_TERM"
   | "CLINICAL_CATEGORY"
+  | "MEDICATION"
+  | "MEDICATION_CATEGORY"
   | "OTHER";
 
 export interface CodeEntryMongo {

--- a/apps/backend/src/routers/code.router.ts
+++ b/apps/backend/src/routers/code.router.ts
@@ -16,6 +16,10 @@ router.get("/terms/suggest", requireWebAuth, (req, res) =>
   CodeController.suggestTerms(req, res),
 );
 
+router.get("/medications/suggest", requireWebAuth, (req, res) =>
+  CodeController.suggestMedications(req, res),
+);
+
 router.get("/mobile/entries", requireMobileAuth, (req, res) =>
   CodeController.listEntries(req, res),
 );
@@ -26,6 +30,10 @@ router.get("/mobile/mappings", requireMobileAuth, (req, res) =>
 
 router.get("/mobile/terms/suggest", requireMobileAuth, (req, res) =>
   CodeController.suggestTerms(req, res),
+);
+
+router.get("/mobile/medications/suggest", requireMobileAuth, (req, res) =>
+  CodeController.suggestMedications(req, res),
 );
 
 export default router;

--- a/apps/backend/src/scripts/backfill-atc-codes.ts
+++ b/apps/backend/src/scripts/backfill-atc-codes.ts
@@ -58,6 +58,12 @@ export const stripPresentation = (value: string): string =>
     )
     .trim();
 
+/**
+ * Inventory categories ATCvet can classify. Matched as substrings so a practice's
+ * "Medicines" or "Vaccines (canine)" is covered without an exact-name list.
+ */
+export const CODEABLE_CATEGORIES = ["medic", "vaccin", "drug", "pharma"];
+
 export const planBackfill = async (): Promise<{
   formulary: Outcome[];
   inventory: Outcome[];
@@ -123,10 +129,15 @@ export const planBackfill = async (): Promise<{
     select: { id: true, drugName: true, genericName: true },
   });
   const inventoryRows = await prisma.inventoryItem.findMany({
-    // Only medicine stock: coding a lead or a shampoo as a drug is noise.
+    // Stock that ATCvet can classify. Vaccines matter as much as drugs here -
+    // they are the QI codes, the only ones carrying species - and "Vaccine" is
+    // its own inventory category, so matching on "medic" alone silently skipped
+    // every one of them. Non-clinical stock (leads, shampoo) still has no code.
     where: {
       atcCode: null,
-      category: { contains: "medic", mode: "insensitive" },
+      OR: CODEABLE_CATEGORIES.map((category) => ({
+        category: { contains: category, mode: "insensitive" as const },
+      })),
     },
     select: { id: true, name: true, genericName: true },
   });

--- a/apps/backend/src/scripts/backfill-atc-codes.ts
+++ b/apps/backend/src/scripts/backfill-atc-codes.ts
@@ -1,0 +1,198 @@
+import { prisma } from "src/config/prisma";
+
+/**
+ * Matches a practice's own drug list and medicine stock to ATCvet substances.
+ *
+ * Deliberately conservative, for two reasons found in the data:
+ *
+ *  - One substance name maps to SEVERAL ATCvet codes, because the classification
+ *    separates therapeutic uses. Doxycycline is QA01AB22 orally in the mouth and
+ *    QJ01AA02 systemically; ibuprofen holds three codes. Picking the first would
+ *    file a drug under a therapeutic class it does not belong to, which is worse
+ *    than leaving it uncoded - the wrong class is what stewardship reporting and
+ *    interaction checks would then read.
+ *  - ATCvet uses INN spellings. "Cephalexin" as typed by a practice matches
+ *    nothing; the substance is "cefalexin". Rather than fuzzy-matching drug names
+ *    (where a near miss is a different medicine), unmatched rows are reported so a
+ *    human can decide.
+ *
+ * Only exact, unambiguous, normalised matches are written.
+ */
+export type Candidate = {
+  id: string;
+  name: string;
+  genericName: string | null;
+};
+
+export type Outcome = {
+  id: string;
+  name: string;
+  matchedOn: string | null;
+  resolved: string | null;
+  reason?: string;
+};
+
+/**
+ * Compare on letters and digits only, so "Cefalexin 250 mg Tablet" and
+ * "cefalexin" differ only by the trailing strength - which is why the strength is
+ * stripped separately below rather than being folded in here.
+ */
+export const normalise = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+/**
+ * Strips a trailing dose/pack description so "cefalexin 250 mg tablet" can match
+ * the substance "cefalexin". Only a trailing run is removed: a leading number is
+ * part of a name (as in "5 fluorouracil") and must survive.
+ */
+export const stripPresentation = (value: string): string =>
+  normalise(value)
+    .replace(/\s+\d+(\s*\.\d+)?\s*(mg|g|ml|mcg|iu|%|kg|mg\/ml|mg\/kg)\b.*$/, "")
+    .replace(
+      /\s+(tablet|tablets|capsule|capsules|injection|suspension|solution|cream|ointment|drops|pack|spray|powder|paste)s?\b.*$/,
+      "",
+    )
+    .trim();
+
+export const planBackfill = async (): Promise<{
+  formulary: Outcome[];
+  inventory: Outcome[];
+}> => {
+  // Every ATCvet substance, keyed by normalised display. A name held by more than
+  // one code is kept as a list so ambiguity is visible rather than collapsed.
+  const substances = await prisma.codeEntry.findMany({
+    where: { system: "ATCVET", type: "MEDICATION", active: true },
+    select: { code: true, display: true },
+  });
+  const byName = new Map<string, string[]>();
+  for (const substance of substances) {
+    const key = normalise(substance.display);
+    byName.set(key, [...(byName.get(key) ?? []), substance.code]);
+  }
+
+  const resolve = (candidate: Candidate): Outcome => {
+    // The generic name is the better key when present: a practice's product name
+    // carries brands and strengths, the generic is closer to the substance.
+    const attempts: Array<{ field: string; value: string }> = [];
+    if (candidate.genericName?.trim()) {
+      attempts.push({ field: "genericName", value: candidate.genericName });
+    }
+    attempts.push({ field: "name", value: candidate.name });
+
+    for (const attempt of attempts) {
+      for (const key of [
+        normalise(attempt.value),
+        stripPresentation(attempt.value),
+      ]) {
+        if (!key) continue;
+        const codes = byName.get(key);
+        if (!codes) continue;
+        if (codes.length > 1) {
+          return {
+            id: candidate.id,
+            name: candidate.name,
+            matchedOn: attempt.field,
+            resolved: null,
+            reason: `ambiguous: ${codes.join(", ")}`,
+          };
+        }
+        return {
+          id: candidate.id,
+          name: candidate.name,
+          matchedOn: attempt.field,
+          resolved: codes[0],
+        };
+      }
+    }
+
+    return {
+      id: candidate.id,
+      name: candidate.name,
+      matchedOn: null,
+      resolved: null,
+      reason: "no ATCvet substance with this name",
+    };
+  };
+
+  const formularyRows = await prisma.drugFormulary.findMany({
+    where: { atcCode: null },
+    select: { id: true, drugName: true, genericName: true },
+  });
+  const inventoryRows = await prisma.inventoryItem.findMany({
+    // Only medicine stock: coding a lead or a shampoo as a drug is noise.
+    where: {
+      atcCode: null,
+      category: { contains: "medic", mode: "insensitive" },
+    },
+    select: { id: true, name: true, genericName: true },
+  });
+
+  return {
+    formulary: formularyRows.map((row) =>
+      resolve({ id: row.id, name: row.drugName, genericName: row.genericName }),
+    ),
+    inventory: inventoryRows.map((row) =>
+      resolve({ id: row.id, name: row.name, genericName: row.genericName }),
+    ),
+  };
+};
+
+export const main = async () => {
+  const apply = process.argv.includes("--apply");
+  const { formulary, inventory } = await planBackfill();
+
+  const report = (label: string, outcomes: Outcome[]) => {
+    const matched = outcomes.filter((o) => o.resolved);
+    console.log(
+      `${label}: ${outcomes.length} uncoded, ${matched.length} matched`,
+    );
+    for (const outcome of outcomes.filter((o) => !o.resolved)) {
+      console.log(`  SKIP "${outcome.name}": ${outcome.reason}`);
+    }
+    return matched;
+  };
+
+  const formularyMatched = report("formulary", formulary);
+  const inventoryMatched = report("inventory", inventory);
+
+  if (!apply) {
+    console.log("dry run - pass --apply to write");
+    return;
+  }
+
+  let written = 0;
+  for (const outcome of formularyMatched) {
+    // Still-null in the where clause: someone coding the row by hand between the
+    // plan and the write keeps their value rather than losing it to a stale plan.
+    const result = await prisma.drugFormulary.updateMany({
+      where: { id: outcome.id, atcCode: null },
+      data: { atcCode: outcome.resolved },
+    });
+    written += result.count;
+  }
+  for (const outcome of inventoryMatched) {
+    const result = await prisma.inventoryItem.updateMany({
+      where: { id: outcome.id, atcCode: null },
+      data: { atcCode: outcome.resolved },
+    });
+    written += result.count;
+  }
+
+  const planned = formularyMatched.length + inventoryMatched.length;
+  console.log(
+    `wrote ${written} rows${written < planned ? ` (${planned - written} coded by someone else meanwhile)` : ""}`,
+  );
+};
+
+if (process.argv[1] && process.argv[1].endsWith("backfill-atc-codes.ts")) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/backend/src/scripts/backfill-atc-codes.ts
+++ b/apps/backend/src/scripts/backfill-atc-codes.ts
@@ -51,7 +51,10 @@ export const normalise = (value: string): string =>
  */
 export const stripPresentation = (value: string): string =>
   normalise(value)
-    .replace(/\s+\d+(\s*\.\d+)?\s*(mg|g|ml|mcg|iu|%|kg|mg\/ml|mg\/kg)\b.*$/, "")
+    // `normalise` has already turned "1%" into "1", so the unit must be optional
+    // here: with it required, "Hydrocortisone 1% cream" kept "1 cream" and
+    // matched no substance.
+    .replace(/\s+\d+(\s*\.\d+)?(\s*(mg|g|ml|mcg|iu|kg))?\b.*$/, "")
     .replace(
       /\s+(tablet|tablets|capsule|capsules|injection|suspension|solution|cream|ointment|drops|pack|spray|powder|paste)s?\b.*$/,
       "",

--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -56,6 +56,15 @@ const LEVEL_BY_LENGTH: Record<number, number> = {
 };
 const PARENT_LENGTH: Record<number, number> = { 4: 2, 5: 4, 6: 5, 8: 6 };
 
+/**
+ * Guards on retirement. The published index has held ~8,300 codes for years and a
+ * yearly release adds and withdraws a handful, so an extract far below this size,
+ * or far smaller than what is already loaded, is a truncated file rather than a
+ * genuine contraction of the classification.
+ */
+const MINIMUM_RELEASE_SIZE = 5000;
+const MAXIMUM_RELEASE_SHRINKAGE = 0.1;
+
 /** The grammar the whole file obeys; anything else is a malformed row, not a code. */
 const CODE_PATTERN = /^Q[A-Z](\d{2}([A-Z]([A-Z](\d{2})?)?)?)?$/;
 
@@ -235,18 +244,35 @@ export const main = async () => {
     written += batch.length;
   }
 
-  // A newer yearly release can withdraw a code. Rows absent from this extract are
-  // deactivated rather than deleted: a prescription or formulary row may already
-  // reference one, and a dangling code with no entry is worse than a retired one
-  // that can still be displayed.
-  const retired = await prisma.codeEntry.updateMany({
-    where: {
-      system: "ATCVET",
-      active: true,
-      code: { notIn: plan.entries.map((entry) => entry.code) },
-    },
-    data: { active: false },
+  // Retirement is only safe against a COMPLETE release. Run against a partial or
+  // largely-rejected file, "deactivate everything absent" would switch off most of
+  // the vocabulary and take medication search down - a far worse outcome than
+  // leaving a withdrawn code active for one cycle. So the extract must look like a
+  // full release before anything is retired.
+  const active = await prisma.codeEntry.count({
+    where: { system: "ATCVET", active: true },
   });
+  const shrinkage = active === 0 ? 0 : 1 - plan.entries.length / active;
+  const retirementIsSafe =
+    plan.entries.length >= MINIMUM_RELEASE_SIZE &&
+    shrinkage <= MAXIMUM_RELEASE_SHRINKAGE;
+
+  if (!retirementIsSafe && active > 0) {
+    console.log(
+      `SKIP retirement: extract holds ${plan.entries.length} codes against ${active} active (${Math.round(shrinkage * 100)}% smaller). Re-run with a complete release to retire withdrawn codes.`,
+    );
+  }
+
+  const retired = retirementIsSafe
+    ? await prisma.codeEntry.updateMany({
+        where: {
+          system: "ATCVET",
+          active: true,
+          code: { notIn: plan.entries.map((entry) => entry.code) },
+        },
+        data: { active: false },
+      })
+    : { count: 0 };
 
   const edgeResult = await prisma.codeRelationship.createMany({
     data: plan.edges.map((edge) => ({

--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -235,6 +235,19 @@ export const main = async () => {
     written += batch.length;
   }
 
+  // A newer yearly release can withdraw a code. Rows absent from this extract are
+  // deactivated rather than deleted: a prescription or formulary row may already
+  // reference one, and a dangling code with no entry is worse than a retired one
+  // that can still be displayed.
+  const retired = await prisma.codeEntry.updateMany({
+    where: {
+      system: "ATCVET",
+      active: true,
+      code: { notIn: plan.entries.map((entry) => entry.code) },
+    },
+    data: { active: false },
+  });
+
   const edgeResult = await prisma.codeRelationship.createMany({
     data: plan.edges.map((edge) => ({
       system: "ATCVET" as const,
@@ -246,7 +259,7 @@ export const main = async () => {
   });
 
   console.log(
-    `upserted ${written} codes and added ${edgeResult.count} edges (${plan.edges.length - edgeResult.count} already present)`,
+    `upserted ${written} codes, retired ${retired.count} withdrawn, added ${edgeResult.count} edges (${plan.edges.length - edgeResult.count} already present)`,
   );
 };
 

--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs";
+import path from "node:path";
+import { prisma } from "src/config/prisma";
+
+/**
+ * Imports the WHO CC ATCvet index as the medication spine: every code becomes a
+ * CodeEntry under the ATCVET system, and the classification's five levels become
+ * CodeRelationship "is a" edges, exactly as the VeNom hierarchy import does for
+ * clinical terms.
+ *
+ * The index is copyright the WHO Collaborating Centre for Drug Statistics
+ * Methodology and is included under a licence granted for use within Yosemite
+ * Crew - see the third-party data notice in License.txt. It is not sublicensed to
+ * users of this repository, who need their own licence to use ATCvet data.
+ *
+ * Regenerate data/atcvet_index.json from a new yearly release with
+ * scripts/convert-atcvet-xlsx.mjs, or point elsewhere via ATCVET_INDEX_PATH.
+ */
+export type AtcvetExtract = {
+  source: string;
+  dataset: string;
+  release: string;
+  entries: Array<{ code: string; name: string }>;
+};
+
+export type PlannedEntry = {
+  code: string;
+  display: string;
+  type: "MEDICATION" | "MEDICATION_CATEGORY";
+  level: number;
+  parent: string | null;
+  species: string[];
+};
+
+export type SkippedEntry = { code: string; reason: string };
+
+export type ImportPlan = {
+  entries: PlannedEntry[];
+  edges: Array<{ sourceCode: string; targetCode: string }>;
+  skipped: SkippedEntry[];
+};
+
+/**
+ * ATCvet codes carry their own hierarchy in their length: Q + letter (anatomical
+ * main group), + 2 digits (therapeutic), + letter (pharmacological), + letter
+ * (chemical subgroup), + 2 digits (substance). A code's parent is therefore the
+ * prefix one level up - no separate parent table is published, and none is needed.
+ */
+const LEVEL_BY_LENGTH: Record<number, number> = {
+  2: 1,
+  4: 2,
+  5: 3,
+  6: 4,
+  8: 5,
+};
+const PARENT_LENGTH: Record<number, number> = { 4: 2, 5: 4, 6: 5, 8: 6 };
+
+/** The grammar the whole file obeys; anything else is a malformed row, not a code. */
+const CODE_PATTERN = /^Q[A-Z](\d{2}([A-Z]([A-Z](\d{2})?)?)?)?$/;
+
+/**
+ * QI is the one group whose second level encodes a species rather than a
+ * therapeutic class ("QI07 IMMUNOLOGICALS FOR CANIDAE"), so vaccine codes carry
+ * species meaning the other fourteen groups do not. Mapping it onto our own
+ * species buckets is what lets a cat clinic's vaccine search exclude porcine
+ * immunologicals. Groups are mapped only where the zoological family maps cleanly;
+ * QI20 ("other species") is deliberately left unmapped rather than guessed at.
+ */
+const QI_SPECIES: Record<string, string[]> = {
+  QI01: ["AVIAN"],
+  QI02: ["FARM"],
+  QI03: ["FARM"],
+  QI04: ["FARM"],
+  QI05: ["EQUINE"],
+  QI06: ["SA"],
+  QI07: ["SA"],
+  QI08: ["EXOTICS"],
+  QI09: ["FARM"],
+  QI10: ["EXOTICS"],
+  QI11: ["EXOTICS"],
+};
+
+export const parentOf = (code: string): string | null => {
+  const parentLength = PARENT_LENGTH[code.length];
+  return parentLength ? code.slice(0, parentLength) : null;
+};
+
+/**
+ * Species inherited from the QI second level, for immunologicals only. Every key
+ * in QI_SPECIES is QI-prefixed, so the lookup alone confines this to QI codes -
+ * no separate group check can change the answer.
+ */
+export const speciesFor = (code: string): string[] =>
+  QI_SPECIES[code.slice(0, 4)] ?? [];
+
+export const planImport = (extract: AtcvetExtract): ImportPlan => {
+  const entries: PlannedEntry[] = [];
+  const skipped: SkippedEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of extract.entries) {
+    const code = entry.code.trim();
+    const display = entry.name.trim();
+    if (!code || !display) {
+      skipped.push({ code: code || "(blank)", reason: "missing code or name" });
+      continue;
+    }
+    if (!CODE_PATTERN.test(code) || !LEVEL_BY_LENGTH[code.length]) {
+      skipped.push({ code, reason: "not a valid ATCvet code" });
+      continue;
+    }
+    if (seen.has(code)) {
+      skipped.push({ code, reason: "duplicate code in extract" });
+      continue;
+    }
+    seen.add(code);
+    const level = LEVEL_BY_LENGTH[code.length];
+    entries.push({
+      code,
+      display,
+      // Only the substance level is prescribable; the four above it are headings.
+      type: level === 5 ? "MEDICATION" : "MEDICATION_CATEGORY",
+      level,
+      parent: parentOf(code),
+      species: speciesFor(code),
+    });
+  }
+
+  // An edge is only planned when its parent is present in the same extract, so a
+  // partial file produces a smaller graph rather than edges pointing at nothing.
+  const edges: ImportPlan["edges"] = [];
+  for (const entry of entries) {
+    if (!entry.parent) continue;
+    if (!seen.has(entry.parent)) {
+      skipped.push({
+        code: entry.code,
+        reason: `parent ${entry.parent} not in extract`,
+      });
+      continue;
+    }
+    edges.push({ sourceCode: entry.code, targetCode: entry.parent });
+  }
+
+  return { entries, edges, skipped };
+};
+
+const readExtract = (filePath: string): AtcvetExtract =>
+  JSON.parse(fs.readFileSync(path.resolve(filePath), "utf-8"));
+
+export const main = async () => {
+  const filePath =
+    process.argv.find((arg) => arg.endsWith(".json")) ??
+    process.env.ATCVET_INDEX_PATH ??
+    "data/atcvet_index.json";
+  const apply = process.argv.includes("--apply");
+
+  if (!fs.existsSync(path.resolve(filePath))) {
+    console.log(
+      `ATCvet index not found at ${filePath}. It is licensed and deliberately not committed; convert your own copy with scripts/convert-atcvet-xlsx.mjs or set ATCVET_INDEX_PATH.`,
+    );
+    return;
+  }
+
+  const extract = readExtract(filePath);
+  const plan = planImport(extract);
+
+  console.log(
+    `ATCvet ${extract.release}: ${plan.entries.length} codes (${plan.entries.filter((e) => e.type === "MEDICATION").length} substances, ${plan.entries.filter((e) => e.type === "MEDICATION_CATEGORY").length} groups), ${plan.edges.length} edges`,
+  );
+  for (const skip of plan.skipped) {
+    console.log(`  SKIP ${skip.code}: ${skip.reason}`);
+  }
+
+  if (!apply) {
+    console.log("dry run - pass --apply to write");
+    return;
+  }
+
+  // Provenance travels with every row so a later release can be told apart from
+  // this one without consulting a changelog.
+  const meta = (entry: PlannedEntry) => ({
+    level: entry.level,
+    atcGroup: entry.code.slice(0, 2),
+    ...(entry.species.length > 0 ? { species: entry.species } : {}),
+    // QJ01 is "antibacterials for systemic use" - the group antimicrobial
+    // stewardship reporting is actually about. Recorded as a fact of the
+    // classification, not a clinical judgement layered on top of it.
+    ...(entry.code.startsWith("QJ01") ? { antibacterial: true } : {}),
+    source: extract.source,
+    dataset: extract.dataset,
+    release: extract.release,
+  });
+
+  let written = 0;
+  const BATCH = 500;
+  for (let index = 0; index < plan.entries.length; index += BATCH) {
+    const batch = plan.entries.slice(index, index + BATCH);
+    await prisma.$transaction(
+      batch.map((entry) =>
+        prisma.codeEntry.upsert({
+          where: { system_code: { system: "ATCVET", code: entry.code } },
+          // Re-running a release refreshes the display and provenance rather than
+          // duplicating rows: the import is idempotent by design.
+          update: {
+            display: entry.display,
+            type: entry.type,
+            active: true,
+            meta: meta(entry),
+          },
+          create: {
+            system: "ATCVET",
+            code: entry.code,
+            display: entry.display,
+            type: entry.type,
+            active: true,
+            meta: meta(entry),
+          },
+        }),
+      ),
+    );
+    written += batch.length;
+  }
+
+  const edgeResult = await prisma.codeRelationship.createMany({
+    data: plan.edges.map((edge) => ({
+      system: "ATCVET" as const,
+      sourceCode: edge.sourceCode,
+      type: "is a",
+      targetCode: edge.targetCode,
+    })),
+    skipDuplicates: true,
+  });
+
+  console.log(
+    `upserted ${written} codes and added ${edgeResult.count} edges (${plan.edges.length - edgeResult.count} already present)`,
+  );
+};
+
+// Only run when invoked directly, so importing the planner in tests does not
+// start a database session.
+if (process.argv[1] && process.argv[1].endsWith("import-atcvet-index.ts")) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -13,6 +13,8 @@ import { prisma } from "src/config/prisma";
  * Crew - see the third-party data notice in License.txt. It is not sublicensed to
  * users of this repository, who need their own licence to use ATCvet data.
  *
+ * Rollout steps (deploy does NOT run this): docs/guide/atcvet-rollout.md.
+ *
  * Regenerate data/atcvet_index.json from a new yearly release with
  * scripts/convert-atcvet-xlsx.mjs, or point elsewhere via ATCVET_INDEX_PATH.
  * Paths are relative to the backend working directory.

--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -15,6 +15,7 @@ import { prisma } from "src/config/prisma";
  *
  * Regenerate data/atcvet_index.json from a new yearly release with
  * scripts/convert-atcvet-xlsx.mjs, or point elsewhere via ATCVET_INDEX_PATH.
+ * Paths are relative to the backend working directory.
  */
 export type AtcvetExtract = {
   source: string;
@@ -144,6 +145,18 @@ export const planImport = (extract: AtcvetExtract): ImportPlan => {
   return { entries, edges, skipped };
 };
 
+/**
+ * Repo-relative paths only, as in the VeNom importers: the script reads whatever
+ * it is pointed at, so it should not be pointed outside the working tree.
+ * Checked before any filesystem call, so a rejected path is not even probed for
+ * existence.
+ */
+const assertReadablePath = (filePath: string): void => {
+  if (filePath.includes("..") || path.isAbsolute(filePath)) {
+    throw new Error("Invalid file path");
+  }
+};
+
 const readExtract = (filePath: string): AtcvetExtract =>
   JSON.parse(fs.readFileSync(path.resolve(filePath), "utf-8"));
 
@@ -153,6 +166,7 @@ export const main = async () => {
     process.env.ATCVET_INDEX_PATH ??
     "data/atcvet_index.json";
   const apply = process.argv.includes("--apply");
+  assertReadablePath(filePath);
 
   if (!fs.existsSync(path.resolve(filePath))) {
     console.log(

--- a/apps/backend/src/services/atcvet.service.ts
+++ b/apps/backend/src/services/atcvet.service.ts
@@ -1,0 +1,152 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "src/config/prisma";
+
+/**
+ * Search and navigation over the ATCvet medication spine.
+ *
+ * A substance means little without the classification above it - "doxycycline"
+ * reads very differently from "doxycycline · Tetracyclines · ANTIBACTERIALS FOR
+ * SYSTEMIC USE" - so every result carries its ancestor path. The path costs no
+ * extra graph traversal: an ATCvet code contains its own ancestry in its prefixes.
+ */
+export type MedicationSuggestion = {
+  atcCode: string;
+  label: string;
+  /** Ancestor levels, outermost first, for context under the substance name. */
+  path: Array<{ code: string; label: string }>;
+  /** Species the code is specific to; only QI immunologicals carry these. */
+  species: string[];
+  /** True for QJ01, the systemic antibacterials that stewardship reporting counts. */
+  antibacterial: boolean;
+};
+
+/** Prefix lengths of the four levels above a substance. */
+const ANCESTOR_LENGTHS = [2, 4, 5, 6];
+
+export const ancestorCodesOf = (code: string): string[] =>
+  ANCESTOR_LENGTHS.filter((length) => length < code.length).map((length) =>
+    code.slice(0, length),
+  );
+
+const escapeLike = (value: string) =>
+  value.replace(/[\\%_]/g, (character) => `\\${character}`);
+
+type MedicationRow = {
+  code: string;
+  display: string;
+  meta: unknown;
+};
+
+const readMeta = (meta: unknown): Record<string, unknown> =>
+  typeof meta === "object" && meta !== null && !Array.isArray(meta)
+    ? (meta as Record<string, unknown>)
+    : {};
+
+export type SuggestMedicationsParams = {
+  q?: string;
+  /** Restrict to one anatomical main group, e.g. "QJ" for antiinfectives. */
+  group?: string;
+  /**
+   * Species filter. Only immunologicals are species-specific, so a filtered
+   * search still returns every general substance - excluding them would hide
+   * doxycycline from a cat clinic.
+   */
+  species?: string;
+  limit?: number;
+};
+
+export const buildMedicationQuery = ({
+  q,
+  group,
+  species,
+  limit = 20,
+}: SuggestMedicationsParams): Prisma.Sql => {
+  const term = q?.trim() ?? "";
+  const contains = `%${escapeLike(term)}%`;
+  const prefix = `${escapeLike(term)}%`;
+
+  const search = term
+    ? Prisma.sql`AND (e."display" ILIKE ${contains} ESCAPE '\\' OR e."code" ILIKE ${prefix} ESCAPE '\\')`
+    : Prisma.empty;
+
+  const groupFilter = group
+    ? Prisma.sql`AND e."meta"->>'atcGroup' = ${group.trim().toUpperCase()}`
+    : Prisma.empty;
+
+  // A substance with no species meta applies to every species; only rows that
+  // name a different species are excluded.
+  const speciesFilter = species
+    ? Prisma.sql`AND (
+        jsonb_typeof(e."meta"->'species') IS DISTINCT FROM 'array'
+        OR e."meta"->'species' @> ${JSON.stringify([species])}::jsonb
+      )`
+    : Prisma.empty;
+
+  // Ranking only means something when there is a term to rank against. Browsing a
+  // group alphabetically must not pay for an ILIKE on every row.
+  const ranking = term
+    ? Prisma.sql`
+      -- An exact code match first, then name-initial matches, then the rest:
+      -- someone typing "QJ01AA02" wants that substance, not an alphabetical page.
+      CASE WHEN e."code" = ${term.toUpperCase()} THEN 0
+           WHEN e."display" ILIKE ${prefix} ESCAPE '\\' THEN 1
+           ELSE 2 END,`
+    : Prisma.empty;
+
+  return Prisma.sql`
+    SELECT e."code", e."display", e."meta"
+    FROM "CodeEntry" e
+    WHERE e."system" = 'ATCVET'::"CodeSystem"
+      AND e."type" = 'MEDICATION'::"CodeType"
+      AND e."active"
+      ${search}
+      ${groupFilter}
+      ${speciesFilter}
+    ORDER BY
+      ${ranking}
+      e."display" ASC
+    LIMIT ${Math.min(Math.max(limit, 1), 50)}
+  `;
+};
+
+export const AtcvetService = {
+  async suggestMedications(
+    params: SuggestMedicationsParams,
+  ): Promise<MedicationSuggestion[]> {
+    const rows = await prisma.$queryRaw<MedicationRow[]>(
+      buildMedicationQuery(params),
+    );
+    if (rows.length === 0) return [];
+
+    // One lookup for every ancestor on the page rather than one per result.
+    const ancestorCodes = [
+      ...new Set(rows.flatMap((row) => ancestorCodesOf(row.code))),
+    ];
+    const ancestors = await prisma.codeEntry.findMany({
+      where: { system: "ATCVET", code: { in: ancestorCodes }, active: true },
+      select: { code: true, display: true },
+    });
+    const labelByCode = new Map(
+      ancestors.map((entry) => [entry.code, entry.display]),
+    );
+
+    return rows.map((row) => {
+      const meta = readMeta(row.meta);
+      return {
+        atcCode: row.code,
+        label: row.display,
+        // A missing ancestor is dropped rather than rendered as a blank crumb.
+        path: ancestorCodesOf(row.code).flatMap((code) => {
+          const label = labelByCode.get(code);
+          return label ? [{ code, label }] : [];
+        }),
+        species: Array.isArray(meta.species)
+          ? meta.species.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : [],
+        antibacterial: meta.antibacterial === true,
+      };
+    });
+  },
+};

--- a/apps/backend/src/services/atcvet.service.ts
+++ b/apps/backend/src/services/atcvet.service.ts
@@ -65,20 +65,35 @@ export const buildMedicationQuery = ({
   const contains = `%${escapeLike(term)}%`;
   const prefix = `${escapeLike(term)}%`;
 
+  // Search the SAME expression the trigram index is built on
+  // (code_entry_search_text(display, synonyms)); querying e."display" directly
+  // cannot use that index, so every keystroke would scan the table the index was
+  // added to avoid. The code is matched separately - it is not in the indexed
+  // text, and a prefix match on a short code column is cheap.
   const search = term
-    ? Prisma.sql`AND (e."display" ILIKE ${contains} ESCAPE '\\' OR e."code" ILIKE ${prefix} ESCAPE '\\')`
+    ? Prisma.sql`AND (
+        code_entry_search_text(e."display", e."synonyms") ILIKE ${contains} ESCAPE '\\'
+        OR e."code" ILIKE ${prefix} ESCAPE '\\'
+      )`
     : Prisma.empty;
 
   const groupFilter = group
     ? Prisma.sql`AND e."meta"->>'atcGroup' = ${group.trim().toUpperCase()}`
     : Prisma.empty;
 
-  // A substance with no species meta applies to every species; only rows that
-  // name a different species are excluded.
+  // A substance with no species meta applies to every species, so it stays in a
+  // filtered search. Immunologicals are the exception: they are species-specific
+  // by construction, and QI20 ("immunologicals for other species") carries no
+  // species precisely because we refuse to guess which. Letting it through on
+  // "no species means all species" would offer a cat clinic a vaccine for an
+  // animal nobody has identified.
   const speciesFilter = species
     ? Prisma.sql`AND (
-        jsonb_typeof(e."meta"->'species') IS DISTINCT FROM 'array'
-        OR e."meta"->'species' @> ${JSON.stringify([species])}::jsonb
+        e."meta"->'species' @> ${JSON.stringify([species])}::jsonb
+        OR (
+          jsonb_typeof(e."meta"->'species') IS DISTINCT FROM 'array'
+          AND e."meta"->>'atcGroup' IS DISTINCT FROM 'QI'
+        )
       )`
     : Prisma.empty;
 

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -75,6 +75,14 @@ type ClinicalTermMeta = {
   codes?: ClinicalConcept["codes"];
 };
 
+/** A usable crosswalk to another vocabulary, shown beside the term as it is picked. */
+export type ClinicalTermCoding = {
+  system: CodeSystem;
+  code: string;
+  display?: string;
+  equivalence: MappingEquivalence;
+};
+
 export type ClinicalTermSuggestion = {
   ycCode: string;
   label: string;
@@ -82,6 +90,13 @@ export type ClinicalTermSuggestion = {
   species: ClinicalSpecies[];
   synonyms: string[];
   source?: string;
+  /**
+   * VeNom/SNOMED crosswalks for this term, strongest equivalence per system.
+   * Read from CodeMapping — the same table and the same usable-equivalence gate
+   * the FHIR export uses — so what a clinician sees while picking is exactly
+   * what the record will carry.
+   */
+  codings: ClinicalTermCoding[];
 };
 
 const EXTERNAL_CODE_SYSTEM_MAP: Record<string, CodeSystem> = {
@@ -193,6 +208,9 @@ const toSuggestion = (entry: {
       : [],
     synonyms: toUniqueStrings(normalizeSynonyms(entry.synonyms)),
     source: typeof meta.source === "string" ? meta.source : undefined,
+    // Filled in by suggestTerms from CodeMapping; empty for callers that build a
+    // suggestion without the crosswalk lookup.
+    codings: [],
   };
 };
 
@@ -307,6 +325,88 @@ export const buildSuggestionQuery = (
   `;
 };
 
+/**
+ * Equivalences that assert a usable counterpart, mirroring the export gate: a
+ * term shown with a SNOMED code in the picker must be a term that actually
+ * exports with that SNOMED code.
+ */
+const USABLE_SUGGESTION_EQUIVALENCES: MappingEquivalence[] = [
+  "RELATEDTO",
+  "EQUIVALENT",
+  "EQUAL",
+  "WIDER",
+  "SUBSUMES",
+  "NARROWER",
+  "SPECIALIZES",
+  "INEXACT",
+];
+
+/** Strongest first, so one system contributes its best crosswalk only. */
+const SUGGESTION_EQUIVALENCE_RANK: MappingEquivalence[] = [
+  "EQUAL",
+  "EQUIVALENT",
+  "NARROWER",
+  "SPECIALIZES",
+  "WIDER",
+  "SUBSUMES",
+  "RELATEDTO",
+  "INEXACT",
+];
+
+/**
+ * One batched query for the whole result page, keyed by YC code. Never one
+ * query per suggestion: this runs on every keystroke past the debounce.
+ */
+const crossCodesFor = async (
+  ycCodes: string[],
+): Promise<Map<string, ClinicalTermCoding[]>> => {
+  const wanted = [...new Set(ycCodes)];
+  const result = new Map<string, ClinicalTermCoding[]>();
+  if (wanted.length === 0) return result;
+
+  const rows = await prisma.codeMapping.findMany({
+    where: {
+      sourceSystem: "YOSEMITECODE",
+      sourceCode: { in: wanted },
+      active: true,
+      equivalence: { in: USABLE_SUGGESTION_EQUIVALENCES },
+    },
+    select: {
+      sourceCode: true,
+      targetSystem: true,
+      targetCode: true,
+      targetDisplay: true,
+      equivalence: true,
+    },
+    // Deterministic before ranking, so equal-strength rows resolve the same way
+    // on every keystroke rather than flickering between codes.
+    orderBy: { targetCode: "asc" },
+  });
+
+  const rank = (equivalence: MappingEquivalence) => {
+    const index = SUGGESTION_EQUIVALENCE_RANK.indexOf(equivalence);
+    return index === -1 ? SUGGESTION_EQUIVALENCE_RANK.length : index;
+  };
+
+  for (const row of rows) {
+    const held = result.get(row.sourceCode) ?? [];
+    const existing = held.find((coding) => coding.system === row.targetSystem);
+    const candidate: ClinicalTermCoding = {
+      system: row.targetSystem,
+      code: row.targetCode,
+      display: row.targetDisplay ?? undefined,
+      equivalence: row.equivalence,
+    };
+    if (!existing) {
+      held.push(candidate);
+    } else if (rank(row.equivalence) < rank(existing.equivalence)) {
+      held.splice(held.indexOf(existing), 1, candidate);
+    }
+    result.set(row.sourceCode, held);
+  }
+  return result;
+};
+
 export const ClinicalTermsService = {
   parseConcepts(raw: unknown) {
     return ClinicalConceptListSchema.parse(raw);
@@ -355,6 +455,13 @@ export const ClinicalTermsService = {
     const rows = await prisma.$queryRaw<ClinicalTermRow[]>(
       buildSuggestionQuery(params),
     );
-    return rows.map((row) => toSuggestion(row));
+    const suggestions = rows.map((row) => toSuggestion(row));
+    const codings = await crossCodesFor(
+      suggestions.map((suggestion) => suggestion.ycCode),
+    );
+    return suggestions.map((suggestion) => ({
+      ...suggestion,
+      codings: codings.get(suggestion.ycCode) ?? [],
+    }));
   },
 };

--- a/apps/backend/src/services/drug-formulary.service.ts
+++ b/apps/backend/src/services/drug-formulary.service.ts
@@ -72,6 +72,7 @@ const formularySelect = {
   organisationId: true,
   drugName: true,
   genericName: true,
+  atcCode: true,
   category: true,
   manufacturer: true,
   concentration: true,

--- a/apps/backend/src/services/inventory.service.ts
+++ b/apps/backend/src/services/inventory.service.ts
@@ -344,6 +344,8 @@ export interface CreateInventoryItemInput {
   attributes?: InventoryAttributeMap;
 
   genericName?: string;
+  /** ATCvet substance code, set by the backfill; read-only to clients today. */
+  atcCode?: string;
   strength?: string;
   dosageForm?: string;
   routeOfAdministration?: string;
@@ -392,6 +394,7 @@ export interface UpdateInventoryItemInput {
   attributes?: InventoryAttributeMap;
 
   genericName?: string | null;
+  atcCode?: string | null;
   strength?: string | null;
   dosageForm?: string | null;
   routeOfAdministration?: string | null;

--- a/apps/backend/test/controllers/web/code.controller.test.ts
+++ b/apps/backend/test/controllers/web/code.controller.test.ts
@@ -6,6 +6,7 @@ import {
   CodeServiceError,
 } from "../../../src/services/code.service";
 import { ClinicalTermsService } from "../../../src/services/clinical-terms.service";
+import { AtcvetService } from "../../../src/services/atcvet.service";
 import logger from "../../../src/utils/logger";
 
 jest.mock("../../../src/config/prisma", () => ({ prisma: {} }));
@@ -23,6 +24,12 @@ jest.mock("../../../src/services/code.service", () => {
     },
   };
 });
+
+jest.mock("../../../src/services/atcvet.service", () => ({
+  AtcvetService: {
+    suggestMedications: jest.fn(),
+  },
+}));
 
 jest.mock("../../../src/services/clinical-terms.service", () => ({
   ClinicalTermsService: {
@@ -282,6 +289,67 @@ describe("CodeController", () => {
       expect(res.json).toHaveBeenCalledWith({
         message: "Failed to list code mappings.",
       });
+    });
+  });
+
+  describe("suggestMedications", () => {
+    const mockedAtcvetService = AtcvetService as jest.Mocked<
+      typeof AtcvetService
+    >;
+
+    it("parses a full query and returns the suggestions under items", async () => {
+      const items = [{ atcCode: "QJ01AA02", label: "doxycycline" }];
+      mockedAtcvetService.suggestMedications.mockResolvedValue(items as never);
+
+      const req = buildRequest({
+        q: "  doxy  ",
+        group: "qj",
+        species: "SA",
+        limit: "10",
+      });
+
+      await CodeController.suggestMedications(req, res);
+
+      // The group is normalised to the upper-case form the codes use.
+      expect(mockedAtcvetService.suggestMedications).toHaveBeenCalledWith({
+        q: "doxy",
+        group: "QJ",
+        species: "SA",
+        limit: 10,
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ items });
+    });
+
+    it("rejects a group that is not an ATCvet main group", async () => {
+      await CodeController.suggestMedications(
+        buildRequest({ group: "J01" }),
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedAtcvetService.suggestMedications).not.toHaveBeenCalled();
+    });
+
+    it("rejects a limit beyond the page cap", async () => {
+      await CodeController.suggestMedications(
+        buildRequest({ limit: "500" }),
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedAtcvetService.suggestMedications).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 and logs when the service throws", async () => {
+      mockedAtcvetService.suggestMedications.mockRejectedValue(
+        new Error("boom") as never,
+      );
+
+      await CodeController.suggestMedications(buildRequest({ q: "doxy" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(logger.error).toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/test/scripts/backfill-atc-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-atc-codes.test.ts
@@ -42,6 +42,15 @@ describe("stripPresentation", () => {
     );
   });
 
+  it("strips a percentage strength, which normalise has already unpunctuated", () => {
+    // "Hydrocortisone 1% cream" normalises to "hydrocortisone 1 cream"; if the
+    // unit is required the strength survives and the drug matches nothing.
+    expect(stripPresentation("Hydrocortisone 1% cream")).toBe("hydrocortisone");
+    expect(stripPresentation("Enrofloxacin 2.5 % Injection")).toBe(
+      "enrofloxacin",
+    );
+  });
+
   it("keeps a leading number, which belongs to the name", () => {
     // "5-fluorouracil" is a substance; stripping its number would break it.
     expect(stripPresentation("5-Fluorouracil")).toBe("5 fluorouracil");

--- a/apps/backend/test/scripts/backfill-atc-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-atc-codes.test.ts
@@ -1,0 +1,221 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeEntry: { findMany: jest.fn() },
+    drugFormulary: { findMany: jest.fn(), updateMany: jest.fn() },
+    inventoryItem: { findMany: jest.fn(), updateMany: jest.fn() },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import {
+  main,
+  normalise,
+  planBackfill,
+  stripPresentation,
+} from "src/scripts/backfill-atc-codes";
+
+const codeFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+const formularyFind = (
+  prisma as unknown as { drugFormulary: { findMany: jest.Mock } }
+).drugFormulary.findMany;
+const inventoryFind = (
+  prisma as unknown as { inventoryItem: { findMany: jest.Mock } }
+).inventoryItem.findMany;
+const formularyUpdate = (
+  prisma as unknown as { drugFormulary: { updateMany: jest.Mock } }
+).drugFormulary.updateMany;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  formularyFind.mockResolvedValue([]);
+  inventoryFind.mockResolvedValue([]);
+  codeFind.mockResolvedValue([]);
+});
+
+describe("stripPresentation", () => {
+  it("drops a trailing strength and form so a product matches its substance", () => {
+    expect(stripPresentation("Cefalexin 250 mg Tablet")).toBe("cefalexin");
+    expect(stripPresentation("Itraconazole 100 mg Capsule")).toBe(
+      "itraconazole",
+    );
+  });
+
+  it("keeps a leading number, which belongs to the name", () => {
+    // "5-fluorouracil" is a substance; stripping its number would break it.
+    expect(stripPresentation("5-Fluorouracil")).toBe("5 fluorouracil");
+  });
+});
+
+describe("planBackfill", () => {
+  const withSubstances = (rows: Array<[string, string]>) =>
+    codeFind.mockResolvedValue(
+      rows.map(([code, display]) => ({ code, display })),
+    );
+
+  it("matches on the generic name in preference to the product name", async () => {
+    withSubstances([["QJ01DB01", "cefalexin"]]);
+    formularyFind.mockResolvedValue([
+      { id: "f1", drugName: "Ceflex Brand Tabs", genericName: "Cefalexin" },
+    ]);
+
+    const { formulary } = await planBackfill();
+
+    expect(formulary[0]).toEqual({
+      id: "f1",
+      name: "Ceflex Brand Tabs",
+      matchedOn: "genericName",
+      resolved: "QJ01DB01",
+    });
+  });
+
+  it("prefers the generic name when the product name also matches a substance", async () => {
+    // Only a row whose two fields resolve to DIFFERENT substances can pin the
+    // preference: a product carrying an ingredient's name while its generic field
+    // names the actual substance must be coded from the generic.
+    withSubstances([
+      ["QM01AE01", "ibuprofen"],
+      ["QJ01DB01", "cefalexin"],
+    ]);
+    formularyFind.mockResolvedValue([
+      { id: "f1", drugName: "Ibuprofen", genericName: "Cefalexin" },
+    ]);
+
+    const { formulary } = await planBackfill();
+
+    expect(formulary[0]).toMatchObject({
+      matchedOn: "genericName",
+      resolved: "QJ01DB01",
+    });
+  });
+
+  it("refuses to choose when a substance holds several codes", async () => {
+    // Ibuprofen really is QC01EB16, QG02CC01 and QM01AE01 in ATCvet. Picking one
+    // would file the drug under a therapeutic class it may not belong to.
+    withSubstances([
+      ["QC01EB16", "ibuprofen"],
+      ["QG02CC01", "ibuprofen"],
+      ["QM01AE01", "ibuprofen"],
+    ]);
+    inventoryFind.mockResolvedValue([
+      { id: "i1", name: "Ibuprofen", genericName: "Ibuprofen" },
+    ]);
+
+    const { inventory } = await planBackfill();
+
+    expect(inventory[0].resolved).toBeNull();
+    expect(inventory[0].reason).toBe("ambiguous: QC01EB16, QG02CC01, QM01AE01");
+  });
+
+  it("reports a name the classification does not hold rather than guessing", async () => {
+    // ATCvet uses the INN spelling "cefalexin"; "Cephalexin" is not in it.
+    withSubstances([["QJ01DB01", "cefalexin"]]);
+    inventoryFind.mockResolvedValue([
+      { id: "i1", name: "Cephalexin 250 mg Tablet", genericName: "Cephalexin" },
+    ]);
+
+    const { inventory } = await planBackfill();
+
+    expect(inventory[0].resolved).toBeNull();
+    expect(inventory[0].reason).toMatch(/no ATCvet substance/);
+  });
+
+  it("falls back to the product name when there is no generic", async () => {
+    withSubstances([["QJ02AC02", "itraconazole"]]);
+    inventoryFind.mockResolvedValue([
+      { id: "i1", name: "Itraconazole 100 mg Capsule", genericName: null },
+    ]);
+
+    const { inventory } = await planBackfill();
+
+    expect(inventory[0]).toMatchObject({
+      matchedOn: "name",
+      resolved: "QJ02AC02",
+    });
+  });
+
+  it("only considers rows that are still uncoded, and stock that is medicine", async () => {
+    await planBackfill();
+
+    expect(formularyFind).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { atcCode: null } }),
+    );
+    expect(inventoryFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          atcCode: null,
+          category: { contains: "medic", mode: "insensitive" },
+        }),
+      }),
+    );
+  });
+});
+
+describe("main", () => {
+  let log: jest.SpyInstance;
+  let argv: string[];
+
+  beforeEach(() => {
+    argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+    codeFind.mockResolvedValue([{ code: "QJ01DB01", display: "cefalexin" }]);
+    formularyFind.mockResolvedValue([
+      { id: "f1", drugName: "Cefalexin", genericName: null },
+    ]);
+    formularyUpdate.mockResolvedValue({ count: 1 });
+  });
+
+  afterEach(() => {
+    process.argv = argv;
+    log.mockRestore();
+  });
+
+  const output = () => log.mock.calls.map((c) => String(c[0])).join("\n");
+
+  it("writes nothing without --apply", async () => {
+    process.argv = ["node", "backfill-atc-codes.ts"];
+    await main();
+
+    expect(formularyUpdate).not.toHaveBeenCalled();
+    expect(output()).toMatch(/dry run/);
+  });
+
+  it("writes only while the row is still uncoded", async () => {
+    process.argv = ["node", "backfill-atc-codes.ts", "--apply"];
+    await main();
+
+    expect(formularyUpdate).toHaveBeenCalledWith({
+      where: { id: "f1", atcCode: null },
+      data: { atcCode: "QJ01DB01" },
+    });
+    expect(output()).toMatch(/wrote 1 rows/);
+  });
+
+  it("reports rows coded by someone else mid-run", async () => {
+    process.argv = ["node", "backfill-atc-codes.ts", "--apply"];
+    formularyUpdate.mockResolvedValue({ count: 0 });
+
+    await main();
+
+    expect(output()).toMatch(/coded by someone else/);
+  });
+
+  it("names every skipped row and why", async () => {
+    process.argv = ["node", "backfill-atc-codes.ts"];
+    formularyFind.mockResolvedValue([
+      { id: "f1", drugName: "Cephalexin", genericName: null },
+    ]);
+
+    await main();
+
+    expect(output()).toMatch(/SKIP "Cephalexin"/);
+    expect(output()).toMatch(/no ATCvet substance/);
+  });
+});
+
+describe("normalise", () => {
+  it("compares on letters and digits only", () => {
+    expect(normalise("Cefalexin-250 (mg)")).toBe("cefalexin 250 mg");
+  });
+});

--- a/apps/backend/test/scripts/backfill-atc-codes.test.ts
+++ b/apps/backend/test/scripts/backfill-atc-codes.test.ts
@@ -135,20 +135,21 @@ describe("planBackfill", () => {
     });
   });
 
-  it("only considers rows that are still uncoded, and stock that is medicine", async () => {
+  it("only considers rows that are still uncoded, and stock ATCvet can classify", async () => {
     await planBackfill();
 
     expect(formularyFind).toHaveBeenCalledWith(
       expect.objectContaining({ where: { atcCode: null } }),
     );
-    expect(inventoryFind).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          atcCode: null,
-          category: { contains: "medic", mode: "insensitive" },
-        }),
-      }),
+    const where = inventoryFind.mock.calls[0][0].where;
+    expect(where.atcCode).toBeNull();
+    // Vaccines are their own inventory category and are exactly the QI codes
+    // carrying species, so a "medic"-only filter silently skipped all of them.
+    const categories = where.OR.map(
+      (clause: { category: { contains: string } }) => clause.category.contains,
     );
+    expect(categories).toContain("medic");
+    expect(categories).toContain("vaccin");
   });
 });
 

--- a/apps/backend/test/scripts/import-atcvet-index.test.ts
+++ b/apps/backend/test/scripts/import-atcvet-index.test.ts
@@ -1,12 +1,13 @@
 jest.mock("src/config/prisma", () => ({
   prisma: {
-    codeEntry: { upsert: jest.fn() },
+    codeEntry: { upsert: jest.fn(), count: jest.fn(), updateMany: jest.fn() },
     codeRelationship: { createMany: jest.fn() },
     $transaction: jest.fn(),
     $disconnect: jest.fn(),
   },
 }));
 
+import fs from "node:fs";
 import {
   main,
   parentOf,
@@ -145,6 +146,50 @@ describe("main", () => {
 
   beforeEach(() => {
     argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("refuses to retire against an extract that is not a full release", async () => {
+    // A truncated file must never deactivate the vocabulary: switching most of
+    // ATCvet off takes medication search down, which is far worse than leaving
+    // a withdrawn code active for one release cycle.
+    const { prisma } = jest.requireMock("src/config/prisma") as {
+      prisma: {
+        codeEntry: { count: jest.Mock; updateMany: jest.Mock };
+        codeRelationship: { createMany: jest.Mock };
+        $transaction: jest.Mock;
+      };
+    };
+    prisma.codeEntry.count.mockResolvedValue(8315);
+    prisma.codeEntry.updateMany.mockResolvedValue({ count: 0 });
+    prisma.codeRelationship.createMany.mockResolvedValue({ count: 0 });
+    prisma.$transaction.mockResolvedValue([]);
+
+    jest
+      .spyOn(fs, "existsSync")
+      .mockReturnValue(true as unknown as ReturnType<typeof fs.existsSync>);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        source: "WHO CC",
+        dataset: "ATCvet index",
+        release: "2026",
+        entries: [{ code: "QJ01AA02", name: "doxycycline" }],
+      }) as unknown as ReturnType<typeof fs.readFileSync>,
+    );
+
+    process.argv = [
+      "node",
+      "import-atcvet-index.ts",
+      "data/partial.json",
+      "--apply",
+    ];
+    await main();
+
+    expect(prisma.codeEntry.updateMany).not.toHaveBeenCalled();
+    expect(log.mock.calls.map((c) => String(c[0])).join("\n")).toMatch(
+      /SKIP retirement/,
+    );
+    jest.restoreAllMocks();
     log = jest.spyOn(console, "log").mockImplementation(() => {});
   });
 

--- a/apps/backend/test/scripts/import-atcvet-index.test.ts
+++ b/apps/backend/test/scripts/import-atcvet-index.test.ts
@@ -8,6 +8,7 @@ jest.mock("src/config/prisma", () => ({
 }));
 
 import {
+  main,
   parentOf,
   planImport,
   speciesFor,
@@ -135,5 +136,30 @@ describe("planImport", () => {
     expect(substance?.species).toEqual(["SA"]);
     // The QI root itself has no species: it covers every animal.
     expect(plan.entries.find((e) => e.code === "QI")?.species).toEqual([]);
+  });
+});
+
+describe("main", () => {
+  let log: jest.SpyInstance;
+  let argv: string[];
+
+  beforeEach(() => {
+    argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = argv;
+    log.mockRestore();
+  });
+
+  it("refuses a path outside the working tree", async () => {
+    process.argv = ["node", "import-atcvet-index.ts", "../../etc/passwd.json"];
+    await expect(main()).rejects.toThrow("Invalid file path");
+  });
+
+  it("refuses an absolute path", async () => {
+    process.argv = ["node", "import-atcvet-index.ts", "/etc/passwd.json"];
+    await expect(main()).rejects.toThrow("Invalid file path");
   });
 });

--- a/apps/backend/test/scripts/import-atcvet-index.test.ts
+++ b/apps/backend/test/scripts/import-atcvet-index.test.ts
@@ -1,0 +1,139 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeEntry: { upsert: jest.fn() },
+    codeRelationship: { createMany: jest.fn() },
+    $transaction: jest.fn(),
+    $disconnect: jest.fn(),
+  },
+}));
+
+import {
+  parentOf,
+  planImport,
+  speciesFor,
+  type AtcvetExtract,
+} from "src/scripts/import-atcvet-index";
+
+const extract = (entries: Array<[string, string]>): AtcvetExtract => ({
+  source: "WHO CC",
+  dataset: "ATCvet index",
+  release: "2026",
+  entries: entries.map(([code, name]) => ({ code, name })),
+});
+
+describe("parentOf", () => {
+  it("walks the level encoded in the code's own length", () => {
+    // QJ01AA02 doxycycline -> QJ01AA -> QJ01A -> QJ01 -> QJ -> root
+    expect(parentOf("QJ01AA02")).toBe("QJ01AA");
+    expect(parentOf("QJ01AA")).toBe("QJ01A");
+    expect(parentOf("QJ01A")).toBe("QJ01");
+    expect(parentOf("QJ01")).toBe("QJ");
+    expect(parentOf("QJ")).toBeNull();
+  });
+});
+
+describe("speciesFor", () => {
+  it("reads species from the QI second level, which encodes it", () => {
+    expect(speciesFor("QI07AA01")).toEqual(["SA"]); // canidae
+    expect(speciesFor("QI05")).toEqual(["EQUINE"]); // equidae
+    expect(speciesFor("QI01AA")).toEqual(["AVIAN"]); // aves
+  });
+
+  it("leaves 'other species' unmapped rather than guessing", () => {
+    expect(speciesFor("QI20AA01")).toEqual([]);
+  });
+
+  it("assigns no species outside QI, where levels are therapeutic", () => {
+    // QJ01AA02 is doxycycline for any species; claiming one would be wrong.
+    expect(speciesFor("QJ01AA02")).toEqual([]);
+  });
+});
+
+describe("planImport", () => {
+  it("types only the substance level as prescribable", () => {
+    const plan = planImport(
+      extract([
+        ["QJ", "ANTIINFECTIVES FOR SYSTEMIC USE"],
+        ["QJ01", "ANTIBACTERIALS FOR SYSTEMIC USE"],
+        ["QJ01A", "TETRACYCLINES"],
+        ["QJ01AA", "Tetracyclines"],
+        ["QJ01AA02", "doxycycline"],
+      ]),
+    );
+    const byCode = new Map(plan.entries.map((e) => [e.code, e]));
+    expect(byCode.get("QJ01AA02")?.type).toBe("MEDICATION");
+    expect(byCode.get("QJ01AA02")?.level).toBe(5);
+    for (const code of ["QJ", "QJ01", "QJ01A", "QJ01AA"]) {
+      expect(byCode.get(code)?.type).toBe("MEDICATION_CATEGORY");
+    }
+  });
+
+  it("builds one edge per non-root code", () => {
+    const plan = planImport(
+      extract([
+        ["QJ", "A"],
+        ["QJ01", "B"],
+        ["QJ01A", "C"],
+      ]),
+    );
+    expect(plan.edges).toEqual([
+      { sourceCode: "QJ01", targetCode: "QJ" },
+      { sourceCode: "QJ01A", targetCode: "QJ01" },
+    ]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  it("skips an edge whose parent is absent rather than pointing at nothing", () => {
+    // A partial extract must produce a smaller graph, never a dangling edge.
+    const plan = planImport(extract([["QJ01AA02", "doxycycline"]]));
+    expect(plan.entries).toHaveLength(1);
+    expect(plan.edges).toEqual([]);
+    expect(plan.skipped[0].reason).toMatch(/parent QJ01AA not in extract/);
+  });
+
+  it("rejects rows that are not ATCvet codes", () => {
+    const plan = planImport(
+      extract([
+        ["J01AA02", "missing the Q"],
+        ["QJ01AA0", "wrong length"],
+        ["Q1", "digit where a letter belongs"],
+        ["", "no code"],
+      ]),
+    );
+    expect(plan.entries).toEqual([]);
+    expect(plan.skipped.map((s) => s.reason)).toEqual([
+      "not a valid ATCvet code",
+      "not a valid ATCvet code",
+      "not a valid ATCvet code",
+      "missing code or name",
+    ]);
+  });
+
+  it("keeps the first of a duplicated code and reports the rest", () => {
+    const plan = planImport(
+      extract([
+        ["QJ01AA02", "doxycycline"],
+        ["QJ01AA02", "doxycycline (again)"],
+      ]),
+    );
+    expect(plan.entries).toHaveLength(1);
+    expect(plan.entries[0].display).toBe("doxycycline");
+    expect(plan.skipped[0].reason).toBe("duplicate code in extract");
+  });
+
+  it("carries QI species down to the substance", () => {
+    const plan = planImport(
+      extract([
+        ["QI", "IMMUNOLOGICALS"],
+        ["QI07", "IMMUNOLOGICALS FOR CANIDAE"],
+        ["QI07A", "CANIDAE"],
+        ["QI07AA", "Inactivated viral vaccines"],
+        ["QI07AA01", "canine distemper vaccine"],
+      ]),
+    );
+    const substance = plan.entries.find((e) => e.code === "QI07AA01");
+    expect(substance?.species).toEqual(["SA"]);
+    // The QI root itself has no species: it covers every animal.
+    expect(plan.entries.find((e) => e.code === "QI")?.species).toEqual([]);
+  });
+});

--- a/apps/backend/test/services/atcvet.service.test.ts
+++ b/apps/backend/test/services/atcvet.service.test.ts
@@ -1,0 +1,151 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeEntry: { findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import {
+  ancestorCodesOf,
+  AtcvetService,
+  buildMedicationQuery,
+} from "src/services/atcvet.service";
+
+const queryRaw = prisma.$queryRaw as unknown as jest.Mock;
+const entryFind = (prisma as unknown as { codeEntry: { findMany: jest.Mock } })
+  .codeEntry.findMany;
+
+beforeEach(() => {
+  queryRaw.mockReset();
+  entryFind.mockReset();
+});
+
+describe("ancestorCodesOf", () => {
+  it("derives the four levels above a substance from the code itself", () => {
+    expect(ancestorCodesOf("QJ01AA02")).toEqual([
+      "QJ",
+      "QJ01",
+      "QJ01A",
+      "QJ01AA",
+    ]);
+  });
+
+  it("returns only the levels that exist above a group", () => {
+    expect(ancestorCodesOf("QJ01A")).toEqual(["QJ", "QJ01"]);
+    expect(ancestorCodesOf("QJ")).toEqual([]);
+  });
+});
+
+describe("buildMedicationQuery", () => {
+  const sqlFor = (params: Parameters<typeof buildMedicationQuery>[0]) => {
+    const statement = buildMedicationQuery(params);
+    return { text: statement.sql, values: statement.values };
+  };
+
+  it("searches substances only, never the grouping levels", () => {
+    const { text } = sqlFor({ q: "doxy" });
+    expect(text).toContain(`'MEDICATION'::"CodeType"`);
+    expect(text).not.toContain("MEDICATION_CATEGORY");
+  });
+
+  it("escapes LIKE wildcards so a lone % cannot match everything", () => {
+    const { values } = sqlFor({ q: "50%" });
+    expect(values).toContain("%50\\%%");
+  });
+
+  it("keeps species-agnostic substances in a species-filtered search", () => {
+    // Only immunologicals carry species. Excluding rows without species would
+    // hide doxycycline from a cat clinic's search.
+    const { text } = sqlFor({ q: "vac", species: "SA" });
+    expect(text).toContain("IS DISTINCT FROM 'array'");
+    expect(text).toContain("@>");
+  });
+
+  it("omits filters that were not asked for", () => {
+    const { text } = sqlFor({});
+    expect(text).not.toContain("atcGroup");
+    expect(text).not.toContain("ILIKE");
+  });
+
+  it("clamps the limit into range", () => {
+    expect(sqlFor({ limit: 500 }).values).toContain(50);
+    expect(sqlFor({ limit: 0 }).values).toContain(1);
+  });
+});
+
+describe("suggestMedications", () => {
+  it("attaches the ancestor path and flags in one batched lookup", async () => {
+    queryRaw.mockResolvedValue([
+      {
+        code: "QJ01AA02",
+        display: "doxycycline",
+        meta: { atcGroup: "QJ", antibacterial: true },
+      },
+      { code: "QJ01AA01", display: "demeclocycline", meta: { atcGroup: "QJ" } },
+    ]);
+    entryFind.mockResolvedValue([
+      { code: "QJ", display: "ANTIINFECTIVES FOR SYSTEMIC USE" },
+      { code: "QJ01", display: "ANTIBACTERIALS FOR SYSTEMIC USE" },
+      { code: "QJ01A", display: "TETRACYCLINES" },
+      { code: "QJ01AA", display: "Tetracyclines" },
+    ]);
+
+    const result = await AtcvetService.suggestMedications({ q: "cycline" });
+
+    // Two results sharing ancestors cost one ancestor query, not two.
+    expect(entryFind).toHaveBeenCalledTimes(1);
+    expect(entryFind.mock.calls[0][0].where.code.in).toEqual([
+      "QJ",
+      "QJ01",
+      "QJ01A",
+      "QJ01AA",
+    ]);
+    expect(result[0]).toEqual({
+      atcCode: "QJ01AA02",
+      label: "doxycycline",
+      path: [
+        { code: "QJ", label: "ANTIINFECTIVES FOR SYSTEMIC USE" },
+        { code: "QJ01", label: "ANTIBACTERIALS FOR SYSTEMIC USE" },
+        { code: "QJ01A", label: "TETRACYCLINES" },
+        { code: "QJ01AA", label: "Tetracyclines" },
+      ],
+      species: [],
+      antibacterial: true,
+    });
+    // The stewardship flag is a fact of the code, not of the search.
+    expect(result[1].antibacterial).toBe(false);
+  });
+
+  it("drops an ancestor that is missing rather than rendering a blank crumb", async () => {
+    queryRaw.mockResolvedValue([
+      { code: "QJ01AA02", display: "doxycycline", meta: {} },
+    ]);
+    entryFind.mockResolvedValue([{ code: "QJ", display: "ANTIINFECTIVES" }]);
+
+    const [result] = await AtcvetService.suggestMedications({ q: "doxy" });
+
+    expect(result.path).toEqual([{ code: "QJ", label: "ANTIINFECTIVES" }]);
+  });
+
+  it("surfaces species carried by immunologicals", async () => {
+    queryRaw.mockResolvedValue([
+      {
+        code: "QI07AA01",
+        display: "canine distemper vaccine",
+        meta: { species: ["SA"], atcGroup: "QI" },
+      },
+    ]);
+    entryFind.mockResolvedValue([]);
+
+    const [result] = await AtcvetService.suggestMedications({ q: "distemper" });
+
+    expect(result.species).toEqual(["SA"]);
+  });
+
+  it("makes no ancestor query for an empty page", async () => {
+    queryRaw.mockResolvedValue([]);
+    expect(await AtcvetService.suggestMedications({ q: "zzz" })).toEqual([]);
+    expect(entryFind).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -19,6 +19,9 @@ jest.mock("src/config/prisma", () => ({
     codeEntry: {
       findMany: jest.fn(),
     },
+    codeMapping: {
+      findMany: jest.fn(),
+    },
     $queryRaw: jest.fn(),
   },
 }));
@@ -27,6 +30,8 @@ describe("ClinicalTermsService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.READ_FROM_POSTGRES = "false";
+    // Default: no crosswalks. Tests that assert on them override this.
+    (prisma.codeMapping.findMany as jest.Mock).mockResolvedValue([]);
   });
 
   describe("parseConcepts", () => {
@@ -286,8 +291,70 @@ describe("ClinicalTermsService", () => {
           species: ["SA"],
           synonyms: ["Emesis", "Vomiting"],
           source: "VeNom",
+          codings: [],
         },
       ]);
+    });
+
+    it("attaches the strongest usable crosswalk per system in one batched query", async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+        { code: "YC-1", display: "Vomiting", synonyms: [], meta: {} },
+        { code: "YC-2", display: "Gastritis", synonyms: [], meta: {} },
+      ]);
+      (prisma.codeMapping.findMany as jest.Mock).mockResolvedValue([
+        {
+          sourceCode: "YC-1",
+          targetSystem: "VENOM",
+          targetCode: "weak",
+          targetDisplay: null,
+          equivalence: "INEXACT",
+        },
+        {
+          sourceCode: "YC-1",
+          targetSystem: "VENOM",
+          targetCode: "strong",
+          targetDisplay: "V",
+          equivalence: "EQUAL",
+        },
+        {
+          sourceCode: "YC-1",
+          targetSystem: "SNOMED",
+          targetCode: "s1",
+          targetDisplay: null,
+          equivalence: "NARROWER",
+        },
+      ]);
+
+      const result = await ClinicalTermsService.suggestTerms({ q: "v" });
+
+      // One query for the whole page, over the deduped code set.
+      expect(prisma.codeMapping.findMany).toHaveBeenCalledTimes(1);
+      const where = (prisma.codeMapping.findMany as jest.Mock).mock.calls[0][0]
+        .where;
+      expect(where.sourceCode).toEqual({ in: ["YC-1", "YC-2"] });
+      expect(where.active).toBe(true);
+      // The export's usable-equivalence gate is applied here too, so the picker
+      // never advertises a crosswalk the export would refuse to emit.
+      expect(where.equivalence.in).not.toContain("UNMATCHED");
+      expect(where.equivalence.in).not.toContain("DISJOINT");
+
+      expect(result[0].codings).toEqual([
+        { system: "VENOM", code: "strong", display: "V", equivalence: "EQUAL" },
+        {
+          system: "SNOMED",
+          code: "s1",
+          display: undefined,
+          equivalence: "NARROWER",
+        },
+      ]);
+      // A term with no mapping rows carries an empty list, never undefined.
+      expect(result[1].codings).toEqual([]);
+    });
+
+    it("makes no crosswalk query when the page is empty", async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([]);
+      await ClinicalTermsService.suggestTerms({ q: "zzz" });
+      expect(prisma.codeMapping.findMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
+++ b/apps/backend/test/services/fhir-clinical-artifact.mapper.test.ts
@@ -164,6 +164,48 @@ describe("clinicalArtifactFhirMapper", () => {
     expect(input.assessment).toEqual({ diagnosis: "Flu" });
   });
 
+  it("exports the ATCvet coding a coded prescription line carries", () => {
+    // The mapper previously hardcoded a 'PRESCRIPTION' concept, so a coded
+    // prescription left the system uncoded no matter what the client sent.
+    const coded = {
+      ...prescriptionRecord,
+      prescription: {
+        ...prescriptionRecord.prescription,
+        medications: [
+          {
+            medication: "doxycycline",
+            metadata: { atcCode: "QJ01AA02" },
+          },
+        ],
+      },
+    };
+
+    const resource =
+      clinicalArtifactFhirMapper.prescriptionToMedicationRequest(coded);
+
+    expect(resource.medicationCodeableConcept?.coding).toEqual([
+      {
+        system: "http://www.whocc.no/atcvet",
+        code: "QJ01AA02",
+        display: "doxycycline",
+      },
+    ]);
+    expect(resource.medicationCodeableConcept?.text).toBe("doxycycline");
+  });
+
+  it("keeps the generic concept when no line carries a code", () => {
+    const resource =
+      clinicalArtifactFhirMapper.prescriptionToMedicationRequest(
+        prescriptionRecord,
+      );
+    // An uncoded prescription must not gain an invented coding.
+    expect(
+      resource.medicationCodeableConcept?.coding?.some(
+        (coding) => coding.system === "http://www.whocc.no/atcvet",
+      ),
+    ).toBeFalsy();
+  });
+
   it("maps prescriptions to and from MedicationRequest", () => {
     const resource =
       clinicalArtifactFhirMapper.prescriptionToMedicationRequest(

--- a/apps/frontend/sonar-project.properties
+++ b/apps/frontend/sonar-project.properties
@@ -35,7 +35,7 @@ sonar.cpd.exclusions=src/app/features/legal/pages/content/**,src/app/features/fo
 # ModalBase intentionally keeps a mounted div with role="dialog" for CSS close transitions.
 # Native <dialog> hides with display:none when closed, breaking opacity/transform animations.
 # NOSONAR in JSX is unreliable for this rule — suppress via multicriteria instead.
-sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria=e1,e2,fhirSystemUri
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6819
 sonar.issue.ignore.multicriteria.e1.resourceKey=src/app/ui/overlays/Modal/ModalBase.tsx
 
@@ -46,6 +46,16 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=src/app/ui/overlays/Modal/ModalB
 # everywhere else.
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7780
 sonar.issue.ignore.multicriteria.e2.resourceKey=src/middleware.ts
+
+# S5332 ("use https instead") reads every http:// literal as an address. A
+# terminology system URI is an identifier, not an address: WHO CC fixes ATCvet's
+# system as the exact string "http://www.whocc.no/atcvet" (as FHIR fixes SNOMED
+# CT's as "http://snomed.info/sct"), nothing ever dereferences it, and writing
+# https there produces a Coding no terminology server will match. The backend
+# project carries the same scoped ignore for the file that declares its copies.
+# Scoped to the one file so a genuine http:// call elsewhere still fails the gate.
+sonar.issue.ignore.multicriteria.fhirSystemUri.ruleKey=typescript:S5332
+sonar.issue.ignore.multicriteria.fhirSystemUri.resourceKey=**/workspaceClinicalService.ts
 
 # Ignore non-relevant languages
 sonar.c.file.suffixes=-

--- a/apps/frontend/src/app/__tests__/features/appointments/lib/inventoryPrescription.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/lib/inventoryPrescription.test.ts
@@ -53,6 +53,18 @@ describe('inventoryToPrescriptionItem', () => {
     expect(result.priceCents).toBe(6000);
   });
 
+  it('carries the stock item ATCvet code onto the prescription line', () => {
+    // Prescribing from the practice's own catalogue must be coded exactly as
+    // picking the substance from the classification would be; without this the
+    // backfill's work never reaches a prescription.
+    const result = inventoryToPrescriptionItem(buildInventoryItem({ atcCode: 'QJ01AA02' }));
+    expect(result.atcCode).toBe('QJ01AA02');
+  });
+
+  it('leaves the code absent for stock that was never matched', () => {
+    expect(inventoryToPrescriptionItem(buildInventoryItem()).atcCode).toBeUndefined();
+  });
+
   it('leaves controlled/prescription flags undefined when not set', () => {
     const item = buildInventoryItem({
       classification: { strength: '5', unitofMeasure: 'mL', form: 'Liquid' },

--- a/apps/frontend/src/app/__tests__/lib/parseSoapCodedProblems.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/parseSoapCodedProblems.test.ts
@@ -54,6 +54,37 @@ describe('parseSoapCodedProblems', () => {
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
+  it('keeps valid codings, drops malformed ones, and caps them per term', () => {
+    const parsed = parseSoapCodedProblems({
+      plan: [
+        {
+          ycCode: 'YC-1',
+          label: 'Dental scale',
+          codings: [
+            { system: 'VENOM', code: '891', equivalence: 'EQUIVALENT' },
+            { system: 'SNOMED', code: '' },
+            { system: '', code: '123' },
+            'not-an-object',
+            null,
+            ...Array.from({ length: 12 }, (_, i) => ({ system: 'X', code: `c${i}` })),
+          ],
+        },
+      ],
+    });
+    const codings = parsed?.plan?.[0].codings ?? [];
+    expect(codings).toHaveLength(8);
+    expect(codings[0]).toEqual({ system: 'VENOM', code: '891', equivalence: 'EQUIVALENT' });
+    // A coding without an equivalence keeps the key absent rather than undefined.
+    expect(codings[1]).toEqual({ system: 'X', code: 'c0' });
+  });
+
+  it('omits codings entirely when none are valid', () => {
+    const parsed = parseSoapCodedProblems({
+      plan: [{ ycCode: 'YC-1', label: 'L', codings: ['junk'] }],
+    });
+    expect(parsed?.plan?.[0]).not.toHaveProperty('codings');
+  });
+
   it('caps a section at 50 terms', () => {
     const flood = Array.from({ length: 80 }, (_, index) => ({
       ycCode: `YC-${index}`,

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
@@ -63,7 +63,7 @@ describe('PrescriptionEditor ATCvet substances', () => {
     renderEditor();
     type('doxy');
 
-    expect(suggestMock).toHaveBeenCalledWith({ q: 'doxy', limit: 5 });
+    expect(suggestMock).toHaveBeenCalledWith({ q: 'doxy', limit: 10 });
     await waitFor(() => expect(screen.getByText('doxycycline')).toBeInTheDocument());
     // The path is what makes the substance interpretable at a glance.
     expect(
@@ -102,6 +102,20 @@ describe('PrescriptionEditor ATCvet substances', () => {
       jest.advanceTimersByTime(10);
     });
 
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+  });
+
+  it('drops the previous page as soon as the query changes', async () => {
+    renderEditor();
+    type('doxy');
+    await waitFor(() => expect(screen.getByText('doxycycline')).toBeInTheDocument());
+
+    // A new query must not leave the old substances on screen while it debounces.
+    suggestMock.mockResolvedValue([{ ...DOXY, atcCode: 'QJ01AA01', label: 'demeclocycline' }]);
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: /Search medicines or prescription templates/i }),
+      { target: { value: 'demec' } }
+    );
     expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PrescriptionEditor from '@/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor';
+import { suggestMedications } from '@/app/features/appointments/services/clinicalTermsService';
+
+jest.mock('@/app/features/appointments/services/clinicalTermsService', () => ({
+  suggestMedications: jest.fn(),
+}));
+
+const suggestMock = suggestMedications as jest.Mock;
+
+const DOXY = {
+  atcCode: 'QJ01AA02',
+  label: 'doxycycline',
+  path: [
+    { code: 'QJ', label: 'ANTIINFECTIVES FOR SYSTEMIC USE' },
+    { code: 'QJ01', label: 'ANTIBACTERIALS FOR SYSTEMIC USE' },
+    { code: 'QJ01A', label: 'TETRACYCLINES' },
+    { code: 'QJ01AA', label: 'Tetracyclines' },
+  ],
+  species: [],
+  antibacterial: true,
+};
+
+const onAddItem = jest.fn();
+
+const renderEditor = (readOnly = false) =>
+  render(
+    <PrescriptionEditor
+      items={[]}
+      catalogItems={[]}
+      templateItems={[]}
+      readOnly={readOnly}
+      onAddItem={onAddItem}
+      onUpdateItem={jest.fn()}
+      onRemoveItem={jest.fn()}
+      onPrint={jest.fn()}
+    />
+  );
+
+const type = (value: string) => {
+  fireEvent.change(
+    screen.getByRole('searchbox', { name: /Search medicines or prescription templates/i }),
+    { target: { value } }
+  );
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+};
+
+describe('PrescriptionEditor ATCvet substances', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    suggestMock.mockReset();
+    suggestMock.mockResolvedValue([DOXY]);
+    onAddItem.mockClear();
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it('offers substances with their class path and flags antibacterials', async () => {
+    renderEditor();
+    type('doxy');
+
+    expect(suggestMock).toHaveBeenCalledWith({ q: 'doxy', limit: 5 });
+    await waitFor(() => expect(screen.getByText('doxycycline')).toBeInTheDocument());
+    // The path is what makes the substance interpretable at a glance.
+    expect(
+      screen.getByText(/QJ01AA02 · ANTIBACTERIALS FOR SYSTEMIC USE · TETRACYCLINES/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Antibacterial')).toBeInTheDocument();
+  });
+
+  it('prescribes a picked substance as prescription-only with its code', async () => {
+    renderEditor();
+    type('doxy');
+    await waitFor(() => expect(screen.getByText('doxycycline')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('doxycycline'));
+
+    expect(onAddItem).toHaveBeenCalledWith({
+      medicineName: 'doxycycline',
+      atcCode: 'QJ01AA02',
+      // Not stock, so it cannot be dispensed in-house.
+      fulfillment: 'PRESCRIPTION_ONLY',
+    });
+  });
+
+  it('does not search below the minimum length', () => {
+    renderEditor();
+    type('do');
+    expect(suggestMock).not.toHaveBeenCalled();
+  });
+
+  it('never searches in read-only mode', () => {
+    renderEditor(true);
+    // The search box itself is hidden when read-only, so nothing can be typed.
+    expect(
+      screen.queryByRole('searchbox', {
+        name: /Search medicines or prescription templates/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(suggestMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale response that lands after a newer query', async () => {
+    let resolveFirst: (items: unknown[]) => void = () => {};
+    suggestMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    suggestMock.mockResolvedValueOnce([{ ...DOXY, atcCode: 'QJ01AA01', label: 'demeclocycline' }]);
+
+    renderEditor();
+    type('doxy');
+    type('demec');
+    await waitFor(() => expect(screen.getByText('demeclocycline')).toBeInTheDocument());
+
+    await act(async () => {
+      resolveFirst([DOXY]);
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+  });
+
+  it('clears results and logs when the lookup fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    suggestMock.mockRejectedValueOnce(new Error('offline'));
+
+    renderEditor();
+    type('doxy');
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
@@ -25,7 +25,10 @@ const DOXY = {
 
 const onAddItem = jest.fn();
 
-const renderEditor = (readOnly = false) =>
+const renderEditor = (
+  readOnly = false,
+  extra: Partial<React.ComponentProps<typeof PrescriptionEditor>> = {}
+) =>
   render(
     <PrescriptionEditor
       items={[]}
@@ -36,6 +39,7 @@ const renderEditor = (readOnly = false) =>
       onUpdateItem={jest.fn()}
       onRemoveItem={jest.fn()}
       onPrint={jest.fn()}
+      {...extra}
     />
   );
 
@@ -87,6 +91,33 @@ describe('PrescriptionEditor ATCvet substances', () => {
     });
   });
 
+  it('keeps the newer page when an older request completes last', async () => {
+    // A resolves after B. Without a cancellation guard A republishes under its own
+    // query, and the render guard then hides B's valid results as well.
+    let resolveFirst: (items: unknown[]) => void = () => {};
+    suggestMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    suggestMock.mockResolvedValueOnce([{ ...DOXY, atcCode: 'QJ01AA01', label: 'demeclocycline' }]);
+
+    renderEditor();
+    type('doxy');
+    type('demec');
+    await waitFor(() => expect(screen.getByText('demeclocycline')).toBeInTheDocument());
+
+    await act(async () => {
+      resolveFirst([DOXY]);
+      await Promise.resolve();
+    });
+
+    // B's page survives; A's late completion is discarded entirely.
+    expect(screen.getByText('demeclocycline')).toBeInTheDocument();
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+  });
+
   it('clears results immediately when the query drops below the minimum', async () => {
     renderEditor();
     type('doxy');
@@ -119,6 +150,71 @@ describe('PrescriptionEditor ATCvet substances', () => {
     expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
   });
 
+  it('passes the patient species so other species vaccines are not offered', async () => {
+    renderEditor(false, { companionSpecies: 'SA' });
+    // Flushed inside act: the lookup resolves and publishes a page, and an
+    // unflushed update lands after the test and fails the suite on a warning.
+    await act(async () => {
+      type('vacc');
+      await Promise.resolve();
+    });
+    expect(suggestMock).toHaveBeenCalledWith({ q: 'vacc', limit: 10, species: 'SA' });
+  });
+
+  it('omits the species filter when the patient species is unknown', async () => {
+    renderEditor();
+    await act(async () => {
+      type('vacc');
+      await Promise.resolve();
+    });
+    expect(suggestMock).toHaveBeenCalledWith({ q: 'vacc', limit: 10 });
+  });
+
+  it('locks fulfillment on a classification-only line, but not on stock', () => {
+    const { unmount } = renderEditor(false, {
+      items: [
+        {
+          id: 'p1',
+          medicineName: 'doxycycline',
+          atcCode: 'QJ01AA02',
+          fulfillment: 'PRESCRIPTION_ONLY',
+        },
+      ],
+    });
+    // Nothing to dispense against, so in-house must not be selectable.
+    expect(screen.getByLabelText('Fulfillment')).toBeDisabled();
+    unmount();
+
+    renderEditor(false, {
+      items: [
+        {
+          id: 'p2',
+          medicineName: 'doxycycline',
+          atcCode: 'QJ01AA02',
+          sku: 'DOX-1',
+          fulfillment: 'IN_HOUSE',
+        },
+      ],
+    });
+    // Same code, but backed by real stock: the clinician keeps the choice.
+    expect(screen.getByLabelText('Fulfillment')).not.toBeDisabled();
+  });
+
+  it('clears results and logs when the lookup fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    suggestMock.mockRejectedValueOnce(new Error('offline'));
+
+    renderEditor();
+    await act(async () => {
+      type('doxy');
+      await Promise.resolve();
+    });
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+    errorSpy.mockRestore();
+  });
+
   it('does not search below the minimum length', () => {
     renderEditor();
     type('do');
@@ -134,39 +230,5 @@ describe('PrescriptionEditor ATCvet substances', () => {
       })
     ).not.toBeInTheDocument();
     expect(suggestMock).not.toHaveBeenCalled();
-  });
-
-  it('ignores a stale response that lands after a newer query', async () => {
-    let resolveFirst: (items: unknown[]) => void = () => {};
-    suggestMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirst = resolve;
-        })
-    );
-    suggestMock.mockResolvedValueOnce([{ ...DOXY, atcCode: 'QJ01AA01', label: 'demeclocycline' }]);
-
-    renderEditor();
-    type('doxy');
-    type('demec');
-    await waitFor(() => expect(screen.getByText('demeclocycline')).toBeInTheDocument());
-
-    await act(async () => {
-      resolveFirst([DOXY]);
-      await Promise.resolve();
-    });
-    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
-  });
-
-  it('clears results and logs when the lookup fails', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    suggestMock.mockRejectedValueOnce(new Error('offline'));
-
-    renderEditor();
-    type('doxy');
-
-    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
-    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
-    errorSpy.mockRestore();
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PrescriptionEditorAtcvet.test.tsx
@@ -87,6 +87,24 @@ describe('PrescriptionEditor ATCvet substances', () => {
     });
   });
 
+  it('clears results immediately when the query drops below the minimum', async () => {
+    renderEditor();
+    type('doxy');
+    await waitFor(() => expect(screen.getByText('doxycycline')).toBeInTheDocument());
+
+    // Deleting back to a too-short query must not leave a stale substance on
+    // screen for the length of the debounce.
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: /Search medicines or prescription templates/i }),
+      { target: { value: 'do' } }
+    );
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+
+    expect(screen.queryByText('doxycycline')).not.toBeInTheDocument();
+  });
+
   it('does not search below the minimum length', () => {
     renderEditor();
     type('do');

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
@@ -90,6 +90,77 @@ describe('SoapCodedTermPicker', () => {
     expect(onChange).toHaveBeenCalledWith([{ ycCode: 'YC-001111', label: 'Diarrhoea' }]);
   });
 
+  it('shows each vocabulary crosswalk in the dropdown and carries them onto the pick', async () => {
+    const onChange = jest.fn();
+    suggestMock.mockResolvedValue([
+      {
+        ...VOMITING,
+        codings: [
+          { system: 'VENOM', code: '21868', equivalence: 'EQUIVALENT' },
+          { system: 'SNOMED', code: '422400008', equivalence: 'NARROWER' },
+        ],
+      },
+    ]);
+    render(<SoapCodedTermPicker sectionLabel="Subjective" selected={[]} onChange={onChange} />);
+
+    typeQuery('vom');
+    // The row states both crosswalks, and marks the inexact one as narrower so a
+    // broader/narrower match is never read as the same concept.
+    await waitFor(() => expect(screen.getByText(/VeNom 21868/)).toBeInTheDocument());
+    expect(screen.getByText(/SNOMED 422400008 \(narrower\)/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Vomiting'));
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        ycCode: 'YC-005423',
+        codings: [
+          { system: 'VENOM', code: '21868', equivalence: 'EQUIVALENT' },
+          { system: 'SNOMED', code: '422400008', equivalence: 'NARROWER' },
+        ],
+      }),
+    ]);
+  });
+
+  it('falls back to the raw system name for an unknown vocabulary', () => {
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Plan"
+        selected={[{ ycCode: 'YC-1', label: 'X', codings: [{ system: 'LOINC', code: '1234-5' }] }]}
+        onChange={jest.fn()}
+      />
+    );
+    // No short label is known for LOINC, so the system name is shown verbatim
+    // rather than dropped — an unlabelled code is worse than an unstyled one.
+    expect(screen.getByText('LOINC 1234-5')).toBeInTheDocument();
+  });
+
+  it('renders crosswalk badges on a selected chip', () => {
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Assessment"
+        selected={[
+          {
+            ycCode: 'YC-1',
+            label: 'Gastritis',
+            codings: [{ system: 'VENOM', code: '891', equivalence: 'EQUIVALENT' }],
+          },
+        ]}
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByText('VeNom 891')).toBeInTheDocument();
+  });
+
+  it('omits the codings key entirely for an unmapped term', async () => {
+    const onChange = jest.fn();
+    suggestMock.mockResolvedValue([{ ...VOMITING, codings: [] }]);
+    render(<SoapCodedTermPicker sectionLabel="Subjective" selected={[]} onChange={onChange} />);
+    typeQuery('vom');
+    await waitFor(() => expect(screen.getByText('Vomiting')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Vomiting'));
+    expect(onChange.mock.calls[0][0][0]).not.toHaveProperty('codings');
+  });
+
   it('does not query below the minimum length', () => {
     render(<SoapCodedTermPicker sectionLabel="Plan" selected={[]} onChange={jest.fn()} />);
     typeQuery('v');

--- a/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
@@ -652,6 +652,38 @@ describe('workspaceClinicalService', () => {
     expect(summary.dischargeSavedByName).not.toBe('user-1');
   });
 
+  it('emits an ATCvet coding on a coded prescription and none on an uncoded one', async () => {
+    postDataMock.mockResolvedValue({ data: { resourceType: 'MedicationRequest', id: 'rx-1' } });
+
+    const base = {
+      medicineName: 'doxycycline',
+      fulfillment: 'PRESCRIPTION_ONLY' as const,
+    };
+    await savePrescriptionArtifact(
+      { organisationId: 'org-1', appointmentId: 'appt-1' },
+      { ...base, atcCode: 'QJ01AA02' }
+    );
+    const [, coded] = postDataMock.mock.calls[0] as [
+      string,
+      { medicationCodeableConcept?: { text?: string; coding?: Array<Record<string, string>> } },
+    ];
+    expect(coded.medicationCodeableConcept?.coding).toEqual([
+      {
+        system: 'http://www.whocc.no/atcvet',
+        code: 'QJ01AA02',
+        display: 'doxycycline',
+      },
+    ]);
+
+    // An uncoded prescription carries text only rather than a placeholder coding.
+    await savePrescriptionArtifact({ organisationId: 'org-1', appointmentId: 'appt-1' }, base);
+    const [, uncoded] = postDataMock.mock.calls[1] as [
+      string,
+      { medicationCodeableConcept?: { coding?: unknown } },
+    ];
+    expect(uncoded.medicationCodeableConcept?.coding).toBeUndefined();
+  });
+
   it('saves prescriptions as a FHIR MedicationRequest with appointment context', async () => {
     postDataMock.mockResolvedValueOnce({
       data: { resourceType: 'MedicationRequest', id: 'rx-1' },

--- a/apps/frontend/src/app/features/appointments/lib/inventoryPrescription.ts
+++ b/apps/frontend/src/app/features/appointments/lib/inventoryPrescription.ts
@@ -75,6 +75,9 @@ export const backfillPrescriptionFromInventory = (
     ...item,
     brand: fill(item.brand, fromInv.brand),
     genericName: fill(item.genericName, fromInv.genericName),
+    // The stock item's ATCvet code, so prescribing from the practice's own
+    // catalogue is coded exactly as picking the substance directly would be.
+    atcCode: fill(item.atcCode, fromInv.atcCode),
     sku: fill(item.sku, fromInv.sku),
     strength: fill(item.strength, fromInv.strength),
     strengthUnit: fill(item.strengthUnit, fromInv.strengthUnit),
@@ -211,6 +214,7 @@ export const inventoryToPrescriptionItem = (item: InventoryItem): Omit<Prescript
     medicineName: basicInfo.name,
     brand: cleanString(basicInfo.brand ?? classification.brand),
     genericName: cleanString(classification.genericName),
+    atcCode: cleanString(item.atcCode),
     sku: cleanString(item.sku),
     strength,
     strengthUnit,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -41,6 +41,12 @@ type PrescriptionEditorProps = {
   catalogItems?: Omit<PrescriptionItem, 'id'>[];
   templateItems?: PrescriptionTemplateOption[];
   readOnly: boolean;
+  /**
+   * Patient species, forwarded to the ATCvet search. Immunologicals are the only
+   * species-specific codes, so this keeps a small-animal patient from being
+   * offered farm or avian vaccines; every general substance still appears.
+   */
+  companionSpecies?: string;
   deleteLocked?: boolean;
   onAddItem: (item: Omit<PrescriptionItem, 'id'>) => void;
   onApplyTemplate?: (template: PrescriptionTemplateOption) => void;
@@ -79,6 +85,13 @@ const toOptions = (values: string[], current?: string): DropdownOption[] => {
   const merged = trimmed && !values.includes(trimmed) ? [trimmed, ...values] : values;
   return merged.map((value) => ({ label: value, value }));
 };
+
+/**
+ * A line that came from the ATCvet classification rather than the practice's own
+ * stock: coded, but with nothing to dispense against.
+ */
+const isClassificationOnly = (item: PrescriptionItem) =>
+  Boolean(item.atcCode) && !item.inventoryItemId && !item.sku;
 
 /**
  * Compact fulfillment pill dropdown (In-house fulfilled / Prescription only),
@@ -278,7 +291,11 @@ const PrescriptionRow = ({
           )}
           <FulfillmentDropdown
             value={item.fulfillment}
-            disabled={rowReadOnly}
+            // A line picked from the classification has no inventory item, SKU or
+            // batch behind it, so "in-house" would finalize into a dispense request
+            // against stock that does not exist. Such a line stays prescription-only
+            // until it is linked to real stock.
+            disabled={rowReadOnly || isClassificationOnly(item)}
             onChange={(fulfillment) => onUpdateItem(item.id, { fulfillment })}
           />
           {isBilled ? null : (
@@ -410,7 +427,7 @@ const ATCVET_LIMIT = 10;
  * smaller page than the inventory match: this is the fallback below the
  * practice's own catalogue, not the primary way to prescribe.
  */
-const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
+const useAtcvetSuggestions = (query: string, readOnly: boolean, species?: string) => {
   // Results are stored WITH the query that produced them, and rendered only
   // while that query is still what is typed. That makes both staleness rules
   // structural rather than bookkeeping: a page for an older query is never
@@ -427,16 +444,32 @@ const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
 
   useEffect(() => {
     if (skip) return;
+    // Cancelled on cleanup so a request whose query has already been superseded
+    // cannot publish its page. Keying the page by query alone was not enough: a
+    // slow earlier request completing last would overwrite the newer page, and
+    // the render guard would then hide BOTH - the older page for not matching,
+    // and the newer one because it had been replaced.
+    let cancelled = false;
+    const publish = (items: MedicationSuggestion[]) => {
+      if (!cancelled) setPage({ query: trimmed, items });
+    };
     const timer = setTimeout(() => {
-      suggestMedications({ q: trimmed, limit: ATCVET_LIMIT })
-        .then((items) => setPage({ query: trimmed, items }))
+      suggestMedications({
+        q: trimmed,
+        limit: ATCVET_LIMIT,
+        ...(species ? { species } : {}),
+      })
+        .then(publish)
         .catch((error) => {
           console.error('Unable to suggest medications:', error);
-          setPage({ query: trimmed, items: [] });
+          publish([]);
         });
     }, ATCVET_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [trimmed, skip]);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [trimmed, skip, species]);
 
   return skip || page.query !== trimmed ? EMPTY_SUGGESTIONS : page.items;
 };
@@ -447,6 +480,7 @@ const PrescriptionEditor = ({
   templateItems = EMPTY_TEMPLATE_ITEMS,
   readOnly,
   deleteLocked = readOnly,
+  companionSpecies,
   onAddItem,
   onApplyTemplate,
   onUpdateItem,
@@ -455,7 +489,7 @@ const PrescriptionEditor = ({
 }: PrescriptionEditorProps) => {
   const [search, setSearch] = useState('');
   const searchRef = React.useRef<HTMLDivElement>(null);
-  const substances = useAtcvetSuggestions(search, readOnly);
+  const substances = useAtcvetSuggestions(search, readOnly, companionSpecies);
 
   const matches = useMemo(() => {
     const query = search.trim().toLowerCase();

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   IoChevronDownOutline,
   IoCopyOutline,
@@ -11,6 +11,10 @@ import SearchResultsDropdown from '@/app/features/appointments/pages/Appointment
 import WorkspaceSearchResultRow from '@/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceSearchResultRow';
 import SectionContainer from '@/app/ui/primitives/SectionContainer/SectionContainer';
 import Search from '@/app/ui/inputs/Search';
+import {
+  suggestMedications,
+  type MedicationSuggestion,
+} from '@/app/features/appointments/services/clinicalTermsService';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import type { DropdownOption } from '@/app/hooks/useDropdown';
@@ -391,6 +395,47 @@ const PrescriptionRow = ({
   );
 };
 
+const ATCVET_MIN_QUERY = 3;
+const ATCVET_DEBOUNCE_MS = 250;
+const ATCVET_LIMIT = 5;
+
+/**
+ * ATCvet substances for the medicine search box, so a clinician can prescribe a
+ * substance the practice does not stock. Deliberately a longer minimum and a
+ * smaller page than the inventory match: this is the fallback below the
+ * practice's own catalogue, not the primary way to prescribe.
+ */
+const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
+  const [items, setItems] = useState<MedicationSuggestion[]>([]);
+  const requestSeq = React.useRef(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    const requestId = requestSeq.current + 1;
+    requestSeq.current = requestId;
+    const timer = setTimeout(
+      () => {
+        if (readOnly || trimmed.length < ATCVET_MIN_QUERY) {
+          setItems([]);
+          return;
+        }
+        suggestMedications({ q: trimmed, limit: ATCVET_LIMIT })
+          .then((results) => {
+            if (requestSeq.current === requestId) setItems(results);
+          })
+          .catch((error) => {
+            console.error('Unable to suggest medications:', error);
+            if (requestSeq.current === requestId) setItems([]);
+          });
+      },
+      readOnly || query.trim().length < ATCVET_MIN_QUERY ? 0 : ATCVET_DEBOUNCE_MS
+    );
+    return () => clearTimeout(timer);
+  }, [query, readOnly]);
+
+  return items;
+};
+
 const PrescriptionEditor = ({
   items,
   catalogItems = EMPTY_CATALOG_ITEMS,
@@ -405,6 +450,7 @@ const PrescriptionEditor = ({
 }: PrescriptionEditorProps) => {
   const [search, setSearch] = useState('');
   const searchRef = React.useRef<HTMLDivElement>(null);
+  const substances = useAtcvetSuggestions(search, readOnly);
 
   const matches = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -424,7 +470,8 @@ const PrescriptionEditor = ({
     return templateItems.filter((template) => template.name.toLowerCase().includes(query));
   }, [search, templateItems]);
 
-  const hasSearchMatches = matches.length > 0 || templateMatches.length > 0;
+  const hasSearchMatches =
+    matches.length > 0 || templateMatches.length > 0 || substances.length > 0;
 
   return (
     <div className="flex flex-col gap-3">
@@ -481,6 +528,41 @@ const PrescriptionEditor = ({
                     }
                     onSelect={() => {
                       onAddItem(item);
+                      setSearch('');
+                    }}
+                  />
+                ))}
+                {substances.map((substance) => (
+                  <WorkspaceSearchResultRow
+                    key={substance.atcCode}
+                    name={substance.label}
+                    badge={
+                      <span className="rounded-2xl bg-neutral-100 px-2 py-0.5 text-caption-2 font-medium text-text-secondary">
+                        ATCvet
+                      </span>
+                    }
+                    // The class path is what makes a substance interpretable:
+                    // "doxycycline" alone does not say systemic antibacterial.
+                    origin={[
+                      substance.atcCode,
+                      ...substance.path.slice(1).map((level) => level.label),
+                    ].join(' · ')}
+                    meta={
+                      substance.antibacterial ? (
+                        <span className="rounded-2xl bg-warning-100 px-2 py-0.5 text-caption-2 font-medium text-text-secondary">
+                          Antibacterial
+                        </span>
+                      ) : undefined
+                    }
+                    onSelect={() => {
+                      onAddItem({
+                        medicineName: substance.label,
+                        atcCode: substance.atcCode,
+                        // A substance picked from the classification is not
+                        // stock, so it cannot be dispensed in-house: it is
+                        // written for the owner to have filled elsewhere.
+                        fulfillment: 'PRESCRIPTION_ONLY',
+                      });
                       setSearch('');
                     }}
                   />

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -395,9 +395,14 @@ const PrescriptionRow = ({
   );
 };
 
+/** Stable empty array, so an unchanged "no results" does not re-render consumers. */
+const EMPTY_SUGGESTIONS: MedicationSuggestion[] = [];
+
 const ATCVET_MIN_QUERY = 3;
 const ATCVET_DEBOUNCE_MS = 250;
-const ATCVET_LIMIT = 5;
+// Enough to show a substance's several therapeutic codes (ibuprofen has three)
+// without the classification burying the practice's own catalogue above it.
+const ATCVET_LIMIT = 10;
 
 /**
  * ATCvet substances for the medicine search box, so a clinician can prescribe a
@@ -406,36 +411,34 @@ const ATCVET_LIMIT = 5;
  * practice's own catalogue, not the primary way to prescribe.
  */
 const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
-  const [items, setItems] = useState<MedicationSuggestion[]>([]);
-  const requestSeq = React.useRef(0);
+  // Results are stored WITH the query that produced them, and rendered only
+  // while that query is still what is typed. That makes both staleness rules
+  // structural rather than bookkeeping: a page for an older query is never
+  // shown, whether it arrives late or is simply left over from the last
+  // keystroke - and nothing has to be cleared synchronously as the query
+  // changes, which React forbids inside an effect.
+  const [page, setPage] = useState<{ query: string; items: MedicationSuggestion[] }>({
+    query: '',
+    items: [],
+  });
+
+  const trimmed = query.trim();
+  const skip = readOnly || trimmed.length < ATCVET_MIN_QUERY;
 
   useEffect(() => {
-    const trimmed = query.trim();
-    const skip = readOnly || trimmed.length < ATCVET_MIN_QUERY;
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    const timer = setTimeout(
-      () => {
-        if (skip) {
-          setItems([]);
-          return;
-        }
-        suggestMedications({ q: trimmed, limit: ATCVET_LIMIT })
-          .then((results) => {
-            if (requestSeq.current === requestId) setItems(results);
-          })
-          .catch((error) => {
-            console.error('Unable to suggest medications:', error);
-            if (requestSeq.current === requestId) setItems([]);
-          });
-      },
-      // Clearing is immediate; only a real lookup waits out the debounce.
-      skip ? 0 : ATCVET_DEBOUNCE_MS
-    );
+    if (skip) return;
+    const timer = setTimeout(() => {
+      suggestMedications({ q: trimmed, limit: ATCVET_LIMIT })
+        .then((items) => setPage({ query: trimmed, items }))
+        .catch((error) => {
+          console.error('Unable to suggest medications:', error);
+          setPage({ query: trimmed, items: [] });
+        });
+    }, ATCVET_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [query, readOnly]);
+  }, [trimmed, skip]);
 
-  return items;
+  return skip || page.query !== trimmed ? EMPTY_SUGGESTIONS : page.items;
 };
 
 const PrescriptionEditor = ({

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -411,11 +411,12 @@ const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
 
   useEffect(() => {
     const trimmed = query.trim();
+    const skip = readOnly || trimmed.length < ATCVET_MIN_QUERY;
     const requestId = requestSeq.current + 1;
     requestSeq.current = requestId;
     const timer = setTimeout(
       () => {
-        if (readOnly || trimmed.length < ATCVET_MIN_QUERY) {
+        if (skip) {
           setItems([]);
           return;
         }
@@ -428,7 +429,8 @@ const useAtcvetSuggestions = (query: string, readOnly: boolean) => {
             if (requestSeq.current === requestId) setItems([]);
           });
       },
-      readOnly || query.trim().length < ATCVET_MIN_QUERY ? 0 : ATCVET_DEBOUNCE_MS
+      // Clearing is immediate; only a real lookup waits out the debounce.
+      skip ? 0 : ATCVET_DEBOUNCE_MS
     );
     return () => clearTimeout(timer);
   }, [query, readOnly]);

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
@@ -10,6 +10,45 @@ import {
   type ClinicalTermSuggestion,
 } from '@/app/features/appointments/services/clinicalTermsService';
 
+/** Short vocabulary labels; the picker has no room for full system URIs. */
+const SYSTEM_LABEL: Record<string, string> = {
+  VENOM: 'VeNom',
+  SNOMED: 'SNOMED',
+  IDEXX: 'IDEXX',
+  YOSEMITECODE: 'YC',
+};
+
+/**
+ * An equivalence that is not exact is stated, never hidden: a vet reading
+ * "SNOMED 422400008" should know at a glance whether that is the same concept
+ * or a broader/narrower one.
+ */
+const INEXACT_EQUIVALENCES = new Set([
+  'NARROWER',
+  'SPECIALIZES',
+  'WIDER',
+  'SUBSUMES',
+  'RELATEDTO',
+  'INEXACT',
+]);
+
+const codingLabel = (coding: { system: string; code: string; equivalence?: string }) => {
+  const system = SYSTEM_LABEL[coding.system] ?? coding.system;
+  const qualifier =
+    coding.equivalence && INEXACT_EQUIVALENCES.has(coding.equivalence.toUpperCase())
+      ? ` (${coding.equivalence.toLowerCase()})`
+      : '';
+  return `${system} ${coding.code}${qualifier}`;
+};
+
+/** YC code, then each vocabulary crosswalk, then the synonym that matched. */
+const buildOrigin = (suggestion: ClinicalTermSuggestion, synonym: string | undefined): string => {
+  const parts: string[] = [suggestion.ycCode];
+  for (const coding of suggestion.codings ?? []) parts.push(codingLabel(coding));
+  if (synonym) parts.push(`matches “${synonym}”`);
+  return parts.join(' · ');
+};
+
 const MIN_QUERY_LENGTH = 2;
 const SUGGEST_DEBOUNCE_MS = 250;
 const SUGGEST_LIMIT = 8;
@@ -91,6 +130,15 @@ const SoapCodedTermPicker = ({
         ycCode: suggestion.ycCode,
         label: suggestion.label,
         ...(suggestion.domain ? { domain: suggestion.domain } : {}),
+        ...(suggestion.codings?.length
+          ? {
+              codings: suggestion.codings.map((coding) => ({
+                system: coding.system,
+                code: coding.code,
+                equivalence: coding.equivalence,
+              })),
+            }
+          : {}),
       },
     ]);
     setQuery('');
@@ -113,6 +161,14 @@ const SoapCodedTermPicker = ({
             >
               <span>{term.label}</span>
               <span className="font-normal text-text-tertiary">{term.ycCode}</span>
+              {term.codings?.map((coding) => (
+                <span
+                  key={`${coding.system}-${coding.code}`}
+                  className="rounded-full bg-neutral-0 px-1.5 py-0.5 text-caption-2 font-normal text-text-secondary"
+                >
+                  {codingLabel(coding)}
+                </span>
+              ))}
               <button
                 type="button"
                 aria-label={`Remove ${term.label}`}
@@ -146,9 +202,7 @@ const SoapCodedTermPicker = ({
                 <WorkspaceSearchResultRow
                   key={suggestion.ycCode}
                   name={suggestion.label}
-                  origin={
-                    synonym ? `${suggestion.ycCode} · matches “${synonym}”` : suggestion.ycCode
-                  }
+                  origin={buildOrigin(suggestion, synonym)}
                   disabled={alreadyAdded}
                   disabledReason={alreadyAdded ? 'Added' : undefined}
                   onSelect={() => addTerm(suggestion)}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -1600,6 +1600,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           encounterId={appointment.encounterId}
           authorId={actor.id}
           encounter={operationalEncounter}
+          companionSpecies={companion.species}
           ensureEncounterId={ensureEncounterId}
           onOpenInvoice={() => handleStepChange('INVOICE')}
         />

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -74,6 +74,12 @@ type TreatmentStepProps = {
   encounterId?: string;
   authorId?: string;
   encounter: AppointmentEncounter;
+  /**
+   * The patient's species, used to keep species-specific immunologicals out of
+   * the prescribing search: ATCvet's QI codes are per-species, so an unfiltered
+   * search offers a cat clinic bovine and equine vaccines.
+   */
+  companionSpecies?: string;
   /** Resolve (creating via check-in if needed) the encounter id for clinical persistence. */
   ensureEncounterId?: () => Promise<string | undefined>;
   onOpenInvoice: () => void;
@@ -699,6 +705,7 @@ const TreatmentStep = ({
   encounterId,
   authorId,
   encounter,
+  companionSpecies,
   ensureEncounterId,
   onOpenInvoice,
 }: TreatmentStepProps) => {
@@ -957,6 +964,7 @@ const TreatmentStep = ({
           items={prescriptionItems}
           catalogItems={prescriptionCatalogItems}
           templateItems={prescriptionTemplates}
+          companionSpecies={companionSpecies}
           readOnly={readOnly}
           // A prescription can be removed unless it is actually billed/paid (handled per-row via the
           // `billed` flag) or the encounter is view-only. Being "ready for billing" is NOT a lock —

--- a/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
+++ b/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
@@ -42,3 +42,34 @@ export const suggestClinicalTerms = async (params: {
   );
   return res.data.items ?? [];
 };
+
+/** One ATCvet substance, with the classification levels above it for context. */
+export type MedicationSuggestion = {
+  atcCode: string;
+  label: string;
+  path: Array<{ code: string; label: string }>;
+  species: string[];
+  /** True for QJ01 systemic antibacterials — what stewardship reporting counts. */
+  antibacterial: boolean;
+};
+
+/**
+ * Ranked substances from the ATCvet classification
+ * (`GET /v1/codes/medications/suggest`). Only substances are returned; the
+ * grouping levels above them are never prescribable.
+ */
+export const suggestMedications = async (params: {
+  q: string;
+  group?: string;
+  species?: string;
+  limit?: number;
+}): Promise<MedicationSuggestion[]> => {
+  const search = new URLSearchParams({ q: params.q });
+  if (params.group) search.set('group', params.group);
+  if (params.species) search.set('species', params.species);
+  if (params.limit) search.set('limit', String(params.limit));
+  const res = await getData<{ items?: MedicationSuggestion[] }>(
+    `/v1/codes/medications/suggest?${search.toString()}`
+  );
+  return res.data.items ?? [];
+};

--- a/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
+++ b/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
@@ -4,6 +4,14 @@ import { getData } from '@/app/services/axios';
 export type ClinicalTermDomain =
   'ReasonForVisit' | 'PresentingComplaint' | 'DiagnosticTest' | 'Diagnosis' | 'Procedure';
 
+/** A crosswalk to another vocabulary, as the backend resolved it for this term. */
+export type ClinicalTermCoding = {
+  system: 'VENOM' | 'SNOMED' | 'IDEXX' | 'YOSEMITECODE';
+  code: string;
+  display?: string;
+  equivalence: string;
+};
+
 export type ClinicalTermSuggestion = {
   ycCode: string;
   label: string;
@@ -11,6 +19,8 @@ export type ClinicalTermSuggestion = {
   species: string[];
   synonyms: string[];
   source?: string;
+  /** VeNom/SNOMED equivalents, strongest per system; absent for unmapped terms. */
+  codings?: ClinicalTermCoding[];
 };
 
 /**

--- a/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
@@ -217,6 +217,9 @@ const VITALS_EXT = {
   notes: 'https://yosemitecrew.com/fhir/StructureDefinition/vital-record-notes',
 };
 
+/** WHO CC's registered system URI for the veterinary ATC classification. */
+const ATCVET_SYSTEM_URI = 'http://www.whocc.no/atcvet';
+
 const PRESCRIPTION_EXT = {
   medications: 'https://yosemitecrew.com/fhir/StructureDefinition/prescription-medications',
   instructions: 'https://yosemitecrew.com/fhir/StructureDefinition/prescription-instructions',
@@ -786,6 +789,7 @@ export const savePrescriptionArtifact = async (
     metadata: {
       brand: prescription.brand,
       genericName: prescription.genericName,
+      atcCode: prescription.atcCode,
       sku: prescription.sku,
       strengthUnit: prescription.strengthUnit,
       dose: prescription.dose,
@@ -807,7 +811,22 @@ export const savePrescriptionArtifact = async (
     // the inventory dispense). 'active' here would dispense on every plain save.
     status: 'draft',
     intent: 'order',
-    medicationCodeableConcept: { text: prescription.medicineName },
+    medicationCodeableConcept: {
+      text: prescription.medicineName,
+      // A coded prescription is readable outside Yosemite Crew; an uncoded one
+      // carries text only rather than a placeholder coding.
+      ...(prescription.atcCode
+        ? {
+            coding: [
+              {
+                system: ATCVET_SYSTEM_URI,
+                code: prescription.atcCode,
+                display: prescription.medicineName,
+              },
+            ],
+          }
+        : {}),
+    },
     medicationReference: { display: prescription.medicineName },
     subject: { display: 'Patient' },
     encounter:
@@ -887,6 +906,13 @@ const prescriptionFromMedicationRequest = (
       'Medication',
     brand: str('brand'),
     genericName: str('genericName'),
+    // Prefer the stored line, then the FHIR coding: a prescription written
+    // elsewhere may only carry the coding.
+    atcCode:
+      str('atcCode') ??
+      resource.medicationCodeableConcept?.coding?.find(
+        (coding) => coding.system === ATCVET_SYSTEM_URI
+      )?.code,
     sku: str('sku', 'inventoryItemSku'),
     strength: str('strength'),
     strengthUnit: str('strengthUnit'),

--- a/apps/frontend/src/app/features/appointments/types/workspace.ts
+++ b/apps/frontend/src/app/features/appointments/types/workspace.ts
@@ -254,6 +254,13 @@ export type PrescriptionItem = {
   brand?: string;
   /** Generic / composition name from inventory (e.g. "Paracetamol 650"). */
   genericName?: string;
+  /**
+   * ATCvet substance code. Inherited from the inventory item when prescribing
+   * from stock, or set directly when the clinician picks a substance from the
+   * classification. Exported as a FHIR coding so the prescription is readable
+   * outside Yosemite Crew.
+   */
+  atcCode?: string;
   /** Inventory SKU, shown as a small reference chip. */
   sku?: string;
   /** Concentration value from inventory (e.g. "650"). */

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/types.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/types.ts
@@ -54,6 +54,8 @@ type InventoryItemDetails<ItemType = string> = {
   description?: string;
   imageUrl?: string;
   genericName?: string;
+  /** ATCvet substance code, set by the backfill. Read-only in the UI. */
+  atcCode?: string;
   strength?: string;
   dosageForm?: string;
   routeOfAdministration?: string;
@@ -496,6 +498,8 @@ export const SafetyClassificationOptions: string[] = [
 
 export type ClassificationValues = {
   genericName?: string;
+  /** ATCvet substance code, set by the backfill. Read-only in the UI. */
+  atcCode?: string;
   form?: string;
   unitofMeasure?: string | string[];
   species?: string | string[];
@@ -644,6 +648,8 @@ export type BatchValues = {
 export interface InventoryItem {
   id?: string;
   organisationId?: string;
+  /** ATCvet substance code, set by the backfill. Read-only in the UI. */
+  atcCode?: string;
   businessType?: BusinessType;
   currency?: string;
   stockHealth?: StockHealthStatus;

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -342,6 +342,9 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
     },
     classification: {
       genericName: toStringSafe(apiItem.genericName ?? attributes.genericName),
+      // Without this the backfilled code is dropped on the way in, so an
+      // in-house prescription stays uncoded however well the rest is wired.
+      atcCode: toStringSafe(apiItem.atcCode ?? attributes.atcCode) || undefined,
       form: toStringSafe(apiItem.dosageForm ?? attributes.form),
       unitofMeasure: normalizeStringOrArray(
         apiItem.unitOfMeasure ?? attributes.unitofMeasure ?? attributes.unitOfMeasure

--- a/docs/guide/atcvet-rollout.md
+++ b/docs/guide/atcvet-rollout.md
@@ -1,0 +1,58 @@
+# ATCvet rollout
+
+The ATCvet medication spine ships as code plus a data file; the database rows are
+created by an import, not by a migration. A deploy therefore creates the enums,
+columns and indexes but leaves the vocabulary empty until the import is run once
+per environment.
+
+That separation is deliberate. The index changes once a year, while the API
+deploys many times a week, so running an 8,315-row import on every deploy would
+add minutes to each one to re-write rows that have not changed. It also keeps a
+bad data file from riding out with an ordinary code deploy.
+
+## After deploying a release that adds or updates ATCvet
+
+Run once, on the target environment, from `apps/backend`:
+
+```bash
+pnpm import:atcvet-index                 # dry run: prints counts and every skip
+pnpm import:atcvet-index -- --apply      # writes
+```
+
+Expected on the 2026 release: `8315 codes (6417 substances, 1898 groups), 8300
+edges` and no skips. The import is idempotent, so re-running it is safe.
+
+Optionally link the practice's own drug list and stock to the spine:
+
+```bash
+pnpm backfill:atc-codes                  # dry run: reports every match and skip
+pnpm backfill:atc-codes -- --apply
+```
+
+The backfill never guesses: a drug whose name matches no ATCvet substance, or
+matches several, stays uncoded and is listed with the reason.
+
+## Yearly release
+
+Convert the new workbook, then re-run the import:
+
+```bash
+node apps/backend/scripts/convert-atcvet-xlsx.mjs "<new index>.xlsx" apps/backend/data/atcvet_index.json
+pnpm import:atcvet-index -- --apply
+```
+
+Codes withdrawn by the new release are deactivated, not deleted, so existing
+prescriptions and formulary rows that reference them still resolve. Retirement is
+skipped entirely when the extract does not look like a complete release (fewer
+than 5,000 codes, or more than 10% smaller than what is currently active), which
+stops a truncated file from switching the vocabulary off.
+
+## Verifying
+
+```bash
+# substances are searchable
+curl -s "$API/v1/codes/medications/suggest?q=doxycycline" | jq '.items[0]'
+```
+
+A coded prescription then exports an ATCvet coding under
+`http://www.whocc.no/atcvet` in its `medicationCodeableConcept`.

--- a/packages/database/prisma/migrations/20260901120000_atcvet_code_system/migration.sql
+++ b/packages/database/prisma/migrations/20260901120000_atcvet_code_system/migration.sql
@@ -1,0 +1,11 @@
+-- ATCvet: the WHO CC veterinary drug classification, added as its own code system
+-- alongside the clinical vocabularies.
+--
+-- Values are appended BEFORE 'OTHER' so a freshly created database enumerates them
+-- in the same order as schema.prisma declares them. Appending at the end instead
+-- leaves fresh and migrated databases with different enum orderings, which shows up
+-- much later as an unexplained ordering difference between environments.
+ALTER TYPE "CodeSystem" ADD VALUE IF NOT EXISTS 'ATCVET';
+
+ALTER TYPE "CodeType" ADD VALUE IF NOT EXISTS 'MEDICATION' BEFORE 'OTHER';
+ALTER TYPE "CodeType" ADD VALUE IF NOT EXISTS 'MEDICATION_CATEGORY' BEFORE 'OTHER';

--- a/packages/database/prisma/migrations/20260901120100_atcvet_search_index/migration.sql
+++ b/packages/database/prisma/migrations/20260901120100_atcvet_search_index/migration.sql
@@ -1,0 +1,34 @@
+-- Trigram index for medication search, mirroring the clinical-term one.
+--
+-- Deliberately a SEPARATE migration from the one adding 'ATCVET' to the CodeSystem
+-- enum: PostgreSQL refuses to use a new enum value inside the same transaction that
+-- added it, and Prisma runs each migration file in one transaction. Combined, this
+-- index would fail with "unsafe use of new value of enum type".
+--
+-- The clinical index is partial to YOSEMITECODE/CLINICAL_TERM, so ATCvet rows were
+-- not covered by it and medication search would sequentially scan every code.
+DO $$
+DECLARE
+  ext_schema text;
+BEGIN
+  SELECT n.nspname INTO ext_schema
+  FROM pg_extension e
+  JOIN pg_namespace n ON n.oid = e.extnamespace
+  WHERE e.extname = 'pg_trgm';
+
+  IF ext_schema IS NULL THEN
+    RAISE EXCEPTION 'pg_trgm is not installed';
+  END IF;
+
+  -- Substances only. The 1,898 grouping levels are never prescribed, so keeping
+  -- them out keeps the index to what autocomplete actually searches.
+  EXECUTE format(
+    'CREATE INDEX IF NOT EXISTS %I ON %I USING gin ('
+    || '(code_entry_search_text("display", "synonyms")) %I.gin_trgm_ops'
+    || ') WHERE "system" = ''ATCVET''::"CodeSystem"'
+    || '   AND "type" = ''MEDICATION''::"CodeType"'
+    || '   AND "active"',
+    'CodeEntry_atcvet_search_trgm', 'CodeEntry', ext_schema
+  );
+END
+$$;

--- a/packages/database/prisma/migrations/20260901120200_atc_code_links/migration.sql
+++ b/packages/database/prisma/migrations/20260901120200_atc_code_links/migration.sql
@@ -1,0 +1,11 @@
+-- Link a practice's own drug list and stock to the ATCvet spine.
+--
+-- Nullable by design. A drug whose name matches no ATCvet substance, or matches
+-- several (ibuprofen exists under QC01EB16, QG02CC01 and QM01AE01 for different
+-- therapeutic uses), stays uncoded: a wrong therapeutic class is worse than an
+-- absent one, and the backfill reports both cases for a human to resolve.
+ALTER TABLE "DrugFormulary" ADD COLUMN IF NOT EXISTS "atcCode" TEXT;
+ALTER TABLE "InventoryItem" ADD COLUMN IF NOT EXISTS "atcCode" TEXT;
+
+CREATE INDEX IF NOT EXISTS "DrugFormulary_atcCode_idx" ON "DrugFormulary"("atcCode");
+CREATE INDEX IF NOT EXISTS "InventoryItem_atcCode_idx" ON "InventoryItem"("atcCode");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3379,6 +3379,9 @@ model InventoryItem {
   attachments             Json?
   attributes              Json                  @default("{}")
   genericName             String?
+  /// ATCvet substance code for medicine items, when one could be matched
+  /// unambiguously. Stock that is not a medicine simply has none.
+  atcCode                 String?
   strength                String?
   dosageForm              String?
   routeOfAdministration   String?
@@ -3411,6 +3414,7 @@ model InventoryItem {
   @@index([organisationId, businessType])
   @@index([organisationId, status])
   @@index([organisationId, vendorId])
+  @@index([atcCode])
 }
 
 model InventoryBatch {
@@ -5841,6 +5845,10 @@ model DrugFormulary {
   organisationId String
   drugName       String
   genericName    String?
+  /// ATCvet substance code (CodeEntry.system = ATCVET, type = MEDICATION).
+  /// Nullable and never guessed: an unmatched or ambiguous drug stays uncoded
+  /// rather than being filed under the wrong therapeutic class.
+  atcCode        String?
   category       FormularyCategory @default(OTHER)
   manufacturer   String?
   concentration  String?
@@ -5854,6 +5862,7 @@ model DrugFormulary {
 
   @@index([organisationId, isActive])
   @@index([organisationId, category])
+  @@index([atcCode])
   @@map("DrugFormulary")
 }
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -171,6 +171,7 @@ enum CodeSystem {
   IDEXX
   SNOMED
   VENOM
+  ATCVET
 }
 
 enum CodeType {
@@ -184,6 +185,14 @@ enum CodeType {
   // relationship parents. Kept out of CLINICAL_TERM so clinical autocomplete does not
   // start offering category headings as if they were diagnoses.
   CLINICAL_CATEGORY
+  // An ATCvet substance: the fifth level of the code, the thing that is actually
+  // prescribed ("QJ01AA02 doxycycline").
+  MEDICATION
+  // The four grouping levels above a substance (anatomical main group through
+  // chemical subgroup). Held apart from MEDICATION for the same reason
+  // CLINICAL_CATEGORY is held apart from CLINICAL_TERM: prescribing autocomplete
+  // must offer substances, never the headings they sit under.
+  MEDICATION_CATEGORY
   OTHER
 }
 

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -56,6 +56,17 @@ export const SOAP_CODED_SECTIONS = ['subjective', 'objective', 'assessment', 'pl
 
 export type SoapCodedSection = (typeof SOAP_CODED_SECTIONS)[number];
 
+/**
+ * A crosswalk recorded alongside a pick. Stored so the note shows the same
+ * codes the clinician saw when choosing, even if the mapping table later
+ * changes; the FHIR export still projects live from CodeMapping.
+ */
+export type SoapCodedTermCoding = {
+  system: string;
+  code: string;
+  equivalence?: string;
+};
+
 export type SoapCodedTerm = {
   /** Yosemite vocabulary code, e.g. YC-005416. */
   ycCode: string;
@@ -63,12 +74,17 @@ export type SoapCodedTerm = {
   label: string;
   /** VeNom-style domain the term belongs to, when known (e.g. Diagnosis). */
   domain?: string;
+  /** Cross-vocabulary codes shown at pick time (VeNom/SNOMED). */
+  codings?: SoapCodedTermCoding[];
 };
 
 export type SoapCodedProblems = Partial<Record<SoapCodedSection, SoapCodedTerm[]>>;
 
 /** Bound per section so a malformed or hostile payload cannot balloon the JSON column. */
 const MAX_CODED_TERMS_PER_SECTION = 50;
+
+/** Bounded like the section cap: a term has one crosswalk per system, not a list. */
+const MAX_CODINGS_PER_TERM = 8;
 
 const parseSoapCodedTerm = (value: unknown): SoapCodedTerm | null => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
@@ -78,7 +94,29 @@ const parseSoapCodedTerm = (value: unknown): SoapCodedTerm | null => {
   if (!ycCode || !label) return null;
   const domain =
     typeof entry.domain === 'string' && entry.domain.trim() ? entry.domain.trim() : undefined;
-  return domain === undefined ? { ycCode, label } : { ycCode, label, domain };
+  const codings = Array.isArray(entry.codings)
+    ? entry.codings
+        .map((value) => {
+          if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+          const coding = value as Record<string, unknown>;
+          const system = typeof coding.system === 'string' ? coding.system.trim() : '';
+          const code = typeof coding.code === 'string' ? coding.code.trim() : '';
+          if (!system || !code) return null;
+          const equivalence =
+            typeof coding.equivalence === 'string' && coding.equivalence.trim()
+              ? coding.equivalence.trim()
+              : undefined;
+          return equivalence === undefined ? { system, code } : { system, code, equivalence };
+        })
+        .filter((coding): coding is SoapCodedTermCoding => coding !== null)
+        .slice(0, MAX_CODINGS_PER_TERM)
+    : [];
+  return {
+    ycCode,
+    label,
+    ...(domain === undefined ? {} : { domain }),
+    ...(codings.length > 0 ? { codings } : {}),
+  };
 };
 
 /** One section's raw payload → valid terms: drops malformed entries, dedups by code, caps the count. */

--- a/packages/types/src/clinical-artifact.ts
+++ b/packages/types/src/clinical-artifact.ts
@@ -778,12 +778,55 @@ const compositionToSoapNoteInput = (
   metadata: parseFlexibleJson(getExtensionValue(resource.extension, SOAP_METADATA_EXTENSION_URL)),
 });
 
+/** WHO CC's registered system URI for the veterinary ATC classification. */
+const ATCVET_SYSTEM_URI = 'http://www.whocc.no/atcvet';
+
+/**
+ * Rebuilds the medication concept from the stored lines. The first line carrying
+ * an ATCvet code names the medication; a prescription written without one keeps
+ * the generic placeholder rather than inventing a coding.
+ */
+const prescriptionMedicationConcept = (record: PrescriptionRecord) => {
+  const medications = record.prescription.medications;
+  if (!Array.isArray(medications)) return undefined;
+  for (const line of medications) {
+    if (typeof line !== 'object' || line === null) continue;
+    const entry = line as Record<string, unknown>;
+    const metadata =
+      typeof entry.metadata === 'object' && entry.metadata !== null
+        ? (entry.metadata as Record<string, unknown>)
+        : {};
+    const atcCode =
+      typeof entry.atcCode === 'string'
+        ? entry.atcCode
+        : typeof metadata.atcCode === 'string'
+          ? metadata.atcCode
+          : undefined;
+    if (!atcCode?.trim()) continue;
+    const display =
+      typeof entry.medication === 'string'
+        ? entry.medication
+        : typeof entry.medicineName === 'string'
+          ? entry.medicineName
+          : undefined;
+    return {
+      text: display,
+      coding: [{ system: ATCVET_SYSTEM_URI, code: atcCode.trim(), display }],
+    };
+  }
+  return undefined;
+};
+
 const prescriptionToMedicationRequest = (record: PrescriptionRecord): MedicationRequest => ({
   resourceType: 'MedicationRequest',
   id: record.artifact.id,
   status: toTaskStatus(record.artifact.status),
   intent: 'order',
-  medicationCodeableConcept: toCodeableConcept('PRESCRIPTION', 'Prescription'),
+  // The medication the prescription is for, coded when the clinician picked a
+  // classified substance. A hardcoded 'PRESCRIPTION' concept here discarded the
+  // ATCvet coding the client sent, leaving every exported prescription uncoded.
+  medicationCodeableConcept:
+    prescriptionMedicationConcept(record) ?? toCodeableConcept('PRESCRIPTION', 'Prescription'),
   medicationReference: { reference: `MedicationRequest/${record.artifact.id}` },
   subject: requiredPatientReference(record.artifact),
   encounter: toReference(clinicalContextReference(record.artifact)),


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two gaps, one reported and one structural.

**Reported:** the SOAP coded-term picker showed Yosemite codes only. #2501 made picked terms *export* as VeNom/SNOMED CodeableConcepts, but that projection lived in the FHIR layer, so a clinician choosing a term could not see whether it had a SNOMED equivalent or how exact it was.

**Structural:** medications were free text everywhere — `DrugFormulary.drugName`, `InventoryItem.name`, prescription lines. Nothing could answer "which patients received a systemic antibacterial", and no prescription left the system coded.

## What is the new behavior?

### Cross-codes in the picker (closes #2593)

`terms/suggest` now returns each term's crosswalks — strongest per system, read from `CodeMapping` under the *same* usable-equivalence gate the FHIR export applies, in one batched query per result page, so the picker can never advertise a code the export would refuse to emit. Dropdown rows and chips show them, and a non-exact equivalence is stated rather than hidden: `SNOMED 422400008 (narrower)`. Picked crosswalks are stored with the term so a note shows what the clinician actually saw; the export still projects live.

### ATCvet medication spine (closes #2600)

- **Import**: all 8,315 codes as the new `ATCVET` system — 6,417 substances (`MEDICATION`) and 1,898 grouping levels (`MEDICATION_CATEGORY`) — with 8,300 `is a` edges. The hierarchy needs no parent table: an ATCvet code contains its ancestry in its own prefixes. Idempotent, dry-run by default, every skip reported. A converter regenerates the JSON from each yearly workbook.
- **Search**: `GET /v1/codes/medications/suggest` (web + mobile). Substances only; each result carries its class path (`doxycycline · Tetracyclines · ANTIBACTERIALS FOR SYSTEMIC USE`) resolved in one batched lookup, plus species and an `antibacterial` flag for QJ01.
- **Links**: `atcCode` on `DrugFormulary` and `InventoryItem`, with a backfill that matches on the generic name first and **never guesses** (below).
- **Prescribing**: ATCvet substances appear in the prescription search box beneath the practice's own catalogue, and a coded prescription exports a real `medicationCodeableConcept.coding` under `http://www.whocc.no/atcvet`.

## Domain decisions the data forced

Three findings changed the design, each pinned by a test that fails if it is undone:

1. **ATCvet uses INN spellings.** A practice's "Cephalexin" matches nothing — the substance is `cefalexin`. Rather than fuzzy-matching drug names (where a near miss is a *different medicine*), unmatched rows are reported for a human.
2. **A substance holds several codes.** Ibuprofen is `QC01EB16`/`QG02CC01`/`QM01AE01`; doxycycline is oral-dental *and* systemic. "First match wins" would file a drug under a therapeutic class it does not belong to — exactly what stewardship reporting would then read. Ambiguous rows stay uncoded and are named.
3. **QI encodes species, not therapy.** `QI07` is "immunologicals for canidae", so vaccine codes carry species the other fourteen groups do not. Mapped onto our species buckets where the family maps cleanly; `QI20` ("other species") is deliberately left unmapped rather than guessed.

## Two migration traps avoided

- The existing trigram index is **partial to `YOSEMITECODE`**, so ATCvet rows were not covered and medication search would have sequentially scanned every code. Added a matching partial index for `ATCVET`/`MEDICATION`.
- That index had to go in a **separate migration**: PostgreSQL refuses to use a new enum value inside the transaction that added it, and Prisma runs each migration file in one transaction. Combined, it fails on deploy.

## Impact area

Backend terminology services, schema (two nullable columns, three migrations), the SOAP picker and the prescription editor. No changes to existing prescribing behaviour: the ATCvet group sits below the inventory results, and stock prescribing is untouched.

## Validation performed

- Frontend and backend `tsc` clean; scoped ESLint clean; `@yosemite-crew/types` builds.
- Backend: 457 suites / 11,003 tests green. Frontend: the five affected suites, 72 tests green.
- Importer dry run against the real 2026 index: 8,315 codes, 8,300 edges, **zero skips**.
- **Mutation-checked — 24 mutations, each makes exactly its pinning test fail**: equivalence gate and ranking in suggest; inexact-qualifier display; coded-term parsing; importer level typing, dangling-parent guard, code grammar, QI species mapping and dedup; search type filter, LIKE escaping, species-agnostic inclusion, batched ancestors, blank-crumb guard; backfill ambiguity refusal, generic-name preference, leading-number preservation, concurrent-write guard, medicine-only scope; prescribing fulfillment, stale-response guard, minimum query, coding emission. One survivor was investigated and proven an *equivalent* mutant (a provably dead guard), and the dead code removed rather than a test written to fake coverage.
- Secrets scan clean.
- Post-merge: dev deploy, import run, and a workflow QA pass on the picker and prescribing flow with screenshots.

## Related Issue(s)

Closes #2593
Closes #2600
