### PR TITLE
fix(backend): flag intramammary antibacterials for stewardship

### DIFF
--- a/apps/backend/src/scripts/import-atcvet-index.ts
+++ b/apps/backend/src/scripts/import-atcvet-index.ts
@@ -64,6 +64,16 @@ const PARENT_LENGTH: Record<number, number> = { 4: 2, 5: 4, 6: 5, 8: 6 };
  * or far smaller than what is already loaded, is a truncated file rather than a
  * genuine contraction of the classification.
  */
+/** Level-2 groups whose published ATCvet name is "ANTIBACTERIALS FOR ...". */
+const ANTIBACTERIAL_GROUPS = ["QJ01", "QJ51"];
+
+/**
+ * Whether a code sits under one of those groups. Exported so the rule is
+ * testable on its own rather than only through a database write.
+ */
+export const isAntibacterial = (code: string): boolean =>
+  ANTIBACTERIAL_GROUPS.some((group) => code.startsWith(group));
+
 const MINIMUM_RELEASE_SIZE = 5000;
 const MAXIMUM_RELEASE_SHRINKAGE = 0.1;
 
@@ -207,10 +217,14 @@ export const main = async () => {
     level: entry.level,
     atcGroup: entry.code.slice(0, 2),
     ...(entry.species.length > 0 ? { species: entry.species } : {}),
-    // QJ01 is "antibacterials for systemic use" - the group antimicrobial
-    // stewardship reporting is actually about. Recorded as a fact of the
-    // classification, not a clinical judgement layered on top of it.
-    ...(entry.code.startsWith("QJ01") ? { antibacterial: true } : {}),
+    // The two groups ATCvet itself names "ANTIBACTERIALS": QJ01 for systemic use
+    // and QJ51 for intramammary use. Both count in veterinary antimicrobial
+    // surveillance - intramammary products treat mastitis and are a large share
+    // of dairy antibiotic use, so flagging QJ01 alone under-reports exactly the
+    // population stewardship exists to watch. Deliberately NOT the QG01/QG51
+    // "antiinfectives and antiseptics" groups, which are broader than
+    // antibacterials and would over-report instead.
+    ...(isAntibacterial(entry.code) ? { antibacterial: true } : {}),
     source: extract.source,
     dataset: extract.dataset,
     release: extract.release,

--- a/apps/backend/test/scripts/import-atcvet-index.test.ts
+++ b/apps/backend/test/scripts/import-atcvet-index.test.ts
@@ -9,6 +9,7 @@ jest.mock("src/config/prisma", () => ({
 
 import fs from "node:fs";
 import {
+  isAntibacterial,
   main,
   parentOf,
   planImport,
@@ -48,6 +49,28 @@ describe("speciesFor", () => {
   it("assigns no species outside QI, where levels are therapeutic", () => {
     // QJ01AA02 is doxycycline for any species; claiming one would be wrong.
     expect(speciesFor("QJ01AA02")).toEqual([]);
+  });
+});
+
+describe("isAntibacterial", () => {
+  it("covers both groups ATCvet names ANTIBACTERIALS", () => {
+    // QJ01 systemic and QJ51 intramammary. Intramammary products treat mastitis
+    // and are a large share of dairy antibiotic use; counting only QJ01 would
+    // under-report exactly the population stewardship surveillance watches.
+    expect(isAntibacterial("QJ01AA02")).toBe(true); // doxycycline, systemic
+    expect(isAntibacterial("QJ51CR02")).toBe(true); // amoxicillin, intramammary
+  });
+
+  it("excludes the broader antiinfective groups", () => {
+    // QG01/QG51 are "antiinfectives and antiseptics" - wider than antibacterials,
+    // so flagging them would over-report instead.
+    expect(isAntibacterial("QG51AA03")).toBe(false);
+    expect(isAntibacterial("QG01AA01")).toBe(false);
+  });
+
+  it("excludes unrelated groups", () => {
+    expect(isAntibacterial("QA01AA01")).toBe(false);
+    expect(isAntibacterial("QJ02AC02")).toBe(false); // antimycotic, not antibacterial
   });
 });
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The ATCvet importer flags `antibacterial: true` on QJ01 codes only, so intramammary antibacterials are not flagged.

Found during visual QA of the new prescribing picker on dev: searching "amoxicillin" returns `QJ51CR02 · ANTIBACTERIALS FOR INTRAMAMMARY USE` with no **Antibacterial** badge, while `QJ01CA04` correctly carries one.

## What is the new behavior?

Both groups the classification itself names ANTIBACTERIALS are flagged — QJ01 (systemic) and QJ51 (intramammary) — through an exported `isAntibacterial` rule so the decision is unit-testable rather than buried in a write path.

Why it matters: intramammary products treat mastitis and are a large share of antibiotic use in dairy practice, and veterinary antimicrobial surveillance counts them. Flagging QJ01 alone under-reports exactly the population stewardship reporting exists to watch.

QG01 and QG51 are deliberately excluded: they are "antiinfectives and antiseptics", broader than antibacterials, and including them would over-report in the other direction.

## Impact area

The ATCvet import only. Re-running it updates existing rows (the import is idempotent), so the fix lands on an environment by re-running `pnpm import:atcvet-index -- --apply` per docs/guide/atcvet-rollout.md.

## Validation performed

- Backend `tsc` clean, scoped ESLint clean, importer suite green (16 tests).
- **Mutation-checked in both directions**: narrowing back to `["QJ01"]` fails the intramammary test, and widening to `["QJ", "QG"]` fails the antiinfective-exclusion test. A rule that is only tested one way can drift wide without anyone noticing.
- Post-merge: re-run the import on dev and confirm the flagged count rises by the QJ51 substances, then re-check the badge in the picker.

## Related Issue(s)

Closes #2618
