### PR TITLE
fix(frontend): say why a scoped coded-term search found nothing

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapCodedTermPicker.test.tsx
@@ -344,3 +344,83 @@ describe('SoapCodedTermPicker vocabulary scope', () => {
     expect(lastCall()).not.toHaveProperty('vocabulary');
   });
 });
+
+describe('SoapCodedTermPicker scoped empty state', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    suggestMock.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const renderPicker = () =>
+    render(
+      <SoapCodedTermPicker
+        sectionLabel="Subjective"
+        domain="PresentingComplaint"
+        selected={[]}
+        onChange={jest.fn()}
+      />
+    );
+
+  const pickScope = async (name: string) => {
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name }));
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+  };
+
+  it('explains an empty result under a scope, and offers to widen it', async () => {
+    suggestMock.mockResolvedValue([]);
+    renderPicker();
+    typeQuery('zzz');
+    await pickScope('SNOMED');
+
+    /* Without this the dropdown simply does not open, which reads as "search is
+       broken" rather than "no term in this vocabulary matches" - the one case
+       the scope control makes common. */
+    expect(screen.getByText(/No term with a SNOMED code matches/)).toBeInTheDocument();
+
+    suggestMock.mockResolvedValue([VOMITING]);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Search all vocabularies' }));
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveAttribute('aria-checked', 'true');
+    expect(suggestMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('vocabulary');
+  });
+
+  it('stays quiet when an unscoped search finds nothing', async () => {
+    suggestMock.mockResolvedValue([]);
+    renderPicker();
+    typeQuery('zzz');
+
+    /* Prove the notice CAN appear for this very response first. Asserting
+       absence straight after typing passes whether or not the scope is
+       checked, because the response has not landed yet - the assertion is
+       then measuring nothing. */
+    await pickScope('SNOMED');
+    expect(screen.getByText(/No term with a SNOMED code matches/)).toBeInTheDocument();
+
+    // Same empty response, no scope: an unscoped miss is just a query with no
+    // matches, and the closed dropdown says that well enough.
+    await pickScope('All');
+    expect(screen.queryByText(/No term with a/)).not.toBeInTheDocument();
+  });
+
+  it('does not blame the vocabulary when the request fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    suggestMock.mockRejectedValue(new Error('network'));
+    renderPicker();
+    typeQuery('vom');
+    await pickScope('VeNom');
+    expect(screen.queryByText(/No term with a/)).not.toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapCodedTermPicker.tsx
@@ -23,6 +23,8 @@ const VOCABULARY_SCOPES: Array<{ value: VocabularyFilter | 'ALL'; label: string 
   { value: 'SNOMED', label: 'SNOMED' },
 ];
 
+const SCOPE_LABEL: Record<VocabularyFilter, string> = { VENOM: 'VeNom', SNOMED: 'SNOMED' };
+
 /** Short vocabulary labels; the picker has no room for full system URIs. */
 const SYSTEM_LABEL: Record<string, string> = {
   VENOM: 'VeNom',
@@ -102,6 +104,10 @@ const SoapCodedTermPicker = ({
   const [scope, setScope] = useState<VocabularyFilter | 'ALL'>('ALL');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<ClinicalTermSuggestion[]>([]);
+  /* A scoped search that finds nothing must say so. Without this the dropdown
+     simply does not open, which reads as "search is broken" rather than "no term
+     in this vocabulary matches" - the one case the scope control makes common. */
+  const [emptyQuery, setEmptyQuery] = useState<string | null>(null);
   // Monotonic request id: a slow earlier response must never overwrite a newer one.
   const requestSeqRef = useRef(0);
 
@@ -117,6 +123,7 @@ const SoapCodedTermPicker = ({
       () => {
         if (belowMinimum) {
           setResults([]);
+          setEmptyQuery(null);
           return;
         }
         suggestClinicalTerms({
@@ -126,17 +133,27 @@ const SoapCodedTermPicker = ({
           ...(scope === 'ALL' ? {} : { vocabulary: scope }),
         })
           .then((items) => {
-            if (requestSeqRef.current === requestId) setResults(items);
+            if (requestSeqRef.current !== requestId) return;
+            setResults(items);
+            setEmptyQuery(items.length === 0 ? trimmed : null);
           })
           .catch((error) => {
             console.error('Unable to suggest clinical terms:', error);
-            if (requestSeqRef.current === requestId) setResults([]);
+            if (requestSeqRef.current !== requestId) return;
+            setResults([]);
+            // An error is not "nothing matched"; leave the explanation off.
+            setEmptyQuery(null);
           });
       },
       belowMinimum ? 0 : SUGGEST_DEBOUNCE_MS
     );
     return () => clearTimeout(timer);
   }, [query, domain, scope]);
+
+  /* Only worth explaining when a scope is on. An unscoped search that finds
+     nothing is just a query with no matches, and the closed dropdown says that
+     well enough. */
+  const scopedEmpty = emptyQuery !== null && scope !== 'ALL' ? { query: emptyQuery, scope } : null;
 
   const selectedCodes = useMemo(() => new Set(selected.map((term) => term.ycCode)), [selected]);
 
@@ -235,9 +252,21 @@ const SoapCodedTermPicker = ({
         />
         <SearchResultsDropdown
           anchorRef={anchorRef}
-          open={results.length > 0}
+          open={results.length > 0 || scopedEmpty !== null}
           onClose={() => setQuery('')}
         >
+          {scopedEmpty !== null ? (
+            <p className="px-4 py-3 text-caption-1 text-text-secondary">
+              No term with a {SCOPE_LABEL[scopedEmpty.scope]} code matches “{scopedEmpty.query}”.{' '}
+              <button
+                type="button"
+                onClick={() => setScope('ALL')}
+                className="font-semibold text-text-brand underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
+              >
+                Search all vocabularies
+              </button>
+            </p>
+          ) : null}
           <ul>
             {results.map((suggestion) => {
               const synonym = matchedSynonym(suggestion, query);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Follow-up to #2626, which added the All / VeNom / SNOMED scope to the coded-term picker.

With a scope on, a query that matches no term in that vocabulary leaves the dropdown closed — the picker opens only when `results.length > 0`. Nothing distinguishes "no term here carries a SNOMED code" from "search is broken", and the scope control is exactly what makes that case common: on dev, 27 terms match `vom` but only 10 hold a usable SNOMED crosswalk.

## What is the new behavior?

The dropdown opens with one line naming the vocabulary and the query, and a button that widens the search back to All.

Deliberately narrow:

- **Only when a scope is on.** An unscoped miss is just a query with no matches, and the closed dropdown says that well enough.
- **Not on error.** A failed request is not "nothing matched", so the explanation stays off and the existing `console.error` path is untouched.

## Tests

Three new tests, and a note on one of them.

My first version of "stays quiet when an unscoped search finds nothing" asserted absence right after typing. It passed — and it also passed against a mutant that dropped the scope check entirely, because the assertion ran before the response landed. It was measuring nothing.

It now proves the notice *can* appear for that same empty response under SNOMED, then switches to All and shows it goes away. That version does fail the mutant.

Both mutants are killed: removing the scope condition, and never recording an empty result.

## Related Issue(s)

Follows #2626.
