### PR TITLE
fix(frontend): stop four surfaces asserting state nothing records

### DIFF
--- a/apps/frontend/src/app/__tests__/features/guides/pages/Guides.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/guides/pages/Guides.test.tsx
@@ -63,11 +63,17 @@ describe('Guides page', () => {
     expect(cardButton('Connect IDEXX in 5 minutes')).toBeInTheDocument();
   });
 
-  it('renders each card status variant', () => {
+  it('renders the New badge, which is content age rather than viewer state', () => {
     render(<ProtectedGuides />);
-    expect(screen.getByText('Watched')).toBeInTheDocument();
-    expect(screen.getByText('60%')).toBeInTheDocument();
     expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('shows no viewing history, because nothing records one', () => {
+    // "Watched" and a 60% progress bar were module literals, so every user of
+    // every clinic was told they had already watched the same guide.
+    render(<ProtectedGuides />);
+    expect(screen.queryByText('Watched')).not.toBeInTheDocument();
+    expect(screen.queryByText('60%')).not.toBeInTheDocument();
   });
 
   it('filters the grid by category chip', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceInfo.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceInfo.test.tsx
@@ -79,10 +79,9 @@ jest.mock('@/app/features/finance/pages/Finance/Sections/InvoiceBilledTo', () =>
 
 jest.mock('@/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger', () => ({
   __esModule: true,
-  default: ({ payerName, payerEmail }: any) => (
+  default: ({ payerName }: any) => (
     <div data-testid="payment-ledger">
       <span data-testid="ledger-payer-name">{payerName}</span>
-      <span data-testid="ledger-payer-email">{payerEmail}</span>
     </div>
   ),
 }));
@@ -258,7 +257,6 @@ describe('InvoiceInfo', () => {
     );
 
     expect(screen.getByTestId('ledger-payer-name')).toHaveTextContent('Lena');
-    expect(screen.getByTestId('ledger-payer-email')).toHaveTextContent('lena@x.com');
   });
 
   it('skips a stored parent whose name parts are all blank and clears the payer email', () => {
@@ -273,7 +271,6 @@ describe('InvoiceInfo', () => {
     );
 
     expect(screen.getByTestId('ledger-payer-name').textContent).toBe('');
-    expect(screen.getByTestId('ledger-payer-email').textContent).toBe('');
   });
 
   it('renders the shell without an active invoice, skipping every invoice-gated block', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
@@ -44,13 +44,12 @@ describe('InvoicePaymentLedger', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders a payment row with caption, amount, receipt and receipt-sent strip', () => {
+  it('renders a payment row with caption, amount and the real receipt link', () => {
     render(
       <InvoicePaymentLedger
         invoice={makeInvoice({ stripeReceiptUrl: 'https://pay.stripe.com/receipts/r_1' })}
         currency="USD"
         payerName="Lena Hartmann"
-        payerEmail="lena@example.com"
       />
     );
 
@@ -63,7 +62,25 @@ describe('InvoicePaymentLedger', () => {
       'href',
       'https://pay.stripe.com/receipts/r_1'
     );
-    expect(screen.getByText('Receipt sent to lena@example.com')).toBeInTheDocument();
+    // No "Receipt sent to ...". Having the payer's address on file is not
+    // evidence anything was delivered, and nothing in the product emails an
+    // invoice receipt.
+    expect(screen.queryByText(/Receipt sent to/)).not.toBeInTheDocument();
+  });
+
+  it('never claims a receipt was sent, even with a payer email and a receipt url', () => {
+    render(
+      <InvoicePaymentLedger
+        invoice={makeInvoice({ stripeReceiptUrl: 'https://pay.stripe.com/receipts/r_1' })}
+        currency="USD"
+        payerName="Lena Hartmann"
+      />
+    );
+
+    expect(screen.queryByText(/Receipt sent to/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/lena@example.com/)).not.toBeInTheDocument();
+    // The link, which is a real signal, is still offered.
+    expect(screen.getByRole('link', { name: 'Receipt' })).toBeInTheDocument();
   });
 
   it('treats a paidAt timestamp as settled even when status is not paid', () => {
@@ -105,7 +122,7 @@ describe('InvoicePaymentLedger', () => {
     expect(screen.getByTestId('card-icon')).toBeInTheDocument();
   });
 
-  it('omits the receipt link and receipt-sent strip when data is missing', () => {
+  it('omits the receipt link when there is no receipt url', () => {
     render(<InvoicePaymentLedger invoice={makeInvoice({})} currency="USD" />);
 
     expect(screen.queryByRole('link', { name: 'Receipt' })).not.toBeInTheDocument();
@@ -131,7 +148,6 @@ describe('InvoicePaymentLedger', () => {
         invoice={makeInvoice({ stripeReceiptUrl: 'https://pay.stripe.com/receipts/r_1' })}
         currency="USD"
         payerName="Lena Hartmann"
-        payerEmail="lena@example.com"
       />
     );
     const results = await axe(container);

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
@@ -72,7 +72,6 @@ const baseProps = {
   statusLabel: 'Paid',
   statusStyle: {},
   payerName: 'Lena Hartmann',
-  payerEmail: 'lena@x.com',
   onClose: jest.fn(),
   onOpenAppointment: jest.fn(),
 };
@@ -116,7 +115,7 @@ describe('InvoicePhoneRecord', () => {
     expect(screen.getByText('-€5')).toBeInTheDocument();
   });
 
-  it('renders the payment ledger, receipt link and finalized note when settled', () => {
+  it('renders the payment ledger and receipt link when settled', () => {
     render(<InvoicePhoneRecord {...baseProps} />);
 
     expect(screen.getByText('Payment recorded')).toBeInTheDocument();
@@ -125,7 +124,9 @@ describe('InvoicePhoneRecord', () => {
       'href',
       'https://receipt'
     );
-    expect(screen.getByText('Receipt sent to lena@x.com')).toBeInTheDocument();
+    // Same as the desktop ledger: an address on file is not proof of delivery.
+    expect(screen.queryByText(/Receipt sent to/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/lena@x.com/)).not.toBeInTheDocument();
   });
 
   it('labels the payment row by the channel the payment came through', () => {
@@ -241,11 +242,6 @@ describe('InvoicePhoneRecord', () => {
     );
     expect(screen.getByText('Payment recorded')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Receipt' })).not.toBeInTheDocument();
-  });
-
-  it('omits the finalized note when there is no payer email', () => {
-    render(<InvoicePhoneRecord {...baseProps} payerEmail="" />);
-    expect(screen.queryByText(/Receipt sent to/)).not.toBeInTheDocument();
   });
 
   it('renders only the Open appointment button when there is no PDF', () => {

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/DocumentESigning.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/DocumentESigning.test.tsx
@@ -36,48 +36,32 @@ jest.mock('react-icons/io5', () => ({
 describe('DocumentESigning settings card', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders the three e-signing channels with their default states', () => {
+  it('renders the card heading and the sealing note', () => {
     render(<DocumentESigning />);
 
     expect(screen.getByText('How consent documents get signed')).toBeInTheDocument();
-    expect(screen.getByRole('switch', { name: 'Sign in the pet parent app' })).toHaveAttribute(
-      'aria-checked',
-      'true'
-    );
-    expect(screen.getByRole('switch', { name: 'Sign on clinic tablet' })).toHaveAttribute(
-      'aria-checked',
-      'true'
-    );
-    expect(
-      screen.getByRole('switch', { name: 'Require signature before surgery check-in' })
-    ).toHaveAttribute('aria-checked', 'false');
     expect(
       screen.getByText(/Signed documents are sealed with a timestamp and signer identity/)
     ).toBeInTheDocument();
-    expect(screen.getByText('Changes apply org-wide')).toBeInTheDocument();
   });
 
-  it('toggles each channel independently', () => {
+  it('offers no channel switches and no Save, because none of it persisted', () => {
+    // The three switches were module-local useState literals, so every user of
+    // every clinic saw the same invented configuration; Save only raised a
+    // success toast claiming the settings applied org-wide, and wrote nothing.
     render(<DocumentESigning />);
 
-    const appToggle = screen.getByRole('switch', { name: 'Sign in the pet parent app' });
-    fireEvent.click(appToggle);
-    expect(appToggle).toHaveAttribute('aria-checked', 'false');
-
-    const requireToggle = screen.getByRole('switch', {
-      name: 'Require signature before surgery check-in',
-    });
-    fireEvent.click(requireToggle);
-    expect(requireToggle).toHaveAttribute('aria-checked', 'true');
+    expect(screen.queryAllByRole('switch')).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Changes apply org-wide')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign in the pet parent app')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sign on clinic tablet')).not.toBeInTheDocument();
+    expect(screen.queryByText('Require signature before surgery check-in')).not.toBeInTheDocument();
   });
 
-  it('notifies on save', () => {
+  it('claims no save happened', () => {
     render(<DocumentESigning />);
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    expect(notifyMock).toHaveBeenCalledWith(
-      'success',
-      expect.objectContaining({ title: 'E-signing preferences updated' })
-    );
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 
   it('discloses and hides the signing portal', () => {

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Payment.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Payment.test.tsx
@@ -34,7 +34,10 @@ describe('Payment organization section', () => {
     render(<Payment />);
 
     expect(screen.getByText('Payments · Stripe')).toBeInTheDocument();
-    expect(screen.getByText('Charges enabled · payouts weekly')).toBeInTheDocument();
+    expect(screen.getByText('Charges and payouts enabled')).toBeInTheDocument();
+    // "payouts weekly" was invented: payoutsEnabled mirrors Stripe's
+    // account.payouts_enabled, a capability boolean carrying no schedule.
+    expect(screen.queryByText(/weekly/)).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Manage' })).toHaveAttribute(
       'href',
       '/stripe-onboarding?orgId=org-1'

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
@@ -60,8 +60,6 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
     return '';
   }, [storedParent, appointment]);
 
-  const payerEmail = storedParent?.email ?? '';
-
   const invoiceStatusLabel = toTitle(activeInvoice?.status ?? '');
   const invoiceStatusTone = getInvoiceStatusTone(activeInvoice?.status ?? '');
 
@@ -95,7 +93,6 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
               statusLabel={invoiceStatusLabel}
               statusTone={invoiceStatusTone}
               payerName={payerName}
-              payerEmail={payerEmail}
               onClose={() => setShowModal(false)}
               onOpenAppointment={goToAppointmentFinance}
             />
@@ -139,7 +136,6 @@ const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProp
                     invoice={activeInvoice}
                     currency={currency}
                     payerName={payerName}
-                    payerEmail={payerEmail}
                   />
                 </div>
                 <div className="flex flex-col gap-5">

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.stories.tsx
@@ -92,7 +92,6 @@ export const PaidInApp: Story = {
   args: {
     invoice: invoice({ stripeReceiptUrl: 'https://pay.stripe.com/receipts/acct_1H/ch_3Ab' }),
     payerName: LONG_PAYER,
-    payerEmail: '  sky.doe@example.com  ',
   },
   play: async ({ canvasElement }) => {
     const region = within(canvasElement).getByRole('region', { name: 'Payments' });
@@ -277,7 +276,6 @@ export const Unsettled: Story = {
   name: 'Unsettled invoice draws nothing',
   args: {
     invoice: invoice({ status: 'AWAITING_PAYMENT', paidAt: undefined }),
-    payerEmail: 'sky.doe@example.com',
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Invoice } from '@yosemite-crew/types';
-import { IoCheckmarkCircle } from 'react-icons/io5';
 import { formatMoney } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
@@ -11,7 +10,6 @@ type InvoicePaymentLedgerProps = {
   invoice: Invoice;
   currency: string;
   payerName?: string;
-  payerEmail?: string;
 };
 
 const SETTLED_STATUSES = new Set(['PAID', 'REFUNDED']);
@@ -30,12 +28,7 @@ const buildLedgerCaption = (invoice: Invoice, payerName?: string): string => {
   return parts.filter(Boolean).join(' · ');
 };
 
-const InvoicePaymentLedger = ({
-  invoice,
-  currency,
-  payerName,
-  payerEmail,
-}: InvoicePaymentLedgerProps) => {
+const InvoicePaymentLedger = ({ invoice, currency, payerName }: InvoicePaymentLedgerProps) => {
   if (!isSettledInvoice(invoice)) return null;
 
   const caption = buildLedgerCaption(invoice, payerName);
@@ -44,7 +37,6 @@ const InvoicePaymentLedger = ({
   // sanitize link protocols, and a receipt URL is invoice data. The helper keeps
   // this to real Stripe receipt hosts over https.
   const receiptUrl = getSafeStripeRedirectUrl(invoice.stripeReceiptUrl);
-  const email = payerEmail?.trim();
 
   return (
     <section className="flex flex-col gap-3" aria-label="Payments">
@@ -75,14 +67,15 @@ const InvoicePaymentLedger = ({
           )}
         </div>
       </div>
-      {email && (
-        <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-xl bg-[var(--inset)] text-[12px] text-text-secondary">
-          <IoCheckmarkCircle size={14} aria-hidden="true" style={{ color: 'var(--success)' }} />
-          <span className="truncate" title={`Receipt sent to ${email}`}>
-            Receipt sent to {email}
-          </span>
-        </div>
-      )}
+      {/*
+        No "Receipt sent to ..." line. It used to render whenever a payer email
+        was on file, which is not evidence that anything was sent: nothing in the
+        product emails an invoice receipt, `receipt_email` is never set on the
+        PaymentIntent, and the invoice carries no delivery state. It also showed
+        for cash and pay-at-clinic settlements, where no receipt exists at all -
+        so staff could stop chasing a receipt a client never got. The Stripe
+        receipt link above is the real signal, and it is already rendered.
+      */}
     </section>
   );
 };

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.stories.tsx
@@ -132,7 +132,6 @@ const meta = {
     statusLabel: 'Paid',
     statusTone: 'success',
     payerName: 'Sky Doe',
-    payerEmail: 'sky.doe@example.com',
     onClose: fn(),
     onOpenAppointment: fn(),
   },
@@ -278,7 +277,7 @@ export const Unsettled: Story = {
 
 export const SettledWithoutEmail: Story = {
   name: 'Settled, but no email on file',
-  args: { payerEmail: '   ' },
+  args: {},
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
-import { IoCheckmarkCircle, IoClose, IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
+import { IoClose, IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { formatMoney } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
@@ -22,7 +22,6 @@ type InvoicePhoneRecordProps = {
   statusStyle?: React.CSSProperties;
   statusTone?: StatusTone;
   payerName?: string;
-  payerEmail?: string;
   onClose: () => void;
   onOpenAppointment?: () => void;
 };
@@ -76,7 +75,6 @@ const InvoicePhoneRecord = ({
   statusStyle,
   statusTone,
   payerName,
-  payerEmail,
   onClose,
   onOpenAppointment,
 }: InvoicePhoneRecordProps) => {
@@ -93,7 +91,6 @@ const InvoicePhoneRecord = ({
   const settled = isSettledInvoice(invoice);
   const caption = buildLedgerCaption(invoice, payerName);
   const { Icon: ChannelIcon, title: channelTitle } = getLedgerChannel(invoice);
-  const email = payerEmail?.trim();
   const pdfUrl = invoice.pdfUrl;
   const receiptUrl = invoice.stripeReceiptUrl;
 
@@ -211,15 +208,8 @@ const InvoicePhoneRecord = ({
         </div>
       )}
 
-      {/* Finalized note */}
-      {settled && email && (
-        <span className="flex items-center gap-2 rounded-xl bg-[var(--inset)] px-3 py-2.5 text-[11px] text-[var(--ink-muted)]">
-          <IoCheckmarkCircle size={13} aria-hidden="true" style={{ color: 'var(--success)' }} />
-          <span className="truncate" title={`Receipt sent to ${email}`}>
-            Receipt sent to {email}
-          </span>
-        </span>
-      )}
+      {/* No "Receipt sent to ..." note - see InvoicePaymentLedger for why the
+          presence of a payer email is not evidence a receipt was delivered. */}
 
       {/* Actions */}
       {(pdfUrl || (appointment && onOpenAppointment)) && (

--- a/apps/frontend/src/app/features/guides/data/guidesData.ts
+++ b/apps/frontend/src/app/features/guides/data/guidesData.ts
@@ -3,8 +3,16 @@ import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
 
 /**
  * Static content library for the Guides screen. There is no video backend — the
- * player surface is presentational — so the copy, durations, categories and
- * completion status below are the seed content, not live data.
+ * player surface is presentational — so the copy, durations, chapters and
+ * categories below are seed content describing the bundled videos.
+ *
+ * Deliberately absent: per-viewer state. Entries used to carry
+ * `status: 'watched'`, `progressPercent: 60` and `currentTime: '3:07'`, which
+ * are claims about the person reading the page, not about the video. Because
+ * they were module literals, every user of every clinic was told they had
+ * already watched "Your first day in the PIMS" and were 60% through "Run a visit
+ * end to end". Nothing records viewing progress — there is no watch-state model
+ * and no route — so these must stay out until something does.
  */
 export const guidesData: GuideVideo[] = [
   {
@@ -17,7 +25,6 @@ export const guidesData: GuideVideo[] = [
     videoUrl: MEDIA_SOURCES.guides.addTeamVideo,
     thumbnailUrl: MEDIA_SOURCES.guides.thumb1,
     featured: true,
-    status: 'watched',
     chapters: [
       { label: 'the shell', time: '0:00' },
       { label: '⌘K search', time: '1:04' },
@@ -33,8 +40,6 @@ export const guidesData: GuideVideo[] = [
     tags: ['visit', 'soap', 'diagnostics', 'payment'],
     videoUrl: MEDIA_SOURCES.guides.addCompanionVideo,
     thumbnailUrl: MEDIA_SOURCES.guides.thumb2,
-    progressPercent: 60,
-    currentTime: '3:07',
     chapters: [
       { label: 'check-in', time: '0:00' },
       { label: 'SOAP', time: '0:48' },

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
@@ -1,66 +1,31 @@
 'use client';
 import React, { useState } from 'react';
-import clsx from 'clsx';
 import { IoShieldCheckmarkOutline } from 'react-icons/io5';
 import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import DocSigningPortal from '@/app/features/docSigning/components/DocSigningPortal';
-import { useNotify } from '@/app/hooks/useNotify';
 
-type ToggleRowProps = {
-  title: string;
-  description: string;
-  checked: boolean;
-  onChange: () => void;
-};
-
-const ToggleRow = ({ title, description, checked, onChange }: ToggleRowProps) => (
-  <div className="flex items-center justify-between gap-3">
-    <span className="min-w-0">
-      <span className="block text-[13px] font-bold text-[var(--ink)]">{title}</span>
-      <span className="block text-[11.5px] text-[var(--ink-muted)]">{description}</span>
-    </span>
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={title}
-      onClick={onChange}
-      className="relative inline-flex h-[26px] w-11 shrink-0 items-center rounded-full border transition-colors cursor-pointer"
-      style={{
-        backgroundColor: checked ? 'var(--blue)' : 'var(--inset)',
-        borderColor: checked ? 'var(--blue)' : 'var(--divider)',
-      }}
-    >
-      <span
-        className={clsx(
-          'inline-block size-5 rounded-full border transition-transform',
-          checked ? 'translate-x-[20px]' : 'translate-x-[2px]'
-        )}
-        style={{
-          backgroundColor: checked ? 'var(--white-text)' : 'var(--screen)',
-          borderColor: checked ? 'transparent' : 'var(--hairline)',
-        }}
-      />
-    </button>
-  </div>
-);
-
+/*
+ * The three e-signing channel switches are gone, along with their Save button.
+ *
+ * They were `useState(true) / useState(true) / useState(false)` - module-local
+ * literals that nothing loaded, so every user of every clinic saw the same
+ * invented configuration, with two channels shown as already enabled org-wide.
+ * `handleSave` contained a single `notify('success')` whose text asserted the
+ * settings "now apply org-wide"; it wrote nothing. Turning a channel off, saving,
+ * and returning showed it back on.
+ *
+ * There is nothing to persist them to: the `Organization` model has no e-signing
+ * preference column (it carries only `documensoTeamId` / `documensoApiKey` for
+ * the Documenso bridge), and no route under apps/backend/src/routers accepts
+ * signing-channel settings. Rather than invent a schema for a product decision
+ * that has not been made, the card is now what it honestly is: the entry point
+ * to the real signing portal it already embedded underneath.
+ */
 const DocumentESigning = () => {
-  const { notify } = useNotify();
-  const [signInApp, setSignInApp] = useState(true);
-  const [signOnTablet, setSignOnTablet] = useState(true);
-  const [requireBeforeSurgery, setRequireBeforeSurgery] = useState(false);
   const [showPortal, setShowPortal] = useState(false);
-
-  const handleSave = () => {
-    notify('success', {
-      title: 'E-signing preferences updated',
-      text: 'Your e-signing channels now apply org-wide.',
-    });
-  };
 
   return (
     <PermissionGate
@@ -73,24 +38,6 @@ const DocumentESigning = () => {
             How consent documents get signed
           </div>
           <div className="px-5! py-4! flex flex-col gap-3">
-            <ToggleRow
-              title="Sign in the pet parent app"
-              description="Send documents to the parent's phone"
-              checked={signInApp}
-              onChange={() => setSignInApp((v) => !v)}
-            />
-            <ToggleRow
-              title="Sign on clinic tablet"
-              description="Front-desk iPad, finger signature"
-              checked={signOnTablet}
-              onChange={() => setSignOnTablet((v) => !v)}
-            />
-            <ToggleRow
-              title="Require signature before surgery check-in"
-              description="Blocks check-in until consent is signed"
-              checked={requireBeforeSurgery}
-              onChange={() => setRequireBeforeSurgery((v) => !v)}
-            />
             <div className="flex gap-2.5 rounded-xl border border-[var(--divider)] bg-[var(--inset)] px-3.5 py-3">
               <IoShieldCheckmarkOutline
                 className="shrink-0 mt-px text-[var(--blue-text)]"
@@ -101,16 +48,6 @@ const DocumentESigning = () => {
                 medical record.
               </span>
             </div>
-          </div>
-          <div className="px-5! py-3! border-t border-[var(--hairline)] flex items-center justify-between gap-3">
-            <span className="text-[11.5px] text-[var(--ink-faint)]">Changes apply org-wide</span>
-            <button
-              type="button"
-              onClick={handleSave}
-              className="inline-flex items-center h-9 px-4 rounded-full bg-[var(--cta)] text-[var(--cta-text)] text-[12.5px] font-semibold"
-            >
-              Save
-            </button>
           </div>
           <div className="px-5! pb-4! pt-1!">
             <button

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
@@ -16,7 +16,15 @@ const resolveStatus = (chargesEnabled?: boolean, payoutsEnabled?: boolean): Paym
   if (chargesEnabled) {
     return {
       connected: true,
-      text: payoutsEnabled ? 'Charges enabled · payouts weekly' : 'Charges enabled',
+      /*
+       * "payouts weekly" was invented. `payoutsEnabled` mirrors Stripe's
+       * `account.payouts_enabled`, a capability boolean carrying no schedule,
+       * and nothing in the product reads a payout interval. The claim was wrong
+       * for any clinic on Stripe's rolling daily default, or on a monthly or
+       * manual schedule - and it sat beside a live status dot, so it read as
+       * account state rather than copy.
+       */
+      text: payoutsEnabled ? 'Charges and payouts enabled' : 'Charges enabled',
     };
   }
   return { connected: false, text: 'Not connected yet' };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for - found by sweeping for the defect class behind #2606 and #2607.
- [x] All existing tests and lints pass.

## What is the current behavior?

A sweep of the remaining feature areas for the same defect as #2606 and #2607: **UI presenting an invented value as real account state.** Each finding below was checked against `schema.prisma` and `apps/backend/src/routers` before being touched, and every candidate went through an adversarial second pass — two were correctly thrown out (a Discord member count in dead code, and a staff dropdown no signed-in user can reach).

### 1. E-signing settings raised a success toast and saved nothing — highest severity

```ts
const [signInApp, setSignInApp] = useState(true);
const [signOnTablet, setSignOnTablet] = useState(true);
const [requireBeforeSurgery, setRequireBeforeSurgery] = useState(false);

const handleSave = () => {
  notify('success', {
    title: 'E-signing preferences updated',
    text: 'Your e-signing channels now apply org-wide.',
  });
};
```

That is the whole of `handleSave`. The switch positions are module-local literals nothing loads, so **every user of every clinic saw the same invented configuration**, with two channels shown as already enabled org-wide. Turn one off, press Save, get told it applied — come back and it is on again.

There is nowhere to persist it: `Organization` has no e-signing column (only `documensoTeamId`/`documensoApiKey` for the Documenso bridge), and no route accepts signing-channel settings. Rather than invent a schema for a product decision nobody has made, the card is now what it honestly is — the entry point to the real signing portal it already embedded underneath.

### 2. "Receipt sent to &lt;email&gt;" was rendered from having an address on file

Desktop (`InvoicePaymentLedger`) and phone (`InvoicePhoneRecord`) both gated a green tick on `payerEmail` being non-empty — and `payerEmail` is just `storedParent?.email`. Nothing in the product emails an invoice receipt: `receipt_email` is never set on the PaymentIntent, the only invoice email is a pay-now link (`invoicePaymentCheckout`), and no model carries delivery state.

It also rendered for **cash and pay-at-clinic settlements**, where no receipt exists at all — so staff could stop chasing a receipt a client never got. The real Stripe receipt **link** was already rendered directly above it and stays.

### 3. "payouts weekly" was invented from a boolean

`payoutsEnabled` mirrors Stripe's `account.payouts_enabled` — a capability flag carrying no schedule — and nothing in the product reads a payout interval. The claim was wrong for any clinic on Stripe's rolling daily default, or monthly, or manual, and it sat beside a pulsing live-status dot, so it read as account state rather than copy. Now **"Charges and payouts enabled"**.

### 4. Guides showed a viewing history that was not the viewer's

Entries carried `status: 'watched'`, `progressPercent: 60` and `currentTime: '3:07'` as literals, so everyone was told they had watched "Your first day in the PIMS" and were 60% through "Run a visit end to end". Nothing records viewing progress.

The `New` badge stays — that is content age, not viewer state — as do durations and chapters, which describe the bundled video files and are plausibly correct. I did not remove those.

## The tests were holding the fabrications in place, again

Seven existing tests asserted these exact strings — `'Charges enabled · payouts weekly'`, `'Receipt sent to lena@example.com'`, `'Watched'`, `'60%'`, and a `notifies on save` case asserting the toast that saved nothing. They now assert the honest behaviour and the absence of each claim. This is the third PR in a row where a test was pinning a fabrication in place.

`payerEmail` became unused and is removed from both components, their callers, stories and tests.

## Validation performed

- **All four CI shards pass locally**: 2798 + 2980 + 3564 + 3058 = **12,400 tests**, exit 0 on each.
- Targeted run over every touched area: 88 suites, 1075 tests.
- Frontend `tsc --noEmit` clean; `lint` clean.

## Not included, needs your call

The sweep also flagged a **`SOC 2 Type II`** compliance chip in the public site footer (`SiteFooter.tsx:523`), beside GDPR / ISO 27001 / HL7 FHIR / 21 CFR Part 11. Whether that is accurate is a business fact I cannot establish from the repository, and removing a compliance claim is not my call — flagging it rather than acting on it.
