### PR TITLE
fix(backend): honour query and limit on the GET lab-tests listing

### DIFF
--- a/apps/backend/src/controllers/web/lab-order.controller.ts
+++ b/apps/backend/src/controllers/web/lab-order.controller.ts
@@ -125,6 +125,16 @@ export const LabOrderController = {
       if (!base) return;
       const { provider } = base;
 
+      /*
+        This handler is registered for GET and POST on the same path. It read
+        only `req.body`, so every GET - which is what the picker sends - arrived
+        with query, limit and page undefined and fell through to an unfiltered
+        alphabetical first page of 50. Typing "SDMA" returned nothing, because
+        the client then filtered client-side over rows that never contained it.
+
+        Query-string values are always strings, so a `typeof === "number"` test
+        can never pass for a GET; the numbers are coerced rather than type-tested.
+      */
       const body = req.body as
         | {
             query?: string;
@@ -133,12 +143,45 @@ export const LabOrderController = {
             codes?: string[];
           }
         | undefined;
-      const query = typeof body?.query === "string" ? body.query : undefined;
-      const limit = typeof body?.limit === "number" ? body.limit : undefined;
-      const page = typeof body?.page === "number" ? body.page : undefined;
-      const codesParam = Array.isArray(body?.codes)
-        ? body?.codes.join(",")
-        : undefined;
+      const search = req.query as {
+        query?: unknown;
+        limit?: unknown;
+        page?: unknown;
+        codes?: unknown;
+      };
+
+      /* The body keeps its strict typing - a POST sending `limit: "10"` is a
+         malformed request and is dropped, which an existing test pins. Only the
+         query string is coerced, because there every value is a string by
+         definition. */
+      const queryString = (value: unknown): string | undefined =>
+        typeof value === "string" && value.trim() ? value : undefined;
+
+      /** Rejects NaN and Infinity, so a junk `?limit=abc` falls back to the
+       *  service's own default rather than reaching it as an unusable number. */
+      const queryNumber = (value: unknown): number | undefined => {
+        if (typeof value !== "string" || !value.trim()) return undefined;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      };
+
+      const query =
+        typeof body?.query === "string"
+          ? body.query
+          : queryString(search.query);
+      const limit =
+        typeof body?.limit === "number"
+          ? body.limit
+          : queryNumber(search.limit);
+      const page =
+        typeof body?.page === "number" ? body.page : queryNumber(search.page);
+
+      /* POST sends codes as an array; a GET sends a comma-separated string, and
+         express hands back an array when the param is repeated. */
+      const rawCodes = Array.isArray(body?.codes) ? body?.codes : search.codes;
+      const codesParam = Array.isArray(rawCodes)
+        ? rawCodes.join(",")
+        : queryString(rawCodes);
       const codes = codesParam
         ? codesParam
             .split(",")
@@ -148,8 +191,8 @@ export const LabOrderController = {
 
       const tests = await LabOrderService.listProviderTests(provider, {
         query,
-        limit: Number.isFinite(limit) ? limit : undefined,
-        page: Number.isFinite(page) ? page : undefined,
+        limit,
+        page,
         codes,
       });
 

--- a/apps/backend/test/controllers/web/lab-order.controller.test.ts
+++ b/apps/backend/test/controllers/web/lab-order.controller.test.ts
@@ -200,6 +200,94 @@ describe("LabOrderController", () => {
       );
       expect(statusMock).toHaveBeenCalledWith(200);
     });
+
+    it("reads the filters off the query string on a GET", async () => {
+      /* The picker sends a GET, and this handler is registered for GET as well
+         as POST. It used to read only req.body, so query/limit/page arrived
+         undefined and the service returned an unfiltered alphabetical first
+         page - typing "SDMA" found nothing while "ACTH" worked purely because
+         it sorts early (#2485). */
+      req.body = {};
+      req.query = { query: "SDMA", limit: "10", page: "3" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        { query: "SDMA", limit: 10, page: 3, codes: undefined },
+      );
+    });
+
+    it("prefers the body over the query string when both carry a value", async () => {
+      req.body = { query: "body-wins", limit: 5 };
+      req.query = { query: "ignored", limit: "99" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        { query: "body-wins", limit: 5, page: undefined, codes: undefined },
+      );
+    });
+
+    it("falls back rather than passing a non-numeric limit through", async () => {
+      /* Number("abc") is NaN, which would reach the service and fail its
+         `> 0` test in a way that silently reinstates the default. Rejected
+         here so the service sees `undefined` and applies its own default. */
+      req.body = {};
+      req.query = { limit: "abc", page: "" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        {
+          query: undefined,
+          limit: undefined,
+          page: undefined,
+          codes: undefined,
+        },
+      );
+    });
+
+    it("accepts codes as a comma-separated string on a GET", async () => {
+      req.body = {};
+      req.query = { codes: "A, B ,,C" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        expect.objectContaining({ codes: ["A", "B", "C"] }),
+      );
+    });
+
+    it("ignores a blank query rather than filtering on an empty string", async () => {
+      req.body = {};
+      req.query = { query: "   " };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        expect.objectContaining({ query: undefined }),
+      );
+    });
   });
 
   describe("createIdexxOrder", () => {


### PR DESCRIPTION
Closes #2485

## The cause

`listProviderTests` is registered for **GET and POST on the same path**, but read only `req.body`:

```ts
const query = typeof body?.query === "string" ? body.query : undefined;
const limit = typeof body?.limit === "number" ? body.limit : undefined;
```

The picker sends a GET — `listIdexxTests` calls `getData(url, { query, page, limit })` — so on every real request `req.body` was empty and all three arrived `undefined`. The service then fell through to an unfiltered listing with its default limit of 50.

That is exactly the reported behaviour: the same alphabetical first page regardless of `query`, and 50 rows for `limit=10`.

It also explains why `ACTH` appeared to work and `SDMA` did not. Neither was ever filtered server-side; `SearchDropdown` filters client-side over whatever is loaded, and `ACTH` happens to sort early enough to be inside that first page. Nothing about the search was working — it was coincidence.

**The service was already correct.** It builds the `OR` over `code`/`display` with `contains`/`insensitive` and applies `skip`/`take`. Only the controller needed to read the request it was given.

## What changed

The controller now falls back to `req.query` when the body carries nothing.

**The body keeps its strict typing.** A POST sending `limit: "10"` is a malformed request and is still dropped — `lab-order.controller.test.ts` has a test pinning exactly that, and my first attempt loosened both paths and broke it. Only the query string is coerced, because there every value is a string by definition, which is also why the original `typeof === "number"` test could never have passed for a GET.

Non-numeric values fall back to `undefined` rather than reaching the service as `NaN`, where its own `> 0` check would have silently reinstated the default — the same wrong answer, one layer further from the cause.

`codes` now accepts both shapes: an array from a POST body, a comma-separated string or repeated param from a GET.

## Validation

- **459 suites / 11084 backend tests pass**
- **Mutation-checked**: restoring the body-only read fails exactly the new GET test and nothing else
- Five new tests: the GET path, body-wins precedence, non-numeric fallback, comma-separated codes, and a whitespace-only query being ignored rather than filtered on
- `npx tsc --noEmit`: **0 errors**. `pnpm --filter backend run lint`: **exit 0, clean**

> **Correction.** An earlier revision of this description claimed a baseline of "482 tsc errors and 13419 lint problems on `dev`, pre-existing". That was wrong, and it was my own environment: I had not run `pnpm --filter @yosemite-crew/database run build` in this worktree, so `@yosemite-crew/database` had no `dist`, every type importing through it resolved to an error type, and `@typescript-eslint/no-unsafe-*` reported thousands of hits. Building that one package takes both to zero. CI was right and I was measuring a broken local setup.

## Not covered here

I verified the fix against the controller, not against a live IDEXX catalogue. The service-side query was already in place and unchanged, so the remaining risk is whether `contains`/`insensitive` over `code` and `display` matches what a clinician types — `"IDEXX SDMA® Test"` contains `SDMA`, so the reported case is covered, but a fuzzier expectation (abbreviations, synonyms) is a separate question from this bug.

## Impact area

`apps/backend` — one controller method. No service, schema or frontend change.

