### PR TITLE
fix(repo): integer pagination and out-of-order search responses on lab tests

### DIFF
--- a/apps/backend/src/controllers/web/lab-order.controller.ts
+++ b/apps/backend/src/controllers/web/lab-order.controller.ts
@@ -165,14 +165,13 @@ export const LabOrderController = {
        * Applied to the body too: `{ limit: 2.5 }` is a number and would have
        * taken the same path.
        */
+      const positiveInteger = (value: number): number | undefined =>
+        Number.isSafeInteger(value) && value > 0 ? value : undefined;
+
       const paginationValue = (value: unknown): number | undefined => {
-        const parsed =
-          typeof value === "number"
-            ? value
-            : typeof value === "string" && value.trim()
-              ? Number(value)
-              : Number.NaN;
-        return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+        if (typeof value === "number") return positiveInteger(value);
+        if (typeof value !== "string" || !value.trim()) return undefined;
+        return positiveInteger(Number(value));
       };
 
       const query =

--- a/apps/backend/src/controllers/web/lab-order.controller.ts
+++ b/apps/backend/src/controllers/web/lab-order.controller.ts
@@ -157,24 +157,37 @@ export const LabOrderController = {
       const queryString = (value: unknown): string | undefined =>
         typeof value === "string" && value.trim() ? value : undefined;
 
-      /** Rejects NaN and Infinity, so a junk `?limit=abc` falls back to the
-       *  service's own default rather than reaching it as an unusable number. */
-      const queryNumber = (value: unknown): number | undefined => {
-        if (typeof value !== "string" || !value.trim()) return undefined;
-        const parsed = Number(value);
-        return Number.isFinite(parsed) ? parsed : undefined;
+      /**
+       * Pagination has to be a positive integer, not merely a finite number.
+       * `skip`/`take` reach Prisma, which rejects a fractional value, so
+       * `?limit=2.5` turned into a 500 instead of falling back to the default -
+       * the service's own `> 0` guard passes a fraction straight through.
+       * Applied to the body too: `{ limit: 2.5 }` is a number and would have
+       * taken the same path.
+       */
+      const paginationValue = (value: unknown): number | undefined => {
+        const parsed =
+          typeof value === "number"
+            ? value
+            : typeof value === "string" && value.trim()
+              ? Number(value)
+              : Number.NaN;
+        return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
       };
 
       const query =
         typeof body?.query === "string"
           ? body.query
           : queryString(search.query);
-      const limit =
-        typeof body?.limit === "number"
-          ? body.limit
-          : queryNumber(search.limit);
-      const page =
-        typeof body?.page === "number" ? body.page : queryNumber(search.page);
+      /* The body stays strict about type - a POST sending `limit: "10"` is
+         malformed and is dropped, which an existing test pins - but both paths
+         share the same integer requirement. */
+      const limit = paginationValue(
+        typeof body?.limit === "number" ? body.limit : search.limit,
+      );
+      const page = paginationValue(
+        typeof body?.page === "number" ? body.page : search.page,
+      );
 
       /* POST sends codes as an array; a GET sends a comma-separated string, and
          express hands back an array when the param is repeated. */

--- a/apps/backend/test/controllers/web/lab-order.controller.test.ts
+++ b/apps/backend/test/controllers/web/lab-order.controller.test.ts
@@ -259,6 +259,56 @@ describe("LabOrderController", () => {
       );
     });
 
+    it("rejects fractional pagination rather than passing it to Prisma", async () => {
+      /* skip/take reach Prisma, which requires integers, so ?limit=2.5 turned
+         into a 500 instead of falling back to the default. The service's own
+         `> 0` guard passes a fraction straight through. */
+      req.body = {};
+      req.query = { limit: "2.5", page: "1.5" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        expect.objectContaining({ limit: undefined, page: undefined }),
+      );
+    });
+
+    it("applies the same integer requirement to a body", async () => {
+      // `{ limit: 2.5 }` is a number, so the strict body path would otherwise
+      // have handed Prisma the same fraction.
+      req.body = { limit: 2.5, page: 0 };
+      req.query = {};
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        expect.objectContaining({ limit: undefined, page: undefined }),
+      );
+    });
+
+    it("still accepts whole-number pagination from either source", async () => {
+      req.body = {};
+      req.query = { limit: "25", page: "2" };
+      (mockedLabOrderService.listProviderTests as any).mockResolvedValue({
+        tests: [],
+      } as any);
+
+      await LabOrderController.listProviderTests(req as Request, res);
+
+      expect(mockedLabOrderService.listProviderTests).toHaveBeenCalledWith(
+        "idexx",
+        expect.objectContaining({ limit: 25, page: 2 }),
+      );
+    });
+
     it("accepts codes as a comma-separated string on a GET", async () => {
       req.body = {};
       req.query = { codes: "A, B ,,C" };

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
@@ -1089,6 +1089,59 @@ describe('LabTests', () => {
     });
   });
 
+  it('ignores a slow earlier search that lands after a newer one', async () => {
+    /* The backend now filters on `query` server-side (#2485), so two in-flight
+       searches return DIFFERENT result sets. Before the request-generation
+       guard, a slower earlier response landing last overwrote the newer results
+       and left the picker showing tests for text the user had already changed.
+       While every response was the same unfiltered page this was unobservable,
+       which is why the 300ms debounce alone had been enough. */
+    const deferred = () => {
+      let resolve!: (value: unknown) => void;
+      const promise = new Promise((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    };
+    const first = deferred();
+    const second = deferred();
+
+    listIdexxTestsMock
+      .mockReturnValueOnce(Promise.resolve({ tests: [] }))
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render(<LabTests activeAppointment={appointment} />);
+    await waitFor(() => {
+      expect(listIdexxTestsMock).toHaveBeenCalledTimes(1);
+    });
+
+    const input = screen.getByTestId('query-Search IDEXX tests');
+
+    fireEvent.change(input, { target: { value: 'SD' } });
+    await waitFor(() => {
+      expect(listIdexxTestsMock).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.change(input, { target: { value: 'SDMA' } });
+    await waitFor(() => {
+      expect(listIdexxTestsMock).toHaveBeenCalledTimes(3);
+    });
+
+    // The NEWER request settles first...
+    await act(async () => {
+      second.resolve({ tests: [{ _id: 't2', code: '3638', display: 'IDEXX SDMA Test' }] });
+    });
+    // ...and then the older one lands late with a different set.
+    await act(async () => {
+      first.resolve({ tests: [{ _id: 't1', code: '0000', display: 'Stale SD Result' }] });
+    });
+
+    const options = screen.getByTestId('rendered-options-Search IDEXX tests').textContent ?? '';
+    expect(options).toContain('IDEXX SDMA Test');
+    expect(options).not.toContain('Stale SD Result');
+  });
+
   it('clears tests and surfaces an error when the search request fails', async () => {
     listIdexxTestsMock.mockRejectedValue(new Error('boom'));
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -326,8 +326,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
   const fetchTestsPage = useCallback(
     async (page: number, append: boolean) => {
       if (!primaryOrgId || !integrationEnabled) return;
-      const seq = testsRequestSeq.current + 1;
-      testsRequestSeq.current = seq;
+      const seq = ++testsRequestSeq.current;
       if (append) setTestsLoadingMore(true);
       try {
         const res = await listIdexxTests({

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -314,9 +314,20 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
     void run();
   }, [primaryOrgId, integrationEnabled]);
 
+  /* Guards against an out-of-order response. The backend now filters on `query`
+     server-side, so two in-flight searches return DIFFERENT result sets - and a
+     slower earlier one landing last would overwrite the newer results, leaving
+     the picker showing tests for text the user has already changed. While every
+     response was the same unfiltered page this could not be observed, which is
+     why the debounce alone was enough before. Compared rather than aborted so a
+     superseded request still settles harmlessly. */
+  const testsRequestSeq = React.useRef(0);
+
   const fetchTestsPage = useCallback(
     async (page: number, append: boolean) => {
       if (!primaryOrgId || !integrationEnabled) return;
+      const seq = testsRequestSeq.current + 1;
+      testsRequestSeq.current = seq;
       if (append) setTestsLoadingMore(true);
       try {
         const res = await listIdexxTests({
@@ -325,15 +336,19 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
           page,
           limit: TESTS_PAGE_SIZE,
         });
+        if (seq !== testsRequestSeq.current) return;
         const nextBatch = res.tests ?? [];
         setTests((prev) => (append ? mergeUniqueTests(prev, nextBatch) : nextBatch));
         setTestsPage(page);
         setTestsHasMore(nextBatch.length >= TESTS_PAGE_SIZE);
       } catch (e) {
+        if (seq !== testsRequestSeq.current) return;
         if (!append) setTests([]);
         setError(getApiErrorMessage(e, 'Unable to load IDEXX tests.'));
       } finally {
-        if (append) setTestsLoadingMore(false);
+        /* Only the newest request owns the spinner; an older one clearing it
+           would hide that a newer fetch is still running. */
+        if (append && seq === testsRequestSeq.current) setTestsLoadingMore(false);
       }
     },
     [integrationEnabled, primaryOrgId, query]


### PR DESCRIPTION
Follow-up to [#2660](https://github.com/YosemiteCrew/Yosemite-Crew/pull/2660). Two Codex P2 findings on that PR, both correct and both consequences of it. I merged #2660 before reading them, which was the wrong order — this is the fix.

## 1. Fractional pagination reached Prisma

`queryNumber` accepted any finite value, so `?limit=2.5` passed the service's own `> 0` guard and became a fractional `take`. Prisma requires integers, so the endpoint answered **500** instead of falling back to the default.

Pagination now requires a **positive safe integer**.

**Applied to the body path too**, which the review did not mention but has the same hole: `{ limit: 2.5 }` is a number, so it took the identical route into the service. The body stays strict about *type* — a POST sending `limit: "10"` is still dropped, which an existing test pins — but both paths now share the integer requirement.

## 2. Out-of-order search responses

Honouring `query` means two in-flight searches return **different** result sets. `fetchTestsPage` called `setTests(nextBatch)` unconditionally, so a slower earlier response landing last replaced the newer results with tests for text the user had already changed.

While every response was the same unfiltered page this was unobservable — which is exactly why the 300ms debounce alone had been sufficient until now. My fix to the backend is what made it reachable.

A request-generation counter now discards a superseded response rather than aborting it, so an in-flight request still settles harmlessly. Only the newest request clears the loading flag; an older one doing so would hide that a newer fetch is still running.

## Validation

Both guards **mutation-checked**:

| mutation | caught by |
|---|---|
| remove the generation guard | the new race test, and nothing else |
| `Number.isSafeInteger` → `Number.isFinite` | both new pagination tests |

The race test resolves the two requests deliberately out of order — newer first, then the stale one — and asserts the picker still shows the newer set.

- backend `tsc` **0 errors**, `lint` **exit 0**
- frontend `tsc` **exit 0**, `lint` **0 errors**
- **101 backend** and **103 frontend** tests pass across the touched suites

## Impact area

`apps/backend` (one controller method) and `apps/frontend` (one callback in `LabTests.tsx`).