### PR TITLE
chore(frontend): clear the three SonarCloud smells

### DIFF
--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -865,7 +865,7 @@ const BookClient = ({ slug }: { slug: string }) => {
     []
   );
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = (event: React.SubmitEvent) => {
     event.preventDefault();
     if (!serviceId || !selectedTime || submitting || !form.consent) return;
 

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
@@ -30,7 +30,7 @@ const CreateKeyForm = ({
   const [environment, setEnvironment] = useState<ApiKeyEnvironment>('live');
   const [scopesInput, setScopesInput] = useState('');
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = (event: React.SubmitEvent) => {
     event.preventDefault();
     if (!name.trim() || creating) return;
 

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
@@ -777,9 +777,13 @@ const FederationSection = () => {
   const [actor, setActor] = useState<APActorSettings | null>(null);
   const [loading, setLoading] = useState(true);
 
+  /* Returns the chain rather than dropping it: the mount effect awaits this, and
+     the license and directory cards pass it as their `onUpdated` refresh. Without
+     the return it resolved to `undefined`, so every one of those awaits completed
+     immediately and nothing actually waited for the reload. */
   const loadActor = useCallback(() => {
     setLoading(true);
-    getActorSettings()
+    return getActorSettings()
       .then((data) => setActor(data))
       .catch(() => {
         notify('error', {


### PR DESCRIPTION
The frontend half of #2652. Pairs with [#2658](https://github.com/YosemiteCrew/Yosemite-Crew/pull/2658), which clears the backend.

## What changed

**Two `React.FormEvent` -> `React.SubmitEvent`.** `@types/react` 19.2.18 deprecates `FormEvent` with a note pointing at `SubmitEvent`, and both sites are `<form onSubmit>` handlers, so `SubmitEvent` is the accurate replacement rather than the generic `SyntheticEvent`.

**One `await` of a non-Promise**, in `FederationSection`. `loadActor` ran

```ts
getActorSettings().then(...).catch(...).finally(...)
```

without returning the chain, so it resolved to `undefined`. That is not only a lint finding — the mount effect awaits it, and `LicenseTokenCard` and the directory card both pass it as their `onUpdated` refresh, so **every one of those awaits was completing immediately while the reload was still in flight**. It now returns the chain.

## How the third one was found

`eslint-plugin-sonarjs` has **no** await-related rule, so the local Sonar proxy cannot see this class at all — consistent with it missing Sonar's TypeScript-analyser rules generally. I used `@typescript-eslint/await-thenable`, which is the type-aware equivalent of `typescript:S4123`.

Two things worth recording for anyone repeating it:

- **Self-test it first.** I ran it against a deliberate `await f()` on a sync function and confirmed it errored before trusting a scan.
- **It needs `--max-old-space-size=8192`.** On the default heap the run aborts partway through with SIGABRT and reports **zero findings** — which is indistinguishable from a clean run. My first scan did exactly that.

## One thing I deliberately did not change

The mount effect wraps the call as `const run = async () => { await loadActor(); }; run();`. Replacing that with `void loadActor()` reads better and I tried it, but it trips `react-hooks/set-state-in-effect`, because `loadActor`'s leading `setLoading(true)` then runs synchronously in the effect body.

The wrapper does not actually defer anything — an async function body runs synchronously up to its first `await` — so it is lint-laundering rather than behaviour. But swapping a hidden concern for a real lint error is not an improvement, and the `return` alone satisfies S4123. Left as-is, and noted here rather than silently.

## Validation

- `@typescript-eslint/await-thenable` across `apps/frontend/src`: **0 findings** after (1 before)
- `npx tsc --noEmit`: exit **0**
- `pnpm run lint`: **0 errors** — back to the single pre-existing warning, and I checked that my first attempt's extra error was gone
- **4 suites / 74 tests pass**; `FederationSection.tsx` at 96.73% statements

## Impact area

`apps/frontend` only — three files, no behaviour change beyond `loadActor` now genuinely resolving when the reload finishes.