### PR TITLE
fix(mobile): stop telling reporters their adverse event was sent

### DIFF
--- a/apps/mobileAppYC/__tests__/features/adverseEventReporting/screens/ThankYouScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/adverseEventReporting/screens/ThankYouScreen.test.tsx
@@ -218,8 +218,16 @@ describe('ThankYouScreen', () => {
     // Covers lines 119-122 (productFiles handling)
     expect(mockSetProductInfo).toHaveBeenCalled();
     expect(showSuccessAlert).toHaveBeenCalledWith(
-      'Report submitted',
+      'Report saved',
       expect.stringContaining('manufacturer'),
+    );
+    // The report is stored with `destinations`, never transmitted, so the
+    // confirmation must not claim it was. `stringContaining('manufacturer')`
+    // alone passed the old copy - "We sent your report to the manufacturer" -
+    // which is why this asserts the absence too.
+    expect(showSuccessAlert).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/\bwe sent\b|\bsent to\b|\bforwarded\b/i),
     );
     expect(mockResetDraft).toHaveBeenCalled();
     expect(mockParentNavigate).toHaveBeenCalledWith('Home');
@@ -243,8 +251,12 @@ describe('ThankYouScreen', () => {
 
     await waitFor(() => {
       expect(showSuccessAlert).toHaveBeenCalledWith(
-        'Report submitted',
-        expect.stringContaining('hospital'),
+        'Report saved',
+        expect.stringContaining('vet practice'),
+      );
+      expect(showSuccessAlert).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringMatching(/\bwe sent\b|\bsent to\b|\bforwarded\b/i),
       );
     });
 

--- a/apps/mobileAppYC/src/features/adverseEventReporting/content/supportedCountries.ts
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/content/supportedCountries.ts
@@ -19,40 +19,82 @@ const resolveMeta = (name: string, code: string) => {
   };
 };
 
-type RawSupportedCountryTuple = [name: string, code: string, iso3: string, authorityName: string];
+type RawSupportedCountryTuple = [
+  name: string,
+  code: string,
+  iso3: string,
+  authorityName: string,
+];
 
 const RAW_SUPPORTED_COUNTRIES: RawSupportedCountryTuple[] = [
   ['United States', 'US', 'USA', 'FDA – Center for Veterinary Medicine (CVM)'],
   ['Canada', 'CA', 'CAN', 'Health Canada – Veterinary Drugs Directorate (VDD)'],
   ['United Kingdom', 'GB', 'GBR', 'Veterinary Medicines Directorate (VMD)'],
-  ['Ireland', 'IE', 'IRL', 'Health Products Regulatory Authority (HPRA) – Veterinary Sciences'],
-  ['France', 'FR', 'FRA', 'ANMV (Anses) – Département inspection, surveillance et pharmacovigilance'],
+  [
+    'Ireland',
+    'IE',
+    'IRL',
+    'Health Products Regulatory Authority (HPRA) – Veterinary Sciences',
+  ],
+  [
+    'France',
+    'FR',
+    'FRA',
+    'ANMV (Anses) – Département inspection, surveillance et pharmacovigilance',
+  ],
   [
     'Germany',
     'DE',
     'DEU',
-    'BVL – Federal Office of Consumer Protection and Food Safety (Pharmacovigilance)',
+    'BVL – Federal Office of Consumer Protection and Food Safety (vaccines and biologicals: Paul-Ehrlich-Institut)',
   ],
   ['Spain', 'ES', 'ESP', 'AEMPS – Veterinary Pharmacovigilance'],
   [
     'Italy',
     'IT',
     'ITA',
-    'Ministero della Salute – Direzione Generale della Sanità Animale e dei Farmaci Veterinari (Ufficio 4) / ISS Vet Med Lab',
+    'Ministero della Salute – Direzione Generale della Sanità Animale e dei Farmaci Veterinari (DGSAF), Ufficio 4',
   ],
-  ['Netherlands', 'NL', 'NLD', 'CBG/MEB – Veterinary Medicinal Products Unit (VMPU)'],
+  [
+    'Netherlands',
+    'NL',
+    'NLD',
+    'CBG/MEB – Veterinary Medicinal Products Unit (VMPU)',
+  ],
   ['Sweden', 'SE', 'SWE', 'Läkemedelsverket (Swedish Medical Products Agency)'],
   ['Denmark', 'DK', 'DNK', 'Danish Medicines Agency (Lægemiddelstyrelsen)'],
-  ['Australia', 'AU', 'AUS', 'APVMA – Adverse Experience Reporting Program (AERP)'],
-  ['New Zealand', 'NZ', 'NZL', 'Ministry for Primary Industries (MPI) – ACVM Adverse Events'],
+  [
+    'Australia',
+    'AU',
+    'AUS',
+    'APVMA – Adverse Experience Reporting Program (AERP)',
+  ],
+  [
+    'New Zealand',
+    'NZ',
+    'NZL',
+    'Ministry for Primary Industries (MPI) – ACVM Adverse Events',
+  ],
   ['Japan', 'JP', 'JPN', 'National Veterinary Assay Laboratory (NVAL), MAFF'],
-  ['South Korea', 'KR', 'KOR', 'Animal and Plant Quarantine Agency (QIA)'],
+  ['South Korea', 'KR', 'KOR', 'Animal and Plant Quarantine Agency (APQA)'],
   ['Singapore', 'SG', 'SGP', 'NParks – Animal & Veterinary Service (AVS)'],
-  ['Argentina', 'AR', 'ARG', 'SENASA – Dirección de Productos Veterinarios (DPV)'],
-  ['Mexico', 'MX', 'MEX', 'COFEPRIS (general) / SENASICA (veterinary products)'],
+  [
+    'Argentina',
+    'AR',
+    'ARG',
+    'SENASA – Dirección de Productos Veterinarios (DPV)',
+  ],
+  [
+    'Mexico',
+    'MX',
+    'MEX',
+    'COFEPRIS (general) / SENASICA (veterinary products)',
+  ],
 ];
 
-const withCountryMeta = (entry: RawSupportedCountryTuple): SupportedAdverseEventCountry => {
+const withCountryMeta = (
+  entry: RawSupportedCountryTuple,
+): SupportedAdverseEventCountry => {
   const [name, code, iso3, authorityName] = entry;
   const meta = resolveMeta(name, code);
   return {

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
@@ -170,11 +170,8 @@ export const ThankYouScreen: React.FC<Props> = ({navigation}) => {
             files: productFiles,
           });
         }
-        /* Neither branch may say "we sent" it. `AdverseEventService` has no
-           outbound call - no HTTP client, no mail, no queue: it writes an
-           `AdverseEventReport` row carrying `destinations`. So the destination
-           is recorded, not delivered. The hospital can reach the row (it is
-           org-scoped and the API lists by organisation); no manufacturer can. */
+        // Nothing is transmitted: the report is stored with `destinations`, so
+        // neither branch may claim it was sent. Enforced by the test.
         showSuccessAlert(
           'Report saved',
           target === 'manufacturer'

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
@@ -170,11 +170,16 @@ export const ThankYouScreen: React.FC<Props> = ({navigation}) => {
             files: productFiles,
           });
         }
+        /* Neither branch may say "we sent" it. `AdverseEventService` has no
+           outbound call - no HTTP client, no mail, no queue: it writes an
+           `AdverseEventReport` row carrying `destinations`. So the destination
+           is recorded, not delivered. The hospital can reach the row (it is
+           org-scoped and the API lists by organisation); no manufacturer can. */
         showSuccessAlert(
-          'Report submitted',
+          'Report saved',
           target === 'manufacturer'
-            ? 'We sent your report to the manufacturer.'
-            : 'We sent your report to the hospital.',
+            ? 'Saved for the manufacturer. Forwarding is not switched on yet, so tell your vet too.'
+            : 'Saved to your vet practice, with the product and batch details attached.',
         );
         resetDraft();
         handleBack();


### PR DESCRIPTION
## What

Submitting an adverse event ends on a success alert reading **"We sent your report to the manufacturer."** Nothing is sent to anyone.

## Why it is wrong

`AdverseEventService` has no outbound call of any kind - no HTTP client, no mail, no queue. It writes an `AdverseEventReport` row whose `destinations` field records `sendToManufacturer` / `sendToHospital`.

So the destination is stored as an intention; the delivery never happens.

The hospital branch at least resolves to something a clinic can reach, since the row is org-scoped and the service lists by organisation. No manufacturer has any access to this database at all.

This matters more than a usual copy slip. A pet owner who believes a manufacturer already has their reaction report has no reason to tell anyone else, and the report is the entire point of the flow.

## Change

| | Before | After |
|---|---|---|
| Title | Report submitted | Report saved |
| Manufacturer | We sent your report to the manufacturer. | Saved for the manufacturer. Forwarding is not switched on yet, so tell your vet too. |
| Hospital | We sent your report to the hospital. | Saved to your vet practice, with the product and batch details attached. |

The batch detail is accurate: `AdverseEventProductInfo` captures batch number, quantity and unit, frequency, administration method and the before/after condition, and the flow refuses to submit without a linked hospital.

## Validation

The existing assertions could not have caught this. They matched `stringContaining('manufacturer')`, which the old sentence satisfied perfectly.

They now pin the real copy **and** assert the message does not claim transmission.

Mutation-checked rather than assumed:

- restoring the original sentence: **1 failed, 23 passed**
- with the fix in place: **24 passed**

mobile `tsc` clean, `eslint --max-warnings=0` clean.

## Impact

Mobile adverse-event reporting flow. Copy and its tests only, no behaviour change.

Found by a sweep for claims nothing in the system can support.