### PR TITLE
fix(backend): return settlement details on the organisation invoice list

### DIFF
--- a/apps/backend/src/services/invoice.service.ts
+++ b/apps/backend/src/services/invoice.service.ts
@@ -431,32 +431,25 @@ const mergeInvoiceLineItems = (
   return merged;
 };
 
-const loadInvoiceFinancialDetails = async (
-  invoice: Pick<
-    PrismaInvoice,
-    "id" | "items" | "totalAmount" | "depositCollectedAmount"
-  >,
+type SettlementInvoice = Pick<
+  PrismaInvoice,
+  "id" | "items" | "totalAmount" | "depositCollectedAmount"
+>;
+
+type SettlementCreditNote = { id: string; amount: number };
+
+/**
+ * The settlement arithmetic, with its inputs already fetched.
+ *
+ * Split out from the loader so a list can fetch payments and credit notes once
+ * for every invoice it is returning instead of twice per invoice. The
+ * computation itself is unchanged.
+ */
+const computeInvoiceFinancialDetails = (
+  invoice: SettlementInvoice,
+  payments: PrismaPaymentWithRefunds[],
+  creditNotes: SettlementCreditNote[],
 ) => {
-  const invoiceId = invoice.id;
-  const payments = (await prisma.payment.findMany({
-    where: { invoiceId },
-    orderBy: [{ createdAt: "desc" }, { updatedAt: "desc" }],
-    include: {
-      refunds: {
-        orderBy: { createdAt: "desc" },
-      },
-    },
-  })) as PrismaPaymentWithRefunds[];
-
-  const creditNotes = (await prisma.creditNote.findMany({
-    where: { invoiceId, status: "ISSUED" },
-    orderBy: { createdAt: "asc" },
-    select: {
-      id: true,
-      amount: true,
-    },
-  })) as Array<{ id: string; amount: number }>;
-
   const buildLineAllocations = (
     amount: number,
     lines: InvoiceSettlementLineAllocation[],
@@ -546,6 +539,89 @@ const loadInvoiceFinancialDetails = async (
       lineAllocations: itemAllocations,
     } satisfies InvoiceSettlementSummary,
   };
+};
+
+/** Payments and credit notes for one invoice, then the settlement arithmetic. */
+const loadInvoiceFinancialDetails = async (invoice: SettlementInvoice) => {
+  const invoiceId = invoice.id;
+  const [payments, creditNotes] = await Promise.all([
+    prisma.payment.findMany({
+      where: { invoiceId },
+      orderBy: [{ createdAt: "desc" }, { updatedAt: "desc" }],
+      include: { refunds: { orderBy: { createdAt: "desc" } } },
+    }) as Promise<PrismaPaymentWithRefunds[]>,
+    prisma.creditNote.findMany({
+      where: { invoiceId, status: "ISSUED" },
+      orderBy: { createdAt: "asc" },
+      select: { id: true, amount: true },
+    }) as Promise<SettlementCreditNote[]>,
+  ]);
+
+  return computeInvoiceFinancialDetails(invoice, payments, creditNotes);
+};
+
+/**
+ * The same settlement details for a whole page of invoices, in two queries
+ * rather than two per invoice.
+ *
+ * The finance list returns every invoice for an organisation - already 400 on
+ * dev - so calling the single-invoice loader in a map would issue 800 queries
+ * to render one screen. That cost is why the list returned no settlement data
+ * at all, which left `getInvoiceOutstanding` unable to take its preferred
+ * branch and every part-paid or credited invoice overstated (#2595).
+ */
+const loadInvoiceFinancialDetailsMany = async (
+  invoices: SettlementInvoice[],
+): Promise<Map<string, ReturnType<typeof computeInvoiceFinancialDetails>>> => {
+  const details = new Map<
+    string,
+    ReturnType<typeof computeInvoiceFinancialDetails>
+  >();
+  if (invoices.length === 0) {
+    return details;
+  }
+
+  const invoiceIds = invoices.map((invoice) => invoice.id);
+  const [payments, creditNotes] = await Promise.all([
+    prisma.payment.findMany({
+      where: { invoiceId: { in: invoiceIds } },
+      orderBy: [{ createdAt: "desc" }, { updatedAt: "desc" }],
+      include: { refunds: { orderBy: { createdAt: "desc" } } },
+    }) as Promise<PrismaPaymentWithRefunds[]>,
+    prisma.creditNote.findMany({
+      where: { invoiceId: { in: invoiceIds }, status: "ISSUED" },
+      orderBy: { createdAt: "asc" },
+      select: { id: true, amount: true, invoiceId: true },
+    }) as Promise<Array<SettlementCreditNote & { invoiceId: string }>>,
+  ]);
+
+  const paymentsByInvoice = new Map<string, PrismaPaymentWithRefunds[]>();
+  for (const payment of payments) {
+    const bucket = paymentsByInvoice.get(payment.invoiceId);
+    if (bucket) bucket.push(payment);
+    else paymentsByInvoice.set(payment.invoiceId, [payment]);
+  }
+
+  const creditNotesByInvoice = new Map<string, SettlementCreditNote[]>();
+  for (const creditNote of creditNotes) {
+    const entry = { id: creditNote.id, amount: creditNote.amount };
+    const bucket = creditNotesByInvoice.get(creditNote.invoiceId);
+    if (bucket) bucket.push(entry);
+    else creditNotesByInvoice.set(creditNote.invoiceId, [entry]);
+  }
+
+  for (const invoice of invoices) {
+    details.set(
+      invoice.id,
+      computeInvoiceFinancialDetails(
+        invoice,
+        paymentsByInvoice.get(invoice.id) ?? [],
+        creditNotesByInvoice.get(invoice.id) ?? [],
+      ),
+    );
+  }
+
+  return details;
 };
 
 const toTaxLineItems = (items: DraftInvoiceItemInput[]) =>
@@ -2009,7 +2085,16 @@ export const InvoiceService = {
       include: invoiceCreditNotesInclude,
       orderBy: { createdAt: "desc" },
     });
-    return docs.map((d) => toInvoiceRecord(d));
+    // Settlement for the whole page in two queries. Without it the list
+    // carries no `settlementSummary`, so `getInvoiceOutstanding` on the client
+    // cannot take its preferred branch and falls back to total minus deposit -
+    // which ignores every recorded payment and every credit note, and
+    // overstates what each part-paid invoice still owes (#2595).
+    const details = await loadInvoiceFinancialDetailsMany(docs);
+    return docs.map((d) => ({
+      ...toInvoiceRecord(d),
+      ...(details.get(d.id) ?? {}),
+    }));
   },
 
   async listForParent(parentId: string, organisationId: string | null) {

--- a/apps/backend/src/services/invoice.service.ts
+++ b/apps/backend/src/services/invoice.service.ts
@@ -2091,10 +2091,11 @@ export const InvoiceService = {
     // which ignores every recorded payment and every credit note, and
     // overstates what each part-paid invoice still owes (#2595).
     const details = await loadInvoiceFinancialDetailsMany(docs);
-    return docs.map((d) => ({
-      ...toInvoiceRecord(d),
-      ...(details.get(d.id) ?? {}),
-    }));
+    return docs.map((d) => {
+      const record = toInvoiceRecord(d);
+      const settlement = details.get(d.id);
+      return settlement ? { ...record, ...settlement } : record;
+    });
   },
 
   async listForParent(parentId: string, organisationId: string | null) {

--- a/apps/backend/test/services/invoice.service.test.ts
+++ b/apps/backend/test/services/invoice.service.test.ts
@@ -3722,6 +3722,78 @@ describe("InvoiceService", () => {
     );
   });
 
+  it("returns settlement details for the whole list in two queries", async () => {
+    // The list used to return no settlementSummary at all, which left the
+    // client's getInvoiceOutstanding unable to take its preferred branch and
+    // falling back to total-minus-deposit - ignoring every recorded payment
+    // and credit note, and overstating what each invoice still owed (#2595).
+    const invoices = [
+      {
+        id: "inv_a",
+        organisationId,
+        items: [],
+        subtotal: 200,
+        totalAmount: 200,
+        depositCollectedAmount: 0,
+        currency: "gbp",
+        status: "AWAITING_PAYMENT",
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "inv_b",
+        organisationId,
+        items: [],
+        subtotal: 100,
+        totalAmount: 100,
+        depositCollectedAmount: 0,
+        currency: "gbp",
+        status: "AWAITING_PAYMENT",
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    (prisma.invoice.findMany as jest.Mock).mockResolvedValueOnce(invoices);
+    (prisma.payment.findMany as jest.Mock).mockResolvedValueOnce([
+      { id: "pay_a", invoiceId: "inv_a", amount: 50, refunds: [] },
+    ]);
+    (prisma.creditNote.findMany as jest.Mock).mockResolvedValueOnce([
+      { id: "cn_a", invoiceId: "inv_a", amount: 20 },
+    ]);
+
+    const results = await InvoiceService.listForOrganisation(organisationId);
+
+    // inv_a: 200 total, 50 paid, 20 credited -> 130 outstanding.
+    expect(results[0].settlementSummary).toEqual(
+      expect.objectContaining({ cashPaid: 50, credited: 20, balance: 130 }),
+    );
+    // inv_b has neither, so it still owes the whole amount.
+    expect(results[1].settlementSummary).toEqual(
+      expect.objectContaining({ cashPaid: 0, credited: 0, balance: 100 }),
+    );
+
+    // Two queries for the page, not two per invoice.
+    expect(prisma.payment.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.creditNote.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { invoiceId: { in: ["inv_a", "inv_b"] } },
+      }),
+    );
+  });
+
+  it("returns an empty list without querying settlement at all", async () => {
+    (prisma.invoice.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(
+      InvoiceService.listForOrganisation(organisationId),
+    ).resolves.toEqual([]);
+    expect(prisma.payment.findMany).not.toHaveBeenCalled();
+    expect(prisma.creditNote.findMany).not.toHaveBeenCalled();
+  });
+
   it("throws when adding items to a missing invoice", async () => {
     (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce(null);
     await expect(


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The finance list overstates what every part-paid or credited invoice still owes.

`getInvoiceOutstanding` (`apps/frontend/src/app/lib/financeMetrics.ts`) documents itself as preferring `settlementSummary.balance` and falling back to `totalAmount - depositCollectedAmount`. `InvoiceService.listForOrganisation` returned no `settlementSummary` and no `payments`, so the preferred branch was unreachable on the primary finance screen and the fallback was the only path ever taken - a fallback that knows nothing about recorded payments or credit notes.

Measured on dev:

- Three unsettled invoices with recorded payments and no deposit were presented as owing **1654.25** against a true **767.03**. One showed 484.13 outstanding when the client had paid all but 3.75.
- After the credit-note UI shipped, an invoice credited by **20.50** still showed its full **144.60** as Outstanding - on the same screen, inches from the credit ledger recording that credit.

The reason the data was missing is cost, not oversight: `loadInvoiceFinancialDetails` issues two queries per invoice, and this list returns every invoice for an organisation - already 400 on dev - so calling it in a `map` would mean 800 queries to render one screen.

## What is the new behavior?

The arithmetic is split from the fetching so the list can afford it:

- `computeInvoiceFinancialDetails(invoice, payments, creditNotes)` - the existing computation, unchanged, with its inputs passed in.
- `loadInvoiceFinancialDetails(invoice)` - unchanged signature and behaviour; now fetches its two queries in parallel and calls the computation.
- `loadInvoiceFinancialDetailsMany(invoices)` - **two queries for the whole page**, grouped in memory by invoice id.

`listForOrganisation` uses the batched loader and merges the result onto each record.

**No client change is required.** `normalizeFinanceInvoice` already carries `settlementSummary` through (added in #2596), so the correct balance reaches `getInvoiceOutstanding` as soon as the API sends one.

### Out of scope

There is a second list path that still calls the single-invoice loader inside a `Promise.all(docs.map(...))`, so it retains the N+1. It is left alone here to keep this change to the screen the issue is about; the batched loader is now available to it.

## Validation performed

Measured, not estimated:

- `pnpm --filter backend run type-check`: exit 0.
- `pnpm --filter backend run lint`: 0 errors.
- Full backend suite: **459 files, 11072 tests, all passing**.
- New tests on `listForOrganisation`: an invoice with a 50 payment and a 20 credit against a 200 total reports `cashPaid: 50, credited: 20, balance: 130`, while an invoice with neither still reports the full amount. A second test proves an empty list issues no settlement queries at all.
- The test asserts the **two-query shape**, not only the numbers - `payment.findMany` and `creditNote.findMany` are each called exactly once, with `invoiceId: { in: [...] }`. A regression to per-invoice fetching fails it.
- **Mutation-checked:** removing the batched call from `listForOrganisation` fails exactly one test. The mutation was confirmed applied before the run and the file restored byte-identical afterwards.

Not verified: the corrected figures have not yet been seen on deployed dev. The wrong ones were captured there and are quoted above; the after needs a pass once this merges.

## Related Issue(s)

Fixes #2595
