### PR TITLE
fix(frontend): notch the meta-bar field labels instead of painting a patch

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
@@ -36,6 +36,14 @@ describe('StaffField', () => {
     expect(label.style.backgroundColor).toBe('');
   });
 
+  it('never paints --screen behind a floating label', () => {
+    // The original bug in one line: `body` paints `--page`, so a label painting
+    // `--screen` sits on a ground it does not match, in either theme. Nothing in
+    // this component may reintroduce that token as a label fill.
+    const { container } = render(<StaffField label="Assigned Lead" name="Dr. Tim Apple" />);
+    expect(container.innerHTML).not.toContain('var(--screen)');
+  });
+
   it('fills the field surface with the theme field background so it does not wash out', () => {
     render(<StaffField label="Assigned Lead" name="Dr. Tim Apple" />);
     // The shell is the fieldset the legend sits in; it carries the filled surface.

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
@@ -18,10 +18,28 @@ describe('StaffField', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
+  it('notches the label into the border rather than painting a patch behind it', () => {
+    render(<StaffField label="Assigned Lead" name="Dr. Tim Apple" />);
+    const label = screen.getByText('Assigned Lead');
+
+    // A real legend inside a fieldset: the browser cuts the border where the text
+    // sits, so the field is correct on any surface.
+    expect(label.tagName).toBe('LEGEND');
+    expect(label.closest('fieldset')).not.toBeNull();
+
+    /* And it must paint NOTHING. The old implementation filled `--screen` behind
+       the label to fake the gap, which only lined up when the field sat directly
+       on the page; on the workspace meta bar it sits on a card, where that patch
+       showed as a pale rectangle laid over the border. Any background here is
+       that bug returning. */
+    expect(label.style.background).toBe('');
+    expect(label.style.backgroundColor).toBe('');
+  });
+
   it('fills the field surface with the theme field background so it does not wash out', () => {
     render(<StaffField label="Assigned Lead" name="Dr. Tim Apple" />);
-    // The shell is the label span's parent box; it carries the filled surface.
-    const shell = screen.getByText('Assigned Lead').parentElement as HTMLElement;
+    // The shell is the fieldset the legend sits in; it carries the filled surface.
+    const shell = screen.getByText('Assigned Lead').closest('fieldset') as HTMLElement;
     expect(shell).toHaveStyle({ background: 'var(--field-bg)' });
     expect(shell).toHaveStyle({ borderColor: 'var(--hairline)' });
   });

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.stories.tsx
@@ -75,9 +75,16 @@ const outpatient = (patch: Partial<AppointmentEncounter> = {}): AppointmentEncou
     ...patch,
   });
 
-/** The listbox portals to `document.body`, so the bar needs room below it. */
+/**
+ * The listbox portals to `document.body`, so the bar needs room below it.
+ *
+ * The ground is `--page`, which is what `body` actually paints - NOT `--screen`,
+ * which is a different token in both themes. The floating labels notch
+ * themselves against the real ground, so a story rendered on `--screen` would
+ * show the very patch this component was fixed to remove.
+ */
 const Room = (Story: React.ComponentType) => (
-  <div className="min-h-[420px] w-full p-6" style={{ background: 'var(--screen)' }}>
+  <div className="min-h-[420px] w-full p-6" style={{ background: 'var(--page)' }}>
     <Story />
   </div>
 );
@@ -105,7 +112,8 @@ const meta = {
           'genuinely fragile one. `EditableMetaDropdown` does not wrap `LabelDropdown` in a styled ' +
           'shell; it reaches *into* it with descendant selectors keyed on its exact DOM nesting. ' +
           "`[&>div>span]` takes LabelDropdown's ordinary stacked 12px label and re-renders it " +
-          'notched into the border - `absolute -top-[7px] left-3`, `bg-[var(--screen)]`, ' +
+          'notched into the border - `absolute -top-[7px] left-3`, `bg-[var(--page)]` (the token ' +
+          '`body` actually paints, so the notch lines up), ' +
           '`px-[5px]`, 10.5px on `--ink-faint` - so it lines up with the `MetaFieldShell` labels ' +
           'beside it. `[&>div>div>button]` then overrides the trigger to a 14px radius, a ' +
           '`--field-bg` fill and 13.5px/600 text so it matches the read-only fields rather than ' +

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
@@ -49,7 +49,7 @@ const EditableMetaDropdown = ({
   value?: string;
   onSelect: (option: DropdownOption) => void;
 }) => (
-  <div className="relative w-full [&>div>span]:pointer-events-none [&>div>span]:absolute [&>div>span]:-top-[7px] [&>div>span]:left-3 [&>div>span]:z-30 [&>div>span]:mb-0 [&>div>span]:bg-[var(--screen)] [&>div>span]:px-[5px] [&>div>span]:text-[10.5px] [&>div>span]:text-[var(--ink-faint)] [&>div>div>button]:rounded-[14px]! [&>div>div>button]:bg-[var(--field-bg)]! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
+  <div className="relative w-full [&>div>span]:pointer-events-none [&>div>span]:absolute [&>div>span]:-top-[7px] [&>div>span]:left-3 [&>div>span]:z-30 [&>div>span]:mb-0 [&>div>span]:bg-[var(--page)] [&>div>span]:px-[5px] [&>div>span]:text-[10.5px] [&>div>span]:text-[var(--ink-faint)] [&>div>div>button]:rounded-[14px]! [&>div>div>button]:bg-[var(--field-bg)]! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
     <LabelDropdown
       placeholder={label}
       options={options}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
@@ -78,11 +78,13 @@ const meta = {
   title: 'Appointments/StaffField',
   component: StaffField,
   decorators: [
-    /* The notched label paints `--screen` behind itself to interrupt the border, so
-       the field is only correct on a `--screen` ground. Rendering it on the bare
-       preview canvas would hide a mismatch that is glaring in the product. */
+    /* Deliberately a CARD ground, not `--screen`. The field sits on a card in the
+       workspace meta bar, and the previous implementation - which painted
+       `--screen` behind the label to fake the notch - showed there as a pale
+       rectangle laid over the border. Rendering the stories on the ground that
+       broke it keeps that regression from coming back unseen. */
     (Story) => (
-      <div className="w-[280px] p-6" style={{ background: 'var(--screen)' }}>
+      <div className="w-[280px] p-6" style={{ background: 'var(--card-bg, var(--surface))' }}>
         <Story />
       </div>
     ),
@@ -96,12 +98,14 @@ const meta = {
           'the chrome every other field in that bar is built from. `MetaFieldShell` is the 46px ' +
           'box with the notched label; `MetaFieldValue` is the 13.5px/600 value text; ' +
           '`StaffField` is the two of them plus an avatar.\n\n' +
-          'The notch is the trick worth pinning. There is no gap cut in the border - the label ' +
-          'is absolutely positioned astride the top edge and paints `--screen` behind itself, so ' +
-          'the border only *reads* as interrupted. That means the field is correct on a ' +
-          '`--screen` ground and wrong on any other: on a card or inside a modal the label ' +
-          'stripe would show as a rectangle of the wrong colour laid over the border. Nothing ' +
-          'in the props expresses that constraint.\n\n' +
+          'The notch is a real one: the box is a `fieldset` and the label is its `legend`, so ' +
+          'the browser cuts the border where the text sits. It paints no background of its own ' +
+          'and is therefore correct on every ground - card, modal or page, light or dark.\n\n' +
+          'It did not always work that way. The label used to be an absolutely positioned span ' +
+          'painting `--screen` behind itself to fake the gap, which only lined up when the field ' +
+          'sat directly on the page; on the workspace meta bar, where it sits on a card, the ' +
+          'patch showed as a rectangle of the wrong shade over the border. The stories now ' +
+          'render on a card ground so that regression cannot return unnoticed.\n\n' +
           'The surface is `--field-bg` rather than transparent, which is what makes the box read ' +
           'as filled instead of as a hole in the page - the two tokens are deliberately different ' +
           'values in both themes, and the stories assert that rather than assuming it.\n\n' +
@@ -158,12 +162,10 @@ export const Assigned: Story = {
     // Inset from the corner, so the border still turns before the label starts.
     await expect(labelBox.left).toBeGreaterThan(shellBox.left);
 
-    /* And the paint behind it has to be the PAGE colour, not the field fill -
-       that is the entire illusion. Matching it to `--field-bg` leaves a visible
-       swatch of the wrong shade sitting on the border. */
-    await expect(globalThis.getComputedStyle(labelEl).backgroundColor).toBe(
-      resolveToken(labelEl, '--screen')
-    );
+    /* The legend must paint NOTHING. Any background here is the old bug: a patch
+       that happens to match one ground and shows as a coloured rectangle on every
+       other. A real notch needs no fill, which is the whole point of the fix. */
+    await expect(globalThis.getComputedStyle(labelEl).backgroundColor).toBe('rgba(0, 0, 0, 0)');
 
     // 13.5px/600 is normal-size text, so the AA bar is 4.5 rather than 3.0.
     await expect(

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
@@ -78,13 +78,14 @@ const meta = {
   title: 'Appointments/StaffField',
   component: StaffField,
   decorators: [
-    /* Deliberately a CARD ground, not `--screen`. The field sits on a card in the
-       workspace meta bar, and the previous implementation - which painted
-       `--screen` behind the label to fake the notch - showed there as a pale
-       rectangle laid over the border. Rendering the stories on the ground that
-       broke it keeps that regression from coming back unseen. */
+    /* `--page`, which is what `body` actually paints and therefore the real ground
+       under the meta bar - NOT `--screen`, which the old faked notch painted
+       behind the label. Those two tokens differ in both themes (#efe8dc vs
+       #f7f3ec light, #201c18 vs #2f271e dark), which is exactly why the patch was
+       visible on the plain page and not only on cards. Rendering on the true
+       ground keeps a mismatch visible here instead of only in the product. */
     (Story) => (
-      <div className="w-[280px] p-6" style={{ background: 'var(--card-bg, var(--surface))' }}>
+      <div className="w-[280px] p-6" style={{ background: 'var(--page)' }}>
         <Story />
       </div>
     ),
@@ -102,10 +103,10 @@ const meta = {
           'the browser cuts the border where the text sits. It paints no background of its own ' +
           'and is therefore correct on every ground - card, modal or page, light or dark.\n\n' +
           'It did not always work that way. The label used to be an absolutely positioned span ' +
-          'painting `--screen` behind itself to fake the gap, which only lined up when the field ' +
-          'sat directly on the page; on the workspace meta bar, where it sits on a card, the ' +
-          'patch showed as a rectangle of the wrong shade over the border. The stories now ' +
-          'render on a card ground so that regression cannot return unnoticed.\n\n' +
+          'painting `--screen` behind itself to fake the gap - but `body` paints `--page`, a ' +
+          'different token in both themes, so the patch never matched its ground and showed as a ' +
+          'rectangle of the wrong shade over the border. The stories now render on `--page`, the ' +
+          'real ground, so a mismatch shows up here rather than only in the product.\n\n' +
           'The surface is `--field-bg` rather than transparent, which is what makes the box read ' +
           'as filled instead of as a hole in the page - the two tokens are deliberately different ' +
           'values in both themes, and the stories assert that rather than assuming it.\n\n' +

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.stories.tsx
@@ -348,17 +348,17 @@ export const Dark: Story = {
     await expect(shellStyle.backgroundColor).toBe(resolveToken(shell, '--field-bg'));
     await expect(shellStyle.backgroundColor).not.toBe(resolveToken(shell, '--screen'));
 
-    // The notch still paints the page colour, which is a different value in dark.
-    await expect(globalThis.getComputedStyle(labelEl).backgroundColor).toBe(
-      resolveToken(labelEl, '--screen')
-    );
+    /* Dark is where a painted notch did the most damage: `--screen` #2f271e over a
+       `--page` #201c18 ground is a visibly lighter block behind the label. The
+       legend paints nothing, so the ground shows through whatever it happens to be. */
+    await expect(globalThis.getComputedStyle(labelEl).backgroundColor).toBe('rgba(0, 0, 0, 0)');
 
     /* Three inks, three grounds, all of them theme-swapped. The 10.5px label is the
-       tightest of them and the one that goes first when `--ink-faint` moves. */
+       tightest of them and the one that goes first when `--ink-faint` moves. Its
+       ground is whatever the field sits on - `--page` in these stories - not the
+       label's own background, which is now transparent and would score infinite. */
     const labelInk = globalThis.getComputedStyle(labelEl).color;
-    await expect(
-      contrast(labelInk, globalThis.getComputedStyle(labelEl).backgroundColor)
-    ).toBeGreaterThanOrEqual(4.5);
+    await expect(contrast(labelInk, resolveToken(labelEl, '--page'))).toBeGreaterThanOrEqual(4.5);
     await expect(
       contrast(
         globalThis.getComputedStyle(canvas.getByText('Dr. Amara Weber')).color,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.tsx
@@ -17,24 +17,30 @@ type MetaFieldShellProps = {
 
 /**
  * Shared meta-bar field chrome: a 46px box with a filled surface, a 1.5px
- * hairline border, and the label notched into the top border (the label paints
- * the screen background behind itself so the border reads as interrupted rather
- * than overlapped). The surface uses `--field-bg` so the field reads as filled —
- * matching the design — instead of washing out transparently over the page.
+ * hairline border, and the label notched into the top border.
+ *
+ * The notch is a real `fieldset`/`legend`, which cuts the border where the text
+ * sits. The previous version painted `--screen` behind the label to fake the
+ * gap, which only lined up when the field happened to sit directly on the page:
+ * inside the workspace meta bar the field sits on a card, so the patch showed as
+ * a lighter box floating on the label. A legend needs no background at all and
+ * is therefore correct on every surface, in both themes.
  */
 export const MetaFieldShell = ({ label, children, className = '' }: MetaFieldShellProps) => (
-  <div
-    className={`relative flex h-[46px] w-full items-center gap-2 rounded-[14px] border-[1.5px] pr-2 pl-3.5 ${className}`}
+  <fieldset
+    // min-w-0 keeps the browser's default `min-inline-size: min-content` on
+    // fieldset from forcing the box wider than its grid column.
+    className={`relative m-0 flex h-[46px] w-full min-w-0 items-center gap-2 rounded-[14px] border-[1.5px] pt-0 pr-2 pb-0 pl-3.5 ${className}`}
     style={{ background: 'var(--field-bg)', borderColor: 'var(--hairline)' }}
   >
-    <span
-      className="absolute -top-[7px] left-3 truncate px-[5px] text-[10.5px] font-semibold leading-[120%]"
-      style={{ background: 'var(--screen)', color: 'var(--ink-faint)' }}
+    <legend
+      className="ml-0 truncate p-0 px-[5px] text-[10.5px] font-semibold leading-[120%]"
+      style={{ color: 'var(--ink-faint)' }}
     >
       {label}
-    </span>
+    </legend>
     {children}
-  </div>
+  </fieldset>
 );
 
 /** Value text shared by every meta-bar field — 13.5px/600 on the body ink. */


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The workspace meta bar's field labels — "Assigned lead", "Support staff", "Consultation type", "Room" — render as a filled rectangle sitting on top of the border instead of a notch cut into it. It is visible in light mode and glaring in dark.

`MetaFieldShell` fakes the notch: the label is an absolutely positioned span that paints `--screen` behind itself so the border only *reads* as interrupted. That lines up only when the field sits directly on the page; in the meta bar the fields sit on a card, so the patch shows as a swatch of the wrong shade laid over the border.

The limitation was known — it was written into the component's own Storybook docs as accepted behaviour, and the stories rendered on a `--screen` ground, which hid it from review.

## What is the new behavior?

The notch is real: the shell is a `fieldset` and the label its `legend`, so the browser cuts the border where the text sits. A legend paints no background, so the field is correct on every ground — page, card or modal, light or dark — with no colour coupling to its surroundings.

The stories now render on a **card** ground (the one that broke it) so the regression cannot return unseen, and the docs describe the real mechanism instead of the workaround.

## Impact area

`MetaFieldShell` / `StaffField`, used by every field in the workspace meta bar. No layout change: same 46px height, 14px radius, `--field-bg` fill, `--hairline` border. `min-w-0` is added because a `fieldset` defaults to `min-inline-size: min-content`, which would otherwise widen the box past its grid column.

## Validation performed

- `tsc` clean, scoped ESLint clean, jest suites for StaffField and WorkspaceMetaBar green.
- Verified visually in Storybook on a card ground, light and dark: the border is cut cleanly around each label, and the play assertions pass (14 in light, 6 in dark, including contrast).
- Verified the bug itself on dev before the fix — screenshot of all four labels showing the mismatched patch in dark mode.
- **Mutation-checked**: restoring the painted background, or reverting the fieldset/legend to div/span, each fails the new jest test.

One process note: the Storybook play assertions do not run in CI (there is no headless story runner in this repo), so the guard was added to jest, where it does run.

## Related Issue(s)

Closes #2612
