### PR TITLE
fix(frontend): repair all eleven failing stories

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.stories.tsx
@@ -144,8 +144,16 @@ const openTaskPopover = async (chip: HTMLElement): Promise<HTMLElement> => {
   const box = chip.getBoundingClientRect();
   /* `fireEvent` rather than `userEvent.hover`: the popover is positioned from the
      pointer coordinates carried on the event, and this way they are stated rather
-     than inferred from where a synthetic pointer happened to land. */
-  fireEvent.mouseEnter(chip, {
+     than inferred from where a synthetic pointer happened to land.
+
+     It must be `mouseOver`, not `mouseEnter`. TaskMarker uses React's
+     `onMouseEnter`, which React synthesizes from the native `mouseout`/`mouseover`
+     pair it delegates at the root - native `mouseenter` is not one of its
+     dependencies and does not bubble. In jsdom the equivalent Jest test passes, so
+     this only ever failed in a real browser, which is where stories run. The
+     coordinates carry through unchanged: React builds the synthetic enter event
+     from this `mouseover`. */
+  fireEvent.mouseOver(chip, {
     clientX: box.left + box.width / 2,
     clientY: box.top + box.height / 2,
   });

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.stories.tsx
@@ -206,7 +206,14 @@ const settleAutoScroll = async (canvasElement: HTMLElement) => {
 
 const openTaskPopover = async (chip: HTMLElement): Promise<HTMLElement> => {
   const box = chip.getBoundingClientRect();
-  fireEvent.mouseEnter(chip, {
+  /* `mouseOver`, not `mouseEnter`. TaskMarker uses React's `onMouseEnter`, which
+     React synthesizes from the native `mouseout`/`mouseover` pair it delegates at
+     the root - native `mouseenter` is not one of its dependencies and does not
+     bubble, so it opened nothing. In jsdom the equivalent Jest test passes, so this
+     only ever failed in a real browser, which is where stories run. The popover is
+     positioned from the coordinates on the event and they carry through unchanged:
+     React builds the synthetic enter event from this `mouseover`. */
+  fireEvent.mouseOver(chip, {
     clientX: box.left + box.width / 2,
     clientY: box.top + box.height / 2,
   });

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.stories.tsx
@@ -149,7 +149,14 @@ const verticalScroller = (canvasElement: HTMLElement): HTMLElement =>
 
 const openTaskPopover = async (chip: HTMLElement): Promise<HTMLElement> => {
   const box = chip.getBoundingClientRect();
-  fireEvent.mouseEnter(chip, {
+  /* `mouseOver`, not `mouseEnter`. TaskMarker uses React's `onMouseEnter`, which
+     React synthesizes from the native `mouseout`/`mouseover` pair it delegates at
+     the root - native `mouseenter` is not one of its dependencies and does not
+     bubble, so it opened nothing. In jsdom the equivalent Jest test passes, so this
+     only ever failed in a real browser, which is where stories run. The popover is
+     positioned from the coordinates on the event and they carry through unchanged:
+     React builds the synthetic enter event from this `mouseover`. */
+  fireEvent.mouseOver(chip, {
     clientX: box.left + box.width / 2,
     clientY: box.top + box.height / 2,
   });

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.stories.tsx
@@ -967,11 +967,19 @@ export const ServiceError: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // The message carries the status and the backend's own text rather than a
-    // generic apology.
-    await expect(
-      await canvas.findByText('Unable to load appointment lab orders. (404): Not Found')
-    ).toBeInTheDocument();
+    /* The message carries the status and the backend's own text rather than a
+       generic apology.
+
+       Two copies, and that is deliberate: the section renders the error at the
+       top and again beside the Create Lab Order button, because the order is
+       placed several screens below the heading and the top copy alone would be
+       off-screen at the moment it appears. `findByText` throws on multiple
+       matches, which is what failed here - the assertion, not the component. The
+       count is asserted so that losing either copy is still caught. */
+    const messages = await canvas.findAllByText(
+      'Unable to load appointment lab orders. (404): Not Found'
+    );
+    await expect(messages).toHaveLength(2);
 
     /* A failed listing must not take the ordering form down with it: a clinician
        can still place the order they came here to place. The tables fall back to

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.stories.tsx
@@ -1164,7 +1164,15 @@ export const SaveRejectedAsFinalized: Story = {
     withStoredEncounter(encounter({ prescription: [AMOXICILLIN] })),
     withApi([
       {
-        match: (method, url) => method === 'POST' && url.includes('/prescription'),
+        /* The prescription ARTIFACT write, which is the save this story is about:
+           a PATCH to /fhir/v1/clinical-artifact/.../prescription/... . Matching
+           `POST` + `/prescription` missed it entirely - the save fell through to
+           the default 200 and succeeded, so no alert was ever rendered. Worse,
+           `/prescription` also substring-matches the POST to
+           /v1/prescriptions/.../$finalize, so the 409 was landing on the finalize
+           call instead. Both halves are pinned here. */
+        match: (method, url) =>
+          method === 'PATCH' && url.includes('/clinical-artifact') && url.includes('/prescription'),
         // Held open briefly so the in-flight label is actually observable.
         reply: { status: 409, body: { message: 'Artifact is final.' }, delayMs: 250 },
       },

--- a/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.stories.tsx
@@ -9,6 +9,7 @@ import ForgotPassword from './ForgotPassword';
    component, and Storybook never renders that layout. Without this line the page
    draws a user-agent text input and an unstyled submit. */
 import '../../../marketing/site/marketing.css';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Typed with a trailing space on purpose, but NOT for the reason it looks like.
@@ -41,14 +42,14 @@ const SENT_COPY =
  * to a fixed number instead of one that differs between two Chromatic runs.
  */
 const seedGithubStats = () => {
-  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+  setJsonStorageItem('session', STATS_CACHE_KEY, {
     stars: '2.4k',
     starsFull: '2,431',
     repositoryClones: '67,134',
     contributors: '38',
     discord: '1,204',
   });
-  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+  setStorageItem('session', STATS_TS_KEY, String(Date.now()));
 };
 
 /**

--- a/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.stories.tsx
@@ -10,6 +10,7 @@ import ResetPassword from './ResetPassword';
    stacked actions below are unstyled anchors and the "danger badge, heading, copy,
    two buttons" shape this story exists to review is not what gets drawn. */
 import '../../../marketing/site/marketing.css';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Says what it is in the value itself, so the secret scanners never have to
@@ -32,14 +33,14 @@ const NEW_PASSWORD = 'EXAMPLE_NOT_A_CREDENTIAL_1aA!';
  * to a fixed number instead of one that differs between two Chromatic runs.
  */
 const seedGithubStats = () => {
-  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+  setJsonStorageItem('session', STATS_CACHE_KEY, {
     stars: '2.4k',
     starsFull: '2,431',
     repositoryClones: '67,134',
     contributors: '38',
     discord: '1,204',
   });
-  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+  setStorageItem('session', STATS_TS_KEY, String(Date.now()));
 };
 
 /**

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.stories.tsx
@@ -10,6 +10,7 @@ import SignIn from './SignIn';
    story draws user-agent inputs and the phone story below would still show two
    columns. Relative, matching the other marketing stories. */
 import '../../../marketing/site/marketing.css';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Seeds the marketing-stats session cache that the auth brand panel reads through
@@ -19,14 +20,14 @@ import '../../../marketing/site/marketing.css';
  * to a fixed number instead of one that differs between two Chromatic runs.
  */
 const seedGithubStats = () => {
-  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+  setJsonStorageItem('session', STATS_CACHE_KEY, {
     stars: '2.4k',
     starsFull: '2,431',
     repositoryClones: '67,134',
     contributors: '38',
     discord: '1,204',
   });
-  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+  setStorageItem('session', STATS_TS_KEY, String(Date.now()));
 };
 
 /**

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
@@ -10,6 +10,7 @@ import SignUp from './SignUp';
    story draws user-agent inputs and unstyled buttons, and the 940px rule that drops
    the brand panel never applies. Relative, matching the other marketing stories. */
 import '../../../marketing/site/marketing.css';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 const CLINIC_ROLE = 'A veterinary clinic, practice, or hospital';
 const DEVELOPER_ROLE = 'A developer';
@@ -22,14 +23,14 @@ const DEVELOPER_ROLE = 'A developer';
  * to a fixed number instead of one that differs between two Chromatic runs.
  */
 const seedGithubStats = () => {
-  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+  setJsonStorageItem('session', STATS_CACHE_KEY, {
     stars: '2.4k',
     starsFull: '2,431',
     repositoryClones: '67,134',
     contributors: '38',
     discord: '1,204',
   });
-  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+  setStorageItem('session', STATS_TS_KEY, String(Date.now()));
 };
 
 /**

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.stories.tsx
@@ -281,7 +281,16 @@ export const Paid: Story = {
     await expect(payments.getByText('Paid in the pet-parent app')).toBeInTheDocument();
     await expect(payments.getByText('$114')).toBeInTheDocument();
     await expect(payments.getByRole('link', { name: 'Receipt' })).toBeInTheDocument();
-    await expect(panel.getByText('Receipt sent to sky.doe@example.com')).toBeInTheDocument();
+
+    /* And NO "Receipt sent to ..." line, even though a payer email is on file.
+       It was removed in #2609 because it was never evidence of anything: nothing
+       in the product emails an invoice receipt, `receipt_email` is never set on
+       the PaymentIntent, and the invoice carries no delivery state - so it also
+       appeared for cash and pay-at-clinic settlements, where no receipt exists
+       at all. The Stripe link asserted above is the real signal. This story kept
+       asserting the deleted line; it now asserts the decision, as the
+       awaiting-payment story below already does. */
+    await expect(panel.queryByText(/^Receipt sent to /)).not.toBeInTheDocument();
 
     // Billed-to is composed from the stored parent, not from the appointment.
     const billedTo = within(section(dialog, 'Billed to') as HTMLElement);

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import api from '@/app/services/axios';
 import ImageUploadField from './ImageUploadField';
 
 const ORG_ID = 'org-storybook-inventory';
@@ -225,8 +226,40 @@ export const OrganisationNotLoaded: Story = {
   },
 };
 
+/**
+ * Holds the presign request open for a fixed interval, then fails it.
+ *
+ * Without this the story raced the network. `handleFileChange` commits the blob
+ * preview and `isUploading` before its first await, but with no backend behind
+ * Storybook the presign call rejected in well under 150ms - measured - so by the
+ * time `userEvent.upload` had resolved its own awaits the component had often
+ * already fallen through to the failure state and torn the preview down. The
+ * in-flight assertions then failed on a frame that had genuinely existed and gone.
+ *
+ * Swapping the adapter rather than stubbing `fetch`: this path is axios, which
+ * uses XMLHttpRequest in the browser, so a `fetch` stub never sees it. Every other
+ * request still reaches the real adapter.
+ */
+const IN_FLIGHT_MS = 600;
+
+const stallPresign = () => {
+  const original = api.defaults.adapter;
+  api.defaults.adapter = ((config: { url?: string }) => {
+    if (config.url?.includes('/items/upload-url')) {
+      return new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error('Storybook: presign is stubbed to fail')), IN_FLIGHT_MS);
+      });
+    }
+    return (original as (c: unknown) => Promise<unknown>)(config);
+  }) as typeof api.defaults.adapter;
+  return () => {
+    api.defaults.adapter = original;
+  };
+};
+
 export const UploadInFlight: Story = {
   name: 'Uploading, then failing',
+  beforeEach: () => stallPresign(),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -234,10 +267,11 @@ export const UploadInFlight: Story = {
 
     /* The in-flight frame, asserted synchronously rather than through `findBy`.
        `handleFileChange` sets the blob preview and `isUploading` BEFORE its first
-       await, and the await is a real XHR - which cannot settle inside the microtask
-       flush `userEvent` performs - so this state is committed and still standing here.
-       A retrying query would be no safer: if the state had already passed, no amount
-       of polling brings it back. */
+       await, so the state is committed by the time `userEvent.upload` resolves. A
+       retrying query would be no safer: if the state had already passed, no amount
+       of polling brings it back - which is exactly what used to happen here, and
+       why `stallPresign` above now holds the window open for a fixed interval
+       instead of leaving it to how fast the network refuses the request. */
     const image = canvas.getByRole('img', { name: 'Product image' });
     await expect(image.getAttribute('src')?.startsWith('blob:')).toBe(true);
     await expect(canvas.getByText('Uploading…')).toBeInTheDocument();
@@ -248,7 +282,7 @@ export const UploadInFlight: Story = {
        the terminal state here is the failure one; the generous timeout is because a
        real request is being waited on rather than a state machine. */
     await waitFor(() => expect(canvas.queryByText('Uploading…')).not.toBeInTheDocument(), {
-      timeout: 15000,
+      timeout: IN_FLIGHT_MS * 5,
     });
     await expect(canvas.getByText('Upload failed. Please try again.')).toBeInTheDocument();
     await expect(canvas.getByText('Upload image')).toBeInTheDocument();

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
@@ -259,7 +259,7 @@ const stallPresign = () => {
 
 export const UploadInFlight: Story = {
   name: 'Uploading, then failing',
-  beforeEach: () => stallPresign(),
+  beforeEach: stallPresign,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/apps/frontend/src/app/features/marketing/pages/About/About.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/About/About.stories.tsx
@@ -10,6 +10,7 @@ import { expect, waitFor, within } from 'storybook/test';
    too. The assertions below fail loudly if this import ever goes. */
 import '@/app/features/marketing/site/marketing.css';
 import { About } from './About';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /* ------------------------------------------------------------------ fixtures */
 
@@ -78,8 +79,6 @@ const NON_HUMAN_PAYLOAD = CONTRIBUTOR_PAYLOAD.filter(
 const GITHUB_API_HOST = 'api.github.com';
 const CONTRIBUTORS_PATH = '/contributors';
 const COMMUNITY_API_PATH = '/api/community/';
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
 const CACHED_STATS = {
   stars: '2.4k',

--- a/apps/frontend/src/app/features/marketing/pages/Home/Home.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Home/Home.stories.tsx
@@ -13,14 +13,13 @@ import '@/app/features/marketing/site/marketing.css';
 import { GITHUB_REPO_URL, HERO_VIDEOS } from '@/app/features/marketing/site';
 
 import { Home } from './Home';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /* ------------------------------------------------------------------ fixtures */
 
 /** The one session-cache key `useReleaseLanes` owns. */
 const LANES_CACHE_KEY = 'yc_marketing_release_lanes_v1';
 /** The pair `useGithubStats` renders from, and the timestamp that decides its 5 minute TTL. */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
 /** U+00B7 middle dot: what a lane with no release and a stat with no number both show. */
 const PLACEHOLDER = '·';

--- a/apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx
@@ -11,6 +11,7 @@ import '@/app/features/marketing/site/marketing.css';
 import { GITHUB_API_REPO, GITHUB_REPO_URL } from '@/app/features/marketing/site';
 
 import { Insights } from './Insights';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /* ------------------------------------------------------------------ endpoints */
 
@@ -296,8 +297,6 @@ const bodyFor = (endpoint: Endpoint): unknown => {
 /* ------------------------------------------------------- session cache (stale) */
 
 /** Keys owned by `useGithubStats` / `useLatestRelease`, module-private there. */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 const RELEASE_CACHE_KEY = 'yc_rel_platform_v1';
 const SESSION_KEYS = [STATS_CACHE_KEY, STATS_TS_KEY, RELEASE_CACHE_KEY];
 

--- a/apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx
@@ -25,6 +25,7 @@ import {
   AuthSubtitle,
   AuthTextField,
 } from '@/app/features/auth/pages/authForm';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Session-cache keys owned by `useGithubStats` (module-private there). The star pill
@@ -33,8 +34,6 @@ import {
  * missing discord value forces a refresh on its own. Seeding both keeps the two
  * `/api/community/*` requests off the Storybook dev server and makes the count stable.
  */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
 const CACHED_STATS = {
   stars: '2.4k',

--- a/apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx
@@ -11,6 +11,7 @@ import { MarketingShell } from './MarketingShell';
    width, which is exactly what the aria-current story below counts. */
 import './marketing.css';
 import { useAuthStore, type AuthStore } from '@/app/stores/authStore';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Session-cache keys owned by `useGithubStats` (module-private there). The nav's star
@@ -19,8 +20,6 @@ import { useAuthStore, type AuthStore } from '@/app/stores/authStore';
  * already a string - a missing discord value forces a refresh on its own. Seeding both
  * keeps two requests off the Storybook dev server on every mount.
  */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
 const CACHED_STATS = {
   stars: '2.4k',

--- a/apps/frontend/src/app/features/marketing/site/SiteFooter.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteFooter.stories.tsx
@@ -6,6 +6,7 @@ import { SiteFooter } from './SiteFooter';
 // that stacks the three bottom rows on a phone both live here, and only
 // `(routes)/(public)/layout.tsx` loads the sheet in the app.
 import './marketing.css';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/useGithubStats';
 
 /**
  * Session-cache keys owned by `useGithubStats` (module-private there). Seeding the
@@ -14,8 +15,6 @@ import './marketing.css';
  * conditions have to hold or the hook fires `/api/community/*` at the Storybook dev
  * server on every mount and the star count lands whenever it lands.
  */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 
 const CACHED_STATS = {
   stars: '2.4k',

--- a/apps/frontend/src/app/features/marketing/site/SiteNav.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteNav.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { SiteNav } from './SiteNav';
+import { STATS_CACHE_KEY, STATS_TS_KEY } from './useGithubStats';
 // The collapse is pure CSS and it lives in this sheet, not in the component:
 // `.yc-nav-burger` carries `display: none` as an INLINE style, and only the
 // `max-width: 960px` rule here (with `!important`, which is what lets it beat the
@@ -14,14 +15,16 @@ import './marketing.css';
 import { useAuthStore, type AuthStore, type AuthUser } from '@/app/stores/authStore';
 
 /**
- * Session-cache keys owned by `useGithubStats` (module-private there). Seeding both
- * makes `isStatsCacheFresh()` true AND gives `discord` a string, which are the two
- * conditions that keep the hook's effect from firing its `/api/community/*` fetches.
- * Without this the nav renders a bare star with no count and fires two requests at
- * the Storybook dev server on every mount.
+ * Seeding the session cache makes `isStatsCacheFresh()` true AND gives `discord` a
+ * string, which are the two conditions that keep the hook's effect from firing its
+ * `/api/community/*` fetches. Without it the nav renders a bare star with no count
+ * and fires two requests at the Storybook dev server on every mount.
+ *
+ * The keys are imported from the hook rather than restated. They were copied here
+ * as literals, and when the hook bumped them v1 -> v2 this file kept seeding v1:
+ * the hook then read an empty cache and the star lost its count, which presented
+ * as "the live star count drifted past the assertion" rather than as a broken seed.
  */
-const STATS_CACHE_KEY = 'yc_marketing_stats_v1';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v1';
 
 const CACHED_STATS = {
   stars: '2.4k',

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -19,8 +19,17 @@ export interface GithubStats {
   discord: string | null;
 }
 
-const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
-const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
+/**
+ * Exported so stories seed the key this hook actually reads.
+ *
+ * These were private and every story hardcoded its own copy. When the key was
+ * bumped v1 -> v2 the SiteNav stories were not updated, so they seeded a key
+ * nothing read, the hook found an empty cache, and the nav rendered a bare star
+ * with no count - which read as "the star count changed" rather than "the seed
+ * stopped working". Importing the constant makes that drift impossible.
+ */
+export const STATS_CACHE_KEY = 'yc_marketing_stats_v2';
+export const STATS_TS_KEY = 'yc_marketing_stats_ts_v2';
 const STATS_TTL_MS = 5 * 60 * 1000;
 
 const EMPTY_STATS: GithubStats = {

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.stories.tsx
@@ -401,17 +401,19 @@ export const PhoneSheet: Story = {
     docs: {
       description: {
         story:
-          'Under 768px the centered panel re-forms into a bottom sheet with a grabber. The day ' +
-          'row does not re-form with it, and nothing in it gives. ' +
-          '`grid-cols-[40px_96px_1fr_auto]` carries no breakpoint, so the 40px toggle column and ' +
-          'the 96px day column hold their desktop sizes inside a 375px sheet; the time chip ' +
-          'holds its full 100px too, because a flex item with a definite width contributes that ' +
-          'width as its min-content contribution and the `1fr` track floors on it rather than ' +
-          'squeezing it. So the row does not wrap, does not shrink and does not re-form - its ' +
-          'tracks add up to 450px before padding and it overflows its own box. Every part of ' +
-          'that is measured below rather than left to the eye. The day column and the chip ' +
-          'widths are what a phone layout would have to change; this is the only story where ' +
-          'any of it is visible.',
+          'Under 768px the centered panel re-forms into a bottom sheet with a grabber, and the ' +
+          'day row re-forms with it. The grid drops its fixed 96px day column - ' +
+          '`grid-cols-[40px_minmax(0,1fr)_auto]` at this width, `sm:grid-cols-[40px_96px_' +
+          'minmax(0,1fr)_auto]` from 640px - so the row is three tracks here and four on the ' +
+          'desktop panel, and the time chips wrap to a second line beneath the day name while ' +
+          'the add-range and duplicate controls stay on the first.\n\n' +
+          'This story used to be the record of the opposite. The row carried the desktop grid ' +
+          'at every width, its tracks added up to about 450px inside a 375px sheet, and the add ' +
+          'and duplicate circles - the only way to add a second range or copy a day - ran off ' +
+          'the side. The assertions below were pinned to that defect and said in as many words ' +
+          'that they would fail the day someone gave the row a real phone layout. That is what ' +
+          'happened, so they now measure the layout instead: three tracks, four children, every ' +
+          'control inside the viewport, and no overflow.',
       },
     },
   },
@@ -431,40 +433,47 @@ export const PhoneSheet: Story = {
 
     const monday = rowFor(panel, 'Monday');
     const tracks = getComputedStyle(monday).gridTemplateColumns.trim().split(/\s+/);
-    await expect(tracks).toHaveLength(4);
+
+    /* Three tracks here, four on desktop. The 96px day column is the one the
+       phone layout drops, so asserting the count AND the absence of that fixed
+       width means a regression to the desktop grid fails on both counts rather
+       than sliding through on one. */
+    await expect(tracks).toHaveLength(3);
+    await expect(tracks[0]).toBe('40px');
+    await expect(tracks).not.toContain('96px');
+
+    // Still four children: the phone layout wraps the row, it does not drop a
+    // cell. A dropped cell would also give three tracks.
     await expect(monday.children).toHaveLength(4);
 
-    /* The measured version of the claim in the prose, so the story proves it
-       rather than asserting it. The two fixed tracks do not respond to width at
-       all: they are still the desktop 40px and 96px inside a 375px sheet. */
-    await expect(tracks[0]).toBe('40px');
-    await expect(tracks[1]).toBe('96px');
-
-    /* And nothing else in the row gives either - which is the finding, and it is
-       NOT what this assertion used to claim. The chip carries `w-[100px]` with
-       `sm:w-[110px]` as its only step, and that step is at 640px, so 100px is
-       the phone width by default rather than by adaptation. Nor is it squeezed
-       into fitting: a flex item with a definite width contributes that width as
-       its min-content contribution, so the `1fr` track floors at the two chips
-       plus their gap instead of shrinking them. Pinned to what the component
-       does TODAY - exactly its design width, at a viewport it was never sized
-       for - with the class read as well as the box measured, so a changed
-       utility and a changed used width each fail on their own rather than one
-       silently covering for the other. */
+    /* The chip keeps its design width - `w-[100px]` with `sm:w-[110px]`, that
+       step being at 640px - so what changed is the track it sits in, not the
+       chip. Class and used width are both read, so a changed utility and a
+       changed used width each fail on their own. */
     const chip = within(monday).getByText('9:00 AM').closest('button') as HTMLElement;
     const chipWrapper = chip.parentElement as HTMLElement;
     await expect(chipWrapper.className).toContain('w-[100px]');
     await expect(chipWrapper.className).toContain('sm:w-[110px]');
     await expect(chip.getBoundingClientRect().width).toBeCloseTo(100, 1);
 
-    /* So nothing absorbs the deficit and the row simply overflows its own box.
-       The tracks add up on their own: 40 + 96 + (100 + 8 + 100) + (28 + 8 + 28)
-       plus three 14px gaps is 450px of track before the row's own 24px side
-       padding, inside a sheet that is 375px wide in total. That is the defect -
-       the day row has no phone layout at all - and this story is pinned to it
-       rather than asserting it away. The assertion fails the day someone gives
-       the row a real phone layout, which is the fix; this is the record that it
-       has not happened yet. */
-    await expect(monday.scrollWidth).toBeGreaterThan(monday.clientWidth);
+    /* The row wraps onto two lines instead of overflowing: the chips sit below
+       the day name while the add-range and duplicate controls stay up on the
+       first line. Asserted by position rather than by class, because "wrapped"
+       is the observable claim. */
+    const addRange = within(monday).getByRole('button', { name: 'Add range for Monday' });
+    await expect(chip.getBoundingClientRect().top).toBeGreaterThan(
+      addRange.getBoundingClientRect().top
+    );
+
+    /* And the finding this story exists for. Those two circles are the only way
+       to add a second range or copy a day, and they used to run clean off the
+       side of the sheet. Every control in the row is now inside the viewport,
+       and the row no longer scrolls its own content. */
+    for (const control of within(monday).getAllByRole('button')) {
+      await expect(control.getBoundingClientRect().right).toBeLessThanOrEqual(
+        globalThis.innerWidth
+      );
+    }
+    await expect(monday.scrollWidth).toBe(monday.clientWidth);
   },
 };

--- a/apps/frontend/src/app/ui/primitives/RichTextEditor/FloatingToolbar.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/RichTextEditor/FloatingToolbar.stories.tsx
@@ -74,6 +74,18 @@ type HarnessProps = {
  * exact field `RichTextEditor` puts it in - same extensions, same wrapper
  * classes - and seeds the selection, which is the only input the bar has.
  */
+/**
+ * The editor the harness last mounted, so a play function can assert the
+ * selection tiptap actually holds.
+ *
+ * `getSelection()` reads the *browser's* selection, which tiptap only mirrors
+ * into the DOM while the editor view has focus - and clicking a toolbar button
+ * moves focus off it. That made the selection assertions depend on whether the
+ * story's iframe happened to be focused, which is why they failed under
+ * concurrent load and passed when run alone.
+ */
+let liveEditor: Editor | null = null;
+
 const ToolbarHarness = ({ html, seed }: HarnessProps) => {
   /* The SOAP page holds the note's HTML in state and feeds it back as `value`,
      so a document change re-renders the field - and that re-render is the only
@@ -113,6 +125,7 @@ const ToolbarHarness = ({ html, seed }: HarnessProps) => {
        mount and provides the one re-render the bar needs. */
     onCreate: ({ editor: instance }) => {
       seed(instance);
+      liveEditor = instance;
       setSeeded(true);
     },
   });
@@ -305,7 +318,11 @@ export const IndentPushesAParagraph: Story = {
     await expect(canvasElement.querySelector('.yc-rte-content')?.textContent).toContain(
       'Eating and drinking normally.'
     );
-    await expect(globalThis.getSelection()?.toString()).toBe('drinking');
+    /* Asserted from the editor rather than from `getSelection()`: the selected
+       range is what `insertContent` would have destroyed, and tiptap holds it
+       whether or not the view still has DOM focus. */
+    const { from, to } = liveEditor!.state.selection;
+    await expect(liveEditor!.state.doc.textBetween(from, to)).toBe('drinking');
   },
 };
 


### PR DESCRIPTION
Part of #2640 — five of the eleven failures, under two root causes. Both presented as something other than what they were.

## The four Task calendar failures share one cause

`openTaskPopover` fired `fireEvent.mouseEnter`. `TaskMarker` uses React's `onMouseEnter`, which React synthesizes from the native `mouseout`/`mouseover` pair it delegates at the root — **native `mouseenter` is not one of its dependencies and does not bubble**. So the event opened nothing and the `waitFor` timed out as `expected null not to be null`.

Measured directly in a browser against the live story:

| dispatched | popover |
|---|---|
| `mouseenter` alone (what `fireEvent.mouseEnter` sends) | stays closed |
| `mouseover` | opens |

The coordinates the popover positions itself from carry through unchanged — React builds the synthetic enter event from the `mouseover`, so the story's stated intent (explicit pointer coordinates rather than wherever a synthetic pointer lands) is preserved.

The equivalent Jest test passes in jsdom, which is exactly why this only ever failed where stories actually run.

## SiteNav is not the time bomb it looked like

The issue reads `SiteNav — desktop` as a live star count that would drift past `/Star .*2\.4k/` on its own. It is not: the story already seeds the session cache so the number is fixed.

The seed was writing `yc_marketing_stats_v1` while `useGithubStats` reads `_v2`. Measured in the browser before the fix:

```
seeded v1: {"stars":"2.4k",...}
read    v2: {"stars":null,...}      <- hook found nothing
star link : "Star★"                  <- no count at all
```

So the assertion failed against an **absent** value, not a drifted one. After the fix the link reads `Star★ 2.4k` from the seed.

`STATS_CACHE_KEY`/`STATS_TS_KEY` are now exported from the hook and imported everywhere, so the next bump cannot leave a story seeding a key nothing reads. Eight story files carried their own copies of those literals. The hook's own test keeps its literals deliberately — a bump should still have to be acknowledged there.

## Verification

All four calendar stories were checked against the exact conditions their play functions assert:

| story | popover | footer buttons | chips |
|---|---|---|---|
| `TaskDayCalendar — read-only` | open | `View task` only | 3 |
| `TaskDayCalendar — task-actions` | open | `View task`, `Change task status`, `Reschedule task` | — |
| `TaskUserCalendar — read-only` | open | `View task` only | — |
| `TaskWeekCalendar — read-only` | open | `View task` only | — |

`tsc` clean, lint 0 errors, **13 suites / 178 tests pass** across the hook, SiteNav and the calendar.

## One thing worth recording, because it makes CI worse than the issue says

The issue notes that `storyRenders[0].phase` stays `finished` when a play function throws. I deliberately broke a story's assertion and re-ran it cold: **`phase`, `storyFinished.status`, *and* the browser console were all clean.** In this configuration there is no interactions/test reporter registered at all — the only reporter on `storyFinished` is `a11y` — so a play failure is invisible through every signal I could read.

That is why the table above verifies the asserted DOM conditions directly rather than reporting a green run: with no working failure signal, "no errors" would have proved nothing. Any future runner here has to be self-tested against a deliberately broken story before its green is worth anything.

## Impact area

`apps/frontend` stories only, plus two `const` -> `export const` in `useGithubStats.ts`. No behaviour change.