### PR TITLE
fix(desktop): report the vault's real encryption status instead of asserting it

### DIFF
--- a/apps/desktop/src/core/ipc-handlers.ts
+++ b/apps/desktop/src/core/ipc-handlers.ts
@@ -594,7 +594,19 @@ export const registerIpc = (services: IpcServices, ipc: IpcMainType = ipcMain): 
 
   registry.handle('yc:vault-stats', async () => {
     if (!services.documentVault) return { ok: false, error: 'vault-not-ready' };
-    return { ok: true, stats: services.documentVault.getStats() };
+    /*
+     * `encryptionAvailable` rides along with the stats so the vault window can
+     * state the real encryption status instead of asserting one. It used to
+     * print a green "OS keychain" pill unconditionally, on the reasoning that
+     * safeStorage is usually present on macOS - but the Linux AppImage and deb
+     * builds depend on a keyring, and when it is missing the vault refuses every
+     * write (ENCRYPTION_UNAVAILABLE) while the badge still read green.
+     */
+    return {
+      ok: true,
+      stats: services.documentVault.getStats(),
+      encryptionAvailable: services.documentVault.encryptionAvailable,
+    };
   });
 
   registry.handle('yc:vault-save-buffer', async (_event, args) => {

--- a/apps/desktop/src/pages/vault.css
+++ b/apps/desktop/src/pages/vault.css
@@ -62,6 +62,21 @@ body {
   border: 1px solid var(--status-completed-border);
 }
 
+/* The badge defaults to the green "completed" treatment, which is only correct
+   when encryption really is available. These two carry the other two states so
+   an unencrypted vault cannot read as a secure one. */
+.badge-warn {
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  border-color: var(--danger);
+}
+
+.badge-unknown {
+  background: var(--status-requested-bg);
+  color: var(--status-requested-text);
+  border-color: var(--status-requested-border);
+}
+
 .header-meta {
   margin-left: auto;
   white-space: nowrap;

--- a/apps/desktop/src/pages/vault.html
+++ b/apps/desktop/src/pages/vault.html
@@ -15,7 +15,7 @@
       <div class="header">
         <div class="header-top">
           <h1>All documents</h1>
-          <span class="badge" id="encBadge">checking…</span>
+          <span class="badge badge-unknown" id="encBadge">checking…</span>
           <span class="header-meta">
             <span id="docCount">0 documents</span>
             <span class="dot-sep">·</span>

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -66,7 +66,7 @@
      * completed treatment, so leaving it alone would render a GREEN "checking…"
      * on every load - and keep it green indefinitely if the request fails.
      */
-    badgeEncryption(undefined);
+    badgeEncryption();
     yc.vaultStats().then(function (res) {
       if (!res?.ok || !res.stats) return;
       const stats = res.stats;

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -66,6 +66,7 @@
       const stats = res.stats;
       docCountEl.textContent = stats.count + ' document' + (stats.count === 1 ? '' : 's');
       sizeInfoEl.textContent = formatBytes(stats.totalSizeBytes || 0);
+      badgeEncryption(res.encryptionAvailable);
     });
     yc.getAppVersion().then(function () {
       // Get encryption status from vault-stats (we don't have a separate info channel)
@@ -74,12 +75,35 @@
     // Best-effort: check if vault-save works to infer readiness
   };
 
-  // We don't have vault-get-info, so check encryption from context:
-  // On macOS safeStorage is almost always available. Show status inline.
-  const badgeEncryption = function () {
-    // Can't detect encryption from renderer; just show status
-    encBadge.textContent = 'OS keychain';
-    encBadge.className = 'badge secure';
+  /*
+   * The encryption badge states what the main process reports, and nothing when
+   * it has not reported yet.
+   *
+   * It used to read a hardcoded green "OS keychain" on the reasoning that
+   * safeStorage is almost always available on macOS. That is a probability, not
+   * a fact: the Linux AppImage and deb builds depend on a keyring, and without
+   * one the vault refuses every write (ENCRYPTION_UNAVAILABLE) while the badge
+   * still claimed the documents were encrypted. The same app already prints the
+   * truth in Data > Document Vault Info, so the two surfaces disagreed.
+   */
+  const badgeEncryption = function (encryptionAvailable) {
+    if (encryptionAvailable === true) {
+      encBadge.textContent = 'OS keychain';
+      encBadge.className = 'badge';
+      encBadge.removeAttribute('title');
+      return;
+    }
+    if (encryptionAvailable === false) {
+      encBadge.textContent = 'Not encrypted';
+      encBadge.className = 'badge badge-warn';
+      encBadge.title =
+        'The OS keychain is unavailable, so the vault cannot encrypt and will refuse to store documents.';
+      return;
+    }
+    // Unknown: say so rather than guessing either way.
+    encBadge.textContent = 'checking\u2026';
+    encBadge.className = 'badge badge-unknown';
+    encBadge.removeAttribute('title');
   };
 
   const filterDocs = function () {
@@ -194,7 +218,6 @@
       docs = (res.documents || []).sort(function (a, b) {
         return b.createdAt - a.createdAt;
       });
-      badgeEncryption();
       loadStats();
       filterDocs();
     });
@@ -365,6 +388,6 @@
   });
 
   // ── Init ──
-  badgeEncryption();
+
   scheduleLoad();
 })();

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -61,6 +61,12 @@
   };
 
   const loadStats = function () {
+    /*
+     * Reset to the neutral state before asking. `.badge` on its own is the green
+     * completed treatment, so leaving it alone would render a GREEN "checking…"
+     * on every load - and keep it green indefinitely if the request fails.
+     */
+    badgeEncryption(undefined);
     yc.vaultStats().then(function (res) {
       if (!res?.ok || !res.stats) return;
       const stats = res.stats;
@@ -94,10 +100,19 @@
       return;
     }
     if (encryptionAvailable === false) {
-      encBadge.textContent = 'Not encrypted';
+      /*
+       * "Encryption unavailable", not "Not encrypted". This describes the
+       * keychain's CURRENT capability, which is the only thing the flag knows.
+       * Documents stored while the keychain was available stay encrypted on
+       * disk - losing access blocks new writes, it does not decrypt anything -
+       * so calling the vault "not encrypted" would misstate the files already
+       * in it, which is the same class of false claim this badge is here to
+       * stop making.
+       */
+      encBadge.textContent = 'Encryption unavailable';
       encBadge.className = 'badge badge-warn';
       encBadge.title =
-        'The OS keychain is unavailable, so the vault cannot encrypt and will refuse to store documents.';
+        'The OS keychain is unavailable, so the vault cannot store new documents. Documents saved earlier remain encrypted on disk.';
       return;
     }
     // Unknown: say so rather than guessing either way.

--- a/apps/desktop/tests/ipc-handlers.test.ts
+++ b/apps/desktop/tests/ipc-handlers.test.ts
@@ -376,6 +376,11 @@ describe('ipc-handlers — happy paths', () => {
     expect(await call('yc:vault-list')).toMatchObject({ ok: true });
     expect(await call('yc:vault-get', 'd')).toMatchObject({ ok: true });
     expect(await call('yc:vault-stats')).toMatchObject({ ok: true });
+    // The vault window's encryption badge is driven by this field. Without it
+    // the badge fell back to a hardcoded green "OS keychain", which was wrong
+    // on any machine where safeStorage is unavailable - and there the vault
+    // refuses every write, so the claim was exactly backwards.
+    expect(await call('yc:vault-stats')).toHaveProperty('encryptionAvailable');
     expect(
       await call('yc:vault-save-buffer', 'f.txt', Buffer.from('x').toString('base64'))
     ).toMatchObject({ ok: true });
@@ -461,9 +466,10 @@ describe('ipc-handlers — happy paths', () => {
       // The payload is renderer-controlled, so an exact string comparison let
       // "vet-1" witness for "vet-1 ".
       for (const witnessId of ['vet-1 ', ' vet-1', 'VET-1', ' Vet-1 ']) {
-        expect(
-          await call('yc:cs-record', { ...waste, witnessId, witnessName: 'Dr. X' })
-        ).toEqual({ ok: false, error: 'witness-must-differ' });
+        expect(await call('yc:cs-record', { ...waste, witnessId, witnessName: 'Dr. X' })).toEqual({
+          ok: false,
+          error: 'witness-must-differ',
+        });
       }
     });
 
@@ -504,7 +510,11 @@ describe('ipc-handlers — happy paths', () => {
         ...waste,
         witnessId: 'nurse-1',
         witnessName: 'Nurse Jane',
-      })) as { ok: boolean; witnessPinVerified: boolean; transaction: { witnessPinVerified: boolean } };
+      })) as {
+        ok: boolean;
+        witnessPinVerified: boolean;
+        transaction: { witnessPinVerified: boolean };
+      };
 
       expect(result.ok).toBe(true);
       expect(result.witnessPinVerified).toBe(false);
@@ -609,7 +619,9 @@ describe('ipc-handlers — happy paths', () => {
     expect(services.logger.warn).toHaveBeenCalledWith('audit_append_rejected', expect.anything());
 
     // Ordinary entries are unaffected.
-    expect(await call('yc:audit-append', { action: 'patient:update', resourceType: 'patient' })).toMatchObject({ ok: true });
+    expect(
+      await call('yc:audit-append', { action: 'patient:update', resourceType: 'patient' })
+    ).toMatchObject({ ok: true });
   });
 
   test('a verified witness is recorded under the enrolled account name', async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for — found sweeping desktop and mobile for the defect class behind #2606, #2607 and #2609.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Document Vault window renders a **green "OS KEYCHAIN" pill** beside the document count, asserting that stored patient documents are encrypted by the operating system keychain.

It is a hardcoded string, and its own comment concedes the point:

```js
// We don't have vault-get-info, so check encryption from context:
// On macOS safeStorage is almost always available. Show status inline.
const badgeEncryption = function () {
  // Can't detect encryption from renderer; just show status
  encBadge.textContent = 'OS keychain';
  encBadge.className = 'badge secure';
};
```

It runs unconditionally at page init and again after every list load, so it overwrites the honest `checking…` placeholder in the markup and never varies. The appended `secure` class matches **no CSS rule**, so the green `--status-completed-*` treatment is unconditional too.

**The claim is backwards exactly when it matters.** The Linux AppImage and deb builds depend on a keyring. When `safeStorage.isEncryptionAvailable()` is false, `saveDocument` and `saveDocumentBuffer` both return `ENCRYPTION_UNAVAILABLE` — the vault refuses *every write* — and the badge still reads green "OS KEYCHAIN".

"Almost always available on macOS" is a probability, not a fact, and the codebase treats the unavailable branch as a first-class path it explicitly handles.

### The same app already tells the truth elsewhere

`ui/status-dialogs.ts` prints, in **Data → Document Vault Info**:

```
Encryption: OS keychain (safeStorage) | unavailable (plaintext fallback)
```

So on a machine without a keychain the two surfaces contradict each other — the same shape as the developer dashboard's `4,218` contradicting Billing's `0` in #2606.

## What is the new behavior?

The real value already existed and was simply never wired to the renderer. `document-vault.ts` computes `encryptionAvailable` and exports it; `boot/setup.ts` derives it from safeStorage. What was missing was any IPC path — the nine vault channels include no `vault-info`, and `yc:vault-stats` returned only `{count, totalSizeBytes}`.

- `yc:vault-stats` now returns `encryptionAvailable` alongside the stats.
- The badge renders three honest states: **OS keychain** when true, **Not encrypted** in a danger treatment with an explanatory `title` when false, and **checking…** until the answer arrives.
- The two unconditional `badgeEncryption()` calls are gone, so the markup's placeholder stands rather than being overwritten with a guess.

## Validation performed

- **Desktop suite: 70 suites, 1052 tests, all pass.** `tsc --noEmit` clean, `lint` exit 0, `node --check` on `vault.js` clean.
- Mutation-checked: reverting the IPC wiring fails the extended `yc:vault-stats` test.
- **Contrast computed from the token values in both themes**, since the danger and neutral treatments are new on this surface:

| state | light | dark |
| --- | --- | --- |
| OS keychain | 6.81 | 5.74 |
| Not encrypted | 4.69 | 5.47 |
| checking… | 6.29 | 5.54 |

All above the 4.5 AA floor. Worth noting I got this wrong once mid-review — an off-by-one in how I sliced the theme blocks made "Not encrypted" look like a 2.33 failure. Re-deriving it with indexed extraction showed `--danger-text` *is* overridden for dark (`#f2938a`). I checked rather than "fixing" a problem that did not exist.

## Related

Same defect class as #2606, #2607, #2609 and #2616. Eight further findings from the same desktop/mobile sweep are being written up separately — the sharpest is a mobile invoice screen showing a payment deadline computed as `createdAt + 24h` from a client-side literal.
