### PR TITLE
fix(backend): stop three money paths failing in silence

### DIFF
--- a/apps/backend/src/controllers/app/companion-organisation.controller.ts
+++ b/apps/backend/src/controllers/app/companion-organisation.controller.ts
@@ -265,11 +265,19 @@ export const CompanionOrganisationController = {
         ...invitePayload,
       });
 
-      // You can trigger email sending here
-      // await EmailService.sendOrganisationInvite(...)
-
+      /*
+       * "Invite sent successfully" was not true. `sendInvite` writes a PENDING
+       * patientOrganisation row with a generated token and stores the address in
+       * `invitedViaEmail`, and nothing reads that column to dispatch anything -
+       * the commented-out `EmailService.sendOrganisationInvite(...)` that used
+       * to sit here was the whole delivery mechanism. A parent inviting their
+       * clinic was told it had been sent, and no message ever left the system.
+       *
+       * Delivery is tracked separately; until it exists this reports what
+       * actually happened rather than what the endpoint is named after.
+       */
       return res.status(201).json({
-        message: "Invite sent successfully",
+        message: "Invite created",
       });
     } catch (error) {
       if (error instanceof CompanionOrganisationServiceError) {

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -23,14 +23,42 @@ const getStripeClient = (): Stripe => {
   return stripeClient;
 };
 
+/*
+ * Stripe's subscription statuses, mapped onto the five this schema has.
+ *
+ * The previous form named four and returned "active" for everything else, so
+ * `unpaid`, `paused` and `incomplete_expired` - all states in which Stripe has
+ * stopped successfully collecting - were stored and shown to the developer as
+ * an active subscription. An unrecognised status now falls to `incomplete`
+ * rather than `active`, and says so: reporting a subscription as healthier than
+ * Stripe believes it to be is the failure worth avoiding, and a new status
+ * Stripe adds later should be noticed rather than absorbed.
+ */
+const STRIPE_STATUS_MAP: Record<string, DeveloperSubscriptionStatus> = {
+  active: "active",
+  trialing: "trialing",
+  past_due: "past_due",
+  canceled: "canceled",
+  incomplete: "incomplete",
+  // Collection has stopped; the developer is not in good standing.
+  unpaid: "past_due",
+  paused: "past_due",
+  // The first payment never completed and Stripe gave up on it.
+  incomplete_expired: "canceled",
+};
+
 const toSubscriptionStatus = (
   value?: string | null,
 ): DeveloperSubscriptionStatus => {
-  if (value === "trialing") return "trialing";
-  if (value === "past_due") return "past_due";
-  if (value === "canceled") return "canceled";
-  if (value === "incomplete") return "incomplete";
-  return "active";
+  if (!value) return "incomplete";
+
+  const mapped = STRIPE_STATUS_MAP[value];
+  if (mapped) return mapped;
+
+  logger.error(
+    `Unrecognised Stripe subscription status "${value}"; recording it as incomplete rather than active`,
+  );
+  return "incomplete";
 };
 
 const resolveMeteredPriceId = (): string => {

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -831,7 +831,15 @@ export const StripeService = {
         patient: true,
       },
     });
-    if (!appointment) return;
+    if (!appointment) {
+      // The charge succeeded. Every other exit from this handler logs; these
+      // used to be the only silent ones, so a captured payment could vanish
+      // without a trace anywhere.
+      logger.error(
+        `Booking payment ${pi.id} succeeded for appointment ${appointmentId}, which no longer exists; no invoice can be minted`,
+      );
+      return;
+    }
 
     // Replay check, and the reason this handler is safe at all. Stripe redelivers
     // on any non-2xx and nothing upstream deduplicates by event id, so the same
@@ -861,12 +869,25 @@ export const StripeService = {
     }
 
     const serviceId = extractAppointmentTypeId(appointment.appointmentType);
-    if (!serviceId) return;
+    if (!serviceId) {
+      logger.error(
+        `Booking payment ${pi.id} succeeded for appointment ${appointmentId}, whose appointmentType carries no service id; no invoice minted`,
+      );
+      return;
+    }
 
     const service = await prisma.service.findUnique({
       where: { id: serviceId },
     });
-    if (!service) return;
+    if (!service) {
+      // Reachable: deleting a speciality hard-deletes its services, and a
+      // payment can be in flight across that (3DS, a resumed checkout, a
+      // delayed payment method). The card is charged either way.
+      logger.error(
+        `Booking payment ${pi.id} succeeded for appointment ${appointmentId}, but service ${serviceId} no longer exists; no invoice minted`,
+      );
+      return;
+    }
 
     const { parentId, patientId } = extractAppointmentPatientRefs(appointment);
 
@@ -939,6 +960,16 @@ export const StripeService = {
       return;
     }
 
+    if (result.action === "NO_INVOICE") {
+      // The charge is captured and no invoice was found to mark PAID, so the
+      // books show it outstanding. ALREADY_PAID and IGNORED below are genuine
+      // replays; this is not one.
+      logger.error(
+        `Payment intent ${pi.id} succeeded but matched no invoice (metadata invoiceId: ${invoiceId ?? "none"}); the charge is captured and nothing was marked paid`,
+      );
+      return;
+    }
+
     if (result.action === "IGNORED") {
       return;
     }
@@ -974,6 +1005,16 @@ export const StripeService = {
       currency: charge.currency,
       reason: charge.refunded ? "Refunded via Stripe" : undefined,
     });
+
+    if (result.action === "NO_INVOICE") {
+      // The customer has their money back and no invoice moved to REFUNDED, so
+      // the books still show it PAID. ALREADY_REFUNDED below is a genuine
+      // replay and stays quiet; this one needs a human.
+      logger.error(
+        `Refund on charge ${charge.id} (intent ${typeof charge.payment_intent === "string" ? charge.payment_intent : "unknown"}) matched no invoice; the invoice it belongs to is still marked paid`,
+      );
+      return;
+    }
 
     if (result.action !== "REFUNDED" || !result.invoice.parentId) {
       return;

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -965,7 +965,7 @@ export const StripeService = {
       // books show it outstanding. ALREADY_PAID and IGNORED below are genuine
       // replays; this is not one.
       logger.error(
-        `Payment intent ${pi.id} succeeded but matched no invoice (metadata invoiceId: ${invoiceId ?? "none"}); the charge is captured and nothing was marked paid`,
+        `Payment intent ${pi.id} succeeded but invoice ${invoiceId} from its metadata could not be found; the charge is captured and nothing was marked paid`,
       );
       return;
     }

--- a/apps/backend/test/controllers/companion-organisation.controller.test.ts
+++ b/apps/backend/test/controllers/companion-organisation.controller.test.ts
@@ -388,6 +388,25 @@ describe("CompanionOrganisationController", () => {
         expect.objectContaining({ email: "test@test.com" }),
       );
       expect(res.status).toHaveBeenCalledWith(201);
+      // Not "Invite sent successfully": nothing reads `invitedViaEmail` to
+      // dispatch anything, so the row is created and no message leaves.
+      expect(res.json).toHaveBeenCalledWith({ message: "Invite created" });
+    });
+
+    it("does not claim the invite was sent, because nothing sends it", async () => {
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validObjectId,
+      });
+      req.body = {
+        patientId: "c1",
+        organisationType: "HOSPITAL",
+        email: "someone@example.com",
+      };
+
+      await CompanionOrganisationController.sendInvite(req, res);
+
+      const body = (res.json as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(body.message).not.toMatch(/sent/i);
     });
 
     it("should succeed when name is provided", async () => {

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -86,6 +86,74 @@ describe("DeveloperBillingService", () => {
     process.env.STRIPE_DEV_WEBHOOK_SECRET = "whsec_test";
   });
 
+  describe("toSubscriptionStatus, via the subscription.updated webhook", () => {
+    // Local fixture: the one in the webhook describe below is out of scope here.
+    const subscriptionFixture = {
+      id: "sub_status",
+      status: "active",
+      customer: "cus_x",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            id: "si_x",
+            price: { id: "price_metered_abc" },
+            current_period_start: 1750000000,
+            current_period_end: 1752678400,
+          },
+        ],
+      },
+    };
+
+    const updateWith = async (stripeStatus: string) => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_metered_abc",
+        stripeSubscriptionItemId: "si_x",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_status",
+        type: "customer.subscription.updated",
+        data: { object: { ...subscriptionFixture, status: stripeStatus } },
+      } as never);
+
+      return mockPrisma.developerSubscription.update.mock.calls.at(-1)?.[0]
+        ?.data?.status;
+    };
+
+    it.each([
+      ["active", "active"],
+      ["trialing", "trialing"],
+      ["past_due", "past_due"],
+      ["canceled", "canceled"],
+      ["incomplete", "incomplete"],
+    ])("passes %s through as %s", async (stripe, expected) => {
+      expect(await updateWith(stripe)).toBe(expected);
+    });
+
+    it.each([
+      ["unpaid", "past_due"],
+      ["paused", "past_due"],
+      ["incomplete_expired", "canceled"],
+    ])(
+      "maps %s to %s rather than active, because collection has stopped",
+      async (stripe, expected) => {
+        expect(await updateWith(stripe)).toBe(expected);
+      },
+    );
+
+    it("records an unrecognised status as incomplete and says so", async () => {
+      // Reporting a subscription as healthier than Stripe believes it to be is
+      // the failure worth avoiding, so an unknown status must not become active.
+      expect(await updateWith("some_future_status")).toBe("incomplete");
+      expect(jest.mocked(logger.error)).toHaveBeenCalledWith(
+        expect.stringContaining("some_future_status"),
+      );
+    });
+  });
+
   describe("cancelForOwner", () => {
     it("cancels the live Stripe subscription and removes the row", async () => {
       mockPrisma.developerSubscription.findUnique.mockResolvedValue({

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -1963,7 +1963,76 @@ describe("StripeService", () => {
     });
   });
 
+  describe("_handleInvoicePayment NO_INVOICE", () => {
+    it("logs when a captured intent names an invoice that cannot be found", async () => {
+      /*
+       * The charge is captured and nothing was marked paid, so the books show it
+       * outstanding. ALREADY_PAID and IGNORED are replays; this is not.
+       *
+       * `metadata.invoiceId` must be set: the handler returns at
+       * stripe.service.ts:918 without it, so NO_INVOICE is only reachable when
+       * the intent names an invoice the lookup then fails to match.
+       */
+      (
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded as jest.Mock
+      ).mockResolvedValueOnce({ action: "NO_INVOICE" });
+
+      await StripeService._handleInvoicePayment({
+        id: "pi_orphan",
+        metadata: { invoiceId: "inv_missing" },
+        currency: "usd",
+      } as any);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("pi_orphan"),
+      );
+    });
+  });
+
   describe("_handleRefund guards", () => {
+    it("logs loudly when a refund matches no invoice", async () => {
+      /*
+       * The customer has their money back and no invoice moved to REFUNDED, so
+       * the books still read PAID. This used to return in silence, and Stripe
+       * was answered 200 either way.
+       */
+      (
+        FinancePaymentService.markInvoiceRefundedFromWebhook as jest.Mock
+      ).mockResolvedValueOnce({ action: "NO_INVOICE" });
+
+      await StripeService._handleRefund({
+        id: "ch_orphan",
+        payment_intent: "pi_orphan",
+        amount: 500,
+        currency: "usd",
+        metadata: {},
+      } as any);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("ch_orphan"),
+      );
+      expect(NotificationService.sendToUser).not.toHaveBeenCalled();
+    });
+
+    it("stays quiet on a replayed refund, which is a genuine idempotency case", async () => {
+      (
+        FinancePaymentService.markInvoiceRefundedFromWebhook as jest.Mock
+      ).mockResolvedValueOnce({
+        action: "ALREADY_REFUNDED",
+        invoice: { id: "inv_1", parentId: "par_1" },
+      });
+
+      await StripeService._handleRefund({
+        id: "ch_1",
+        payment_intent: "pi_1",
+        amount: 500,
+        currency: "usd",
+        metadata: { invoiceId: "inv_1" },
+      } as any);
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it("returns without notifying when the refund was not applied", async () => {
       (
         FinancePaymentService.markInvoiceRefundedFromWebhook as jest.Mock
@@ -2271,7 +2340,7 @@ describe("StripeService", () => {
       expect(prisma.appointment.findUnique).not.toHaveBeenCalled();
     });
 
-    it("ignores events when the appointment is gone", async () => {
+    it("ignores events when the appointment is gone, and says so", async () => {
       (prisma.appointment.findUnique as jest.Mock).mockResolvedValueOnce(null);
 
       await StripeService._handleAppointmentBookingPayment({
@@ -2280,6 +2349,37 @@ describe("StripeService", () => {
       } as any);
 
       expect(prisma.invoice.findUnique).not.toHaveBeenCalled();
+      // The charge is captured either way; a silent return loses it.
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("no longer exists"),
+      );
+    });
+
+    it("logs when the service behind the appointment has been deleted", async () => {
+      /*
+       * Reachable in production: deleting a speciality hard-deletes its
+       * services, and a booking payment can be in flight across that (3DS, a
+       * resumed checkout, a delayed payment method). Stripe captures the money,
+       * no invoice can be minted, and this used to return in silence.
+       */
+      (prisma.appointment.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "appt_1",
+        appointmentType: { id: "service_gone" },
+        organisationId: "org_1",
+        patient: {},
+      });
+      (prisma.invoice.findFirst as jest.Mock).mockResolvedValue(null);
+      (prisma.service.findUnique as jest.Mock).mockResolvedValueOnce(null);
+
+      await StripeService._handleAppointmentBookingPayment({
+        id: "pi_1",
+        metadata: { appointmentId: "appt_1" },
+      } as any);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("service_gone"),
+      );
+      expect(prisma.invoice.create).not.toHaveBeenCalled();
     });
 
     const bookingAppointment = () =>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for - found by sweeping the backend for the server-side form of the defect behind #2606, #2607 and #2609.
- [x] All existing tests and lints pass.

## What is the current behavior?

A sweep for handlers that report success without doing the work. Each finding below already had a **sibling branch in the same function that logs**, so these were the uncovered exits rather than a deliberate house style.

### 1. A captured booking payment could vanish without a trace

`_handleAppointmentBookingPayment` had three bare `return`s. Every other exit logs — the replay check, `mintBookingInvoice`'s P2002 branches, `settleAppointmentBookingInvoice`'s no-charge branch — and `stripe.controller.ts:50` answers Stripe `200 OK` whenever the handler does not throw.

The reachable one is the deleted service:

```ts
const service = await prisma.service.findUnique({ where: { id: serviceId } });
if (!service) return;   // card already charged
```

`Service` has no FK protecting it and `ServiceService.delete` is a hard `deleteMany`, so **deleting a speciality hard-deletes every service under it**. A booking payment can be in flight across that — 3DS, an abandoned-then-resumed checkout, a delayed payment method. Stripe captures the money, no `Invoice` row is minted, and nothing anywhere records that it happened.

### 2. A refund could leave the invoice marked PAID forever

`charge.refunded` → `markInvoiceRefundedFromWebhook` → `{ action: "NO_INVOICE" }` short-circuited into a bare return. The customer has their money back, the books still read paid, nothing logged. `ALREADY_REFUNDED` stays quiet, because that one is a genuine replay.

### 3. A captured intent naming an unfindable invoice did the same

`_handleInvoicePayment` logs `ACCOUNT_MISMATCH` and `MISSING_AMOUNT` but let `NO_INVOICE` fall through to nothing.

## Two claims that were simply untrue

**"Invite sent successfully" sent nothing.** `sendInvite` writes a PENDING row and stores the address in `invitedViaEmail`; nothing reads that column to dispatch anything. The delivery mechanism was a commented-out line sitting directly above the success message:

```ts
// You can trigger email sending here
// await EmailService.sendOrganisationInvite(...)

return res.status(201).json({ message: "Invite sent successfully" });
```

A pet parent inviting their clinic was told it had been sent. Now `"Invite created"`. Actually sending it is separate work, tracked below.

**Unrecognised Stripe subscription statuses became `active`.** The mapper named four and returned `"active"` for everything else, so `unpaid`, `paused` and `incomplete_expired` — all states where Stripe has **stopped collecting** — were stored and shown to the developer as an active subscription. Now mapped explicitly (`unpaid`/`paused` → `past_due`, `incomplete_expired` → `canceled`), with an unknown status falling to `incomplete` and logging, rather than reading as healthier than Stripe believes it to be.

## Validation performed

- **Full backend suite: 459 suites, 11,065 tests, all pass.**
- `tsc --noEmit` clean; `lint` exit 0.
- 13 new tests: the deleted-service and appointment-gone guards, refund `NO_INVOICE` plus an `ALREADY_REFUNDED` control proving replays stay quiet, invoice `NO_INVOICE`, the invite message, and nine status-mapping cases.

One of those tests earned its place immediately: my first `NO_INVOICE` case passed empty metadata, but the handler returns earlier without an `invoiceId`, so the branch was unreachable as written. The test failed, I corrected the test rather than the assertion, and the comment now says why the id must be present.

### Reproducing the suite

`jest --runInBand` **hangs** on this suite — three separate runs wedged for 5 to 10 hours while I was working tonight, with no output and no failure. Run it the way CI does, `--ci --maxWorkers=2`, which completes in minutes. Worth knowing before anyone else loses an evening to it.

## Deliberately not fixed here

The sweep confirmed several findings that need a product decision rather than a patch, written up separately: actually sending the companion invite, care reminders marked `SENT` regardless of dispatch outcome, `"Business deleted successfully"` for a soft delete that hard-deletes its children, and an IDEXX batch confirmed to the provider when a status did not map.
