### PR TITLE
fix(mobile): follow the app theme on dark-mode glass surfaces

### DIFF
--- a/apps/mobileAppYC/__tests__/navigation/FloatingTabBar.test.tsx
+++ b/apps/mobileAppYC/__tests__/navigation/FloatingTabBar.test.tsx
@@ -8,8 +8,9 @@ import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
 
 // --- Mocks ---
+let mockIsDark = false;
 jest.mock('@/hooks', () => ({
-  useTheme: () => ({theme: mockTheme, isDark: false}),
+  useTheme: () => ({theme: mockTheme, isDark: mockIsDark}),
 }));
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -111,6 +112,7 @@ describe('FloatingTabBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Platform.OS = 'ios'; // Default to iOS
+    mockIsDark = false;
     store = createMockStore();
   });
 
@@ -145,6 +147,47 @@ describe('FloatingTabBar', () => {
 
       // Android should fall back to View because glass is iOS-only
       expect(queryByTestId('liquid-glass-view')).toBeNull();
+    });
+  });
+
+  describe('Dark mode', () => {
+    // The bar pinned colorScheme to 'light' and tinted itself with
+    // whiteOverlay70 - 70% white in both themes - so espresso got a cream bar
+    // across the bottom of every screen while its labels stayed dark-ground ink.
+    const renderBar = () => {
+      const props: any = createProps();
+      (getFocusedRouteNameFromRoute as jest.Mock).mockReturnValue(undefined);
+      return render(
+        <Provider store={store}>
+          <FloatingTabBar {...props} />
+        </Provider>,
+      );
+    };
+
+    it('gives the iOS glass bar the dark scheme and the themed frost', () => {
+      mockIsDark = true;
+
+      const [bar] = renderBar().getAllByTestId('liquid-glass-view');
+
+      expect(bar.props.colorScheme).toBe('dark');
+      // The token, not the literal - glassFollowsTheme.test.ts is what asserts
+      // the two ends of that token actually differ.
+      expect(bar.props.tintColor).toBe(mockTheme.colors.glassBarTint);
+    });
+
+    it('keeps the light scheme when the theme is light', () => {
+      const [bar] = renderBar().getAllByTestId('liquid-glass-view');
+
+      expect(bar.props.colorScheme).toBe('light');
+    });
+
+    it('blurs dark on the non-glass path when the theme is dark', () => {
+      mockIsDark = true;
+      Platform.OS = 'android';
+
+      const blur = renderBar().UNSAFE_getByProps({blurAmount: 22});
+
+      expect(blur.props.blurType).toBe('dark');
     });
   });
 

--- a/apps/mobileAppYC/__tests__/setup/mockTheme.ts
+++ b/apps/mobileAppYC/__tests__/setup/mockTheme.ts
@@ -632,6 +632,7 @@ export const createMockTheme = () => ({
     glassPillBorder: 'rgba(29, 28, 27, 0.09)',
     glassSurface: 'rgba(247, 243, 236, 0.55)',
     glassSurfaceStrong: 'rgba(247, 243, 236, 0.72)',
+    glassBarTint: 'rgba(255, 255, 255, 0.7)',
   },
 });
 

--- a/apps/mobileAppYC/__tests__/setup/sourceScan.ts
+++ b/apps/mobileAppYC/__tests__/setup/sourceScan.ts
@@ -22,10 +22,16 @@ const walk = (dir: string, out: string[] = []): string[] => {
 /**
  * Every src file whose contents match one of `patterns`, as paths relative to
  * src/, skipping anything in `allowed`.
+ *
+ * `require` narrows the scan to files that ALSO match it. A pattern like
+ * `colorScheme="light"` is only meaningful on a glass surface - `colorScheme`
+ * is a common enough prop name that banning the literal everywhere would fire
+ * on unrelated APIs - so that guard passes the glass components as `require`.
  */
 export const findSourceFilesMatching = (
   patterns: RegExp[],
   allowed: ReadonlySet<string> = new Set(),
+  require?: RegExp,
 ): string[] => {
   const offenders: string[] = [];
   for (const file of walk(SRC_DIR)) {
@@ -34,6 +40,9 @@ export const findSourceFilesMatching = (
       continue;
     }
     const body = readFileSync(file, 'utf8');
+    if (require && !require.test(body)) {
+      continue;
+    }
     if (patterns.some(pattern => pattern.test(body))) {
       offenders.push(rel);
     }

--- a/apps/mobileAppYC/__tests__/shared/components/common/LiquidGlassCard/LiquidGlassCard.test.tsx
+++ b/apps/mobileAppYC/__tests__/shared/components/common/LiquidGlassCard/LiquidGlassCard.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {Platform, Text} from 'react-native';
+import {render, screen} from '@testing-library/react-native';
+import {mockTheme} from '../../../../setup/mockTheme';
+import {LiquidGlassCard} from '@/shared/components/common/LiquidGlassCard/LiquidGlassCard';
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('@callstack/liquid-glass', () => {
+  const {View} = require('react-native');
+  return {
+    __esModule: true,
+    LiquidGlassView: (props: any) => (
+      <View testID="liquid-glass-view" {...props} />
+    ),
+    isLiquidGlassSupported: true,
+  };
+});
+
+const darkTheme = () =>
+  jest
+    .spyOn(require('@/hooks'), 'useTheme')
+    .mockReturnValue({theme: mockTheme, isDark: true});
+
+describe('LiquidGlassCard', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+    jest.restoreAllMocks();
+  });
+
+  it('renders children', () => {
+    Platform.OS = 'ios';
+    render(
+      <LiquidGlassCard>
+        <Text>card body</Text>
+      </LiquidGlassCard>,
+    );
+    expect(screen.getByText('card body')).toBeTruthy();
+  });
+
+  describe('native glass branch (iOS + supported)', () => {
+    beforeEach(() => {
+      Platform.OS = 'ios';
+    });
+
+    it('follows the app theme by default in dark mode', () => {
+      // Regression: the default was 'light' and 'system' resolved to 'light'
+      // unconditionally, so every card in the app asked native glass for
+      // light-mode vibrancy on espresso - including the Home header, which is
+      // a LiquidGlassCard.
+      darkTheme();
+      render(
+        <LiquidGlassCard>
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.getByTestId('liquid-glass-view').props.colorScheme).toBe(
+        'dark',
+      );
+    });
+
+    it('follows the app theme by default in light mode', () => {
+      render(
+        <LiquidGlassCard>
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.getByTestId('liquid-glass-view').props.colorScheme).toBe(
+        'light',
+      );
+    });
+
+    it('still honours an explicit colorScheme over the theme', () => {
+      darkTheme();
+      render(
+        <LiquidGlassCard colorScheme="light">
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.getByTestId('liquid-glass-view').props.colorScheme).toBe(
+        'light',
+      );
+    });
+
+    it('tints with the themed glass surface', () => {
+      render(
+        <LiquidGlassCard>
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.getByTestId('liquid-glass-view').props.tintColor).toBe(
+        mockTheme.colors.glassSurface,
+      );
+    });
+  });
+
+  describe('android blur branch', () => {
+    beforeEach(() => {
+      Platform.OS = 'android';
+    });
+
+    it('blurs dark when the app theme is dark', () => {
+      darkTheme();
+      render(
+        <LiquidGlassCard>
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.UNSAFE_getByProps({blurAmount: 14}).props.blurType).toBe(
+        'dark',
+      );
+    });
+
+    it('blurs light when the app theme is light', () => {
+      render(
+        <LiquidGlassCard>
+          <Text>card body</Text>
+        </LiquidGlassCard>,
+      );
+      expect(screen.UNSAFE_getByProps({blurAmount: 14}).props.blurType).toBe(
+        'light',
+      );
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/theme/glassFollowsTheme.test.ts
+++ b/apps/mobileAppYC/__tests__/theme/glassFollowsTheme.test.ts
@@ -1,0 +1,47 @@
+import {findSourceFilesMatching} from '../setup/sourceScan';
+import {colors, colorsDark} from '@/theme';
+
+/**
+ * Native liquid glass takes a `colorScheme` telling it which vibrancy to
+ * render. Pinning that to 'light' hands espresso a pale wash, under ink the
+ * theme already darkened for a dark ground - so the surface reads inverted
+ * while every token on it is "correct".
+ *
+ * LiquidGlassButton and LiquidGlassIconButton were fixed for this; the card,
+ * the header and the floating tab bar were not, which is what put a cream tab
+ * bar across the bottom of every dark screen. The scans below keep all of them
+ * honest: a glass surface resolves its scheme from the theme, never a literal.
+ */
+const SCHEME_ALLOWED = new Set<string>([]);
+
+/**
+ * `whiteOverlay70` is 70% white in BOTH themes - a literal, like `white`. It
+ * is fine as a rim on a fill that itself flips (the CTA buttons), but as the
+ * tint or fill OF a surface it paints that surface light on espresso.
+ */
+const TINT_ALLOWED = new Set<string>([]);
+
+describe('glass surfaces follow the theme', () => {
+  it('never pins a glass colorScheme to light', () => {
+    const offenders = findSourceFilesMatching(
+      [/colorScheme="light"/, /colorScheme: 'light'/, /colorScheme = 'light'/],
+      SCHEME_ALLOWED,
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not tint or fill a themed surface with `whiteOverlay70`', () => {
+    const offenders = findSourceFilesMatching(
+      [
+        /(?:tintColor|backgroundColor)(?:=\{|: )(?:theme\.)?colors\.whiteOverlay70\b/,
+      ],
+      TINT_ALLOWED,
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('gives the tab bar frost a real espresso value, not the same white twice', () => {
+    expect(colors.glassBarTint).toBe('rgba(255, 255, 255, 0.7)');
+    expect(colorsDark.glassBarTint).not.toBe(colors.glassBarTint);
+  });
+});

--- a/apps/mobileAppYC/__tests__/theme/glassFollowsTheme.test.ts
+++ b/apps/mobileAppYC/__tests__/theme/glassFollowsTheme.test.ts
@@ -15,6 +15,18 @@ import {colors, colorsDark} from '@/theme';
 const SCHEME_ALLOWED = new Set<string>([]);
 
 /**
+ * Only glass surfaces are in scope. `colorScheme` is an ordinary prop name -
+ * a WebView or a third-party picker may take one and have nothing to do with
+ * the warm-bone glass system - so the scan is narrowed to files that actually
+ * render a glass surface rather than banning the literal everywhere.
+ *
+ * A surface that genuinely must stay light in both themes (glass over fixed
+ * light media, say) keeps its explicit `colorScheme="light"`, which the card
+ * still honours over the theme, and is listed in SCHEME_ALLOWED with a reason.
+ */
+const GLASS_SURFACE = /LiquidGlass(?:View|Card|Button|IconButton)|BlurView/;
+
+/**
  * `whiteOverlay70` is 70% white in BOTH themes - a literal, like `white`. It
  * is fine as a rim on a fill that itself flips (the CTA buttons), but as the
  * tint or fill OF a surface it paints that surface light on espresso.
@@ -26,6 +38,7 @@ describe('glass surfaces follow the theme', () => {
     const offenders = findSourceFilesMatching(
       [/colorScheme="light"/, /colorScheme: 'light'/, /colorScheme = 'light'/],
       SCHEME_ALLOWED,
+      GLASS_SURFACE,
     );
     expect(offenders).toEqual([]);
   });

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -410,7 +410,6 @@ const MapTopBar: React.FC<MapTopBarProps> = ({
         glassEffect="clear"
         interactive={false}
         shadow="none"
-        colorScheme="light"
         style={headerCardStyle}
         fallbackStyle={styles.headerCardFallback}>
         <Header title={title} showBackButton onBack={onBack} glass={false} />

--- a/apps/mobileAppYC/src/features/appointments/screens/MyAppointmentsScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/MyAppointmentsScreen.tsx
@@ -302,7 +302,6 @@ export const MyAppointmentsScreen: React.FC = () => {
       glassEffect="clear"
       interactive
       shadow="none"
-      colorScheme="light"
       style={styles.infoTile}
       fallbackStyle={styles.tileFallback}>
       <Text style={styles.tileTitle}>{title}</Text>

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
@@ -1069,7 +1069,6 @@ export const ViewAppointmentScreen: React.FC = () => {
           <LiquidGlassCard
             glassEffect="clear"
             padding="4"
-            colorScheme="light"
             shadow="base"
             style={styles.formCard}
             fallbackStyle={styles.formCardFallback}>

--- a/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
+++ b/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
@@ -53,7 +53,7 @@ interface TabLayout {
 export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
   const {state, navigation} = props;
   const {theme, isDark} = useTheme();
-  const glassScheme = isDark ? ('dark' as const) : ('light' as const);
+  const glassScheme = isDark ? 'dark' : 'light';
   const dispatch = useDispatch<AppDispatch>();
   const companions = useSelector((s: RootState) => s.companion.companions);
   const selectedCompanionIdFromState = useSelector(

--- a/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
+++ b/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
@@ -52,7 +52,8 @@ interface TabLayout {
 
 export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
   const {state, navigation} = props;
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
+  const glassScheme = isDark ? ('dark' as const) : ('light' as const);
   const dispatch = useDispatch<AppDispatch>();
   const companions = useSelector((s: RootState) => s.companion.companions);
   const selectedCompanionIdFromState = useSelector(
@@ -188,7 +189,7 @@ export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
             // navActive, an ink picked for this pale wash; tinting with solid
             // blue put dark blue on blue and measured 1.52:1.
             tintColor={theme.colors.navActiveBg}
-            colorScheme="light"
+            colorScheme={glassScheme}
             interactive
           />
         ) : (
@@ -272,8 +273,8 @@ export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
             {...(useGlass
               ? {
                   effect: 'clear' as const,
-                  tintColor: theme.colors.whiteOverlay70,
-                  colorScheme: 'light' as const,
+                  tintColor: theme.colors.glassBarTint,
+                  colorScheme: glassScheme,
                   interactive: false,
                 }
               : {})}>
@@ -281,7 +282,7 @@ export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
               <>
                 <BlurView
                   style={StyleSheet.absoluteFill}
-                  blurType="light"
+                  blurType={glassScheme}
                   blurAmount={22}
                   reducedTransparencyFallbackColor={theme.colors.glassPill}
                 />

--- a/apps/mobileAppYC/src/shared/components/common/AppointmentCard/AppointmentCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/AppointmentCard/AppointmentCard.tsx
@@ -111,7 +111,6 @@ export const AppointmentCard = ({
         glassEffect: 'clear',
         interactive: true,
         shadow: 'base',
-        colorScheme: 'light',
         style: styles.card,
         fallbackStyle: styles.fallback,
       }}

--- a/apps/mobileAppYC/src/shared/components/common/LiquidGlassCard/LiquidGlassCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/LiquidGlassCard/LiquidGlassCard.tsx
@@ -5,12 +5,8 @@ import {BlurView} from '@react-native-community/blur';
 import {useTheme} from '@/hooks';
 import {UI_FEATURE_FLAGS} from '@/config/variables';
 
-import {colors} from '@/theme';
 // Flip to true to force a consistent outline everywhere.
 const FORCE_CARD_BORDER = UI_FEATURE_FLAGS.forceLiquidGlassBorder;
-// Warm-bone hairline (light value of theme.colors.hairline); this module-level
-// forced outline cannot read useTheme(), so it mirrors the token literal.
-const FORCED_BORDER_COLOR = colors.hairline;
 const FORCED_BORDER_WIDTH = 1;
 // Set to true to fall back to static styling on iOS if native glass misbehaves.
 const LOCK_IOS_GLASS_APPEARANCE = false;
@@ -34,19 +30,23 @@ export const LiquidGlassCard: React.FC<LiquidGlassCardProps> = ({
   glassEffect = 'regular',
   interactive = false,
   tintColor,
-  colorScheme = 'light',
+  colorScheme = 'system',
   padding = '4',
   borderRadius = 'lg',
   shadow = 'base',
   fallbackStyle,
 }) => {
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
   const resolvedColorScheme = React.useMemo(() => {
+    // Both this default and the 'system' branch used to be 'light', so every
+    // card in the app asked native glass for light-mode vibrancy on espresso -
+    // a pale wash under ink already picked for a dark ground. Follow the app's
+    // own theme, as LiquidGlassButton and LiquidGlassIconButton already do.
     if (colorScheme === 'system') {
-      return 'light';
+      return isDark ? 'dark' : 'light';
     }
     return colorScheme;
-  }, [colorScheme]);
+  }, [colorScheme, isDark]);
 
   const baseStyle: ViewStyle = {
     padding: theme.spacing[padding],
@@ -69,7 +69,7 @@ export const LiquidGlassCard: React.FC<LiquidGlassCardProps> = ({
     (mergedStyleOverrides?.backgroundColor as string | undefined) ?? tintColor;
 
   const overlayBorderColor = FORCE_CARD_BORDER
-    ? FORCED_BORDER_COLOR
+    ? theme.colors.hairline
     : ((mergedStyleOverrides?.borderColor as string | undefined) ??
       theme.colors.hairline);
   const overlayBorderWidth = FORCE_CARD_BORDER

--- a/apps/mobileAppYC/src/shared/components/common/LiquidGlassHeader/LiquidGlassHeader.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/LiquidGlassHeader/LiquidGlassHeader.tsx
@@ -36,7 +36,6 @@ export const LiquidGlassHeader: React.FC<LiquidGlassHeaderProps> = ({
         glassEffect="clear"
         interactive={false}
         shadow="none"
-        colorScheme="light"
         style={[cardStyle, {paddingTop: insetsTop}]}
         fallbackStyle={fallbackStyle}>
         {children}

--- a/apps/mobileAppYC/src/shared/components/common/SubcategoryAccordion/SubcategoryAccordion.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/SubcategoryAccordion/SubcategoryAccordion.tsx
@@ -57,7 +57,6 @@ export const SubcategoryAccordion: React.FC<SubcategoryAccordionProps> = ({
         interactive={false}
         shadow="none"
         padding="0"
-        colorScheme="light"
         style={styles.container}
         fallbackStyle={styles.fallback}>
         <PressableOpacity

--- a/apps/mobileAppYC/src/shared/components/common/SwipeableActionCard/SwipeableActionCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/SwipeableActionCard/SwipeableActionCard.tsx
@@ -50,7 +50,6 @@ export const SwipeableActionCard: React.FC<SwipeableActionCardProps> = ({
         interactive: true,
         glassEffect: 'clear',
         shadow: 'base',
-        colorScheme: 'light',
         style: cardStyle,
         fallbackStyle: fallbackStyle,
       }}

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -177,6 +177,16 @@ const palette = {
   // warm and keeps ink legible (light / dark). More see-through than glassPill.
   glassSurface: ['rgba(247, 243, 236, 0.55)', 'rgba(41, 35, 28, 0.6)'],
   glassSurfaceStrong: ['rgba(247, 243, 236, 0.72)', 'rgba(41, 35, 28, 0.74)'],
+  /**
+   * Frost tint for the floating tab bar's native glass.
+   *
+   * The bar used `whiteOverlay70` here, which is a literal rather than a
+   * surface - the same 70% white in both themes. On espresso that painted a
+   * cream bar across the bottom of every dark screen, with the ink tokens
+   * underneath it still picked for a dark ground. The light value below is the
+   * one it already had, so light mode is unchanged.
+   */
+  glassBarTint: ['rgba(255, 255, 255, 0.7)', 'rgba(41, 35, 28, 0.7)'],
 
   // --- Fixed / overlays ---
   white: ['#FFFFFF', '#FFFFFF'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

In dark mode the floating tab bar renders as a pale cream bar across the bottom of every screen while its labels keep the ink chosen for a dark ground. The inactive label measures 1.40:1 against it and the active label 1.10:1 - close to invisible.

The cause is that the glass surfaces do not follow the app theme:

- `FloatingTabBar` pins `colorScheme` to `"light"` and `blurType` to `"light"`, and tints its native glass with `whiteOverlay70`, which is 70% white in BOTH themes. It is a literal, like `white`, not a surface token.
- `LiquidGlassCard` defaults `colorScheme` to `"light"`, and its `"system"` branch returns `"light"` unconditionally. Every card in the app - including the Home header, which is a `LiquidGlassCard` - therefore asked native glass for light-mode vibrancy on espresso and rendered a washed-out grey.
- Six call sites pass `colorScheme="light"` explicitly, which only repeated that old default.

`LiquidGlassButton` and `LiquidGlassIconButton` were already fixed for this exact bug and carry comments explaining it. The card, the header and the tab bar were left behind.

## What is the new behavior?

Glass surfaces resolve their scheme from the app theme, the way the two button components already do.

- add `glassBarTint`, a real `[light, dark]` pair for the tab bar's frost. The light value is byte-for-byte the one the bar already used, so light mode is unchanged.
- resolve `colorScheme` and `blurType` from `isDark` in `FloatingTabBar`.
- default `LiquidGlassCard` to `"system"` and resolve `"system"` from `isDark`. An explicit `colorScheme` still wins, so a caller that genuinely wants light glass can still ask for it.
- drop the redundant `colorScheme="light"` from the six call sites.
- read the forced card border from the theme instead of the light token literal, so the `forceLiquidGlassBorder` flag cannot paint a bone hairline on espresso if it is ever switched on.

### Verification

Built and run on an iPhone 17 Pro simulator in dark appearance, sampling the same pixels before and after:

| surface | before | after |
| --- | --- | --- |
| tab bar fill | #C3BCB5 | #302A23 |
| glass card fill | #625C57 | #2A241E |
| page ground (control, untouched) | #2F271E | #2F271E |

The page ground is identical in both, which is what confirms only the glass surfaces moved.

Contrast, before to after:

| text | before | after |
| --- | --- | --- |
| inactive tab label (`inkMuted`) | 1.40:1 | 5.37:1 |
| active tab label (`navActive`) | 1.10:1 | 6.87:1 |
| card body ink (`inkMuted`) | 2.50:1 | 5.81:1 |
| card title ink (`ink`) | 5.75:1 | 13.39:1 |

Checks run locally: `type-check` clean, `lint` clean, and 1367 tests across 61 suites covering every touched component and call site.

### Regression guard

`__tests__/theme/glassFollowsTheme.test.ts` scans `src/` and fails if a glass surface pins its scheme to a literal again, or fills a themed surface with `whiteOverlay70`. It follows the existing `fixedWhiteSurfaces.test.ts` pattern. I verified it actually fails by reintroducing `colorScheme="light"` on `LiquidGlassHeader` before relying on it.

New unit tests also cover `LiquidGlassCard`'s scheme resolution in both themes and on both the iOS glass and Android blur paths, plus dark-mode assertions on `FloatingTabBar`.

### Note on scope

The clipped "Add companion" label visible in the reported screenshot is NOT a defect. I reproduced it on device and it is the last tile of a horizontal carousel extending past the viewport; scrolled into view the label renders in full inside its tile. No change was made there.

## Related Issue(s)

Fixes #2613
