### PR TITLE
fix(frontend): label invoice money in the invoice's own currency, to the penny

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/common/AppointmentPopover.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/AppointmentPopover.test.tsx
@@ -76,6 +76,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/lib/timezone', () => ({

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/AppointmentPopover.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/AppointmentPopover.test.tsx
@@ -72,6 +72,10 @@ jest.mock('@/app/lib/invoice', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: jest.fn(() => '$ 0.00'),
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/lib/timezone', () => ({

--- a/apps/frontend/src/app/__tests__/components/Cards/InvoiceCard/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Cards/InvoiceCard/index.test.tsx
@@ -66,9 +66,9 @@ describe('InvoiceCard Component', () => {
     expect(screen.getByText('Jan 01, 2023')).toBeInTheDocument();
 
     // Financials
-    expect(screen.getByText('$100')).toBeInTheDocument(); // Subtotal
-    expect(screen.getByText('$10')).toBeInTheDocument(); // Tax
-    expect(screen.getByText('$110')).toBeInTheDocument(); // Total
+    expect(screen.getByText('$100.00')).toBeInTheDocument(); // Subtotal
+    expect(screen.getByText('$10.00')).toBeInTheDocument(); // Tax
+    expect(screen.getByText('$110.00')).toBeInTheDocument(); // Total
     expect(screen.getByText('Paid in cash')).toBeInTheDocument();
   });
 
@@ -94,9 +94,9 @@ describe('InvoiceCard Component', () => {
     render(<InvoiceCard invoice={untaxedInvoice} handleViewInvoice={mockHandleView} />);
 
     // Both the (absent) discount and the (absent) tax render as $0.
-    expect(screen.getAllByText('$0')).toHaveLength(2);
-    expect(screen.getByText('$100')).toBeInTheDocument(); // Subtotal unaffected
-    expect(screen.getByText('$110')).toBeInTheDocument(); // Total unaffected
+    expect(screen.getAllByText('$0.00')).toHaveLength(2);
+    expect(screen.getByText('$100.00')).toBeInTheDocument(); // Subtotal unaffected
+    expect(screen.getByText('$110.00')).toBeInTheDocument(); // Total unaffected
   });
 
   // --- 3. Status Rendering ---

--- a/apps/frontend/src/app/__tests__/components/Stats/RevenueStat.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Stats/RevenueStat.test.tsx
@@ -54,6 +54,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/ui/cards/CardHeader/CardHeader', () => ({

--- a/apps/frontend/src/app/__tests__/components/Stats/RevenueStat.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Stats/RevenueStat.test.tsx
@@ -50,6 +50,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (value: number, currency: string) => `${currency} ${value}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/ui/cards/CardHeader/CardHeader', () => ({

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -89,9 +89,9 @@ describe('InvoiceCreditNotes', () => {
 
     expect(screen.getAllByRole('listitem')).toHaveLength(2);
     expect(screen.getByText('CN-0001')).toBeInTheDocument();
-    expect(screen.getByText('$40')).toBeInTheDocument();
+    expect(screen.getByText('$40.00')).toBeInTheDocument();
     expect(screen.getByText('CN-0002')).toBeInTheDocument();
-    expect(screen.getByText('$25')).toBeInTheDocument();
+    expect(screen.getByText('$25.00')).toBeInTheDocument();
   });
 
   it('labels a voided note and offers Void only on an issued one', () => {
@@ -141,9 +141,9 @@ describe('InvoiceCreditNotes', () => {
     });
 
     const creditedRow = screen.getByText('Credited').parentElement as HTMLElement;
-    expect(within(creditedRow).getByText('$40')).toBeInTheDocument();
+    expect(within(creditedRow).getByText('$40.00')).toBeInTheDocument();
     // The voided $60 must not be added in: $100 would be the naive total.
-    expect(within(creditedRow).queryByText('$100')).not.toBeInTheDocument();
+    expect(within(creditedRow).queryByText('$100.00')).not.toBeInTheDocument();
     // and the remaining figure is the total minus the issued note only.
     expect(screen.getByText(/Up to \$160.00 can still be credited/)).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/__tests__/lib/money.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/money.test.ts
@@ -1,4 +1,10 @@
-import { currencySymbol, formatMoney, formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
+import {
+  currencySymbol,
+  formatMoney,
+  formatMoneyPrecise,
+  recordCurrency,
+  sharedCurrency,
+} from '@/app/lib/money';
 
 describe('formatMoney', () => {
   it('formats USD correctly', () => {
@@ -144,5 +150,29 @@ describe('recordCurrency', () => {
   it('composes with the formatter on a real record shape', () => {
     const invoice = { currency: 'GBP', totalAmount: 144.6 };
     expect(formatMoneyPrecise(invoice.totalAmount, recordCurrency(invoice, 'USD'))).toBe('£144.60');
+  });
+});
+
+describe('sharedCurrency', () => {
+  it('uses the one currency when every record agrees', () => {
+    expect(sharedCurrency([{ currency: 'GBP' }, { currency: 'GBP' }], 'USD')).toBe('GBP');
+  });
+
+  it('falls back when the records disagree, because the sum has no single currency', () => {
+    expect(sharedCurrency([{ currency: 'GBP' }, { currency: 'EUR' }], 'USD')).toBe('USD');
+  });
+
+  it('ignores records with no usable currency rather than treating them as a conflict', () => {
+    expect(
+      sharedCurrency([{ currency: 'GBP' }, {}, { currency: null }, { currency: '  ' }], 'USD')
+    ).toBe('GBP');
+  });
+
+  it('falls back for an empty list', () => {
+    expect(sharedCurrency([], 'USD')).toBe('USD');
+  });
+
+  it('trims before comparing, so a padded code is not a false conflict', () => {
+    expect(sharedCurrency([{ currency: ' GBP ' }, { currency: 'GBP' }], 'USD')).toBe('GBP');
   });
 });

--- a/apps/frontend/src/app/__tests__/lib/money.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/money.test.ts
@@ -1,4 +1,4 @@
-import { currencySymbol, formatMoney, formatMoneyPrecise } from '@/app/lib/money';
+import { currencySymbol, formatMoney, formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 
 describe('formatMoney', () => {
   it('formats USD correctly', () => {
@@ -115,5 +115,34 @@ describe('formatMoneyPrecise currency precision', () => {
     expect(() => formatMoneyPrecise(9.5, '123')).not.toThrow();
     expect(formatMoneyPrecise(9.5, '123')).toBe('123 9.50');
     expect(formatMoneyPrecise(9.5, 'ZZ')).toBe('ZZ 9.50');
+  });
+});
+
+describe('recordCurrency', () => {
+  it("prefers the record's own currency over the ambient fallback", () => {
+    expect(recordCurrency({ currency: 'GBP' }, 'USD')).toBe('GBP');
+  });
+
+  it('falls back when the record carries no usable currency', () => {
+    // Each of these is a real shape: an invoice loaded before its currency
+    // arrived, a column that is nullable, and the blank string a trimmed-empty
+    // field leaves behind. None of them should be handed to Intl.
+    expect(recordCurrency(undefined, 'USD')).toBe('USD');
+    expect(recordCurrency(null, 'USD')).toBe('USD');
+    expect(recordCurrency({}, 'USD')).toBe('USD');
+    expect(recordCurrency({ currency: null }, 'USD')).toBe('USD');
+    expect(recordCurrency({ currency: '' }, 'USD')).toBe('USD');
+    expect(recordCurrency({ currency: '   ' }, 'USD')).toBe('USD');
+  });
+
+  it('trims a padded code so it still resolves', () => {
+    // Intl throws on ' GBP ' but not on 'GBP', and this helper feeds Intl.
+    expect(recordCurrency({ currency: ' GBP ' }, 'USD')).toBe('GBP');
+    expect(() => formatMoneyPrecise(1, recordCurrency({ currency: ' GBP ' }, 'USD'))).not.toThrow();
+  });
+
+  it('composes with the formatter on a real record shape', () => {
+    const invoice = { currency: 'GBP', totalAmount: 144.6 };
+    expect(formatMoneyPrecise(invoice.totalAmount, recordCurrency(invoice, 'USD'))).toBe('£144.60');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Details.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Details.test.tsx
@@ -56,6 +56,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock(

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Details.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Details.test.tsx
@@ -52,6 +52,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (value: number, currency: string) => `${currency} ${value}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock(

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Summary.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Summary.test.tsx
@@ -44,6 +44,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/lib/validators', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Summary.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Finance/Summary.test.tsx
@@ -40,6 +40,10 @@ jest.mock('@/app/hooks/useInvoices', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (value: number, currency: string) => `${currency} ${value}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/lib/validators', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceBilledItems.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceBilledItems.test.tsx
@@ -20,9 +20,9 @@ describe('InvoiceBilledItems', () => {
     expect(screen.getByText('Vaccination visit')).toBeInTheDocument();
     expect(screen.getByText('Nobivac Rabies 1 ml')).toBeInTheDocument();
     // Gross and amount of the first row both format to $49.
-    expect(screen.getAllByText('$49')).toHaveLength(2);
-    expect(screen.getByText('$24')).toBeInTheDocument();
-    expect(screen.getByText('$48')).toBeInTheDocument();
+    expect(screen.getAllByText('$49.00')).toHaveLength(2);
+    expect(screen.getByText('$24.00')).toBeInTheDocument();
+    expect(screen.getByText('$48.00')).toBeInTheDocument();
   });
 
   it('renders an honest empty state when there are no items', () => {
@@ -39,7 +39,7 @@ describe('InvoiceBilledItems', () => {
     );
     expect(screen.getByText('Waste & sharps fee')).toBeInTheDocument();
     // gross and amount both fall back to $0
-    expect(screen.getAllByText('$0').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('$0.00').length).toBeGreaterThanOrEqual(2);
   });
 
   it('has no axe accessibility violations', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
@@ -57,7 +57,7 @@ describe('InvoicePaymentLedger', () => {
     expect(
       screen.getByText('Online payment · 12 Jun, 10:31 · by Lena Hartmann')
     ).toBeInTheDocument();
-    expect(screen.getByText('$86')).toBeInTheDocument();
+    expect(screen.getByText('$86.00')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Receipt' })).toHaveAttribute(
       'href',
       'https://pay.stripe.com/receipts/r_1'
@@ -139,7 +139,7 @@ describe('InvoicePaymentLedger', () => {
       <InvoicePaymentLedger invoice={makeInvoice({ totalAmount: undefined })} currency="USD" />
     );
     expect(screen.getByText('Paid in the pet-parent app')).toBeInTheDocument();
-    expect(screen.getByText('$0')).toBeInTheDocument();
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
   });
 
   it('has no axe accessibility violations', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
@@ -11,6 +11,10 @@ jest.mock('next/image', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number) => `€${amount}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/lib/forms', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
@@ -102,7 +102,7 @@ describe('InvoicePhoneRecord', () => {
     expect(screen.getByText('Nobivac Rabies')).toBeInTheDocument();
     expect(screen.getByText('Tax 8.1%')).toBeInTheDocument();
     expect(screen.getByText('Total')).toBeInTheDocument();
-    expect(screen.getByText('€86.2')).toBeInTheDocument();
+    expect(screen.getByText('EUR 86.20')).toBeInTheDocument();
   });
 
   it('renders the empty items note when there are no items', () => {
@@ -116,7 +116,7 @@ describe('InvoicePhoneRecord', () => {
 
     rerender(<InvoicePhoneRecord {...baseProps} invoice={{ ...baseInvoice, discountTotal: 5 }} />);
     expect(screen.getByText('Discount')).toBeInTheDocument();
-    expect(screen.getByText('-€5')).toBeInTheDocument();
+    expect(screen.getByText('-EUR 5.00')).toBeInTheDocument();
   });
 
   it('renders the payment ledger and receipt link when settled', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
@@ -15,6 +15,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/lib/forms', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceSummaryPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceSummaryPanel.test.tsx
@@ -28,12 +28,12 @@ describe('InvoiceSummaryPanel', () => {
     render(<InvoiceSummaryPanel invoice={makeInvoice({})} currency="USD" />);
 
     expect(screen.getByText('Subtotal')).toBeInTheDocument();
-    expect(screen.getByText('$79')).toBeInTheDocument();
+    expect(screen.getByText('$79.00')).toBeInTheDocument();
     expect(screen.getByText('Discount')).toBeInTheDocument();
     expect(screen.getByText('Total')).toBeInTheDocument();
-    expect(screen.getByText('$86')).toBeInTheDocument();
+    expect(screen.getByText('$86.00')).toBeInTheDocument();
     expect(screen.getByText('Outstanding')).toBeInTheDocument();
-    expect(screen.getByText('$0')).toBeInTheDocument();
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
   });
 
   it('renders a plain Tax label when no tax percent is set', () => {
@@ -54,7 +54,7 @@ describe('InvoiceSummaryPanel', () => {
       />
     );
     // Outstanding equals the total when nothing has been collected.
-    expect(screen.getAllByText('$214').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('$214.00').length).toBeGreaterThanOrEqual(1);
   });
 
   it('falls back to zero for missing money fields', () => {
@@ -70,7 +70,7 @@ describe('InvoiceSummaryPanel', () => {
       />
     );
     // Subtotal / Discount / Tax / Total / Outstanding all resolve to $0.
-    expect(screen.getAllByText('$0').length).toBeGreaterThanOrEqual(4);
+    expect(screen.getAllByText('$0.00').length).toBeGreaterThanOrEqual(4);
   });
 
   it('has no axe accessibility violations', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
@@ -19,6 +19,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/lib/forms', () => ({
@@ -119,9 +129,12 @@ describe('PhoneInvoiceList', () => {
     render(<PhoneInvoiceList {...baseProps} filteredList={[paid]} />);
 
     expect(screen.getByText('Collected · wk')).toBeInTheDocument();
-    expect(screen.getByText('€4820')).toBeInTheDocument();
+    // The KPI tiles sum across the list, so they take the currency the list
+    // agrees on. This fixture carries none, so the helper falls back to the
+    // ambient value rather than inventing one.
+    expect(screen.getByText('EUR 4820.00')).toBeInTheDocument();
     expect(screen.getByText('Outstanding')).toBeInTheDocument();
-    expect(screen.getByText('€214')).toBeInTheDocument();
+    expect(screen.getByText('EUR 214.00')).toBeInTheDocument();
   });
 
   it('renders the status filter pills', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
@@ -113,6 +113,7 @@ const baseProps = {
   setActiveStatus: jest.fn(),
   metrics: { collectedThisWeek: 4820, outstanding: 214 },
   currency: 'EUR',
+  metricsCurrency: 'EUR',
   onViewInvoice: jest.fn(),
 };
 

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/PhoneInvoiceList.test.tsx
@@ -15,6 +15,10 @@ jest.mock('@/app/hooks/useAppointments', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number) => `€${amount}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/lib/forms', () => ({
@@ -154,7 +158,10 @@ describe('PhoneInvoiceList', () => {
     render(<PhoneInvoiceList {...baseProps} filteredList={[partial]} />);
     const card = screen.getByRole('button', { name: 'View invoice #3' });
     expect(card.className).not.toContain('border-l-[var(--warn)]');
-    expect(screen.getByText('Deposit €20 applied')).toBeInTheDocument();
+    // The fixture invoice carries currency: 'EUR'. Before this change the
+    // footnote used the ambient organisation currency and would have said USD
+    // for a euro invoice - that is the bug, visible here.
+    expect(screen.getByText('Deposit EUR 20.00 applied')).toBeInTheDocument();
   });
 
   it('renders the empty state when there are no invoices', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/index.test.tsx
@@ -334,7 +334,7 @@ describe('Finance page', () => {
     render(<ProtectedFinance />);
 
     expect(screen.getByText(/collected this week/)).toHaveTextContent(
-      '$4,820 collected this week · $214 outstanding'
+      '$4,820.00 collected this week · $214.00 outstanding'
     );
   });
   it('links to the Discounts page from the finance header controls', () => {

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Specialities/ArchiveTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Specialities/ArchiveTab.test.tsx
@@ -96,6 +96,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 const mockFormatMoney = jest.fn((amount: number, _currency?: string) => `$ ${amount.toFixed(2)}`);
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number, currency?: string) => mockFormatMoney(amount, currency),
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Specialities/ArchiveTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Specialities/ArchiveTab.test.tsx
@@ -100,6 +100,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownTable.test.tsx
@@ -74,6 +74,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number) => `$ ${amount.toFixed(2)}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 const baseItem: PackageBreakdownItem = {

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownTable.test.tsx
@@ -78,6 +78,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 const baseItem: PackageBreakdownItem = {

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
@@ -22,6 +22,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number) => `$ ${amount.toFixed(2)}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('zustand/react/shallow', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
@@ -26,6 +26,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('zustand/react/shallow', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Specialities/ServicesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/ServicesTab.test.tsx
@@ -43,6 +43,16 @@ jest.mock('@/app/lib/money', () => ({
     record?.currency ?? fallback,
   formatMoneyPrecise: (amount: number, currency: string) =>
     `${currency} ${Number(amount).toFixed(2)}`,
+  sharedCurrency: (records: ReadonlyArray<{ currency?: string | null }>, fallback: string) => {
+    let shared: string | null = null;
+    for (const record of records) {
+      const own = record.currency;
+      if (typeof own !== 'string' || !own.trim()) continue;
+      if (shared === null) shared = own.trim();
+      else if (shared !== own.trim()) return fallback;
+    }
+    return shared ?? fallback;
+  },
 }));
 
 jest.mock('@/app/features/organization/services/catalogCalculations', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Specialities/ServicesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/ServicesTab.test.tsx
@@ -39,6 +39,10 @@ jest.mock('@/app/hooks/useBilling', () => ({
 
 jest.mock('@/app/lib/money', () => ({
   formatMoney: (amount: number) => `$ ${amount.toFixed(2)}`,
+  recordCurrency: (record: { currency?: string | null } | null | undefined, fallback: string) =>
+    record?.currency ?? fallback,
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
 }));
 
 jest.mock('@/app/features/organization/services/catalogCalculations', () => ({

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 import type { CreditNote } from '@yosemite-crew/types';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { Secondary } from '@/app/ui/primitives/Buttons';
@@ -54,7 +54,7 @@ const CreditNoteLedger = ({ notes, currency, busy, onVoid }: CreditNoteLedgerPro
               className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]"
               style={note.status === 'VOIDED' ? { textDecoration: 'line-through' } : undefined}
             >
-              {formatMoney(note.amount, currency)}
+              {formatMoneyPrecise(note.amount, currency)}
             </span>
             {isIssued(note) && (
               <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { InvoiceItem } from '@yosemite-crew/types';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise } from '@/app/lib/money';
 import TableHead from '@/app/ui/tables/TableHead';
 
 type InvoiceBilledItemsProps = {
@@ -45,10 +45,10 @@ const InvoiceBilledItems = ({ items, currency }: InvoiceBilledItemsProps) => {
               </span>
               <span className="tabular-nums">{item.quantity}</span>
               <span className="text-right tabular-nums">
-                {formatMoney(item.unitPrice ?? 0, currency)}
+                {formatMoneyPrecise(item.unitPrice ?? 0, currency)}
               </span>
               <span className="text-right tabular-nums font-bold">
-                {formatMoney(item.total ?? 0, currency)}
+                {formatMoneyPrecise(item.total ?? 0, currency)}
               </span>
             </div>
           ))

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useMemo, useState } from 'react';
 import type { CreditNote } from '@yosemite-crew/types';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import {
@@ -78,7 +78,7 @@ const InvoiceCreditNotes = ({
             <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
               <span>Credited</span>
               <span className="tabular-nums text-[13px] font-bold text-[var(--ink-body)]">
-                {formatMoney(credited, currency)}
+                {formatMoneyPrecise(credited, currency)}
               </span>
             </div>
           </>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.tsx
@@ -20,6 +20,7 @@ import InvoicePaymentLedger from '@/app/features/finance/pages/Finance/Sections/
 import InvoicePhoneRecord from '@/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord';
 import InvoiceCreditNotes from '@/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes';
 import { useInvoiceCreditNotes } from '@/app/features/finance/hooks/useInvoiceCreditNotes';
+import { recordCurrency } from '@/app/lib/money';
 
 type InvoiceInfoProps = {
   showModal: boolean;
@@ -30,7 +31,10 @@ type InvoiceInfoProps = {
 const InvoiceInfo = ({ showModal, setShowModal, activeInvoice }: InvoiceInfoProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
   const creditNotes = useInvoiceCreditNotes(activeInvoice);
-  const currency = useCurrencyForPrimaryOrg();
+  const orgCurrency = useCurrencyForPrimaryOrg();
+  // Every figure in this drawer belongs to one invoice, so it is labelled in
+  // that invoice's currency rather than the organisation's ambient one (#2597).
+  const currency = recordCurrency(activeInvoice, orgCurrency);
   const router = useRouter();
   const isPhone = useIsPhone();
   const titleId = useId();

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Invoice } from '@yosemite-crew/types';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
 import { getLedgerChannel } from '@/app/features/finance/pages/Finance/Sections/ledgerChannel';
@@ -53,7 +53,7 @@ const InvoicePaymentLedger = ({ invoice, currency, payerName }: InvoicePaymentLe
             </span>
           </span>
           <span className="text-[13px] font-bold text-[var(--ink)] tabular-nums">
-            {formatMoney(invoice.totalAmount ?? 0, currency)}
+            {formatMoneyPrecise(invoice.totalAmount ?? 0, recordCurrency(invoice, currency))}
           </span>
           {receiptUrl && (
             <a

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { IoClose, IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getInvoiceNumberLabel } from '@/app/lib/invoice';
 import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
@@ -158,7 +158,7 @@ const InvoicePhoneRecord = ({
                 {item.name}
               </span>
               <span className="shrink-0 font-bold tabular-nums">
-                {formatMoney(item.total ?? 0, currency)}
+                {formatMoneyPrecise(item.total ?? 0, currency)}
               </span>
             </div>
           ))
@@ -166,19 +166,21 @@ const InvoicePhoneRecord = ({
         {discount > 0 && (
           <div className="flex items-center justify-between gap-3 px-3.5 py-2.5 border-t border-[var(--hairline)] bg-[var(--screen-2)] text-[12.5px] text-[var(--ink-muted)]">
             <span>Discount</span>
-            <span className="font-semibold tabular-nums">-{formatMoney(discount, currency)}</span>
+            <span className="font-semibold tabular-nums">
+              -{formatMoneyPrecise(discount, currency)}
+            </span>
           </div>
         )}
         <div className="flex items-center justify-between gap-3 px-3.5 py-2.5 border-t border-[var(--hairline)] bg-[var(--screen-2)] text-[12.5px] text-[var(--ink-muted)]">
           <span>{taxLabel}</span>
           <span className="font-semibold tabular-nums">
-            {formatMoney(invoice.taxTotal ?? 0, currency)}
+            {formatMoneyPrecise(invoice.taxTotal ?? 0, currency)}
           </span>
         </div>
         <div className="flex items-baseline justify-between gap-3 px-3.5 py-3 border-t border-[var(--hairline)]">
           <span className="text-[12.5px] font-bold text-[var(--ink)]">Total</span>
           <span className="text-[20px] font-bold tracking-[-0.03em] tabular-nums text-[var(--ink)]">
-            {formatMoney(invoice.totalAmount ?? 0, currency)}
+            {formatMoneyPrecise(invoice.totalAmount ?? 0, currency)}
           </span>
         </div>
       </div>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceSummaryPanel.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceSummaryPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Invoice } from '@yosemite-crew/types';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import { getInvoiceOutstanding } from '@/app/lib/financeMetrics';
 
 type InvoiceSummaryPanelProps = {
@@ -10,6 +10,11 @@ type InvoiceSummaryPanelProps = {
 
 const InvoiceSummaryPanel = ({ invoice, currency }: InvoiceSummaryPanelProps) => {
   const outstanding = getInvoiceOutstanding(invoice);
+  // The invoice's own currency, and to the penny. The prop is an organisation
+  // value that is always USD (#2597), and these figures have to reconcile with
+  // the stored amount and with the credit ledger below - 144.60 rounded to 145
+  // is a different number to the client.
+  const money = recordCurrency(invoice, currency);
   const taxLabel = invoice.taxPercent ? `Tax · ${invoice.taxPercent}%` : 'Tax';
 
   return (
@@ -19,26 +24,26 @@ const InvoiceSummaryPanel = ({ invoice, currency }: InvoiceSummaryPanelProps) =>
         <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
           <span>Subtotal</span>
           <span className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]">
-            {formatMoney(invoice.subtotal ?? 0, currency)}
+            {formatMoneyPrecise(invoice.subtotal ?? 0, money)}
           </span>
         </div>
         <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
           <span>Discount</span>
           <span className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]">
-            {formatMoney(invoice.discountTotal ?? 0, currency)}
+            {formatMoneyPrecise(invoice.discountTotal ?? 0, money)}
           </span>
         </div>
         <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
           <span>{taxLabel}</span>
           <span className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]">
-            {formatMoney(invoice.taxTotal ?? 0, currency)}
+            {formatMoneyPrecise(invoice.taxTotal ?? 0, money)}
           </span>
         </div>
         <span className="h-px bg-card-border" aria-hidden="true" />
         <div className="flex items-baseline justify-between">
           <span className="text-[13.5px] font-bold text-[var(--ink)]">Total</span>
           <span className="text-[24px] font-bold tracking-[-0.03em] tabular-nums text-[var(--ink)]">
-            {formatMoney(invoice.totalAmount ?? 0, currency)}
+            {formatMoneyPrecise(invoice.totalAmount ?? 0, money)}
           </span>
         </div>
         <div className="flex items-center justify-between text-[13px] text-[var(--ink-muted)]">
@@ -49,7 +54,7 @@ const InvoiceSummaryPanel = ({ invoice, currency }: InvoiceSummaryPanelProps) =>
               color: outstanding > 0 ? 'var(--warn-text)' : 'var(--success-text)',
             }}
           >
-            {formatMoney(outstanding, currency)}
+            {formatMoneyPrecise(outstanding, money)}
           </span>
         </div>
       </div>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { StatusOption } from '@/app/features/companions/pages/Companions/types';
 import { useAppointmentsForPrimaryOrg } from '@/app/hooks/useAppointments';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoney, formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import { formatDateLabel } from '@/app/lib/forms';
 import { toTitle } from '@/app/lib/validators';
 import {
@@ -43,7 +43,8 @@ const buildOwnerAndCompanion = (parentName: string, companionName: string): stri
 
 const buildFootnote = (invoice: Invoice, currency: string): string => {
   const deposit = invoice.depositCollectedAmount ?? 0;
-  if (deposit > 0) return `Deposit ${formatMoney(deposit, currency)} applied`;
+  if (deposit > 0)
+    return `Deposit ${formatMoneyPrecise(deposit, recordCurrency(invoice, currency))} applied`;
   if (getInvoiceOutstanding(invoice) === 0) {
     const method = getInvoicePaymentMethodLabel(invoice);
     if (method && method !== '-') return method;
@@ -121,7 +122,7 @@ const PhoneInvoiceCard = ({
           {identityLine || 'Unlinked invoice'}
         </span>
         <span className="shrink-0 text-[14px] font-bold tabular-nums text-[var(--ink)]">
-          {formatMoney(invoice.totalAmount ?? 0, currency)}
+          {formatMoneyPrecise(invoice.totalAmount ?? 0, recordCurrency(invoice, currency))}
         </span>
       </span>
       {footnote && <span className="text-[11px] text-[var(--ink-faint)]">{footnote}</span>}

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { StatusOption } from '@/app/features/companions/pages/Companions/types';
 import { useAppointmentsForPrimaryOrg } from '@/app/hooks/useAppointments';
-import { formatMoney, formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency, sharedCurrency } from '@/app/lib/money';
 import { formatDateLabel } from '@/app/lib/forms';
 import { toTitle } from '@/app/lib/validators';
 import {
@@ -149,6 +149,10 @@ const PhoneInvoiceList = ({
 }: PhoneInvoiceListProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
   const companionsById = useCompanionStore((state) => state.companionsById);
+  // The KPI tiles sum across the list, so they carry a currency only when every
+  // invoice agrees on one. Otherwise the total is not meaningful in any single
+  // currency and the ambient value is as good as it gets.
+  const metricsCurrency = sharedCurrency(filteredList, currency);
 
   const cards = useMemo(
     () =>
@@ -182,7 +186,7 @@ const PhoneInvoiceList = ({
         >
           <span className="block text-[10.5px] text-[var(--ink-faint)]">Collected · wk</span>
           <span className="block text-[18px] font-bold tabular-nums tracking-[-0.03em] text-[var(--ink)]">
-            {formatMoney(metrics.collectedThisWeek, currency)}
+            {formatMoneyPrecise(metrics.collectedThisWeek, metricsCurrency)}
           </span>
         </div>
         <div
@@ -190,7 +194,7 @@ const PhoneInvoiceList = ({
         >
           <span className="block text-[10.5px] text-[var(--ink-faint)]">Outstanding</span>
           <span className="block text-[18px] font-bold tabular-nums tracking-[-0.03em] text-[var(--warn-text)]">
-            {formatMoney(metrics.outstanding, currency)}
+            {formatMoneyPrecise(metrics.outstanding, metricsCurrency)}
           </span>
         </div>
       </div>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { StatusOption } from '@/app/features/companions/pages/Companions/types';
 import { useAppointmentsForPrimaryOrg } from '@/app/hooks/useAppointments';
-import { formatMoneyPrecise, recordCurrency, sharedCurrency } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import { formatDateLabel } from '@/app/lib/forms';
 import { toTitle } from '@/app/lib/validators';
 import {
@@ -29,6 +29,14 @@ type PhoneInvoiceListProps = {
   setActiveStatus: (value: string) => void;
   metrics: FinanceMetrics;
   currency: string;
+  /**
+   * The currency for the KPI totals.
+   *
+   * Separate from `currency` because `metrics` is computed over EVERY invoice
+   * while `filteredList` is the visible subset - deriving it here would label a
+   * total with the currency of a different set of invoices to the one it sums.
+   */
+  metricsCurrency: string;
   onViewInvoice: (invoice: Invoice) => void;
 };
 
@@ -145,14 +153,11 @@ const PhoneInvoiceList = ({
   setActiveStatus,
   metrics,
   currency,
+  metricsCurrency,
   onViewInvoice,
 }: PhoneInvoiceListProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
   const companionsById = useCompanionStore((state) => state.companionsById);
-  // The KPI tiles sum across the list, so they carry a currency only when every
-  // invoice agrees on one. Otherwise the total is not meaningful in any single
-  // currency and the ambient value is as good as it gets.
-  const metricsCurrency = sharedCurrency(filteredList, currency);
 
   const cards = useMemo(
     () =>

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -14,7 +14,7 @@ import { PERMISSIONS } from '@/app/lib/permissions';
 import Fallback from '@/app/ui/overlays/Fallback';
 import { useCurrencyForPrimaryOrg, useSubscriptionForPrimaryOrg } from '@/app/hooks/useBilling';
 import { computeFinanceMetrics } from '@/app/lib/financeMetrics';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise, sharedCurrency } from '@/app/lib/money';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import { IoInformationCircleOutline } from 'react-icons/io5';
@@ -95,6 +95,10 @@ const Finance = () => {
     });
   }, [invoices, activeStatus, query]);
   const financeMetrics = useMemo(() => computeFinanceMetrics(invoices), [invoices]);
+  // The header sums across every invoice, so it carries a currency only when
+  // they all agree - otherwise "$48,797 outstanding" sits above cards reading
+  // GBP.
+  const metricsCurrency = useMemo(() => sharedCurrency(invoices, currency), [invoices, currency]);
 
   const { wrapperClassName, plannerSectionClassName } = getPlannerLayoutClassNames({
     activeView: 'list',
@@ -186,9 +190,9 @@ const Finance = () => {
                   </GlassTooltip>
                 </div>
                 <p className="text-[13.5px] text-text-secondary">
-                  {`${formatMoney(financeMetrics.collectedThisWeek, currency)} collected this week · ${formatMoney(
+                  {`${formatMoneyPrecise(financeMetrics.collectedThisWeek, metricsCurrency)} collected this week · ${formatMoneyPrecise(
                     financeMetrics.outstanding,
-                    currency
+                    metricsCurrency
                   )} outstanding`}
                 </p>
               </div>

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -163,6 +163,7 @@ const Finance = () => {
               activeStatus={activeStatus}
               setActiveStatus={setActiveStatus}
               metrics={financeMetrics}
+              metricsCurrency={metricsCurrency}
               currency={currency}
               onViewInvoice={openInvoice}
             />

--- a/apps/frontend/src/app/lib/money.ts
+++ b/apps/frontend/src/app/lib/money.ts
@@ -44,3 +44,20 @@ export const formatMoneyPrecise = (amount: number, currency: string) => {
     return `${currency} ${amount.toFixed(2)}`;
   }
 };
+
+/**
+ * The currency a money figure actually belongs to.
+ *
+ * Prefer the record's own `currency` over any ambient organisation value.
+ * `useCurrencyForPrimaryOrg` reads `subscription.currency`, which
+ * `normalizeSubscription` never populates, so it always answers USD - see
+ * #2597. Invoices and estimates each carry the currency they were written in,
+ * and that is the only value that can be trusted to match the stored amount.
+ */
+export const recordCurrency = (
+  record: { currency?: string | null } | null | undefined,
+  fallback: string
+): string => {
+  const own = record?.currency;
+  return typeof own === 'string' && own.trim() ? own.trim() : fallback;
+};

--- a/apps/frontend/src/app/lib/money.ts
+++ b/apps/frontend/src/app/lib/money.ts
@@ -61,3 +61,28 @@ export const recordCurrency = (
   const own = record?.currency;
   return typeof own === 'string' && own.trim() ? own.trim() : fallback;
 };
+
+/**
+ * The one currency a set of records shares, or the fallback when they do not.
+ *
+ * An aggregate figure - a week's takings, a total outstanding - is a sum across
+ * records, so it can only carry a currency if every record agrees on one.
+ * Where they do, labelling the total in the ambient organisation value would
+ * print "$48,797 outstanding" above a list of cards reading "GBP 145". Where
+ * they genuinely differ the sum is not meaningful in any single currency, and
+ * the fallback at least does not claim otherwise.
+ */
+export const sharedCurrency = (
+  records: ReadonlyArray<{ currency?: string | null }>,
+  fallback: string
+): string => {
+  let shared: string | null = null;
+  for (const record of records) {
+    const own = record.currency;
+    if (typeof own !== 'string' || !own.trim()) continue;
+    const code = own.trim();
+    if (shared === null) shared = code;
+    else if (shared !== code) return fallback;
+  }
+  return shared ?? fallback;
+};

--- a/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
@@ -18,7 +18,9 @@ type InvoiceCardProps = {
 
 const InvoiceCard = ({ invoice, handleViewInvoice }: InvoiceCardProps) => {
   const appointments = useAppointmentsForPrimaryOrg();
-  const currency = useCurrencyForPrimaryOrg();
+  const orgCurrency = useCurrencyForPrimaryOrg();
+  // Resolved once: every figure on this card belongs to the same invoice.
+  const money = recordCurrency(invoice, orgCurrency);
 
   const companionName = useMemo(
     () => getCompanionNameFromAppointments(appointments, invoice.appointmentId),
@@ -50,25 +52,25 @@ const InvoiceCard = ({ invoice, handleViewInvoice }: InvoiceCardProps) => {
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Sub-total:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoneyPrecise(invoice.subtotal, recordCurrency(invoice, currency))}
+          {formatMoneyPrecise(invoice.subtotal, money)}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Discount:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoneyPrecise(invoice.discountTotal ?? 0, recordCurrency(invoice, currency))}
+          {formatMoneyPrecise(invoice.discountTotal ?? 0, money)}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Tax:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoneyPrecise(invoice.taxTotal ?? 0, recordCurrency(invoice, currency))}
+          {formatMoneyPrecise(invoice.taxTotal ?? 0, money)}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Total:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoneyPrecise(invoice.totalAmount, recordCurrency(invoice, currency))}
+          {formatMoneyPrecise(invoice.totalAmount, money)}
         </div>
       </div>
       <StatusPill tone={getInvoiceStatusTone(invoice.status)} label={toTitle(invoice?.status)} />

--- a/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
@@ -7,7 +7,7 @@ import { Secondary } from '@/app/ui/primitives/Buttons';
 import { toTitle } from '@/app/lib/validators';
 import { useAppointmentsForPrimaryOrg } from '@/app/hooks/useAppointments';
 import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import { getCompanionNameFromAppointments, getParentNameFromAppointments } from '@/app/lib/invoice';
 import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
 
@@ -50,25 +50,25 @@ const InvoiceCard = ({ invoice, handleViewInvoice }: InvoiceCardProps) => {
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Sub-total:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoney(invoice.subtotal, currency)}
+          {formatMoneyPrecise(invoice.subtotal, recordCurrency(invoice, currency))}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Discount:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoney(invoice.discountTotal ?? 0, currency)}
+          {formatMoneyPrecise(invoice.discountTotal ?? 0, recordCurrency(invoice, currency))}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Tax:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoney(invoice.taxTotal ?? 0, currency)}
+          {formatMoneyPrecise(invoice.taxTotal ?? 0, recordCurrency(invoice, currency))}
         </div>
       </div>
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Total:</div>
         <div className="text-caption-1 text-text-primary">
-          {formatMoney(invoice.totalAmount, currency)}
+          {formatMoneyPrecise(invoice.totalAmount, recordCurrency(invoice, currency))}
         </div>
       </div>
       <StatusPill tone={getInvoiceStatusTone(invoice.status)} label={toTitle(invoice?.status)} />

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -61,7 +61,7 @@ span.cell-overflow-count {
 }
 .invoice-table-fixed {
   table-layout: fixed;
-  min-width: 1244px; /* 96+200+180+150+90+70+80+180+110+88 */
+  min-width: 1308px; /* 96+200+180+150+104+96+104+180+110+88 */
 }
 .companions-table-fixed {
   table-layout: fixed;
@@ -278,15 +278,23 @@ span.cell-overflow-count {
    with tabular figures (`cell-figure`), the emphasised figures - Invoice # and
    Total - are bold ink (`cell-strong` / `cell-figure-strong`), and the secondary
    Services / Payment columns are muted ink (`cell-muted`). */
+/* Money never breaks mid-number. The base rule sets `overflow-wrap: anywhere`,
+   which is right for names and descriptions and wrong here: once figures carry
+   their minor units, "AED 12.00" is long enough to wrap in a narrow column and
+   would render as two lines of digits. */
 .appointment-profile-title.cell-figure {
   text-align: right;
   font-variant-numeric: tabular-nums;
+  overflow-wrap: normal;
+  white-space: nowrap;
 }
 .appointment-profile-title.cell-figure-strong {
   text-align: right;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   color: var(--ink);
+  overflow-wrap: normal;
+  white-space: nowrap;
 }
 .appointment-profile-title.cell-strong {
   font-weight: 700;

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -271,18 +271,20 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
   );
 
   const renderTotal = (item: Invoice, foldBreakdown: boolean) => {
+    // One resolution for the whole row: every figure here is the same invoice's.
+    const money = recordCurrency(item, currency);
     // Tablet drops Subtotal / Discount / Tax, so the derivation folds under Total.
     const breakdown = foldBreakdown
       ? joinMeta(
-          `Sub ${formatMoneyPrecise(item.subtotal, recordCurrency(item, currency))}`,
-          `Disc ${formatMoneyPrecise(item.discountTotal ?? 0, recordCurrency(item, currency))}`,
-          `Tax ${formatMoneyPrecise(item.taxTotal ?? 0, recordCurrency(item, currency))}`
+          `Sub ${formatMoneyPrecise(item.subtotal, money)}`,
+          `Disc ${formatMoneyPrecise(item.discountTotal ?? 0, money)}`,
+          `Tax ${formatMoneyPrecise(item.taxTotal ?? 0, money)}`
         )
       : '';
     return (
       <div className="appointment-profile-two min-w-0">
         <div className="appointment-profile-title cell-figure-strong">
-          {formatMoneyPrecise(item.totalAmount ?? 0, recordCurrency(item, currency))}
+          {formatMoneyPrecise(item.totalAmount ?? 0, money)}
         </div>
         {breakdown && (
           <div className="appointment-profile-sub truncate" title={breakdown}>
@@ -319,12 +321,12 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     },
     { label: 'Services', key: 'service', width: '180px', render: renderServices },
     { label: 'Date', key: 'date', width: '150px', render: renderDate },
-    { label: 'Subtotal', key: 'sub-total', width: '90px', render: renderSubtotal },
-    { label: 'Tax', key: 'tax', width: '70px', render: renderTax },
+    { label: 'Subtotal', key: 'sub-total', width: '104px', render: renderSubtotal },
+    { label: 'Tax', key: 'tax', width: '96px', render: renderTax },
     {
       label: 'Total',
       key: 'total',
-      width: '80px',
+      width: '104px',
       render: (item: Invoice) => renderTotal(item, false),
     },
     { label: 'Status', key: 'status', width: STATUS_COLUMN_WIDTH, render: renderStatus },

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'next/navigation';
 import './DataTable.css';
 import { useAppointmentsForPrimaryOrg } from '@/app/hooks/useAppointments';
 import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
-import { formatMoney } from '@/app/lib/money';
+import { formatMoneyPrecise, recordCurrency } from '@/app/lib/money';
 import {
   getAppointmentByIdFromList,
   getCompanionNameFromAppointments,
@@ -260,13 +260,13 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
 
   const renderSubtotal = (item: Invoice) => (
     <div className="appointment-profile-title cell-figure">
-      {formatMoney(item.subtotal, currency)}
+      {formatMoneyPrecise(item.subtotal, recordCurrency(item, currency))}
     </div>
   );
 
   const renderTax = (item: Invoice) => (
     <div className="appointment-profile-title cell-figure">
-      {formatMoney(item.taxTotal ?? 0, currency)}
+      {formatMoneyPrecise(item.taxTotal ?? 0, recordCurrency(item, currency))}
     </div>
   );
 
@@ -274,15 +274,15 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     // Tablet drops Subtotal / Discount / Tax, so the derivation folds under Total.
     const breakdown = foldBreakdown
       ? joinMeta(
-          `Sub ${formatMoney(item.subtotal, currency)}`,
-          `Disc ${formatMoney(item.discountTotal ?? 0, currency)}`,
-          `Tax ${formatMoney(item.taxTotal ?? 0, currency)}`
+          `Sub ${formatMoneyPrecise(item.subtotal, recordCurrency(item, currency))}`,
+          `Disc ${formatMoneyPrecise(item.discountTotal ?? 0, recordCurrency(item, currency))}`,
+          `Tax ${formatMoneyPrecise(item.taxTotal ?? 0, recordCurrency(item, currency))}`
         )
       : '';
     return (
       <div className="appointment-profile-two min-w-0">
         <div className="appointment-profile-title cell-figure-strong">
-          {formatMoney(item.totalAmount ?? 0, currency)}
+          {formatMoneyPrecise(item.totalAmount ?? 0, recordCurrency(item, currency))}
         </div>
         {breakdown && (
           <div className="appointment-profile-sub truncate" title={breakdown}>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Every money figure on the finance surfaces is labelled USD and rounded to whole units, whatever the record actually says.

Reproduced end to end on deployed dev by creating an estimate through the new UI, converting it, and issuing a credit note against the resulting invoice:

| field | stored | displayed |
| --- | --- | --- |
| `Invoice.currency` | `GBP` | `$` |
| `Invoice.totalAmount` | `144.6` | `$145` |
| `Invoice.subtotal` | `120.5` | `$121` |
| `CreditNote.amount` | `20.5` | `$21` |

The same money renders correctly as GBP 120.50 / GBP 144.60 on the estimates screen, because that screen reads the record's own `currency`. So the two halves of one transaction were labelled in different currencies on the same deployment.

Two independent causes:

- **Currency.** `useCurrencyForPrimaryOrg` returns `subscription?.currency ?? 'USD'`, and `normalizeSubscription` never sets `currency`. `BillingSubscription.currency` is declared in the type and nothing writes to it; the backend payload carries none. The fallback is the only value it ever returns.
- **Rounding.** `formatMoney` runs at `maximumFractionDigits: 0`. Right for a dashboard tile, wrong for a figure that has to reconcile with a stored amount and with the credit ledger beside it.

## What is the new behavior?

A new `recordCurrency(record, fallback)` helper, and every per-invoice figure now uses it with `formatMoneyPrecise`:

- `InvoiceTable` - each row uses its own invoice's currency
- `PhoneInvoiceList` - card totals and the deposit footnote
- `InvoiceSummaryPanel` - subtotal, discount, tax, total, outstanding
- `InvoiceBilledItems`, `InvoicePaymentLedger`, `CreditNoteLedger`, `InvoiceCard`
- `InvoiceInfo` resolves the drawer's currency from the invoice once and passes it down

**Deliberately unchanged:** the two KPI tiles in `PhoneInvoiceList` (`collectedThisWeek`, `outstanding`) keep `formatMoney` and the ambient currency. They aggregate across invoices, so no single record's currency applies, and a rounded headline is appropriate there.

### Out of scope

This does not fix the root cause. There is still no organisation-level currency the client can resolve, so service and package prices elsewhere in the app remain labelled with the always-USD value. #2597 tracks that and now carries these measurements.

## Validation performed

Measured, not estimated:

- `npx tsc --noEmit` from `apps/frontend`: exit 0.
- `pnpm --filter frontend run lint`: 0 errors.
- `pnpm --filter frontend run test -- --testPathPatterns="Invoice|invoice|money|Finance|estimate|Estimate"`: **42 suites, 732 tests, all passing**.
- sonarjs + jsx-a11y sweep over the changed source: clean.

Ten test files mocked `@/app/lib/money` and needed the new exports added; the money literals in five suites moved from whole units to two decimals, which is the behaviour change itself.

**One test now proves the fix on its own:** `PhoneInvoiceList`'s partial-invoice fixture carries `currency: 'EUR'`. Its deposit footnote now reads EUR where it previously used the ambient organisation currency - a euro invoice labelled in dollars was exactly the defect.

Not verified: the change has not yet been seen signed-in on deployed dev. The before state was captured there; the after needs a pass once this merges.

## Related Issue(s)

Refs #2597
