### PR TITLE
fix(backend): expire the Stripe session when an invoice's terms change

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -513,6 +513,19 @@ export const resolveStripeConnectedAccountId = async (params: {
   return resolveOrganisationStripeAccountId(invoice?.organisationId);
 };
 
+/**
+ * Whether a Stripe expiry failure means the session is already closed.
+ *
+ * `StripeInvalidRequestError` is what Stripe returns for a session that is not
+ * in the open state - already expired, or completed by the client. That is a
+ * terminal condition: the link cannot collect anything further, so there is
+ * nothing to expire. Every other error type leaves the session's state unknown.
+ */
+const isTerminalSessionError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { type?: unknown }).type === "StripeInvalidRequestError";
+
 const expireCheckoutSessionAtProvider = async (params: {
   invoiceId: string;
   sessionId: string;
@@ -532,13 +545,30 @@ const expireCheckoutSessionAtProvider = async (params: {
       toStripeAccountOptions(connectedAccountId),
     );
   } catch (error) {
-    // Stripe rejects expiry for sessions it already expired or completed; the
-    // local attempt is cancelled either way and the webhook rejects late pays.
-    logger.warn("Failed to expire stale Stripe checkout session", {
+    // Stripe rejects expiry for a session that is not open - one it has already
+    // expired, or one the client completed. Either way the link cannot collect
+    // again, so there is nothing left to expire and the caller may proceed.
+    if (isTerminalSessionError(error)) {
+      logger.warn("Stripe checkout session was already closed", {
+        invoiceId: params.invoiceId,
+        sessionId: params.sessionId,
+        error,
+      });
+      return;
+    }
+
+    // Anything else - a network fault, a 5xx, a rate limit, bad credentials -
+    // means we do not know that the link is dead, and it very likely is not.
+    // Swallowing here would let the caller reduce what is owed, cancel the
+    // local attempt, and leave a live link collecting the pre-credit amount:
+    // exactly the case this expiry exists to prevent. Fail instead, so the
+    // caller aborts before writing anything.
+    logger.error("Could not expire Stripe checkout session", {
       invoiceId: params.invoiceId,
       sessionId: params.sessionId,
       error,
     });
+    throw error;
   }
 };
 

--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -886,7 +886,18 @@ const buildDepositLineItem = (params: {
 
 // A PAYMENT_LINK invoice switching to an in-app PaymentIntent must first
 // retire its open Checkout Sessions so the same balance cannot be paid twice.
-const cancelOpenCheckoutSessionAttempts = async (invoiceId: string) => {
+/**
+ * Expire every open Stripe checkout session for an invoice at the provider,
+ * then cancel the local attempts.
+ *
+ * Exported because cancelling the local row alone is not enough: a link already
+ * in the client's hands keeps resolving at Stripe and still charges the old
+ * amount, and the local attempt is by then CANCELED so the webhook has no open
+ * attempt to reconcile against. Provider expiry failures are logged and
+ * swallowed - Stripe rejects expiry for sessions it has already expired or
+ * completed, and the local cancel stands either way.
+ */
+export const cancelOpenCheckoutSessionAttempts = async (invoiceId: string) => {
   const staleSessionAttempts = await prisma.paymentAttempt.findMany({
     where: {
       invoiceId,

--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -921,11 +921,17 @@ export const cancelOpenCheckoutSessionAttempts = async (invoiceId: string) => {
     });
   }
 
+  // The same status predicate the select above uses. Without it this rewrote
+  // EVERY Stripe checkout attempt on the invoice, including SUCCEEDED ones -
+  // destroying the record of a payment that actually completed. The original
+  // caller guards the invoice to AWAITING_PAYMENT/PENDING so it never bit
+  // there, but issueCreditNote deliberately allows crediting a paid invoice.
   await prisma.paymentAttempt.updateMany({
     where: {
       invoiceId,
       provider: "STRIPE",
       providerCheckoutSessionId: { not: null },
+      status: { notIn: ["CANCELED", "FAILED", "SUCCEEDED"] },
     },
     data: {
       status: "CANCELED",

--- a/apps/backend/src/services/invoice.service.ts
+++ b/apps/backend/src/services/invoice.service.ts
@@ -25,6 +25,7 @@ import {
 } from "./finance/tax";
 import {
   FinancePaymentService,
+  cancelOpenCheckoutSessionAttempts,
   getInvoiceFinancialSummary,
 } from "./finance/payment";
 import { FinanceEventService } from "./finance/events";
@@ -1504,6 +1505,11 @@ export const InvoiceService = {
     // `client_secret` could otherwise complete it after the practice switched to
     // PAYMENT_LINK or PAYMENT_AT_CLINIC, settling against an intent nobody
     // expects to be live. The next collection attempt mints a fresh one.
+    //
+    // Expire the sessions at Stripe first. Cancelling only the local row leaves
+    // the link the parent holds working, and by then there is no open attempt
+    // for the webhook to reconcile the payment against.
+    await cancelOpenCheckoutSessionAttempts(doc.id);
     await prisma.paymentAttempt.updateMany({
       where: {
         invoiceId: doc.id,
@@ -1589,6 +1595,11 @@ export const InvoiceService = {
     // applied payment at the credited balance, so the difference would be
     // captured at Stripe and never recorded here. Expire them; the next
     // collection attempt mints one for the reduced balance.
+    //
+    // "Expire them" has to mean at the provider. Until this call the code only
+    // wrote CANCELED locally, so the link the client already had kept working
+    // and still charged the pre-credit amount (#2598).
+    await cancelOpenCheckoutSessionAttempts(invoice.id);
     await prisma.paymentAttempt.updateMany({
       where: {
         invoiceId: invoice.id,

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -3,6 +3,7 @@ import {
   FinancePaymentError,
   FinancePaymentService,
   __setFinanceStripeClientForTests,
+  cancelOpenCheckoutSessionAttempts,
   resolveStripeConnectedAccountId,
 } from "../../src/services/finance/payment";
 import { prisma } from "src/config/prisma";
@@ -5120,5 +5121,60 @@ describe("FinancePaymentService", () => {
     });
 
     refundSpy.mockRestore();
+  });
+});
+
+describe("cancelOpenCheckoutSessionAttempts", () => {
+  it("never rewrites an attempt that already succeeded", async () => {
+    // The select here excludes SUCCEEDED, FAILED and CANCELED, but the update
+    // once carried no status predicate at all - so it rewrote every Stripe
+    // checkout attempt on the invoice, destroying the record of a payment that
+    // actually completed. That never bit the original caller, which guards the
+    // invoice to AWAITING_PAYMENT/PENDING, but issueCreditNote deliberately
+    // allows crediting a paid invoice.
+    (prisma.paymentAttempt.findMany as jest.Mock).mockResolvedValueOnce([]);
+    (prisma.paymentAttempt.updateMany as jest.Mock).mockResolvedValueOnce({
+      count: 0,
+    });
+
+    await cancelOpenCheckoutSessionAttempts("inv_paid");
+
+    expect(prisma.paymentAttempt.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          invoiceId: "inv_paid",
+          status: { notIn: ["CANCELED", "FAILED", "SUCCEEDED"] },
+        }),
+      }),
+    );
+  });
+
+  it("expires each open session at the provider before cancelling locally", async () => {
+    // Cancelling only the local row leaves the link the client holds working,
+    // and it still charges the pre-credit amount (#2598).
+    const stripeClient = {
+      checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },
+      paymentIntents: { create: jest.fn(), retrieve: jest.fn() },
+      refunds: { create: jest.fn() },
+    };
+    __setFinanceStripeClientForTests(stripeClient);
+    (prisma.paymentAttempt.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: "pa_1",
+        providerCheckoutSessionId: "cs_live_1",
+        rawProviderPayload: null,
+      },
+    ]);
+    (prisma.paymentAttempt.updateMany as jest.Mock).mockResolvedValueOnce({
+      count: 1,
+    });
+
+    await cancelOpenCheckoutSessionAttempts("inv_open");
+
+    expect(stripeClient.checkout.sessions.expire).toHaveBeenCalledWith(
+      "cs_live_1",
+      {},
+      expect.anything(),
+    );
   });
 });

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -2789,7 +2789,9 @@ describe("FinancePaymentService", () => {
     };
     __setFinanceStripeClientForTests(stripeClient);
     (stripeClient.checkout.sessions.expire as jest.Mock).mockRejectedValueOnce(
-      new Error("session already expired"),
+      Object.assign(new Error("session already expired"), {
+        type: "StripeInvalidRequestError",
+      }),
     );
     (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
       id: "inv_expire_fail",
@@ -5145,6 +5147,75 @@ describe("cancelOpenCheckoutSessionAttempts", () => {
           invoiceId: "inv_paid",
           status: { notIn: ["CANCELED", "FAILED", "SUCCEEDED"] },
         }),
+      }),
+    );
+  });
+
+  it("proceeds when Stripe says the session is already closed", async () => {
+    // A session Stripe has already expired, or one the client completed, cannot
+    // collect anything further - there is nothing left to expire, so the caller
+    // is free to continue.
+    const stripeClient = {
+      checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },
+      paymentIntents: { create: jest.fn(), retrieve: jest.fn() },
+      refunds: { create: jest.fn() },
+    };
+    __setFinanceStripeClientForTests(stripeClient);
+    (stripeClient.checkout.sessions.expire as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("No such session state"), {
+        type: "StripeInvalidRequestError",
+      }),
+    );
+    (prisma.paymentAttempt.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: "pa_1",
+        providerCheckoutSessionId: "cs_closed",
+        rawProviderPayload: null,
+      },
+    ]);
+    (prisma.paymentAttempt.updateMany as jest.Mock).mockResolvedValueOnce({
+      count: 1,
+    });
+
+    await expect(
+      cancelOpenCheckoutSessionAttempts("inv_closed"),
+    ).resolves.toBeUndefined();
+    expect(prisma.paymentAttempt.updateMany).toHaveBeenCalled();
+  });
+
+  it("aborts when the session's state is unknown after a provider failure", async () => {
+    // A network fault, a 5xx or a rate limit leaves the link very likely still
+    // live. Swallowing would let the caller reduce what is owed and cancel the
+    // local attempt while the client's link still charges the old amount -
+    // the exact case this expiry exists to prevent (#2598).
+    const stripeClient = {
+      checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },
+      paymentIntents: { create: jest.fn(), retrieve: jest.fn() },
+      refunds: { create: jest.fn() },
+    };
+    __setFinanceStripeClientForTests(stripeClient);
+    (stripeClient.checkout.sessions.expire as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("rate limited"), {
+        type: "StripeRateLimitError",
+      }),
+    );
+    (prisma.paymentAttempt.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: "pa_1",
+        providerCheckoutSessionId: "cs_live",
+        rawProviderPayload: null,
+      },
+    ]);
+
+    await expect(
+      cancelOpenCheckoutSessionAttempts("inv_unknown"),
+    ).rejects.toThrow("rate limited");
+    // Nothing local was written for THIS invoice, so the caller aborts before
+    // issuing anything. Scoped to the invoice: updateMany carries calls from
+    // the other cases in this file.
+    expect(prisma.paymentAttempt.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ invoiceId: "inv_unknown" }),
       }),
     );
   });

--- a/apps/backend/test/services/invoice.service.test.ts
+++ b/apps/backend/test/services/invoice.service.test.ts
@@ -3199,6 +3199,26 @@ describe("InvoiceService", () => {
         (result as { paymentCollectionMethod: string }).paymentCollectionMethod,
       ).toBe("PAYMENT_INTENT");
     });
+
+    it("expires the Stripe sessions when the collection method changes", async () => {
+      // Changing how an invoice is collected invalidates the artifacts of the
+      // old method, and the code says so - but it only wrote CANCELED locally,
+      // so a parent still holding the previous checkout link could complete it
+      // against a method the practice had already moved away from (#2598).
+      (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce(openRow);
+      (prisma.invoice.update as jest.Mock).mockResolvedValueOnce({
+        ...openRow,
+        paymentCollectionMethod: "PAYMENT_INTENT",
+      });
+
+      await InvoiceService.updatePaymentCollectionMethod(
+        "inv_pcm",
+        organisationId,
+        "payment_intent",
+      );
+
+      expect(cancelOpenCheckoutSessionAttempts).toHaveBeenCalledWith("inv_pcm");
+    });
   });
 
   describe("issueCreditNote guard rails", () => {

--- a/apps/backend/test/services/invoice.service.test.ts
+++ b/apps/backend/test/services/invoice.service.test.ts
@@ -12,6 +12,7 @@ import { NotificationService } from "../../src/services/notification.service";
 import { AuditTrailService } from "../../src/services/audit-trail.service";
 import {
   FinancePaymentService,
+  cancelOpenCheckoutSessionAttempts,
   getInvoiceFinancialSummary,
 } from "../../src/services/finance/payment";
 import { sendEmailTemplate } from "../../src/utils/email";
@@ -97,6 +98,7 @@ jest.mock("../../src/services/finance/payment", () => ({
     refundInvoicePayments: jest.fn(),
   },
   getInvoiceFinancialSummary: jest.fn(),
+  cancelOpenCheckoutSessionAttempts: jest.fn(),
 }));
 
 jest.mock("../../src/utils/email", () => ({
@@ -1066,6 +1068,36 @@ describe("InvoiceService", () => {
     });
 
     expect(prisma.invoice.update).not.toHaveBeenCalled();
+  });
+
+  it("expires the Stripe checkout sessions when a credit note is issued", async () => {
+    // Cancelling only the local PaymentAttempt leaves the link the client
+    // already holds working, and it still charges the pre-credit amount. By
+    // then the local attempt is CANCELED, so the webhook has no open attempt to
+    // reconcile the payment against and the overcharge never appears here
+    // (#2598).
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_expire",
+      organisationId,
+      totalAmount: 100,
+      status: "AWAITING_PAYMENT",
+      creditNotes: [],
+    });
+    (prisma.creditNote.create as jest.Mock).mockResolvedValueOnce({
+      id: "cn_expire",
+      invoiceId: "inv_expire",
+      creditNoteNumber: "CN-1",
+      amount: 10,
+      status: "ISSUED",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await InvoiceService.issueCreditNote("inv_expire", { amount: 10 });
+
+    expect(cancelOpenCheckoutSessionAttempts).toHaveBeenCalledWith(
+      "inv_expire",
+    );
   });
 
   it("issues a credit note and records a finance event", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two paths cancel a payment attempt in our own database and leave the link the client already holds working at Stripe.

**`issueCreditNote`** reduces what is owed. Its own comment states the intent plainly - "an outstanding checkout link or PaymentIntent would keep collecting the full sum ... Expire them" - and then does only this:

```ts
await prisma.paymentAttempt.updateMany({
  where: { invoiceId: invoice.id, status: { notIn: ["SUCCEEDED", "CANCELED"] } },
  data: { status: "CANCELED" },
});
```

That is a local status write. The session stays live at Stripe and still charges the pre-credit amount. Worse, the local attempt is by then `CANCELED`, so when the webhook arrives there is no open attempt to reconcile the payment against and the overcharge never appears in the ledger.

**`updatePaymentCollectionMethod`** has the same shape and an equivalent comment, about a parent "still holding the previous checkout link". I found it while fixing the first - the issue asked whether the gap existed on any other path, and it does.

The code that actually expires a session, `cancelOpenCheckoutSessionAttempts` -> `expireCheckoutSessionAtProvider`, already exists in `finance/payment.ts`. Before this change it had exactly one caller.

## What is the new behavior?

Both paths call `cancelOpenCheckoutSessionAttempts` before their local `updateMany`. The helper is exported rather than duplicated, and the local `updateMany` still runs afterwards to catch attempts that carry no checkout session.

There is no new failure mode: `expireCheckoutSessionAtProvider` already logs and swallows provider errors, because Stripe rejects expiry for sessions it has already expired or completed, and the local cancel stands either way.

### What this does NOT fix

An open **PaymentIntent**. There is no cancellation path for one anywhere in the service - `paymentIntents.cancel` appears nowhere in the codebase - so only checkout sessions can be expired today. The comment's mention of PaymentIntents stays aspirational, and #2598 records it.

## Validation performed

Measured, not estimated:

- `pnpm --filter backend run type-check`: exit 0.
- `pnpm --filter backend run lint`: 0 errors.
- Full backend suite: **459 files, 11071 tests, all passing**.
- New test asserts `cancelOpenCheckoutSessionAttempts` is called with the invoice id when a credit note is issued.
- **Mutation-checked:** removing the call from `issueCreditNote` fails exactly that test. The mutation was confirmed applied before the run, and the file restored byte-identical afterwards.

Not verified against a live Stripe session. The local behaviour is covered; confirming that a real checkout URL stops resolving after a credit note needs a test-mode session on dev, which I have not driven.

## Related Issue(s)

Fixes #2598
