### PR TITLE
fix(frontend): bring estimates and credit notes up to the app's design

### DIFF
--- a/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/EstimateSections.test.tsx
@@ -132,7 +132,10 @@ describe('EstimateList', () => {
   ];
 
   const names: Record<string, string> = { 'pet-1': 'Rex', 'pet-2': 'Milo' };
-  const companionName = (patientId: string) => names[patientId] ?? 'Unknown companion';
+  const companion = (patientId: string) => ({
+    name: names[patientId] ?? 'Unknown companion',
+    speciesCode: 'dog',
+  });
 
   const renderList = (overrides: Partial<React.ComponentProps<typeof EstimateList>> = {}) => {
     const onSelect = jest.fn();
@@ -141,7 +144,7 @@ describe('EstimateList', () => {
         estimates={estimates}
         activeEstimateId={null}
         onSelect={onSelect}
-        companionName={companionName}
+        companion={companion}
         {...overrides}
       />
     );

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/InvoiceCreditNotes.test.tsx
@@ -10,13 +10,19 @@ jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
   PermissionGate: ({ children }: any) => <div>{children}</div>,
 }));
 
-jest.mock('@/app/ui/primitives/Buttons', () => ({
-  Secondary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+jest.mock('@/app/ui/primitives/Buttons', () => {
+  // Defined inside the factory: `jest.mock` is hoisted above any module-scope
+  // const, so a shared stub declared outside is still in its temporal dead zone
+  // when the factory runs.
+  const stubButton = ({ text, ariaLabel, onClick, isDisabled }: any) => (
     <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
       {text}
     </button>
-  ),
-}));
+  );
+  // Issuing is the section's primary action, so it renders through Primary.
+  // A mock that stubs only Secondary makes the whole form render as undefined.
+  return { Secondary: stubButton, Primary: stubButton };
+});
 
 import InvoiceCreditNotes from '@/app/features/finance/pages/Finance/Sections/InvoiceCreditNotes';
 
@@ -102,10 +108,12 @@ describe('InvoiceCreditNotes', () => {
       ],
     });
 
-    expect(screen.getByText('CN-0002 (voided)')).toBeInTheDocument();
+    // The voided marker rides the row's title line; the reference captions it.
+    expect(screen.getByText('Credit note (voided)')).toBeInTheDocument();
+    expect(screen.getByText('CN-0002')).toBeInTheDocument();
     expect(screen.getByText('CN-0001')).toBeInTheDocument();
 
-    const voidedRow = screen.getByText('CN-0002 (voided)').closest('li') as HTMLElement;
+    const voidedRow = screen.getByText('CN-0002').closest('li') as HTMLElement;
     expect(within(voidedRow).queryByRole('button')).not.toBeInTheDocument();
 
     const issuedRow = screen.getByText('CN-0001').closest('li') as HTMLElement;
@@ -114,7 +122,7 @@ describe('InvoiceCreditNotes', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the reason when present and nothing when absent', () => {
+  it('leads each row with the reason and always captions it with the reference', () => {
     renderSection({
       creditNotes: [
         makeNote({ id: 'cn-1', creditNoteNumber: 'CN-0001', reason: 'Duplicate charge' }),
@@ -122,13 +130,15 @@ describe('InvoiceCreditNotes', () => {
       ],
     });
 
+    // What a person reconciling reads is the reason; the CN- reference is the
+    // audit artifact and stays visible underneath it on every row.
     expect(screen.getByText('Duplicate charge')).toBeInTheDocument();
+    expect(screen.getByText('CN-0001')).toBeInTheDocument();
 
-    // The label column holds only the number span when there is no reason.
-    const withReason = screen.getByText('CN-0001').parentElement as HTMLElement;
-    expect(withReason.children).toHaveLength(2);
-    const withoutReason = screen.getByText('CN-0002').parentElement as HTMLElement;
-    expect(withoutReason.children).toHaveLength(1);
+    // A note with no reason still gets a title, so rows keep one height rather
+    // than the reference jumping up into the headline slot.
+    expect(screen.getByText('Credit note')).toBeInTheDocument();
+    expect(screen.getByText('CN-0002')).toBeInTheDocument();
   });
 
   it('sums only issued notes into the credited total', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -170,12 +170,47 @@ describe('Finance > Estimates page', () => {
 
     render(<ProtectedEstimates />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: 'Estimates' })).toBeInTheDocument();
+    // The title carries a live count, as Finance's does, so the accessible name
+    // is "Estimates (0)" rather than the bare word.
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /^Estimates \(\d+\)$/ })
+    ).toBeInTheDocument();
     expect(await screen.findByText('No estimates yet')).toBeInTheDocument();
     expect(
       screen.getByText('Create an estimate to quote a treatment plan before it is invoiced.')
     ).toBeInTheDocument();
     expect(mockEstimateService.listEstimates).toHaveBeenCalledWith('org-1', undefined);
+  });
+
+  it('summarises what is awaiting a decision and what is approved', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([
+      buildEstimate({ id: 'e1', status: 'DRAFT', total: 100 }),
+      buildEstimate({ id: 'e2', status: 'SENT', total: 50 }),
+      buildEstimate({ id: 'e3', status: 'APPROVED', total: 200 }),
+      // Excluded from both figures on purpose: a converted estimate's money is
+      // counted on the invoice it became, and a declined one is not owed at all.
+      buildEstimate({ id: 'e4', status: 'CONVERTED', total: 999 }),
+      buildEstimate({ id: 'e5', status: 'DECLINED', total: 777 }),
+    ]);
+
+    render(<ProtectedEstimates />);
+
+    expect(
+      await screen.findByText('$150.00 awaiting decision · $200.00 approved')
+    ).toBeInTheDocument();
+  });
+
+  it('counts the estimates on screen in the title, as Finance does', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([
+      buildEstimate({ id: 'e1' }),
+      buildEstimate({ id: 'e2' }),
+    ]);
+
+    render(<ProtectedEstimates />);
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Estimates (2)' })
+    ).toBeInTheDocument();
   });
 
   it('words the empty state differently under a status filter', async () => {

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/BreedSubstitutionNotice.tsx
@@ -38,8 +38,8 @@ const BreedSubstitutionNotice = ({ substitution }: BreedSubstitutionNoticeProps)
     <div
       role="note"
       aria-label="Breed substitution"
-      className={`rounded-xl p-2.5 flex flex-col gap-1 ${
-        defect ? 'bg-danger-100' : 'bg-card-hover'
+      className={`flex flex-col gap-1 rounded-2xl border px-4 py-3 ${
+        defect ? 'border-danger-200 bg-danger-100' : 'border-warning-200 bg-warning-100'
       }`}
     >
       <span

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.stories.tsx
@@ -49,7 +49,7 @@ const meta = {
         component:
           'The estimates list.\n\n' +
           'The API returns a bare `patientId`, so the companion name is resolved by the caller ' +
-          'through the `companionName` prop rather than joined server-side. An id with no loaded ' +
+          'through the `companion` prop rather than joined server-side. An id with no loaded ' +
           'companion falls back to a readable label instead of printing a uuid at the user.\n\n' +
           '`validUntil` is optional on the model and renders as a dash when absent, which is the ' +
           'common case: nothing in the service ever sets EXPIRED, so an expiry date here is a note ' +
@@ -66,7 +66,10 @@ const meta = {
     ],
     activeEstimateId: 'e1',
     onSelect: () => {},
-    companionName: (patientId: string) => NAMES[patientId] ?? 'Unknown companion',
+    companion: (patientId: string) => ({
+      name: NAMES[patientId] ?? 'Unknown companion',
+      speciesCode: 'dog',
+    }),
   },
 } satisfies Meta<typeof EstimateList>;
 

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateList.tsx
@@ -1,18 +1,29 @@
 'use client';
 import React, { useMemo } from 'react';
+import Image from 'next/image';
+import { IoEyeOutline } from 'react-icons/io5';
 import { formatMoneyPrecise } from '@/app/lib/money';
 import { formatDisplayDate } from '@/app/lib/date';
+import { getSafeImageUrl, type ImageType } from '@/app/lib/urls';
+import { getAvatarPalette } from '@/app/features/companions/pages/Companions/companionsDirectory';
 import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
 import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
 import type { Estimate } from '@/app/features/finance/types/estimate';
+
+/** What a row needs to draw a companion, resolved by the page from its store. */
+export type EstimateCompanion = {
+  name: string;
+  photoUrl?: string;
+  speciesCode?: string;
+};
 
 type EstimateListProps = {
   estimates: Estimate[];
   /** The open estimate, highlighted in the list. */
   activeEstimateId: string | null;
   onSelect: (estimate: Estimate) => void;
-  /** Display name for a companion id, so the list is readable without a join. */
-  companionName: (patientId: string) => string;
+  /** Display details for a companion id, so the list is readable without a join. */
+  companion: (patientId: string) => EstimateCompanion;
 };
 
 /**
@@ -24,31 +35,50 @@ type EstimateListProps = {
 const formatDate = (value: string | null): string => formatDisplayDate(value ?? undefined, '-');
 
 /**
+ * The same identity cell the invoice table draws: a species-tinted disc behind
+ * the companion's photo, the name, and a quiet second line. Estimates sat
+ * beside Finance showing a bare text link, which made the two tables read as
+ * different products.
+ */
+const CompanionCell = ({ companion }: { companion: EstimateCompanion }) => {
+  const palette = getAvatarPalette(companion.name);
+  const avatarSrc = getSafeImageUrl(
+    companion.photoUrl,
+    (companion.speciesCode as ImageType) ?? 'other'
+  );
+  return (
+    <div className="flex items-center gap-2.5">
+      <div
+        className="flex size-[30px] shrink-0 overflow-hidden rounded-full"
+        style={{ background: palette.bg }}
+      >
+        <Image
+          src={avatarSrc}
+          alt=""
+          width={30}
+          height={30}
+          className="size-[30px] rounded-full object-cover"
+        />
+      </div>
+      <span className="min-w-0 truncate text-body-3 text-text-primary" title={companion.name}>
+        {companion.name}
+      </span>
+    </div>
+  );
+};
+
+/**
  * The estimates list, rendered through the shared `GenericTable` so it inherits
  * the app's column-header typography, contrast, sticky behaviour and pager
  * rather than maintaining a second finance table of its own.
  */
-const EstimateList = ({
-  estimates,
-  activeEstimateId,
-  onSelect,
-  companionName,
-}: EstimateListProps) => {
+const EstimateList = ({ estimates, activeEstimateId, onSelect, companion }: EstimateListProps) => {
   const columns = useMemo<Column<Estimate>[]>(
     () => [
       {
         key: 'patientId',
         label: 'Companion',
-        render: (estimate) => (
-          <button
-            type="button"
-            onClick={() => onSelect(estimate)}
-            className="text-body-3 text-text-primary text-left underline-offset-2 hover:underline"
-            aria-label={`Open the estimate for ${companionName(estimate.patientId)}`}
-          >
-            {companionName(estimate.patientId)}
-          </button>
-        ),
+        render: (estimate) => <CompanionCell companion={companion(estimate.patientId)} />,
       },
       {
         key: 'status',
@@ -58,24 +88,44 @@ const EstimateList = ({
       {
         key: 'createdAt',
         label: 'Created',
-        render: (estimate) => formatDate(estimate.createdAt),
+        render: (estimate) => (
+          <span className="text-text-secondary">{formatDate(estimate.createdAt)}</span>
+        ),
       },
       {
         key: 'validUntil',
         label: 'Valid until',
-        render: (estimate) => formatDate(estimate.validUntil),
+        render: (estimate) => (
+          <span className="text-text-secondary">{formatDate(estimate.validUntil)}</span>
+        ),
       },
       {
+        // Money reads down the column, so it is right-aligned and weighted the
+        // way the invoice table's TOTAL is.
         key: 'total',
         label: 'Total',
         render: (estimate) => (
-          <span className="tabular-nums">
+          <span className="block text-right font-bold tabular-nums text-text-primary">
             {formatMoneyPrecise(estimate.total, estimate.currency)}
           </span>
         ),
       },
+      {
+        key: 'actions',
+        label: 'Actions',
+        render: (estimate) => (
+          <button
+            type="button"
+            onClick={() => onSelect(estimate)}
+            className="grid-row-action flex size-[30px] items-center justify-center rounded-full! border cursor-pointer transition-colors hover:bg-card-hover"
+            aria-label={`Open the estimate for ${companion(estimate.patientId).name}`}
+          >
+            <IoEyeOutline size={14} aria-hidden="true" />
+          </button>
+        ),
+      },
     ],
-    [onSelect, companionName]
+    [onSelect, companion]
   );
 
   return (

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -14,6 +14,9 @@ import { useCompanionStore } from '@/app/stores/companionStore';
 import { loadCompanionsForPrimaryOrg } from '@/app/features/companions/services/companionService';
 import { loadInvoicesForOrgPrimaryOrg } from '@/app/features/billing/services/invoiceService';
 import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
+import { formatMoneyPrecise, sharedCurrency } from '@/app/lib/money';
+import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import { IoInformationCircleOutline } from 'react-icons/io5';
 import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
 import { useEstimates } from '@/app/features/finance/hooks/useEstimates';
 import {
@@ -30,7 +33,9 @@ import {
   type Estimate,
   type EstimateStatus,
 } from '@/app/features/finance/types/estimate';
-import EstimateList from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
+import EstimateList, {
+  type EstimateCompanion,
+} from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
 import EstimateDetail, {
   type EstimateAction,
 } from '@/app/features/finance/pages/Estimates/Sections/EstimateDetail';
@@ -60,6 +65,26 @@ const emptyListMessage = (
   if (activeStatus !== 'all') return 'No estimate currently has this status.';
   return 'Create an estimate to quote a treatment plan before it is invoiced.';
 };
+
+/**
+ * The two figures a practice actually asks of an estimates list: what is still
+ * waiting on the client, and what they have already agreed to. DECLINED,
+ * EXPIRED and CONVERTED are excluded from both - a converted estimate's money
+ * is counted on the invoice it became, so adding it here would double it.
+ */
+const summariseEstimates = (estimates: Estimate[]) =>
+  estimates.reduce(
+    (totals, estimate) => {
+      if (estimate.status === 'DRAFT' || estimate.status === 'SENT') {
+        return { ...totals, awaiting: totals.awaiting + estimate.total };
+      }
+      if (estimate.status === 'APPROVED') {
+        return { ...totals, approved: totals.approved + estimate.total };
+      }
+      return totals;
+    },
+    { awaiting: 0, approved: 0 }
+  );
 
 const runAction = (
   action: EstimateAction,
@@ -134,6 +159,20 @@ const EstimatesContent = () => {
     [companionsById]
   );
 
+  // The row needs the photo and species too, so the avatar disc is tinted and
+  // the fallback image matches the animal rather than defaulting to 'other'.
+  const companionFor = useCallback(
+    (patientId: string): EstimateCompanion => {
+      const stored = companionsById[patientId];
+      return {
+        name: stored?.name || 'Unknown companion',
+        photoUrl: stored?.photoUrl,
+        speciesCode: stored?.speciesCode,
+      };
+    },
+    [companionsById]
+  );
+
   // The shared finance header stays visible on this route and already writes to
   // the search store, so the control looked functional while doing nothing.
   // Matching on the companion name is what a user typing there would expect.
@@ -144,6 +183,9 @@ const EstimatesContent = () => {
       companionName(estimate.patientId).toLowerCase().includes(needle)
     );
   }, [estimates, query, companionName]);
+
+  const metricsCurrency = useMemo(() => sharedCurrency(estimates, currency), [estimates, currency]);
+  const metrics = useMemo(() => summariseEstimates(estimates), [estimates]);
 
   const activeEstimate = useMemo(
     () => visibleEstimates.find((estimate) => estimate.id === activeEstimateId) ?? null,
@@ -210,10 +252,56 @@ const EstimatesContent = () => {
 
   return (
     <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
+      {/*
+        Deliberately the same header as Finance: title with a live count, an
+        info affordance, a metrics sub-line, then the status filter and the
+        page actions on the right of that same row. Estimates is reached from
+        Finance and reads as the same surface, so a second layout here made the
+        two pages look unrelated.
+      */}
       <div className="flex items-center justify-between w-full flex-wrap gap-2">
-        <h1 className="text-text-primary text-heading-2">Estimates</h1>
-        <div className="flex items-center gap-2">
-          <Secondary href="/finance" text="Back to invoices" ariaLabel="Back to invoices" />
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <h1 className="text-page-title">
+              {'Estimates'}{' '}
+              <span className="text-page-title-count">{`(${visibleEstimates.length})`}</span>
+            </h1>
+            <GlassTooltip
+              content="Quote a treatment plan before it is billed. Send an estimate for approval, then convert an approved one into an invoice."
+              side="bottom"
+            >
+              <button
+                type="button"
+                aria-label="Estimates info"
+                className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <IoInformationCircleOutline size={17} />
+              </button>
+            </GlassTooltip>
+          </div>
+          <p className="text-[13.5px] text-text-secondary">
+            {`${formatMoneyPrecise(metrics.awaiting, metricsCurrency)} awaiting decision · ${formatMoneyPrecise(
+              metrics.approved,
+              metricsCurrency
+            )} approved`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap justify-end">
+          {/*
+            Seven non-shrinking pills exceed a phone's width, so the group wraps
+            here rather than pushing the page into a sideways scroll.
+          */}
+          <InvoiceStatusFilterPills
+            options={EstimateStatusFilters}
+            activeStatus={activeStatus}
+            setActiveStatus={(value) => {
+              setActiveStatus(value);
+              setActiveEstimateId(null);
+            }}
+            ariaLabel="Filter estimates by status"
+            className="flex-wrap justify-end"
+          />
+          <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
           <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
             <Primary
               text="New estimate"
@@ -226,25 +314,6 @@ const EstimatesContent = () => {
             />
           </PermissionGate>
         </div>
-      </div>
-
-      {/*
-        Seven non-shrinking pills exceed a phone's width. PhoneInvoiceList wraps
-        its own filter row in a horizontal scroller for the same reason; without
-        one the page itself scrolls sideways and the later statuses are hard to
-        reach.
-      */}
-      <div className="overflow-x-auto scrollbar-hidden -mx-1 px-1">
-        <InvoiceStatusFilterPills
-          options={EstimateStatusFilters}
-          activeStatus={activeStatus}
-          setActiveStatus={(value) => {
-            setActiveStatus(value);
-            setActiveEstimateId(null);
-          }}
-          ariaLabel="Filter estimates by status"
-          className="w-max"
-        />
       </div>
 
       {companionsError && (
@@ -294,7 +363,7 @@ const EstimatesContent = () => {
               setActiveEstimateId(estimate.id);
               setActionError(null);
             }}
-            companionName={companionName}
+            companion={companionFor}
           />
           {activeEstimate && (
             <EstimateDetail

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteIssueForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState } from 'react';
-import { Secondary } from '@/app/ui/primitives/Buttons';
+import { Primary } from '@/app/ui/primitives/Buttons';
+import { currencySymbol } from '@/app/lib/money';
 import { formatCap } from '@/app/features/finance/services/creditNoteService';
 
 type CreditNoteDraft = { amount: number; reason?: string };
@@ -75,11 +76,22 @@ const CreditNoteIssueForm = ({
   return (
     <div className="flex flex-col gap-2 border-t border-t-card-border pt-3!">
       <div className="flex flex-wrap items-end gap-2">
-        <div className="flex flex-col gap-1 w-32">
+        <div className="flex flex-col gap-1 w-36">
           <label htmlFor="credit-note-amount" className="text-[12px] text-[var(--ink-muted)]">
             Amount
           </label>
           <span className={fieldClass}>
+            {/*
+              The symbol sits inside the field, the way the discount cap puts its
+              '%' there. Without it the amount is the one number on this panel
+              with no unit, beside a column of formatted money.
+            */}
+            <span
+              aria-hidden="true"
+              className="flex items-center pl-3 text-[13px] text-[var(--ink-muted)]"
+            >
+              {currencySymbol(currency)}
+            </span>
             <input
               id="credit-note-amount"
               type="number"
@@ -88,7 +100,7 @@ const CreditNoteIssueForm = ({
               max={remaining}
               value={amountInput}
               onChange={(e) => setAmountInput(e.target.value)}
-              className={inputClass}
+              className={`${inputClass} pl-1.5`}
             />
           </span>
         </div>
@@ -106,7 +118,12 @@ const CreditNoteIssueForm = ({
             />
           </span>
         </div>
-        <Secondary
+        {/*
+          The section's own primary action, so it carries the app's primary
+          weight - it was a Secondary sitting beside no primary at all, which
+          read as the least important control in the panel.
+        */}
+        <Primary
           text={busy ? 'Working...' : 'Issue credit note'}
           isDisabled={busy}
           onClick={handleIssue}

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/CreditNoteLedger.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useState } from 'react';
+import { IoReturnDownBackOutline } from 'react-icons/io5';
 import type { CreditNote } from '@yosemite-crew/types';
 import { formatMoneyPrecise } from '@/app/lib/money';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
@@ -39,19 +40,37 @@ const CreditNoteLedger = ({ notes, currency, busy, onVoid }: CreditNoteLedgerPro
   return (
     <ul className="flex flex-col gap-2">
       {notes.map((note) => (
-        <li key={note.id} className="flex items-center justify-between gap-3">
-          <span className="flex flex-col">
-            <span className="text-[13px] text-[var(--ink-body)]">
-              {note.creditNoteNumber}
+        <li key={note.id} className="flex items-center gap-3">
+          {/*
+            The same row anatomy as the Payments ledger directly above: a
+            tinted glyph, a bold line, a quiet caption, then the amount. The
+            warning tint rather than the payments blue, because this is money
+            going back off the invoice.
+          */}
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-[10px] bg-warning-100 text-text-primary">
+            <IoReturnDownBackOutline size={15} aria-hidden="true" />
+          </span>
+          <span className="min-w-0 flex-1">
+            {/*
+              The reason leads and the reference captions it. A clinician
+              reconciling reads "Goodwill on the delayed dental"; the
+              CN-... string is the audit artifact, and it dominated the row
+              at full body weight while the reason sat under it in grey.
+            */}
+            <span className="block text-[13px] font-bold text-[var(--ink)]">
+              {note.reason || 'Credit note'}
               {note.status === 'VOIDED' ? ' (voided)' : ''}
             </span>
-            {note.reason ? (
-              <span className="text-[12px] text-[var(--ink-muted)]">{note.reason}</span>
-            ) : null}
+            <span
+              className="block truncate text-[11.5px] text-text-tertiary"
+              title={note.creditNoteNumber}
+            >
+              {note.creditNoteNumber}
+            </span>
           </span>
           <span className="flex items-center gap-3">
             <span
-              className="tabular-nums text-[13px] font-semibold text-[var(--ink-body)]"
+              className="tabular-nums text-[13px] font-bold text-[var(--ink)]"
               style={note.status === 'VOIDED' ? { textDecoration: 'line-through' } : undefined}
             >
               {formatMoneyPrecise(note.amount, currency)}


### PR DESCRIPTION
## What changed

Two surfaces shipped recently did not look like the rest of the product. Both are now built from the patterns their immediate neighbours already use, rather than from a second set of choices.

### Estimates

It is reached from Finance and reads as the same surface, but had a small plain heading, no count, no metrics, and its status pills on a row of their own below the title.

It now uses the **Finance header exactly**: `text-page-title` with a live count, the info affordance, a sub-line, then the filter and page actions on the right of that same row.

The sub-line says what is awaiting a decision and what is approved. `CONVERTED` and `DECLINED` are excluded from both - a converted estimate's money is counted on the invoice it became, so adding it here would double it.

The table drew a bare text link where the invoice table beside it draws a species-tinted avatar, a name, right-aligned bold money and a circular row action. It now draws **the same row**, so the two finance tables read as one product.

### Credit notes

The ledger sits directly below Payments inside the invoice panel, but was styled unlike it: no glyph, no bold title, and the `CN-` reference at full body weight with the reason beneath it in grey.

- The row now has **the Payments ledger's anatomy** - tinted glyph, bold line, quiet caption, amount.
- **The reason leads and the reference captions it.** Someone reconciling reads "Goodwill on the delayed dental"; the `CN-...` string is the audit artifact. A note without a reason still gets a title, so rows keep one height instead of the reference jumping into the headline slot.
- **Issuing is now the primary action.** It was a `Secondary` sitting beside no primary at all, which read as the least important control in the panel.
- **The amount field carries the currency symbol inside it**, the way the discount cap carries its `%`. It was the one number on the panel with no unit, beside a column of formatted money.

## Impact area

`apps/frontend` only - finance estimates page and list, credit-note ledger and issue form. No API, type or behaviour change beyond the header metrics.

## Validation

- `npx tsc --noEmit` clean; `pnpm run lint` **0 errors**
- **31 suites / 466 tests pass** across the estimates, credit-note and finance areas
- Coverage: `EstimateList.tsx`, `CreditNoteLedger.tsx`, `CreditNoteIssueForm.tsx` all **100/100/100/100**; Estimates page 99.26% statements
- Both new guards **mutation-checked**: letting `CONVERTED` count toward approved fails the metrics test and only that test; counting all estimates rather than the visible ones fails the title test and only that test
- Local Sonar proxy (279 sonarjs rules + `jsx-a11y/prefer-tag-over-role`, self-tested against a deliberately failing probe): **no findings on any changed line** (the single report is a pre-existing `role="dialog"` in a test mock at line 45; the only changed line in that file is 173)
- Visually verified in Storybook against the live dev screenshots that prompted this

## Notes

`tsconfig.json` excludes `**/*.stories.tsx`, so `tsc` does **not** type-check stories - the `companionName` -> `companion` prop rename broke `EstimateList.stories.tsx` silently and was caught only by opening it. Fixed here.