### PR TITLE
feat(frontend): show the clinic when a different breed code went to the lab

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import BreedSubstitutionNotice from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice';
+import type { LabBreedSubstitution } from '@/app/features/integrations/services/types';
+
+const substitution = (overrides: Partial<LabBreedSubstitution> = {}): LabBreedSubstitution => ({
+  requestedBreedCode: 'LABRADOR_RETRIEVER',
+  usedBreedCode: 'CANINE_OTHER',
+  usedTargetCode: 'CANINE',
+  reason: 'UNMAPPED_BREED',
+  ...overrides,
+});
+
+const notice = () => screen.getByRole('note', { name: 'Breed substitution' });
+
+describe('BreedSubstitutionNotice', () => {
+  it('renders nothing when the order carries no substitution', () => {
+    const { container } = render(<BreedSubstitutionNotice substitution={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the field is absent altogether', () => {
+    const { container } = render(<BreedSubstitutionNotice substitution={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names both the code that was sent and the breed on the record', () => {
+    render(<BreedSubstitutionNotice substitution={substitution()} />);
+
+    // The whole point: the order reads back showing the breed the clinician
+    // chose, while the requisition named something else.
+    expect(notice()).toHaveTextContent('CANINE_OTHER');
+    expect(notice()).toHaveTextContent('LABRADOR_RETRIEVER');
+  });
+
+  it.each([
+    ['UNMAPPED_BREED', 'the lab has no code for this breed'],
+    ['UNCODED_BREED', 'no breed code is recorded for this companion'],
+    ['MISMATCHED_BREED', "the companion's breed code does not match its species"],
+  ] as const)('explains %s', (reason, expected) => {
+    render(<BreedSubstitutionNotice substitution={substitution({ reason })} />);
+    expect(notice()).toHaveTextContent(expected);
+  });
+
+  it('distinguishes a mismatch from a mapping gap', () => {
+    // MISMATCHED_BREED is a defect on the patient record, not a gap in the
+    // provider's vocabulary, so it must not read like the other two.
+    const { unmount } = render(
+      <BreedSubstitutionNotice substitution={substitution({ reason: 'MISMATCHED_BREED' })} />
+    );
+    expect(notice()).toHaveTextContent('Breed code does not match the species');
+    expect(notice()).toHaveTextContent('Correct the breed on the companion record');
+    expect(notice().className).toContain('bg-danger-100');
+    unmount();
+
+    render(<BreedSubstitutionNotice substitution={substitution({ reason: 'UNMAPPED_BREED' })} />);
+    expect(notice()).toHaveTextContent('A different breed code was sent');
+    expect(notice()).not.toHaveTextContent('Correct the breed on the companion record');
+    expect(notice().className).not.toContain('bg-danger-100');
+  });
+
+  it('omits the recorded-breed clause when there is no recorded code', () => {
+    render(
+      <BreedSubstitutionNotice
+        substitution={substitution({ reason: 'UNCODED_BREED', requestedBreedCode: null })}
+      />
+    );
+
+    expect(notice()).toHaveTextContent('no breed code is recorded for this companion');
+    expect(notice()).not.toHaveTextContent('recorded breed:');
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import BreedSubstitutionNotice from './BreedSubstitutionNotice';
+import type { LabBreedSubstitution } from '@/app/features/integrations/services/types';
+
+const substitution = (overrides: Partial<LabBreedSubstitution> = {}): LabBreedSubstitution => ({
+  requestedBreedCode: 'LABRADOR_RETRIEVER',
+  usedBreedCode: 'CANINE_OTHER',
+  usedTargetCode: 'CANINE',
+  reason: 'UNMAPPED_BREED',
+  ...overrides,
+});
+
+const meta = {
+  title: 'Appointments/BreedSubstitutionNotice',
+  component: BreedSubstitutionNotice,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Says which breed code actually reached the lab when it is not the one on the ' +
+          "companion's record.\n\n" +
+          'The substitution has always been recorded on the order - `resolveIdexxBreedCode` ' +
+          'produces it and both the create and update paths persist it - but nothing displayed ' +
+          'it, so a clinician reading the order back saw the breed they had chosen with no ' +
+          'indication that a different code was transmitted. That is a clinical claim about the ' +
+          'animal, and the requisition is what the lab acts on.\n\n' +
+          '`MISMATCHED_BREED` is styled apart from the other two on purpose. `UNMAPPED_BREED` ' +
+          "and `UNCODED_BREED` are gaps in the provider's vocabulary and nothing is wrong with " +
+          "the record; a mismatch means the companion's stored breed code disagrees with its " +
+          'species, which is a defect on the patient record that someone should correct.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { substitution: substitution() },
+} satisfies Meta<typeof BreedSubstitutionNotice>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const notice = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('note', { name: 'Breed substitution' });
+
+export const UnmappedBreed: Story = {
+  name: 'The lab has no code for this breed',
+  play: async ({ canvasElement }) => {
+    await expect(notice(canvasElement)).toHaveTextContent('CANINE_OTHER');
+    await expect(notice(canvasElement)).toHaveTextContent('LABRADOR_RETRIEVER');
+  },
+};
+
+export const UncodedBreed: Story = {
+  name: 'The companion has no breed code at all',
+  args: {
+    substitution: substitution({ reason: 'UNCODED_BREED', requestedBreedCode: null }),
+  },
+  play: async ({ canvasElement }) => {
+    // Nothing was requested, so the "recorded breed" clause is omitted rather
+    // than printed empty.
+    await expect(notice(canvasElement)).not.toHaveTextContent('recorded breed:');
+  },
+};
+
+export const MismatchedBreed: Story = {
+  name: 'Mismatch - a defect on the patient record',
+  args: { substitution: substitution({ reason: 'MISMATCHED_BREED' }) },
+  play: async ({ canvasElement }) => {
+    await expect(notice(canvasElement)).toHaveTextContent('Breed code does not match the species');
+    await expect(notice(canvasElement)).toHaveTextContent(
+      'Correct the breed on the companion record'
+    );
+  },
+};
+
+export const NoSubstitution: Story = {
+  name: 'No substitution - nothing is shown',
+  args: { substitution: null },
+  play: async ({ canvasElement }) => {
+    // An order whose breed went through untouched must carry no notice at all.
+    await expect(
+      within(canvasElement).queryByRole('note', { name: 'Breed substitution' })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
@@ -20,8 +20,6 @@ const REASON_TEXT: Record<LabBreedSubstitution['reason'], string> = {
   MISMATCHED_BREED: "the companion's breed code does not match its species",
 };
 
-const isRecordDefect = (reason: LabBreedSubstitution['reason']) => reason === 'MISMATCHED_BREED';
-
 /**
  * Says which breed was requested and which code actually reached the lab.
  *
@@ -34,7 +32,7 @@ const BreedSubstitutionNotice = ({ substitution }: BreedSubstitutionNoticeProps)
   if (!substitution) return null;
 
   const { requestedBreedCode, usedBreedCode, reason } = substitution;
-  const defect = isRecordDefect(reason);
+  const defect = reason === 'MISMATCHED_BREED';
 
   return (
     <div

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
@@ -1,0 +1,65 @@
+'use client';
+import React from 'react';
+import type { LabBreedSubstitution } from '@/app/features/integrations/services/types';
+
+type BreedSubstitutionNoticeProps = {
+  substitution: LabBreedSubstitution | null | undefined;
+};
+
+/**
+ * What each reason means for the clinician reading the order back.
+ *
+ * `MISMATCHED_BREED` is deliberately separated: the other two are mapping gaps
+ * in the provider's vocabulary and nothing is wrong with the record, whereas a
+ * mismatch means the companion's stored breed code disagrees with its species -
+ * a defect on the patient record that someone should correct.
+ */
+const REASON_TEXT: Record<LabBreedSubstitution['reason'], string> = {
+  UNMAPPED_BREED: 'the lab has no code for this breed',
+  UNCODED_BREED: 'no breed code is recorded for this companion',
+  MISMATCHED_BREED: "the companion's breed code does not match its species",
+};
+
+const isRecordDefect = (reason: LabBreedSubstitution['reason']) => reason === 'MISMATCHED_BREED';
+
+/**
+ * Says which breed was requested and which code actually reached the lab.
+ *
+ * Without this the substitution is invisible: the order reads back showing the
+ * breed the clinician chose, while the requisition that reached the provider
+ * named something else. It is recorded on the order either way - the gap was
+ * only ever that nothing displayed it.
+ */
+const BreedSubstitutionNotice = ({ substitution }: BreedSubstitutionNoticeProps) => {
+  if (!substitution) return null;
+
+  const { requestedBreedCode, usedBreedCode, reason } = substitution;
+  const defect = isRecordDefect(reason);
+
+  return (
+    <div
+      role="note"
+      aria-label="Breed substitution"
+      className={`rounded-xl p-2.5 flex flex-col gap-1 ${
+        defect ? 'bg-danger-100' : 'bg-card-hover'
+      }`}
+    >
+      <span
+        className={`text-caption-1 font-bold ${defect ? 'text-text-error' : 'text-text-primary'}`}
+      >
+        {defect ? 'Breed code does not match the species' : 'A different breed code was sent'}
+      </span>
+      <span className="text-caption-1 text-text-secondary">
+        {`Sent as ${usedBreedCode} because ${REASON_TEXT[reason]}`}
+        {requestedBreedCode ? ` (recorded breed: ${requestedBreedCode})` : ''}.
+      </span>
+      {defect ? (
+        <span className="text-caption-1 text-text-secondary">
+          Correct the breed on the companion record so future orders carry it.
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+export default BreedSubstitutionNotice;

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -60,6 +60,7 @@ import {
   resolveLatestOrder,
   shouldCloseOrderIframe,
 } from './LabTests.helpers';
+import BreedSubstitutionNotice from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice';
 
 const TESTS_PAGE_SIZE = 25;
 const IDEXX_REGIONAL_AVAILABILITY_DISCLAIMER =
@@ -162,6 +163,7 @@ const PastOrderCard = ({
         label={getOrderDisplayStatus(order)}
       />
     </div>
+    <BreedSubstitutionNotice substitution={order.breedSubstitution} />
     <div className="flex flex-wrap items-center gap-2 justify-end">
       {getOrderDisplayStatus(order) === 'Complete' ? (
         <Primary href="#" text="Result PDF" onClick={() => openResultPdfForOrder(order)} />

--- a/apps/frontend/src/app/features/integrations/services/types.ts
+++ b/apps/frontend/src/app/features/integrations/services/types.ts
@@ -64,6 +64,23 @@ export type CreateLabOrderPayload = {
   ivls?: string[];
 };
 
+/**
+ * Recorded when the breed sent to the provider is not the companion's recorded
+ * breed, because the provider's vocabulary has no counterpart for it.
+ *
+ * This is a clinical claim about the animal: the requisition that reached the
+ * lab says the patient is, for example, a canine catch-all rather than the
+ * specific breed on the record. Produced by `resolveIdexxBreedCode` and stored
+ * on the order; the shape mirrors `LabBreedSubstitution` in
+ * `apps/backend/src/labs/types.ts`.
+ */
+export type LabBreedSubstitution = {
+  requestedBreedCode: string | null;
+  usedBreedCode: string;
+  usedTargetCode: string;
+  reason: 'UNCODED_BREED' | 'UNMAPPED_BREED' | 'MISMATCHED_BREED';
+};
+
 export type LabOrder = {
   _id: string;
   organisationId: string;
@@ -83,6 +100,8 @@ export type LabOrder = {
   notes?: string | null;
   specimenCollectionDate?: string | null;
   externalStatus?: string | null;
+  /** Set only when the transmitted breed differs from the companion's. */
+  breedSubstitution?: LabBreedSubstitution | null;
   createdAt?: string;
   updatedAt?: string;
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

When an IDEXX order is placed under a breed fallback, the substitution is recorded and shown nowhere.

The data has been reaching the browser the whole time:

- `resolveIdexxBreedCode` produces the substitution (`apps/backend/src/labs/idexx/idexx.shared.ts`).
- Both the create and update paths persist it to `LabOrder.breedSubstitution` (`lab-order.service.ts:330` and `:513`).
- `listOrders` does a `findMany` with no `select`, so the field is returned on every order.

The client simply drops it. `LabOrder` in `features/integrations/services/types.ts` did not declare the field, and a repository-wide search for `breedSubstitution` across `apps/frontend/src` and `apps/mobileAppYC/src` returned nothing.

Why it matters: the substitution is a clinical claim about the animal. The requisition that reached IDEXX says the patient is, for example, a canine catch-all rather than the specific breed on the record. A clinician reading the order back sees the breed they chose, with nothing indicating a different code was transmitted.

## What is the new behavior?

`LabBreedSubstitution` is declared on the client type, and a `BreedSubstitutionNotice` renders on each placed order in the lab-tests panel. It names the code that was sent, the breed on the record, and the reason.

**`MISMATCHED_BREED` is deliberately not treated like the other two.** `UNMAPPED_BREED` and `UNCODED_BREED` are gaps in the provider's vocabulary and nothing is wrong with the record. A mismatch means the companion's stored breed code disagrees with its species - a defect on the patient record - so that case is styled apart and says to correct the record.

An order with no substitution renders nothing at all.

### Out of scope

The fallback logic itself, which works and is tested, and anything about what is transmitted to IDEXX.

## Validation performed

Measured, not estimated:

- `npx tsc --noEmit` from `apps/frontend`: exit 0.
- `pnpm --filter frontend run lint`: 0 errors.
- `pnpm --filter frontend run test -- --testPathPatterns="BreedSubstitution|LabTests"`: 3 suites, 62 tests, all passing.
- `BreedSubstitutionNotice.tsx`: **100% statements, branches, functions and lines** across 8 tests - every `reason` value, both absent shapes (`null` and `undefined`), and the no-recorded-code case.
- sonarjs + jsx-a11y sweep over the changed source: clean.
- Four stories cover each reason plus the absent case.

Not verified: an order with a real substitution on deployed dev. There are none to look at - a substitution only occurs for a breed IDEXX has no code for, and I have not forced that condition against the live integration.

## Related Issue(s)

Fixes #2528
