### PR TITLE
fix(frontend): show clipped workspace text in full on hover

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TotalBillContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TotalBillContainer.test.tsx
@@ -70,6 +70,24 @@ const renderBill = (
 const overallDiscountInput = () => screen.getByLabelText('Overall discount percent');
 
 describe('TotalBillContainer', () => {
+  it('carries the billed item name as a tooltip, since the column clips it', () => {
+    /* On dev this column renders 150px of text in an 88px box, so
+       "Anal Gland Expression" shows as "Anal Gland...". It is what the client
+       is being charged for, so the full name has to stay reachable. */
+    const { view } = renderBill({
+      ...baseItem,
+      id: 'line-long',
+      name: 'Anal Gland Expression',
+    });
+    /* The name also appears in the remove button's label, and the panel heading
+       is itself a truncating span, so find the cell by both class and text. */
+    const cell = [...view.container.querySelectorAll('span.truncate')].find(
+      (node) => node.textContent === 'Anal Gland Expression'
+    );
+    expect(cell).toBeDefined();
+    expect(cell).toHaveAttribute('title', 'Anal Gland Expression');
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/WorkspaceSearchResultRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/WorkspaceSearchResultRow.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WorkspaceSearchResultRow from '@/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceSearchResultRow';
+
+/* The two ATCvet rows that motivated the tooltip: identical once the origin
+   line clips, and one digit apart in the code. */
+const SYSTEMIC =
+  'QJ01CR02 · ANTIBACTERIALS FOR SYSTEMIC USE · BETA-LACTAM ANTIBACTERIALS, PENICILLINS';
+const INTRAMAMMARY =
+  'QJ51CR02 · ANTIBACTERIALS FOR INTRAMAMMARY USE · BETA-LACTAM ANTIBACTERIALS, PENICILLINS';
+
+describe('WorkspaceSearchResultRow', () => {
+  it('carries the full name and origin as tooltips, so a clipped line stays readable', () => {
+    render(
+      <ul>
+        <WorkspaceSearchResultRow
+          name="amoxicillin and beta-lactamase inhibitor"
+          origin={SYSTEMIC}
+          onSelect={jest.fn()}
+        />
+        <WorkspaceSearchResultRow
+          name="amoxicillin and enzyme inhibitor"
+          origin={INTRAMAMMARY}
+          onSelect={jest.fn()}
+        />
+      </ul>
+    );
+
+    expect(screen.getByText(SYSTEMIC)).toHaveAttribute('title', SYSTEMIC);
+    expect(screen.getByText(INTRAMAMMARY)).toHaveAttribute('title', INTRAMAMMARY);
+    expect(screen.getByText('amoxicillin and enzyme inhibitor')).toHaveAttribute(
+      'title',
+      'amoxicillin and enzyme inhibitor'
+    );
+  });
+
+  it('leaves the disabled reason as the only tooltip on a disabled row', () => {
+    render(
+      <ul>
+        <WorkspaceSearchResultRow
+          name="amoxicillin and enzyme inhibitor"
+          origin={INTRAMAMMARY}
+          disabled
+          disabledReason="Added"
+          onSelect={jest.fn()}
+        />
+      </ul>
+    );
+
+    /* A nested title wins over an ancestor's, so leaving one on the inner spans
+       would hide "Added" behind the text the user already picked. */
+    expect(screen.getByRole('button')).toHaveAttribute('title', 'Added');
+    expect(screen.getByText(INTRAMAMMARY)).not.toHaveAttribute('title');
+    expect(screen.getByText('amoxicillin and enzyme inhibitor')).not.toHaveAttribute('title');
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -305,7 +305,12 @@ const BillRow = ({
     <li className={`${ROW_GRID} text-body-4 text-text-primary ${hasDiscountMeta ? 'pb-2' : ''}`}>
       <TextCell className="min-w-0">
         <span className="inline-flex min-w-0 items-center gap-1">
-          <span className="truncate">{item.name}</span>
+          {/* The billed item name clips in this column - on dev "Anal Gland
+              Expression" renders 150px of text in an 88px box. It is what the
+              client is being charged for, so it needs to be readable. */}
+          <span className="truncate" title={item.name}>
+            {item.name}
+          </span>
           <PackageBreakdownTooltip item={item} currency={currency} />
           {incomplete && (
             <InfoTooltipIcon

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceSearchResultRow.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceSearchResultRow.tsx
@@ -48,10 +48,26 @@ const WorkspaceSearchResultRow = ({
       className="flex w-full items-center gap-2 px-4 py-2 text-left text-body-4 text-text-primary hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-60"
     >
       {leadingIcon}
+      {/* Both lines clip, and the origin is the one that loses meaning when it does:
+          an ATCvet class path opens with its group, so "QJ01CR02 - ANTIBACTERIALS
+          FOR SYSTEMIC USE ..." and "QJ51CR02 - ANTIBACTERIALS FOR INTRAMAMMARY
+          USE ..." truncate to the same visible text - systemic and intramammary,
+          told apart by one digit. The full string is already in the DOM for
+          assistive tech; `title` gives a sighted user the same on hover.
+
+          Only while the row is enabled: a nested title beats the button's own,
+          and on a disabled row "Added" is the more useful thing to say. */}
       <span className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate">{name}</span>
+        <span className="truncate" title={disabled ? undefined : name}>
+          {name}
+        </span>
         {origin ? (
-          <span className="truncate text-caption-2 text-text-secondary">{origin}</span>
+          <span
+            className="truncate text-caption-2 text-text-secondary"
+            title={disabled ? undefined : origin}
+          >
+            {origin}
+          </span>
         ) : null}
       </span>
       {disabled && disabledReason ? (

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -497,7 +497,10 @@ export const InvoiceBreakdown = ({
         {invoice.items.map((item) => (
           <li key={item.id} className={`${ROW_GRID} px-1 py-2.5 text-body-4 text-text-primary`}>
             <span className="inline-flex min-w-0 items-center gap-1 font-medium">
-              <span className="truncate">{item.name}</span>
+              {/* Same clipped billed-item name as TotalBillContainer. */}
+              <span className="truncate" title={item.name}>
+                {item.name}
+              </span>
               <PackageBreakdownTooltip item={item} currency={currency} />
             </span>
             <span>{formatCents(item.unitPriceCents, currency)}</span>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Workspace search result rows clip both the name and the origin line, and neither carries a tooltip. The origin line is the one that loses meaning when it clips.

Searching `amoxicillin` in the treatment step on dev returns, among others:

```
amoxicillin and beta-...        QJ01CR02 · ANTIBACTERI...
amoxicillin and enzy...         QJ51CR02 · ANTIBACTERI...
```

Those are **ANTIBACTERIALS FOR SYSTEMIC USE** and **ANTIBACTERIALS FOR INTRAMAMMARY USE**. Truncated, they are one digit apart, and the digit is the only thing on screen that distinguishes them.

## What is the new behavior?

Both lines carry a `title`, so hovering reveals the full string. The text was already complete in the DOM for assistive tech; this gives a sighted user the same.

Not while the row is disabled. A nested `title` beats the button's own, and on an already-added row "Added" is the more useful thing to say, so the tooltips are dropped in that state and the existing behaviour is untouched.

## Tests

The component had no tests at all. This adds the first two: one for the tooltips, one for the disabled row keeping "Added" as its only tooltip.

Both were mutation-checked. Dropping the origin `title`, and ungating it so it shadows "Added", each fail a test.

## Related Issue(s)

Found while visually verifying the ATCvet prescribing work (#2601, #2619) on dev.
