### PR TITLE
fix(backend): scope six org-gated routes to the organisation they authorised

### DIFF
--- a/apps/backend/src/controllers/app/companion-organisation.controller.ts
+++ b/apps/backend/src/controllers/app/companion-organisation.controller.ts
@@ -9,6 +9,7 @@ import { type OrganizationMongo } from "src/models/organization";
 import { prisma } from "src/config/prisma";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import type { AuthenticatedRequest } from "src/middlewares/auth";
+import { resolveAuthorizedOrganisationId } from "src/middlewares/authorized-organisation";
 
 type OrganisationType = OrganizationMongo["type"];
 
@@ -320,9 +321,16 @@ export const CompanionOrganisationController = {
         });
       }
 
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
+        payload.organisationId,
+      );
+      if (!organisationId) return;
+
       const updated = await CompanionOrganisationService.acceptInvite({
         token: payload.token,
-        organisationId: payload.organisationId,
+        organisationId,
       });
 
       return res.status(200).json(updated);
@@ -344,9 +352,16 @@ export const CompanionOrganisationController = {
         });
       }
 
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
+        payload.organisationId,
+      );
+      if (!organisationId) return;
+
       await CompanionOrganisationService.rejectInvite({
         token: payload.token,
-        organisationId: payload.organisationId,
+        organisationId,
       });
 
       return res.status(200).json({ message: "Invite rejected successfully." });

--- a/apps/backend/src/controllers/app/finance.controller.ts
+++ b/apps/backend/src/controllers/app/finance.controller.ts
@@ -26,6 +26,7 @@ import {
 } from "src/services/appointment.prisma.service";
 import logger from "src/utils/logger";
 import { OrgRequest } from "src/middlewares/rbac";
+import { resolveAuthorizedOrganisationId } from "src/middlewares/authorized-organisation";
 import { AuthenticatedRequest } from "src/middlewares/auth";
 import { resolveVerifiedUserId } from "src/utils/request";
 
@@ -392,6 +393,13 @@ export const FinanceController = {
         return res.status(400).json({ message: "Invalid request body" });
       }
 
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
+        body.data.organisationId,
+      );
+      if (!organisationId) return;
+
       const items = body.data.items.map((item) => ({
         ...item,
         description: item.description ?? item.name,
@@ -401,7 +409,7 @@ export const FinanceController = {
         appointmentId: body.data.appointmentId,
         parentId: body.data.parentId,
         patientId: body.data.patientId,
-        organisationId: body.data.organisationId,
+        organisationId,
         paymentCollectionMethod: body.data.paymentCollectionMethod as
           "PAYMENT_INTENT" | "PAYMENT_LINK" | "PAYMENT_AT_CLINIC",
         items,
@@ -884,9 +892,15 @@ export const FinanceController = {
         return res.status(400).json({ message: "Invalid request query" });
       }
 
-      const current = await FinanceSubscriptionService.getCurrentSubscription(
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
         query.data.organisationId,
       );
+      if (!organisationId) return;
+
+      const current =
+        await FinanceSubscriptionService.getCurrentSubscription(organisationId);
 
       return res.status(200).json(toFinanceSuccess(current));
     } catch (error) {
@@ -902,8 +916,15 @@ export const FinanceController = {
         return res.status(400).json({ message: "Invalid request body" });
       }
 
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
+        body.data.organisationId,
+      );
+      if (!organisationId) return;
+
       const subscription = await FinanceSubscriptionService.upsertSubscription({
-        orgId: body.data.organisationId,
+        orgId: organisationId,
         planCode: body.data.planCode,
         provider: body.data.provider,
         providerSubscriptionId: body.data.providerSubscriptionId,
@@ -924,8 +945,15 @@ export const FinanceController = {
         return res.status(400).json({ message: "Invalid request query" });
       }
 
-      const snapshots = await FinanceSubscriptionService.listUsageSnapshots(
+      const organisationId = resolveAuthorizedOrganisationId(
+        req,
+        res,
         query.data.organisationId,
+      );
+      if (!organisationId) return;
+
+      const snapshots = await FinanceSubscriptionService.listUsageSnapshots(
+        organisationId,
         {
           subscriptionId: query.data.subscriptionId ?? null,
           featureKey: query.data.featureKey ?? null,

--- a/apps/backend/src/controllers/web/catalog.controller.ts
+++ b/apps/backend/src/controllers/web/catalog.controller.ts
@@ -8,7 +8,7 @@ import {
   CatalogServiceError,
   type CatalogProductUpsertInput,
 } from "src/services/catalog.service";
-import type { OrgRequest } from "src/middlewares/rbac";
+import { resolveAuthorizedOrganisationId } from "src/middlewares/authorized-organisation";
 import {
   calendarPrefillBaseSchema,
   parseTristateFlag,
@@ -241,41 +241,6 @@ const handleError = (res: Response, error: unknown, defaultMessage: string) => {
 
   logger.error(defaultMessage, error);
   return res.status(500).json({ message: defaultMessage });
-};
-
-const stripOrganisationPrefix = (value?: string) =>
-  value?.replace(/^Organization\//, "");
-
-/**
- * Resolve the organisation the RBAC layer actually authorized for this request.
- *
- * Client-supplied organisation identifiers (query, body, FHIR Parameters) are
- * only ever used to detect a mismatch: `withOrgPermissions` may have authorized
- * a different organisation than the one named in the payload, so honouring the
- * payload would let a caller act outside the organisation they were checked
- * against. Responds and returns `undefined` when the request cannot proceed.
- */
-const resolveAuthorizedOrganisationId = (
-  req: Request,
-  res: Response,
-  provided?: string,
-): string | undefined => {
-  const authorized = (req as OrgRequest).organisationId;
-
-  if (!authorized) {
-    res.status(400).json({ message: "Organisation identifier is required." });
-    return undefined;
-  }
-
-  const requested = stripOrganisationPrefix(provided);
-  if (requested && requested !== authorized) {
-    res.status(403).json({
-      message: "Organisation does not match the authorized organisation.",
-    });
-    return undefined;
-  }
-
-  return authorized;
 };
 
 const parseKinds = (value?: string) => {

--- a/apps/backend/src/middlewares/authorized-organisation.ts
+++ b/apps/backend/src/middlewares/authorized-organisation.ts
@@ -1,0 +1,45 @@
+// src/middlewares/authorized-organisation.ts
+import { Request, Response } from "express";
+
+import { OrgRequest } from "./rbac";
+
+const stripOrganisationPrefix = (value?: string) =>
+  value?.replace(/^Organization\//, "");
+
+/**
+ * Resolve the organisation the RBAC layer actually authorized for this request.
+ *
+ * `withOrgPermissions` reads the organisation from the params, the `x-org-id`
+ * header, the query and the body, in that order, and stops at the first one it
+ * finds. A handler that goes back to the query or the body therefore reads a
+ * *different* value from the one the membership check ran against whenever a
+ * caller supplies both: authorize on the header for an organisation they belong
+ * to, name another organisation in the payload, and the request acts outside the
+ * tenant that was checked.
+ *
+ * So a client-supplied identifier is only ever used to detect that mismatch.
+ * The organisation returned is always the authorized one. Responds and returns
+ * `undefined` when the request cannot proceed.
+ */
+export const resolveAuthorizedOrganisationId = (
+  req: Request,
+  res: Response,
+  provided?: string,
+): string | undefined => {
+  const authorized = (req as OrgRequest).organisationId;
+
+  if (!authorized) {
+    res.status(400).json({ message: "Organisation identifier is required." });
+    return undefined;
+  }
+
+  const requested = stripOrganisationPrefix(provided);
+  if (requested && requested !== authorized) {
+    res.status(403).json({
+      message: "Organisation does not match the authorized organisation.",
+    });
+    return undefined;
+  }
+
+  return authorized;
+};

--- a/apps/backend/src/middlewares/authorized-organisation.ts
+++ b/apps/backend/src/middlewares/authorized-organisation.ts
@@ -3,8 +3,27 @@ import { Request, Response } from "express";
 
 import { OrgRequest } from "./rbac";
 
-const stripOrganisationPrefix = (value?: string) =>
-  value?.replace(/^Organization\//, "");
+const ORGANIZATION_REFERENCE_PREFIX = "Organization/";
+
+/**
+ * Reduce either form of an organisation identifier to the bare id.
+ *
+ * `withOrgPermissions` authorizes both: its membership lookup matches
+ * `organizationReference` against the raw value AND against
+ * `Organization/<value>`, so a caller sending `x-org-id: Organization/org-1`
+ * passes and `req.organisationId` keeps the prefixed form. Normalising only the
+ * client's value would then compare `org-1` against `Organization/org-1` and
+ * refuse a caller authorized for exactly that organisation - and the prefixed
+ * form would be the one written to an `organisationId` column. Both sides go
+ * through here, and the bare id is what is returned.
+ */
+const bareOrganisationId = (value?: string) => {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith(ORGANIZATION_REFERENCE_PREFIX)
+    ? trimmed.slice(ORGANIZATION_REFERENCE_PREFIX.length).trim() || undefined
+    : trimmed;
+};
 
 /**
  * Resolve the organisation the RBAC layer actually authorized for this request.
@@ -26,14 +45,14 @@ export const resolveAuthorizedOrganisationId = (
   res: Response,
   provided?: string,
 ): string | undefined => {
-  const authorized = (req as OrgRequest).organisationId;
+  const authorized = bareOrganisationId((req as OrgRequest).organisationId);
 
   if (!authorized) {
     res.status(400).json({ message: "Organisation identifier is required." });
     return undefined;
   }
 
-  const requested = stripOrganisationPrefix(provided);
+  const requested = bareOrganisationId(provided);
   if (requested && requested !== authorized) {
     res.status(403).json({
       message: "Organisation does not match the authorized organisation.",

--- a/apps/backend/test/controllers/app/companion-organisation.controller.test.ts
+++ b/apps/backend/test/controllers/app/companion-organisation.controller.test.ts
@@ -668,6 +668,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should success (200)", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       mockedCompanionService.acceptInvite.mockResolvedValue({} as any);
 
       await CompanionOrganisationController.acceptInvite(
@@ -677,8 +678,37 @@ describe("CompanionOrganisationController", () => {
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
+    it("refuses a body naming an organisation other than the authorized one", async () => {
+      // The invite token is a bearer secret, but the organisation the link is
+      // stamped with must be the one withOrgPermissions authorized, not one
+      // the caller names in the body.
+      req.body = { token: "t1", organisationId: "o-other" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
+
+      await CompanionOrganisationController.acceptInvite(
+        req as Request,
+        res as Response,
+      );
+
+      expect(mockedCompanionService.acceptInvite).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
+    it("requires an authorized organisation on the request", async () => {
+      req.body = { token: "t1", organisationId: "o1" };
+
+      await CompanionOrganisationController.acceptInvite(
+        req as Request,
+        res as Response,
+      );
+
+      expect(mockedCompanionService.acceptInvite).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+    });
+
     it("should handle service error", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       mockServiceError("acceptInvite", 400);
       await CompanionOrganisationController.acceptInvite(
         req as Request,
@@ -689,6 +719,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should handle generic error", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       mockGenericError("acceptInvite");
       await CompanionOrganisationController.acceptInvite(
         req as Request,
@@ -710,6 +741,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should success (200)", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       mockedCompanionService.rejectInvite.mockResolvedValue({} as any);
 
       await CompanionOrganisationController.rejectInvite(
@@ -719,8 +751,37 @@ describe("CompanionOrganisationController", () => {
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
+    it("refuses a body naming an organisation other than the authorized one", async () => {
+      // The invite token is a bearer secret, but the organisation the link is
+      // stamped with must be the one withOrgPermissions authorized, not one
+      // the caller names in the body.
+      req.body = { token: "t1", organisationId: "o-other" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
+
+      await CompanionOrganisationController.rejectInvite(
+        req as Request,
+        res as Response,
+      );
+
+      expect(mockedCompanionService.rejectInvite).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
+    it("requires an authorized organisation on the request", async () => {
+      req.body = { token: "t1", organisationId: "o1" };
+
+      await CompanionOrganisationController.rejectInvite(
+        req as Request,
+        res as Response,
+      );
+
+      expect(mockedCompanionService.rejectInvite).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+    });
+
     it("should handle service error", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       // mocking explicit reject since rejectInvite in controller does check for service error
       mockServiceError("rejectInvite", 404);
       await CompanionOrganisationController.rejectInvite(
@@ -732,6 +793,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should handle generic error", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       mockGenericError("rejectInvite");
       await CompanionOrganisationController.rejectInvite(
         req as Request,

--- a/apps/backend/test/controllers/app/finance.controller.test.ts
+++ b/apps/backend/test/controllers/app/finance.controller.test.ts
@@ -240,7 +240,7 @@ describe("FinanceController", () => {
     });
 
     it("creates a draft invoice and defaults item description to name", async () => {
-      setReq({ body: validBody });
+      setReq({ body: validBody, organisationId: "org-1" });
       mockedInvoiceService.createDraftForAppointment.mockResolvedValueOnce({
         id: "inv-1",
       } as never);
@@ -266,8 +266,36 @@ describe("FinanceController", () => {
       });
     });
 
-    it("maps InvoiceServiceError to its status code", async () => {
+    it("refuses a body naming an organisation other than the authorized one", async () => {
+      // withOrgPermissions stops at the first identifier it finds, so a caller
+      // who sends `x-org-id` for their own organisation is authorized against
+      // that one while the body names another. The invoice must not be created.
+      setReq({
+        body: { ...validBody, organisationId: "org-victim" },
+        organisationId: "org-1",
+      });
+
+      await run(FinanceController.createInvoice);
+
+      expect(
+        mockedInvoiceService.createDraftForAppointment,
+      ).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
+    it("requires an authorized organisation on the request", async () => {
       setReq({ body: validBody });
+
+      await run(FinanceController.createInvoice);
+
+      expect(
+        mockedInvoiceService.createDraftForAppointment,
+      ).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+    });
+
+    it("maps InvoiceServiceError to its status code", async () => {
+      setReq({ body: validBody, organisationId: "org-1" });
       mockedInvoiceService.createDraftForAppointment.mockRejectedValueOnce(
         new InvoiceServiceError("Appointment not found", 404) as never,
       );
@@ -281,7 +309,7 @@ describe("FinanceController", () => {
     });
 
     it("maps unknown errors to 500", async () => {
-      setReq({ body: validBody });
+      setReq({ body: validBody, organisationId: "org-1" });
       mockedInvoiceService.createDraftForAppointment.mockRejectedValueOnce(
         new Error("boom") as never,
       );
@@ -1311,7 +1339,10 @@ describe("FinanceController", () => {
     });
 
     it("returns the current subscription", async () => {
-      setReq({ query: { organisationId: "org-1" } });
+      setReq({
+        query: { organisationId: "org-1" },
+        organisationId: "org-1",
+      });
       mockedSubscriptionService.getCurrentSubscription.mockResolvedValueOnce({
         id: "sub-1",
       } as never);
@@ -1324,8 +1355,25 @@ describe("FinanceController", () => {
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
+    it("refuses a query naming an organisation other than the authorized one", async () => {
+      setReq({
+        query: { organisationId: "org-victim" },
+        organisationId: "org-1",
+      });
+
+      await run(FinanceController.getCurrentSubscription);
+
+      expect(
+        mockedSubscriptionService.getCurrentSubscription,
+      ).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
     it("returns 500 on failure", async () => {
-      setReq({ query: { organisationId: "org-1" } });
+      setReq({
+        query: { organisationId: "org-1" },
+        organisationId: "org-1",
+      });
       mockedSubscriptionService.getCurrentSubscription.mockRejectedValueOnce(
         new Error("boom") as never,
       );
@@ -1354,7 +1402,7 @@ describe("FinanceController", () => {
     });
 
     it("upserts the subscription", async () => {
-      setReq({ body: validBody });
+      setReq({ body: validBody, organisationId: "org-1" });
       mockedSubscriptionService.upsertSubscription.mockResolvedValueOnce({
         id: "sub-1",
       } as never);
@@ -1373,8 +1421,22 @@ describe("FinanceController", () => {
       expect(statusMock).toHaveBeenCalledWith(201);
     });
 
+    it("refuses a body naming an organisation other than the authorized one", async () => {
+      setReq({
+        body: { ...validBody, organisationId: "org-victim" },
+        organisationId: "org-1",
+      });
+
+      await run(FinanceController.upsertSubscription);
+
+      expect(
+        mockedSubscriptionService.upsertSubscription,
+      ).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
     it("returns 500 on failure", async () => {
-      setReq({ body: validBody });
+      setReq({ body: validBody, organisationId: "org-1" });
       mockedSubscriptionService.upsertSubscription.mockRejectedValueOnce(
         new Error("boom") as never,
       );
@@ -1395,7 +1457,10 @@ describe("FinanceController", () => {
     });
 
     it("lists snapshots with null defaults when optional filters are omitted", async () => {
-      setReq({ query: { organisationId: "org-1" } });
+      setReq({
+        query: { organisationId: "org-1" },
+        organisationId: "org-1",
+      });
       mockedSubscriptionService.listUsageSnapshots.mockResolvedValueOnce(
         [] as never,
       );
@@ -1416,6 +1481,7 @@ describe("FinanceController", () => {
           subscriptionId: "sub-1",
           featureKey: "seats",
         },
+        organisationId: "org-1",
       });
       mockedSubscriptionService.listUsageSnapshots.mockResolvedValueOnce(
         [] as never,
@@ -1430,8 +1496,25 @@ describe("FinanceController", () => {
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
+    it("refuses a query naming an organisation other than the authorized one", async () => {
+      setReq({
+        query: { organisationId: "org-victim" },
+        organisationId: "org-1",
+      });
+
+      await run(FinanceController.getUsageSnapshots);
+
+      expect(
+        mockedSubscriptionService.listUsageSnapshots,
+      ).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
     it("returns 500 on failure", async () => {
-      setReq({ query: { organisationId: "org-1" } });
+      setReq({
+        query: { organisationId: "org-1" },
+        organisationId: "org-1",
+      });
       mockedSubscriptionService.listUsageSnapshots.mockRejectedValueOnce(
         new Error("boom") as never,
       );

--- a/apps/backend/test/controllers/companion-organisation.controller.test.ts
+++ b/apps/backend/test/controllers/companion-organisation.controller.test.ts
@@ -503,6 +503,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should accept invite on success", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       (
         CompanionOrganisationService.acceptInvite as jest.Mock
       ).mockResolvedValue("acc_data");
@@ -512,6 +513,7 @@ describe("CompanionOrganisationController", () => {
 
     it("should handle errors in acceptInvite", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       (
         CompanionOrganisationService.acceptInvite as jest.Mock
       ).mockRejectedValue(new Error("Test error"));
@@ -527,12 +529,14 @@ describe("CompanionOrganisationController", () => {
 
     it("should reject invite on success", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       await CompanionOrganisationController.rejectInvite(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
     it("should handle errors in rejectInvite", async () => {
       req.body = { token: "t1", organisationId: "o1" };
+      (req as unknown as { organisationId?: string }).organisationId = "o1";
       (
         CompanionOrganisationService.rejectInvite as jest.Mock
       ).mockRejectedValue(new Error("Test error"));

--- a/apps/backend/test/controllers/finance.controller.test.ts
+++ b/apps/backend/test/controllers/finance.controller.test.ts
@@ -551,6 +551,7 @@ describe("FinanceController", () => {
           },
         ],
       },
+      organisationId: "org_1",
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),
@@ -867,6 +868,7 @@ describe("FinanceController", () => {
 
     const req = {
       query: { organisationId: "org_1" },
+      organisationId: "org_1",
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),
@@ -907,6 +909,7 @@ describe("FinanceController", () => {
         providerSubscriptionId: "sub_1",
         quantity: 3,
       },
+      organisationId: "org_1",
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),
@@ -936,6 +939,7 @@ describe("FinanceController", () => {
         subscriptionId: "sub_1",
         featureKey: "appointments",
       },
+      organisationId: "org_1",
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),

--- a/apps/backend/test/middlewares/authorized-organisation.test.ts
+++ b/apps/backend/test/middlewares/authorized-organisation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { Request, Response } from "express";
+
+import { resolveAuthorizedOrganisationId } from "../../src/middlewares/authorized-organisation";
+
+const buildRes = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { res: { status, json } as unknown as Response, status, json };
+};
+
+const buildReq = (organisationId?: string) =>
+  ({ organisationId }) as unknown as Request;
+
+describe("resolveAuthorizedOrganisationId", () => {
+  it("returns the authorized organisation when nothing else is supplied", () => {
+    const { res, status } = buildRes();
+
+    expect(resolveAuthorizedOrganisationId(buildReq("org-1"), res)).toBe(
+      "org-1",
+    );
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("returns the authorized organisation when the request agrees with it", () => {
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(buildReq("org-1"), res, "org-1"),
+    ).toBe("org-1");
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("accepts a FHIR-style reference for the authorized organisation", () => {
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(
+        buildReq("org-1"),
+        res,
+        "Organization/org-1",
+      ),
+    ).toBe("org-1");
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("answers 403 when the request names a different organisation", () => {
+    const { res, status, json } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(buildReq("org-1"), res, "org-victim"),
+    ).toBeUndefined();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({
+      message: "Organisation does not match the authorized organisation.",
+    });
+  });
+
+  it("answers 403 for a FHIR-style reference to a different organisation", () => {
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(
+        buildReq("org-1"),
+        res,
+        "Organization/org-victim",
+      ),
+    ).toBeUndefined();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it("answers 400 when the RBAC layer authorized no organisation", () => {
+    const { res, status, json } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(buildReq(undefined), res, "org-1"),
+    ).toBeUndefined();
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      message: "Organisation identifier is required.",
+    });
+  });
+});

--- a/apps/backend/test/middlewares/authorized-organisation.test.ts
+++ b/apps/backend/test/middlewares/authorized-organisation.test.ts
@@ -44,6 +44,55 @@ describe("resolveAuthorizedOrganisationId", () => {
     expect(status).not.toHaveBeenCalled();
   });
 
+  it("accepts a prefixed authorized id against a bare request value", () => {
+    // withOrgPermissions matches membership against both `org-1` and
+    // `Organization/org-1`, so a caller sending the FHIR form in `x-org-id` is
+    // authorized and req.organisationId keeps the prefix. Normalising only the
+    // client value would refuse them.
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(
+        buildReq("Organization/org-1"),
+        res,
+        "org-1",
+      ),
+    ).toBe("org-1");
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("returns the bare id when only the authorized value is prefixed", () => {
+    // The return value is written into an `organisationId` column, so it must
+    // be the bare id and never the reference form.
+    const { res } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(buildReq("Organization/org-1"), res),
+    ).toBe("org-1");
+  });
+
+  it("still refuses a different organisation when both sides are prefixed", () => {
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(
+        buildReq("Organization/org-1"),
+        res,
+        "Organization/org-victim",
+      ),
+    ).toBeUndefined();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it("treats a bare prefix with no id as no organisation", () => {
+    const { res, status } = buildRes();
+
+    expect(
+      resolveAuthorizedOrganisationId(buildReq("Organization/"), res, "org-1"),
+    ).toBeUndefined();
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
   it("answers 403 when the request names a different organisation", () => {
     const { res, status, json } = buildRes();
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. Reported through the repository security policy rather than a public issue, per `.github/ISSUE_TEMPLATE`.
- [x] All existing tests and lints pass.

## What is the current behavior?

`withOrgPermissions()` resolves the organisation in a fixed order and stops at the first identifier it finds:

```ts
extractOrgIdFromParams(req.params)          // 1
  ?? extractOrgIdFromHeader(req.headers["x-org-id"])  // 2
  ?? extractOrgIdFromQuery(req.query)       // 3
  ?? extractOrgIdFromBody(req.body)         // 4
```

It then stamps the winner on the request as `req.organisationId`. A handler that goes back to the query or the body reads a *different* value from the one the membership and permission checks ran against, because the frontend's axios interceptor sends `x-org-id` on every request. Authorise on the header for an organisation you belong to, name another organisation in the payload, and the request acts on the second one.

Six routes did that. All sit behind `withOrgPermissions()` and none carry an `:organisationId` path param, so the header wins the extraction while the handler reads the payload.

| Route | Read from | Effect |
| --- | --- | --- |
| `POST /v1/finance/invoices` | body | invoice created in the named organisation |
| `POST /v1/finance/subscriptions` | body | subscription upserted for the named organisation |
| `GET /v1/finance/subscriptions/current` | query | another tenant's subscription returned |
| `GET /v1/finance/usage-snapshots` | query | another tenant's usage returned |
| `POST /v1/companion-organisation/pms/accept` | body | companion link claimed into the named organisation |
| `POST /v1/companion-organisation/pms/reject` | body | companion link stamped with the named organisation |

Two qualifications, because the severity is not uniform:

- `createInvoice` calls `assertAppointmentInOrganisation(appointmentId, organisationId)`, so reaching another tenant needs a known appointment id inside it. The authorisation check still verified a different organisation from the one written to, which is the defect.
- The invite routes are not theft of an existing link. The invite is created by a pet parent with no organisation at all and the accepting clinic stamps its own; the token is a bearer secret sent by email. What the bug allows is claiming a link into an organisation the caller does not belong to.

## What is the new behavior?

Every one of the six resolves the authorised organisation and treats the client-supplied value only as something to check against:

```ts
const organisationId = resolveAuthorizedOrganisationId(req, res, body.data.organisationId);
if (!organisationId) return;
```

A payload naming a different organisation is answered 403; a request the RBAC layer authorised no organisation for is answered 400.

`resolveAuthorizedOrganisationId` moves out of the catalog controller into `src/middlewares/authorized-organisation.ts` **unchanged**, so this adds no fifth copy of the block against the 0% duplication ceiling. The two lookalikes in `case-encounter.controller.ts` and `appointment.prisma.controller.ts` have different contracts - one throws a service error, the other performs no comparison at all - and are left alone.

### How the six were found, and what was cleared

A script parsed all **664** route registrations. **135** sit behind `withOrgPermissions()` with no organisation path param, which is the only shape where the extraction order can diverge from what the handler reads. Of those, **16** needed reading by hand and **6** were exposed.

The rest were cleared for concrete reasons, not by absence of a match:

- `catalog`, `case-encounter`, `document`, `observation-tool`, `speciality`, `task`, `inventory`, `organisation-document` already resolve the authorised organisation, several of them through the very helper this PR promotes.
- `FinanceController.listInvoices` and `recordVisitMilestone` already carry the equality check.
- `blood-transfusion`, `diagnostic-image` and `post-op-care-plan` looked exposed only because their base path is assembled from a template literal; each has `:organisationId` in it, and params take the highest precedence, so authorisation and the write use the same value.

## Validation performed

- Backend `npx tsc --noEmit`: 0 errors. `pnpm --filter backend run lint`: clean.
- 9 new controller tests and 6 new unit tests for the helper.
- **Mutation-checked.** With the guard replaced by a passthrough that returns the client value, exactly the 9 new controller tests fail:
  ```
  ● FinanceController › createInvoice › refuses a body naming an organisation other than the authorized one
  ● FinanceController › createInvoice › requires an authorized organisation on the request
  ● FinanceController › upsertSubscription › refuses a body naming an organisation other than the authorized one
  ● FinanceController › getCurrentSubscription › refuses a query naming an organisation other than the authorized one
  ● FinanceController › getUsageSnapshots › refuses a query naming an organisation other than the authorized one
  ● CompanionOrganisationController › acceptInvite › refuses a body naming an organisation other than the authorized one
  ● CompanionOrganisationController › acceptInvite › requires an authorized organisation on the request
  ● CompanionOrganisationController › rejectInvite › refuses a body naming an organisation other than the authorized one
  ● CompanionOrganisationController › rejectInvite › requires an authorized organisation on the request
  ```
  Restored, all pass again.
- Wider run `--testPathPatterns="catalog|finance|companion|authorized-organisation|invoice|subscription|rbac"`: **1492 passed, 37 suites**.

Four existing test files had to start supplying an authorised organisation on the request. That they did not before is the same defect, seen from the test side: the handlers accepted a payload organisation with nothing authorised at all.

## Related Issue(s)

No public issue: the repository bug template states security vulnerabilities must not be reported there because issues are public. Reported through the security policy instead.
