### PR TITLE
fix(frontend): derive the booking test's dates instead of hardcoding them

### DIFF
--- a/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/book/BookClient.test.tsx
@@ -73,12 +73,34 @@ const fillForm = () => {
   fireEvent.change(screen.getByLabelText('Species'), { target: { value: 'Dog' } });
 };
 
+/*
+ * Dates are derived, never written down.
+ *
+ * These were the literals '2026-09-01' and '2026-09-02', standing for today
+ * and tomorrow. BookClient initialises its own state with `useState(todayIso)`, so
+ * once the real date reached 2026-09-02 the "change the day" test was setting
+ * the field to the value it already held: React saw no transition, no refetch
+ * ran, and the 11:00 slot it waited for never rendered. The suite failed on
+ * every branch in the repo from that midnight onward - not flakily, but for
+ * good, since from 2026-09-03 the literal is also before the input's `min`.
+ *
+ * UTC arithmetic to match `todayIso`, which is `toISOString().slice(0, 10)`.
+ */
+const isoDaysFromToday = (days: number) => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const TODAY = isoDaysFromToday(0);
+const TOMORROW = isoDaysFromToday(1);
+
 describe('BookClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getPracticeMock.mockResolvedValue({ kind: 'practice', practice: practice() });
     getSlotsMock.mockResolvedValue({
-      date: '2026-09-01',
+      date: TODAY,
       serviceId: 'svc-1',
       durationMinutes: 30,
       windows: [
@@ -194,7 +216,7 @@ describe('BookClient', () => {
 
   it('says when a day has no times at all', async () => {
     getSlotsMock.mockResolvedValue({
-      date: '2026-09-01',
+      date: TODAY,
       serviceId: 'svc-1',
       durationMinutes: 30,
       windows: [],
@@ -266,13 +288,13 @@ describe('BookClient', () => {
     expect(screen.getByRole('button', { name: '09:00' })).toHaveAttribute('aria-pressed', 'true');
 
     getSlotsMock.mockResolvedValue({
-      date: '2026-09-02',
+      date: TOMORROW,
       serviceId: 'svc-1',
       durationMinutes: 30,
       windows: [{ startTime: '11:00', endTime: '11:30' }],
     });
     fireEvent.change(screen.getByLabelText('Preferred day'), {
-      target: { value: '2026-09-02' },
+      target: { value: TOMORROW },
     });
 
     // The old time is gone from the new day's list, so it cannot remain chosen.
@@ -411,7 +433,7 @@ describe('BookClient', () => {
 
   it('heads the day parts only when a day actually spans more than one', async () => {
     getSlotsMock.mockResolvedValue({
-      date: '2026-09-01',
+      date: TODAY,
       serviceId: 'svc-1',
       durationMinutes: 30,
       windows: [
@@ -495,7 +517,7 @@ describe('BookClient', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
     await act(async () => {
-      settle({ date: '2026-09-01', serviceId: 'svc-1', durationMinutes: 30, windows: [] });
+      settle({ date: TODAY, serviceId: 'svc-1', durationMinutes: 30, windows: [] });
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for - this is a live CI blocker, found on #2607.
- [x] All existing tests and lints pass.

## What is the current behavior?

**`dev` CI is broken for every branch as of 2026-09-02T00:00Z.** This is not a flake.

`BookClient.test.tsx` wrote today and tomorrow down as literals:

```ts
getSlotsMock.mockResolvedValue({ date: '2026-09-01', ... });   // "today"
// ...
fireEvent.change(screen.getByLabelText('Preferred day'), {
  target: { value: '2026-09-02' },                              // "tomorrow"
});
await waitFor(() => expect(screen.getByRole('button', { name: '11:00' })).toBeInTheDocument());
```

At midnight UTC those stopped meaning that, and `deselects a chosen time when the day changes` began failing:

```
● BookClient › deselects a chosen time when the day changes
  Unable to find role="button" and name "11:00"
```

The mechanism: `BookClient` initialises its own state from the clock —

```ts
const todayIso = () => new Date().toISOString().slice(0, 10);
// ...
const [date, setDate] = useState(todayIso);
```

so the field **already held `2026-09-02`**. Firing a change to the value React already has is not a transition: nothing re-rendered, no slot refetch ran, and the `11:00` button the test waits for never appeared.

It would not have recovered tomorrow either. From 2026-09-03 the literal is *earlier* than the input's own `min` (also `new Date().toISOString()`), so the field would refuse it rather than ignore it.

## What is the new behavior?

Dates are derived, in UTC to match `todayIso`:

```ts
const isoDaysFromToday = (days: number) => {
  const date = new Date();
  date.setUTCDate(date.getUTCDate() + days);
  return date.toISOString().slice(0, 10);
};

const TODAY = isoDaysFromToday(0);
const TOMORROW = isoDaysFromToday(1);
```

Five `'2026-09-01'` and three `'2026-09-02'` literals replaced. The comment above the helper records what happened, so the next person to reach for a date literal here sees the cost.

## Validation performed

Verified in both directions, today:

- **Restoring the two literals reproduces the exact CI failure locally** — `1 failed, 28 passed`, same test, same "Unable to find ... 11:00" message.
- **With the dates derived** — `29 passed, 29 total`.
- **CI shard 2/4**, which is where this surfaced, passes **247 suites / 2980 tests**.
- Frontend `tsc --noEmit` clean; `lint` clean.

Timing corroborates the diagnosis: `date -u` reads `2026-09-02 00:16` and the failing run started 16 minutes after the rollover. Earlier PRs merged tonight (#2606 at ~01:2x local) passed the same shard before midnight UTC.

## Impact

This unblocks **#2607** and every other open PR — none of them can go green until this lands.
