### PR TITLE
docs(docs): record ADR 0005, the AI editing agent security model

### DIFF
--- a/docs/adr/0005-ai-editing-agent-security-model.md
+++ b/docs/adr/0005-ai-editing-agent-security-model.md
@@ -1,0 +1,95 @@
+# 0005. Security model for the Tier 1 in-browser AI editing agent
+
+**Status:** Proposed
+
+> **Nothing described here is implemented on `dev` as of 2026-09-02.** The ADR is
+> recorded ahead of the build on purpose - the Context says the model must be
+> decided before the surface exists - so it is a constraint on future work, not a
+> description of a shipped feature. `authorizeApiKey` and `requireScope` exist in
+> the tree but are mounted on no route; the Developer Data API this design reads
+> through is not deployed; there is no agent surface in the product. The
+> "Definition of done" section lists what would have to be true for that to
+> change. This ADR keeps the status `Proposed` past its merge, against the
+> convention in [README](README.md), for exactly that reason.
+> **Date:** 2026-07-07
+
+## Context
+
+Epic #1582 Phase 2 puts an AI editing agent inside `/developers`: a developer chats with a model in the browser and the agent edits their PIMS configuration (Forms, Templates, ObservationTool, FHIR mappings) through an MCP toolset over the planned Developer Data API contract (designed on the `feat/dev-portal-phase2-foundations` branch, not in this repo). The developer brings their own inference key (Claude or OpenAI); Yosemite Crew does not proxy or meter inference in Tier 1.
+
+This is the highest-risk surface in the developer platform, and its security model must be decided **before** it is built:
+
+- The agent operates inside a system holding veterinary health data. Model output is probabilistic; a hallucinated or prompt-injected tool call must not be able to change what clinicians see in production, alter the database schema, or exfiltrate patient data.
+- Data the agent reads back from the PIMS (patient names, form field contents, template bodies) can itself contain adversarial text. Any security model that assumes the model "follows instructions" fails here.
+- The BYO inference key is a valuable credential belonging to the developer. Custody, logging, and revocation need explicit rules, or the key leaks into logs and error reports by default.
+- The building blocks are already built and constrain the design: versioned form/template models with a draft-then-publish lifecycle in the config engine, `DeveloperApiKey` with hashed keys and scoped auth (`authorizeApiKey` + `requireScope` in `apps/backend/src/middlewares/api-key-auth.ts`, which are on `dev` but mounted on no route, so they are a written contract rather than a live boundary), `DeveloperApiUsage` metering (same PR) with per-key rate limiting specified in the data API contract, and the read-only data-plane pattern prototyped in closed PR #1726 (`developer-data.router.ts`, `packages/mcp-server`) and superseded by the planned Developer Data API contract.
+
+## Decision
+
+The Tier 1 agent is a **config-scoped, draft-only, human-promoted** editor. Five rules define the model.
+
+### 1. Capability boundary: config tools only
+
+- The MCP toolset exposes exactly: CRUD on Forms, Templates, and ObservationTool definitions **in draft state**, plus read-only access to data the developer's account can already see (the read endpoints of the planned Developer Data API contract (designed on the `feat/dev-portal-phase2-foundations` branch, not in this repo), e.g. `GET /v1/developer/appointments` and `GET /v1/developer/patients`, and config reads).
+- The agent never gets schema or migration tools - Prisma Migrate stays the human-only source of truth (ADR 0001).
+- No arbitrary HTTP fetch tool. No code-commit rights: code changes are Tier 2, a human path through the Yosemite GitHub App (see the planned Tier 2 GitHub App design, not in this repo).
+- The tool list is a static allowlist compiled into the client. There is no "register a new tool at runtime" surface. Later config surfaces extend the allowlist only by code change reviewed against this ADR (the Phase 3b planned website builder, not in this repo registers its site-config tools this way).
+
+### 2. Draft/promote gate: no agent-initiated publish
+
+- Every agent write creates or updates a **draft version** using the existing versioned form/template models - the same versioning and publish machinery clinicians already use, not a parallel one.
+- Publishing (promoting a draft to the active version) is a separate endpoint requiring an interactive human session (`requireWebAuth`, ADR 0003 / PR #1763, unmerged as of this ADR's date). It is deliberately absent from the MCP toolset.
+- The `/developers` UI shows a diff between the draft and the published version before the publish button.
+- A prompt-injected agent can therefore at worst litter the draft space; it cannot change what renders in a clinic.
+
+### 3. Key custody: client-side by default, vaulted opt-in
+
+- The BYO inference key lives in the browser session by default (memory/session storage, never a cookie). Inference calls go browser-to-provider directly; the key never transits Yosemite Crew servers.
+- As an opt-in convenience ("remember my key"), the key may be stored server-side encrypted with AES-256-GCM under a per-developer data key, itself wrapped by a key-encryption-key supplied from environment/KMS - the same envelope pattern as other platform secrets.
+- The key is never written to logs, error reports, or audit entries in any storage mode.
+- The developer can revoke (delete) the vaulted copy at any time.
+
+### 4. Tool-call auth: the developer's own identity, narrow scope
+
+- Agent tool calls hit the backend as the developer, never as a service account: either the developer's own web session, or a purpose-issued `DeveloperApiKey` created for the agent.
+- That key carries a dedicated narrow scope set - `config:draft:write` plus read scopes (`config:read` and the canonical `:read` scopes from the data API contract, section 4) - enforced per route by the existing `requireScope` middleware. It cannot publish, and it cannot write outside config drafts.
+- The key gets the `DeveloperApiUsage` metering from PR #1696 and the standard per-key rate limits defined in the data API contract.
+- Every tool call is audit-logged with the developer id, key id, tool name, target entity, and the agent conversation id, so a bad edit is traceable to the exact chat turn that produced it.
+
+### 5. Prompt-injection stance: assume the model is compromised
+
+- All data returned from PIMS reads is treated as untrusted input to the model.
+- Defences are structural, not behavioural: the tool allowlist is static (an injected instruction cannot add tools); no tool accepts an arbitrary URL or can send data anywhere except the Yosemite Crew API, limiting exfiltration to what the developer's own scopes already permit; write blast radius is capped at drafts.
+- The human diff-review-publish step is the final backstop. System-prompt hardening is applied but never relied on.
+
+## Consequences
+
+**Good:**
+
+- Worst-case agent compromise (full prompt injection) is bounded: garbage drafts and reads the developer was already entitled to. No schema change, no production config change, no cross-tenant access, no exfiltration channel.
+- Reuses already-built machinery - versioned drafts, `authorizeApiKey`/`requireScope`, rate limiting, usage metering - instead of a new privileged execution path, so the agent's surface is reviewable as ordinary API routes.
+- BYO client-side keys mean Yosemite Crew holds no inference credentials by default: nothing to breach, no provider terms-of-service exposure, no inference cost pass-through in v1.
+- The audit trail (tool call + conversation id) makes agent behaviour debuggable and gives compliance a complete answer to "what did the AI change and who approved it".
+
+**Bad / accepted trade-offs:**
+
+- Draft/promote adds friction: the "vibe code your PIMS" loop always ends in a manual review-and-publish click. Rapid iterate-preview cycles must work against drafts (the Phase 2 sandboxed preview) to keep the loop tight.
+- Client-side key custody is worse UX: the key must be re-entered per browser/session unless the developer opts into the vault, and browser-to-provider calls depend on the provider's CORS support (Anthropic supports this; a thin egress-pinned relay may be needed for providers that do not).
+- Audit volume is high - one row per tool call, and an agent conversation can emit dozens - so audit storage needs retention limits from day one.
+- A dedicated `config:draft:write` scope and a draft-only write path add scope-model and endpoint complexity to the API surface shipped in PR #1696.
+
+## Definition of done
+
+This ADR is implemented when:
+
+- The MCP toolset ships with only the tools named in rule 1, and adding a tool requires a code change reviewed against this ADR.
+- No publish/promote endpoint accepts the agent's API key scope; publish requires `requireWebAuth`.
+- The `config:draft:write` scope exists in the `DeveloperApiKey` scope model and is enforced by `requireScope` on every agent-writable route.
+- Key vaulting is opt-in, envelope-encrypted, and a log/error-report scan shows no inference-key material.
+- Every agent tool call produces an audit row carrying the conversation id.
+
+## Alternatives considered
+
+- **Server-side agent execution** (backend holds the conversation loop and calls the inference provider): rejected for v1. It forces server custody of every developer's BYO key and moves the agent inside the trust boundary, where a compromise has server-level blast radius instead of one browser session. Revisit if the platform later meters inference itself - platform-owned keys change the custody calculus entirely.
+- **Agent with direct publish rights** (no draft gate, writes go live): rejected. An unreviewed model output changing forms and templates that clinicians use on real patients is not defensible for a system handling health data. The human diff review is the compliance control, not an optional convenience.
+- **Fully client-side agent with no server tools** (model only generates config JSON the developer pastes in): rejected. It cannot read current config or data to ground its edits, which is the whole value of the loop, and manual paste bypasses validation and audit rather than avoiding risk.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,5 +22,14 @@ Skip it for anything a code review can fully capture on its own — a new utilit
 | [0001](./0001-postgres-prisma-source-of-truth.md)            | Postgres + Prisma as the target source of truth                           | Accepted (migration complete - exit criteria met by #1819, 2026-07-18) | 2026-06-07 |
 | [0002](./0002-stripe-direct-charges-merchant-of-record.md)   | Stripe Standard Connect with direct charges; clinic as merchant of record | Accepted                                                               | 2026-06-25 |
 | [0003](./0003-provider-neutral-auth-boundary-supertokens.md) | Provider-neutral auth boundary with SuperTokens as the first adapter      | Accepted (implemented via PR #1763, merged 2026-07-16)                 | 2026-07-02 |
+| [0005](./0005-ai-editing-agent-security-model.md)            | Security model for the AI editing agent in the developer portal           | Proposed (nothing implemented on `dev`; see the note in the ADR)       | 2026-07-07 |
+
+0004 is deliberately unused. It was drafted as a developer-tenant data-residency
+decision on the `feat/dev-portal-phase2-foundations` branch, but its Context asserts
+that `packages/database/src/tenant.ts` implements a live schema-per-tenant primitive,
+and that table was dropped in `20260609102059_catalog_module` on 2026-06-12, 25 days
+before the draft was written. Rather than merge a public document asserting a deleted
+capability, the number is left free for a residency ADR written against what the repo
+actually has.
 
 See also [SuperAdmin ADR-0001](https://github.com/YosemiteCrew/SuperAdmin/blob/main/docs/adr/0001-audit-log-on-supertokens-usermetadata.md) for the audit-log persistence decision in the SuperAdmin app (separate repo, separate ADR log — it documents SuperAdmin's own codebase).


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for - epic #1787 / PR #1788.
- [x] All existing tests and lints pass.

## What is the current behavior?

PR #1788 has been open since 2026-07-07 with 86 files. It bundles design docs, two ADRs, an MCP server package, a scaffolding CLI, a Swagger explorer and an agent playground. None of it has landed.

I assessed each part against `dev` as it stands rather than against the PR description. The governing fact:

```
$ git grep -n "authorizeApiKey\|api-key-auth" origin/dev -- apps/backend/src
apps/backend/src/middlewares/api-key-auth.ts:25
apps/backend/src/middlewares/api-key-auth.ts:55
```

Two hits, both definitions. **`api-key-auth` is mounted on no route.** A developer API key minted today unlocks zero endpoints, and `dev` serves only the session-authenticated management plane at `/v1/developers/{api-keys,billing,usage}` - plural. There is no `/v1/developer` data plane.

## What is the new behavior?

This PR takes **one file** from that branch, plus its README entry.

### Why only one

| Area | Verdict | Why |
| --- | --- | --- |
| `packages/mcp-server` | blocked | All ten tools call `/v1/developer/*`. Zero exist. |
| `packages/create-yosemite-app` | blocked | Scaffolds a client for the same absent API. |
| dev-docs Swagger explorer | drop | Interactive try-it-out over endpoints that 404. |
| `/developers/playground` | blocked | Tool layer targets the same absent API. |
| 7 Phase 3 plans + data-api contract | defer | See below. |
| ADR 0004 | drop | See below. |
| **ADR 0005** | **take, with edits** | This PR. |

Shipping the first four would add four more surfaces that look real and resolve to 404 - the same class PR #2571 has just finished removing from the developer docs. The MCP server is the sharpest case: against `dev`'s actual mount shape it renders *"Not found ... the resource does not exist or belongs to a different organisation than this API key"*, which sends a developer hunting for a fault in their own key. Its `connect-claude.md` would also be wired into the published dev-docs sidebar, giving a navigable documented path to nothing.

The seven Phase 3 plans are honestly framed - every one carries `Status: Proposed - a design for ratification, not an implementation log` and a Non-goals section - and `docs/plans/` is repo-only, so they are not a fake surface. They are deferred for a different reason: eight of the nine files would carry a link to `docs/plans/developer-portal-data-api.md`, and that contract is falsified by PR #2599. It states org scoping is absolute and that no header selects an organisation; #2599 re-keys `DeveloperApiKey` to `ownerUserId` precisely because a public-door developer has no organisation. Taking the set while holding the contract leaves dangling links in a public repo, one of them pointing at the website-builder plan.

**ADR 0004 is dropped and its number left free.** Its Context asserts that `packages/database/src/tenant.ts` implements a live schema-per-tenant primitive. `DROP TABLE public."Tenant"` landed in `20260609102059_catalog_module` on 2026-06-12 - 25 days before the ADR was drafted - and `model Tenant` does not exist in `schema.prisma`. This repo is public. The reason is recorded in the ADR README so the gap is deliberate rather than a mystery.

### Why ADR 0005 is worth taking alone

It records the constraints on the highest-risk surface the portal will grow - an AI agent editing PIMS configuration - **before** anyone builds it, which is what an ADR is for. Each of its five rules rejects a named alternative, and it carries a Definition of done listing what is still unmet.

It is also not orphaned. The staged `feat/developer-data-plane` branch already cites it seven times as governing law for its draft-only install path:

```
routers/template-pack.router.ts:42
services/template-pack.service.ts:15, :205
services/developer-api-key.service.ts:40
test/services/template-pack.service.test.ts:270
test/services/developer-api-key.service.test.ts:140
packages/database/prisma/schema.prisma:3110
```

### Edits made against the branch version

1. **The five `docs/plans/` links are de-linked** to plain text. Those files are not in this repo and dangling links in a public one are not free.
2. **The "already built" claim is corrected.** It listed `authorizeApiKey` + `requireScope` among four blocks that "are already built"; they are on `dev` but mounted on no route, so they are now described as a written contract rather than a live boundary.
3. **A note at the top** states that nothing described is implemented on `dev`, and why the status stays `Proposed` past merge against the README's own convention.

## Validation performed

- `prettier --check docs/adr/` clean under the repo's prettier 3.9.6.
- Every relative link in the ADR resolves against the repo tree - checked programmatically, zero dangling.
- Docs-only: no source, schema or test files touched, so no conflict with #2599 or the staged data-plane branch (verified: neither diff contains a `docs/adr` file).

## Related Issue(s)

Refs #1787, #1788
