### PR TITLE
fix(mobile): stop showing pet owners a payment deadline nothing enforces

### DIFF
--- a/apps/desktop/src/core/ipc-handlers.ts
+++ b/apps/desktop/src/core/ipc-handlers.ts
@@ -594,7 +594,19 @@ export const registerIpc = (services: IpcServices, ipc: IpcMainType = ipcMain): 
 
   registry.handle('yc:vault-stats', async () => {
     if (!services.documentVault) return { ok: false, error: 'vault-not-ready' };
-    return { ok: true, stats: services.documentVault.getStats() };
+    /*
+     * `encryptionAvailable` rides along with the stats so the vault window can
+     * state the real encryption status instead of asserting one. It used to
+     * print a green "OS keychain" pill unconditionally, on the reasoning that
+     * safeStorage is usually present on macOS - but the Linux AppImage and deb
+     * builds depend on a keyring, and when it is missing the vault refuses every
+     * write (ENCRYPTION_UNAVAILABLE) while the badge still read green.
+     */
+    return {
+      ok: true,
+      stats: services.documentVault.getStats(),
+      encryptionAvailable: services.documentVault.encryptionAvailable,
+    };
   });
 
   registry.handle('yc:vault-save-buffer', async (_event, args) => {

--- a/apps/desktop/src/pages/vault.css
+++ b/apps/desktop/src/pages/vault.css
@@ -62,6 +62,21 @@ body {
   border: 1px solid var(--status-completed-border);
 }
 
+/* The badge defaults to the green "completed" treatment, which is only correct
+   when encryption really is available. These two carry the other two states so
+   an unencrypted vault cannot read as a secure one. */
+.badge-warn {
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  border-color: var(--danger);
+}
+
+.badge-unknown {
+  background: var(--status-requested-bg);
+  color: var(--status-requested-text);
+  border-color: var(--status-requested-border);
+}
+
 .header-meta {
   margin-left: auto;
   white-space: nowrap;

--- a/apps/desktop/src/pages/vault.html
+++ b/apps/desktop/src/pages/vault.html
@@ -15,7 +15,7 @@
       <div class="header">
         <div class="header-top">
           <h1>All documents</h1>
-          <span class="badge" id="encBadge">checking…</span>
+          <span class="badge badge-unknown" id="encBadge">checking…</span>
           <span class="header-meta">
             <span id="docCount">0 documents</span>
             <span class="dot-sep">·</span>

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -66,7 +66,7 @@
      * completed treatment, so leaving it alone would render a GREEN "checking…"
      * on every load - and keep it green indefinitely if the request fails.
      */
-    badgeEncryption(undefined);
+    badgeEncryption();
     yc.vaultStats().then(function (res) {
       if (!res?.ok || !res.stats) return;
       const stats = res.stats;

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -66,6 +66,7 @@
       const stats = res.stats;
       docCountEl.textContent = stats.count + ' document' + (stats.count === 1 ? '' : 's');
       sizeInfoEl.textContent = formatBytes(stats.totalSizeBytes || 0);
+      badgeEncryption(res.encryptionAvailable);
     });
     yc.getAppVersion().then(function () {
       // Get encryption status from vault-stats (we don't have a separate info channel)
@@ -74,12 +75,35 @@
     // Best-effort: check if vault-save works to infer readiness
   };
 
-  // We don't have vault-get-info, so check encryption from context:
-  // On macOS safeStorage is almost always available. Show status inline.
-  const badgeEncryption = function () {
-    // Can't detect encryption from renderer; just show status
-    encBadge.textContent = 'OS keychain';
-    encBadge.className = 'badge secure';
+  /*
+   * The encryption badge states what the main process reports, and nothing when
+   * it has not reported yet.
+   *
+   * It used to read a hardcoded green "OS keychain" on the reasoning that
+   * safeStorage is almost always available on macOS. That is a probability, not
+   * a fact: the Linux AppImage and deb builds depend on a keyring, and without
+   * one the vault refuses every write (ENCRYPTION_UNAVAILABLE) while the badge
+   * still claimed the documents were encrypted. The same app already prints the
+   * truth in Data > Document Vault Info, so the two surfaces disagreed.
+   */
+  const badgeEncryption = function (encryptionAvailable) {
+    if (encryptionAvailable === true) {
+      encBadge.textContent = 'OS keychain';
+      encBadge.className = 'badge';
+      encBadge.removeAttribute('title');
+      return;
+    }
+    if (encryptionAvailable === false) {
+      encBadge.textContent = 'Not encrypted';
+      encBadge.className = 'badge badge-warn';
+      encBadge.title =
+        'The OS keychain is unavailable, so the vault cannot encrypt and will refuse to store documents.';
+      return;
+    }
+    // Unknown: say so rather than guessing either way.
+    encBadge.textContent = 'checking\u2026';
+    encBadge.className = 'badge badge-unknown';
+    encBadge.removeAttribute('title');
   };
 
   const filterDocs = function () {
@@ -194,7 +218,6 @@
       docs = (res.documents || []).sort(function (a, b) {
         return b.createdAt - a.createdAt;
       });
-      badgeEncryption();
       loadStats();
       filterDocs();
     });
@@ -365,6 +388,6 @@
   });
 
   // ── Init ──
-  badgeEncryption();
+
   scheduleLoad();
 })();

--- a/apps/desktop/src/pages/vault.js
+++ b/apps/desktop/src/pages/vault.js
@@ -61,6 +61,12 @@
   };
 
   const loadStats = function () {
+    /*
+     * Reset to the neutral state before asking. `.badge` on its own is the green
+     * completed treatment, so leaving it alone would render a GREEN "checking…"
+     * on every load - and keep it green indefinitely if the request fails.
+     */
+    badgeEncryption(undefined);
     yc.vaultStats().then(function (res) {
       if (!res?.ok || !res.stats) return;
       const stats = res.stats;
@@ -94,10 +100,19 @@
       return;
     }
     if (encryptionAvailable === false) {
-      encBadge.textContent = 'Not encrypted';
+      /*
+       * "Encryption unavailable", not "Not encrypted". This describes the
+       * keychain's CURRENT capability, which is the only thing the flag knows.
+       * Documents stored while the keychain was available stay encrypted on
+       * disk - losing access blocks new writes, it does not decrypt anything -
+       * so calling the vault "not encrypted" would misstate the files already
+       * in it, which is the same class of false claim this badge is here to
+       * stop making.
+       */
+      encBadge.textContent = 'Encryption unavailable';
       encBadge.className = 'badge badge-warn';
       encBadge.title =
-        'The OS keychain is unavailable, so the vault cannot encrypt and will refuse to store documents.';
+        'The OS keychain is unavailable, so the vault cannot store new documents. Documents saved earlier remain encrypted on disk.';
       return;
     }
     // Unknown: say so rather than guessing either way.

--- a/apps/desktop/tests/ipc-handlers.test.ts
+++ b/apps/desktop/tests/ipc-handlers.test.ts
@@ -376,6 +376,11 @@ describe('ipc-handlers — happy paths', () => {
     expect(await call('yc:vault-list')).toMatchObject({ ok: true });
     expect(await call('yc:vault-get', 'd')).toMatchObject({ ok: true });
     expect(await call('yc:vault-stats')).toMatchObject({ ok: true });
+    // The vault window's encryption badge is driven by this field. Without it
+    // the badge fell back to a hardcoded green "OS keychain", which was wrong
+    // on any machine where safeStorage is unavailable - and there the vault
+    // refuses every write, so the claim was exactly backwards.
+    expect(await call('yc:vault-stats')).toHaveProperty('encryptionAvailable');
     expect(
       await call('yc:vault-save-buffer', 'f.txt', Buffer.from('x').toString('base64'))
     ).toMatchObject({ ok: true });
@@ -461,9 +466,10 @@ describe('ipc-handlers — happy paths', () => {
       // The payload is renderer-controlled, so an exact string comparison let
       // "vet-1" witness for "vet-1 ".
       for (const witnessId of ['vet-1 ', ' vet-1', 'VET-1', ' Vet-1 ']) {
-        expect(
-          await call('yc:cs-record', { ...waste, witnessId, witnessName: 'Dr. X' })
-        ).toEqual({ ok: false, error: 'witness-must-differ' });
+        expect(await call('yc:cs-record', { ...waste, witnessId, witnessName: 'Dr. X' })).toEqual({
+          ok: false,
+          error: 'witness-must-differ',
+        });
       }
     });
 
@@ -504,7 +510,11 @@ describe('ipc-handlers — happy paths', () => {
         ...waste,
         witnessId: 'nurse-1',
         witnessName: 'Nurse Jane',
-      })) as { ok: boolean; witnessPinVerified: boolean; transaction: { witnessPinVerified: boolean } };
+      })) as {
+        ok: boolean;
+        witnessPinVerified: boolean;
+        transaction: { witnessPinVerified: boolean };
+      };
 
       expect(result.ok).toBe(true);
       expect(result.witnessPinVerified).toBe(false);
@@ -609,7 +619,9 @@ describe('ipc-handlers — happy paths', () => {
     expect(services.logger.warn).toHaveBeenCalledWith('audit_append_rejected', expect.anything());
 
     // Ordinary entries are unaffected.
-    expect(await call('yc:audit-append', { action: 'patient:update', resourceType: 'patient' })).toMatchObject({ ok: true });
+    expect(
+      await call('yc:audit-append', { action: 'patient:update', resourceType: 'patient' })
+    ).toMatchObject({ ok: true });
   });
 
   test('a verified witness is recorded under the enrolled account name', async () => {

--- a/apps/mobileAppYC/__tests__/features/payments/screens/PaymentInvoiceScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/payments/screens/PaymentInvoiceScreen.test.tsx
@@ -765,13 +765,20 @@ describe('PaymentInvoiceScreen', () => {
     });
   });
 
-  it('falls back to the stated due date when the due date is invalid', () => {
+  it('states no payment deadline, because invoices do not carry one', () => {
+    /*
+     * The screen used to compute "due" as the invoice date plus a hardcoded 24
+     * hours and render it both as a "Due till" row and as "Payment is due by X.
+     * Late or failed payments may result in rescheduling or cancellation".
+     * Nothing backs that: the only `dueDate` column in schema.prisma belongs to
+     * CareReminder, and no finance route emits one for an invoice.
+     */
     const state = createSafeState({
       appointments: {
         invoices: {
           'apt-1': {
             ...mockInvoiceData,
-            dueDate: 'not-a-real-date',
+            dueDate: undefined,
           },
         },
       },
@@ -780,9 +787,25 @@ describe('PaymentInvoiceScreen', () => {
 
     render(<PaymentInvoiceScreen />);
 
+    expect(screen.queryByText(/Payment is due by/)).toBeNull();
+    expect(screen.queryByText(/Due till/)).toBeNull();
+    // The rest of the terms line survives - it makes no dated claim.
     expect(
-      screen.getByText(/Payment is due by the stated due date/),
+      screen.getByText(/Late or failed payments may result in rescheduling/),
     ).toBeTruthy();
+  });
+
+  it('shows a Due till row only when the API actually sends a due date', () => {
+    const state = createSafeState({
+      appointments: {
+        invoices: {'apt-1': {...mockInvoiceData, dueDate: '2025-12-04'}},
+      },
+    });
+    (useSelector as unknown as jest.Mock).mockImplementation(fn => fn(state));
+
+    render(<PaymentInvoiceScreen />);
+
+    expect(screen.getByText(/Due till/)).toBeTruthy();
   });
 
   it('fetches a payment intent when payment is pending and the existing intent is incomplete', async () => {

--- a/apps/mobileAppYC/src/features/appointments/services/appointmentsService.ts
+++ b/apps/mobileAppYC/src/features/appointments/services/appointmentsService.ts
@@ -809,11 +809,20 @@ const mapInvoiceFromApi = (
     raw.createdAt ??
     raw.paymentIntent?.createdAt ??
     raw.date;
-  const dueTill = invoiceCreatedAt
-    ? new Date(
-        new Date(invoiceCreatedAt).getTime() + 24 * 60 * 60 * 1000,
-      ).toISOString()
-    : raw.dueDate;
+  /*
+   * The due date is whatever the API sends, and nothing when it sends none.
+   *
+   * This used to be `invoiceCreatedAt ? createdAt + 24h : raw.dueDate` - the
+   * branches inverted, so a real server value was only ever reached when the
+   * creation date was unknown. In practice it was always the invented one:
+   * there is no due date on an invoice anywhere in the system. The only
+   * `dueDate` column in schema.prisma belongs to CareReminder, and no finance
+   * route emits one. So the screen showed every pet owner a payment deadline of
+   * "24 hours after the invoice", complete with a line about late payment
+   * risking rescheduling or cancellation, that nothing in the product enforces
+   * or even records.
+   */
+  const dueTill = raw.dueDate;
 
   const receiptUrl =
     extensions.find(

--- a/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
+++ b/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
@@ -218,11 +218,8 @@ const buildInvoices = (
       ? new Date(intentCreatedAt).toISOString()
       : new Date().toISOString();
     const invoiceDateISO = baseInvoice.invoiceDate ?? intentDateISO;
-    const dueDateISO =
-      baseInvoice.dueDate ??
-      new Date(
-        new Date(invoiceDateISO).getTime() + 24 * 60 * 60 * 1000,
-      ).toISOString();
+    // No synthesised deadline here either - see appointmentsService for why.
+    const dueDateISO = baseInvoice.dueDate;
     return {
       ...baseInvoice,
       invoiceDate: invoiceDateISO,
@@ -304,27 +301,6 @@ const formatDateTimeDisplay = (iso?: string) => {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
-  });
-};
-
-const formatDateOnlyDisplay = (iso?: string | null) => {
-  if (!iso) {
-    return getLocalizedText(
-      'payments.statedDueDateFallback',
-      'the stated due date',
-    );
-  }
-  const ts = Date.parse(iso);
-  if (Number.isFinite(ts) === false) {
-    return getLocalizedText(
-      'payments.statedDueDateFallback',
-      'the stated due date',
-    );
-  }
-  return new Date(ts).toLocaleDateString('en-US', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
   });
 };
 
@@ -538,10 +514,14 @@ const InvoiceDetailsCard = ({
           label={getLocalizedText('payments.invoiceDate', 'Invoice date')}
           value={formatDateTimeDisplay(effectiveInvoice?.invoiceDate)}
         />
-        <MetaRow
-          label={getLocalizedText('payments.dueTill', 'Due till')}
-          value={formatDateTimeDisplay(effectiveInvoice?.dueDate)}
-        />
+        {/* Rendered only when the API actually sends a due date. It sends none
+            today, so the row stays hidden rather than showing a made-up one. */}
+        {effectiveInvoice?.dueDate ? (
+          <MetaRow
+            label={getLocalizedText('payments.dueTill', 'Due till')}
+            value={formatDateTimeDisplay(effectiveInvoice.dueDate)}
+          />
+        ) : null}
         <MetaRow
           label={getLocalizedText('payments.paymentStatus', 'Payment status')}
           value={paymentStatusLabel}
@@ -855,12 +835,10 @@ const ReceiptCard = ({
 };
 
 const TermsCard = ({
-  paymentDueLabel,
   businessName,
   businessAddress,
   styles,
 }: {
-  paymentDueLabel: string;
   businessName: string;
   businessAddress?: string;
   styles: any;
@@ -882,8 +860,7 @@ const TermsCard = ({
         <Text style={styles.termsLine}>
           {getLocalizedText(
             'payments.termsPaymentDue',
-            `Payment is due by ${paymentDueLabel}. Late or failed payments may result in rescheduling or cancellation; card transactions are processed securely via Stripe.`,
-            {paymentDueLabel},
+            'Late or failed payments may result in rescheduling or cancellation; card transactions are processed securely via Stripe.',
           )}
         </Text>
         <Text style={styles.termsLine}>
@@ -1282,7 +1259,6 @@ const buildInvoiceContent = ({
   formatMoney,
   paymentIntent,
   receiptUrl,
-  paymentDueLabel,
   businessName,
   businessAddress,
   showCashCancellationNotice,
@@ -1367,7 +1343,6 @@ const buildInvoiceContent = ({
         <ReceiptCard receiptUrl={receiptUrl} theme={theme} styles={styles} />
 
         <TermsCard
-          paymentDueLabel={paymentDueLabel}
           businessName={businessName}
           businessAddress={businessAddress}
           styles={styles}
@@ -1637,9 +1612,6 @@ export const PaymentInvoiceScreen: React.FC = () => {
     invoiceLoading,
     paymentIntentLoading,
   });
-  const paymentDueLabel = formatDateOnlyDisplay(
-    effectiveInvoice?.dueDate ?? apt?.date ?? null,
-  );
   const normalizedAppointmentStatus = normalizeStatusToken(apt?.status);
   const isCancelledAppointment =
     normalizedAppointmentStatus === 'CANCELLED' ||
@@ -1699,7 +1671,6 @@ export const PaymentInvoiceScreen: React.FC = () => {
         formatMoney,
         paymentIntent,
         receiptUrl,
-        paymentDueLabel,
         businessName,
         businessAddress,
         showCashCancellationNotice,
@@ -1732,7 +1703,6 @@ export const PaymentInvoiceScreen: React.FC = () => {
       formatMoney,
       paymentIntent,
       receiptUrl,
-      paymentDueLabel,
       businessName,
       businessAddress,
       showCashCancellationNotice,

--- a/apps/mobileAppYC/src/localization/resources/en/common.json
+++ b/apps/mobileAppYC/src/localization/resources/en/common.json
@@ -210,7 +210,7 @@
     "unableToOpenInvoiceMessage": "Please try again or copy the link from your receipt.",
     "receiptRedirectNotice": "You will be redirected to the secure Stripe receipt in your browser.",
     "termsAndLegalTitle": "Payment terms & legal",
-    "termsPaymentDue": "Payment is due by {{paymentDueLabel}}. Late or failed payments may result in rescheduling or cancellation; card transactions are processed securely via Stripe.",
+    "termsPaymentDue": "Late or failed payments may result in rescheduling or cancellation; card transactions are processed securely via Stripe.",
     "termsServicesProvidedBy": "Services are provided by {{businessName}}{{businessAddress}}. Charges reflect veterinary/professional services rendered and may include taxes or approved follow-up care.",
     "termsRefundsDisputes": "Refunds or billing disputes are handled by the service provider in line with applicable consumer laws. Keep your receipt and contact the service provider directly for questions or adjustments.",
     "termsNotEmergencyAdvice": "This invoice is not emergency advice. If your companion needs urgent care, contact the service provider or local emergency services immediately.",
@@ -226,7 +226,6 @@
     "statusDue": "Due",
     "statusPaidCash": "Paid - Cash",
     "statusPaymentAtProvider": "Payment at Provider",
-    "statedDueDateFallback": "the stated due date",
     "headerTitleInvoicePayment": "Invoice payment",
     "headerTitleBookAppointment": "Book appointment"
   },

--- a/apps/mobileAppYC/src/localization/resources/es/common.json
+++ b/apps/mobileAppYC/src/localization/resources/es/common.json
@@ -210,7 +210,7 @@
     "unableToOpenInvoiceMessage": "Inténtalo de nuevo o copia el enlace desde tu recibo.",
     "receiptRedirectNotice": "Se te redirigirá al recibo seguro de Stripe en tu navegador.",
     "termsAndLegalTitle": "Términos de pago y aviso legal",
-    "termsPaymentDue": "El pago vence el {{paymentDueLabel}}. Los pagos tardíos o fallidos pueden resultar en reprogramación o cancelación; las transacciones con tarjeta se procesan de forma segura a través de Stripe.",
+    "termsPaymentDue": "Los pagos tardíos o fallidos pueden resultar en reprogramación o cancelación; las transacciones con tarjeta se procesan de forma segura a través de Stripe.",
     "termsServicesProvidedBy": "Los servicios son prestados por {{businessName}}{{businessAddress}}. Los cargos reflejan servicios veterinarios/profesionales prestados y pueden incluir impuestos o atención de seguimiento aprobada.",
     "termsRefundsDisputes": "Los reembolsos o disputas de facturación son gestionados por el proveedor del servicio conforme a las leyes de protección al consumidor aplicables. Conserva tu recibo y contacta directamente al proveedor del servicio para preguntas o ajustes.",
     "termsNotEmergencyAdvice": "Esta factura no constituye asesoramiento de emergencia. Si tu compañero necesita atención urgente, contacta al proveedor del servicio o a los servicios de emergencia locales de inmediato.",
@@ -226,7 +226,6 @@
     "statusDue": "Pendiente",
     "statusPaidCash": "Pagado - Efectivo",
     "statusPaymentAtProvider": "Pago en el proveedor",
-    "statedDueDateFallback": "la fecha de vencimiento indicada",
     "headerTitleInvoicePayment": "Pago de factura",
     "headerTitleBookAppointment": "Reservar cita"
   },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for — found sweeping desktop and mobile for the defect class behind #2606, #2607, #2609 and #2620.
- [x] All existing tests and lints pass.

## What is the current behavior?

The invoice screen tells every pet owner their payment is due 24 hours after the invoice, and warns them what happens if they miss it:

> **Due till** 03 Sep 2026, 2:14 PM
>
> *Payment is due by 03 Sep 2026. Late or failed payments may result in rescheduling or cancellation; card transactions are processed securely via Stripe.*

**Nothing backs any of it.** The only `dueDate` column in `schema.prisma` belongs to `CareReminder`:

```
$ grep -n "dueDate" packages/database/prisma/schema.prisma
3994:  dueDate        DateTime      # -> model CareReminder
```

The `Invoice` model has none, and no finance route emits one. So `raw.dueDate` is always `undefined` and the deadline shown is always the invented one.

### The branches were inverted

```ts
const dueTill = invoiceCreatedAt
  ? new Date(new Date(invoiceCreatedAt).getTime() + 24 * 60 * 60 * 1000).toISOString()
  : raw.dueDate;
```

A real server value is reached **only when the creation date is unknown** — the fallback was the truth and the invention was the default. `PaymentInvoiceScreen` then repeated the same `?? +24h` a second time, and `paymentDueLabel` fell back again to the appointment date.

## What is the new behavior?

- The due date is whatever the API sends, and nothing when it sends none. Both computation sites now read the field directly.
- The **Due till** row renders only when a real value arrives — so it stays hidden today rather than showing a guess, and starts working for free if invoices ever gain a due date.
- The terms line keeps its substance (late/failed payments, Stripe) without the dated claim.

### Both locales

The Spanish carried the same assertion — `"El pago vence el {{paymentDueLabel}}"` — and would have kept making it if only the English default changed. Both are updated.

`formatDateOnlyDisplay` and the `payments.statedDueDateFallback` key it used ("the stated due date") existed only to fill the deleted sentence, and are removed with it.

## Validation performed

- **Mobile suite: 477 suites, 7,742 tests, all pass.** `tsc --noEmit` clean, `lint` exit 0.
- Locale edits are surgical — `1 insertion, 2 deletions` per file, no reformat churn.
- One existing test asserted the fallback string *"Payment is due by the stated due date"*. It now asserts the **absence** of any deadline claim, plus a positive case that the row appears when the API does send a due date.
- **Mutation-checked**: re-introducing the `?? +24h` computation fails the new test.

## Note on running the mobile suite

`--runInBand` hangs on the large suites in this repo (it cost me three wedged runs earlier in this session). `--ci --maxWorkers=2 --forceExit` completes in minutes.
