### PR TITLE
feat(frontend): search coded terms in one vocabulary

### DIFF
--- a/apps/backend/src/controllers/web/code.controller.ts
+++ b/apps/backend/src/controllers/web/code.controller.ts
@@ -61,6 +61,9 @@ const TermsSuggestQuerySchema = z.object({
       "Procedure",
     ])
     .optional(),
+  // Only terms carrying a usable crosswalk to this vocabulary. A practice that
+  // works in SNOMED wants a list it can actually code in SNOMED.
+  vocabulary: z.enum(["VENOM", "SNOMED"]).optional(),
   species: z
     .union([z.string(), z.array(z.string())])
     .optional()
@@ -173,13 +176,14 @@ export const CodeController = {
         });
       }
 
-      const { q, domain, species, limit } = queryResult.data;
+      const { q, domain, species, limit, vocabulary } = queryResult.data;
 
       const items = await ClinicalTermsService.suggestTerms({
         q,
         domain,
         species,
         limit,
+        vocabulary,
       });
 
       return res.status(200).json({ items });

--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -83,6 +83,14 @@ export type ClinicalTermCoding = {
   equivalence: MappingEquivalence;
 };
 
+/**
+ * Restrict results to terms that actually carry a usable crosswalk to one
+ * vocabulary. A practice that works in SNOMED wants a list it can code in
+ * SNOMED; showing terms with no SNOMED counterpart wastes their time and
+ * produces records they cannot export the way they need.
+ */
+export type VocabularyFilter = "VENOM" | "SNOMED";
+
 export type ClinicalTermSuggestion = {
   ycCode: string;
   label: string;
@@ -240,6 +248,8 @@ export type SuggestTermsParams = {
   domain?: ClinicalDomain;
   species?: ClinicalSpecies[];
   limit?: number;
+  /** Only terms with a usable crosswalk to this vocabulary. */
+  vocabulary?: VocabularyFilter;
 };
 
 /**
@@ -287,6 +297,22 @@ export const buildSuggestionQuery = (
     const speciesElements = jsonTextArray(SPECIES_META);
     filters.push(
       Prisma.sql`EXISTS (SELECT 1 FROM ${speciesElements} sp WHERE sp = ANY(${params.species}))`,
+    );
+  }
+
+  if (params.vocabulary) {
+    // Same usable-equivalence gate the picker and the export apply, so a term is
+    // only offered under a vocabulary filter when that vocabulary genuinely holds
+    // a counterpart for it - not merely a row saying "no counterpart exists".
+    filters.push(
+      Prisma.sql`EXISTS (
+        SELECT 1 FROM "CodeMapping" m
+        WHERE m."sourceCode" = e."code"
+          AND m."sourceSystem" = 'YOSEMITECODE'::"CodeSystem"
+          AND m."targetSystem" = ${params.vocabulary}::"CodeSystem"
+          AND m."active"
+          AND m."equivalence" = ANY(${USABLE_SUGGESTION_EQUIVALENCES}::"MappingEquivalence"[])
+      )`,
     );
   }
 

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -358,6 +358,25 @@ describe("ClinicalTermsService", () => {
     });
   });
 
+  describe("buildSuggestionQuery vocabulary filter", () => {
+    const sqlFor = (params: Parameters<typeof buildSuggestionQuery>[0]) =>
+      buildSuggestionQuery(params).sql;
+
+    it("restricts to terms that hold a usable crosswalk in that vocabulary", () => {
+      const text = sqlFor({ q: "vom", vocabulary: "SNOMED" });
+      expect(text).toContain('"CodeMapping"');
+      expect(text).toContain('m."targetSystem"');
+      // The same gate the picker and export use: a row saying "no counterpart
+      // exists" must not qualify a term for a SNOMED-only list.
+      expect(text).toContain('m."equivalence" = ANY');
+      expect(text).toContain('m."active"');
+    });
+
+    it("adds no mapping join when no vocabulary is asked for", () => {
+      expect(sqlFor({ q: "vom" })).not.toContain('"CodeMapping"');
+    });
+  });
+
   describe("buildSuggestionQuery", () => {
     // The filtering lives in SQL now, so these assert the statement itself. Mocking the
     // database and asserting the rows it was told to return would prove nothing.

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
@@ -259,3 +259,88 @@ describe('SoapCodedTermPicker', () => {
     await waitFor(() => expect(screen.queryByText('Vomiting')).not.toBeInTheDocument());
   });
 });
+
+describe('SoapCodedTermPicker vocabulary scope', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    suggestMock.mockReset();
+    suggestMock.mockResolvedValue([VOMITING]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const lastCall = () => suggestMock.mock.calls.at(-1)?.[0] ?? {};
+
+  it('asks for every vocabulary until a scope is picked', async () => {
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Subjective"
+        domain="PresentingComplaint"
+        selected={[]}
+        onChange={jest.fn()}
+      />
+    );
+    typeQuery('vom');
+    await waitFor(() => expect(suggestMock).toHaveBeenCalled());
+    // No `vocabulary` key at all, rather than an explicit "ALL" the API
+    // would have to know about.
+    expect(lastCall()).not.toHaveProperty('vocabulary');
+  });
+
+  it('re-queries in the picked vocabulary and marks the control checked', async () => {
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Subjective"
+        domain="PresentingComplaint"
+        selected={[]}
+        onChange={jest.fn()}
+      />
+    );
+    typeQuery('vom');
+    await waitFor(() => expect(suggestMock).toHaveBeenCalled());
+
+    const snomed = screen.getByRole('radio', { name: 'SNOMED' });
+    await act(async () => {
+      fireEvent.click(snomed);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    /* The scope is part of the query, not a filter over what came back: a term
+       with no SNOMED counterpart must never be fetched and then hidden, or the
+       result count silently disagrees with the limit. */
+    expect(lastCall()).toMatchObject({ q: 'vom', vocabulary: 'SNOMED' });
+    expect(snomed).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('drops the filter again when the scope goes back to All', async () => {
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Subjective"
+        domain="PresentingComplaint"
+        selected={[]}
+        onChange={jest.fn()}
+      />
+    );
+    typeQuery('vom');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: 'VeNom' }));
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(lastCall()).toMatchObject({ vocabulary: 'VENOM' });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: 'All' }));
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(lastCall()).not.toHaveProperty('vocabulary');
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
@@ -8,7 +8,20 @@ import {
   suggestClinicalTerms,
   type ClinicalTermDomain,
   type ClinicalTermSuggestion,
+  type VocabularyFilter,
 } from '@/app/features/appointments/services/clinicalTermsService';
+
+/**
+ * Vocabulary scope for the search. "All" offers every term and shows whichever
+ * crosswalks exist; picking a vocabulary narrows the list to terms that can
+ * actually be coded in it, which is what a practice working in SNOMED (or
+ * VeNom) alone needs — a list with no dead ends.
+ */
+const VOCABULARY_SCOPES: Array<{ value: VocabularyFilter | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All' },
+  { value: 'VENOM', label: 'VeNom' },
+  { value: 'SNOMED', label: 'SNOMED' },
+];
 
 /** Short vocabulary labels; the picker has no room for full system URIs. */
 const SYSTEM_LABEL: Record<string, string> = {
@@ -86,6 +99,7 @@ const SoapCodedTermPicker = ({
   onChange,
 }: SoapCodedTermPickerProps) => {
   const anchorRef = useRef<HTMLDivElement>(null);
+  const [scope, setScope] = useState<VocabularyFilter | 'ALL'>('ALL');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<ClinicalTermSuggestion[]>([]);
   // Monotonic request id: a slow earlier response must never overwrite a newer one.
@@ -105,7 +119,12 @@ const SoapCodedTermPicker = ({
           setResults([]);
           return;
         }
-        suggestClinicalTerms({ q: trimmed, domain, limit: SUGGEST_LIMIT })
+        suggestClinicalTerms({
+          q: trimmed,
+          domain,
+          limit: SUGGEST_LIMIT,
+          ...(scope === 'ALL' ? {} : { vocabulary: scope }),
+        })
           .then((items) => {
             if (requestSeqRef.current === requestId) setResults(items);
           })
@@ -117,7 +136,7 @@ const SoapCodedTermPicker = ({
       belowMinimum ? 0 : SUGGEST_DEBOUNCE_MS
     );
     return () => clearTimeout(timer);
-  }, [query, domain]);
+  }, [query, domain, scope]);
 
   const selectedCodes = useMemo(() => new Set(selected.map((term) => term.ycCode)), [selected]);
 
@@ -181,6 +200,31 @@ const SoapCodedTermPicker = ({
           ))}
         </ul>
       )}
+      <div
+        className="flex items-center gap-1"
+        role="radiogroup"
+        aria-label={`Vocabulary for ${sectionLabel} coded terms`}
+      >
+        {VOCABULARY_SCOPES.map((option) => {
+          const active = scope === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => setScope(option.value)}
+              className={`rounded-full border px-2.5 py-1 text-caption-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${
+                active
+                  ? 'border-transparent bg-neutral-200 text-text-primary'
+                  : 'border-card-border bg-transparent text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
       <div ref={anchorRef} className="relative w-full sm:max-w-90">
         <Search
           value={query}

--- a/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
+++ b/apps/frontend/src/app/features/appointments/services/clinicalTermsService.ts
@@ -29,13 +29,18 @@ export type ClinicalTermSuggestion = {
  * synonyms; `domain` narrows to one clinical bucket (e.g. Diagnosis for the
  * Assessment section) and is omitted to search everything.
  */
+/** A practice can narrow the list to terms it can code in one vocabulary. */
+export type VocabularyFilter = 'VENOM' | 'SNOMED';
+
 export const suggestClinicalTerms = async (params: {
   q: string;
   domain?: ClinicalTermDomain;
   limit?: number;
+  vocabulary?: VocabularyFilter;
 }): Promise<ClinicalTermSuggestion[]> => {
   const search = new URLSearchParams({ q: params.q });
   if (params.domain) search.set('domain', params.domain);
+  if (params.vocabulary) search.set('vocabulary', params.vocabulary);
   if (params.limit) search.set('limit', String(params.limit));
   const res = await getData<{ items?: ClinicalTermSuggestion[] }>(
     `/v1/codes/terms/suggest?${search.toString()}`


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The SOAP coded-term picker offers every Yosemite term and shows whichever crosswalks each one happens to carry. A practice that codes in SNOMED alone, or in VeNom alone, has no way to avoid picking a term with no counterpart in the vocabulary it actually uses. They find out at export time, when the record cannot be coded the way they need.

## What is the new behavior?

A scope control beside the search box: **All / VeNom / SNOMED**.

Picking one restricts the search to terms that hold a usable crosswalk in that vocabulary.

Two details that matter:

- The scope narrows the **query**, not the results. Filtering after the fact would silently disagree with the result limit: ask for 8, get 3, with no way to tell whether the rest exist.
- The gate is the same usable-equivalence set the picker and the FHIR export already apply. A `CodeMapping` row that records *no counterpart exists* does not qualify a term.

Picked terms still store every crosswalk they carry. The scope changes what a clinician is offered, never what the record holds.

### Verification against the dev database

Running the exact `EXISTS` clause against dev, for the query `vom`:

| filter | terms |
| --- | --- |
| none | 27 |
| usable SNOMED crosswalk | 10 |
| usable VeNom crosswalk | 17 |

The entries dropped under SNOMED-only are the VeNom-native ones (`YCAT:VENOM:102` "Vomiting finding", `YCAT:VENOM:17954` "Other vomiting finding"), which is exactly right.

## Related Issue(s)

Follows the coded-term work in #2601. Requested directly: a practice may want to refer to VeNom only, or SNOMED only.
