### PR TITLE
chore(backend): clear the remaining Zod v4 deprecations

### DIFF
--- a/apps/backend/src/controllers/app/chat.controller.ts
+++ b/apps/backend/src/controllers/app/chat.controller.ts
@@ -115,7 +115,10 @@ export const ChatController = {
       if (!parsed.success) {
         return res
           .status(400)
-          .json({ message: "Invalid payload", errors: parsed.error.flatten() });
+          .json({
+            message: "Invalid payload",
+            errors: z.flattenError(parsed.error),
+          });
       }
 
       const record = await SharedChatEntityService.shareEntity({

--- a/apps/backend/src/controllers/web/activitypub.controller.ts
+++ b/apps/backend/src/controllers/web/activitypub.controller.ts
@@ -386,7 +386,7 @@ export const ActivityPubController = {
       if (!parsed.success) {
         return res.status(400).json({
           error: "Invalid referral payload",
-          details: parsed.error.flatten().fieldErrors,
+          details: z.flattenError(parsed.error).fieldErrors,
         });
       }
       const body = parsed.data;

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -18,10 +18,10 @@ import { resolveVerifiedUserId } from "src/utils/request";
 
 const caseResourceSchema = z
   .object({ resourceType: z.literal("EpisodeOfCare") })
-  .passthrough();
+  .loose();
 const encounterResourceSchema = z
   .object({ resourceType: z.literal("Encounter") })
-  .passthrough();
+  .loose();
 
 const caseListQuerySchema = z.object({
   organization: z.string().trim().optional(),
@@ -55,7 +55,7 @@ const dischargeEncounterSchema = z
       )
       .optional(),
   })
-  .passthrough();
+  .loose();
 const assignUnitSchema = z
   .object({
     resourceType: z.literal("Parameters").optional(),
@@ -69,7 +69,7 @@ const assignUnitSchema = z
       )
       .optional(),
   })
-  .passthrough();
+  .loose();
 const lifecycleOperationSchema = z
   .object({
     resourceType: z.literal("Parameters").optional(),
@@ -82,7 +82,7 @@ const lifecycleOperationSchema = z
       )
       .optional(),
   })
-  .passthrough();
+  .loose();
 
 const unitAssignmentResource = (assignment: {
   id: string;

--- a/apps/backend/src/controllers/web/catalog.controller.ts
+++ b/apps/backend/src/controllers/web/catalog.controller.ts
@@ -41,7 +41,7 @@ const healthcareServiceSchema = z
   .object({
     resourceType: z.literal("HealthcareService"),
   })
-  .passthrough();
+  .loose();
 
 const resolveSchema = z.object({
   productItemId: z.string().trim().min(1),
@@ -372,7 +372,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid payload. Expected FHIR HealthcareService resource.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -395,7 +395,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid payload. Expected FHIR HealthcareService resource.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -474,7 +474,7 @@ export const CatalogController = {
       if (!queryResult.success) {
         return res.status(400).json({
           message: "Invalid catalog list query.",
-          errors: queryResult.error.flatten(),
+          errors: z.flattenError(queryResult.error),
         });
       }
 
@@ -523,7 +523,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid speciality catalog query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -547,7 +547,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid catalog resolve payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -575,7 +575,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid FHIR Parameters payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -614,7 +614,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid FHIR Parameters payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -668,7 +668,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid organisation catalog summary query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -699,7 +699,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid specialities list query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -724,7 +724,7 @@ export const CatalogController = {
           message: "Invalid speciality payload.",
           errors: parsed.success
             ? { fieldErrors: { name: ["Name is required."] } }
-            : parsed.error.flatten(),
+            : z.flattenError(parsed.error),
         });
       }
 
@@ -752,7 +752,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid speciality payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -835,7 +835,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid services list query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -880,7 +880,7 @@ export const CatalogController = {
                   ...(parsed.data.kind ? {} : { kind: ["Kind is required."] }),
                 },
               }
-            : parsed.error.flatten(),
+            : z.flattenError(parsed.error),
         });
       }
 
@@ -906,7 +906,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid service payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -984,7 +984,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid packages list query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -1021,7 +1021,7 @@ export const CatalogController = {
           message: "Invalid package payload.",
           errors: parsed.success
             ? { fieldErrors: { name: ["Name is required."] } }
-            : parsed.error.flatten(),
+            : z.flattenError(parsed.error),
         });
       }
 
@@ -1048,7 +1048,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid package payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -1126,7 +1126,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid catalog search query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -1189,7 +1189,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid catalog nearby search query.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -1219,7 +1219,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid catalog bookable slots payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 
@@ -1254,7 +1254,7 @@ export const CatalogController = {
       if (!parsed.success) {
         return res.status(400).json({
           message: "Invalid catalog calendar prefill payload.",
-          errors: parsed.error.flatten(),
+          errors: z.flattenError(parsed.error),
         });
       }
 

--- a/apps/backend/src/controllers/web/client-complaint.controller.ts
+++ b/apps/backend/src/controllers/web/client-complaint.controller.ts
@@ -55,7 +55,7 @@ export const clientComplaintController = {
     const { organisationId } = req.params;
     const parsed = CreateComplaintSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { reportedAt, ...rest } = parsed.data;
@@ -108,7 +108,7 @@ export const clientComplaintController = {
     const { organisationId, complaintId } = req.params;
     const parsed = UpdateComplaintSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { resolvedAt, ...rest } = parsed.data;
@@ -132,7 +132,7 @@ export const clientComplaintController = {
     const { organisationId, complaintId } = req.params;
     const parsed = AddNoteSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {

--- a/apps/backend/src/controllers/web/clinic-note.controller.ts
+++ b/apps/backend/src/controllers/web/clinic-note.controller.ts
@@ -40,7 +40,7 @@ export const ClinicNoteController = {
   create: async (req: Request, res: Response) => {
     const parsed = CreateNoteSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const note = await ClinicNoteService.create({
@@ -92,7 +92,7 @@ export const ClinicNoteController = {
   update: async (req: Request, res: Response) => {
     const parsed = UpdateNoteSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const note = await ClinicNoteService.update(

--- a/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
@@ -34,13 +34,13 @@ const resolvePrescriptionActor = (req: Request): PrescriptionActor => {
 
 const compositionSchema = z
   .object({ resourceType: z.literal("Composition") })
-  .passthrough();
+  .loose();
 const medicationRequestSchema = z
   .object({ resourceType: z.literal("MedicationRequest") })
-  .passthrough();
+  .loose();
 const observationSchema = z
   .object({ resourceType: z.literal("Observation") })
-  .passthrough();
+  .loose();
 
 const handleError = createFhirErrorHandler({
   isServiceError: (error): error is ClinicalArtifactServiceError =>

--- a/apps/backend/src/controllers/web/code.controller.ts
+++ b/apps/backend/src/controllers/web/code.controller.ts
@@ -147,7 +147,7 @@ export const CodeController = {
       if (!queryResult.success) {
         return res.status(400).json({
           message: "Invalid medication suggestion query.",
-          error: queryResult.error.flatten(),
+          error: z.flattenError(queryResult.error),
         });
       }
 
@@ -172,7 +172,7 @@ export const CodeController = {
       if (!queryResult.success) {
         return res.status(400).json({
           message: "Invalid term suggestion query.",
-          error: queryResult.error.flatten(),
+          error: z.flattenError(queryResult.error),
         });
       }
 

--- a/apps/backend/src/controllers/web/deceased-record.controller.ts
+++ b/apps/backend/src/controllers/web/deceased-record.controller.ts
@@ -53,7 +53,7 @@ export const deceasedRecordController = {
     const { organisationId } = req.params;
     const parsed = CreateDeceasedRecordSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { deceasedAt, ownerNotifiedAt, ...rest } = parsed.data;
@@ -118,7 +118,7 @@ export const deceasedRecordController = {
     const { organisationId, recordId } = req.params;
     const parsed = UpdateDeceasedRecordSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { deceasedAt, ownerNotifiedAt, ...rest } = parsed.data;

--- a/apps/backend/src/controllers/web/developer-api-key.controller.ts
+++ b/apps/backend/src/controllers/web/developer-api-key.controller.ts
@@ -53,7 +53,10 @@ export const DeveloperApiKeyController = {
       if (!parsed.success) {
         return res
           .status(400)
-          .json({ message: "Invalid request", errors: parsed.error.flatten() });
+          .json({
+            message: "Invalid request",
+            errors: z.flattenError(parsed.error),
+          });
       }
 
       const { name, scopes, environment, expiresAt } = parsed.data;

--- a/apps/backend/src/controllers/web/drug-formulary.controller.ts
+++ b/apps/backend/src/controllers/web/drug-formulary.controller.ts
@@ -62,7 +62,7 @@ export const drugFormularyController = {
     const { organisationId } = req.params;
     const parsed = CreateFormularySchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {
@@ -111,7 +111,7 @@ export const drugFormularyController = {
     const { organisationId, formularyId } = req.params;
     const parsed = UpdateFormularySchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {
@@ -131,7 +131,7 @@ export const drugFormularyController = {
     const { organisationId, formularyId } = req.params;
     const parsed = DosageSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {

--- a/apps/backend/src/controllers/web/estimate.controller.ts
+++ b/apps/backend/src/controllers/web/estimate.controller.ts
@@ -56,7 +56,7 @@ export const estimateController = {
     const { organisationId } = req.params;
     const parsed = CreateEstimateSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { validUntil, ...rest } = parsed.data;
@@ -105,7 +105,7 @@ export const estimateController = {
     const { organisationId, estimateId } = req.params;
     const parsed = UpdateEstimateSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { validUntil, ...rest } = parsed.data;
@@ -148,7 +148,7 @@ export const estimateController = {
     }
     const parsed = ApproveDeclineSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {
@@ -167,7 +167,7 @@ export const estimateController = {
   convert: async (req: Request, res: Response) => {
     const params = ConvertParamsSchema.safeParse(req.params);
     if (!params.success) {
-      res.status(400).json({ error: params.error.flatten() });
+      res.status(400).json({ error: z.flattenError(params.error) });
       return;
     }
     const { organisationId, estimateId } = params.data;
@@ -198,7 +198,7 @@ export const estimateController = {
     }
     const parsed = ApproveDeclineSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {

--- a/apps/backend/src/controllers/web/inventory-count.controller.ts
+++ b/apps/backend/src/controllers/web/inventory-count.controller.ts
@@ -31,7 +31,7 @@ export const InventoryCountController = {
   record: async (req: Request, res: Response) => {
     const parsed = RecordCountSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const count = await InventoryCountService.record({
@@ -88,7 +88,7 @@ export const InventoryCountController = {
   reconcile: async (req: Request, res: Response) => {
     const parsed = ReconcileSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const count = await InventoryCountService.reconcile(

--- a/apps/backend/src/controllers/web/patient-flag.controller.ts
+++ b/apps/backend/src/controllers/web/patient-flag.controller.ts
@@ -47,7 +47,7 @@ export const PatientFlagController = {
   create: async (req: Request, res: Response) => {
     const parsed = CreateFlagSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const flag = await PatientFlagService.create({
@@ -99,7 +99,7 @@ export const PatientFlagController = {
   update: async (req: Request, res: Response) => {
     const parsed = UpdateFlagSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      return res.status(400).json({ error: z.flattenError(parsed.error) });
     }
     try {
       const flag = await PatientFlagService.update(

--- a/apps/backend/src/controllers/web/service.controller.ts
+++ b/apps/backend/src/controllers/web/service.controller.ts
@@ -203,7 +203,7 @@ const HealthcareServiceSchema = z
   .object({
     resourceType: z.literal("HealthcareService"),
   })
-  .passthrough();
+  .loose();
 
 const HealthcareServiceListSchema = z.array(HealthcareServiceSchema).min(1);
 

--- a/apps/backend/src/controllers/web/super-admin-business.controller.ts
+++ b/apps/backend/src/controllers/web/super-admin-business.controller.ts
@@ -27,7 +27,7 @@ const updateBusinessSchema = z
 
     if (provided.length !== 1) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message: "Exactly one status field is required.",
       });
     }

--- a/apps/backend/src/controllers/web/surgical-checklist.controller.ts
+++ b/apps/backend/src/controllers/web/surgical-checklist.controller.ts
@@ -38,7 +38,7 @@ export const surgicalChecklistController = {
     const { organisationId } = req.params;
     const parsed = CreateChecklistSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {
@@ -88,7 +88,7 @@ export const surgicalChecklistController = {
     const { organisationId, checklistId } = req.params;
     const parsed = UpdateChecklistSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     const { completedAt, ...rest } = parsed.data;
@@ -112,7 +112,7 @@ export const surgicalChecklistController = {
     const { organisationId, checklistId, itemId } = req.params;
     const parsed = CheckItemSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.flatten() });
+      res.status(400).json({ error: z.flattenError(parsed.error) });
       return;
     }
     try {

--- a/apps/backend/src/controllers/web/task-schedule.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/task-schedule.fhir.controller.ts
@@ -16,7 +16,7 @@ import { resolveVerifiedUserId } from "src/utils/request";
 
 const parametersSchema = z
   .object({ resourceType: z.literal("Parameters") })
-  .passthrough();
+  .loose();
 
 const handleError = createFhirErrorHandler({
   isServiceError: (error): error is TaskWorkflowServiceError =>

--- a/apps/backend/src/controllers/web/task.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/task.fhir.controller.ts
@@ -10,7 +10,7 @@ import type { OrgRequest } from "src/middlewares/rbac";
 
 const taskResourceSchema = z
   .object({ resourceType: z.literal("Task") })
-  .passthrough();
+  .loose();
 
 const listQuerySchema = z.object({
   status: z.union([z.string(), z.array(z.string())]).optional(),

--- a/apps/backend/src/controllers/web/template.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/template.fhir.controller.ts
@@ -24,13 +24,13 @@ import { resolveVerifiedUserId } from "src/utils/request";
 
 const questionnaireResourceSchema = z
   .object({ resourceType: z.literal("Questionnaire") })
-  .passthrough();
+  .loose();
 const planDefinitionResourceSchema = z
   .object({ resourceType: z.literal("PlanDefinition") })
-  .passthrough();
+  .loose();
 const questionnaireResponseSchema = z
   .object({ resourceType: z.literal("QuestionnaireResponse") })
-  .passthrough();
+  .loose();
 
 const listQuerySchema = z.object({
   kind: z

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -169,7 +169,7 @@ export const createTemplateSchema = z
       value.organisationId === undefined
     ) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["organisationId"],
         message: "Organisation is required for organisation templates",
       });
@@ -178,7 +178,7 @@ export const createTemplateSchema = z
     if (value.ownership === "USER_TEMPLATE") {
       if (value.organisationId === undefined) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           path: ["organisationId"],
           message: "Organisation is required for user templates",
         });
@@ -186,7 +186,7 @@ export const createTemplateSchema = z
 
       if (value.ownerUserId === undefined) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: "custom",
           path: ["ownerUserId"],
           message: "Owner user is required for user templates",
         });


### PR DESCRIPTION
Closes #2652 for the backend.

## What changed

Three categories, 67 call sites across 21 files:

| deprecated | replacement | sites |
|---|---|---|
| `parsed.error.flatten()` | `z.flattenError(parsed.error)` | 48 |
| `.passthrough()` | `.loose()` | 15 |
| `z.ZodIssueCode.custom` | `"custom"` | 4 |

## The issue's counts are stale

#2652 lists **eleven** categories totalling 353. Measured against `origin/dev` before starting, **eight of them are already at zero**: `datetime`, `uuid`, `nativeEnum`, `url`, `email`, `merge`, `finite`, `date`. Only these three remained, which is 67 sites rather than 353.

That also means the ordering trap the issue flags — where a `.trim()` before a validator has to become `z.string().trim().pipe(z.email())` rather than `z.email().trim()` — **does not arise here**. It applies only to the string validators, all of which are already migrated.

## Equivalence was checked, not assumed

Against the installed zod (4.4.3), not the migration guide:

```
err.flatten():        {"formErrors":[],"fieldErrors":{"a":["Invalid input: expected string, received number"]}}
z.flattenError(err):  {"formErrors":[],"fieldErrors":{"a":["Invalid input: expected string, received number"]}}
identical: true

passthrough({a:'x', extra:1}) -> {"a":"x","extra":1}
loose({a:'x', extra:1})       -> {"a":"x","extra":1}

z.ZodIssueCode.custom === "custom"
```

## Validation

- **459 suites / 11079 backend tests pass**
- **Mutation-checked**: replacing `z.flattenError(...)` with the raw error object in `code.controller.ts` fails 5 tests in `code.controller.test.ts`, so the flattened shape is genuinely guarded rather than incidentally passing
- Local Sonar proxy (279 sonarjs rules, self-tested against a deliberately failing probe): **no findings on any changed file**
- Type-check and lint output are **identical before and after, error for error**

## Two pre-existing conditions worth flagging separately

Both measured on `dev` with my changes reverted, and unchanged by this PR:

- `apps/backend` `tsc --noEmit` reports **450 errors** (largely `TS7006 implicitly any` in `auth-hooks`, `search.controller` and the backfill scripts)
- `pnpm --filter backend run lint` reports **13270 errors**

Neither is caused by this change and neither is in scope here, but a repo whose backend type-check and lint are both red by default cannot use either as a gate. Happy to file that if it is not already known.

## Impact area

`apps/backend` only — controllers and services. No behaviour change: every replacement is byte-equivalent to what it replaced.