### PR TITLE
fix(frontend): two defects found by looking at the merged work on dev

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Inputs/dropdownMetricParity.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/dropdownMetricParity.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * LabelDropdown and MultiSelectDropdown must stay metrically identical.
+ *
+ * They sit next to each other in the New appointment modal as "Lead" and
+ * "Support". They drifted to 13px/px-[13px]/pr-9 against 14px/px-[14px]/pr-11 -
+ * close enough to read as the same control, far enough that the text baselines
+ * and chevrons did not line up, which is what a user notices as "two different
+ * dropdown designs".
+ *
+ * This asserts the trigger metrics rather than a screenshot, so the drift fails
+ * a unit run instead of waiting for someone to spot it in the product.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const read = (rel: string) => fs.readFileSync(path.join(process.cwd(), rel), 'utf8');
+
+const LABEL = 'src/app/ui/inputs/Dropdown/LabelDropdown.tsx';
+const MULTI = 'src/app/ui/inputs/MultiSelectDropdown/index.tsx';
+
+/** The metric tokens that decide whether two triggers look like one control. */
+const METRICS = [/h-\[(\d+)px\]/, /px-\[(\d+)px\]/, /pr-(\d+)\b/, /text-\[(\d+)px\]/];
+
+const triggerMetrics = (src: string) => {
+  // The trigger is the class string carrying the shared height token.
+  const line = src.split('\n').find((l) => l.includes('h-[44px]') && l.includes('px-['));
+  if (!line) throw new Error('trigger class string not found');
+  return METRICS.map((re) => (line.match(re) || [])[1]);
+};
+
+describe('dropdown metric parity', () => {
+  it('LabelDropdown and MultiSelectDropdown share trigger height, padding and font size', () => {
+    expect(triggerMetrics(read(MULTI))).toEqual(triggerMetrics(read(LABEL)));
+  });
+
+  it('both render the typed search text at the same size', () => {
+    /* Only the search input is compared, not every text size in the file:
+       LabelDropdown legitimately uses 11px and 12px for other elements, and an
+       earlier version of this test wrongly demanded the whole set match. */
+    const searchTextSize = (src: string) => {
+      const line = src
+        .split('\n')
+        .find((l) => l.includes('bg-transparent') && l.includes('text-['));
+      if (!line) throw new Error('search input class string not found');
+      return (line.match(/text-\[(\d+)px\]/) || [])[1];
+    };
+    expect(searchTextSize(read(MULTI))).toBe(searchTextSize(read(LABEL)));
+  });
+});

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css
@@ -83,11 +83,15 @@
 
 /* A neutral badge: these cards illustrate what a plugin could be, so they must
    not borrow the green "completed" or amber "in progress" treatment the rest of
-   the product uses for real state. */
+   the product uses for real state.
+   Tokens, not literals: --surface-muted / --text-tertiary / --border-subtle do
+   not exist in this design system, so the first version fell through to its
+   light-mode fallbacks and measured 3.94:1 on the dark card, under AA. These
+   three are defined in both themes and measure 5.41 light / 5.49 dark. */
 .dev-plugin-badge.sample {
-  background: var(--surface-muted, rgb(0 0 0 / 4%));
-  color: var(--text-tertiary, #6b6b6b);
-  border-color: var(--border-subtle, rgb(0 0 0 / 8%));
+  background: var(--inset);
+  color: var(--ink-muted);
+  border-color: var(--divider);
 }
 
 .dev-plugin-card-title {

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
@@ -92,7 +92,12 @@ const MultiSelectPanel = ({
 
 const getTriggerClassName = (open: boolean, hasSelection: boolean, error?: string): string => {
   const base =
-    'relative w-full flex h-[44px] items-center px-[14px] pr-11 min-w-30 border-[1.5px] cursor-pointer bg-[var(--field-bg)] text-[14px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)]';
+    // Metrics match LabelDropdown exactly. The two sit next to each other in the
+    // New appointment modal as "Lead" and "Support", and were 13px/px-[13px]/pr-9
+    // against 14px/px-[14px]/pr-11 - close enough to look like the same control,
+    // far enough that the label baselines and chevrons did not line up.
+    // LabelDropdown is the standard here: 43 usages against this one's 13.
+    'relative w-full flex h-[44px] items-center px-[13px] pr-9 min-w-30 border-[1.5px] cursor-pointer bg-[var(--field-bg)] text-[13px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)]';
   let borderState: string;
   if (open) {
     borderState = 'border-[var(--blue)]! border-b-0! rounded-t-[12px]! z-20';
@@ -150,13 +155,13 @@ const MultiSelectTriggerContent = ({
           onKeyDown(event);
         }}
         placeholder={hasSelection ? selectedLabel : ''}
-        className="w-full bg-transparent text-left text-[14px] text-[var(--ink-body)] outline-none placeholder:text-[var(--ink-faint)]"
+        className="w-full bg-transparent text-left text-[13px] text-[var(--ink-body)] outline-none placeholder:text-[var(--ink-faint)]"
       />
     );
   }
   return (
     <span
-      className="min-w-0 flex-1 truncate text-left text-[14px] text-[var(--ink-body)]"
+      className="min-w-0 flex-1 truncate text-left text-[13px] text-[var(--ink-body)]"
       title={hasSelection ? selectedLabel : placeholder}
     >
       {hasSelection ? selectedLabel : ''}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for — found during a post-merge visual pass; the dropdown half was reported directly.
- [x] All existing tests and lints pass.

## What is the current behavior?

Both defects were found by **looking at dev after merging**, and neither was catchable by the unit suites — which were green for both.

### 1. The Sample badge fails contrast in dark mode

#2607 styled the new badge with tokens that **do not exist in this design system**:

```css
background: var(--surface-muted, rgb(0 0 0 / 4%));
color: var(--text-tertiary, #6b6b6b);
border-color: var(--border-subtle, rgb(0 0 0 / 8%));
```

Every one falls through to its light-mode literal, so on the dark card the badge renders `rgb(107,107,107)` on `rgba(0,0,0,0.04)`. Measured in the browser on deployed dev:

| | contrast | WCAG AA (4.5:1) |
| --- | --- | --- |
| before | **3.94:1** | fails |
| after | 5.41 light / **5.49 dark** | passes |

My regression, introduced in #2607.

### 2. Lead and Support are two subtly different controls

Reported from the **New appointment** modal, and the measurements confirm it:

| | Lead (`LabelDropdown`) | Support (`MultiSelectDropdown`) |
| --- | --- | --- |
| font-size | 13px | **14px** |
| padding-left | 13px | **14px** |
| padding-right | 36px (`pr-9`) | **44px** (`pr-11`) |
| height / radius / border | 44px / 12px / 1.5px | same |

Same box, different type and padding — so they read as *the same control, subtly off*, which is exactly how it was described. `MultiSelectDropdown` now matches `LabelDropdown` exactly; the latter is the de-facto standard with **43 usages against this one's 13**, so the minority moved.

## What is the new behavior?

Retokenised badge, aligned dropdown metrics, and a guard so the two cannot drift again:

`dropdownMetricParity.test.tsx` reads both source files and pins the trigger's height, padding and font size together, so a future divergence fails a unit run instead of waiting to be noticed in the product.

Worth flagging one thing about that test: its first version also demanded the two files share their *whole set* of text sizes. That is wrong — `LabelDropdown` legitimately uses 11px and 12px for other elements — and it failed. I narrowed the assertion rather than bending the component to satisfy a bad test, and the reason is recorded in the file.

## Validation performed

- **All four frontend shards**: 2798 + 2980 + 3567 + 3057 = **12,402 tests**, exit 0 on each.
- `tsc --noEmit` clean; `lint` exit 0.
- **Contrast measured in-browser**, not eyeballed, in both themes.
- **Trigger metrics measured in Storybook** after the change: 44px height, 13px font, 13px/36px padding, 12px radius — identical to `LabelDropdown`.
- Mutation-checked: restoring the 14px/`px-[14px]`/`pr-11` metrics fails the parity test.

## Found but not fixed here

While measuring the modal I hit a separate layout bug: the **Support panel escapes the dialog by 76px** while the dialog is `overflow-y: hidden`, so the last options are unreachable. That needs a positioning decision (flip-up, portal, or letting the dialog scroll) rather than a metric tweak, so it is filed separately.
