### PR TITLE
fix(frontend): give the Room and Unit pickers a real notch too

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
@@ -20,6 +20,23 @@ describe('LabelDropdown', () => {
     { label: 'Feline', value: 'cat' },
   ];
 
+  describe('hideLabel', () => {
+    it('drops the stacked label but keeps it on the trigger for assistive tech', () => {
+      render(<LabelDropdown placeholder="Room" options={options} onSelect={jest.fn()} hideLabel />);
+      /* Omitted, not hidden with CSS: a hidden element keeps the same text in
+         the accessibility tree and reappears the moment the selector that hides
+         it stops matching - which is how the meta bar's label got duplicated. */
+      const labels = screen.queryAllByText('Room').filter((node) => node.tagName !== 'BUTTON');
+      expect(labels).toHaveLength(0);
+      expect(screen.getByRole('button', { name: 'Room' })).toBeInTheDocument();
+    });
+
+    it('still renders the stacked label by default', () => {
+      render(<LabelDropdown placeholder="Room" options={options} onSelect={jest.fn()} />);
+      expect(screen.getAllByText('Room').some((node) => node.tagName === 'SPAN')).toBe(true);
+    });
+  });
+
   it('renders placeholder and error when no selection', () => {
     render(
       <LabelDropdown

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
@@ -62,12 +62,12 @@ const EditableMetaDropdown = ({
   onSelect: (option: DropdownOption) => void;
 }) => (
   <MetaFieldShell label={label}>
-    {/* The shell already supplies the box, its padding and the 43px of content
-        height below its legend, so the trigger gives all three up: no border, no
-        fill, no left padding, and `h-full` rather than its own 44px - the
-        fieldset's content box is what is left under the legend, about 32px, and
-        a fixed height overflows it. What the trigger keeps is the right padding
-        the chevron is positioned into. */}
+    {/* The shell already supplies the box, its padding and its content height, so
+        the trigger gives all three up: no border, no fill, no left padding, and
+        `h-full` rather than its own 44px. A fieldset's content box is only what
+        is left *under* the legend - about 32px inside the 46px box - so any
+        fixed height overflows the bottom. What the trigger keeps is the right
+        padding the chevron is positioned into. */}
     <div className="h-full w-full min-w-0 [&>div]:h-full [&>div>div]:h-full [&>div>div>button]:h-full [&>div>div>button]:w-full [&>div>div>button]:rounded-[14px]! [&>div>div>button]:border-0! [&>div>div>button]:bg-transparent! [&>div>div>button]:pl-0! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
       <LabelDropdown
         placeholder={label}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
@@ -31,12 +31,24 @@ const ReadOnlyMetaField = ({ label, value }: { label: string; value: string }) =
 );
 
 /**
- * Editable Room/Unit dropdown. LabelDropdown's trigger already carries the
- * design's 46px / 1.5px-hairline / 13px-radius box, so the changes needed here
- * are the label and the fill: its stacked label is hidden and re-rendered
- * notched into the trigger's top border, and the trigger is filled with
- * `--field-bg` (theme-live via var()) so it matches the sibling read-only meta
- * fields instead of washing out transparently.
+ * Editable Room/Unit dropdown, wearing the same chrome as its read-only
+ * siblings.
+ *
+ * It used to fake the notch the way StaffField did: pull LabelDropdown's
+ * stacked label up over the trigger's top border and paint a background behind
+ * it to hide the line. That cannot be made to work. The label straddles the
+ * border, so its top half sits on the page and its bottom half on the field -
+ * two different colours - and a single background can only match one of them.
+ * Painting `--page` left a beige rectangle biting into the near-white field;
+ * painting `--field-bg` would leave a pale one on the page instead.
+ *
+ * So the box now comes from MetaFieldShell, whose notch is a real
+ * `fieldset`/`legend` the browser cuts out of the border, and the trigger is
+ * stripped of its own border, fill and height to sit inside it. LabelDropdown
+ * omits its own label via `hideLabel` - the trigger's `aria-label` already
+ * carries "Room: <value>", so nothing is lost to assistive tech, and omitting
+ * the element beats hiding it with CSS, which leaves the same text in the
+ * accessibility tree and renders twice the moment the selector stops matching.
  */
 const EditableMetaDropdown = ({
   label,
@@ -49,14 +61,23 @@ const EditableMetaDropdown = ({
   value?: string;
   onSelect: (option: DropdownOption) => void;
 }) => (
-  <div className="relative w-full [&>div>span]:pointer-events-none [&>div>span]:absolute [&>div>span]:-top-[7px] [&>div>span]:left-3 [&>div>span]:z-30 [&>div>span]:mb-0 [&>div>span]:bg-[var(--page)] [&>div>span]:px-[5px] [&>div>span]:text-[10.5px] [&>div>span]:text-[var(--ink-faint)] [&>div>div>button]:rounded-[14px]! [&>div>div>button]:bg-[var(--field-bg)]! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
-    <LabelDropdown
-      placeholder={label}
-      options={options}
-      defaultOption={value}
-      onSelect={onSelect}
-    />
-  </div>
+  <MetaFieldShell label={label}>
+    {/* The shell already supplies the box, its padding and the 43px of content
+        height below its legend, so the trigger gives all three up: no border, no
+        fill, no left padding, and `h-full` rather than its own 44px - the
+        fieldset's content box is what is left under the legend, about 32px, and
+        a fixed height overflows it. What the trigger keeps is the right padding
+        the chevron is positioned into. */}
+    <div className="h-full w-full min-w-0 [&>div]:h-full [&>div>div]:h-full [&>div>div>button]:h-full [&>div>div>button]:w-full [&>div>div>button]:rounded-[14px]! [&>div>div>button]:border-0! [&>div>div>button]:bg-transparent! [&>div>div>button]:pl-0! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
+      <LabelDropdown
+        placeholder={label}
+        options={options}
+        defaultOption={value}
+        onSelect={onSelect}
+        hideLabel
+      />
+    </div>
+  </MetaFieldShell>
 );
 
 /**

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
@@ -24,6 +24,15 @@ type DropdownProps = {
    * that moves - showing an answer the record does not contain.
    */
   disabled?: boolean;
+  /**
+   * Drop the stacked label above the trigger, for callers that supply their own
+   * (the workspace meta bar renders it as a `legend` notched into the field
+   * border). The trigger's `aria-label` already carries "<label>: <value>", so
+   * nothing is lost - and omitting the element beats hiding it with CSS, which
+   * leaves the same text in the accessibility tree and renders twice the moment
+   * the selector stops matching.
+   */
+  hideLabel?: boolean;
 };
 
 const TERMINOLOGY_LOCK_SELECTOR = "[data-terminology-lock='true']";
@@ -200,6 +209,7 @@ const LabelDropdown = ({
   portal = true,
   noOptionsMessage,
   disabled = false,
+  hideLabel = false,
 }: DropdownProps) => {
   const [internalSelected, setInternalSelected] = useState<DropdownOption | null>(() =>
     findDropdownOption(options, defaultOption)
@@ -291,10 +301,12 @@ const LabelDropdown = ({
 
   return (
     <div className="flex flex-col w-full">
-      <span className="mb-1.5 flex items-center gap-1 truncate text-[12px] font-semibold text-[var(--ink-soft)]">
-        {icon}
-        {placeholder}
-      </span>
+      {!hideLabel && (
+        <span className="mb-1.5 flex items-center gap-1 truncate text-[12px] font-semibold text-[var(--ink-soft)]">
+          {icon}
+          {placeholder}
+        </span>
+      )}
       <div className="w-full relative" ref={attachDropdownRef}>
         <button
           type="button"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2615 gave the read-only meta fields a real `fieldset`/`legend` notch. The editable **Room** and **Unit** pickers are a different component and kept faking theirs, so on dev right now three fields are clean and Room still sits on a patch:

The faked notch pulls `LabelDropdown`'s stacked label up over the trigger's top border and paints a background behind it to hide the line.

That cannot be made to work, and it is worth being precise about why. The label **straddles** the border: its top half is over the page, its bottom half over the field. Those are different colours, and one background can only match one of them. #2615 changed the patch from `--screen` to `--page` so it matched the page exactly, and it is still visible, because the half sitting over the near-white `--field-bg` now paints beige into it.

Measured on dev after #2615 deployed: the Room label's background computes to `rgb(239, 232, 220)`, exactly `--page` — and it still reads as a rectangle.

## What is the new behavior?

The box comes from `MetaFieldShell`, so the notch is a real border cut the browser makes, and the trigger gives up its border, fill, left padding and fixed height to sit inside it.

Measured in Storybook, all four fields now agree exactly:

| field | value text left | vertical centre | box height | legend background |
| --- | --- | --- | --- | --- |
| Assigned lead | 16 | 29 | 46 | transparent |
| Support staff | 16 | 29 | 46 | transparent |
| Consultation type | 16 | 29 | 46 | transparent |
| **Room** | **16** | **29** | **46** | **transparent** |

Two details worth flagging for review:

- The trigger uses `h-full`, not a fixed height. A `fieldset`'s content box is what is left *under* the legend — about 32px inside the 46px box — so the 43px I first tried overflowed the bottom by 10px.
- `LabelDropdown` gains a `hideLabel` prop rather than the caller hiding the span with a CSS descendant selector. Hiding left the same text in the accessibility tree and rendered the label twice the moment the selector stopped matching. A `WorkspaceShell` test caught exactly that ("Found multiple elements with the text: Room"). The trigger's `aria-label` already carries "Room: <value>", so nothing is lost.

## Tests

- Two new `LabelDropdown` tests for `hideLabel`, both directions mutation-checked (ignoring the prop, and always dropping the label, each fail).
- 1139 existing tests across `AppointmentWorkspace|Dropdown` pass, including the `WorkspaceShell` one that fails on the duplicate label.

Verified visually in Storybook in both themes, and with the Room listbox open, which still positions correctly under the trigger.

## Related Issue(s)

Finishes the meta-bar label work from #2615. Room was named directly in the original report alongside the other three.
