### PR TITLE
docs(repo): stop advertising a token package nothing imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ A pnpm + Turborepo workspace. Apps ship; packages are the shared spine underneat
 | `@yosemite-crew/types`         | Shared domain and form types across web, mobile, and API.                     |
 | `@yosemite-crew/fhir`          | FHIR R4 helpers.                                                              |
 | `@yosemite-crew/fhirtypes`     | FHIR R4 resource type definitions.                                            |
-| `@yosemite-crew/design-tokens` | Semantic design tokens shared by web and mobile. Intent, not platform detail. |
+| `@yosemite-crew/design-tokens` | Semantic token definitions. No app imports it yet; the live web palette is the `@theme` block in `apps/frontend/src/app/globals.css`. |
 | `@yosemite-crew/lib`           | Cross-workspace utilities.                                                    |
 
 <br>

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -1,7 +1,8 @@
 # UI Tokens
 
-Primary source of tokens is `src/app/globals.css` under the `@theme` block.
-Shared semantic token definitions live in `packages/design-tokens/src/`.
+The source of tokens is `src/app/globals.css` under the `@theme` block - all 713 of them.
+`packages/design-tokens/src/` holds a parallel set of semantic definitions, but nothing
+imports it: it is a proposal, not a dependency. Edit `globals.css`.
 For the shared UI overview see [`README.md`](./README.md); for the full component list and status labels see [`INVENTORY.md`](./INVENTORY.md).
 
 ## Typography


### PR DESCRIPTION
## What

The public README's packages table describes `@yosemite-crew/design-tokens` as **"Semantic design tokens shared by web and mobile."**

It is shared by neither.

## Evidence

Searching `apps/frontend`, `apps/mobileAppYC`, `apps/backend`, `apps/desktop` and every other package for an import or require of `@yosemite-crew/design-tokens` returns only the usage examples inside the package's own docstring:

```
packages/design-tokens/src/index.ts:11:  import { color, spacing, radius } from '@yosemite-crew/design-tokens'
packages/design-tokens/src/index.ts:12:  import { webCssVars } from '@yosemite-crew/design-tokens/web'
packages/design-tokens/src/index.ts:13:  import { mobileTheme } from '@yosemite-crew/design-tokens/mobile'
```

Zero real consumers.

- `apps/frontend` declares the dependency in `package.json` and never imports it.
- `apps/mobileAppYC` does not declare it at all, and its own `src/theme/semanticTokens.ts` says so in a comment.
- The live web palette is the `@theme` block in `apps/frontend/src/app/globals.css` - 713 custom properties.

## Why it matters

This is a repository someone reads to decide whether to build on the platform, and the packages table is where they look to see what the workspace offers. A package presented as the shared source of truth for two apps, which neither app imports, sends a contributor to the wrong file to make a change.

## Change

| File | Was | Now |
|---|---|---|
| `README.md` | "Semantic design tokens shared by web and mobile" | Definitions with no importer, pointing at `globals.css` |
| `apps/frontend/src/app/ui/tokens.md` | "Shared semantic token definitions live in `packages/design-tokens/src/`" - reads as instruction | The package is a proposal, not a dependency; edit `globals.css` |

## Scope

The package is left in place. This corrects what is **claimed** about it, not whether it should exist - adopting it or deleting it is a separate decision.

Documentation only. No code, no behaviour change.