### PR TITLE
fix(frontend): make the dev-docs links work on the deployed site

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -67,30 +67,46 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   /*
    * The developer docs are a Docusaurus build copied into `public/dev-docs`.
-   * It links extensionlessly - `/dev-docs/apps/backend` - while writing
+   * Docusaurus links extensionlessly - `/dev-docs/apps/backend` - while writing
    * `apps/backend.html`, so on the deployed site every internal link 404'd:
    * only `/dev-docs/index.html`, typed by hand, ever loaded.
    *
-   * Setting `trailingSlash: true` in Docusaurus does not fix it. This app
-   * leaves `trailingSlash` at its default of false, so it 308-redirects
-   * `/dev-docs/x/` to `/dev-docs/x` and the slashed links would land back on
-   * the same 404.
+   * These are REDIRECTS, not rewrites, and that distinction is the whole fix.
+   * A rewrite is what this started as, and it works locally and nowhere else:
+   * `next dev` serves `public/` itself, so an internal rewrite to a file in it
+   * resolves. On Amplify it cannot. Amplify serves everything under `public/`
+   * from its own CDN layer (see customHttp.yml, which exists for exactly that
+   * reason), and the Next server has no route for a file it does not serve - so
+   * the rewrite fired and then 404'd. Verified on the deployed site: a request
+   * for `/dev-docs/apps/backend` came back 404 with `x-nextjs-cache: HIT`,
+   * meaning Next answered, while `/dev-docs/apps/backend.html` came back 200
+   * from CloudFront with an ETag and no Next headers at all.
    *
-   * The rewrite runs after filesystem routes, so a real asset (`/img/x.png`,
-   * `/assets/x.css`) is served directly and never reaches it. Only a path with
-   * no extension is mapped onto its `.html` file.
+   * A redirect sends the browser to the `.html` path instead, which CloudFront
+   * does serve. The trade is a visible `.html` in the URL. The alternative that
+   * keeps clean URLs is a rewrite rule in the Amplify console, which is not in
+   * this repo and cannot be reviewed with the code.
+   *
+   * `permanent: false` deliberately: a 308 is cached hard by browsers, and if
+   * the console rule is added later these should stop firing without users
+   * carrying a stale permanent redirect.
+   *
+   * Only extensionless paths match, so real assets - `/dev-docs/img/x.png`,
+   * `/dev-docs/assets/x.css` - are untouched and keep being served directly.
    */
-  async rewrites() {
+  async redirects() {
     return [
-      // The site's own home link is `/dev-docs/`, which this app redirects to
-      // `/dev-docs`; without this the docs' own logo link 404s.
+      // The docs' own logo links to `/dev-docs/`, which this app redirects to
+      // `/dev-docs`; without this that link 404s.
       {
         source: '/dev-docs',
         destination: '/dev-docs/index.html',
+        permanent: false,
       },
       {
         source: '/dev-docs/:path((?!.*\\.).*)',
         destination: '/dev-docs/:path.html',
+        permanent: false,
       },
     ];
   },


### PR DESCRIPTION
## What

#2629 unbroke the documentation links locally and **not in production**. Half of it landed - the canonical and `og:url` metadata is correct on dev now - but every internal doc link still 404s there, so the fix as shipped did not do what its description said.

This is the correction, and I am flagging it rather than quietly amending it.

## What it missed

Amplify serves everything under `public/` from its own CDN layer. That is not a guess: `apps/frontend/customHttp.yml` exists in this repo for exactly that reason, and says so.

The Next server therefore never sees those files, so an internal **rewrite** to one of them has no route to resolve and returns Next's 404. `next dev` *does* serve `public/` itself, which is precisely why it passed local verification.

Measured on the deployed site rather than reasoned about:

| Request | Result |
|---|---|
| `/dev-docs/apps/backend` | `404`, `x-nextjs-cache: HIT` - **Next answered** |
| `/dev-docs/apps/backend.html` | `200`, ETag, no Next headers - **CloudFront answered** |

So the destination has to be a URL CloudFront will serve, which means redirecting the browser rather than rewriting internally. Extensionless paths still reach Next - that 404 is the proof - so the redirect fires.

## Verification

Locally, unfollowed and then followed:

| Path | Status | Location | Final |
|---|---|---|---|
| `/dev-docs` | 307 | `/dev-docs/index.html` | 200 |
| `/dev-docs/apps/backend` | 307 | `/dev-docs/apps/backend.html` | 200 |
| `/dev-docs/openapi` | 307 | `/dev-docs/openapi.html` | 200 |
| `/dev-docs/guides/backend-chat` | 307 | `/dev-docs/guides/backend-chat.html` | 200 |

And the things that must not change: `styles.db762067.css`, `main.*.js` and `img/logo.svg` all 200 directly, `/dev-docs/does-not-exist` still 404s, `/developers/documentation` unaffected.

I also checked that a `.html` URL **renders** correctly rather than assuming it - a static host serving the file is not the same as the SPA accepting the route. It renders in full: sidebar, content and TOC.

## Two deliberate choices

- **`permanent: false`.** A 308 is cached hard by browsers. The better fix keeps clean URLs via a rewrite rule in the Amplify console - which is not in this repo and cannot be reviewed alongside the code. If that lands later, these should stop firing without users carrying a stale permanent redirect.
- **Extensionless paths only**, so assets never enter the rule.

## Trade-off

A visible `.html` in the address bar. Worse than clean URLs; much better than a documentation site where no link works.

If you would rather I not spend a redirect on this, the console rule is the alternative - say the word and I will write up the exact rule for you to paste instead.