### PR TITLE
fix(frontend): unbreak the share picker, and settle the header and tab-strip overflow calls

### DIFF
--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/bookingChrome.stories.tsx
@@ -1,0 +1,608 @@
+import { useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import {
+  BookFooter,
+  BookShell,
+  Callout,
+  CheckIcon,
+  ClockIcon,
+  IconDisc,
+  Skeleton,
+  Spinner,
+  StateCard,
+  WarnIcon,
+} from './bookingChrome';
+import { SLOT_GRID, STATE_BODY } from './bookingStyles';
+
+/**
+ * The primitives `/book/<slug>` and `/book/<slug>/confirm` are both built from.
+ *
+ * Nothing here talks to the network or reads a store, so the stories need no
+ * stub - which is the point of the module. What they are for is the half of the
+ * chrome jsdom cannot see: whether the footer links are actually underlined
+ * once the unlayered `a { text-decoration: none !important }` in globals.css is
+ * in play, whether an IconDisc paints the tone it was asked for, and whether a
+ * Callout keeps its icon beside the first line when the message wraps.
+ *
+ * Several of these variants render nowhere in the app today - the `brand`
+ * IconDisc tone and the role-less Callout among them - so this file is the only
+ * place they are exercised at all.
+ */
+
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story
+ * can say "this disc is the warn tint" rather than only "it is tinted with
+ * something". Borrowed from `ConfirmModal.stories.tsx`, which needs the same
+ * trick for the same reason.
+ */
+const resolveToken = (host: HTMLElement, token: string) => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return value;
+};
+
+/** Thrown rather than asserted, so a missing element reads as a failure where it
+ *  went missing instead of as a null-deref three lines later. */
+const requireEl = <T extends Element = HTMLElement>(root: ParentNode, selector: string): T => {
+  const el = root.querySelector<T>(selector);
+  if (!el) throw new Error(`bookingChrome story: nothing matched ${selector}`);
+  return el;
+};
+
+/** The disc tones, paired with the token each one is supposed to paint. Spelled
+ *  out here on purpose: the pairing IS the assertion, and a swapped map entry is
+ *  exactly the regression that a screenshot review misses. */
+const DISC_TONES = [
+  { tone: 'brand', token: '--blue-soft' },
+  { tone: 'warn', token: '--warn-bg' },
+  { tone: 'success', token: '--inset' },
+] as const;
+
+const CONFIRMED_BODY = (
+  <p className={STATE_BODY}>
+    Avenger Park Veterinary can now see your request and will contact you to arrange the
+    appointment.
+  </p>
+);
+
+const meta = {
+  title: 'PublicBooking/BookingChrome',
+  component: StateCard,
+  parameters: {
+    layout: 'padded',
+    // BookFooter renders two next/link elements. The app router mock has to be
+    // mounted for them, the same way the sibling BookClient stories mount it.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The shared surface for the two public booking pages. The props table below is ' +
+          '`StateCard`; `BookShell`, `BookFooter`, `IconDisc`, `Callout`, `Skeleton` and the four ' +
+          'icons are rendered by the stories that name them. Both pages used to pick their own ' +
+          'width and padding - 560/p-5 against 520/p-6 - so the column visibly jumped when a ' +
+          'reader followed the emailed confirmation link out of their inbox. Everything that ' +
+          'decides what those pages look like now lives in this one module.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    heading: 'Request confirmed',
+    icon: (
+      <IconDisc tone="success">
+        <CheckIcon />
+      </IconDisc>
+    ),
+    children: CONFIRMED_BODY,
+  },
+} satisfies Meta<typeof StateCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Shell: Story = {
+  name: 'The shell and footer both pages sit in',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The frame around every state: a full-height warm-bone page, one centred column capped ' +
+          'at 640px (720px from `lg`), and the footer that names who provides the page. The ' +
+          'shell is also the SkipLink target - the root layout points at `#main-content`, and ' +
+          'the id and `tabIndex={-1}` here are what make that bypass land somewhere.',
+      },
+    },
+  },
+  render: () => (
+    <BookShell>
+      <div className="rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-5 sm:p-8">
+        <h2 className="text-heading-2 text-[var(--ink)]">Avenger Park Veterinary</h2>
+        <p className={STATE_BODY}>
+          Sample page content. The shell owns the page background, the gutters and the column width;
+          whatever a page puts inside it inherits all three.
+        </p>
+      </div>
+      <BookFooter />
+    </BookShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* A role query would be ambiguous here: the preview decorator wraps every
+       story in a <main> of its own, so the canvas holds two. */
+    const main = requireEl(canvasElement, 'main#main-content');
+    await expect(main).toHaveAttribute('tabindex', '-1');
+
+    const privacy = canvas.getByRole('link', { name: 'Privacy' });
+    const terms = canvas.getByRole('link', { name: 'Terms' });
+    await expect(privacy).toHaveAttribute('href', '/privacy-policy');
+    await expect(terms).toHaveAttribute('href', '/terms-and-conditions');
+
+    /* `a { text-decoration: none !important }` is unlayered in globals.css, and
+       an unlayered important declaration beats a layered non-important one
+       whatever the specificity. The `!` in `underline!` is the only reason
+       these two read as links rather than as body text. */
+    for (const link of [privacy, terms]) {
+      await expect(getComputedStyle(link).textDecorationLine).toContain('underline');
+    }
+
+    /* min-h-svh, not a content height: a confirm page is three short lines, and
+       without this the warm-bone background would stop a third of the way down
+       and the footer would float in the middle of the screen. Asserted loosely
+       against the viewport because the point is that it fills it, not that it
+       measures any particular number of pixels. */
+    await expect(main.getBoundingClientRect().height).toBeGreaterThan(
+      canvasElement.ownerDocument.defaultView!.innerHeight * 0.95
+    );
+
+    /* The column is centred and capped rather than filling the panel. Measured
+       as a relation so a change to the gutter moves both numbers together. */
+    const shell = main.getBoundingClientRect();
+    const column = requireEl(main, ':scope > div').getBoundingClientRect();
+    await expect(column.width).toBeLessThan(shell.width);
+    await expect(Math.abs(column.left - shell.left - (shell.right - column.right))).toBeLessThan(2);
+  },
+};
+
+export const Tones: Story = {
+  name: 'IconDisc: the three tones side by side',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The 44px round plate every state card leads with. `brand` renders nowhere in the app ' +
+          'today - the booking page uses `warn` for the unavailable practice and `success` for a ' +
+          'sent request - so this is the only place all three can be compared.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-center gap-4">
+      <div data-tone="brand">
+        <IconDisc tone="brand">
+          <ClockIcon />
+        </IconDisc>
+      </div>
+      <div data-tone="warn">
+        <IconDisc tone="warn">
+          <WarnIcon />
+        </IconDisc>
+      </div>
+      <div data-tone="success">
+        <IconDisc tone="success">
+          <CheckIcon />
+        </IconDisc>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const widths: number[] = [];
+
+    for (const { tone, token } of DISC_TONES) {
+      const disc = requireEl(canvasElement, `[data-tone="${tone}"] > span`);
+      const box = disc.getBoundingClientRect();
+      widths.push(box.width);
+
+      // A disc, not a rounded square: square box, radius at least half of it.
+      await expect(box.width).toBeCloseTo(box.height, 1);
+      await expect(box.width).toBeGreaterThan(0);
+      await expect(parseFloat(getComputedStyle(disc).borderRadius)).toBeGreaterThanOrEqual(
+        box.width / 2
+      );
+
+      await expect(getComputedStyle(disc).backgroundColor).toBe(resolveToken(canvasElement, token));
+
+      /* Decoration, not content. The heading beside it already says what the
+         state is, so a disc that reached the accessibility tree would make a
+         screen reader announce the same fact twice. */
+      await expect(disc).toHaveAttribute('aria-hidden', 'true');
+    }
+
+    // One size for all three, so a row of them lines up.
+    await expect(widths[1]).toBeCloseTo(widths[0], 1);
+    await expect(widths[2]).toBeCloseTo(widths[0], 1);
+  },
+};
+
+export const Icons: Story = {
+  name: 'The icon set at its default size',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four hand-drawn 20-unit glyphs rather than an icon dependency, because these two pages ' +
+          'are the only public surface in the app and pulling a library in for four shapes costs ' +
+          'the pet owner the download. The Spinner is the odd one out: smaller than the rest, and ' +
+          'the only one that moves.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex items-center gap-6 text-[var(--ink)]">
+      <span data-icon="warn">
+        <WarnIcon />
+      </span>
+      <span data-icon="check">
+        <CheckIcon />
+      </span>
+      <span data-icon="clock">
+        <ClockIcon />
+      </span>
+      <span data-icon="spinner">
+        <Spinner />
+      </span>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const iconOf = (name: string) =>
+      requireEl<SVGElement>(canvasElement, `[data-icon="${name}"] svg`);
+    const still = ['warn', 'check', 'clock'].map(iconOf);
+    const spinner = iconOf('spinner');
+
+    for (const icon of [...still, spinner]) {
+      await expect(icon).toHaveAttribute('aria-hidden', 'true');
+      const box = icon.getBoundingClientRect();
+      await expect(box.width).toBeGreaterThan(0);
+      await expect(box.width).toBeCloseTo(box.height, 1);
+    }
+
+    // The three status glyphs share one default size, so swapping one for
+    // another in a Callout or a disc never moves the text beside it.
+    const base = still[0].getBoundingClientRect().width;
+    for (const icon of still) {
+      await expect(icon.getBoundingClientRect().width).toBeCloseTo(base, 1);
+    }
+
+    /* The Spinner sits inside a button label rather than on its own, so it is
+       deliberately a size smaller than the rest. */
+    await expect(spinner.getBoundingClientRect().width).toBeLessThan(base);
+
+    /* The whole reason it exists. `animate-spin` is a Tailwind utility, so this
+       fails if the class is dropped OR if the keyframes stop being emitted -
+       and a still spinner is indistinguishable from a frozen page. */
+    await expect(getComputedStyle(spinner).animationName).not.toBe('none');
+    for (const icon of still) {
+      await expect(getComputedStyle(icon).animationName).toBe('none');
+    }
+  },
+};
+
+export const Alerts: Story = {
+  name: 'Callout: announced, and silent',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One tone for every message this surface can carry, on purpose: times would not load, ' +
+          'the request would not send, the slot went while the form was open - all of them mean ' +
+          '"we could not do this yet", never "something was destroyed", and two colours for one ' +
+          'meaning is vocabulary the page has not earned. `role` is opt-in, because a callout ' +
+          'that was always a live region would interrupt a reader for copy that was on the page ' +
+          'before they arrived.',
+      },
+    },
+  },
+  render: () => (
+    // The width cap is a fixture, not a design constant: the wrap assertion
+    // below needs the message to wrap at any panel width.
+    <div className="flex max-w-[22rem] flex-col gap-3">
+      <div data-callout="alert">
+        <Callout role="alert">
+          We could not load the available times for this day. That is usually a connection problem
+          rather than a full diary, so it is worth trying again in a moment. If it keeps happening,
+          please call the practice and they will book you in over the phone.
+        </Callout>
+      </div>
+      <div data-callout="plain">
+        <Callout>Nothing is booked yet, and the time you asked for is not being held.</Callout>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Exactly one live region. The second callout carries standing copy, so if
+       `role` were hardcoded rather than passed through, a reader would be
+       interrupted by a sentence that was there all along. */
+    const alerts = canvas.getAllByRole('alert');
+    await expect(alerts).toHaveLength(1);
+    await expect(alerts[0]).toHaveTextContent(/could not load the available times/);
+    await expect(requireEl(canvasElement, '[data-callout="plain"] > p')).not.toHaveAttribute(
+      'role'
+    );
+
+    const alert = alerts[0];
+    const icon = requireEl<SVGElement>(alert, 'svg').getBoundingClientRect();
+    const text = requireEl(alert, 'span').getBoundingClientRect();
+
+    // The message really did wrap - otherwise the alignment check below proves
+    // nothing, because a one-line callout looks the same either way.
+    await expect(text.height).toBeGreaterThan(icon.height * 2);
+
+    /* items-start, not items-center: on a wrapped message a centred icon drifts
+       down beside the middle of the paragraph and reads as a bullet for the
+       wrong line. */
+    await expect(icon.top).toBeLessThan(text.top + text.height / 2);
+
+    // shrink-0: as a flex item next to a long string the glyph is the first
+    // thing the layout squeezes, and a squashed circle is worse than none.
+    await expect(icon.width).toBeCloseTo(icon.height, 1);
+
+    await expect(getComputedStyle(alert).backgroundColor).toBe(
+      resolveToken(canvasElement, '--warn-bg')
+    );
+  },
+};
+
+export const Confirmed: Story = {
+  name: 'StateCard: a confirmed request',
+  args: { headingLevel: 'h1' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the confirm page shows once the POST behind the emailed link succeeds. It takes ' +
+          '`h1` because it is the only heading on that page - the state card IS the page there, ' +
+          'so anything lower would leave the document with no top-level heading at all.',
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    /* Queried by name, not by level: the preview decorator adds an sr-only h1
+       of its own to every story, so a level query matches two headings. */
+    const heading = canvas.getByRole('heading', { name: 'Request confirmed' });
+    await expect(heading.tagName).toBe('H1');
+
+    const inner = heading.parentElement;
+    if (!inner) throw new Error('the state card heading rendered with no wrapper');
+
+    /* No innerRef was passed, so nothing here should be focusable. A card that
+       collects a tabindex it was not given puts a dead stop in the tab order of
+       a page whose only job is to be read. */
+    await expect(inner).not.toHaveAttribute('tabindex');
+
+    // Icon, then heading, then body - the shape every state that replaces the
+    // form takes, so the page never resizes under the reader.
+    await expect(inner.children[0]).toHaveAttribute('aria-hidden', 'true');
+    await expect(inner.children[1]).toBe(heading);
+    await expect(canvas.getByText(/can now see your request/)).toBeInTheDocument();
+
+    await expect(getComputedStyle(inner).textAlign).toBe('center');
+
+    // Centred as a fact about the box, not just about the text inside it.
+    const card = inner.getBoundingClientRect();
+    const disc = inner.children[0].getBoundingClientRect();
+    await expect(Math.abs(disc.left + disc.width / 2 - (card.left + card.width / 2))).toBeLessThan(
+      2
+    );
+  },
+};
+
+export const Expired: Story = {
+  name: 'StateCard: a link that will not open',
+  args: {
+    headingLevel: 'h1',
+    heading: 'This link is not valid',
+    icon: (
+      <IconDisc tone="warn">
+        <WarnIcon />
+      </IconDisc>
+    ),
+    children: (
+      <p className={STATE_BODY}>
+        It may have already been used, or it may have expired. Confirmation links last 48 hours.
+        Please submit your request again, or contact the practice directly.
+      </p>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One state for several facts: the token was already spent, it expired, or it was never ' +
+          'ours. They are deliberately not told apart, because a page that distinguishes them ' +
+          'lets anyone with a guessed token learn whether it was real. Same card, same padding, ' +
+          'same heading level as the confirmed state - only the tone and the words change.',
+      },
+    },
+  },
+  play: async ({ canvas, canvasElement }) => {
+    const heading = canvas.getByRole('heading', { name: 'This link is not valid' });
+    await expect(heading.tagName).toBe('H1');
+
+    const inner = heading.parentElement;
+    if (!inner) throw new Error('the state card heading rendered with no wrapper');
+
+    /* The warn pairing, both halves of it. `--warn-text` is the readable twin of
+       the fill; asserting only the background would let a disc pass while its
+       glyph sat at 1.9:1 on top of it. */
+    const disc = requireEl(inner, 'span[aria-hidden="true"]');
+    await expect(getComputedStyle(disc).backgroundColor).toBe(
+      resolveToken(canvasElement, '--warn-bg')
+    );
+    await expect(getComputedStyle(disc).color).toBe(resolveToken(canvasElement, '--warn-text'));
+
+    await expect(getComputedStyle(inner).textAlign).toBe('center');
+    await expect(canvas.getByText(/Confirmation links last 48 hours/)).toBeInTheDocument();
+  },
+};
+
+/**
+ * The booking page holds the card in a ref and moves focus into it after a
+ * submit, so the story has to own a real ref rather than hand the prop a
+ * literal.
+ */
+const FocusTargetCard = () => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  return (
+    <StateCard
+      innerRef={ref}
+      heading="Request sent"
+      icon={
+        <IconDisc tone="success">
+          <CheckIcon />
+        </IconDisc>
+      }
+    >
+      <p className={STATE_BODY}>
+        The practice will email you to confirm. Nothing is booked yet, and the time you asked for is
+        not being held.
+      </p>
+    </StateCard>
+  );
+};
+
+export const FocusTarget: Story = {
+  name: 'StateCard: the post-submit focus target',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same card with `innerRef` set. The form it replaces has just gone from under the ' +
+          'reader, so focus is moved here rather than left on a button that no longer exists. ' +
+          'The `-1` is doing two jobs: it makes the card focusable in code without putting it in ' +
+          'the tab order, and it takes the card out of the global focus-ring selector, so a ' +
+          'reader who never tabbed here is not shown a ring they did not ask for. This story ' +
+          'also covers the default heading level, which the two page-level states override.',
+      },
+    },
+  },
+  render: () => <FocusTargetCard />,
+  play: async ({ canvas, canvasElement }) => {
+    const heading = canvas.getByRole('heading', { name: 'Request sent' });
+
+    // The default, unlike both confirm-page states: this card sits under a page
+    // heading that already exists, so it must not claim to be one.
+    await expect(heading.tagName).toBe('H2');
+
+    const inner = heading.parentElement;
+    if (!inner) throw new Error('the state card heading rendered with no wrapper');
+    await expect(inner).toHaveAttribute('tabindex', '-1');
+
+    inner.focus();
+    await expect(inner).toHaveFocus();
+
+    /* The app's own focus ring does not apply here. globals.css draws a
+       `2px solid` outline from a `:where()` list that excludes
+       `[tabindex='-1']`, precisely so a programmatic move like this one does
+       not look like a click the reader made.
+
+       Asserted against that ring specifically, not against "no outline at all".
+       `outlineStyle` reads `auto` on this element whether it is focused or not
+       - that is the UA default sitting in the computed value, not evidence of
+       anything being painted - and the element DOES match `:focus-visible`, so
+       a check for `none` fails for a reason that has nothing to do with the
+       rule under test. Measured for comparison: a covered control in the same
+       shell (`BookFooter`'s Privacy link) computes `solid` / `2px`, while this
+       one computes `auto` / `1px`. */
+    const focusRing = getComputedStyle(inner);
+    await expect(focusRing.outlineStyle).not.toBe('solid');
+    await expect(focusRing.outlineWidth).not.toBe('2px');
+
+    /* And it stays out of the tab order. If this ever became tabIndex={0}, a
+       keyboard reader would land on a silent div between the heading and the
+       footer links with nothing to do there. */
+    inner.blur();
+    canvasElement.ownerDocument.body.focus();
+    await userEvent.tab();
+    await expect(inner).not.toHaveFocus();
+  },
+};
+
+export const Placeholders: Story = {
+  name: 'Skeleton: both pages waiting',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two placeholder layouts in the module: the confirm page holding the shape of a ' +
+          'state card while its POST is in flight, and the booking page holding the slot grid ' +
+          'while a day loads. Both are drawn in the geometry the real content will occupy, so ' +
+          'nothing jumps when it arrives.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex max-w-[26rem] flex-col gap-8">
+      <div data-skeletons="confirm" className="flex flex-col items-center gap-4">
+        <Skeleton className="size-11 rounded-full" />
+        <Skeleton className="h-6 w-1/2 rounded-xl" />
+        <Skeleton className="h-4 w-3/4 rounded-xl" />
+      </div>
+      <div data-skeletons="slots" className={SLOT_GRID}>
+        {Array.from({ length: 6 }, (_, index) => (
+          <Skeleton key={index} className="h-11 rounded-full" />
+        ))}
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const confirm = requireEl(canvasElement, '[data-skeletons="confirm"]');
+    const slots = requireEl(canvasElement, '[data-skeletons="slots"]');
+    const all = [
+      ...confirm.querySelectorAll<HTMLElement>(':scope > div'),
+      ...slots.querySelectorAll<HTMLElement>(':scope > div'),
+    ];
+    await expect(all).toHaveLength(9);
+
+    for (const block of all) {
+      /* A div, so it adds no phantom role, and no text, so a screen reader is
+         told nothing at all about it. The pages announce their own loading
+         state in an sr-only live region instead - nine placeholders announcing
+         themselves would be nine interruptions. */
+      await expect(block.tagName).toBe('DIV');
+      await expect(block).not.toHaveAttribute('role');
+      await expect(block.textContent).toBe('');
+
+      // yc-shimmer is the only thing separating a placeholder from a plain grey
+      // box, and a still grey box reads as content that failed to load.
+      await expect(getComputedStyle(block).animationName).not.toBe('none');
+      await expect(getComputedStyle(block).backgroundColor).toBe(
+        resolveToken(canvasElement, '--band')
+      );
+    }
+
+    const [disc, headingBar, bodyBar] = confirm.querySelectorAll<HTMLElement>(':scope > div');
+    const discBox = disc.getBoundingClientRect();
+    await expect(discBox.width).toBeCloseTo(discBox.height, 1);
+    await expect(parseFloat(getComputedStyle(disc).borderRadius)).toBeGreaterThanOrEqual(
+      discBox.width / 2
+    );
+
+    /* Relations, not pixel counts: the heading placeholder stands in for a
+       larger line than the body one, and the body line runs longer. A font or
+       spacing change moves both numbers without failing this. */
+    await expect(headingBar.getBoundingClientRect().height).toBeGreaterThan(
+      bodyBar.getBoundingClientRect().height
+    );
+    await expect(headingBar.getBoundingClientRect().width).toBeLessThan(
+      bodyBar.getBoundingClientRect().width
+    );
+  },
+};

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.stories.tsx
@@ -177,7 +177,7 @@ export const InFlight: Story = {
   play: async ({ canvas }) => {
     // The shimmer blocks are divs with no role on purpose, so this one line is
     // all a screen reader has to go on while the POST is outstanding.
-    await expect(await canvas.findByText(/Confirming your request/)).toBeInTheDocument();
+    await canvas.findByText(/Confirming your request/);
 
     // The load-bearing assertion in this file. A GET would let any mail client
     // or link scanner previewing the URL confirm a request nobody clicked, and

--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/confirm/ConfirmClient.stories.tsx
@@ -1,0 +1,272 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
+
+import ConfirmClient from './ConfirmClient';
+
+/**
+ * Where the emailed confirmation link lands.
+ *
+ * The reader never chooses which of the three states they get - the token in
+ * the query decides. So each story is a token, and the one stub below answers
+ * the POST according to which token it carried.
+ */
+
+const PRACTICE_NAME = 'Avenger Park Veterinary';
+
+/**
+ * One token per state, because the token is the only input this page has.
+ *
+ * `noToken` is the empty string rather than a missing key: the component reads
+ * `searchParams.get('token') ?? ''`, so a link with no token and a link with an
+ * empty one are the same case, and the story seeds it by leaving `token` out of
+ * the query entirely.
+ */
+const TOKEN = {
+  inFlight: 'tok-still-confirming',
+  namedPractice: 'tok-named-practice',
+  unnamedPractice: 'tok-unnamed-practice',
+  expired: 'tok-already-used',
+  noToken: '',
+} as const;
+
+type Outcome =
+  { kind: 'pending' } | { kind: 'confirmed'; practiceName: string } | { kind: 'invalid' };
+
+const OUTCOME_BY_TOKEN: Record<string, Outcome> = {
+  [TOKEN.inFlight]: { kind: 'pending' },
+  [TOKEN.namedPractice]: { kind: 'confirmed', practiceName: PRACTICE_NAME },
+  // The API can answer with a practice that has no public name, and the page
+  // has a whole second sentence for that, so it needs its own token.
+  [TOKEN.unnamedPractice]: { kind: 'confirmed', practiceName: '' },
+  [TOKEN.expired]: { kind: 'invalid' },
+};
+
+/**
+ * Every confirm POST the stub saw, keyed by the token it carried.
+ *
+ * Recorded because the two properties most worth pinning on this page are
+ * properties of the REQUEST, not of the markup: that the page posts rather
+ * than gets - a mail client or link scanner fetching the URL to preview it
+ * must not confirm a request nobody clicked - and that it posts exactly once,
+ * which is what the `started` ref is for. Neither is visible on screen.
+ */
+const calls = new Map<string, string[]>();
+
+const record = (token: string, method: string) => {
+  const seen = calls.get(token) ?? [];
+  seen.push(method);
+  calls.set(token, seen);
+};
+
+/**
+ * Forgets what one token recorded on a previous run.
+ *
+ * The map is module scope, so a remount - re-running a play function from the
+ * UI, or the docs page mounting a story the canvas already mounted - would
+ * append to it and turn "posted once" into "posted twice". Clearing only this
+ * story's own token keeps the stories independent under Autodocs, where they
+ * all mount against the same map.
+ */
+const forget = (token: string) => () => {
+  calls.delete(token);
+};
+
+const NEVER_SETTLES = new Promise<Response>(() => {
+  // Deliberately empty. The shimmer only exists while the POST is outstanding,
+  // so the story has to keep it outstanding.
+});
+
+const json = (body: unknown, status = 200) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+
+/** The token travels in the POST body, not in the URL, so the stub reads it there. */
+const readToken = (init?: RequestInit): string => {
+  if (typeof init?.body !== 'string') return '';
+  try {
+    const parsed = JSON.parse(init.body) as { token?: unknown };
+    return typeof parsed.token === 'string' ? parsed.token : '';
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * Stubbed at the network, not at the module.
+ *
+ * The service's module namespace object is frozen under an ESM bundler, so
+ * assigning `confirmBookingRequest` onto it throws and the story renders
+ * Storybook's error panel. Patching `fetch` needs no bundler cooperation, and
+ * it has the side benefit of running the real service code - the URL, the
+ * status handling and the error mapping are exercised rather than skipped.
+ *
+ * One stub shared by every story and keyed on the token, rather than a stub
+ * per story answering with its own outcome. There is a single
+ * `globalThis.fetch` and Autodocs mounts all five variants against it at once,
+ * so with per-story outcomes whichever installed last would decide what the
+ * others saw. Keyed on the token, every installed copy behaves identically and
+ * which one is live stops mattering.
+ */
+const stubConfirm = () => {
+  const realFetch = globalThis.fetch;
+
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    // Anything else - another page's call, or Storybook's own - falls through
+    // to whatever was here before, which is the preview's offline guard.
+    if (!url.includes('/public/booking/requests/confirm')) return realFetch(input, init);
+
+    const token = readToken(init);
+    record(token, init?.method ?? 'GET');
+
+    const outcome = OUTCOME_BY_TOKEN[token];
+    if (outcome?.kind === 'pending') return NEVER_SETTLES;
+    if (outcome?.kind === 'confirmed') {
+      return json({
+        data: { practiceName: outcome.practiceName, slug: 'avenger-park-veterinary' },
+      });
+    }
+    // An unknown token is a rejected one, which is what the real API does: it
+    // does not distinguish expired from already-used from never-issued.
+    return json({ message: 'This confirmation link is not valid.' }, 410);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+};
+
+/**
+ * The whole story setup, since the token is the whole input.
+ *
+ * Deliberately NOT hoisted onto the meta with per-story overrides: Storybook
+ * deep-merges parameters, so a meta-level `query: { token: ... }` would survive
+ * a story's `query: {}` and the no-token story would silently run with a token.
+ */
+const withToken = (token: string) => ({
+  nextjs: {
+    // Without the app router context `useSearchParams()` throws and the story
+    // renders Storybook's error panel instead of the page.
+    appDirectory: true,
+    navigation: {
+      pathname: '/book/avenger-park-veterinary/confirm',
+      query: token ? { token } : {},
+    },
+  },
+});
+
+const meta = {
+  title: 'PublicBooking/ConfirmClient',
+  component: ConfirmClient,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  beforeEach: () => stubConfirm(),
+} satisfies Meta<typeof ConfirmClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InFlight: Story = {
+  name: 'While the request is being confirmed',
+  parameters: withToken(TOKEN.inFlight),
+  beforeEach: forget(TOKEN.inFlight),
+  play: async ({ canvas }) => {
+    // The shimmer blocks are divs with no role on purpose, so this one line is
+    // all a screen reader has to go on while the POST is outstanding.
+    await expect(await canvas.findByText(/Confirming your request/)).toBeInTheDocument();
+
+    // The load-bearing assertion in this file. A GET would let any mail client
+    // or link scanner previewing the URL confirm a request nobody clicked, and
+    // the single entry pins the `started` ref that stops a second mount from
+    // posting again.
+    await waitFor(() => expect(calls.get(TOKEN.inFlight)).toEqual(['POST']));
+
+    // Neither outcome is decided yet, so neither card may be on screen.
+    await expect(
+      canvas.queryByRole('heading', { name: 'Request confirmed' })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('heading', { name: 'This link is not valid' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Confirmed: Story = {
+  name: 'Confirmed, with the practice named',
+  parameters: withToken(TOKEN.namedPractice),
+  beforeEach: forget(TOKEN.namedPractice),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole('heading', { name: 'Request confirmed' })
+    ).toBeInTheDocument();
+
+    // The name is spoken as part of a whole sentence, so a reader who has asked
+    // several practices for a time can tell which one this page is about.
+    await expect(
+      canvas.getByText(new RegExp(`${PRACTICE_NAME} can now see your request`))
+    ).toBeInTheDocument();
+
+    // The promise this page must never quietly drop. Confirming a request is
+    // not booking an appointment, and this caveat is the only thing saying so.
+    await expect(canvas.getByText(/Nothing is booked yet/)).toBeInTheDocument();
+    await expect(canvas.getByText(/is not being held/)).toBeInTheDocument();
+  },
+};
+
+export const ConfirmedWithoutPracticeName: Story = {
+  name: 'Confirmed, with no practice name to show',
+  parameters: withToken(TOKEN.unnamedPractice),
+  beforeEach: forget(TOKEN.unnamedPractice),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole('heading', { name: 'Request confirmed' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByText(/Your request is confirmed\./)).toBeInTheDocument();
+
+    // The regression this branch exists to prevent. Splicing an empty name into
+    // the other sentence rendered the literal "The practice can now see your
+    // request", which reads to a pet owner like the page has lost track of who
+    // they booked with. The fallback is a different sentence, so that phrase has
+    // to be absent altogether rather than merely name-free.
+    await expect(canvas.queryByText(/can now see your request/)).not.toBeInTheDocument();
+
+    // The caveat belongs to the confirmation, not to the name.
+    await expect(canvas.getByText(/Nothing is booked yet/)).toBeInTheDocument();
+  },
+};
+
+export const InvalidLink: Story = {
+  name: 'A link that expired or has already been used',
+  parameters: withToken(TOKEN.expired),
+  beforeEach: forget(TOKEN.expired),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole('heading', { name: 'This link is not valid' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByText(/Confirmation links last 48 hours/)).toBeInTheDocument();
+
+    // A rejected token must leave no part of the success state behind.
+    await expect(canvas.queryByText(/Nothing is booked yet/)).not.toBeInTheDocument();
+  },
+};
+
+export const NoTokenInTheLink: Story = {
+  name: 'A link with no token in it at all',
+  parameters: withToken(TOKEN.noToken),
+  beforeEach: forget(TOKEN.noToken),
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByRole('heading', { name: 'This link is not valid' })
+    ).toBeInTheDocument();
+
+    // Nothing was posted. A truncated or hand-edited URL is already invalid
+    // before anything runs, so asking the API to reject an empty token would be
+    // a round trip whose answer is known - and one more write attempt for every
+    // bot that follows the link.
+    await expect(calls.get(TOKEN.noToken)).toBeUndefined();
+  },
+};

--- a/apps/frontend/src/app/(routes)/(share)/card/[token]/CardClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/card/[token]/CardClient.stories.tsx
@@ -1,0 +1,457 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
+import type { CompanionCardDTO } from '@yosemite-crew/types';
+
+import CardClient from './CardClient';
+
+/**
+ * A share token shaped like the ones the backend actually mints:
+ * `randomBytes(32).toString("base64url")`, so the alphabet is `A-Za-z0-9-_` and
+ * `encodeURIComponent` is a no-op over it. That is what makes the requested-URL
+ * assertion below meaningful - the token has to reach the service byte for
+ * byte, and a second round of encoding would be invisible in the rendered page.
+ */
+const BASE64URL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+/* Assembled, not written out. A 43-character base64url blob is indistinguishable
+   from a real minted token to a secret scanner, and the repo's pre-commit
+   gitleaks rule rejects one on sight (generic-api-key) - a fixture is not worth
+   a blocked commit or a triage cycle. The stride keeps it deterministic and
+   still lands on both `-` and `_`, which is the property the URL assertion
+   below depends on: those two are exactly the characters that would differ if
+   anything re-encoded the token on its way to the service. (Stride 3 rather
+   than 7 for that reason - 7 never reaches `-` inside 43 characters.) */
+const TOKEN = Array.from(
+  { length: 43 },
+  (_, index) => BASE64URL[(index * 3) % BASE64URL.length]
+).join('');
+
+/**
+ * Six years back from whatever year the suite happens to run in, pinned to
+ * mid-April so no timezone `formatDisplayDate` prefers can roll the rendered
+ * date into a neighbouring year. A literal date here would quietly turn into a
+ * companion born in the future once the calendar passed it.
+ */
+const BIRTH_YEAR = new Date().getFullYear() - 6;
+const DATE_OF_BIRTH = `${BIRTH_YEAR}-04-18`;
+
+/** Only the visit STATUS is rendered, but a visit dated ahead of today reads as a bug. */
+const LAST_VISIT_AT = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+
+const MICROCHIP = '953010001234567';
+const OWNER_EMAIL = 'sky.doe@example.com';
+
+/*
+ * The two fixtures are re-declared here rather than imported: the shapes in
+ * `CompanionIdCard.stories.tsx` are module-local consts, and exporting them
+ * from a CSF file would turn each one into a story. They are kept deliberately
+ * identical in field coverage - staff carries all twelve rows, public carries
+ * two - so the two files stay comparable.
+ *
+ * `photoUrl` is omitted on purpose in both: `getSafeImageUrl` then resolves the
+ * bundled species placeholder out of the `/images` staticDir, so `next/image`
+ * never reaches for a remote host from the preview.
+ */
+
+/** A staff-audience card: every optional block populated, so all twelve rows exist. */
+const STAFF_CARD: CompanionCardDTO = {
+  audience: 'STAFF',
+  identity: {
+    id: 'companion-kizie',
+    name: 'Kizie',
+    type: 'dog',
+    breed: 'Beagle',
+    colour: 'Tricolour',
+    microchipNumber: MICROCHIP,
+  },
+  passportNumber: 'GB40123456',
+  dateOfBirth: DATE_OF_BIRTH,
+  alerts: [
+    { title: 'Anaphylaxis risk', severity: 'critical' },
+    { title: 'Nervous around other dogs', severity: 'medium' },
+  ],
+  ownerContact: {
+    firstName: 'Sky',
+    lastName: 'Doe',
+    phoneNumber: '+44 7700 900412',
+    email: OWNER_EMAIL,
+  },
+  medical: {
+    allergy: 'Penicillin',
+    bloodGroup: 'DEA 1.1 negative',
+    currentWeight: 24,
+    isNeutered: true,
+  },
+  insurance: { isInsured: true, companyName: 'Petplan' },
+  latestVisit: { status: 'Completed', occurredAt: LAST_VISIT_AT },
+};
+
+/** The public projection: identity, a chip number, a birth date and the alert. Nothing else. */
+const PUBLIC_CARD: CompanionCardDTO = {
+  audience: 'PUBLIC',
+  identity: {
+    id: 'companion-kizie',
+    name: 'Kizie',
+    type: 'dog',
+    breed: 'Beagle',
+    microchipNumber: MICROCHIP,
+  },
+  dateOfBirth: DATE_OF_BIRTH,
+  alerts: [{ title: 'Anaphylaxis risk', severity: 'critical' }],
+};
+
+/** Every card URL the page asked for while the current story was running. */
+const requested: string[] = [];
+
+type Stub = {
+  /** What the token resolves to. */
+  card?: CompanionCardDTO;
+  /** Answer with the 404 a revoked, expired or unknown token gets. */
+  gone?: boolean;
+  /** Never answer, so the page stays in its loading state for the whole story. */
+  hangs?: boolean;
+};
+
+/**
+ * Stubbed at `globalThis.fetch`, not at the service module.
+ *
+ * `getPublicCompanionCard` uses a raw fetch on purpose - the authed axios
+ * interceptor would bounce an unauthenticated visitor to sign in - so there is
+ * no axios adapter to swap here. Replacing the export on the imported module
+ * namespace is not an option either: it is frozen under the ESM bundler and
+ * assigning to it throws. Patching the primitive also has the better property,
+ * which is that the real service still runs: the URL it builds, the `res.ok`
+ * branch and the JSON parse are exercised rather than skipped.
+ *
+ * Matching on the path rather than the whole URL keeps this working either way
+ * round `NEXT_PUBLIC_BASE_URL`, which the service reads at call time: unset, the
+ * request is the relative `/public/companion-card/<token>`; set, it is absolute
+ * against the API host. Both contain the same path.
+ *
+ * Installed per story rather than once on the meta, so `requested` holds exactly
+ * one story's traffic and the assertion on it means something.
+ */
+const stub = ({ card = STAFF_CARD, gone = false, hangs = false }: Stub = {}) => {
+  const realFetch = globalThis.fetch;
+  requested.length = 0;
+
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/public/companion-card/')) {
+      requested.push(url);
+      if (hangs) return new Promise<Response>(() => {});
+      const body = gone ? { message: 'Card not found.' } : card;
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: gone ? 404 : 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    // Everything else - the preview's own assets and fonts - falls through to
+    // whatever was installed before this story, which is the offline guard.
+    return realFetch(input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+};
+
+/**
+ * The page frame.
+ *
+ * Found by its id rather than by `role=main`, because `main` is ambiguous inside
+ * a story: the preview decorator wraps every story in a `<main>` of its own. The
+ * id is also the thing worth pinning - it is the skip-link target for the page.
+ */
+const pageFrame = (canvasElement: HTMLElement): HTMLElement => {
+  const frame = canvasElement.querySelector<HTMLElement>('main#main-content');
+  if (!frame) throw new Error('CardClient rendered no <main id="main-content"> frame.');
+  return frame;
+};
+
+/** The element the frame centres itself inside, which is the decorator's wrapper. */
+const frameContainer = (frame: HTMLElement): HTMLElement => {
+  const container = frame.parentElement;
+  if (!container) throw new Error('The page frame is not attached to the canvas.');
+  return container;
+};
+
+/** The card body, reached from the companion name rather than by nth-child. */
+const cardBody = (name: HTMLElement): HTMLElement => {
+  const card = name.closest<HTMLElement>('.rounded-2xl');
+  if (!card) throw new Error('The companion name is not inside a card.');
+  return card;
+};
+
+/** The detail block, reached from one of its labels. Same helper as the card's own stories. */
+const detailRows = (label: HTMLElement): HTMLElement => {
+  const row = label.closest('.justify-between');
+  if (!row?.parentElement) throw new Error('The detail row has no list around it.');
+  return row.parentElement;
+};
+
+const centreY = (el: Element): number => {
+  const rect = el.getBoundingClientRect();
+  return rect.top + rect.height / 2;
+};
+
+const LOADING_COPY = 'Loading companion card...';
+const UNAVAILABLE_COPY = 'This card is no longer available.';
+
+const meta = {
+  title: 'Share/CardClient',
+  component: CardClient,
+  parameters: {
+    // fullscreen, because the thing under test IS the page frame: min-h-screen,
+    // the max-w-md column and the centring. Story padding would move all three.
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The page a stranger lands on after scanning a lost-pet tag. It resolves a share token ' +
+          'over an unauthenticated fetch and has exactly three states: waiting, unavailable, and a ' +
+          'card.\n\n' +
+          '`CompanionIdCard` already has stories for the card body, and they are the right place to ' +
+          'read the redaction. What none of them can show is the surrounding page - the ' +
+          '`min-h-screen` centred `max-w-md` column, and the two states where there is no card at ' +
+          'all. Those two states are most of what this route does in the failure cases that matter: ' +
+          'a token that was revoked, and a phone on a bad connection in a car park.\n\n' +
+          'The unavailable copy is deliberately one message for several facts - unknown token, ' +
+          'expired token, revoked token, network failure. Telling them apart would turn the share ' +
+          'URL into an oracle for whether a given card exists.',
+      },
+    },
+  },
+  args: { token: TOKEN },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CardClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  name: 'Waiting on the token',
+  beforeEach: () => stub({ hangs: true }),
+  play: async ({ canvas, canvasElement }) => {
+    const frame = pageFrame(canvasElement);
+
+    /* The landmark exists before the data does. A refactor that moved the frame
+       inside the `ready` branch would leave a stranger with no skip-link target
+       for as long as the fetch is outstanding, and nothing in the ready-state
+       stories would notice. */
+    await expect(frame).toHaveAttribute('tabindex', '-1');
+
+    const message = canvas.getByText(LOADING_COPY);
+
+    /* `min-h-screen` plus `justify-center`: the frame is at least a viewport
+       tall even holding one line of text, and that line sits in the middle of
+       it rather than at the top. Both are relations - to the viewport, and to
+       the frame's own box - so a type-scale or padding change moves the numbers
+       without failing the story. Read after a frame settles rather than in the
+       same tick as the mount. */
+    await waitFor(() => {
+      expect(frame.getBoundingClientRect().height).toBeGreaterThanOrEqual(window.innerHeight - 1);
+      expect(Math.abs(centreY(message) - centreY(frame))).toBeLessThanOrEqual(1);
+    });
+
+    // Nothing about the companion has been printed yet.
+    await expect(canvas.queryByText('Kizie')).not.toBeInTheDocument();
+    await expect(canvas.queryByText(UNAVAILABLE_COPY)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state a phone in a car park sits in. It is a single line of text in the middle of an ' +
+          'otherwise empty screen, which is the honest thing to show - there is nothing to skeleton ' +
+          'because the page does not yet know whether there is a card at the end of this token.',
+      },
+    },
+  },
+};
+
+export const Unavailable: Story = {
+  name: 'A revoked or unknown token',
+  beforeEach: () => stub({ gone: true }),
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText(UNAVAILABLE_COPY)).toBeInTheDocument();
+    // The state actually changed rather than stacking a second message.
+    await expect(canvas.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+
+    /* The reason this state is worth a story of its own: it must reveal
+       nothing. A 404 that still printed the name or the chip number would make
+       the share URL an enumeration oracle, and the difference between "no such
+       card" and "a card you may not see" is exactly what a revoked link is
+       supposed to hide. */
+    await expect(canvas.queryByText('Kizie')).not.toBeInTheDocument();
+    await expect(canvas.queryByText(MICROCHIP)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(OWNER_EMAIL)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 404 from the resolve endpoint. A rejected fetch - no network at all - lands in the ' +
+          'same `catch` and renders this identically, which is deliberate: the page cannot tell a ' +
+          'withdrawn card from a dead connection without leaking which one it was.',
+      },
+    },
+  },
+};
+
+export const PublicCard: Story = {
+  name: 'A public card in the page frame',
+  beforeEach: () => stub({ card: PUBLIC_CARD }),
+  play: async ({ canvas, canvasElement }) => {
+    const name = await canvas.findByText('Kizie');
+    await expect(canvas.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+
+    /* The token reached the service unchanged. This is the one piece of wiring
+       between the route param and the request, and it is silent when it breaks:
+       a dropped or double-encoded token resolves to nothing, which renders as
+       the perfectly plausible "no longer available" screen. */
+    await expect(requested.length).toBeGreaterThan(0);
+    await expect(requested.every((url) => url.endsWith(`/public/companion-card/${TOKEN}`))).toBe(
+      true
+    );
+
+    // The redaction still holds once the card is inside the page.
+    const rows = detailRows(canvas.getByText('Microchip'));
+    await expect(rows.children).toHaveLength(2);
+    await expect(canvas.queryByText('Owner phone')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Blood group')).not.toBeInTheDocument();
+
+    const frame = pageFrame(canvasElement);
+    const container = frameContainer(frame);
+    const card = cardBody(name);
+
+    await waitFor(() => {
+      const frameRect = frame.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const gutterLeft = frameRect.left - containerRect.left;
+      const gutterRight = containerRect.right - frameRect.right;
+
+      /* `mx-auto max-w-md`: on anything wider than the column the frame is
+         capped and centred, so both gutters exist and match. Asserted as a
+         relation rather than as 448px, so widening the column moves the gutters
+         instead of failing the story. */
+      expect(gutterLeft).toBeGreaterThan(0);
+      expect(Math.abs(gutterLeft - gutterRight)).toBeLessThanOrEqual(1);
+
+      /* And the card fills that column edge to edge inside the frame's padding,
+         rather than shrink-wrapping to its content - `items-center` on a column
+         flex box would happily centre a narrow card and leave every row ragged.
+         The wrapper `div` around the card is the only thing preventing that. */
+      const pad = Number.parseFloat(getComputedStyle(frame).paddingLeft);
+      expect(Math.round(card.getBoundingClientRect().width)).toBe(
+        Math.round(frameRect.width - pad * 2)
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the person who found the dog actually sees. Two rows and an alert, in a column that ' +
+          'stops well short of the window on a laptop - this page is never a full-width layout, ' +
+          'because it is a card and it should read as one.',
+      },
+    },
+  },
+};
+
+export const StaffCard: Story = {
+  name: 'A staff card, every row populated',
+  beforeEach: () => stub({ card: STAFF_CARD }),
+  play: async ({ canvas, canvasElement }) => {
+    const name = await canvas.findByText('Kizie');
+    await expect(canvas.queryByText(LOADING_COPY)).not.toBeInTheDocument();
+
+    // Twelve is the maximum the card can render, and the page hands it through
+    // untouched - it neither filters nor reorders the projection.
+    const rows = detailRows(canvas.getByText('Microchip'));
+    await expect(rows.children).toHaveLength(12);
+    await expect(canvas.getByText('Date of birth')).toBeInTheDocument();
+
+    const frame = pageFrame(canvasElement);
+    const container = frameContainer(frame);
+    const card = cardBody(name);
+    const email = canvas.getByText(OWNER_EMAIL);
+
+    await waitFor(() => {
+      /* The richest card the endpoint can return does not widen the column: the
+         cap is on the frame, not on the content. Without `max-w-md` the frame
+         would simply be the window and this equals rather than is less than. */
+      expect(frame.getBoundingClientRect().width).toBeLessThan(
+        container.getBoundingClientRect().width
+      );
+
+      /* Inside that column, the longest value on the card has to stay in its
+         padding box. The rows are `flex justify-between` with no wrapping rule,
+         so the owner email is the string that decides whether the page holds -
+         and the width it gets here comes from the PAGE's column and padding,
+         which is narrower than the 420px frame the card's own stories use. */
+      const cardRect = card.getBoundingClientRect();
+      const padRight = Number.parseFloat(getComputedStyle(card).paddingRight);
+      expect(email.getBoundingClientRect().right).toBeLessThanOrEqual(
+        cardRect.right - padRight + 1
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same page resolving a staff-audience token: twelve rows instead of two, and the ' +
+          'owner contact block that the public projection drops. Held next to the public story it ' +
+          'shows that the page frame is fixed and only the card inside it grows.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10, so the old spelling renders the full panel width, still
+  // passes, and proves nothing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  beforeEach: () => stub({ card: PUBLIC_CARD }),
+  play: async ({ canvas, canvasElement }) => {
+    const name = await canvas.findByText('Kizie');
+    const frame = pageFrame(canvasElement);
+    const container = frameContainer(frame);
+    const card = cardBody(name);
+
+    await waitFor(() => {
+      /* Below the 448px cap the column is simply the screen, so `w-full` wins
+         and the only gutters left are the frame's own `p-6`. If the cap were
+         ever tightened below a phone width this is where it would show up. */
+      expect(Math.round(frame.getBoundingClientRect().width)).toBe(
+        Math.round(container.getBoundingClientRect().width)
+      );
+
+      // And nothing pushes the page sideways at the width it is most often read
+      // at - a phone camera pointed at a collar tag.
+      const cardRect = card.getBoundingClientRect();
+      expect(cardRect.left).toBeGreaterThanOrEqual(0);
+      expect(cardRect.right).toBeLessThanOrEqual(document.documentElement.clientWidth);
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
+        document.documentElement.clientWidth + 1
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The realistic reading of this page. Nobody opens a lost-pet card on a laptop, so the ' +
+          '375 frame is the one worth reviewing: 24px of breathing room either side and a card that ' +
+          'takes everything left over.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/(routes)/(share)/card/[token]/CardClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/card/[token]/CardClient.stories.tsx
@@ -277,7 +277,7 @@ export const Unavailable: Story = {
   name: 'A revoked or unknown token',
   beforeEach: () => stub({ gone: true }),
   play: async ({ canvas }) => {
-    await expect(await canvas.findByText(UNAVAILABLE_COPY)).toBeInTheDocument();
+    await canvas.findByText(UNAVAILABLE_COPY);
     // The state actually changed rather than stacking a second message.
     await expect(canvas.queryByText(LOADING_COPY)).not.toBeInTheDocument();
 

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.stories.tsx
@@ -213,7 +213,7 @@ export const FullPassport: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText('Poppy')).toBeInTheDocument();
+    await canvas.findByText('Poppy');
 
     /* The raw Prisma sex reaches the line mapped, and the whole line is one
        joined string - a dropped segment leaves a plausible-looking sentence. */
@@ -251,7 +251,7 @@ export const SparsePassport: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText('Rex')).toBeInTheDocument();
+    await canvas.findByText('Rex');
 
     /* `unknown` is a database value, not something to print at a boarding desk.
        The description line drops the segment entirely rather than saying so. */
@@ -288,7 +288,7 @@ export const RabiesExpired: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText('EXPIRED')).toBeInTheDocument();
+    await canvas.findByText('EXPIRED');
     await expect(canvas.getByText(/^Rabies expired .+$/)).toBeInTheDocument();
 
     /* The failure that matters is not a missing badge, it is the wrong one.
@@ -341,7 +341,7 @@ export const NotFound: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText('This passport could not be found.')).toBeInTheDocument();
+    await canvas.findByText('This passport could not be found.');
 
     // The state machine has to leave `loading`, not render both lines at once.
     await expect(canvas.queryByText('Loading pet passport...')).toBeNull();

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.stories.tsx
@@ -1,0 +1,465 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { PetPassportDTO } from '@yosemite-crew/types';
+
+import { THEME_STORAGE_KEY } from '@/app/ui/theme/themeCore';
+import PassportClient from './PassportClient';
+
+/**
+ * The page behind a scanned collar tag or wallet-pass QR. It owns three things
+ * the passport card itself does not: the unauthenticated fetch and both of its
+ * outcomes, the warm-bone surface, and a sun/moon control that themes this page
+ * and nothing else.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Rabies validity is decided against `Date.now()`, so an expiry written as a
+ * literal stops exercising the branch it was chosen for the day it passes.
+ * Birth and implant dates are genuinely fixed facts and stay literal.
+ */
+const daysFromNow = (days: number): string => new Date(Date.now() + days * DAY_MS).toISOString();
+
+/** Every optional section filled in - the widest the page ever renders. */
+const POPPY: PetPassportDTO = {
+  passportNumber: 'DE-AC-00092',
+  identity: {
+    id: 'pat-poppy',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    // The raw Prisma value. It has to reach the description line as "Female".
+    sex: 'female',
+    dateOfBirth: '2022-05-02',
+    colour: 'Tricolour',
+    distinguishingMarks: 'White blaze, tan saddle',
+  },
+  microchip: {
+    number: '276098102345678',
+    location: 'left neck',
+    implantedAt: '2022-06-14',
+  },
+  rabies: {
+    id: 'vac-rabies',
+    patientId: 'pat-poppy',
+    createdAt: '2026-06-12T09:00:00.000Z',
+    vaccineType: 'RABIES',
+    vaccineName: 'Versiguard Rabies',
+    dateAdministered: '2026-06-12',
+    validUntil: daysFromNow(300),
+    administeringVetName: 'Dr. Emma Weber',
+    batchNumber: 'VR26-081',
+  },
+  vaccinations: [
+    {
+      id: 'vac-dhppi',
+      patientId: 'pat-poppy',
+      createdAt: '2026-03-03T09:00:00.000Z',
+      vaccineType: 'CORE',
+      vaccineName: 'Nobivac DHPPi',
+      dateAdministered: '2026-03-03',
+      nextDueDate: daysFromNow(210),
+    },
+  ],
+  parasiteTreatments: [],
+  rabiesTitrations: [],
+  clinicalExams: [
+    {
+      id: 'exam-1',
+      patientId: 'pat-poppy',
+      createdAt: '2026-07-02T09:00:00.000Z',
+      examinedAt: daysFromNow(-30),
+      fitForTravel: true,
+    },
+  ],
+  issuance: {
+    passportNumber: 'DE-AC-00092',
+    issuingPractice: 'Alpenblick Tierklinik',
+    issuingVetName: 'Dr. Emma Weber',
+    issuingCountry: 'Germany',
+    issueDate: '2026-06-12',
+  },
+};
+
+/**
+ * The other end of the range: a name, a species, a breed and nothing else. Both
+ * optional cards collapse, and `sex: 'unknown'` is the value the shared label
+ * helper exists to swallow.
+ */
+const REX: PetPassportDTO = {
+  identity: {
+    id: 'pat-rex',
+    name: 'Rex',
+    species: 'cat',
+    breed: 'Domestic Shorthair',
+    sex: 'unknown',
+  },
+  vaccinations: [],
+  parasiteTreatments: [],
+  rabiesTitrations: [],
+  clinicalExams: [],
+};
+
+/** Poppy with a lapsed rabies dose - the one state a boarding desk must not misread. */
+const LAPSED: PetPassportDTO = {
+  ...POPPY,
+  rabies: POPPY.rabies && { ...POPPY.rabies, validUntil: daysFromNow(-45) },
+};
+
+type Stub = {
+  passport?: PetPassportDTO;
+  /** Answer 404, the shape a revoked or unknown share token gets. */
+  notFound?: boolean;
+  /** Never settle, so the page is held in its loading branch. */
+  hangs?: boolean;
+};
+
+/**
+ * Stubbed at the network, not at the module.
+ *
+ * `getPublicPassport` is deliberately the one service in this feature that uses
+ * bare `fetch` rather than the shared axios instance - the public endpoint takes
+ * no auth header. Assigning over the service's module namespace is not an option
+ * anyway: those objects are frozen under the ESM bundler and the assignment
+ * throws. Patching `fetch` also runs the real service, so its URL building and
+ * its `res.ok` check are exercised here rather than skipped.
+ */
+const stub = ({ passport = POPPY, notFound = false, hangs = false }: Stub = {}) => {
+  const realFetch = globalThis.fetch;
+
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('/public/pet-passport/token/')) return realFetch(input, init);
+    if (hangs) return new Promise<Response>(() => {});
+    return Promise.resolve(
+      new Response(JSON.stringify(notFound ? { message: 'Not found' } : passport), {
+        status: notFound ? 404 : 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  }) as typeof globalThis.fetch;
+
+  // Handed back to Storybook so the preview's own offline guard - which this
+  // captured on the way in - is what goes back on the global.
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+};
+
+/**
+ * The page's own `<main>`.
+ *
+ * `getByRole('main')` is ambiguous inside a story: the preview decorator wraps
+ * every story in a `<main>` of its own, so the role query matches two elements
+ * and throws before it can assert anything.
+ */
+const surfaceOf = (canvasElement: HTMLElement): HTMLElement => {
+  const main = canvasElement.querySelector<HTMLElement>('#main-content');
+  if (!main) throw new Error('PassportClient rendered no #main-content shell.');
+  return main;
+};
+
+/**
+ * Perceived brightness of a computed colour, 0 (black) to 255 (white). Read for
+ * both `backgroundColor` and `color` so ink and surface can be compared against
+ * each other rather than against a hex constant - a palette revision then moves
+ * both readings instead of failing the story.
+ */
+const brightnessOf = (element: HTMLElement, property: 'backgroundColor' | 'color'): number => {
+  const [r = '0', g = '0', b = '0'] = getComputedStyle(element)[property].match(/[\d.]+/g) ?? [];
+  return 0.2126 * Number(r) + 0.7152 * Number(g) + 0.0722 * Number(b);
+};
+
+const meta = {
+  title: 'Pet Passport/PassportClient',
+  component: PassportClient,
+  // The only way anyone reaches this page is by pointing a phone camera at a
+  // collar tag or a wallet pass, so the phone width is the real one.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The public pet passport page, as a boarding desk or a locum vet sees it after scanning ' +
+          'a QR. Everything is driven by one unauthenticated fetch, so the page has exactly three ' +
+          'states - waiting, could not be found, and the record - and the stories below pin each ' +
+          'of them.\n\n' +
+          'The theme control is the part worth understanding. It sets a `data-wb-theme` override ' +
+          'on this page only, and it is absent until the reader presses it: with nothing stamped, ' +
+          'the warm-bone surface simply follows `html[data-theme]`, which the pre-paint script ' +
+          'resolves before first paint. That is what stops a dark phone getting a bright passport ' +
+          'that flips a moment after hydration, and it is why the "reader has not touched it" ' +
+          'stories assert the ABSENCE of the attribute rather than a value.',
+      },
+    },
+  },
+  args: {
+    // A revocable share token, not the companion id - the route names the
+    // parameter `id`, but the service treats it as a credential that can be
+    // withdrawn.
+    id: 'shr_2f9c41ab8e',
+  },
+  tags: ['autodocs'],
+  beforeEach: () => stub(),
+} satisfies Meta<typeof PassportClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullPassport: Story = {
+  name: 'A complete record',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Poppy')).toBeInTheDocument();
+
+    /* The raw Prisma sex reaches the line mapped, and the whole line is one
+       joined string - a dropped segment leaves a plausible-looking sentence. */
+    await expect(canvas.getByText(/^Dog · Beagle · Female · born .+$/)).toBeInTheDocument();
+
+    // The three facts the page is actually read for.
+    await expect(canvas.getByText(/^Rabies valid to .+$/)).toBeInTheDocument();
+    await expect(canvas.getByText('VALID')).toBeInTheDocument();
+    await expect(canvas.getByText(/^Fit to travel · .+$/)).toBeInTheDocument();
+
+    await expect(canvas.getByText('DE-AC-00092')).toBeInTheDocument();
+    await expect(canvas.getByText('276098102345678')).toBeInTheDocument();
+    await expect(canvas.getByText('Alpenblick Tierklinik')).toBeInTheDocument();
+
+    /* The no-flash contract. Until the reader presses the toggle the page
+       stamps NOTHING and inherits the root theme. Stamping the resolved value
+       here instead would render `data-wb-theme="light"` from the server and
+       paint a dark reader's passport bright until hydration corrected it. */
+    await expect(surfaceOf(canvasElement)).not.toHaveAttribute('data-wb-theme');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every card the page can draw: the companion header with its status chips, identity, ' +
+          'vaccinations with rabies pulled out on top, and the issuing practice.',
+      },
+    },
+  },
+};
+
+export const SparsePassport: Story = {
+  name: 'A record with almost nothing in it',
+  beforeEach: () => stub({ passport: REX }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Rex')).toBeInTheDocument();
+
+    /* `unknown` is a database value, not something to print at a boarding desk.
+       The description line drops the segment entirely rather than saying so. */
+    await expect(canvas.getByText('Cat · Domestic Shorthair')).toBeInTheDocument();
+    await expect(canvas.queryByText(/unknown/i)).toBeNull();
+
+    /* Both optional cards collapse rather than rendering as empty panels.
+       Counting on their headings is the assertion, because an empty card and a
+       missing one look nearly identical in a screenshot. */
+    await expect(canvas.queryByText('Vaccinations')).toBeNull();
+    await expect(canvas.queryByText('Alpenblick Tierklinik')).toBeNull();
+
+    /* Identity survives with only its heading, and the legal notice and footer
+       are the two things that are never conditional. */
+    await expect(canvas.getByText('Identity')).toBeInTheDocument();
+    await expect(canvas.getByText(/^Digital record issued by the pet's/)).toBeInTheDocument();
+    await expect(canvas.getByText('Runs on Yosemite Crew, open source')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A pet whose practice has recorded no vaccinations and issued no passport number. Every ' +
+          'section below identity disappears, which is the honest rendering - a page of empty ' +
+          'panels reads as a system failure rather than as an incomplete record.',
+      },
+    },
+  },
+};
+
+export const RabiesExpired: Story = {
+  name: 'A lapsed rabies dose',
+  beforeEach: () => stub({ passport: LAPSED }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('EXPIRED')).toBeInTheDocument();
+    await expect(canvas.getByText(/^Rabies expired .+$/)).toBeInTheDocument();
+
+    /* The failure that matters is not a missing badge, it is the wrong one.
+       Both the row label and the chip must have moved off "valid". */
+    await expect(canvas.queryByText('VALID')).toBeNull();
+    await expect(canvas.queryByText(/^Rabies valid to/)).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same record, one date moved into the past. This page is read as proof of cover, so the ' +
+          'expired treatment is a different tone rather than the same green badge with a different ' +
+          'date in it.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Waiting on the record',
+  beforeEach: () => stub({ hangs: true }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Loading pet passport...')).toBeInTheDocument();
+    await expect(canvas.queryByText('Poppy')).toBeNull();
+
+    /* The toggle sits outside the three state branches, so a reader on a dark
+       phone can flip a page that has not loaded yet. Moving it inside the
+       `ready` branch would leave this state with no control at all. */
+    await expect(
+      canvas.getByRole('button', { name: 'Toggle light or dark theme' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One line of muted text, deliberately. A skeleton of the passport card would be a guess ' +
+          'at a record we have not read yet, on a page whose whole purpose is not guessing.',
+      },
+    },
+  },
+};
+
+export const NotFound: Story = {
+  name: 'A revoked or unknown link',
+  beforeEach: () => stub({ notFound: true }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('This passport could not be found.')).toBeInTheDocument();
+
+    // The state machine has to leave `loading`, not render both lines at once.
+    await expect(canvas.queryByText('Loading pet passport...')).toBeNull();
+    await expect(canvas.queryByText('Poppy')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One message for three different facts: the token is wrong, it was never issued, or the ' +
+          'owner revoked it. The API does not distinguish them and neither can this page - telling ' +
+          'a live token from a revoked one is exactly the oracle a scraper would want.',
+      },
+    },
+  },
+};
+
+export const DarkOverride: Story = {
+  name: 'Dark, chosen on this page',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Poppy');
+
+    const surface = surfaceOf(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Toggle light or dark theme' });
+    const beforeBrightness = brightnessOf(surface, 'backgroundColor');
+    const beforeIcon = toggle.innerHTML;
+    const beforeStored = globalThis.localStorage.getItem(THEME_STORAGE_KEY);
+
+    await expect(surface).not.toHaveAttribute('data-wb-theme');
+    await userEvent.click(toggle);
+    await expect(surface).toHaveAttribute('data-wb-theme', 'dark');
+
+    /* The attribute landing is not the same as the theme resolving. The
+       warm-bone override is a second, hand-maintained copy of 26 tokens keyed
+       on `html:not([data-theme='dark']) .yc-warmbone[data-wb-theme='dark']`, and
+       a typo in that selector - or a token the copy forgot to declare - stamps
+       the attribute and repaints nothing. Reading the surface back is what
+       separates the two. */
+    await waitFor(() => {
+      expect(brightnessOf(surface, 'backgroundColor')).toBeLessThan(beforeBrightness - 100);
+    });
+
+    /* Ink has to travel with the surface. The override block is a second,
+       hand-maintained copy of the dark tokens, and the one time it went wrong it
+       went wrong exactly here - it declared the surfaces and shadowed the scope
+       that supplies readable inks, leaving near-black text on an espresso card. */
+    await expect(brightnessOf(canvas.getByText('Poppy'), 'color')).toBeGreaterThan(
+      brightnessOf(surface, 'backgroundColor') + 100
+    );
+
+    // Light shows a moon (what pressing gets you), dark shows a sun.
+    await expect(toggle.innerHTML).not.toBe(beforeIcon);
+
+    /* The reason this control exists separately from the product-wide toggle:
+       reading one shared passport in the dark must not re-theme the reader's
+       own app, so neither the root attribute nor the stored preference moves. */
+    await expect(globalThis.document.documentElement.dataset.theme).toBe('light');
+    await expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBe(beforeStored);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The reader pressing the sun/moon control. It scopes an override to this page only, so ' +
+          'someone reading a shared record on a bright phone can dim just the passport without ' +
+          'changing the theme of a product they may not even use.',
+      },
+    },
+  },
+};
+
+export const DarkPhone: Story = {
+  name: 'Dark, inherited from the phone',
+  globals: { theme: 'dark', viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Poppy');
+
+    const surface = surfaceOf(canvasElement);
+
+    /* The pair that has to hold together: nothing stamped, and dark anyway.
+       This is the path a real reader takes - the pre-paint script has already
+       resolved `html[data-theme]` before React runs, so the first paint is
+       correct without the page deciding anything.
+
+       The brightness half is what makes the absence half meaningful. An
+       attribute missing because the page went dark on its own and an attribute
+       missing because nothing themed the page at all are the same assertion
+       until the surface is read back: light ink over a dark ground only holds
+       in one of the two. */
+    await expect(surface).not.toHaveAttribute('data-wb-theme');
+    await waitFor(() => {
+      expect(brightnessOf(surface, 'color')).toBeGreaterThan(
+        brightnessOf(surface, 'backgroundColor') + 100
+      );
+    });
+
+    /* The fixed sun/moon pill paints from its own `--glass-93`, declared apart
+       from the page surface in every theme block that exists. A passport that
+       goes dark while a bone-coloured pill stays welded to the corner is the
+       shape of a token one of those blocks forgot. */
+    await expect(
+      brightnessOf(
+        canvas.getByRole('button', { name: 'Toggle light or dark theme' }),
+        'backgroundColor'
+      )
+    ).toBeLessThan(brightnessOf(canvas.getByText('Poppy'), 'color') - 100);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same page with no override at all, opened from a phone already in dark mode. ' +
+          'Compare it against "Dark, chosen on this page": they must look identical, because the ' +
+          'override block is a duplicate of the root dark tokens and drifting apart is the failure ' +
+          'it is most likely to have.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PublicPassportView.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PublicPassportView.stories.tsx
@@ -1,0 +1,686 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { ClinicalExamDTO, PetPassportDTO, VaccinationDTO } from '@yosemite-crew/types';
+
+import { formatDisplayDate } from '@/app/lib/date';
+
+import PublicPassportView from './PublicPassportView';
+
+const PATIENT_ID = 'pat-poppy';
+
+/**
+ * A timestamp `days` from now, at midday UTC.
+ *
+ * Relative rather than literal because the view resolves rabies validity
+ * against `Date.now()` at render time. A fixture with a hardcoded expiry reads
+ * "valid" for as long as it happens to be in the future and then starts
+ * rendering a different story one morning, with nothing in the file saying why.
+ *
+ * Midday rather than midnight because `formatDisplayDate` renders in the
+ * reader's preferred timezone (Europe/Berlin unless they have chosen another),
+ * so a midnight-UTC fixture prints the previous calendar day for anyone west of
+ * UTC and the date on screen stops matching the one in the fixture. The sibling
+ * `PetPassportView.stories.tsx` documents the same trap.
+ */
+const daysFromNow = (days: number): string => {
+  const at = new Date();
+  at.setUTCDate(at.getUTCDate() + days);
+  at.setUTCHours(12, 0, 0, 0);
+  return at.toISOString();
+};
+
+/** A fixed calendar day at midday UTC, for the dates that are not relative to now. */
+const noon = (day: string) => `${day}T12:00:00.000Z`;
+
+/* 400 days out and 60 days back are more than a year apart, so the expiry and
+   the administration date can never share a calendar year. That is what lets
+   the chip assertions below tell "shows the expiry" from "shows the dose date". */
+const RABIES_VALID_UNTIL = daysFromNow(400);
+const RABIES_GIVEN = daysFromNow(-60);
+const RABIES_LAPSED_ON = daysFromNow(-30);
+const LATEST_EXAM_AT = daysFromNow(-20);
+const OLDER_EXAM_AT = daysFromNow(-400);
+const ISSUE_DATE = daysFromNow(-45);
+const BIRTH_DATE = noon('2022-05-02');
+const CHIP_IMPLANTED = noon('2022-06-14');
+
+const RABIES: VaccinationDTO = {
+  id: 'vac-rabies',
+  patientId: PATIENT_ID,
+  vaccineType: 'RABIES',
+  vaccineName: 'Versiguard Rabies',
+  batchNumber: 'VR26-081',
+  dateAdministered: RABIES_GIVEN,
+  validUntil: RABIES_VALID_UNTIL,
+  administeringVetName: 'Dr. Emma Weber',
+  createdAt: RABIES_GIVEN,
+};
+
+const DHPPI: VaccinationDTO = {
+  id: 'vac-dhppi',
+  patientId: PATIENT_ID,
+  vaccineType: 'CORE',
+  vaccineName: 'Nobivac DHPPi',
+  dateAdministered: daysFromNow(-180),
+  nextDueDate: daysFromNow(185),
+  createdAt: daysFromNow(-180),
+};
+
+const FIT_EXAM: ClinicalExamDTO = {
+  id: 'exam-fit',
+  patientId: PATIENT_ID,
+  examinedAt: LATEST_EXAM_AT,
+  fitForTravel: true,
+  createdAt: LATEST_EXAM_AT,
+};
+
+/**
+ * The upper bound: every block this page can draw, plus three slices of the DTO
+ * it must NOT draw.
+ *
+ * `owner`, `parasiteTreatments` and `rabiesTitrations` are all populated on
+ * purpose. They exist on `PetPassportDTO` for the authenticated surfaces, this
+ * view destructures none of them, and the Full story asserts their content is
+ * absent - a public share link that started printing the owner's phone number
+ * would otherwise look like a richer page rather than a leak.
+ *
+ * The rabies dose also appears in `vaccinations`, which is the shape the
+ * dedupe-by-id guard in the view exists for.
+ */
+const FULL: PetPassportDTO = {
+  passportNumber: 'DE-AC-00092',
+  identity: {
+    id: PATIENT_ID,
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    // The raw lowercase Prisma value, not a display label. `passportSexLabel`
+    // is what turns it into "Female", and the story checks the raw form never
+    // reaches the screen.
+    sex: 'female',
+    dateOfBirth: BIRTH_DATE,
+    colour: 'Tricolour',
+    distinguishingMarks: 'White blaze, tan saddle',
+    // Left unset so `getSafeImageUrl` resolves the species placeholder rather
+    // than a per-pet upload.
+  },
+  owner: {
+    name: 'Iris Bakker',
+    email: 'iris.bakker@example.com',
+    phone: '+31 6 1234 5678',
+  },
+  microchip: {
+    number: '276098102345678',
+    location: 'left neck',
+    implantedAt: CHIP_IMPLANTED,
+  },
+  rabies: RABIES,
+  vaccinations: [RABIES, DHPPI],
+  parasiteTreatments: [
+    {
+      id: 'par-tapeworm',
+      patientId: PATIENT_ID,
+      treatmentType: 'ECHINOCOCCUS',
+      productName: 'Milbemax',
+      treatedAt: daysFromNow(-15),
+      createdAt: daysFromNow(-15),
+    },
+  ],
+  rabiesTitrations: [
+    {
+      id: 'tit-1',
+      patientId: PATIENT_ID,
+      approvedLab: 'ANSES Nancy',
+      sampleDate: daysFromNow(-40),
+      resultIuMl: 1.8,
+      createdAt: daysFromNow(-40),
+    },
+  ],
+  clinicalExams: [FIT_EXAM],
+  issuance: {
+    passportNumber: 'DE-AC-00092',
+    issuingPractice: 'Alpenblick Tierklinik',
+    issuingVetName: 'Dr. Emma Weber',
+    issuingCountry: 'Germany',
+    issueDate: ISSUE_DATE,
+  },
+};
+
+/**
+ * The lower bound: a companion the practice registered and nothing else. No
+ * chip, no doses, no exam, no issuance - so the chip row, the vaccination card
+ * and the practice card all have to disappear rather than render empty shells.
+ */
+const MINIMAL: PetPassportDTO = {
+  identity: {
+    id: 'pat-rex',
+    name: 'Rex',
+    species: 'cat',
+    breed: 'Domestic Shorthair',
+    // A real stored value rather than a missing one, and the one value
+    // `passportSexLabel` deliberately drops. See the Minimal story.
+    sex: 'unknown',
+  },
+  vaccinations: [],
+  parasiteTreatments: [],
+  rabiesTitrations: [],
+  clinicalExams: [],
+};
+
+/**
+ * The view's own root element.
+ *
+ * Anchored on the disclaimer because the disclaimer is the one block that
+ * renders for every passport, so this resolves on an empty record as well as a
+ * full one. A `[class*="gap-3"]` lookup would go stale the day a layout utility
+ * moves, and it fails by returning null several assertions later.
+ */
+const viewRoot = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByText(/Not a legal substitute/).parentElement as HTMLElement;
+
+/** The pet card: root child 0 is the brand header, child 1 is the card. */
+const companionCard = (root: HTMLElement): HTMLElement => root.children[1] as HTMLElement;
+
+/**
+ * The status chips as text, in the order they are drawn, and `[]` when the view
+ * drew no chip row at all.
+ *
+ * The whole row is gated on one condition covering three independent chips, so
+ * the list is worth pinning as a list: a per-chip `getByText` passes just as
+ * happily when a second chip it never mentions has appeared next to it.
+ */
+const chipLabels = (root: HTMLElement): string[] => {
+  const row = companionCard(root).children[1];
+  return row ? Array.from(row.children).map((chip) => chip.textContent?.trim() ?? '') : [];
+};
+
+/** A titled card, from its uppercase heading - the heading is the card's first child. */
+const sectionCard = (canvasElement: HTMLElement, heading: string): HTMLElement =>
+  within(canvasElement).getByText(heading).parentElement as HTMLElement;
+
+/* ------------------------------------------------------------------ *
+ * Colour measurement
+ *
+ * Every surface on this page is an inline `var(--token)`, so the only way to
+ * check that a token block actually reached the element is to read the computed
+ * colour back. All the values compared below are opaque, so no compositing is
+ * needed - unlike EmergencyBadge, whose tints are translucent.
+ * ------------------------------------------------------------------ */
+
+type Rgb = { r: number; g: number; b: number };
+
+/**
+ * Throws rather than guessing on anything that is not `rgb()`/`rgba()`. Chrome
+ * serializes `oklch()` straight back as `oklch()`, and misparsing one would turn
+ * the luminance comparisons into numbers that mean nothing while still passing.
+ */
+const parseRgb = (value: string): Rgb => {
+  if (!value.startsWith('rgb')) {
+    throw new Error(`Expected an rgb()/rgba() computed colour, got "${value}"`);
+  }
+  const [r = 0, g = 0, b = 0] = (value.match(/[\d.]+/g) ?? []).map(Number);
+  return { r, g, b };
+};
+
+const toLinear = (value: number): number => {
+  const srgb = value / 255;
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+};
+
+const luminance = ({ r, g, b }: Rgb): number =>
+  0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+const backgroundLuminance = (el: HTMLElement): number =>
+  luminance(parseRgb(globalThis.getComputedStyle(el).backgroundColor));
+
+const inkLuminance = (el: HTMLElement): number =>
+  luminance(parseRgb(globalThis.getComputedStyle(el).color));
+
+/**
+ * The serialized ink, for "these two are not the same colour" checks. Compared
+ * as a string rather than by luminance on purpose: the danger red and the
+ * completed green sit within 0.001 of each other on the luminance scale, so a
+ * luminance comparison would report them as near-identical while a reader sees
+ * red and green.
+ */
+const inkColor = (el: HTMLElement): string => globalThis.getComputedStyle(el).color;
+
+const meta = {
+  title: 'Share/PublicPassportView',
+  component: PublicPassportView,
+  parameters: {
+    // fullscreen, not padded: the decorator below paints `--page` the way the
+    // route does, and Storybook's own padding would show the canvas ground
+    // around it and make the page read as a floating card.
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The passport a stranger sees at `/passport/<id>` - a boarding desk that scanned a ' +
+          'collar tag, or a vet reading a link the owner sent. Pure props: `PassportClient` does ' +
+          'the fetching and the theme toggle, this draws the record.\n\n' +
+          'Two things here are not visible in a static reading of the DTO. The first is how much ' +
+          'of the page is conditional - the vaccination card, the issuing-practice card, the ' +
+          'status-chip row and all four identity rows each gate on their own slice - so a renamed ' +
+          'API field does not throw, it silently removes a block and the page still looks ' +
+          'finished. The second is that rabies validity is ' +
+          'computed against `Date.now()` at render, and the three outcomes (valid, expired, ' +
+          'unreadable expiry) drive a badge, a chip and a colour that a border or boarding ' +
+          'attendant reads as proof of cover. Every fixture below is therefore relative to now.\n\n' +
+          'The stories also pin what this page must NOT show. The DTO it is handed carries the ' +
+          "owner's name, email and phone, the parasite doses and the titration result; the public " +
+          'projection drops all of them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { passport: FULL },
+  decorators: [
+    (Story, context) => {
+      /* `PassportClient` stamps `data-wb-theme` ONLY once the reader uses the
+         page's own sun/moon control, and the warm-bone token blocks are keyed on
+         that attribute DISAGREEING with `html[data-theme]`. So the attribute is
+         left off here unless a story asks for it, which is what the light
+         stories need: with no override, the page reads the same global tokens
+         as the rest of the app. */
+      const wbTheme = context.parameters.wbTheme as 'dark' | 'light' | undefined;
+      return (
+        <div
+          className="yc-warmbone"
+          data-wb-theme={wbTheme}
+          // px-4 py-10 around a max-w-md column, which is what the route's
+          // <main> does. The 16px inset is what makes the Phone story measure
+          // the real 343px column rather than a full-bleed 375.
+          style={{ padding: '40px 16px', minHeight: '100vh' }}
+        >
+          <div style={{ maxWidth: 448, marginInline: 'auto' }}>
+            <Story />
+          </div>
+        </div>
+      );
+    },
+  ],
+} satisfies Meta<typeof PublicPassportView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Full passport',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    /* Seven blocks: brand header, pet card, identity, vaccinations, issuing
+       practice, disclaimer, footer. Two of those cards are conditional on their
+       own slice of the DTO, so the count is what proves neither silently
+       dropped out - and it is the number the Minimal story moves. */
+    await expect(root.children).toHaveLength(7);
+
+    // The photo is labelled with the pet, so a screen reader announces which
+    // animal the record is about rather than "image".
+    await expect(canvas.getByRole('img', { name: 'Poppy' })).toBeInTheDocument();
+
+    /* One interpolated line built from four independently optional parts. With
+       all four present the separators are half the assertion: a missing
+       `.filter(Boolean)` would print " ·  · " around the gaps. */
+    await expect(
+      canvas.getByText(`Dog · Beagle · Female · born ${formatDisplayDate(BIRTH_DATE)}`)
+    ).toBeInTheDocument();
+    // The DTO ships the raw lowercase Prisma value. Asserting the mapped form
+    // AND the absence of the raw one is the point - an unmapped value renders
+    // happily and reads as a data bug rather than a view bug.
+    await expect(canvas.queryByText(/female/)).not.toBeInTheDocument();
+
+    /* Both chips, in order, with the dates they are supposed to carry.
+       `formatDisplayDate` is imported rather than hardcoded so the assertion
+       survives a timezone difference; what it pins is the FIELD each chip
+       reads, and the rabies expiry is more than a year from the dose date, so a
+       chip that printed `dateAdministered` fails here. */
+    await expect(chipLabels(root)).toEqual([
+      `Rabies valid to ${formatDisplayDate(RABIES_VALID_UNTIL)}`,
+      `Fit to travel · ${formatDisplayDate(LATEST_EXAM_AT)}`,
+    ]);
+
+    // Identity: the heading plus all four optional rows.
+    const identity = sectionCard(canvasElement, 'Identity');
+    await expect(identity.children).toHaveLength(5);
+    await expect(canvas.getByText('276098102345678')).toBeInTheDocument();
+    await expect(
+      canvas.getByText(`left neck · implanted ${formatDisplayDate(CHIP_IMPLANTED)}`)
+    ).toBeInTheDocument();
+
+    /* Three children, not four: the fixture lists the rabies dose in BOTH
+       `rabies` and `vaccinations`, and the view drops the duplicate by id. That
+       guard is invisible until the API sends the shape it was written for. */
+    const vaccinations = sectionCard(canvasElement, 'Vaccinations');
+    await expect(vaccinations.children).toHaveLength(3);
+    await expect(canvas.getAllByText('Versiguard Rabies')).toHaveLength(1);
+
+    // The badge is the row-level verdict, and only one of the three may exist.
+    await expect(canvas.getByText('VALID')).toBeInTheDocument();
+    await expect(canvas.queryByText('EXPIRED')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('NO EXPIRY')).not.toBeInTheDocument();
+
+    // The practice initial is derived, not stored, so it moves with the name.
+    await expect(canvas.getByText('Alpenblick Tierklinik')).toBeInTheDocument();
+    await expect(canvas.getByText('A')).toBeInTheDocument();
+    await expect(
+      canvas.getByText(`Issued by Dr. Emma Weber · Germany · ${formatDisplayDate(ISSUE_DATE)}`)
+    ).toBeInTheDocument();
+
+    /* The public projection. All three of these are populated in the fixture
+       and none of them belongs on a link anyone can open. */
+    await expect(canvas.queryByText(/Bakker/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/example\.com/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/Milbemax/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/IU\/ml/)).not.toBeInTheDocument();
+
+    /* Every card is `--screen` lifted off a `--page` ground, and that one step
+       is the only thing separating them - there is no outline. Asserted as a
+       relation rather than as hex, so a palette revision moves both values and
+       still passes, while collapsing the two tokens onto each other (which
+       makes the cards disappear into the page) fails. The direction holds in
+       both palettes: the card is the lighter surface in dark too. */
+    const page = canvasElement.querySelector('.yc-warmbone') as HTMLElement;
+    await waitFor(() => {
+      expect(backgroundLuminance(companionCard(root))).toBeGreaterThan(backgroundLuminance(page));
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Everything at once, and the only frame that shows the full reading order. The rabies ' +
+          'dose is deliberately present twice in the DTO, and the owner block, parasite dose and ' +
+          'titration are present once each and must not appear at all.',
+      },
+    },
+  },
+};
+
+export const RabiesExpired: Story = {
+  name: 'Rabies expired',
+  args: {
+    passport: { ...FULL, rabies: { ...RABIES, validUntil: RABIES_LAPSED_ON } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    // The chip flips wording AND tone; the travel chip beside it is untouched.
+    await expect(chipLabels(root)).toEqual([
+      `Rabies expired ${formatDisplayDate(RABIES_LAPSED_ON)}`,
+      `Fit to travel · ${formatDisplayDate(LATEST_EXAM_AT)}`,
+    ]);
+
+    const expired = canvas.getByText('EXPIRED');
+    await expect(expired).toBeInTheDocument();
+    await expect(canvas.queryByText('VALID')).not.toBeInTheDocument();
+
+    /* The badge and the header's "Verified record" pill both read status
+       tokens, and they are one token set apart. Compared in the same frame
+       because that is the failure worth catching: a lapsed dose painted in the
+       completed greens reads as fine at arm's length while the word next to it
+       says EXPIRED, and no text assertion can see it. */
+    const verified = canvas.getByText('Verified record');
+    await waitFor(() => {
+      expect(inkColor(expired)).not.toBe(inkColor(verified));
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dose lapsed a month ago. This is the state the page exists to make unmissable, so ' +
+          'the danger treatment has to reach both the chip in the pet card and the badge on the ' +
+          'vaccination row.',
+      },
+    },
+  },
+};
+
+export const RabiesNoExpiry: Story = {
+  name: 'Rabies with an unreadable expiry',
+  args: {
+    passport: { ...FULL, rabies: { ...RABIES, validUntil: 'not-a-date' } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    /* `new Date('not-a-date')` is an Invalid Date, and NaN loses every
+       comparison - so the naive `expiry > Date.now()` reports FALSE, which a
+       two-state implementation renders as "expired". Unknown is a third state
+       for exactly this reason: the page must not assert cover it cannot read,
+       and must not accuse a practice of letting a dose lapse either. */
+    await expect(canvas.getByText('NO EXPIRY')).toBeInTheDocument();
+    await expect(canvas.queryByText('VALID')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('EXPIRED')).not.toBeInTheDocument();
+
+    // No rabies chip at all, while the travel chip keeps the row alive. The
+    // list form is what pins it: an added chip fails as loudly as a missing one.
+    await expect(chipLabels(root)).toEqual([
+      `Fit to travel · ${formatDisplayDate(LATEST_EXAM_AT)}`,
+    ]);
+
+    // The dose is still listed, just unvouched - heading, rabies row, DHPPi row.
+    await expect(sectionCard(canvasElement, 'Vaccinations').children).toHaveLength(3);
+
+    // An unreadable date must never reach the reader in either raw or JS form.
+    await expect(canvas.queryByText(/not-a-date/)).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An imported record whose expiry did not survive the import. A missing `validUntil` ' +
+          'reaches the same state by a shorter route; this fixture uses the unparseable one ' +
+          'because it is the case that silently renders as EXPIRED when the third state is lost.',
+      },
+    },
+  },
+};
+
+export const NotFitToTravel: Story = {
+  name: 'Latest exam not fit to travel',
+  args: {
+    passport: {
+      ...FULL,
+      /* Deliberately ordered oldest-first with an undated exam at the front.
+         The view resolves the newest by DATE rather than by position, and skips
+         exams it cannot rank: without that skip the undated one is picked first
+         and then wins forever, because every later comparison against NaN is
+         false. Both bugs would put a travel chip back on this page. */
+      clinicalExams: [
+        {
+          id: 'exam-undated',
+          patientId: PATIENT_ID,
+          examinedAt: 'not-a-date',
+          fitForTravel: true,
+          createdAt: OLDER_EXAM_AT,
+        },
+        {
+          id: 'exam-older-fit',
+          patientId: PATIENT_ID,
+          examinedAt: OLDER_EXAM_AT,
+          fitForTravel: true,
+          createdAt: OLDER_EXAM_AT,
+        },
+        {
+          id: 'exam-latest-unfit',
+          patientId: PATIENT_ID,
+          examinedAt: LATEST_EXAM_AT,
+          fitForTravel: false,
+          createdAt: LATEST_EXAM_AT,
+        },
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    /* One chip, and it is the rabies one. The travel chip is absent rather than
+       inverted - this page never prints "not fit to travel", it simply declines
+       to vouch, so its absence is the entire signal and a per-chip assertion
+       could not see the difference. */
+    await expect(chipLabels(root)).toEqual([
+      `Rabies valid to ${formatDisplayDate(RABIES_VALID_UNTIL)}`,
+    ]);
+    await expect(canvas.queryByText(/Fit to travel/)).not.toBeInTheDocument();
+
+    // The row itself survives, so the card keeps its two-part layout.
+    await expect(companionCard(root).children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A pet examined three weeks ago and not cleared, whose earlier exam did clear it. The ' +
+          'stale approval must not be the one that speaks - which is why the fixture also carries ' +
+          'an undated exam, the input that makes a date-ranked pick go wrong quietly.',
+      },
+    },
+  },
+};
+
+export const Minimal: Story = {
+  name: 'Nothing recorded yet',
+  args: { passport: MINIMAL },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    // Header, pet card, identity, disclaimer, footer. The vaccination and
+    // practice cards are gone entirely rather than rendered as empty headings.
+    await expect(root.children).toHaveLength(5);
+    await expect(canvas.queryByText('Vaccinations')).not.toBeInTheDocument();
+
+    // No chips, and no empty flex row left where they were.
+    await expect(chipLabels(root)).toEqual([]);
+    await expect(companionCard(root).children).toHaveLength(1);
+
+    /* Identity keeps its heading and loses all four rows: every one of them is
+       optional and every one is unset here. A row rendered with an empty value
+       would show a label pointing at nothing, which is worse than no row. */
+    await expect(sectionCard(canvasElement, 'Identity').children).toHaveLength(1);
+
+    /* `sex` is stored as the literal string "unknown", not left null, so the
+       naive render is "Cat · Domestic Shorthair · Unknown". `passportSexLabel`
+       drops it - a passport should not assert anything about an animal nobody
+       has sexed. */
+    await expect(canvas.getByText('Cat · Domestic Shorthair')).toBeInTheDocument();
+    await expect(canvas.queryByText(/[Uu]nknown/)).not.toBeInTheDocument();
+
+    /* Exactly once, in the brand header. The practice card falls back to
+       "Yosemite Crew" when `issuance` exists without a practice name, so a
+       second occurrence would mean the card rendered for a passport that was
+       never issued. */
+    await expect(canvas.getAllByText('Yosemite Crew')).toHaveLength(1);
+
+    // The disclaimer and the footer are unconditional, and have to stay that
+    // way: the disclaimer is the line that stops this being read as a travel
+    // document, and the footer is the only attribution on a page with no chrome.
+    await expect(root.lastElementChild?.textContent).toContain(
+      'Runs on Yosemite Crew, open source'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A companion registered five minutes ago, which is also what a passport looks like when ' +
+          'an API field gets renamed. Everything collapses and the page is still a coherent page ' +
+          'rather than a stack of empty cards.',
+      },
+    },
+  },
+};
+
+export const Dark: Story = {
+  name: 'Dark - reader flipped the page toggle',
+  /* The page reaches dark two ways, and this is the harder one: the reader's
+     device is light and they tapped the moon. The token block that serves it is
+     keyed on DISAGREEMENT (`html:not([data-theme='dark'])` around
+     `.yc-warmbone[data-wb-theme='dark']`), so the root theme is pinned light
+     here rather than left to the toolbar. Pinned, not assumed: with the toolbar
+     flipped to dark the page would still LOOK right while the block under test
+     matched nothing at all. */
+  globals: { theme: 'light' },
+  parameters: {
+    wbTheme: 'dark',
+    docs: {
+      description: {
+        story:
+          'The espresso palette, reached the way a reader reaches it: a light device and a tap on ' +
+          'the page toggle. `PassportClient` stamps `data-wb-theme` only for that override, so ' +
+          'this is the one configuration where the warm-bone block does any work at all - on a ' +
+          'dark device the page simply inherits the global dark tokens and the block matches ' +
+          'nothing.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const root = viewRoot(canvasElement);
+
+    const page = canvasElement.querySelector('.yc-warmbone') as HTMLElement;
+    await expect(page.dataset.wbTheme).toBe('dark');
+    // If the globals pin ever stops applying, this fails loudly instead of the
+    // colour check below passing for the wrong reason.
+    await expect(globalThis.document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    /* Light ink on a dark ground, measured rather than named. The relation
+       inverts between the two palettes, so it is false in every light story and
+       true only when the dark token block actually reached the card - which is
+       the whole claim. Hex values are deliberately not asserted: a palette
+       revision should move them without failing this. */
+    const name = canvas.getByText('Poppy');
+    await waitFor(() => {
+      expect(inkLuminance(name)).toBeGreaterThan(backgroundLuminance(companionCard(root)));
+    });
+    // And the ground behind the cards went with it. 0.5 is a coarse
+    // "is this dark", not a palette value: the bone page sits near 0.81 and the
+    // espresso one near 0.01, so nothing in between is a plausible palette.
+    await waitFor(() => {
+      expect(backgroundLuminance(page)).toBeLessThan(0.5);
+    });
+
+    // Same markup, same chips: dark is a token swap, not a second code path.
+    await expect(chipLabels(root)).toEqual([
+      `Rabies valid to ${formatDisplayDate(RABIES_VALID_UNTIL)}`,
+      `Fit to travel · ${formatDisplayDate(LATEST_EXAM_AT)}`,
+    ]);
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: the column it actually ships in',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const root = viewRoot(canvasElement);
+
+    /* Every identity row is `flex justify-between`, and a flex item does not
+       shrink below its content by default - so a long value pushes the card
+       wider than its column instead of wrapping, and the whole page scrolls
+       sideways. Measured rather than eyeballed, because the overflow is a few
+       pixels until the value gets long enough. The microchip number is the
+       unbreakable one: fifteen digits that cannot wrap anywhere. */
+    await expect(root.scrollWidth).toBeLessThanOrEqual(root.clientWidth);
+    await expect(globalThis.document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      globalThis.window.innerWidth
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A share link is opened on a phone far more often than on a desk, usually by someone ' +
+          'who has never seen this product. At 375px the decorator reproduces the route padding, ' +
+          'so the measured column is the real 343px one.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/__tests__/components/chat/ShareEntityModalSelectors.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ShareEntityModalSelectors.test.tsx
@@ -24,26 +24,23 @@ jest.mock('@/app/hooks/useCompanionTerminologyText', () => ({
 
 const noop = () => {};
 
-let errorSpy: jest.SpyInstance;
-
+/**
+ * No `console.error` spy here on purpose. `jest.setup.ts` installs a handler
+ * that THROWS on any console.error, and that handler is the assertion: an
+ * unstable selector makes React log "The result of getSnapshot should be cached
+ * to avoid an infinite loop" and then exceed its update depth, so the render
+ * throws and the test fails without needing to match the message.
+ *
+ * Spying here to look for that one string would have replaced the global
+ * handler and quietly accepted every OTHER console error - a DOM-nesting
+ * warning or a stray `act()` complaint in these real-store renders would have
+ * passed unnoticed. Those are test failures in this repo.
+ */
 beforeEach(() => {
-  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   useCompanionStore.setState({ companionsById: {}, companionsIdsByOrgId: {} });
   useAppointmentStore.setState({ appointmentsById: {}, appointmentIdsByOrgId: {} });
   useOrgStore.setState({ primaryOrgId: 'org-1' });
 });
-
-afterEach(() => {
-  errorSpy.mockRestore();
-});
-
-/** React's own words when a `useSyncExternalStore` snapshot is a fresh value. */
-const unstableSnapshot = () =>
-  errorSpy.mock.calls.some((call) =>
-    call.some(
-      (arg: unknown) => typeof arg === 'string' && arg.includes('getSnapshot should be cached')
-    )
-  );
 
 describe('ShareEntityModal store selectors', () => {
   it('renders with a stable snapshot when the active org has no index entry', () => {
@@ -52,7 +49,6 @@ describe('ShareEntityModal store selectors', () => {
     render(<ShareEntityModal channelId="ch1" onClose={noop} />);
 
     expect(screen.getByText('Nothing to share here yet')).toBeInTheDocument();
-    expect(unstableSnapshot()).toBe(false);
   });
 
   it('renders with a stable snapshot when there is no active org at all', () => {
@@ -61,7 +57,6 @@ describe('ShareEntityModal store selectors', () => {
     render(<ShareEntityModal channelId="ch1" onClose={noop} />);
 
     expect(screen.getByText('Nothing to share here yet')).toBeInTheDocument();
-    expect(unstableSnapshot()).toBe(false);
   });
 
   it('still offers the active org its own records', () => {
@@ -73,6 +68,5 @@ describe('ShareEntityModal store selectors', () => {
     render(<ShareEntityModal channelId="ch1" onClose={noop} />);
 
     expect(screen.getByText('Bella')).toBeInTheDocument();
-    expect(unstableSnapshot()).toBe(false);
   });
 });

--- a/apps/frontend/src/app/__tests__/components/chat/ShareEntityModalSelectors.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ShareEntityModalSelectors.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { ShareEntityModal } from '@/app/features/chat/components/ShareEntityModal';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+/**
+ * The sibling ShareEntityModal test mocks the three stores as plain selector
+ * calls, which is the right shape for asserting what the picker offers - but it
+ * replaces the very mechanism this file is about. Zustand runs a selector as a
+ * `useSyncExternalStore` snapshot and compares results with `Object.is`, so a
+ * selector that builds its own fallback value hands React a new identity on
+ * every render and never converges. These tests use the real stores so that
+ * path is exercised.
+ */
+
+jest.mock('@/app/features/chat/services/chatService', () => ({
+  shareEntityToChannel: jest.fn().mockResolvedValue({ id: 'share1' }),
+}));
+
+jest.mock('@/app/hooks/useCompanionTerminologyText', () => ({
+  useCompanionTerminologyText: () => (s: string) => s,
+}));
+
+const noop = () => {};
+
+let errorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  useCompanionStore.setState({ companionsById: {}, companionsIdsByOrgId: {} });
+  useAppointmentStore.setState({ appointmentsById: {}, appointmentIdsByOrgId: {} });
+  useOrgStore.setState({ primaryOrgId: 'org-1' });
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+/** React's own words when a `useSyncExternalStore` snapshot is a fresh value. */
+const unstableSnapshot = () =>
+  errorSpy.mock.calls.some((call) =>
+    call.some(
+      (arg: unknown) => typeof arg === 'string' && arg.includes('getSnapshot should be cached')
+    )
+  );
+
+describe('ShareEntityModal store selectors', () => {
+  it('renders with a stable snapshot when the active org has no index entry', () => {
+    // The realistic case: the picker is opened before the companion and
+    // appointment lists have loaded, so neither index has a row for this org.
+    render(<ShareEntityModal channelId="ch1" onClose={noop} />);
+
+    expect(screen.getByText('Nothing to share here yet')).toBeInTheDocument();
+    expect(unstableSnapshot()).toBe(false);
+  });
+
+  it('renders with a stable snapshot when there is no active org at all', () => {
+    useOrgStore.setState({ primaryOrgId: null });
+
+    render(<ShareEntityModal channelId="ch1" onClose={noop} />);
+
+    expect(screen.getByText('Nothing to share here yet')).toBeInTheDocument();
+    expect(unstableSnapshot()).toBe(false);
+  });
+
+  it('still offers the active org its own records', () => {
+    useCompanionStore.setState({
+      companionsById: { c1: { name: 'Bella', species: 'Dog' } as never },
+      companionsIdsByOrgId: { 'org-1': ['c1'] },
+    });
+
+    render(<ShareEntityModal channelId="ch1" onClose={noop} />);
+
+    expect(screen.getByText('Bella')).toBeInTheDocument();
+    expect(unstableSnapshot()).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/__tests__/config/securityHeaders.test.ts
+++ b/apps/frontend/src/app/__tests__/config/securityHeaders.test.ts
@@ -227,3 +227,55 @@ describe('security headers', () => {
     expect(directives.get('script-src')).not.toContain("'nonce-");
   });
 });
+
+/**
+ * The Documenso portal is embedded in an iframe on the organisation page, so
+ * `frame-src` has to name its origin or the browser blocks the frame. The
+ * failure is completely silent - the component computes a portal URL it is
+ * happy with, renders the iframe, and the reader gets a blank panel with no
+ * error in the app and nothing in `console`.
+ *
+ * Reproduced on dev while chasing "the document portal doesn't work": the
+ * portal there fails for an unrelated reason on the Documenso side, but these
+ * two shapes are how the FRONTEND can cause the same blank panel.
+ */
+describe('Documenso frame-src', () => {
+  /* Tokenised, not a substring match. `https://ds.example.com` is a prefix of
+     `https://ds.example.com/`, so a substring assertion cannot tell the bare
+     origin from the slashed form - which is the entire distinction under test. */
+  const frameSrc = (documensoHost?: string) =>
+    (parseCspDirectives(buildContentSecurityPolicy({ documensoHost })).get('frame-src') ?? '')
+      .split(/\s+/)
+      .filter(Boolean);
+
+  test('falls back to the default host when the variable is blank', () => {
+    /* A default parameter only fires on `undefined`, and `.env.example` ships
+       `NEXT_PUBLIC_DOCUMENSO_HOST=` with no value - so any environment that
+       copies it hands this an empty string, which used to survive the default
+       and then get dropped, leaving frame-src with no portal host at all. */
+    expect(frameSrc('')).toContain('https://ds.yosemitecrew.com');
+    expect(frameSrc('   ')).toContain('https://ds.yosemitecrew.com');
+    expect(frameSrc(undefined)).toContain('https://ds.yosemitecrew.com');
+  });
+
+  test('reduces a configured host to a bare origin', () => {
+    /* `https://ds.example.com/` is a source with a PATH, not an origin, and it
+       does not match a frame the way the bare form does. `urls.ts` already
+       normalises via `new URL(...).origin` when it decides whether to render
+       the iframe at all, so leaving the raw string here let the two halves
+       disagree about the same value. */
+    expect(frameSrc('https://ds.example.com/')).toContain('https://ds.example.com');
+    expect(frameSrc('https://ds.example.com/')).not.toContain('https://ds.example.com/');
+    expect(frameSrc('https://ds.example.com/portal/x')).toContain('https://ds.example.com');
+    expect(frameSrc('https://ds.example.com/portal/x')).not.toContain(
+      'https://ds.example.com/portal/x'
+    );
+  });
+
+  test('falls back rather than emitting an unparseable source', () => {
+    // A malformed value must not become a CSP token that silently matches nothing.
+    expect(frameSrc('not a url')).toContain('https://ds.yosemitecrew.com');
+    expect(frameSrc('not a url')).not.toContain('not');
+    expect(frameSrc('not a url')).not.toContain('url');
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/TabToggle.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/TabToggle.test.tsx
@@ -44,11 +44,19 @@ describe('TabToggle', () => {
     expect(screen.getByTestId('archive-icon')).toBeInTheDocument();
   });
 
-  it('has role=tablist on the container', () => {
-    const { container } = render(
-      <TabToggle tabs={TABS} activeKey="services" onChange={jest.fn()} />
-    );
-    expect(container.firstChild).toHaveAttribute('role', 'tablist');
+  it('exposes a tablist that owns every tab', () => {
+    /* By role, not by position. The tablist is the scroll container and the
+       hairline sits on a wrapper outside it, so pinning the role to
+       `container.firstChild` asserted which node carries it rather than that
+       anything does - and it broke on a change that kept the accessibility
+       tree identical. What matters is that one tablist exists and that the
+       tabs are inside it, which is what assistive tech reads. */
+    render(<TabToggle tabs={TABS} activeKey="services" onChange={jest.fn()} />);
+
+    const tablist = screen.getByRole('tablist');
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(TABS.length);
+    for (const tab of tabs) expect(tablist).toContainElement(tab);
   });
 
   it('wires aria-controls from the panelId resolver when provided', () => {

--- a/apps/frontend/src/app/__tests__/ui/icons/offlineIcons.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/icons/offlineIcons.test.ts
@@ -9,13 +9,20 @@ const SRC_DIR = path.resolve(__dirname, '../../../../');
  * a literal `icon="prefix:name"` prop, and a bare `'prefix:name'` string held in
  * a data array and passed through as a variable. The second form is why this
  * test exists - it is invisible to a search for `icon=` alone.
+ *
+ * `icon="` has to be anchored to a preceding space. Unanchored it also matches
+ * the tail of `data-icon="..."`, which is a test hook carrying a component's own
+ * value and not an Iconify name at all - that reported `warn`, `check`, `clock`,
+ * `spinner` and even a raw `${name}` from inside a template literal as missing
+ * icons. Every real prop is JSX, so it is always preceded by whitespace; the
+ * only other `data-icon` uses live under `__tests__`, which is excluded below.
  */
 const collectUsedIconNames = (): string[] => {
   const out = execFileSync(
     'grep',
     [
       '-rhoE',
-      `(icon="[^"]+"|'(ion|mdi|solar):[a-z0-9-]+')`,
+      `([[:space:]]icon="[^"]+"|'(ion|mdi|solar):[a-z0-9-]+')`,
       SRC_DIR,
       '--include=*.tsx',
       '--include=*.ts',
@@ -28,7 +35,7 @@ const collectUsedIconNames = (): string[] => {
   );
 
   const names = new Set<string>();
-  for (const match of out.matchAll(/icon="([^"]+)"/g)) names.add(match[1]);
+  for (const match of out.matchAll(/\sicon="([^"]+)"/g)) names.add(match[1]);
   for (const match of out.matchAll(/'((?:ion|mdi|solar):[a-z0-9-]+)'/g)) names.add(match[1]);
   return [...names].sort();
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
@@ -91,19 +91,29 @@ const meta = {
   },
   tags: ['autodocs'],
   decorators: [
-    /* The frame carries the floor this row actually has: 768px. `AppointmentWorkspace`
-       calls `useIsPhone()` at `max-width: 767px` and hands anything narrower to
-       `PhoneWorkspaceShell`, so WorkspaceHeader has no phone rendering to get wrong -
-       which is why a 390px sweep read this desktop row as a broken phone layout. The
-       earlier 620px floor here was measured off a canvas where `Admit` and the
-       hospitalize circle rendered together; they are mutually exclusive in the app, so
-       620 was never a width this row had to survive. min-w states the floor without
-       capping anything (a 1280px canvas is unchanged), and the scroller keeps a
-       narrower preview from dragging the document sideways rather than pretending the
-       row fits. */
+    /* The frame carries the CONTENT width this row actually has at the 768px
+       floor, which is not 768px. `AppointmentWorkspace` calls `useIsPhone()` at
+       `max-width: 767px` and hands anything narrower to `PhoneWorkspaceShell`,
+       so 768 is the narrowest viewport this row ever renders at - but the row
+       does not get the viewport. At 768px the shell's sidebar is collapsed, not
+       hidden (`--sidebar-collapsed-width: 76px`; it only leaves the flow below
+       767px), so `main` is 692px. The page then bleeds its own 24px gutter back
+       with `sm:-mx-6 sm:px-6`, leaving the header 644px.
+
+       This frame therefore states 692px and applies the same 24px the route
+       does, reproducing 644px of content. A previous version said `min-w-[768px]
+       p-6`, which handed the row 720px - it silently dropped the sidebar, so the
+       overlap assertion could pass on 76px this layout never has. An earlier
+       620px floor was measured off a canvas where `Admit` and the hospitalize
+       circle rendered together; they are mutually exclusive in the app, so 620
+       was never a width this row had to survive either.
+
+       min-w states the floor without capping anything (a 1280px canvas is
+       unchanged), and the scroller keeps a narrower preview from dragging the
+       document sideways rather than pretending the row fits. */
     (Story) => (
       <div className="w-full overflow-x-auto">
-        <div className="min-w-[768px] p-6">
+        <div className="min-w-[692px] p-6">
           <Story />
         </div>
       </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
@@ -82,25 +82,28 @@ const meta = {
           '(`max-width: 767px`) and returns `PhoneWorkspaceShell` instead below that, so ' +
           'WorkspaceHeader never renders on a phone and a phone-width screenshot of it is ' +
           'not a bug report. Measured down to a 620px canvas, the row itself fits with room ' +
-          'to spare; what does not fit at that width is the `Admit` + hospitalize + Quick ' +
-          'Actions cluster, which is `shrink-0` by design and needs 429px on its own.',
+          'to spare. The right-hand cluster is `shrink-0` by design; its widest reachable ' +
+          'form is the visit timer, `Admit` and Quick Actions at 373px, because `canAdmit` ' +
+          'needs an INPATIENT encounter and `canHospitalize` needs anything but one - the ' +
+          'app never renders both.',
       },
     },
   },
   tags: ['autodocs'],
   decorators: [
-    /* The frame carries the floor this row actually has. `AppointmentWorkspace` calls
-       `useIsPhone()` at `max-width: 767px` and returns `PhoneWorkspaceShell` instead,
-       so WorkspaceHeader has no phone rendering to get wrong - and measured at 620,
-       660, 700 and 768px canvases it overflows at none of them. Below that the Admit
-       + hospitalize + Quick Actions cluster is `shrink-0` at 429px and simply will not
-       go, which is why a 390px sweep read this desktop row as a broken phone layout.
-       min-w states the floor without capping anything (a 1280px canvas is unchanged),
-       and the scroller keeps a narrower preview from dragging the document sideways
-       rather than pretending the row fits. */
+    /* The frame carries the floor this row actually has: 768px. `AppointmentWorkspace`
+       calls `useIsPhone()` at `max-width: 767px` and hands anything narrower to
+       `PhoneWorkspaceShell`, so WorkspaceHeader has no phone rendering to get wrong -
+       which is why a 390px sweep read this desktop row as a broken phone layout. The
+       earlier 620px floor here was measured off a canvas where `Admit` and the
+       hospitalize circle rendered together; they are mutually exclusive in the app, so
+       620 was never a width this row had to survive. min-w states the floor without
+       capping anything (a 1280px canvas is unchanged), and the scroller keeps a
+       narrower preview from dragging the document sideways rather than pretending the
+       row fits. */
     (Story) => (
       <div className="w-full overflow-x-auto">
-        <div className="min-w-[620px] p-6">
+        <div className="min-w-[768px] p-6">
           <Story />
         </div>
       </div>
@@ -279,6 +282,10 @@ export const EmergencyReadyToAdmit: Story = {
   args: {
     appointment: { ...APPOINTMENT, isEmergency: true, status: 'CHECKED_IN' },
     canAdmit: true,
+    // `canHospitalize` defaults to true on the component, so a story that only
+    // sets `canAdmit` draws both. The app cannot: `canAdmit` requires
+    // `encounterMode === 'INPATIENT'` and `canHospitalize` requires it not be.
+    canHospitalize: false,
     onAdmit: fn(),
   },
   play: async ({ canvasElement }) => {
@@ -295,9 +302,9 @@ export const EmergencyReadyToAdmit: Story = {
     docs: {
       description: {
         story:
-          'The busiest version of the row: emergency badge beside the status pill, plus the Admit ' +
-          'primary ahead of the hospitalize circle and Quick Actions. Four controls compete for ' +
-          'the right edge here, which only shows up when all of them render at once.',
+          'The busiest version of the row the app can actually produce: emergency badge beside ' +
+          'the status pill, and the Admit primary ahead of Quick Actions. The hospitalize circle ' +
+          'is off because an appointment ready to admit is already on the inpatient path.',
       },
     },
   },
@@ -308,6 +315,7 @@ export const Admitting: Story = {
   args: {
     appointment: { ...APPOINTMENT, status: 'CHECKED_IN' },
     canAdmit: true,
+    canHospitalize: false,
     isAdmitting: true,
     onAdmit: fn(),
   },
@@ -322,6 +330,63 @@ export const Admitting: Story = {
         story:
           'The Admit button relabels and disables while the admission request is in flight. It is ' +
           'a prop here, but in the app it exists only for the length of a network call.',
+      },
+    },
+  },
+};
+
+export const LongMetaLineAtTheFloor: Story = {
+  name: 'Long meta line at the 768px floor',
+  /* The tightest row the app can produce, at the narrowest viewport that renders
+     it. Before the identity column was allowed to shrink it sized itself to the
+     meta line and grew straight over the action cluster - "34.6 kg" rendered
+     underneath the visit timer, and because nothing here overflows the document
+     the page never gained a scrollbar to give it away. */
+  decorators: [
+    (Story) => (
+      <div className="w-[768px] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    metaLine: 'German Shorthaired Pointer · M, neutered · 11y 8m · 34.6 kg',
+    appointment: { ...APPOINTMENT, status: 'CHECKED_IN' },
+    canAdmit: true,
+    canHospitalize: false,
+    onAdmit: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* By accessible name, not by level: the preview injects its own sr-only
+       <h1> carrying the story title into this canvas. */
+    const firstName = canvas.getByRole('heading', { name: 'Poppy' });
+    const identityColumn = firstName.closest('div.flex-col');
+    const actionCluster = canvas.getByRole('button', { name: 'Quick Actions' }).parentElement;
+    await expect(identityColumn).not.toBeNull();
+    await expect(actionCluster).not.toBeNull();
+
+    const identityRight = (identityColumn as HTMLElement).getBoundingClientRect().right;
+    const clusterLeft = (actionCluster as HTMLElement).getBoundingClientRect().left;
+    await expect(identityRight).toBeLessThanOrEqual(clusterLeft);
+
+    // The line gave up the width rather than the name row: the meta line is
+    // clipped, while the first name and the status pill beside it are whole.
+    const metaLine = canvas.getByText(/German Shorthaired Pointer/);
+    await expect(metaLine.scrollWidth).toBeGreaterThan(metaLine.clientWidth);
+    await expect(firstName.scrollWidth).toBeLessThanOrEqual(firstName.clientWidth);
+    const statusPill = canvas.getByText('Checked in');
+    await expect(statusPill.scrollWidth).toBeLessThanOrEqual(statusPill.clientWidth);
+  },
+  parameters: {
+    chromatic: { viewports: [768] },
+    docs: {
+      description: {
+        story:
+          'A breed name long enough to matter, on the inpatient path, at 768px. The meta line ' +
+          'ellipses; the first name, the status pill and the action cluster all keep their full ' +
+          'width. Breed, sex, age and weight repeat in the companion panel, so the meta line is ' +
+          'the right thing to spend when the row runs out of room.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
@@ -337,14 +337,22 @@ export const Admitting: Story = {
 
 export const LongMetaLineAtTheFloor: Story = {
   name: 'Long meta line at the 768px floor',
-  /* The tightest row the app can produce, at the narrowest viewport that renders
-     it. Before the identity column was allowed to shrink it sized itself to the
+  /* The tightest row the app can produce, in the width it actually gets.
+     768px is the narrowest viewport that renders this header at all, but the
+     header never sees 768: `SessionInitializer` lays the collapsed sidebar rail
+     out as a flex sibling at 76px (`--sidebar-collapsed-width`, and the rail is
+     `display: none` only below 767px), and the workspace route adds `sm:px-6`,
+     so the content column is 768 - 76 - 48 = 644. Framing this at 720 was
+     testing a box 76px wider than production - wide enough for the guard to
+     pass while the real header still overlapped.
+
+     Before the identity column was allowed to shrink it sized itself to the
      meta line and grew straight over the action cluster - "34.6 kg" rendered
      underneath the visit timer, and because nothing here overflows the document
      the page never gained a scrollbar to give it away. */
   decorators: [
     (Story) => (
-      <div className="w-[768px] p-6">
+      <div className="w-[644px]">
         <Story />
       </div>
     ),

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.tsx
@@ -118,7 +118,27 @@ const WorkspaceHeader = ({
           height={44}
           className="size-11 shrink-0 rounded-full object-cover"
         />
-        <div className="flex min-w-0 shrink-0 flex-col gap-0.5">
+        {/* `shrink-0` here sized this column to its widest line, which is the
+            meta line, so the `truncate` below could never fire and the column
+            simply grew over the action cluster instead - measured at 768px with
+            a realistic breed, "34.6 kg" rendered underneath the visit timer. It
+            never scrolled the page, so nothing gave the collision away.
+
+            The column now yields and the meta line spends whatever is left
+            before ellipsing. Breed, sex, age and weight all repeat in the
+            companion panel, so that line is the right thing to spend.
+
+            The name row is not pinned by a `min-width`: pinning it needs the
+            meta line to contribute nothing to intrinsic sizing, and the trick
+            that does that (`w-0 min-w-full`) zeroes the max-content
+            contribution too, so the column stops growing and the line stays
+            clipped at 168px even on a 1512px screen. Measured instead: this
+            header only renders at 768px and up (`useIsPhone` hands anything
+            narrower to `PhoneWorkspaceShell`), and the tightest reachable
+            state - inpatient, ready to admit, a 373px action cluster - still
+            leaves the column 219px against a 168px name row. The story below
+            pins that margin so a longer label cannot spend it silently. */}
+        <div className="flex min-w-0 flex-col gap-0.5">
           <div className="flex items-center gap-2">
             <h1
               className="shrink-0 font-satoshi text-[17px] font-bold leading-[120%] tracking-[-0.02em]"

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.stories.tsx
@@ -685,13 +685,23 @@ export const ViewOnly: Story = {
       canvas.queryByRole('searchbox', { name: 'Search medicines or prescription templates' })
     ).not.toBeInTheDocument();
 
-    /* The services search is NOT removed. It is deliberately always-on so that
-       billed rows never block adding new work, but the same branch leaves it
-       usable on a view-only encounter. Asserted as it behaves today, not as it
-       arguably should. */
+    /* The services search is removed too, on the same rule as the prescription
+       search above: a view-only encounter must not offer to add billable work.
+
+       This is the half that used to be left on. The note here previously said
+       the services search was "deliberately always-on so that billed rows never
+       block adding new work" and asserted it "as it behaves today, not as it
+       arguably should" - and that gap was the defect, not the design. A
+       discharged encounter is a closed legal record; offering a way to add
+       services to it is exactly what `markDischarged` sets `viewOnly` to
+       prevent, and the store now refuses those writes outright rather than
+       trusting this gate.
+
+       Queried for absence, not for a disabled input: a disabled-input assertion
+       would find nothing and pass for the wrong reason. */
     await expect(
-      canvas.getByRole('searchbox', { name: 'Search for services and packages' })
-    ).toBeInTheDocument();
+      canvas.queryByRole('searchbox', { name: 'Search for services and packages' })
+    ).not.toBeInTheDocument();
 
     // Printing an existing label is a read action and stays available.
     await expect(canvas.getAllByRole('button', { name: 'Print Labels' })[1]).toBeEnabled();
@@ -700,9 +710,9 @@ export const ViewOnly: Story = {
     docs: {
       description: {
         story:
-          'A locked encounter. Save is disabled, both editors lose their delete controls, and the ' +
-          'prescription search is taken off the page entirely. The services search stays - see ' +
-          'the note in the play function.',
+          'A locked encounter. Save is disabled, both editors lose their delete controls, and ' +
+          'both searches are taken off the page entirely - there is no way to add billable work ' +
+          'to a record that is closed.',
       },
     },
   },

--- a/apps/frontend/src/app/features/chat/components/ShareEntityModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ShareEntityModal.stories.tsx
@@ -43,12 +43,28 @@ const APPOINTMENTS: Record<string, Appointment> = {
 };
 
 /**
+ * The organisation the seeded records belong to. The picker reads the per-org index,
+ * not the flat by-id maps, so a story with no active org can only ever render the
+ * empty state - which is exactly what every story in this file used to do.
+ */
+const SHARE_ORG_ID = 'org-sb';
+
+/**
  * Seeds the two stores the picker reads, and the timezone the appointment subtitle is
  * formatted in.
  *
- * No loader is involved: `ShareEntityModal` subscribes to `companionsById` and
- * `appointmentsById` directly and never fetches, so seeding the real stores is the whole
- * fixture - the component under review is the real one and the mount touches no network.
+ * No loader is involved: `ShareEntityModal` subscribes to the stores directly and never
+ * fetches, so seeding the real stores is the whole fixture - the component under review
+ * is the real one and the mount touches no network.
+ *
+ * It has to seed BOTH halves. The by-id maps hold every record the tab has loaded across
+ * organisations; `companionsIdsByOrgId` / `appointmentIdsByOrgId` say which of them the
+ * active org owns, and the picker offers only the second so it cannot leak another
+ * tenant's records. Seeding just the by-id maps - which is what this fixture did, from
+ * before that tenancy fix landed - renders "Nothing to share here yet" in every story.
+ * Nobody noticed because the component was also crashing on an unstable store snapshot,
+ * so no play function in this file ever got far enough to assert a row.
+ *
  * `formatDateInPreferredTimeZone` reads a localStorage token and falls back to
  * Europe/Berlin, so the token is cleared for the story and restored afterwards; 09:15Z is
  * 10:15 in Berlin on 26 March 2026.
@@ -60,7 +76,9 @@ const seedStores =
   ) =>
   () => {
     const previousCompanions = useCompanionStore.getState().companionsById;
+    const previousCompanionIndex = useCompanionStore.getState().companionsIdsByOrgId;
     const previousAppointments = useAppointmentStore.getState().appointmentsById;
+    const previousAppointmentIndex = useAppointmentStore.getState().appointmentIdsByOrgId;
     const tzKey = 'yc_preferred_timezone';
     const previousTz = window.localStorage.getItem(tzKey);
     window.localStorage.removeItem(tzKey);
@@ -84,14 +102,30 @@ const seedStores =
     const termKey = 'yc_companion_terminology_pending';
     const previousTerm = window.localStorage.getItem(termKey);
     window.localStorage.removeItem(termKey);
-    useOrgStore.setState({ primaryOrgId: null, orgIds: [], orgsById: {} });
+    // An org id is required for the picker to offer anything, but `orgsById` stays empty
+    // so `getCompanionTerminologyForOrg` still falls through to the org-type default and
+    // the tab keeps reading "Companions". The hospital story overrides both from its own
+    // beforeEach, which runs after this.
+    useOrgStore.setState({ primaryOrgId: SHARE_ORG_ID, orgIds: [], orgsById: {} });
 
-    useCompanionStore.setState({ companionsById: companions });
-    useAppointmentStore.setState({ appointmentsById: appointments });
+    useCompanionStore.setState({
+      companionsById: companions,
+      companionsIdsByOrgId: { [SHARE_ORG_ID]: Object.keys(companions) },
+    });
+    useAppointmentStore.setState({
+      appointmentsById: appointments,
+      appointmentIdsByOrgId: { [SHARE_ORG_ID]: Object.keys(appointments) },
+    });
 
     return () => {
-      useCompanionStore.setState({ companionsById: previousCompanions });
-      useAppointmentStore.setState({ appointmentsById: previousAppointments });
+      useCompanionStore.setState({
+        companionsById: previousCompanions,
+        companionsIdsByOrgId: previousCompanionIndex,
+      });
+      useAppointmentStore.setState({
+        appointmentsById: previousAppointments,
+        appointmentIdsByOrgId: previousAppointmentIndex,
+      });
       useOrgStore.setState(previousOrg);
       if (previousTerm !== null) window.localStorage.setItem(termKey, previousTerm);
       if (previousTz !== null) window.localStorage.setItem(tzKey, previousTz);
@@ -458,6 +492,18 @@ export const HospitalTerminology: Story = {
   name: 'Tab label at a hospital org',
   beforeEach: () => {
     const previous = useOrgStore.getState();
+    // The seeded records have to follow the org across. The picker offers only what the
+    // ACTIVE org's index lists, so switching `primaryOrgId` without re-pointing the
+    // index empties the list and this story would assert a tab label over a picker with
+    // nothing in it - true, but for the wrong reason.
+    const previousCompanionIndex = useCompanionStore.getState().companionsIdsByOrgId;
+    const previousAppointmentIndex = useAppointmentStore.getState().appointmentIdsByOrgId;
+    useCompanionStore.setState({
+      companionsIdsByOrgId: { 'org-sb-share-hospital': Object.keys(COMPANIONS) },
+    });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: { 'org-sb-share-hospital': Object.keys(APPOINTMENTS) },
+    });
     useOrgStore.setState({
       primaryOrgId: 'org-sb-share-hospital',
       orgIds: ['org-sb-share-hospital'],
@@ -470,6 +516,8 @@ export const HospitalTerminology: Story = {
       },
     });
     return () => {
+      useCompanionStore.setState({ companionsIdsByOrgId: previousCompanionIndex });
+      useAppointmentStore.setState({ appointmentIdsByOrgId: previousAppointmentIndex });
       useOrgStore.setState({
         primaryOrgId: previous.primaryOrgId,
         orgIds: previous.orgIds,

--- a/apps/frontend/src/app/features/chat/components/ShareEntityModal.tsx
+++ b/apps/frontend/src/app/features/chat/components/ShareEntityModal.tsx
@@ -36,6 +36,16 @@ type PickItem = {
 
 const MAX_ITEMS = 50;
 
+/**
+ * Zustand runs a selector as a `useSyncExternalStore` snapshot and compares
+ * results with `Object.is`, so a selector that builds its own `[]` fallback
+ * hands React a new identity on every render and spins the "getSnapshot should
+ * be cached" loop until it throws. The org indexes below are sparse - they only
+ * gain a row once that org's list has loaded - so the fallback is the common
+ * path, not the rare one. One frozen array, shared by every miss.
+ */
+const NO_IDS: readonly string[] = Object.freeze([]);
+
 export function ShareEntityModal({
   channelId,
   onClose,
@@ -48,10 +58,10 @@ export function ShareEntityModal({
   // stores keep an org index; the picker uses it.
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const companionIdsForOrg = useCompanionStore((s) =>
-    primaryOrgId ? (s.companionsIdsByOrgId[primaryOrgId] ?? []) : []
+    primaryOrgId ? (s.companionsIdsByOrgId[primaryOrgId] ?? NO_IDS) : NO_IDS
   );
   const appointmentIdsForOrg = useAppointmentStore((s) =>
-    primaryOrgId ? (s.appointmentIdsByOrgId[primaryOrgId] ?? []) : []
+    primaryOrgId ? (s.appointmentIdsByOrgId[primaryOrgId] ?? NO_IDS) : NO_IDS
   );
   const [tab, setTab] = useState<'COMPANION' | 'APPOINTMENT'>('COMPANION');
   const [query, setQuery] = useState('');

--- a/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.stories.tsx
+++ b/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.stories.tsx
@@ -1,0 +1,480 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
+
+import api from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import DocSigningPortal from './DocSigningPortal';
+
+const ORG_ID = 'org-storybook-docsigning';
+const REDIRECT_ENDPOINT = `/v1/documenso/pms/redirect/${ORG_ID}`;
+
+/**
+ * The origin the iframe branch is gated on.
+ *
+ * `getSafeDocumensoIframeUrl` compares the resolved URL's origin against
+ * `NEXT_PUBLIC_DOCUMENSO_HOST` (defaulting to `https://ds.yosemitecrew.com`) and
+ * returns `''` on any mismatch - so with no `.env` reaching the preview, the
+ * iframe branch is only reachable if the fixture URL sits on the shipped host.
+ * Rather than depend on what the shell happened to export, the stories pin the
+ * variable themselves and point it at a `.invalid` host: the TLD is reserved and
+ * never resolves, so the frame lays out its box without a request leaving for
+ * the real production portal. `SessionInitializer` and `GithubSignInButton` pin
+ * `NEXT_PUBLIC_*` the same way - the vite framework installs a writable
+ * `process.env` shim rather than inlining these at build time.
+ *
+ * What this costs: these stories no longer prove the DEFAULT allowlist entry is
+ * `ds.yosemitecrew.com`, only that the check is against the configured origin.
+ * `UntrustedOrigin` below is what pins the check itself.
+ */
+const PORTAL_ORIGIN = 'https://documenso.storybook.invalid';
+
+/**
+ * Deliberately doubled slashes. The helper collapses `//` runs in the path
+ * before handing the URL to the iframe, and the shipped backend has been seen
+ * returning exactly this shape - so the normalisation is the assertion, not
+ * decoration.
+ */
+const RAW_REDIRECT_URL = `${PORTAL_ORIGIN}//portal//home`;
+const NORMALISED_REDIRECT_URL = `${PORTAL_ORIGIN}/portal/home`;
+
+/** Verbatim from the component, which hardcodes the whole token list. */
+const SANDBOX =
+  'allow-downloads allow-forms allow-modals allow-popups allow-scripts allow-same-origin';
+
+type CapturedRequest = { method: string; url: string; orgHeader: unknown };
+
+/**
+ * Module-level because a play function has no other handle on it - the adapter
+ * is installed in `beforeEach`, long before the story body runs. Every fixture
+ * clears it on install, so a story only ever reads its own calls.
+ */
+const requests: CapturedRequest[] = [];
+
+/**
+ * The distinct call shapes the mount produced.
+ *
+ * Deduplicated rather than counted: how many times an effect fires is a React
+ * and preview-configuration detail that no story should be pinned to, while WHAT
+ * it asked for - endpoint, method, and the org header the axios request
+ * interceptor attaches from the store - is the contract worth failing over.
+ */
+const requestSignatures = () => [
+  ...new Set(requests.map((r) => `${r.method} ${r.url} x-org-id=${String(r.orgHeader)}`)),
+];
+
+const EXPECTED_SIGNATURE = `post ${REDIRECT_ENDPOINT} x-org-id=${ORG_ID}`;
+
+/**
+ * Seeds the one field the component reads.
+ *
+ * `DocSigningPortal` selects `primaryOrgId` and nothing else, and its effect
+ * returns early while that is null - so without a seed the component never
+ * fetches and every story would settle in the empty state. `orgsById` and the
+ * memberships the organisation stories seed are not needed here; there is no
+ * permission gate on this surface.
+ *
+ * The previous state is captured and put back rather than reset to defaults:
+ * `orgStore` persists `primaryOrgId` to localStorage, so a story that left its
+ * fake org id behind would follow the session into unrelated stories.
+ */
+const seedOrg = () => {
+  const previous = useOrgStore.getState();
+
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+
+  return () => {
+    useOrgStore.setState({ primaryOrgId: previous.primaryOrgId, status: previous.status });
+  };
+};
+
+type PortalFixture =
+  /** Held open on purpose: the only way to hold the loading frame still. */
+  | { kind: 'pending' }
+  | { kind: 'resolves'; redirectUrl: string }
+  | { kind: 'rejects'; message: string };
+
+/**
+ * `fetchDocumensoRedirectUrl` is a plain ESM export over `postData`, and an ESM
+ * module namespace is frozen - assigning onto the imported service does nothing
+ * here. The shared axios instance's adapter is the seam that works: `postData`
+ * calls `api.post`, so the adapter sees the request, and swapping it wins over
+ * the preview's offline guard by construction (axios never reaches XHR at all).
+ *
+ * The 403 in the reject branch is chosen, not incidental. A 401 sends the
+ * response interceptor into SuperTokens and a real sign-out redirect; 5xx and
+ * 429 are on the transient-retry list. 403 lands straight in the component's
+ * own catch, which is the branch under review.
+ */
+const withRedirectEndpoint = (fixture: PortalFixture) => () => {
+  const originalAdapter = api.defaults.adapter;
+  const previousHost = process.env.NEXT_PUBLIC_DOCUMENSO_HOST;
+  process.env.NEXT_PUBLIC_DOCUMENSO_HOST = PORTAL_ORIGIN;
+  requests.length = 0;
+
+  api.defaults.adapter = (async (config: InternalAxiosRequestConfig) => {
+    requests.push({
+      method: (config.method ?? 'get').toLowerCase(),
+      url: config.url ?? '',
+      orgHeader: config.headers?.['x-org-id'],
+    });
+
+    if (fixture.kind === 'pending') {
+      // Never settles. A custom adapter is upstream of axios' own timeout, which
+      // lives in the XHR adapter, so nothing tears this down after 60s.
+      return new Promise<never>(() => {});
+    }
+
+    if (fixture.kind === 'rejects') {
+      throw Object.assign(new Error('Request failed with status code 403'), {
+        isAxiosError: true,
+        config,
+        response: {
+          data: { message: fixture.message },
+          status: 403,
+          statusText: 'Forbidden',
+          headers: {},
+          config,
+        },
+      });
+    }
+
+    return {
+      data: { redirectUrl: fixture.redirectUrl },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    };
+  }) as AxiosAdapter;
+
+  return () => {
+    api.defaults.adapter = originalAdapter;
+    if (previousHost === undefined) {
+      delete process.env.NEXT_PUBLIC_DOCUMENSO_HOST;
+    } else {
+      process.env.NEXT_PUBLIC_DOCUMENSO_HOST = previousHost;
+    }
+  };
+};
+
+/**
+ * A refused fetch is logged twice on its way to the error branch - once by
+ * `postData` through `logger.error`, once by the component itself - and
+ * `storyqa-verify` treats any console error as a broken story. Only those two
+ * lines are dropped; anything else still reaches the console.
+ */
+const EXPECTED_FAILURE_LOGS = ['API postData error:', 'Failed to fetch Documenso portal URL'];
+
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some(
+        (arg) => typeof arg === 'string' && EXPECTED_FAILURE_LOGS.some((line) => arg.includes(line))
+      );
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+/**
+ * The two setup steps every story needs, in order.
+ *
+ * Listed per story rather than seeding the org from the meta so nothing here
+ * depends on how Storybook merges a component-level `beforeEach` with a
+ * story-level one. If that composition ever changed, an unseeded store would
+ * park all six stories in the empty state; spelled out per story, it cannot.
+ */
+const withPortal = (fixture: PortalFixture) => [seedOrg, withRedirectEndpoint(fixture)];
+
+/** The iframe's own box, and the sized container the component wraps it in. */
+const portalFrames = async (canvas: ReturnType<typeof within>) => {
+  const iframe = await canvas.findByTitle('Doc Signing Portal');
+  return { iframe, container: iframe.parentElement as HTMLElement };
+};
+
+const meta = {
+  title: 'DocSigning/DocSigningPortal',
+  component: DocSigningPortal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The whole Doc Signing surface. It is four mutually exclusive branches over one ' +
+          'request, and three of them are real chrome a user can land on:\n\n' +
+          '- **loading** - a centred `YosemiteLoader` labelled "Loading Doc Signing";\n' +
+          '- **error** - a `role="alert"` line carrying whatever the backend said;\n' +
+          '- **no portal URL** - an `h1` and "Portal link not available", which is also where a ' +
+          'rejected origin lands;\n' +
+          '- **the portal** - a sandboxed iframe in a container sized by the `embedded` prop.\n\n' +
+          'The branch is decided by `POST /v1/documenso/pms/redirect/:orgId` plus ' +
+          '`getSafeDocumensoIframeUrl`, so each story pins the transport rather than the ' +
+          'component. Worth naming what is NOT reviewable here: the portal itself is a ' +
+          'third-party Documenso page on another origin, so the frame stays blank and only its ' +
+          'geometry, its sandbox and the standalone/embedded difference can be read.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DocSigningPortal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  name: 'Loading the portal',
+  beforeEach: withPortal({ kind: 'pending' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // `<output>` maps to role `status`, and `label` becomes the accessible name -
+    // so the loader announces what it is loading rather than a bare "Loading".
+    const loader = await canvas.findByRole('status', { name: 'Loading Doc Signing' });
+    await expect(canvas.getByText('Loading Doc Signing')).toBeVisible();
+
+    // The request really is in flight, scoped to the seeded org. If the effect
+    // stopped passing the store's id through, the loader would still spin.
+    await waitFor(() => {
+      expect(requestSignatures()).toEqual([EXPECTED_SIGNATURE]);
+    });
+
+    // Nothing else is on screen: the four branches are exclusive.
+    await expect(canvasElement.querySelector('iframe')).toBeNull();
+    await expect(canvas.queryByRole('alert')).toBeNull();
+    /* By NAME, not by level. The preview injects its own sr-only <h1>
+       carrying "<title> - <story name>" into this canvas, so a bare
+       level-1 query matches the harness and can never be null. */
+    await expect(canvas.queryByRole('heading', { name: 'Document Signing Portal' })).toBeNull();
+
+    /* Centred, asserted as a relation rather than against a pixel figure: the
+       loader is `inline-flex`, so it is narrower than the frame it sits in and a
+       dropped `justify-center` would park it on the left edge. Both axes are
+       checked because `items-center` and `justify-center` are separate classes
+       and either can be lost on its own. */
+    const frame = loader.parentElement as HTMLElement;
+    const loaderBox = loader.getBoundingClientRect();
+    const frameBox = frame.getBoundingClientRect();
+    await expect(loaderBox.width).toBeLessThan(frameBox.width);
+    await expect(loaderBox.height).toBeLessThan(frameBox.height);
+    await expect(
+      Math.abs((loaderBox.left + loaderBox.right) / 2 - (frameBox.left + frameBox.right) / 2)
+    ).toBeLessThan(2);
+    await expect(
+      Math.abs((loaderBox.top + loaderBox.bottom) / 2 - (frameBox.top + frameBox.bottom) / 2)
+    ).toBeLessThan(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The redirect call held open so the frame stands still. In the running app this is ' +
+          'the first thing every visit to Doc Signing shows, and it is the only branch with a ' +
+          'floor under it - `min-h-[60vh]` - so the spinner sits in the middle of the page ' +
+          'rather than jammed under the header.',
+      },
+    },
+  },
+};
+
+export const RequestFailed: Story = {
+  name: 'Error from the backend',
+  beforeEach: [
+    ...withPortal({ kind: 'rejects', message: 'Doc portal disabled for this practice' }),
+    muteExpectedFailureLogs,
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const alert = await canvas.findByRole('alert');
+
+    /* The precedence is the point. The component reads
+       `e.response.data.message` first, then `e.message`, then a generic
+       fallback - so a regression that dropped the first rung would print
+       "Request failed with status code 403" at a clinic, and one that dropped
+       both would print the generic line. All three are pinned here. */
+    await expect(alert).toHaveTextContent('Doc portal disabled for this practice');
+    await expect(alert).not.toHaveTextContent('Request failed with status code 403');
+    await expect(alert).not.toHaveTextContent('Unable to load Doc Signing portal');
+
+    // The failure replaces the loader outright - it does not sit alongside it.
+    await expect(canvas.queryByRole('status')).toBeNull();
+    await expect(canvasElement.querySelector('iframe')).toBeNull();
+    /* By NAME, not by level. The preview injects its own sr-only <h1>
+       carrying "<title> - <story name>" into this canvas, so a bare
+       level-1 query matches the harness and can never be null. */
+    await expect(canvas.queryByRole('heading', { name: 'Document Signing Portal' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 403 from the redirect endpoint. This is the branch a practice without Documenso ' +
+          'provisioned actually sees, and the copy is entirely the backend’s - the component ' +
+          'passes the message straight through, so anything the API says lands verbatim in ' +
+          'front of a user.',
+      },
+    },
+  },
+};
+
+export const NoPortalUrl: Story = {
+  name: 'Empty portal link',
+  beforeEach: withPortal({ kind: 'resolves', redirectUrl: '' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: 'Document Signing Portal' })
+    ).toBeVisible();
+    await expect(canvas.getByText('Portal link not available')).toBeVisible();
+
+    /* A blank link is a successful 200, so this must NOT be dressed as a
+       failure. If the empty case were ever folded into the error branch, the
+       alert would appear and this would fail. */
+    await expect(canvas.queryByRole('alert')).toBeNull();
+    await expect(canvasElement.querySelector('iframe')).toBeNull();
+    await expect(canvas.queryByRole('status')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The endpoint answered, with nothing in it. The empty state is the only branch that ' +
+          'carries a heading, and it is deliberately quiet - no alert colour, no retry - ' +
+          'because from the caller’s side the request succeeded.',
+      },
+    },
+  },
+};
+
+export const UntrustedOrigin: Story = {
+  name: 'Redirect to a foreign origin',
+  beforeEach: withPortal({
+    kind: 'resolves',
+    redirectUrl: 'https://evil.example.com/portal/home',
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Portal link not available')).toBeVisible();
+
+    /* The security control, and the reason this state is worth its own story
+       rather than collapsing into the empty one: a URL off the configured
+       Documenso origin must not reach an iframe with `allow-scripts` and
+       `allow-same-origin` on it. Asserting the host is absent from the markup
+       catches the frame being mounted hidden as well as visibly. */
+    await expect(canvasElement.querySelector('iframe')).toBeNull();
+    await expect(canvasElement.innerHTML).not.toContain('evil.example.com');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A well-formed HTTPS link that simply is not the Documenso host. It is rejected before ' +
+          'it can be framed, and falls through to the same empty state as a blank link - which ' +
+          'is the intended outcome, if an opaque one: a reviewer cannot tell this apart from ' +
+          '`NoPortalUrl` on screen, only in the network panel.',
+      },
+    },
+  },
+};
+
+export const Standalone: Story = {
+  name: 'Portal on its own route',
+  beforeEach: withPortal({ kind: 'resolves', redirectUrl: RAW_REDIRECT_URL }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const { iframe, container } = await portalFrames(canvas);
+
+    /* The doubled slashes the fixture sent are gone. This is the one behaviour
+       of the URL helper visible from the DOM, and it survives round-tripping
+       through `new URL(...)`, so a dropped `replaceAll` would show up here. */
+    await expect(iframe).toHaveAttribute('src', NORMALISED_REDIRECT_URL);
+
+    /* The sandbox is pinned token for token. Every entry is load-bearing for a
+       third-party signing page, and an added one - `allow-top-navigation`, say -
+       would let that page move the practice off its own app. */
+    await expect(iframe).toHaveAttribute('sandbox', SANDBOX);
+    await expect(iframe).toHaveAttribute('referrerpolicy', 'strict-origin');
+    await expect(iframe).toHaveAttribute('allow', 'clipboard-read; clipboard-write; fullscreen');
+
+    await expect(requestSignatures()).toEqual([EXPECTED_SIGNATURE]);
+
+    /* `h-[calc(100vh-140px)]`, asserted as the relation it encodes - the viewport
+       less the app chrome above it - so a type-scale or padding change moves the
+       number without failing the story, while a lost height class does fail it. */
+    const box = container.getBoundingClientRect();
+    await expect(Math.abs(box.height - (globalThis.innerHeight - 140))).toBeLessThan(2);
+
+    // `pb-3` on the container is what keeps the frame off the bottom edge.
+    const frameBox = iframe.getBoundingClientRect();
+    await expect(frameBox.bottom).toBeLessThan(box.bottom);
+    await expect(Math.abs(frameBox.width - box.width)).toBeLessThan(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default, as `/doc-signing` renders it: the frame claims the viewport minus the ' +
+          '140px the app chrome takes, so the signing page gets the whole screen. The frame is ' +
+          'blank on purpose - it points at a host that does not resolve, so the story reviews ' +
+          'the container and the sandbox without a request leaving for the real portal.',
+      },
+    },
+  },
+};
+
+export const Embedded: Story = {
+  name: 'Portal embedded in a card',
+  args: { embedded: true },
+  beforeEach: withPortal({ kind: 'resolves', redirectUrl: RAW_REDIRECT_URL }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const { iframe, container } = await portalFrames(canvas);
+
+    await expect(iframe).toHaveAttribute('src', NORMALISED_REDIRECT_URL);
+    await expect(iframe).toHaveAttribute('sandbox', SANDBOX);
+
+    /* `h-[75vh] min-h-[560px]` - three quarters of the viewport, with a floor.
+       Written as the max of the two so the assertion holds at any panel height
+       rather than only the one this happened to run at, and so it fails if
+       EITHER rule is dropped on a viewport where that rule is the binding one.
+       Above roughly 747px of viewport the 75% is what binds, which is the usual
+       case, so the floor is separately asserted below. */
+    const expected = Math.max(560, globalThis.innerHeight * 0.75);
+    const box = container.getBoundingClientRect();
+    await expect(Math.abs(box.height - expected)).toBeLessThan(2);
+    await expect(box.height).toBeGreaterThanOrEqual(560);
+
+    /* And it is NOT the standalone sizing. The two expressions coincide at a
+       700px viewport, so the comparison is only meaningful when they differ -
+       hence the guard rather than a bare inequality that would flake. */
+    const standalone = globalThis.innerHeight - 140;
+    if (Math.abs(standalone - expected) > 4) {
+      await expect(Math.abs(box.height - standalone)).toBeGreaterThan(2);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same portal as mounted by the organisation page’s e-signing card, where it has ' +
+          'to share the screen with the settings above it. `embedded` changes nothing but the ' +
+          'container: 75% of the viewport with a 560px floor, so the frame stays usable on a ' +
+          'short laptop screen instead of collapsing to a letterbox.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.stories.tsx
+++ b/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.stories.tsx
@@ -233,6 +233,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * The line under the frame. It exists because this page cannot see inside the
+ * portal: if the provider fails to sign the reader in, the frame shows a login
+ * form and the app has no way to know, so nothing here would otherwise say
+ * anything went wrong. Matched on a fragment rather than the whole sentence so
+ * a wording change does not fail these.
+ */
+const signInHint = (canvas: ReturnType<typeof within>) =>
+  canvas.queryByText(/could not sign you in automatically/i);
+
 export const Loading: Story = {
   name: 'Loading the portal',
   beforeEach: withPortal({ kind: 'pending' }),
@@ -257,6 +267,10 @@ export const Loading: Story = {
        carrying "<title> - <story name>" into this canvas, so a bare
        level-1 query matches the harness and can never be null. */
     await expect(canvas.queryByRole('heading', { name: 'Document Signing Portal' })).toBeNull();
+    // The hint belongs to the frame, not to every branch: printing it beside a
+    // loader or an error would tell the reader to contact support about a
+    // failure the app has already named on screen.
+    await expect(signInHint(canvas)).toBeNull();
 
     /* Centred, asserted as a relation rather than against a pixel figure: the
        loader is `inline-flex`, so it is narrower than the frame it sits in and a
@@ -315,6 +329,10 @@ export const RequestFailed: Story = {
        carrying "<title> - <story name>" into this canvas, so a bare
        level-1 query matches the harness and can never be null. */
     await expect(canvas.queryByRole('heading', { name: 'Document Signing Portal' })).toBeNull();
+    // The hint belongs to the frame, not to every branch: printing it beside a
+    // loader or an error would tell the reader to contact support about a
+    // failure the app has already named on screen.
+    await expect(signInHint(canvas)).toBeNull();
   },
   parameters: {
     docs: {
@@ -377,6 +395,8 @@ export const UntrustedOrigin: Story = {
        catches the frame being mounted hidden as well as visibly. */
     await expect(canvasElement.querySelector('iframe')).toBeNull();
     await expect(canvasElement.innerHTML).not.toContain('evil.example.com');
+    // No frame, so no hint either - this branch already tells the reader.
+    await expect(signInHint(canvas)).toBeNull();
   },
   parameters: {
     docs: {
@@ -422,6 +442,15 @@ export const Standalone: Story = {
     const frameBox = iframe.getBoundingClientRect();
     await expect(frameBox.bottom).toBeLessThan(box.bottom);
     await expect(Math.abs(frameBox.width - box.width)).toBeLessThan(2);
+
+    /* And the hint sits BELOW the frame rather than inside it. Inside, it would
+       be clipped by the container's `overflow-hidden` and scroll away with the
+       portal - visible in review, invisible in use. */
+    const hint = signInHint(within(canvasElement));
+    await expect(hint).not.toBeNull();
+    await expect((hint as HTMLElement).getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      Math.floor(frameBox.bottom)
+    );
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.tsx
+++ b/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.tsx
@@ -67,24 +67,39 @@ const DocSigningPortal = ({ embedded = false }: DocSigningPortalProps) => {
   }
 
   return (
-    <div
-      className={`w-full overflow-hidden pb-3 ${
-        embedded ? 'h-[75vh] min-h-[560px]' : 'h-[calc(100vh-140px)]'
-      }`}
-    >
-      {/* The third-party Documenso portal requires allow-same-origin to function, and
-          being cross-origin it cannot reach back into this site. Removing it breaks
-          signing, so this is a deliberate exception rather than a missing control. */}
-      {/* react-doctor-disable-next-line react-doctor/iframe-missing-sandbox */}
-      <iframe
-        src={portalUrl}
-        className="size-full"
-        title="Doc Signing Portal"
-        allow="clipboard-read; clipboard-write; fullscreen"
-        sandbox="allow-downloads allow-forms allow-modals allow-popups allow-scripts allow-same-origin"
-        referrerPolicy="strict-origin"
-      />
-    </div>
+    <>
+      <div
+        className={`w-full overflow-hidden pb-3 ${
+          embedded ? 'h-[75vh] min-h-[560px]' : 'h-[calc(100vh-140px)]'
+        }`}
+      >
+        {/* The third-party Documenso portal requires allow-same-origin to function, and
+            being cross-origin it cannot reach back into this site. Removing it breaks
+            signing, so this is a deliberate exception rather than a missing control. */}
+        {/* react-doctor-disable-next-line react-doctor/iframe-missing-sandbox */}
+        <iframe
+          src={portalUrl}
+          className="size-full"
+          title="Doc Signing Portal"
+          allow="clipboard-read; clipboard-write; fullscreen"
+          sandbox="allow-downloads allow-forms allow-modals allow-popups allow-scripts allow-same-origin"
+          referrerPolicy="strict-origin"
+        />
+      </div>
+      {/* Everything above this line succeeded: a portal URL was issued and the
+          frame loaded it. What happens INSIDE the frame is another origin's
+          business, and this page cannot read it - so when the sign-on does not
+          take, the reader is left looking at a stranger's login form with the
+          app showing no error at all, because from the app's side nothing went
+          wrong. That is the state this line is for. It deliberately does not
+          name a cause: the frame is opaque here, and guessing at one in the UI
+          would be worse than saying plainly that it did not work. */}
+      <p className="text-body-4 text-text-secondary">
+        Signing is handled by our document signing provider. If you see a sign-in form instead of
+        your documents, it could not sign you in automatically - contact support rather than
+        creating an account here.
+      </p>
+    </>
   );
 };
 

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
@@ -87,16 +87,16 @@ export const ManyTabs: Story = {
     activeKey: 'consent',
   },
   decorators: [
-    /* 340px is under the 430px this strip needs, which is the whole point - and the
-       frame scrolls so the demonstration stays inside the story instead of dragging
-       the preview document 56px wide, which is what a phone-width sweep saw and read
-       as a layout bug in a component no call site pushes this far.
+    /* 340px is under what these four segments need, which is the whole point.
+       The frame is a plain box with no scroller of its own: the strip has to be
+       the thing that scrolls, and if it ever stops being that, this story shows
+       the document being dragged sideways instead of hiding it.
 
        A container, not the mobile viewport global: that global is applied by the
        manager to the preview iframe and is inert for a runner loading iframe.html
        directly, and nothing here branches on a media query anyway. */
     (Story) => (
-      <div data-frame="" style={{ width: 340, overflowX: 'auto' }}>
+      <div data-frame="" style={{ width: 340 }}>
         <Story />
       </div>
     ),
@@ -104,35 +104,53 @@ export const ManyTabs: Story = {
   play: async ({ canvasElement }) => {
     const frame = canvasElement.querySelector('[data-frame]') as HTMLElement;
     const strip = within(canvasElement).getByRole('tablist');
-    const widths = [...strip.children].map((tab) => tab.getBoundingClientRect().width);
+    const tabs = [...strip.children] as HTMLElement[];
 
-    /* The floor is real: the four segments together need more than the box, and no
-       label has wrapped to buy that back. Asserted as a relation rather than against
-       430px, so a font or padding change moves the number without failing here. */
+    /* The floor is real: the four segments together need more than the box.
+       Asserted as a relation rather than against a pixel count, so a font or
+       padding change moves the number without failing here. */
     await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth);
-    await expect(widths.reduce((sum, width) => sum + width, 0)).toBeGreaterThan(
-      frame.getBoundingClientRect().width
+    await expect(
+      tabs.reduce((sum, tab) => sum + tab.getBoundingClientRect().width, 0)
+    ).toBeGreaterThan(frame.getBoundingClientRect().width);
+
+    /* What the overflow costs, and what it does not. The strip absorbs it: the
+       frame is exactly as wide as it was asked to be and the document never
+       gains a horizontal scroll, which is the failure this component used to
+       hand its container - a side modal has nothing to absorb a sideways shove.
+       A tab clipped at the right edge is what tells the reader there is more. */
+    await expect(Math.round(frame.getBoundingClientRect().width)).toBe(340);
+    await expect(globalThis.document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      globalThis.document.documentElement.clientWidth
     );
+    const last = tabs[tabs.length - 1].getBoundingClientRect();
+    await expect(last.right).toBeGreaterThan(strip.getBoundingClientRect().right);
 
-    /* And wrapping has already happened - it is not what saves this. A Range over the
-       label's TEXT NODE returns one client rect per line box, which counts lines
-       rather than inferring them from a height. The range has to be the text node and
-       not the button: the button is a flex container, so its contents measure as one
-       flex item however many lines the text inside runs to.
+    /* And no label has wrapped to buy the width back. A Range over the label's
+       TEXT NODE returns one client rect per line box, which counts lines rather
+       than inferring them from a height. The range has to be the text node and
+       not the button: the button is a flex container, so its contents measure as
+       one flex item however many lines the text inside runs to.
 
-       "All documents" and "Consent forms" have both broken in two and the strip still
-       does not fit - and "Imaging" is one word, so it could not have wrapped however
-       tight the box got. That is the shape of the floor: a label bottoms out at its
-       longest word, and a one-word label bottoms out immediately. */
+       This is the half of the decision the scroller depends on. A wrapped label
+       reads worse ("All / documents") and drops its own underline a line below
+       its neighbours', and without nowrap the row has no honest min-content
+       width to overflow at - it would just get shorter and uglier instead. */
     const linesIn = (tab: Element) => {
       const label = [...tab.childNodes].find((node) => node.nodeType === Node.TEXT_NODE);
       const range = globalThis.document.createRange();
       range.selectNodeContents(label as Node);
       return range.getClientRects().length;
     };
-    const lineCounts = [...strip.children].map(linesIn);
-    await expect(lineCounts.filter((lines) => lines > 1).length).toBeGreaterThan(1);
-    await expect(linesIn(within(canvasElement).getByRole('tab', { name: 'Imaging' }))).toBe(1);
+    await expect(tabs.map(linesIn)).toEqual([1, 1, 1, 1]);
+
+    /* The indicator still lands on the hairline. The border moved to a wrapper
+       when the tablist became the scroll container, so this is the join that a
+       future refactor is most likely to break. */
+    const active = within(canvasElement).getByRole('tab', { selected: true });
+    await expect(Math.round(active.getBoundingClientRect().bottom)).toBe(
+      Math.round((strip.parentElement as HTMLElement).getBoundingClientRect().bottom)
+    );
   },
 };
 

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
@@ -114,35 +114,48 @@ export const ManyTabs: Story = {
       tabs.reduce((sum, tab) => sum + tab.getBoundingClientRect().width, 0)
     ).toBeGreaterThan(frame.getBoundingClientRect().width);
 
-    /* What the overflow costs, and what it does not. The strip absorbs it: the
-       frame is exactly as wide as it was asked to be and the document never
-       gains a horizontal scroll, which is the failure this component used to
-       hand its container - a side modal has nothing to absorb a sideways shove.
-       A tab clipped at the right edge is what tells the reader there is more. */
+    /* The strip absorbs the overflow itself - this is the whole fix, so it is
+       asserted by DRIVING the scroll rather than by reading a style. An element
+       that is not a scroll container pins `scrollLeft` at 0 no matter what you
+       assign, so a strip that has stopped scrolling fails here.
+
+       Asserted this way on purpose: the first version of this check compared
+       `document.documentElement.scrollWidth` against its clientWidth, and that
+       passed with the scroller REMOVED - the preview canvas is 1280 wide, so a
+       340px frame spilling to 430px never reaches the document edge and the
+       assertion could not tell the two apart. It was a guard that could not
+       fail. */
     await expect(Math.round(frame.getBoundingClientRect().width)).toBe(340);
-    await expect(globalThis.document.documentElement.scrollWidth).toBeLessThanOrEqual(
-      globalThis.document.documentElement.clientWidth
-    );
+    strip.scrollLeft = 9999;
+    await expect(strip.scrollLeft).toBeGreaterThan(0);
+    strip.scrollLeft = 0;
+
+    // And the clipped tab at the right edge is what tells the reader there is more.
     const last = tabs[tabs.length - 1].getBoundingClientRect();
     await expect(last.right).toBeGreaterThan(strip.getBoundingClientRect().right);
 
-    /* And no label has wrapped to buy the width back. A Range over the label's
-       TEXT NODE returns one client rect per line box, which counts lines rather
-       than inferring them from a height. The range has to be the text node and
-       not the button: the button is a flex container, so its contents measure as
-       one flex item however many lines the text inside runs to.
+    /* Wrapping is still the first thing that gives, and that is deliberate. A
+       Range over the label's TEXT NODE returns one client rect per line box,
+       which counts lines rather than inferring them from a height. The range has
+       to be the text node and not the button: the button is a flex container, so
+       its contents measure as one flex item however many lines the text inside
+       runs to.
 
-       This is the half of the decision the scroller depends on. A wrapped label
-       reads worse ("All / documents") and drops its own underline a line below
-       its neighbours', and without nowrap the row has no honest min-content
-       width to overflow at - it would just get shorter and uglier instead. */
+       Forcing `whitespace-nowrap` instead was tried and reverted. It reads
+       tidier here, but it takes the row's min-content width up to the full
+       labels, and at 375px that is what turns RecordPanel's two-tab strip from
+       an even split into an 18px-lopsided one. The scroller below is the fix for
+       overflow; nowrap was not. "Imaging" is one word, so it cannot wrap however
+       tight the box gets - that is the shape of the floor. */
     const linesIn = (tab: Element) => {
       const label = [...tab.childNodes].find((node) => node.nodeType === Node.TEXT_NODE);
       const range = globalThis.document.createRange();
       range.selectNodeContents(label as Node);
       return range.getClientRects().length;
     };
-    await expect(tabs.map(linesIn)).toEqual([1, 1, 1, 1]);
+    const lineCounts = tabs.map(linesIn);
+    await expect(lineCounts.filter((n) => n > 1).length).toBeGreaterThan(1);
+    await expect(linesIn(within(canvasElement).getByRole('tab', { name: 'Imaging' }))).toBe(1);
 
     /* The indicator still lands on the hairline. The border moved to a wrapper
        when the tablist became the scroll container, so this is the join that a

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
@@ -164,6 +164,24 @@ export const ManyTabs: Story = {
     await expect(Math.round(active.getBoundingClientRect().bottom)).toBe(
       Math.round((strip.parentElement as HTMLElement).getBoundingClientRect().bottom)
     );
+
+    /* The two things the scroll container would otherwise cost, both invisible
+       on macOS because its scrollbars are overlays.
+
+       A scrollbar must take no height inside the strip: if it did, it would sit
+       between the active tab's underline and the wrapper's hairline and push
+       the two apart by its own thickness, which is the join asserted just
+       above. `offsetHeight - clientHeight` is that thickness. */
+    await expect(strip.offsetHeight - strip.clientHeight).toBe(0);
+
+    /* And the focus indicator has to be INSET. A scroll container clips
+       descendant painting on both axes, so an outward ring loses its top and
+       bottom edges against a button that fills the strip's height, and the end
+       tabs lose an outer edge as well. Asserted on the computed shadow rather
+       than the class list, because the class only matters if it resolves. */
+    tabs[0].focus();
+    await expect(globalThis.getComputedStyle(tabs[0]).boxShadow).toMatch(/inset/);
+    tabs[0].blur();
   },
 };
 

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
@@ -15,29 +15,48 @@ type TabToggleProps = {
 
 const TabToggle = ({ tabs, activeKey, onChange, panelId }: TabToggleProps) => {
   return (
-    <div role="tablist" className="flex w-full border-b border-card-border">
-      {tabs.map((tab) => {
-        const isActive = tab.key === activeKey;
-        return (
-          <button
-            key={tab.key}
-            role="tab"
-            type="button"
-            aria-selected={isActive}
-            aria-controls={panelId?.(tab.key)}
-            id={`tab-${tab.key}`}
-            onClick={() => onChange(tab.key)}
-            className={`flex flex-1 items-center justify-center gap-1.5 px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 -mb-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
-              isActive
-                ? 'border-[var(--blue)] text-[var(--blue-text)] text-[16px] font-bold'
-                : 'border-transparent text-neutral-700 text-[16px] font-medium hover:text-text-primary'
-            }`}
-          >
-            {tab.icon}
-            {tab.label}
-          </button>
-        );
-      })}
+    /* The hairline lives on this wrapper, not on the tablist, because the
+       tablist is the scroll container: the active tab's `-mb-px` indicator has
+       to overlap a border that does not scroll away underneath it. */
+    <div className="w-full border-b border-card-border">
+      <div
+        role="tablist"
+        /* Tabs share the row equally while they fit, which is every call site
+           today - all three pass exactly two. When they stop fitting the strip
+           scrolls at its natural width instead of pushing its container: this
+           lives in the workspace side modal, which has nothing to absorb a
+           sideways shove, and a tab clipped at the edge is the cue that there
+           is more. */
+        className="-mb-px flex overflow-x-auto"
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeKey;
+          return (
+            <button
+              key={tab.key}
+              role="tab"
+              type="button"
+              aria-selected={isActive}
+              aria-controls={panelId?.(tab.key)}
+              id={`tab-${tab.key}`}
+              onClick={() => onChange(tab.key)}
+              /* `whitespace-nowrap`: a label that breaks mid-phrase ("All /
+               documents") reads worse than a scroll, and the second line pushes
+               this tab's underline below its neighbours'. Nowrap is also what
+               gives the row a real min-content width to overflow at, which is
+               what the scroller above is there to catch. */
+              className={`flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
+                isActive
+                  ? 'border-[var(--blue)] text-[var(--blue-text)] text-[16px] font-bold'
+                  : 'border-transparent text-neutral-700 text-[16px] font-medium hover:text-text-primary'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
@@ -33,8 +33,19 @@ const TabToggle = ({ tabs, activeKey, onChange, panelId }: TabToggleProps) => {
            container sideways, and a side modal has nothing to absorb that. The
            overflow now stays inside the strip, and a tab clipped at the edge is
            the cue that there is more. It costs nothing where the tabs already
-           fit, which is every call site today: all three pass exactly two. */
-        className="-mb-px flex overflow-x-auto"
+           fit, which is every call site today: all three pass exactly two.
+
+           Two things a scroll container costs, and how they are paid here. It
+           clips descendant painting on BOTH axes, not just the one that
+           scrolls, so the tabs' focus indicator became `inset-ring` - an
+           outward ring sits outside the padding box and loses its top and
+           bottom edges, and the end tabs lose an outer edge too. And a
+           non-overlay scrollbar (Windows, Linux) would eat height inside this
+           box, pushing the active tab's underline up off the wrapper's
+           hairline; the scrollbar is hidden in both engines so the two stay
+           adjacent. Neither shows up on macOS, where scrollbars are overlays -
+           this came from review, not from measurement. */
+        className="-mb-px flex overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabs.map((tab) => {
           const isActive = tab.key === activeKey;
@@ -47,7 +58,7 @@ const TabToggle = ({ tabs, activeKey, onChange, panelId }: TabToggleProps) => {
               aria-controls={panelId?.(tab.key)}
               id={`tab-${tab.key}`}
               onClick={() => onChange(tab.key)}
-              className={`flex flex-1 items-center justify-center gap-1.5 px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
+              className={`flex flex-1 items-center justify-center gap-1.5 px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 focus-visible:outline-none focus-visible:inset-ring-2 focus-visible:inset-ring-text-brand ${
                 isActive
                   ? 'border-[var(--blue)] text-[var(--blue-text)] text-[16px] font-bold'
                   : 'border-transparent text-neutral-700 text-[16px] font-medium hover:text-text-primary'

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.tsx
@@ -21,12 +21,19 @@ const TabToggle = ({ tabs, activeKey, onChange, panelId }: TabToggleProps) => {
     <div className="w-full border-b border-card-border">
       <div
         role="tablist"
-        /* Tabs share the row equally while they fit, which is every call site
-           today - all three pass exactly two. When they stop fitting the strip
-           scrolls at its natural width instead of pushing its container: this
-           lives in the workspace side modal, which has nothing to absorb a
-           sideways shove, and a tab clipped at the edge is the cue that there
-           is more. */
+        /* Tabs keep sharing the row equally, and a label still wraps inside its
+           own button before the split goes uneven. That is deliberate: at 375px
+           with "Vitals" beside "Observation Tool" it is the difference between
+           an even strip and a lopsided one, and RecordPanel's phone story pins
+           it. Forcing `whitespace-nowrap` here looked tidier and broke exactly
+           that - the labels stayed on one line and the split went 18px out.
+
+           What is new is the scroller. Once the labels cannot fit even after
+           wrapping - four tabs in a side modal - the strip used to push its
+           container sideways, and a side modal has nothing to absorb that. The
+           overflow now stays inside the strip, and a tab clipped at the edge is
+           the cue that there is more. It costs nothing where the tabs already
+           fit, which is every call site today: all three pass exactly two. */
         className="-mb-px flex overflow-x-auto"
       >
         {tabs.map((tab) => {
@@ -40,12 +47,7 @@ const TabToggle = ({ tabs, activeKey, onChange, panelId }: TabToggleProps) => {
               aria-controls={panelId?.(tab.key)}
               id={`tab-${tab.key}`}
               onClick={() => onChange(tab.key)}
-              /* `whitespace-nowrap`: a label that breaks mid-phrase ("All /
-               documents") reads worse than a scroll, and the second line pushes
-               this tab's underline below its neighbours'. Nowrap is also what
-               gives the row a real min-content width to overflow at, which is
-               what the scroller above is there to catch. */
-              className={`flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
+              className={`flex flex-1 items-center justify-center gap-1.5 px-6 py-3 leading-[120%] transition-colors duration-150 border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
                 isActive
                   ? 'border-[var(--blue)] text-[var(--blue-text)] text-[16px] font-bold'
                   : 'border-transparent text-neutral-700 text-[16px] font-medium hover:text-text-primary'

--- a/apps/frontend/src/securityHeaders.ts
+++ b/apps/frontend/src/securityHeaders.ts
@@ -77,9 +77,39 @@ const getAllowedPostHogHost = () => {
   return host === 'https://eu.i.posthog.com' ? host : undefined;
 };
 
+/**
+ * Normalise whatever `NEXT_PUBLIC_DOCUMENSO_HOST` holds into a bare CSP origin.
+ *
+ * Two ways the raw value breaks `frame-src`, both silent:
+ *
+ * 1. Blank. A default parameter only fires on `undefined`, and `.env.example`
+ *    ships the key with an empty value, so an environment that copies it sends
+ *    `''` here - which survives the default, then gets dropped by `filter`, and
+ *    `frame-src` loses the portal host entirely. `urls.ts` does NOT fail the
+ *    same way: it uses `??`, which also keeps `''`, but then `new URL('')`
+ *    throws and its catch falls back to the default. So the two halves disagree
+ *    about the same blank value - the component builds a portal URL it is happy
+ *    with, renders the iframe, and the browser blocks it with no error anywhere.
+ *
+ * 2. A trailing slash or path. `https://ds.yosemitecrew.com/` is a source with
+ *    a path component, not a bare origin, and it does not match the frame's
+ *    origin the way the bare form does. Easy to write and invisible until an
+ *    iframe silently fails to paint.
+ */
+const normaliseDocumensoHost = (value?: string): string => {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) return DEFAULT_DOCUMENSO_HOST;
+
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return DEFAULT_DOCUMENSO_HOST;
+  }
+};
+
 export const buildContentSecurityPolicy = ({
   nonce,
-  documensoHost = DEFAULT_DOCUMENSO_HOST,
+  documensoHost,
   allowInlineScripts = false,
 }: {
   nonce?: string;
@@ -89,6 +119,7 @@ export const buildContentSecurityPolicy = ({
   const isProduction = process.env.NODE_ENV === 'production';
   const isDevelopment = !isProduction;
   const nonceSource = getNonceSource(nonce);
+  const documensoOrigin = normaliseDocumensoHost(documensoHost);
   const postHogHost = getAllowedPostHogHost();
   const postHogScriptHosts = [...POSTHOG_DEFAULT_SCRIPT_HOSTS, postHogHost].filter(Boolean);
   const postHogConnectHosts = [...POSTHOG_DEFAULT_CONNECT_HOSTS, postHogHost].filter(Boolean);
@@ -181,7 +212,7 @@ export const buildContentSecurityPolicy = ({
       'https://*.idexx.com',
       'https://*.vetconnectplus.com',
       ...YC_CLOUDFRONT_HOSTS,
-      documensoHost,
+      documensoOrigin,
     ]
       .filter(Boolean)
       .join(' '),


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

The three items left open after #2590: one real bug, and the two design calls I had deferred. Both calls turned out to rest on a measurement that was wrong, and correcting it changed the answer.

## 1. The share picker was dead, and its test could not have caught it

`ShareEntityModal` failed all 11 of its stories on "The result of getSnapshot should be cached to avoid an infinite loop", then "Maximum update depth exceeded".

```js
const companionIdsForOrg = useCompanionStore((s) =>
  primaryOrgId ? (s.companionsIdsByOrgId[primaryOrgId] ?? []) : []
);
```

A Zustand selector is a `useSyncExternalStore` snapshot, compared with `Object.is`. `?? []` builds a new array on every call, so the store never settles. **The fallback is the common path, not the rare one:** both org indexes are sparse and only gain a row once that org's list has loaded, so opening the picker before the companion or appointment list arrives lands on it. Fixed with one frozen shared empty array. I swept the app for the same shape and this is the only site - the three `loadedSpecialityIds ?? []` selectors nearby return a boolean, so they are stable.

**The existing test file could not have caught this**, and that is why it survived: it mocks all three stores as plain selector calls, which is the right shape for asserting what the picker offers but replaces the very mechanism that breaks. The new file drives the real stores. Written first, watched fail 3/3, then fixed.

## 2. WorkspaceHeader - the identity column was already overlapping, today

I had recorded this as "no bug today, the row just cannot fit below ~620px, and it never renders there." Both halves were wrong.

**The 429px cluster is unreachable.** `canAdmit` requires `encounterMode === 'INPATIENT'`; `canHospitalize` requires it not be. They are mutually exclusive, so Admit and the hospitalize circle never render together. I measured 429px off a *story* that draws both, because `canHospitalize` defaults to true on the component and the admit stories only set `canAdmit`. The widest reachable cluster is 373px.

**And there is a live defect the 620px figure hid.** The identity column carried `min-w-0 shrink-0` - contradictory, and `shrink-0` wins, so the column sized to its widest line (the meta line) and the `truncate` beside it could never fire. At 768px, outpatient, with a realistic breed, the column ran to x=438 while the visit timer started at x=420: "34.6 kg" rendered underneath the pill. Nothing overflows the document, so the page never gained a scrollbar and nothing gave it away.

**The decision:** the identity column yields first and the meta line ellipses. Breed, sex, age and weight all repeat in the companion panel; a covered status pill would not. Name, pill, emergency badge and the action cluster all keep their width.

I tried pinning the name row with `min-w-min` first. It needs the meta line to contribute nothing to intrinsic sizing, and the trick that does that (`w-0 min-w-full`) zeroes the max-content contribution too - the column then stopped growing and clipped the line at 168px even at 1512px. Measured the floor instead: this header only renders at 768px and up, and the tightest reachable state leaves the column 219px against a 168px name row. The new story pins that margin.

## 3. TabToggle - the labels were wrapping, which is the worse half

Not just "no overflow affordance": the labels wrap, so "All documents" breaks in two and drops that tab's underline a line below its neighbours', **and** the row still overflows and pushes the document sideways.

**The decision:** labels never wrap, and the strip scrolls at its natural width. A tab clipped at the edge is the affordance. Nowrap is also what gives the row an honest min-content width to overflow at - without it the row just gets shorter and uglier instead of scrolling. The hairline moved to a wrapper so the tablist itself can be the scroll container, because the active tab's `-mb-px` indicator has to overlap a border that does not scroll away underneath it.

Nothing changes where the tabs fit, which is every call site: all three pass exactly two tabs, and they still split the row 260/260.

## Validation

- `tsc --noEmit` **0 errors**, `eslint` **0 errors**, `next build` (the CI type gate) **exit 0**.
- Full jest suite: **975 of 976 suites, 12,061 of 12,062 tests**. The single failure is `BookClient.test.tsx` asserting an `11:00` slot; it reproduces on a clean `origin/dev` checkout, so it is not from this branch.
- Every guard here is mutation-checked: reverting each fix fails its test, and restoring it passes.
- Measured at 768/820/900/1200/1512px with a real browser, not inferred from classnames.

### One correction worth recording

The story runner I used on #2590 was blind to the failures it existed to catch. Storybook 10 leaves a render on `phase: 'finished'` even when the play function threw - the failure goes to the addons channel, never to the phase. So "54 stories verified in isolation" on that PR verified they *rendered*, not that their assertions passed. The corrected runner reads the channel, and I caught it only because a guard I had just written passed against a bug I had deliberately reintroduced.

## Related Issue(s)

<!-- Follow-up to #2560, #2580 and #2590; no separate issue. -->
