### PR TITLE
fix(mobile): three more surfaces stating things nothing knows

### DIFF
--- a/apps/mobileAppYC/__tests__/features/chat/screens/ChatChannelScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/chat/screens/ChatChannelScreen.test.tsx
@@ -200,6 +200,26 @@ describe('ChatChannelScreen', () => {
 
   // --- Rendering & Initialization Tests ---
 
+  it('shows no presence indicator, because nothing tracks presence', async () => {
+    /*
+     * The dot used to render unconditionally, so every vet always appeared
+     * online. Nothing subscribes to presence and the transport exposes none.
+     *
+     * Asserted structurally - the avatar holds the initials and nothing else.
+     * A first attempt matched on the style NAME containing "presence", which
+     * silently never bites: RN StyleSheet compiles styles to numeric ids, so
+     * re-adding the dot still passed.
+     */
+    const {getByTestId} = render(<ChatChannelScreen />);
+    const avatar = await waitFor(() => getByTestId('ChatHeaderAvatar'));
+
+    expect(avatar.props.children).toBeTruthy();
+    const children = Array.isArray(avatar.props.children)
+      ? avatar.props.children.filter(Boolean)
+      : [avatar.props.children];
+    expect(children).toHaveLength(1);
+  });
+
   it('renders loading state initially', async () => {
     (connectStreamUser as jest.Mock).mockImplementation(
       () => new Promise(() => {}),

--- a/apps/mobileAppYC/__tests__/features/home/screens/HomeScreen/HomeScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/home/screens/HomeScreen/HomeScreen.test.tsx
@@ -601,7 +601,8 @@ describe('HomeScreen', () => {
   describe('deriveHomeGreetingName', () => {
     it('handles names correctly', () => {
       expect(deriveHomeGreetingName('  Jane  ').displayName).toBe('Jane');
-      expect(deriveHomeGreetingName(null).resolvedName).toBe('Sky');
+      // A missing name greets neutrally rather than borrowing a fixture name.
+      expect(deriveHomeGreetingName(null).resolvedName).toBe('there');
       expect(deriveHomeGreetingName('Christopherrr').displayName).toBe(
         'Christopherrr',
       );
@@ -737,7 +738,7 @@ describe('HomeScreen', () => {
         </Provider>,
       );
 
-      expect(getByText('Hello, Sky')).toBeTruthy();
+      expect(getByText('Hello, there')).toBeTruthy();
     });
 
     // #2368's disguise on Home: an empty companion list rendered "Add your

--- a/apps/mobileAppYC/__tests__/screens/HomeScreen.greeting.test.ts
+++ b/apps/mobileAppYC/__tests__/screens/HomeScreen.greeting.test.ts
@@ -1,18 +1,18 @@
 import {deriveHomeGreetingName} from '@/features/home/screens/HomeScreen/HomeScreen.helpers';
 
 describe('deriveHomeGreetingName', () => {
-  it('falls back to Sky when name is empty', () => {
+  it('greets neutrally when the name is empty', () => {
     expect(deriveHomeGreetingName('')).toEqual({
-      resolvedName: 'Sky',
-      displayName: 'Sky',
+      resolvedName: 'there',
+      displayName: 'there',
     });
     expect(deriveHomeGreetingName('   ')).toEqual({
-      resolvedName: 'Sky',
-      displayName: 'Sky',
+      resolvedName: 'there',
+      displayName: 'there',
     });
     expect(deriveHomeGreetingName(undefined)).toEqual({
-      resolvedName: 'Sky',
-      displayName: 'Sky',
+      resolvedName: 'there',
+      displayName: 'there',
     });
   });
 

--- a/apps/mobileAppYC/__tests__/screens/HomeScreen.logic.test.ts
+++ b/apps/mobileAppYC/__tests__/screens/HomeScreen.logic.test.ts
@@ -2,16 +2,17 @@ import {deriveHomeGreetingName} from '@/features/home/screens/HomeScreen/HomeScr
 
 describe('deriveHomeGreetingName', () => {
   it('uses trimmed name when provided', () => {
+    // 'Sky' here is the supplied name, not the fallback - it must survive.
     const r = deriveHomeGreetingName('  Sky  ');
     expect(r.resolvedName).toBe('Sky');
     expect(r.displayName).toBe('Sky');
   });
 
-  it('falls back to Sky when blank', () => {
+  it('greets neutrally when blank, rather than borrowing a name', () => {
     const r1 = deriveHomeGreetingName('   ');
     const r2 = deriveHomeGreetingName(undefined);
-    expect(r1.resolvedName).toBe('Sky');
-    expect(r2.resolvedName).toBe('Sky');
+    expect(r1.resolvedName).toBe('there');
+    expect(r2.resolvedName).toBe('there');
   });
 
   it('truncates very long names to 13 chars + ellipsis', () => {

--- a/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
+++ b/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
@@ -95,7 +95,10 @@ const ChatChannelHeader: React.FC<{
       </PressableOpacity>
       <View style={styles.avatar}>
         <Text style={styles.avatarText}>{initials}</Text>
-        <View style={styles.presenceDot} />
+        {/* No presence dot. It rendered unconditionally, so every vet always
+            appeared online - nothing in the app subscribes to presence, and the
+            chat transport exposes none. A dot that is always green tells the
+            pet owner nothing and implies someone is there to answer. */}
       </View>
       <View style={styles.titleBlock}>
         <Text style={styles.name} numberOfLines={1}>
@@ -410,17 +413,6 @@ const createHeaderStyles = (theme: any) =>
     avatarText: {
       ...theme.typography.subtitleBold14,
       color: theme.colors.avatarVioletInk,
-    },
-    presenceDot: {
-      position: 'absolute',
-      bottom: 0,
-      right: 0,
-      width: 11,
-      height: 11,
-      borderRadius: theme.borderRadius.full,
-      backgroundColor: theme.colors.success,
-      borderWidth: 2,
-      borderColor: theme.colors.screen,
     },
     titleBlock: {
       flex: 1,

--- a/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
+++ b/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
@@ -93,12 +93,8 @@ const ChatChannelHeader: React.FC<{
         testID="HeaderBackButton">
         <Ionicons name="chevron-back" size={18} color={theme.colors.inkBody} />
       </PressableOpacity>
-      <View style={styles.avatar}>
+      <View style={styles.avatar} testID="ChatHeaderAvatar">
         <Text style={styles.avatarText}>{initials}</Text>
-        {/* No presence dot. It rendered unconditionally, so every vet always
-            appeared online - nothing in the app subscribes to presence, and the
-            chat transport exposes none. A dot that is always green tells the
-            pet owner nothing and implies someone is there to answer. */}
       </View>
       <View style={styles.titleBlock}>
         <Text style={styles.name} numberOfLines={1}>

--- a/apps/mobileAppYC/src/features/documents/constants.ts
+++ b/apps/mobileAppYC/src/features/documents/constants.ts
@@ -9,7 +9,6 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
     description: 'Certificates, insurance',
     icon: Images.adminIcon,
     iconTint: 'avatarVioletBg',
-    isSynced: false,
     fileCount: 0,
     subcategories: [
       {
@@ -27,7 +26,6 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
     description: 'Passport, prescriptions, labs, vaccinations',
     icon: Images.healthIconCategory,
     iconTint: 'blueSoft',
-    isSynced: true,
     fileCount: 0,
     subcategories: [
       {id: S.PASSPORT, label: 'Passport', fileCount: 0},
@@ -48,7 +46,6 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
     description: 'Grooming, dental, skin care',
     icon: Images.hygieneIcon,
     iconTint: 'pinkGlow',
-    isSynced: true,
     fileCount: 0,
     subcategories: [
       {id: S.BATHING, label: 'Bathing', fileCount: 0},
@@ -71,7 +68,6 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
     description: 'Nutrition plans',
     icon: Images.dietaryIcon,
     iconTint: 'avatarGreenBg',
-    isSynced: false,
     fileCount: 0,
     subcategories: [
       {id: S.NUTRITION_PLANS, label: 'Nutrition plans', fileCount: 0},
@@ -83,7 +79,6 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
     description: 'Weight logs, behaviour notes, photos',
     icon: Images.othersIconCategory,
     iconTint: 'avatarAmberBg',
-    isSynced: false,
     fileCount: 0,
     subcategories: [
       {

--- a/apps/mobileAppYC/src/features/documents/screens/DocumentsScreen/DocumentsScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/DocumentsScreen/DocumentsScreen.tsx
@@ -200,7 +200,6 @@ export const DocumentsScreen: React.FC = () => {
                 title={category.label}
                 subtitle={category.description ?? ''}
                 count={category.fileCount}
-                isSynced={category.isSynced}
                 onPress={() => handleCategoryPress(category.id)}
                 containerStyle={styles.categoryTile}
                 iconTint={

--- a/apps/mobileAppYC/src/features/documents/types.ts
+++ b/apps/mobileAppYC/src/features/documents/types.ts
@@ -38,7 +38,13 @@ export interface DocumentCategory {
   description?: string;
   /** Warm-bone surface-token key for the category's pastel icon tile. */
   iconTint?: string;
-  isSynced: boolean;
+  /*
+   * No `isSynced` on a category. It was a hardcoded literal - health and
+   * hygiene-maintenance true, the rest false - so two tiles claimed a SYNCED
+   * state regardless of what was in them. Sync is a property of a document,
+   * derived from `uploadedByPmsUserId`, and DocumentListItem and
+   * DocumentPreviewScreen already show it correctly per document.
+   */
   fileCount: number;
   subcategories: DocumentSubcategory[];
 }

--- a/apps/mobileAppYC/src/features/documents/types.ts
+++ b/apps/mobileAppYC/src/features/documents/types.ts
@@ -38,13 +38,6 @@ export interface DocumentCategory {
   description?: string;
   /** Warm-bone surface-token key for the category's pastel icon tile. */
   iconTint?: string;
-  /*
-   * No `isSynced` on a category. It was a hardcoded literal - health and
-   * hygiene-maintenance true, the rest false - so two tiles claimed a SYNCED
-   * state regardless of what was in them. Sync is a property of a document,
-   * derived from `uploadedByPmsUserId`, and DocumentListItem and
-   * DocumentPreviewScreen already show it correctly per document.
-   */
   fileCount: number;
   subcategories: DocumentSubcategory[];
 }

--- a/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.helpers.ts
+++ b/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.helpers.ts
@@ -1,6 +1,11 @@
 export const deriveHomeGreetingName = (rawFirstName?: string | null) => {
   const trimmed = rawFirstName?.trim() ?? '';
-  const resolvedName = trimmed.length > 0 ? trimmed : 'Sky';
+  /*
+   * No stand-in name. This used to fall back to 'Sky', so an account with no
+   * first name was greeted by someone else's - a fixture name that reached
+   * production. 'there' reads as a greeting rather than as the user's name.
+   */
+  const resolvedName = trimmed.length > 0 ? trimmed : 'there';
   const displayName =
     resolvedName.length > 13 ? `${resolvedName.slice(0, 13)}...` : resolvedName;
   return {resolvedName, displayName};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for — from the desktop/mobile sweep behind #2620 and #2623.
- [x] All existing tests and lints pass.

## What is the current behavior?

### 1. Every vet appears online

`ChatChannelScreen` renders the presence dot unconditionally inside the avatar:

```tsx
<Text style={styles.avatarText}>{initials}</Text>
<View style={styles.presenceDot} />
```

Nothing in the app subscribes to presence and the chat transport exposes none — the only two references to `presence` in the file are this render and its style. A dot that is always green tells the pet owner nothing, and implies someone is there to answer.

### 2. Two document categories claim to be SYNCED

`isSynced` was a hardcoded literal on the category constants — `true` for **health** and **hygiene-maintenance**, `false` for the other three — and `CategoryTile` paints a `SYNCED` pill from it. Those two tiles claimed a sync state regardless of what was in them.

Sync is a property of a **document**, not a category. `DocumentListItem` and `DocumentPreviewScreen` already derive it correctly from `uploadedByPmsUserId`, and that is untouched — the flag is removed from the constants, the tile call site, and the `DocumentCategory` type.

### 3. An account with no first name is greeted as "Sky"

```ts
const resolvedName = trimmed.length > 0 ? trimmed : 'Sky';
```

A fixture name that reached production. Now `'there'`, which reads as a greeting rather than as somebody's name.

## Validation performed

- **Mobile suite: 479 suites, 7,754 tests, all pass.** `tsc --noEmit` clean, `lint` exit 0.

Two notes on the tests, both worth reading:

- One existing case passes `'  Sky  '` as the *supplied* name and expects it trimmed to `'Sky'`. That is the trim being tested, not the fallback, so it still expects `'Sky'`. My first pass replaced it along with the fallback assertions — the suite caught it and I narrowed the change rather than bending the test.
- Test titles that read *"falls back to Sky"* now describe the behaviour instead of the old value, so they do not go stale the next time the copy changes.

## Dropped from this sweep, deliberately

The sweep also flagged the desktop offline screen's *"Edits are saved on this device and sync when the connection returns"* as a false promise. **It is not.** `sync/offline-store.ts` is a real SQLite store with `_dirty` tracking, `getDirtyRows` and `markSynced`, and `sync/sync-engine.ts` pushes dirty rows and marks them synced. I verified this before touching it — removing that reassurance would have made the product worse and the statement less true, not more.

## Filed separately

Notification actions are a bigger problem than a copy fix: **archive, delete, clear-all and mark-all-read are all local-only mocks** (`await mockDelay(...)` with the API call commented out), and the backend exposes only `GET /mobile` and `POST /mobile/:id/seen` — so four of the five actions have no endpoint to call at all. Swipe-to-archive animates the row away, drops the unread count, and the notification returns on reload. That needs backend endpoints or the affordances removed, so it is going in its own issue rather than being half-fixed here.
