### PR TITLE
fix(frontend): stop the plugin catalog claiming installs it cannot count

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperPlugins.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperPlugins.test.tsx
@@ -44,15 +44,32 @@ describe('DeveloperPlugins page', () => {
     expect(screen.getByTestId('primary-Submit a plugin')).toHaveAttribute('href', '/contact-us');
   });
 
-  test('renders the three catalog plugin cards with badges', () => {
+  test('renders three sample cards, every one badged as a sample', () => {
     render(<DeveloperPlugins />);
-    expect(screen.getByRole('heading', { name: 'IDEXX lab bridge' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'MSD Vet Manual' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Anesthesia monitor sync' })).toBeInTheDocument();
-    expect(screen.getByText('Installed · 412 clinics')).toBeInTheDocument();
-    expect(screen.getByText('In review')).toBeInTheDocument();
-    expect(screen.getByText('Review status')).toBeInTheDocument();
-    expect(screen.getAllByText('Manage').length).toBe(2);
+    expect(screen.getByRole('heading', { name: 'Lab result bridge' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Clinical reference' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Monitor sync' })).toBeInTheDocument();
+    expect(screen.getAllByText('Sample')).toHaveLength(3);
+  });
+
+  test('claims no installs, and names no third party as having one', () => {
+    // Nothing counts installs - there is no plugin model and no plugin
+    // endpoint - and two of these named real companies.
+    render(<DeveloperPlugins />);
+    expect(screen.queryByText(/Installed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/412 clinics/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/1,208 clinics/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/IDEXX/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/MSD/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Jonas Timm/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Manage')).not.toBeInTheDocument();
+  });
+
+  test('says on the page that the cards are illustrations', () => {
+    render(<DeveloperPlugins />);
+    expect(
+      screen.getByText(/cards below are illustrations, not installed integrations/i)
+    ).toBeInTheDocument();
   });
 
   test('renders the website builder promo card linking to the builder route', () => {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
@@ -81,8 +81,21 @@ const CreateKeyForm = ({
         className="DevApiKeys-input"
         value={scopesInput}
         onChange={(event) => setScopesInput(event.target.value)}
-        placeholder="appointments:read, inventory:read"
+        placeholder="appointments:read"
+        aria-describedby="apiKeyScopesHelp"
       />
+      {/*
+        The scopes are stored on the key and returned when it is listed, but
+        nothing checks them yet: `requireScope` exists in
+        apps/backend/src/middlewares/api-key-auth.ts and is mounted on no route.
+        Saying so is the difference between a field a developer can plan around
+        and one that looks like an access control it is not. The old placeholder
+        also suggested `inventory:read`, a scope no endpoint has ever read.
+      */}
+      <p id="apiKeyScopesHelp" className="text-caption-2 text-text-tertiary">
+        Recorded on the key for forward compatibility. No endpoint enforces scopes yet, so a key is
+        not restricted by what you enter here.
+      </p>
       <div className="DevApiKeys-formActions">
         <Primary
           text={creating ? 'Creating…' : 'Create'}

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css
@@ -81,16 +81,13 @@
   text-align: center;
 }
 
-.dev-plugin-badge.installed {
-  background: var(--status-completed-bg);
-  color: var(--status-completed-text);
-  border-color: var(--status-completed-border);
-}
-
-.dev-plugin-badge.in-review {
-  background: var(--status-in-progress-bg);
-  color: var(--status-in-progress-text);
-  border-color: var(--status-in-progress-border);
+/* A neutral badge: these cards illustrate what a plugin could be, so they must
+   not borrow the green "completed" or amber "in progress" treatment the rest of
+   the product uses for real state. */
+.dev-plugin-badge.sample {
+  background: var(--surface-muted, rgb(0 0 0 / 4%));
+  color: var(--text-tertiary, #6b6b6b);
+  border-color: var(--border-subtle, rgb(0 0 0 / 8%));
 }
 
 .dev-plugin-card-title {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.stories.tsx
@@ -140,9 +140,11 @@ const meta = {
           'loading, empty or error state to draw. The page says as much itself, in the ' +
           '"Preview · the plugin catalog and submission flow are coming soon" pill.\n\n' +
           'Worth knowing before reading the stories: **none of the plugin cards are ' +
-          'interactive**. "Manage" and "Review status" are bare `<span>`s in the accent ink, so ' +
-          'they read as links, cannot be tabbed to, and do nothing when clicked. The only three ' +
-          'real controls on the page are "Submit a plugin" (to `/contact-us`) and the two ' +
+          'interactive**, and they no longer pretend to be. They previously ended in ' +
+          'accent-inked "Manage" and "Review status" spans that read as links, could not be ' +
+          'tabbed to and did nothing - on cards that also claimed IDEXX and MSD integrations ' +
+          'were installed in 412 and 1,208 clinics, which nothing counts. The only three real ' +
+          'controls on the page are "Submit a plugin" (to `/contact-us`) and the two ' +
           'website-builder CTAs, which share a single destination.\n\n' +
           'The lower half is a promo panel painted from `--spot`, the always-dark token, holding ' +
           'a hand-built browser-chrome mock - three dots, a URL pill and a miniature clinic ' +
@@ -170,36 +172,31 @@ export const Catalog: Story = {
     // level-1 query ambiguous on every story in this repo.
     await expect(canvas.getByRole('heading', { level: 1, name: 'Plugins' })).toBeInTheDocument();
 
-    /* The three fixtures, in order. Reading the h2s as a list pins the order too,
-       which a per-title `getByText` would not: the in-review card is deliberately
-       last so the two installed ones lead. */
+    /* The three illustrations, in order. */
     const titles = canvas.getAllByRole('heading', { level: 2 }).map((h) => h.textContent);
-    await expect(titles).toEqual(['IDEXX lab bridge', 'MSD Vet Manual', 'Anesthesia monitor sync']);
+    await expect(titles).toEqual(['Lab result bridge', 'Clinical reference', 'Monitor sync']);
 
-    /* The badge is one element whose STATUS lives only in a class name, and that
-       class is the only thing choosing between the completed and in-progress
-       token triples. Drop it and the badge still reads correctly while being
-       silently the wrong colour, so the computed background is compared rather
-       than the class alone. */
+    /* Every badge reads "Sample" and carries the neutral treatment. These cards
+       used to claim "Installed · 412 clinics" against IDEXX and "1,208 clinics"
+       against MSD - real companies - while nothing in the platform counts
+       installs. They must not borrow the green "completed" token triple the rest
+       of the product uses for real state. */
     const badges = [...canvasElement.querySelectorAll('.dev-plugin-badge')] as HTMLElement[];
-    await expect(badges.map((b) => b.textContent)).toEqual([
-      'Installed · 412 clinics',
-      'Installed · 1,208 clinics',
-      'In review',
-    ]);
-    await expect(badges[0]).toHaveClass('installed');
-    await expect(badges[2]).toHaveClass('in-review');
-    await expect(getComputedStyle(badges[0]).backgroundColor).not.toBe(
-      getComputedStyle(badges[2]).backgroundColor
-    );
+    await expect(badges.map((b) => b.textContent)).toEqual(['Sample', 'Sample', 'Sample']);
+    for (const badge of badges) await expect(badge).toHaveClass('sample');
+    await expect(canvas.queryByText(/Installed/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/IDEXX|MSD|Jonas Timm/)).not.toBeInTheDocument();
 
     /* The finding this page is worth reviewing for. Every card ends in an
        accent-inked word that looks exactly like a link, and every one of them is
        a `<span>`: the grid contains no anchor, no button and nothing focusable at
        all. A keyboard user tabs straight past all three. */
     const grid = must(canvasElement, '.dev-plugins-grid');
-    const actions = [...grid.querySelectorAll('.dev-plugin-card-action')];
-    await expect(actions.map((a) => a.textContent)).toEqual(['Manage', 'Manage', 'Review status']);
+    /* The accent-inked pseudo-links are gone with the fabricated state they
+       described: "Manage" on a plugin nothing can manage was the clearest case
+       of a control that looked real and did nothing. The grid is now plainly
+       non-interactive, which matches what it is. */
+    await expect(grid.querySelectorAll('.dev-plugin-card-action')).toHaveLength(0);
     await expect(grid.querySelectorAll('a, button, [tabindex]')).toHaveLength(0);
 
     /* So the whole page carries exactly three controls, and two of them go to the
@@ -393,7 +390,7 @@ export const NotADeveloper: Story = {
     ).not.toBeInTheDocument();
     await expect(canvasElement.querySelector('.dev-plugins-grid')).toBeNull();
     await expect(canvasElement.querySelector('.dev-website-card')).toBeNull();
-    await expect(canvas.queryByText('IDEXX lab bridge')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Lab result bridge')).not.toBeInTheDocument();
 
     /* Both ways out are present, and neither is clicked here: "Create a developer
        account" calls the store's real `signout`, which POSTs `/v1/auth/logout`

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.tsx
@@ -10,7 +10,7 @@ import DevRouteGuard from '@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard';
 import './DeveloperPlugins.css';
 import '@/app/features/organizations/styles/Organizations.css';
 
-type PluginStatus = 'installed' | 'in-review';
+type PluginStatus = 'sample';
 
 type PluginCard = {
   id: string;
@@ -20,39 +20,46 @@ type PluginCard = {
   badge: string;
   status: PluginStatus;
   author: string;
-  action: string;
 };
 
+/*
+ * Illustrations of the kind of integration the catalog is for, not a catalog.
+ *
+ * These cards used to carry adoption figures - "Installed · 412 clinics" and
+ * "Installed · 1,208 clinics" - against IDEXX and MSD, two real companies, plus
+ * a named author and version for a third. Nothing counts installs, because
+ * there is no plugin model in the schema and no plugin endpoint in the backend.
+ * A "coming soon" line at the top of the page does not neutralise a specific
+ * claim about a named third party further down it, so the claims are gone
+ * rather than merely disclaimed.
+ */
 const PLUGINS: PluginCard[] = [
   {
-    id: 'idexx-lab-bridge',
-    title: 'IDEXX lab bridge',
-    description: 'Order and result IDEXX lab work inside the appointment workspace.',
+    id: 'lab-bridge',
+    title: 'Lab result bridge',
+    description: 'Order lab work and read results inside the appointment workspace.',
     icon: 'ion:flask-outline',
-    badge: 'Installed · 412 clinics',
-    status: 'installed',
-    author: 'by Yosemite Crew · v2.3',
-    action: 'Manage',
+    badge: 'Sample',
+    status: 'sample',
+    author: 'Example of a diagnostics integration',
   },
   {
-    id: 'msd-vet-manual',
-    title: 'MSD Vet Manual',
-    description: 'Reference the veterinary manual from the workspace side rail.',
+    id: 'clinical-reference',
+    title: 'Clinical reference',
+    description: 'Read a veterinary reference from the workspace side rail.',
     icon: 'ion:book-outline',
-    badge: 'Installed · 1,208 clinics',
-    status: 'installed',
-    author: 'by Yosemite Crew · v1.8',
-    action: 'Manage',
+    badge: 'Sample',
+    status: 'sample',
+    author: 'Example of a reference integration',
   },
   {
-    id: 'anesthesia-monitor-sync',
-    title: 'Anesthesia monitor sync',
-    description: 'Your submission. It streams Mindray vitals into the workspace.',
+    id: 'monitor-sync',
+    title: 'Monitor sync',
+    description: 'Stream vitals from theatre monitors into the workspace.',
     icon: 'ion:pulse-outline',
-    badge: 'In review',
-    status: 'in-review',
-    author: 'by Jonas Timm · v0.4.1',
-    action: 'Review status',
+    badge: 'Sample',
+    status: 'sample',
+    author: 'Example of a device integration',
   },
 ];
 
@@ -84,7 +91,8 @@ const DeveloperPlugins = () => {
         </div>
 
         <p className="dev-plugins-preview text-caption-2">
-          Preview · the plugin catalog and submission flow are coming soon.
+          Preview · the plugin catalog and submission flow are coming soon. The cards below are
+          illustrations, not installed integrations.
         </p>
 
         <section className="DevPlugins">
@@ -103,7 +111,6 @@ const DeveloperPlugins = () => {
                 <p className="dev-plugin-card-desc">{plugin.description}</p>
                 <div className="dev-plugin-card-foot">
                   <span className="dev-plugin-card-author">{plugin.author}</span>
-                  <span className="dev-plugin-card-action">{plugin.action}</span>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for - found while e2e testing the developer portal on dev.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Plugins page states adoption figures for two real companies:

| Card | Badge | Author |
| --- | --- | --- |
| IDEXX lab bridge | **Installed · 412 clinics** | by Yosemite Crew · v2.3 |
| MSD Vet Manual | **Installed · 1,208 clinics** | by Yosemite Crew · v1.8 |
| Anesthesia monitor sync | In review | **by Jonas Timm** · v0.4.1 |

Nothing counts installs:

```
$ grep -n "^model .*Plugin" packages/database/prisma/schema.prisma
(no matches)
$ grep -rn "plugin" apps/backend/src/routers/index.ts
(no matches)
```

`DeveloperPlugins.tsx` makes **zero API calls** across its 173 lines — `PLUGINS` is a module-level array. So these are specific claims about named third parties, with no source, on a signed-in product surface.

The page already carries a `Preview · the plugin catalog and submission flow are coming soon` pill, which is probably why this survived review. A disclaimer about the *catalog* does not neutralise a claim about a named company further down the same page.

## What is the new behavior?

The three cards keep the job they were actually useful for — showing the *kind* of integration the catalog is for — with the assertions removed:

- Retitled generically: **Lab result bridge**, **Clinical reference**, **Monitor sync**. No company named, no person named, no version.
- Every badge reads **Sample**, matching the pattern the Website Builder page already uses for its template cards.
- Footers read "Example of a diagnostics / reference / device integration".
- The preview pill now says the cards are illustrations, not installed integrations.

Two smaller things fixed alongside:

- **The badges borrowed real status tokens.** `.installed` used `--status-completed-*` (green) and `.in-review` used `--status-in-progress-*` (amber) — the same triples the product uses for genuine state elsewhere. Replaced with a neutral treatment so a sample cannot read as a status.
- **Each card ended in a fake control.** `Manage` / `Review status` were accent-inked `<span>`s: styled like links, not focusable, doing nothing — on a plugin nothing can manage. Removed along with the state they described. The page's own Storybook docs had already flagged these as non-interactive.

### Also: the API key scopes field

`CreateKeyForm` suggested `appointments:read, inventory:read` and read as an access control. No route enforces scopes — `requireScope` in `api-key-auth.ts` is mounted nowhere — and `inventory:read` has never been read by anything:

```
$ grep -rn "inventory:read\|appointments:read" apps/backend/src --include="*.ts" | grep -v '\.test\.'
(no matches)
```

The field now carries help text saying the scopes are recorded on the key but not enforced, so a developer can plan around it rather than believing a key is restricted.

## Validation performed

- Frontend `npx tsc --noEmit`: clean. `pnpm --filter frontend run lint`: clean.
- `--testPathPatterns="Developer|developers|offlineIcons"`: **16 suites, 121 tests, all pass.**
- **Mutation-checked.** Restoring the `IDEXX lab bridge` title and the `Installed · 412 clinics` badge fails both new tests (`claims no installs, and names no third party as having one`, `renders three sample cards, every one badged as a sample`).
- Storybook play functions updated: they had been asserting the exact fabricated badge strings and the `Manage`/`Review status` span order.

## Related

Follows #2606, which removed the same class of invented data from the developer dashboard, and #2571, which removed a Webhooks docs page that had no model behind it.
