### PR TITLE
fix(frontend): stop the public site selling things that do not exist

### DIFF
--- a/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
@@ -474,13 +474,13 @@ function HeroTerminalCard() {
       >
         <span style={{ color: '#54b492' }}>$</span> git clone yosemitecrew/Yosemite-Crew
         {'\n'}
-        <span style={{ color: '#54b492' }}>$</span> bun install{' '}
-        <span style={{ color: '#5c5956' }}>&amp;&amp;</span> bun run dev
+        <span style={{ color: '#54b492' }}>$</span> pnpm install{' '}
+        <span style={{ color: '#5c5956' }}>&amp;&amp;</span> pnpm dev
         {'\n'}
-        <span style={{ color: '#8f8984' }}>→ PIMS live on :3000 &nbsp;·&nbsp; works offline</span>
+        <span style={{ color: '#8f8984' }}>→ PIMS live on :3000</span>
         {'\n'}
         <span style={{ color: '#54b492' }}>$</span>
-        {' yc plugins publish ./ai-scribe'}
+        {' open localhost:3000/dev-docs'}
         <span
           style={{
             display: 'inline-block',
@@ -1214,10 +1214,11 @@ function Marketplace() {
                 textWrap: 'pretty',
               }}
             >
-              It works the way WordPress plugins do. You build against the API, publish to the
-              marketplace, and any clinic running Yosemite Crew installs your work with one click.
-              The distribution is already there, so the only thing between your idea and a paying
-              practice is the building.
+              The model is the one WordPress proved: build against the API, and every clinic running
+              Yosemite Crew is a clinic that can run your work. The API and the FHIR layer are here
+              today and the whole platform is open source, so you can build and self-host against a
+              real practice now. The marketplace that turns that into one-click distribution is not
+              built yet, and until it is, installing a plugin means deploying it yourself.
             </p>
             <Link
               href="/developers/signup"

--- a/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
@@ -1818,8 +1818,9 @@ function PrinciplesGrid() {
         padding="40px 0 40px 48px"
         borderLeft
       >
-        Records stay in the country where you practice, under laws you actually agreed to, not
-        wherever cheap servers happened to have spare room that week.
+        The platform is open source and self-hostable, so you can run it in the country you practice
+        in, under laws you actually agreed to, rather than wherever cheap servers happened to have
+        spare room that week.
       </PrincipleCell>
     </div>
   );

--- a/apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx
@@ -810,7 +810,7 @@ const FEATURES: readonly Feature[] = [
   {
     icon: IoShieldCheckmarkOutline,
     title: 'Report a reaction, protect the next animal',
-    body: 'If a medicine or vaccine goes wrong, report it in a few taps. It reaches the people who track drug safety, so one bad day helps keep the next animal well.',
+    body: 'If a medicine or vaccine goes wrong, record it in a few taps. It reaches your vet with the dose, the batch and the timeline already attached, so the report they file is the one that helps the next animal.',
     delay: 160,
   },
   {


### PR DESCRIPTION
## What

Four claims on the public marketing pages describe capabilities nothing in the repository backs. Three of them are in the first thing a visiting developer sees.

## The /developers hero terminal is wrong on every line

It is the quickstart a developer is invited to copy:

| Line | Problem |
|---|---|
| `bun install && bun run dev` | The repo is a pnpm workspace. `package.json` pins `pnpm@8.15.6`, the only lockfile is `pnpm-lock.yaml`, there is no `bun.lockb`. The command does not work. |
| `→ PIMS live on :3000 · works offline` | No service worker, no PWA config, no workbox anywhere in `apps/frontend`. |
| `yc plugins publish ./ai-scribe` | There is no `yc` CLI. No package in the workspace declares that binary. |

Now `pnpm install && pnpm dev`, the offline claim is gone, and the last command is `open localhost:3000/dev-docs`, which is real and now navigable.

## The marketplace is sold in the present tense

> You build against the API, publish to the marketplace, and any clinic running Yosemite Crew installs your work with one click. The distribution is already there.

There is no marketplace. No plugin, marketplace or listing model in `schema.prisma`; no marketplace or plugin router in `apps/backend`.

The copy now leads with what is actually here (the API, the FHIR layer, an open-source platform you can build and self-host against today) and says plainly that one-click distribution is not built yet.

## Home principle 04 promises data residency

> Records stay in the country where you practice.

Nothing implements per-tenant residency: one `DATABASE_URL`, one datasource in `schema.prisma`, no region column on `Organization`. The principle now rests on the part that is true, that the platform is open source so you can run it where you practice, rather than promising a hosted guarantee that does not exist.

## Pet parents are told a reaction report reaches drug-safety authorities

> It reaches the people who track drug safety.

`AdverseEventService` has no outbound call of any kind: no HTTP client, no mail, no queue. It writes a row.

What is true is that the report carries real detail and reaches the clinic. `AdverseEventProductInfo` captures batch number, quantity and unit, frequency, administration method and the before/after condition, and the mobile flow refuses to submit without a linked hospital. The copy now says that instead.

## Validation

Each absence was verified by grep against `apps/`, `packages/` and the Prisma schema rather than inferred from the copy. frontend `tsc` clean; `lint` clean (the single warning is pre-existing in `CompanionIdCard.test.tsx`, untouched here); 47 tests across the three pages pass.

## Impact

Public marketing pages only. No behaviour change.

## Not in this PR

Two findings from the same sweep are deliberately left out:

- The mobile app tells a reporter **"We sent your report to the manufacturer"** when nothing is sent. Different workspace, follow-up PR.
- The certification pills on `/trust-center` assert `SOC 2 Type I` and `ISO 27001:2022` as COMPLIANT. **This one needs a human answer, not a code fix** - a certificate would not live in this repo either way, so absence here is not evidence the company lacks one. Flagging rather than changing it.