### PR TITLE
chore(repo): wire eslint-plugin-sonarjs in and clear the Zod deprecations it found

### DIFF
--- a/apps/backend/eslint.config.js
+++ b/apps/backend/eslint.config.js
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import sonarjs from "eslint-plugin-sonarjs";
 import tseslint from "typescript-eslint";
 
 export default [
@@ -30,6 +31,64 @@ export default [
       },
     },
   ),
+  /*
+    Sonar smells, locally (#2565). The backend gate runs with an issues ceiling
+    of 0, so a single MAJOR smell blocks the merge - and until now the first
+    sight of one was a red `sonar` check about ten minutes into CI.
+
+    It is a proxy, not SonarCloud. Each rule turned off below was measured
+    against this repo and shown to fire where SonarCloud does not; leaving them
+    on would make `lint` red over findings the gate never raises, which teaches
+    people to ignore the linter.
+  */
+  {
+    ...sonarjs.configs.recommended,
+    files: ["**/*.ts"],
+  },
+  {
+    files: ["**/*.ts"],
+    rules: {
+      /* Fires on canonical system URIs, which are identifiers rather than
+         requests: "http://snomed.info/sct" in clinical-terms.service.ts is a
+         fixed string defined by SNOMED CT, and rewriting it to https breaks
+         FHIR conformance. */
+      "sonarjs/no-clear-text-protocols": "off",
+      /* SonarCloud honours NOSONAR and eslint does not, so this reports the
+         PassKit SHA-1 in wallet-pass.service.ts that already carries a NOSONAR
+         and an explanation - Apple's manifest format mandates SHA-1. */
+      "sonarjs/hashing": "off",
+      // app.ts calls app.disable("x-powered-by") and mounts helmet.
+      "sonarjs/x-powered-by": "off",
+      // Duplicates @typescript-eslint's own unused-vars, already enforced.
+      "sonarjs/no-unused-vars": "off",
+      /* Warnings, not errors: SonarCloud does not raise these on this project,
+         so failing the build on them would make `lint` red over findings the
+         gate never asks about. They are left visible because some are worth
+         looking at.
+
+         different-types-comparison is the clearest example of why. It fires on
+         `value === null` where the parameter is typed `value?: string | number
+         | Date` - by the type, null is impossible, so the check "can never be
+         true". These are controllers reading untrusted input, where a null very
+         much can arrive at runtime, so the check is correct and the type is
+         simply narrower than reality. */
+      "sonarjs/different-types-comparison": "warn",
+      "sonarjs/function-return-type": "warn",
+      "sonarjs/use-type-alias": "warn",
+      "sonarjs/no-redundant-optional": "warn",
+    },
+  },
+  {
+    /* The one remaining deprecation is documenso.documents.createV0, which
+       already carries a NOSONAR and an explanation there - SonarCloud honours
+       that comment and eslint does not. Migrating it is #2643, and it cannot be
+       verified without a live Documenso instance, so it is scoped off here
+       rather than suppressed inline. Delete this block when #2643 lands. */
+    files: ["src/services/documenso.service.ts"],
+    rules: {
+      "sonarjs/deprecation": "off",
+    },
+  },
   {
     // Auth boundary guard (#1672): product code must use the provider-neutral
     // boundary from @yosemite-crew/auth. Provider SDKs may only be imported

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -92,6 +92,7 @@
     "chromium-bidi": "^17.0.2",
     "esbuild": "^0.28.2",
     "eslint": "^9.27.0",
+    "eslint-plugin-sonarjs": "^4.2.0",
     "jest": "^30.4.2",
     "jose": "^6.2.8",
     "nodemon": "^3.1.14",

--- a/apps/backend/src/controllers/app/finance.controller.ts
+++ b/apps/backend/src/controllers/app/finance.controller.ts
@@ -34,7 +34,7 @@ const CreateInvoicePaymentSessionBodySchema = z.object({
   provider: z.string().trim().min(1).optional(),
   // Major units. Present when the caller is collecting a deposit rather than
   // the whole outstanding balance.
-  depositAmount: z.number().finite().positive().optional(),
+  depositAmount: z.number().positive().optional(),
 });
 
 const InvoiceItemBodySchema = z.object({
@@ -145,8 +145,8 @@ const SubscriptionCheckoutCompletedBodySchema = z.object({
     ])
     .optional(),
   cancelAtPeriodEnd: z.boolean().optional(),
-  currentPeriodStart: z.string().datetime().optional(),
-  currentPeriodEnd: z.string().datetime().optional(),
+  currentPeriodStart: z.iso.datetime().optional(),
+  currentPeriodEnd: z.iso.datetime().optional(),
   livemode: z.boolean().optional(),
   seatQuantity: z.number().int().nonnegative().optional(),
 });
@@ -167,10 +167,10 @@ const SubscriptionUpdatedBodySchema = z.object({
     ])
     .optional(),
   cancelAtPeriodEnd: z.boolean().optional(),
-  canceledAt: z.string().datetime().optional(),
+  canceledAt: z.iso.datetime().optional(),
   seatQuantity: z.number().int().nonnegative().optional(),
-  currentPeriodStart: z.string().datetime().optional(),
-  currentPeriodEnd: z.string().datetime().optional(),
+  currentPeriodStart: z.iso.datetime().optional(),
+  currentPeriodEnd: z.iso.datetime().optional(),
 });
 
 const SubscriptionLifecycleBodySchema = z.object({
@@ -186,7 +186,7 @@ const UsageEventBodySchema = z.object({
   referenceType: z.string().trim().min(1).optional(),
   referenceId: z.string().trim().min(1).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
-  occurredAt: z.string().datetime().optional(),
+  occurredAt: z.iso.datetime().optional(),
 });
 
 const UsageSnapshotBodySchema = z.object({
@@ -196,7 +196,7 @@ const UsageSnapshotBodySchema = z.object({
   appointmentsUsed: z.number().int().nonnegative().optional(),
   toolsUsed: z.number().int().nonnegative().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
-  snapshotAt: z.string().datetime().optional(),
+  snapshotAt: z.iso.datetime().optional(),
 });
 
 const RecordInvoicePaymentBodySchema = z.object({
@@ -205,13 +205,13 @@ const RecordInvoicePaymentBodySchema = z.object({
   amount: z.number().positive(),
   currency: z.string().trim().min(1).optional(),
   reference: z.string().trim().min(1).optional(),
-  receivedAt: z.string().datetime().optional(),
+  receivedAt: z.iso.datetime().optional(),
 });
 
 const CloseoutInvoiceBodySchema = z.object({
   settlementChannel: z.string().trim().min(1).optional(),
   reference: z.string().trim().min(1).optional(),
-  receivedAt: z.string().datetime().optional(),
+  receivedAt: z.iso.datetime().optional(),
 });
 
 const RefundPaymentBodySchema = z.object({

--- a/apps/backend/src/controllers/app/public-booking.controller.ts
+++ b/apps/backend/src/controllers/app/public-booking.controller.ts
@@ -34,11 +34,11 @@ const timeOfDay = z
  * submission carrying a megabyte of text into either.
  */
 const RequestSchema = z.object({
-  serviceId: z.string().uuid(),
+  serviceId: z.uuid(),
   date: isoDate,
   startTime: timeOfDay,
   ownerName: z.string().trim().min(1).max(120),
-  ownerEmail: z.string().trim().email().max(254),
+  ownerEmail: z.string().trim().pipe(z.email().max(254)),
   ownerPhone: z.string().trim().max(40).optional().nullable(),
   petName: z.string().trim().min(1).max(120),
   petSpecies: z.string().trim().min(1).max(60),
@@ -52,7 +52,7 @@ const RequestSchema = z.object({
 });
 
 const SlotsQuerySchema = z.object({
-  serviceId: z.string().uuid(),
+  serviceId: z.uuid(),
   date: isoDate,
 });
 

--- a/apps/backend/src/controllers/web/activitypub.controller.ts
+++ b/apps/backend/src/controllers/web/activitypub.controller.ts
@@ -106,7 +106,7 @@ const PatientSummarySchema = z.object({
 });
 
 const SendReferralBodySchema = z.object({
-  toActorUri: z.string().url().max(512),
+  toActorUri: z.url().max(512),
   patientSummary: PatientSummarySchema,
   urgency: ReferralUrgencySchema.optional(),
   clinicalContext: z.string().max(5000).optional(),

--- a/apps/backend/src/controllers/web/aftercare-plan.controller.ts
+++ b/apps/backend/src/controllers/web/aftercare-plan.controller.ts
@@ -21,7 +21,7 @@ const AftercareTypeEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   type: AftercareTypeEnum,
   provider: z.string().max(200).optional(),
   estimatedCost: z.number().min(0).optional(),
@@ -31,7 +31,7 @@ const CreateBodySchema = z.object({
   urnsRequested: z.number().int().min(0).optional(),
   instructions: z.string().max(3000).optional(),
   certificateNumber: z.string().max(100).optional(),
-  completedAt: z.string().datetime().optional(),
+  completedAt: z.iso.datetime().optional(),
   notes: z.string().max(3000).optional(),
 });
 
@@ -41,7 +41,7 @@ const UpdateBodySchema = CreateBodySchema.omit({
 }).partial();
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   type: AftercareTypeEnum.optional(),
   completed: z.string().optional().transform(parseOptionalBooleanFlag),
 });

--- a/apps/backend/src/controllers/web/appointment-reminder-log.controller.ts
+++ b/apps/backend/src/controllers/web/appointment-reminder-log.controller.ts
@@ -26,12 +26,8 @@ const RecordSchema = z.object({
   clientId: z.string(),
   channel: ChannelEnum,
   outcome: OutcomeEnum.optional(),
-  sentAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
-  respondedAt: z
-    .string()
+  sentAt: z.iso.datetime().transform((v) => new Date(v)),
+  respondedAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),
@@ -42,8 +38,7 @@ const RecordSchema = z.object({
 
 const UpdateOutcomeSchema = z.object({
   outcome: OutcomeEnum,
-  respondedAt: z
-    .string()
+  respondedAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),

--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -134,7 +134,7 @@ const resolveAuthorizedOrganisationId = (req: Request): string | undefined => {
 };
 
 const admitAppointmentSchema = z.object({
-  admittedAt: z.string().datetime().optional(),
+  admittedAt: z.iso.datetime().optional(),
   expectedStayDays: z.number().int().nonnegative().optional(),
   lead: z
     .object({
@@ -158,7 +158,7 @@ const admitAppointmentSchema = z.object({
     })
     .optional(),
   roomUnitId: z.string().trim().min(1).optional(),
-  assignedAt: z.string().datetime().optional(),
+  assignedAt: z.iso.datetime().optional(),
   assignedBy: z.string().trim().min(1).optional(),
   assignmentReason: z.string().trim().min(1).optional(),
 });

--- a/apps/backend/src/controllers/web/behavior-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/behavior-assessment.controller.ts
@@ -26,9 +26,9 @@ const HandlingToleranceEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   fasScore: FasScoreEnum.optional(),
   nailTrimTolerance: HandlingToleranceEnum.optional(),
   handlingTolerance: HandlingToleranceEnum.optional(),

--- a/apps/backend/src/controllers/web/blood-bank.controller.ts
+++ b/apps/backend/src/controllers/web/blood-bank.controller.ts
@@ -29,23 +29,23 @@ const DonationStatusEnum = z.enum([
 const CrossmatchSchema = z.object({
   recipientId: z.string().max(100),
   compatible: z.boolean(),
-  testedAt: z.string().datetime().optional(),
+  testedAt: z.iso.datetime().optional(),
   notes: z.string().max(500).optional(),
 });
 
 const RegisterDonorSchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   bloodType: BloodTypeEnum,
-  lastScreeningAt: z.string().datetime().optional(),
+  lastScreeningAt: z.iso.datetime().optional(),
   isActive: z.boolean().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const UpdateDonorSchema = z.object({
   bloodType: BloodTypeEnum.optional(),
-  lastScreeningAt: z.string().datetime().optional(),
-  lastDonationAt: z.string().datetime().optional(),
-  nextEligibleAt: z.string().datetime().optional(),
+  lastScreeningAt: z.iso.datetime().optional(),
+  lastDonationAt: z.iso.datetime().optional(),
+  nextEligibleAt: z.iso.datetime().optional(),
   isActive: z.boolean().optional(),
   totalDonations: z.number().int().min(0).optional(),
   disqualificationReason: z.string().max(1000).optional(),
@@ -58,12 +58,12 @@ const ListDonorsQuerySchema = z.object({
 });
 
 const RecordDonationSchema = z.object({
-  donorId: z.string().uuid(),
-  collectedAt: z.string().datetime(),
+  donorId: z.uuid(),
+  collectedAt: z.iso.datetime(),
   volumeMl: z.number().positive(),
   anticoagulant: z.string().max(100).optional(),
   unitId: z.string().max(100).optional(),
-  expiresAt: z.string().datetime().optional(),
+  expiresAt: z.iso.datetime().optional(),
   crossmatchResults: z.array(CrossmatchSchema).optional(),
   notes: z.string().max(2000).optional(),
 });
@@ -75,7 +75,7 @@ const UpdateDonationSchema = z.object({
 });
 
 const ListDonationsQuerySchema = z.object({
-  donorId: z.string().uuid().optional(),
+  donorId: z.uuid().optional(),
   status: DonationStatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/blood-transfusion.controller.ts
+++ b/apps/backend/src/controllers/web/blood-transfusion.controller.ts
@@ -29,14 +29,14 @@ const ReactionEnum = z.enum([
 ]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   donorId: z.string().max(200).optional(),
   productType: z.string().min(1).max(200),
   bloodType: BloodTypeEnum,
   volumeMl: z.number().positive(),
-  startedAt: z.string().datetime(),
-  endedAt: z.string().datetime().optional(),
+  startedAt: z.iso.datetime(),
+  endedAt: z.iso.datetime().optional(),
   durationMinutes: z.number().int().positive().optional(),
   reaction: ReactionEnum.optional(),
   reactionNotes: z.string().max(2000).optional(),
@@ -52,7 +52,7 @@ const ReactionBodySchema = z.object({
 });
 
 const UpdateBodySchema = z.object({
-  endedAt: z.string().datetime().optional(),
+  endedAt: z.iso.datetime().optional(),
   durationMinutes: z.number().int().positive().optional(),
   reaction: ReactionEnum.optional(),
   reactionNotes: z.string().max(2000).optional(),

--- a/apps/backend/src/controllers/web/body-condition.controller.ts
+++ b/apps/backend/src/controllers/web/body-condition.controller.ts
@@ -14,25 +14,25 @@ import {
 const BcsScaleEnum = z.enum(["BCS_5", "BCS_9"]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   bcsScale: BcsScaleEnum,
   bcsScore: z.number().min(1).max(9),
   muscleConditionScore: z.string().max(200).optional(),
   weightKg: z.number().min(0).max(1000).optional(),
   bodyFatPercentage: z.number().min(0).max(100).optional(),
-  recordedAt: z.string().datetime(),
+  recordedAt: z.iso.datetime(),
   notes: z.string().max(2000).optional(),
 });
 
 const ListQuerySchema = patientScopeQuery.extend({
   bcsScale: BcsScaleEnum.optional(),
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const TrendQuerySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   limit: z
     .string()
     .transform((v) => Number.parseInt(v, 10))

--- a/apps/backend/src/controllers/web/booking-page.controller.ts
+++ b/apps/backend/src/controllers/web/booking-page.controller.ts
@@ -29,12 +29,12 @@ import {
  * inheriting whatever an admin typed.
  */
 const SettingsSchema = z.object({
-  serviceIds: z.array(z.string().uuid()).max(200),
+  serviceIds: z.array(z.uuid()).max(200),
   bookingWindowDays: z.number().int().min(1).max(180),
   bufferMinutes: z.number().int().min(0).max(240),
   autoConfirm: z.boolean(),
   welcomeMessage: z.string().trim().max(500).nullish(),
-  replyToEmail: z.string().trim().email().max(254).nullish(),
+  replyToEmail: z.string().trim().pipe(z.email().max(254)).nullish(),
   // Optional on purpose: a caller that omits it is saving settings, not
   // changing what the public can reach.
   publicBookingEnabled: z.boolean().optional(),

--- a/apps/backend/src/controllers/web/cardiology-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/cardiology-assessment.controller.ts
@@ -33,9 +33,9 @@ const MurmurGradeEnum = z.enum([
 const AcvimClassEnum = z.enum(["A", "B1", "B2", "C", "D"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   heartRate: z.number().int().min(1).max(500).optional(),
   heartRhythm: HeartRhythmEnum.optional(),
   murmurGrade: MurmurGradeEnum.optional(),

--- a/apps/backend/src/controllers/web/care-reminder.controller.ts
+++ b/apps/backend/src/controllers/web/care-reminder.controller.ts
@@ -27,32 +27,32 @@ const ReminderStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   reminderType: ReminderTypeEnum,
   customMessage: z.string().max(1000).optional(),
-  dueDate: z.string().datetime(),
-  sendAt: z.string().datetime().optional(),
+  dueDate: z.iso.datetime(),
+  sendAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const BulkCreateBodySchema = z.object({
-  patientIds: z.array(z.string().uuid()).min(1).max(200),
+  patientIds: z.array(z.uuid()).min(1).max(200),
   reminderType: ReminderTypeEnum,
   customMessage: z.string().max(1000).optional(),
-  dueDate: z.string().datetime(),
-  sendAt: z.string().datetime().optional(),
+  dueDate: z.iso.datetime(),
+  sendAt: z.iso.datetime().optional(),
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: ReminderStatusEnum.optional(),
   reminderType: ReminderTypeEnum.optional(),
-  dueBefore: z.string().datetime().optional(),
-  dueAfter: z.string().datetime().optional(),
+  dueBefore: z.iso.datetime().optional(),
+  dueAfter: z.iso.datetime().optional(),
 });
 
 const MarkRespondedBodySchema = z.object({
-  appointmentId: z.string().uuid().optional(),
+  appointmentId: z.uuid().optional(),
 });
 
 const ReminderParamsSchema = orgParams.extend({ reminderId: uuid() });

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -49,7 +49,7 @@ const dischargeEncounterSchema = z
       .array(
         z.object({
           name: z.string(),
-          valueDateTime: z.string().datetime().optional(),
+          valueDateTime: z.iso.datetime().optional(),
           valueString: z.string().trim().min(1).optional(),
         }),
       )
@@ -64,7 +64,7 @@ const assignUnitSchema = z
         z.object({
           name: z.string(),
           valueString: z.string().optional(),
-          valueDateTime: z.string().datetime().optional(),
+          valueDateTime: z.iso.datetime().optional(),
         }),
       )
       .optional(),
@@ -77,7 +77,7 @@ const lifecycleOperationSchema = z
       .array(
         z.object({
           name: z.string(),
-          valueDateTime: z.string().datetime().optional(),
+          valueDateTime: z.iso.datetime().optional(),
         }),
       )
       .optional(),

--- a/apps/backend/src/controllers/web/catalog.controller.ts
+++ b/apps/backend/src/controllers/web/catalog.controller.ts
@@ -163,7 +163,7 @@ const specialityMutationSchema = z.object({
   name: z.string().trim().min(1).optional(),
   headUserId: z.string().trim().min(1).nullable().optional(),
   headName: z.string().trim().min(1).nullable().optional(),
-  headProfilePicUrl: z.string().trim().url().nullable().optional(),
+  headProfilePicUrl: z.string().trim().pipe(z.url()).nullable().optional(),
   teamMemberIds: z.array(z.string().trim().min(1)).optional(),
 });
 

--- a/apps/backend/src/controllers/web/client-complaint.controller.ts
+++ b/apps/backend/src/controllers/web/client-complaint.controller.ts
@@ -29,7 +29,7 @@ const CreateComplaintSchema = z.object({
   category: CategoryEnum.optional(),
   summary: z.string().min(1),
   description: z.string().optional(),
-  reportedAt: z.string().datetime().optional(),
+  reportedAt: z.iso.datetime().optional(),
   reportedBy: z.string().optional(),
   assignedTo: z.string().optional(),
 });
@@ -40,7 +40,7 @@ const UpdateComplaintSchema = z.object({
   summary: z.string().min(1).optional(),
   description: z.string().optional(),
   assignedTo: z.string().optional(),
-  resolvedAt: z.string().datetime().optional(),
+  resolvedAt: z.iso.datetime().optional(),
   resolutionNotes: z.string().optional(),
 });
 

--- a/apps/backend/src/controllers/web/clinic-equipment.controller.ts
+++ b/apps/backend/src/controllers/web/clinic-equipment.controller.ts
@@ -24,13 +24,11 @@ const CreateEquipmentSchema = z.object({
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   manufacturer: z.string().optional(),
-  purchasedAt: z
-    .string()
+  purchasedAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),
-  warrantyExpiry: z
-    .string()
+  warrantyExpiry: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),
@@ -43,17 +41,12 @@ const AddMaintenanceLogSchema = z.object({
   maintenanceType: MaintenanceTypeEnum,
   performedBy: z.string().optional(),
   vendor: z.string().optional(),
-  scheduledAt: z
-    .string()
+  scheduledAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),
-  performedAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
-  nextDueAt: z
-    .string()
+  performedAt: z.iso.datetime().transform((v) => new Date(v)),
+  nextDueAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),

--- a/apps/backend/src/controllers/web/clinical-progress-note.controller.ts
+++ b/apps/backend/src/controllers/web/clinical-progress-note.controller.ts
@@ -20,8 +20,8 @@ const NoteTypeEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   noteType: NoteTypeEnum,
   subjectiveFindings: z.string().max(10000).optional(),
   objectiveFindings: z.string().max(10000).optional(),

--- a/apps/backend/src/controllers/web/companion-history.controller.ts
+++ b/apps/backend/src/controllers/web/companion-history.controller.ts
@@ -26,7 +26,7 @@ const DEFAULT_NON_LAB_TYPES: HistoryEntryType[] = [
 ];
 
 const ObjectIdSchema = z.string().regex(/^[a-fA-F0-9]{24}$/);
-const UuidSchema = z.string().uuid();
+const UuidSchema = z.uuid();
 const CompanionIdSchema = z.union([ObjectIdSchema, UuidSchema]);
 
 const ParamsSchema = z.object({

--- a/apps/backend/src/controllers/web/controlled-substance-log.controller.ts
+++ b/apps/backend/src/controllers/web/controlled-substance-log.controller.ts
@@ -21,9 +21,9 @@ const DrugUnitEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid().optional(),
-  encounterId: z.string().uuid().optional(),
-  loggedAt: z.string().datetime(),
+  patientId: z.uuid().optional(),
+  encounterId: z.uuid().optional(),
+  loggedAt: z.iso.datetime(),
   drug: z.string().min(1).max(200),
   deaSchedule: DeaScheduleEnum,
   lotNumber: z.string().max(100).optional(),
@@ -52,11 +52,11 @@ const UpdateBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   drug: z.string().optional(),
   deaSchedule: DeaScheduleEnum.optional(),
-  fromDate: z.string().datetime().optional(),
-  toDate: z.string().datetime().optional(),
+  fromDate: z.iso.datetime().optional(),
+  toDate: z.iso.datetime().optional(),
 });
 
 const LogParamsSchema = orgParams.extend({ logId: uuid() });

--- a/apps/backend/src/controllers/web/deceased-record.controller.ts
+++ b/apps/backend/src/controllers/web/deceased-record.controller.ts
@@ -29,7 +29,7 @@ const BodyDispositionEnum = z.enum([
  * record is first written, and every field is optional on update.
  */
 const DeceasedRecordFieldsSchema = z.object({
-  deceasedAt: z.string().datetime(),
+  deceasedAt: z.iso.datetime(),
   causeOfDeathType: CauseOfDeathEnum,
   causeOfDeathDetail: z.string().optional(),
   bodyWeightKg: z.number().positive().optional(),
@@ -37,14 +37,14 @@ const DeceasedRecordFieldsSchema = z.object({
   necropsyRequested: z.boolean().optional(),
   necropsyFacility: z.string().optional(),
   bodyDisposition: BodyDispositionEnum.optional(),
-  ownerNotifiedAt: z.string().datetime().optional(),
+  ownerNotifiedAt: z.iso.datetime().optional(),
   certifiedBy: z.string().optional(),
   notes: z.string().optional(),
 });
 
 const CreateDeceasedRecordSchema = z
   .object({ patientId: z.string() })
-  .merge(DeceasedRecordFieldsSchema);
+  .extend(DeceasedRecordFieldsSchema.shape);
 
 const UpdateDeceasedRecordSchema = DeceasedRecordFieldsSchema.partial();
 

--- a/apps/backend/src/controllers/web/dental-examination.controller.ts
+++ b/apps/backend/src/controllers/web/dental-examination.controller.ts
@@ -44,9 +44,9 @@ const ToothFindingSchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  examinedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  examinedAt: z.iso.datetime(),
   overallGrade: DentalGradeEnum,
   findings: z.array(ToothFindingSchema),
   calculusScore: z.number().int().min(0).max(3).optional(),

--- a/apps/backend/src/controllers/web/dermatology-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/dermatology-assessment.controller.ts
@@ -17,9 +17,9 @@ const LesionMapRegionSchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   pruritusScore: z.number().int().min(0).max(10).optional(),
   affectedRegions: z.array(z.string().max(200)).optional(),
   primaryLesions: z.array(z.string().max(200)).optional(),

--- a/apps/backend/src/controllers/web/developer-api-key.controller.ts
+++ b/apps/backend/src/controllers/web/developer-api-key.controller.ts
@@ -25,8 +25,8 @@ import { resolveVerifiedUserId } from "src/utils/request";
 const CreateApiKeySchema = z.object({
   name: z.string().trim().min(1).max(100),
   scopes: z.array(z.string().trim().min(1)).max(50).optional(),
-  environment: z.nativeEnum(DeveloperApiKeyEnvironment).optional(),
-  expiresAt: z.string().datetime().optional(),
+  environment: z.enum(DeveloperApiKeyEnvironment).optional(),
+  expiresAt: z.iso.datetime().optional(),
 });
 
 const handleError = (
@@ -51,12 +51,10 @@ export const DeveloperApiKeyController = {
 
       const parsed = CreateApiKeySchema.safeParse(req.body);
       if (!parsed.success) {
-        return res
-          .status(400)
-          .json({
-            message: "Invalid request",
-            errors: z.flattenError(parsed.error),
-          });
+        return res.status(400).json({
+          message: "Invalid request",
+          errors: z.flattenError(parsed.error),
+        });
       }
 
       const { name, scopes, environment, expiresAt } = parsed.data;

--- a/apps/backend/src/controllers/web/developer-billing.controller.ts
+++ b/apps/backend/src/controllers/web/developer-billing.controller.ts
@@ -22,12 +22,12 @@ import {
 } from "../../services/developer-billing.service";
 
 const CheckoutSchema = z.object({
-  successUrl: z.string().url(),
-  cancelUrl: z.string().url(),
+  successUrl: z.url(),
+  cancelUrl: z.url(),
 });
 
 const PortalSchema = z.object({
-  returnUrl: z.string().url(),
+  returnUrl: z.url(),
 });
 
 const handleError = (err: unknown, res: Response): void => {

--- a/apps/backend/src/controllers/web/diagnostic-image.controller.ts
+++ b/apps/backend/src/controllers/web/diagnostic-image.controller.ts
@@ -27,19 +27,19 @@ const ImagingStatusEnum = z.enum([
 ]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   imagingType: ImagingTypeEnum,
   bodyRegion: z.string().max(200).optional(),
   indication: z.string().max(1000).optional(),
-  takenAt: z.string().datetime(),
+  takenAt: z.iso.datetime(),
   takenBy: z.string().max(200).optional(),
   interpretedBy: z.string().max(200).optional(),
-  interpretedAt: z.string().datetime().optional(),
+  interpretedAt: z.iso.datetime().optional(),
   findings: z.string().max(5000).optional(),
   impression: z.string().max(2000).optional(),
   followUpRequired: z.boolean().optional(),
-  documentId: z.string().uuid().optional(),
+  documentId: z.uuid().optional(),
 });
 
 const ReviewBodySchema = z.object({
@@ -57,7 +57,7 @@ const UpdateBodySchema = z.object({
   findings: z.string().max(5000).optional(),
   impression: z.string().max(2000).optional(),
   followUpRequired: z.boolean().optional(),
-  documentId: z.string().uuid().optional(),
+  documentId: z.uuid().optional(),
   status: ImagingStatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/discharge-instruction.controller.ts
+++ b/apps/backend/src/controllers/web/discharge-instruction.controller.ts
@@ -13,14 +13,14 @@ import {
 const DischargeStatusEnum = z.enum(["DRAFT", "SENT", "ACKNOWLEDGED"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   medicationSchedule: z.string().max(5000).optional(),
   dietaryNotes: z.string().max(2000).optional(),
   activityNotes: z.string().max(2000).optional(),
   woundCareNotes: z.string().max(2000).optional(),
   warningSigns: z.string().max(2000).optional(),
-  followUpDate: z.string().datetime().optional(),
+  followUpDate: z.iso.datetime().optional(),
   followUpNotes: z.string().max(2000).optional(),
   emergencyContact: z.string().max(500).optional(),
   additionalNotes: z.string().max(5000).optional(),

--- a/apps/backend/src/controllers/web/emergency-triage.controller.ts
+++ b/apps/backend/src/controllers/web/emergency-triage.controller.ts
@@ -20,11 +20,11 @@ const TriagePriorityEnum = z.enum([
 ]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   triagePriority: TriagePriorityEnum,
   chiefComplaint: z.string().min(1).max(1000),
-  presentationAt: z.string().datetime(),
+  presentationAt: z.iso.datetime(),
   heartRate: z.number().int().min(0).max(500).optional(),
   respiratoryRate: z.number().int().min(0).max(200).optional(),
   temperature: z.number().min(25).max(45).optional(),
@@ -41,8 +41,8 @@ const EscalateBodySchema = z.object({
 });
 
 const ListQuerySchema = patientScopeQuery.extend({
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const TriageParamsSchema = orgParams.extend({ triageId: uuid() });

--- a/apps/backend/src/controllers/web/estimate.controller.ts
+++ b/apps/backend/src/controllers/web/estimate.controller.ts
@@ -22,14 +22,14 @@ const EstimateItemSchema = z.object({
 const CreateEstimateSchema = z.object({
   patientId: z.string(),
   encounterId: z.string().optional(),
-  validUntil: z.string().datetime().optional(),
+  validUntil: z.iso.datetime().optional(),
   currency: z.string().length(3).optional(),
   notes: z.string().optional(),
   items: z.array(EstimateItemSchema).min(1),
 });
 
 const UpdateEstimateSchema = z.object({
-  validUntil: z.string().datetime().optional(),
+  validUntil: z.iso.datetime().optional(),
   currency: z.string().length(3).optional(),
   notes: z.string().optional(),
   items: z.array(EstimateItemSchema).optional(),

--- a/apps/backend/src/controllers/web/fluid-therapy-plan.controller.ts
+++ b/apps/backend/src/controllers/web/fluid-therapy-plan.controller.ts
@@ -23,17 +23,17 @@ const FluidTypeEnum = z.enum([
 const StatusEnum = z.enum(["ACTIVE", "PAUSED", "COMPLETED", "DISCONTINUED"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  admissionId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  admissionId: z.uuid().optional(),
   fluidType: FluidTypeEnum,
   customFluidName: z.string().max(200).optional(),
   additives: z.string().max(500).optional(),
   rateMlPerHour: z.number().positive(),
   totalVolumeMl: z.number().positive().optional(),
   durationHours: z.number().positive().optional(),
-  startedAt: z.string().datetime(),
-  endedAt: z.string().datetime().optional(),
+  startedAt: z.iso.datetime(),
+  endedAt: z.iso.datetime().optional(),
   indication: z.string().max(1000).optional(),
   notes: z.string().max(2000).optional(),
 });
@@ -45,14 +45,14 @@ const UpdateBodySchema = z.object({
   rateMlPerHour: z.number().positive().optional(),
   totalVolumeMl: z.number().positive().optional(),
   durationHours: z.number().positive().optional(),
-  endedAt: z.string().datetime().optional(),
+  endedAt: z.iso.datetime().optional(),
   status: StatusEnum.optional(),
   indication: z.string().max(1000).optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ListQuerySchema = patientScopeQuery.extend({
-  admissionId: z.string().uuid().optional(),
+  admissionId: z.uuid().optional(),
   status: StatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/genetic-health-screen.controller.ts
+++ b/apps/backend/src/controllers/web/genetic-health-screen.controller.ts
@@ -36,9 +36,9 @@ const DnaTestSchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  screenedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  screenedAt: z.iso.datetime(),
   laboratoryName: z.string().max(200).optional(),
   dnaTests: z.array(DnaTestSchema).optional(),
   ofa_hips: OrthoRatingEnum.optional(),
@@ -47,7 +47,7 @@ const CreateBodySchema = z.object({
   ofa_cardiac: z.string().max(200).optional(),
   ofa_eyes: z.string().max(200).optional(),
   certificateNumber: z.string().max(100).optional(),
-  certificationExpiry: z.string().datetime().optional(),
+  certificationExpiry: z.iso.datetime().optional(),
   notes: z.string().max(3000).optional(),
 });
 

--- a/apps/backend/src/controllers/web/hospitalization-monitoring.controller.ts
+++ b/apps/backend/src/controllers/web/hospitalization-monitoring.controller.ts
@@ -11,10 +11,10 @@ import {
 } from "src/controllers/web/shared/clinical-controller.helpers";
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  admissionId: z.string().uuid().optional(),
-  encounterId: z.string().uuid().optional(),
-  observedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  admissionId: z.uuid().optional(),
+  encounterId: z.uuid().optional(),
+  observedAt: z.iso.datetime(),
   temperature: z.number().optional(),
   temperatureUnit: z.enum(["C", "F"]).optional(),
   heartRate: z.number().int().positive().optional(),
@@ -36,11 +36,11 @@ const RecordBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
-  admissionId: z.string().uuid().optional(),
-  encounterId: z.string().uuid().optional(),
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  patientId: z.uuid().optional(),
+  admissionId: z.uuid().optional(),
+  encounterId: z.uuid().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const ObsParamsSchema = orgParams.extend({ obsId: uuid() });

--- a/apps/backend/src/controllers/web/icu-care-plan.controller.ts
+++ b/apps/backend/src/controllers/web/icu-care-plan.controller.ts
@@ -35,13 +35,13 @@ const CareFieldsSchema = z.object({
   alertThresholds: z.string().max(2000).optional(),
   primaryVet: z.string().max(300).optional(),
   nursePrimary: z.string().max(300).optional(),
-  anticipatedDischarge: z.string().datetime().optional(),
+  anticipatedDischarge: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const CreateBodySchema = patientScopeBody
-  .extend({ admittedAt: z.string().datetime() })
-  .merge(CareFieldsSchema);
+  .extend({ admittedAt: z.iso.datetime() })
+  .extend(CareFieldsSchema.shape);
 
 const DischargeBodySchema = z.object({
   status: DischargeStatusEnum,
@@ -49,7 +49,7 @@ const DischargeBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: IcuStatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/insurance-claim.controller.ts
+++ b/apps/backend/src/controllers/web/insurance-claim.controller.ts
@@ -21,7 +21,7 @@ const ClaimStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   invoiceId: z.string().optional(),
   encounterId: z.string().optional(),
   insurerName: z.string().min(1).max(200),
@@ -50,7 +50,7 @@ const UpdateStatusBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: ClaimStatusEnum.optional(),
   invoiceId: z.string().optional(),
 });

--- a/apps/backend/src/controllers/web/inventory-count.controller.ts
+++ b/apps/backend/src/controllers/web/inventory-count.controller.ts
@@ -9,7 +9,7 @@ import { parseOptionalBooleanFlag } from "src/utils/query-flags";
 const RecordCountSchema = z.object({
   inventoryItemId: z.string().min(1),
   countedBy: z.string().optional(),
-  countedAt: z.string().datetime(),
+  countedAt: z.iso.datetime(),
   systemCount: z.number().int().min(0),
   physicalCount: z.number().int().min(0),
   notes: z.string().optional(),

--- a/apps/backend/src/controllers/web/isolation-protocol.controller.ts
+++ b/apps/backend/src/controllers/web/isolation-protocol.controller.ts
@@ -28,20 +28,14 @@ const StartSchema = z.object({
   reason: ReasonEnum.optional(),
   level: LevelEnum.optional(),
   unitId: z.string().optional(),
-  startedAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
+  startedAt: z.iso.datetime().transform((v) => new Date(v)),
   initiatedBy: z.string().optional(),
   ppe: z.array(z.string()).optional(),
   notes: z.string().optional(),
 });
 
 const EndSchema = z.object({
-  endedAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
+  endedAt: z.iso.datetime().transform((v) => new Date(v)),
   endedBy: z.string().optional(),
   notes: z.string().optional(),
 });

--- a/apps/backend/src/controllers/web/mar.controller.ts
+++ b/apps/backend/src/controllers/web/mar.controller.ts
@@ -17,17 +17,17 @@ const MARStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  prescriptionId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  prescriptionId: z.uuid().optional(),
   medicationName: z.string().min(1).max(200),
   dose: z.string().min(1).max(100),
   route: z.string().min(1).max(100),
-  scheduledAt: z.string().datetime(),
+  scheduledAt: z.iso.datetime(),
 });
 
 const AdministerBodySchema = z.object({
-  administeredAt: z.string().datetime().optional(),
+  administeredAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
@@ -37,8 +37,8 @@ const HoldBodySchema = z.object({
 
 const ListQuerySchema = patientScopeQuery.extend({
   status: MARStatusEnum.optional(),
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const EntryParamsSchema = orgParams.extend({ marEntryId: uuid() });

--- a/apps/backend/src/controllers/web/medical-certificate.controller.ts
+++ b/apps/backend/src/controllers/web/medical-certificate.controller.ts
@@ -33,7 +33,7 @@ const CreateSchema = z.object({
 
 const IssueSchema = z.object({
   issuedBy: z.string().min(1),
-  expiresAt: z.string().datetime().optional(),
+  expiresAt: z.iso.datetime().optional(),
   clinicalFindings: z.string().optional(),
   restrictions: z.string().optional(),
   notes: z.string().optional(),

--- a/apps/backend/src/controllers/web/medication-reconciliation.controller.ts
+++ b/apps/backend/src/controllers/web/medication-reconciliation.controller.ts
@@ -46,8 +46,8 @@ const DiscrepancySchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   homeMedications: z.array(HomeMedSchema),
   hospitalOrders: z.array(HospitalOrderSchema),
   discrepancies: z.array(DiscrepancySchema).optional(),

--- a/apps/backend/src/controllers/web/neurology-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/neurology-assessment.controller.ts
@@ -26,9 +26,9 @@ const SpinalReflexGradeEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   consciousnessLevel: ConsciousnessLevelEnum.optional(),
   gaitScore: GaitScoreEnum.optional(),
   cranialNerveFindings: z.string().max(3000).optional(),

--- a/apps/backend/src/controllers/web/nutrition-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/nutrition-assessment.controller.ts
@@ -20,9 +20,9 @@ const FeedingRouteEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   appetiteScore: AppetiteScoreEnum.optional(),
   bodyConditionScore: z.number().int().min(1).max(9).optional(),
   muscleConditionScore: z.number().int().min(1).max(4).optional(),

--- a/apps/backend/src/controllers/web/nutrition-plan.controller.ts
+++ b/apps/backend/src/controllers/web/nutrition-plan.controller.ts
@@ -29,11 +29,11 @@ const PlanFieldsSchema = z.object({
   waterIntake: z.string().max(200).optional(),
   restrictions: z.string().max(2000).optional(),
   indication: z.string().max(1000).optional(),
-  reviewDate: z.string().datetime().optional(),
+  reviewDate: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
-const CreateBodySchema = patientScopeBody.merge(PlanFieldsSchema);
+const CreateBodySchema = patientScopeBody.extend(PlanFieldsSchema.shape);
 
 const UpdateBodySchema = PlanFieldsSchema.partial().extend({
   status: StatusEnum.optional(),

--- a/apps/backend/src/controllers/web/oncology-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/oncology-assessment.controller.ts
@@ -25,16 +25,16 @@ const OncologyStageEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   tumorType: z.string().max(200).optional(),
   primaryTumorStage: z.string().max(10).optional(),
   nodeStage: z.string().max(10).optional(),
   metastasisStage: z.string().max(10).optional(),
   overallStage: OncologyStageEnum.optional(),
   chemotherapyProtocol: z.string().max(200).optional(),
-  chemotherapyStartDate: z.string().datetime().optional(),
+  chemotherapyStartDate: z.iso.datetime().optional(),
   chemotherapyCycles: z.number().int().min(1).max(100).optional(),
   qualityOfLifeScore: z.number().int().min(0).max(10).optional(),
   prognosis: z.string().max(3000).optional(),

--- a/apps/backend/src/controllers/web/ophthalmology-examination.controller.ts
+++ b/apps/backend/src/controllers/web/ophthalmology-examination.controller.ts
@@ -41,9 +41,9 @@ const EyeFindingSchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  examinedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  examinedAt: z.iso.datetime(),
   visionLeft: VisionStatusEnum.optional(),
   visionRight: VisionStatusEnum.optional(),
   menaceLeft: z.boolean().optional(),

--- a/apps/backend/src/controllers/web/organization.controller.ts
+++ b/apps/backend/src/controllers/web/organization.controller.ts
@@ -16,8 +16,8 @@ import { getParentAddressForAuthUser } from "src/utils/location";
 // as `{"not": null}` survives mongoSanitize and would otherwise match an arbitrary org.
 const organisationSearchSchema = z.object({
   placeId: z.string().min(1).optional(),
-  lat: z.number().finite().optional(),
-  lng: z.number().finite().optional(),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
   name: z.string().min(1).optional(),
   addressLine: z.string().min(1).optional(),
 });

--- a/apps/backend/src/controllers/web/pain-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/pain-assessment.controller.ts
@@ -29,24 +29,24 @@ const PainInterventionEnum = z.enum([
 ]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   painScale: PainScaleEnum,
   painScore: z.number().int().min(0).max(10),
   rawScore: z.string().max(50).optional(),
   behaviouralSigns: z.string().max(1000).optional(),
   vocalisation: z.boolean().optional(),
   posture: z.string().max(500).optional(),
-  assessedAt: z.string().datetime(),
+  assessedAt: z.iso.datetime(),
   interventionType: PainInterventionEnum.optional(),
   interventionDetail: z.string().max(1000).optional(),
-  reassessAt: z.string().datetime().optional(),
+  reassessAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ListQuerySchema = patientScopeQuery.extend({
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const AssessmentParamsSchema = orgParams.extend({ assessmentId: uuid() });

--- a/apps/backend/src/controllers/web/pathology-submission.controller.ts
+++ b/apps/backend/src/controllers/web/pathology-submission.controller.ts
@@ -31,13 +31,13 @@ const PathologyStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   pathologyType: PathologyTypeEnum,
   sampleType: z.string().min(1).max(300),
   anatomicSite: z.string().min(1).max(500),
-  collectedAt: z.string().datetime(),
-  submittedAt: z.string().datetime().optional(),
+  collectedAt: z.iso.datetime(),
+  submittedAt: z.iso.datetime().optional(),
   labName: z.string().max(300).optional(),
   labRefNumber: z.string().max(200).optional(),
   clinicalHistory: z.string().max(3000).optional(),
@@ -59,7 +59,7 @@ const ReviewBodySchema = z.object({
 });
 
 const UpdateBodySchema = z.object({
-  submittedAt: z.string().datetime().optional(),
+  submittedAt: z.iso.datetime().optional(),
   labName: z.string().max(300).optional(),
   labRefNumber: z.string().max(200).optional(),
   clinicalHistory: z.string().max(3000).optional(),

--- a/apps/backend/src/controllers/web/patient-allergy.controller.ts
+++ b/apps/backend/src/controllers/web/patient-allergy.controller.ts
@@ -19,13 +19,13 @@ const AllergySeverityEnum = z.enum([
 const AllergyStatusEnum = z.enum(["ACTIVE", "RESOLVED", "UNCONFIRMED"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   allergen: z.string().min(1).max(200),
   allergyType: AllergyTypeEnum,
   severity: AllergySeverityEnum,
   reaction: z.string().max(1000).optional(),
   status: AllergyStatusEnum.optional(),
-  onsetDate: z.string().datetime().optional(),
+  onsetDate: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
@@ -35,17 +35,17 @@ const UpdateBodySchema = z.object({
   severity: AllergySeverityEnum.optional(),
   reaction: z.string().max(1000).optional(),
   status: AllergyStatusEnum.optional(),
-  onsetDate: z.string().datetime().optional(),
-  resolvedDate: z.string().datetime().optional(),
+  onsetDate: z.iso.datetime().optional(),
+  resolvedDate: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ResolveBodySchema = z.object({
-  resolvedDate: z.string().datetime().optional(),
+  resolvedDate: z.iso.datetime().optional(),
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: AllergyStatusEnum.optional(),
   allergyType: AllergyTypeEnum.optional(),
 });

--- a/apps/backend/src/controllers/web/patient-check-in.controller.ts
+++ b/apps/backend/src/controllers/web/patient-check-in.controller.ts
@@ -22,10 +22,7 @@ const CreateSchema = z.object({
   patientId: z.string(),
   clientId: z.string(),
   appointmentId: z.string().optional(),
-  arrivedAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
+  arrivedAt: z.iso.datetime().transform((v) => new Date(v)),
   triagePriority: TriagePriorityEnum.optional(),
   triageNote: z.string().optional(),
   checkedInBy: z.string().optional(),
@@ -35,8 +32,7 @@ const CreateSchema = z.object({
 const ListQuerySchema = z.object({
   patientId: z.string().optional(),
   status: StatusEnum.optional(),
-  date: z
-    .string()
+  date: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),

--- a/apps/backend/src/controllers/web/patient-consent.controller.ts
+++ b/apps/backend/src/controllers/web/patient-consent.controller.ts
@@ -21,17 +21,17 @@ const ConsentTypeEnum = z.enum([
 const ConsentStatusEnum = z.enum(["ACTIVE", "REVOKED", "EXPIRED"]);
 
 const GrantBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   consentType: ConsentTypeEnum,
   procedureDesc: z.string().max(2000).optional(),
   // `consentedBy` is deliberately NOT accepted from the body: the service uses
   // it as the CONSENT_GRANTED audit actor, so it may only ever come from the
   // authenticated session. `consentedByName` is the free-text human field.
   consentedByName: z.string().max(200).optional(),
-  consentedAt: z.string().datetime().optional(),
-  expiresAt: z.string().datetime().optional(),
+  consentedAt: z.iso.datetime().optional(),
+  expiresAt: z.iso.datetime().optional(),
   witnessedBy: z.string().max(200).optional(),
-  documentId: z.string().uuid().optional(),
+  documentId: z.uuid().optional(),
   notes: z.string().max(2000).optional(),
 });
 
@@ -40,7 +40,7 @@ const RevokeBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: ConsentStatusEnum.optional(),
   consentType: ConsentTypeEnum.optional(),
 });

--- a/apps/backend/src/controllers/web/patient-problem.controller.ts
+++ b/apps/backend/src/controllers/web/patient-problem.controller.ts
@@ -13,13 +13,13 @@ const StatusEnum = z.enum(["ACTIVE", "INACTIVE", "RESOLVED"]);
 const SeverityEnum = z.enum(["MILD", "MODERATE", "SEVERE"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   encounterId: z.string().optional(),
   name: z.string().min(1).max(300),
   codeSystem: z.string().max(50).optional(),
   code: z.string().max(50).optional(),
   severity: SeverityEnum.optional(),
-  onsetDate: z.string().datetime().optional(),
+  onsetDate: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
@@ -29,17 +29,17 @@ const UpdateBodySchema = z.object({
   code: z.string().max(50).optional(),
   status: StatusEnum.optional(),
   severity: SeverityEnum.optional(),
-  onsetDate: z.string().datetime().optional(),
-  resolvedDate: z.string().datetime().optional(),
+  onsetDate: z.iso.datetime().optional(),
+  resolvedDate: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ResolveBodySchema = z.object({
-  resolvedDate: z.string().datetime().optional(),
+  resolvedDate: z.iso.datetime().optional(),
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: StatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/patient-transfer.controller.ts
+++ b/apps/backend/src/controllers/web/patient-transfer.controller.ts
@@ -17,10 +17,7 @@ const CreateTransferSchema = z.object({
   receivingFacility: z.string(),
   receivingVetName: z.string().optional(),
   receivingVetContact: z.string().optional(),
-  transferredAt: z
-    .string()
-    .datetime()
-    .transform((v) => new Date(v)),
+  transferredAt: z.iso.datetime().transform((v) => new Date(v)),
   transferredBy: z.string().optional(),
   chiefComplaint: z.string().optional(),
   currentDiagnoses: z.string().optional(),

--- a/apps/backend/src/controllers/web/pet-passport.controller.ts
+++ b/apps/backend/src/controllers/web/pet-passport.controller.ts
@@ -46,7 +46,7 @@ const roundTripsToSameDay = (value: string): boolean => {
 };
 
 const ClinicalDateSchema = z
-  .union([z.string().date(), z.string().datetime({ offset: true })])
+  .union([z.iso.date(), z.iso.datetime({ offset: true })])
   .refine(roundTripsToSameDay, {
     message: "Must be a real ISO-8601 date or datetime",
   });

--- a/apps/backend/src/controllers/web/physiotherapy-plan.controller.ts
+++ b/apps/backend/src/controllers/web/physiotherapy-plan.controller.ts
@@ -34,10 +34,10 @@ const PlanFieldsSchema = z.object({
   tapeApplication: z.boolean().optional(),
   precautions: z.string().max(2000).optional(),
   homeExercises: z.string().max(5000).optional(),
-  startDate: z.string().datetime().optional(),
-  endDate: z.string().datetime().optional(),
-  lastSessionAt: z.string().datetime().optional(),
-  nextSessionAt: z.string().datetime().optional(),
+  startDate: z.iso.datetime().optional(),
+  endDate: z.iso.datetime().optional(),
+  lastSessionAt: z.iso.datetime().optional(),
+  nextSessionAt: z.iso.datetime().optional(),
   therapist: z.string().max(300).optional(),
   status: StatusEnum.optional(),
   notes: z.string().max(2000).optional(),
@@ -45,10 +45,10 @@ const PlanFieldsSchema = z.object({
 
 const CreateBodySchema = patientScopeBody
   .extend({ surgicalProcedureId: uuid().optional() })
-  .merge(
+  .extend(
     PlanFieldsSchema.omit({ lastSessionAt: true, status: true }).required({
       diagnosis: true,
-    }),
+    }).shape,
   );
 
 const ListQuerySchema = patientScopeQuery.extend({

--- a/apps/backend/src/controllers/web/poc-lab.controller.ts
+++ b/apps/backend/src/controllers/web/poc-lab.controller.ts
@@ -32,9 +32,9 @@ const LabResultParamSchema = z.object({
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  conductedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  conductedAt: z.iso.datetime(),
   testType: PocTestTypeEnum,
   analyzerName: z.string().max(200).optional(),
   sampleType: z.string().max(100).optional(),

--- a/apps/backend/src/controllers/web/post-op-care-plan.controller.ts
+++ b/apps/backend/src/controllers/web/post-op-care-plan.controller.ts
@@ -14,9 +14,9 @@ import {
 const StatusEnum = z.enum(["ACTIVE", "COMPLETED", "CANCELLED"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  surgicalProcedureId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  surgicalProcedureId: z.uuid().optional(),
   painScore: z.number().int().min(0).max(10).optional(),
   analgesiaProtocol: z.string().max(2000).optional(),
   woundCareInstructions: z.string().max(5000).optional(),
@@ -24,15 +24,15 @@ const CreateBodySchema = z.object({
   dietaryNotes: z.string().max(2000).optional(),
   fluidTherapyNotes: z.string().max(2000).optional(),
   monitoringParams: z.string().max(2000).optional(),
-  firstReviewAt: z.string().datetime().optional(),
-  nextReviewAt: z.string().datetime().optional(),
+  firstReviewAt: z.iso.datetime().optional(),
+  nextReviewAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ReviewBodySchema = z.object({
   painScore: z.number().int().min(0).max(10).optional(),
   reviewNotes: z.string().min(1).max(5000),
-  nextReviewAt: z.string().datetime().optional(),
+  nextReviewAt: z.iso.datetime().optional(),
   status: StatusEnum.optional(),
 });
 
@@ -43,8 +43,8 @@ const UpdateBodySchema = z.object({
   dietaryNotes: z.string().max(2000).optional(),
   fluidTherapyNotes: z.string().max(2000).optional(),
   monitoringParams: z.string().max(2000).optional(),
-  firstReviewAt: z.string().datetime().optional(),
-  nextReviewAt: z.string().datetime().optional(),
+  firstReviewAt: z.iso.datetime().optional(),
+  nextReviewAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
   status: StatusEnum.optional(),
 });

--- a/apps/backend/src/controllers/web/pre-op-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/pre-op-assessment.controller.ts
@@ -15,8 +15,7 @@ const CreatePreOpSchema = z.object({
   patientId: z.string(),
   encounterId: z.string(),
   asaClass: AsaClassEnum.optional(),
-  fastingStartedAt: z
-    .string()
+  fastingStartedAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),
@@ -33,8 +32,7 @@ const CreatePreOpSchema = z.object({
   cardiovascularNotes: z.string().optional(),
   notes: z.string().optional(),
   assessedBy: z.string().optional(),
-  assessedAt: z
-    .string()
+  assessedAt: z.iso
     .datetime()
     .transform((v) => new Date(v))
     .optional(),

--- a/apps/backend/src/controllers/web/preventive-care-plan.controller.ts
+++ b/apps/backend/src/controllers/web/preventive-care-plan.controller.ts
@@ -23,12 +23,12 @@ const ItemSchema = z.object({
   careType: z.string().min(1).max(200),
   frequency: FrequencyEnum,
   intervalDays: z.number().int().positive().optional(),
-  nextDueAt: z.string().datetime().optional(),
+  nextDueAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   name: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   items: z.array(ItemSchema).optional(),
@@ -41,13 +41,13 @@ const UpdatePlanBodySchema = z.object({
 });
 
 const CompleteItemBodySchema = z.object({
-  completedAt: z.string().datetime().optional(),
-  nextDueAt: z.string().datetime().optional(),
+  completedAt: z.iso.datetime().optional(),
+  nextDueAt: z.iso.datetime().optional(),
   notes: z.string().max(2000).optional(),
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: StatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/qol-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/qol-assessment.controller.ts
@@ -15,9 +15,9 @@ import { parseOptionalBooleanFlag } from "src/utils/query-flags";
 const HhScore = z.number().int().min(1).max(10);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  assessedAt: z.string().datetime(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  assessedAt: z.iso.datetime(),
   hhhhhmmScore: z.number().int().min(0).max(70).optional(),
   painScore: HhScore.optional(),
   appetiteScore: HhScore.optional(),

--- a/apps/backend/src/controllers/web/referral-letter.controller.ts
+++ b/apps/backend/src/controllers/web/referral-letter.controller.ts
@@ -18,11 +18,11 @@ const ReferralStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   encounterId: z.string().optional(),
   specialistName: z.string().max(200).optional(),
   specialistClinic: z.string().max(200).optional(),
-  specialistEmail: z.string().email().optional(),
+  specialistEmail: z.email().optional(),
   reasonForReferral: z.string().min(1).max(5000),
   historySummary: z.string().max(5000).optional(),
   examFindings: z.string().max(5000).optional(),
@@ -33,7 +33,7 @@ const CreateBodySchema = z.object({
 const UpdateBodySchema = z.object({
   specialistName: z.string().max(200).optional(),
   specialistClinic: z.string().max(200).optional(),
-  specialistEmail: z.string().email().optional(),
+  specialistEmail: z.email().optional(),
   reasonForReferral: z.string().min(1).max(5000).optional(),
   historySummary: z.string().max(5000).optional(),
   examFindings: z.string().max(5000).optional(),
@@ -42,7 +42,7 @@ const UpdateBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   status: ReferralStatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/reproductive-record.controller.ts
+++ b/apps/backend/src/controllers/web/reproductive-record.controller.ts
@@ -26,19 +26,19 @@ const PregnancyStatusEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
+  patientId: z.uuid(),
   reproductiveStatus: ReproductiveStatusEnum,
-  lastHeatDate: z.string().datetime().optional(),
-  nextHeatExpected: z.string().datetime().optional(),
-  matingDate: z.string().datetime().optional(),
-  sireId: z.string().uuid().optional(),
+  lastHeatDate: z.iso.datetime().optional(),
+  nextHeatExpected: z.iso.datetime().optional(),
+  matingDate: z.iso.datetime().optional(),
+  sireId: z.uuid().optional(),
   sireName: z.string().max(300).optional(),
   pregnancyStatus: PregnancyStatusEnum.optional(),
-  pregnancyConfirmedAt: z.string().datetime().optional(),
-  expectedWhelp: z.string().datetime().optional(),
+  pregnancyConfirmedAt: z.iso.datetime().optional(),
+  expectedWhelp: z.iso.datetime().optional(),
   litterSizeUltrasound: z.number().int().min(0).optional(),
   litterSizeXray: z.number().int().min(0).optional(),
-  actualWhelp: z.string().datetime().optional(),
+  actualWhelp: z.iso.datetime().optional(),
   litterSizeBorn: z.number().int().min(0).optional(),
   litterSizeAlive: z.number().int().min(0).optional(),
   notes: z.string().max(3000).optional(),
@@ -47,7 +47,7 @@ const CreateBodySchema = z.object({
 const UpdateBodySchema = CreateBodySchema.omit({ patientId: true }).partial();
 
 const ListQuerySchema = z.object({
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   reproductiveStatus: ReproductiveStatusEnum.optional(),
 });
 

--- a/apps/backend/src/controllers/web/staff-shift.controller.ts
+++ b/apps/backend/src/controllers/web/staff-shift.controller.ts
@@ -16,9 +16,9 @@ const ShiftStatusEnum = z.enum([
 const CreateSchema = z.object({
   staffId: z.string().min(1),
   role: z.string().min(1),
-  shiftDate: z.string().datetime(),
-  startTime: z.string().datetime(),
-  endTime: z.string().datetime(),
+  shiftDate: z.iso.datetime(),
+  startTime: z.iso.datetime(),
+  endTime: z.iso.datetime(),
   breakMinutes: z.number().int().min(0).optional(),
   notes: z.string().optional(),
   createdBy: z.string().optional(),
@@ -26,9 +26,9 @@ const CreateSchema = z.object({
 
 const UpdateSchema = z.object({
   role: z.string().min(1).optional(),
-  shiftDate: z.string().datetime().optional(),
-  startTime: z.string().datetime().optional(),
-  endTime: z.string().datetime().optional(),
+  shiftDate: z.iso.datetime().optional(),
+  startTime: z.iso.datetime().optional(),
+  endTime: z.iso.datetime().optional(),
   breakMinutes: z.number().int().min(0).optional(),
   notes: z.string().optional(),
   updatedBy: z.string().optional(),

--- a/apps/backend/src/controllers/web/surgical-checklist.controller.ts
+++ b/apps/backend/src/controllers/web/surgical-checklist.controller.ts
@@ -25,7 +25,7 @@ const UpdateChecklistSchema = z.object({
   status: StatusEnum.optional(),
   conductedBy: z.string().optional(),
   notes: z.string().optional(),
-  completedAt: z.string().datetime().optional(),
+  completedAt: z.iso.datetime().optional(),
 });
 
 const CheckItemSchema = z.object({

--- a/apps/backend/src/controllers/web/surgical-procedure.controller.ts
+++ b/apps/backend/src/controllers/web/surgical-procedure.controller.ts
@@ -20,16 +20,16 @@ const AnesthesiaEnum = z.enum([
 ]);
 
 const CreateBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
   procedureName: z.string().min(1).max(300),
   surgeon: z.string().max(200).optional(),
   assistants: z.array(z.string().max(200)).optional(),
   anesthesiaType: AnesthesiaEnum.optional(),
   anesthesiaAgent: z.string().max(200).optional(),
   anesthesiaDoseMs: z.number().positive().optional(),
-  startedAt: z.string().datetime().optional(),
-  endedAt: z.string().datetime().optional(),
+  startedAt: z.iso.datetime().optional(),
+  endedAt: z.iso.datetime().optional(),
   durationMinutes: z.number().int().positive().optional(),
   outcome: OutcomeEnum.optional(),
   complications: z.string().max(2000).optional(),

--- a/apps/backend/src/controllers/web/template.controller.ts
+++ b/apps/backend/src/controllers/web/template.controller.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import { TemplateKind, TemplateScope, TemplateStatus } from "@prisma/client";
 
 const templateKindQuerySchema = z.union([
-  z.nativeEnum(TemplateKind),
+  z.enum(TemplateKind),
   z.enum([
     "SOAP_NOTE",
     "VITAL_RECORD",
@@ -43,8 +43,8 @@ const TASK_TEMPLATE_KINDS = ["TASK_TEMPLATE", "CARE_PATHWAY"] as const;
 
 const listQuerySchema = z.object({
   kind: templateKindQuerySchema.optional(),
-  status: z.nativeEnum(TemplateStatus).optional(),
-  scope: z.nativeEnum(TemplateScope).optional(),
+  status: z.enum(TemplateStatus).optional(),
+  scope: z.enum(TemplateScope).optional(),
   search: z.string().trim().optional(),
 });
 

--- a/apps/backend/src/controllers/web/template.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/template.fhir.controller.ts
@@ -35,7 +35,7 @@ const questionnaireResponseSchema = z
 const listQuerySchema = z.object({
   kind: z
     .union([
-      z.nativeEnum(PrismaTemplateKind),
+      z.enum(PrismaTemplateKind),
       z.enum([
         "SOAP_NOTE",
         "VITAL_RECORD",
@@ -48,8 +48,8 @@ const listQuerySchema = z.object({
       ]),
     ])
     .optional(),
-  status: z.nativeEnum(TemplateStatus).optional(),
-  scope: z.nativeEnum(TemplateScope).optional(),
+  status: z.enum(TemplateStatus).optional(),
+  scope: z.enum(TemplateScope).optional(),
 });
 
 const handleError = createFhirErrorHandler({

--- a/apps/backend/src/controllers/web/treatment-outcome.controller.ts
+++ b/apps/backend/src/controllers/web/treatment-outcome.controller.ts
@@ -20,18 +20,18 @@ const RecordSchema = z.object({
   patientId: z.string().min(1),
   encounterId: z.string().optional(),
   episodeOfCareId: z.string().optional(),
-  recordedAt: z.string().datetime(),
+  recordedAt: z.iso.datetime(),
   recordedBy: z.string().optional(),
   outcomeType: OutcomeTypeEnum,
   clinicalNotes: z.string().optional(),
-  followUpDate: z.string().datetime().optional(),
+  followUpDate: z.iso.datetime().optional(),
   followUpNotes: z.string().optional(),
 });
 
 const UpdateSchema = z.object({
   outcomeType: OutcomeTypeEnum.optional(),
   clinicalNotes: z.string().optional(),
-  followUpDate: z.string().datetime().nullable().optional(),
+  followUpDate: z.iso.datetime().nullable().optional(),
   followUpNotes: z.string().optional(),
   resolved: z.boolean().optional(),
 });

--- a/apps/backend/src/controllers/web/treatment-protocol.controller.ts
+++ b/apps/backend/src/controllers/web/treatment-protocol.controller.ts
@@ -28,7 +28,7 @@ const StepSchema = z.object({
   stepType: StepTypeEnum,
   title: z.string().min(1).max(200),
   description: z.string().max(1000).optional(),
-  inventoryItemId: z.string().uuid().optional(),
+  inventoryItemId: z.uuid().optional(),
   doseValue: z.number().positive().optional(),
   doseUnit: z.string().max(50).optional(),
   routeOfAdmin: z.string().max(100).optional(),
@@ -59,8 +59,8 @@ const UpdateBodySchema = z.object({
 
 const ApplyBodySchema = z.object({
   encounterId: z.string().min(1),
-  patientId: z.string().uuid(),
-  appointmentDate: z.string().datetime().optional(),
+  patientId: z.uuid(),
+  appointmentDate: z.iso.datetime().optional(),
 });
 
 const ListQuerySchema = z.object({

--- a/apps/backend/src/controllers/web/waitlist.controller.ts
+++ b/apps/backend/src/controllers/web/waitlist.controller.ts
@@ -15,18 +15,18 @@ const WaitlistStatusEnum = z.enum([
 ]);
 
 const AddBodySchema = z.object({
-  patientId: z.string().uuid(),
-  preferredLeadId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  preferredLeadId: z.uuid().optional(),
   appointmentType: z.string().max(100).optional(),
-  earliestDate: z.string().datetime().optional(),
-  latestDate: z.string().datetime().optional(),
+  earliestDate: z.iso.datetime().optional(),
+  latestDate: z.iso.datetime().optional(),
   notes: z.string().max(500).optional(),
-  expiresAt: z.string().datetime().optional(),
+  expiresAt: z.iso.datetime().optional(),
 });
 
 const ListQuerySchema = z.object({
   status: WaitlistStatusEnum.optional(),
-  patientId: z.string().uuid().optional(),
+  patientId: z.uuid().optional(),
   appointmentType: z.string().max(100).optional(),
 });
 

--- a/apps/backend/src/controllers/web/wound-assessment.controller.ts
+++ b/apps/backend/src/controllers/web/wound-assessment.controller.ts
@@ -37,9 +37,9 @@ const HealingStatusEnum = z.enum([
 ]);
 
 const RecordBodySchema = z.object({
-  patientId: z.string().uuid(),
-  encounterId: z.string().uuid().optional(),
-  surgicalProcedureId: z.string().uuid().optional(),
+  patientId: z.uuid(),
+  encounterId: z.uuid().optional(),
+  surgicalProcedureId: z.uuid().optional(),
   woundType: WoundTypeEnum,
   location: z.string().min(1).max(500),
   lengthCm: z.number().min(0).optional(),
@@ -55,14 +55,14 @@ const RecordBodySchema = z.object({
   periwoundSkin: z.string().max(500).optional(),
   dressing: z.string().max(500).optional(),
   dressingChangeFreq: z.string().max(200).optional(),
-  assessedAt: z.string().datetime(),
+  assessedAt: z.iso.datetime(),
   notes: z.string().max(2000).optional(),
 });
 
 const ListQuerySchema = patientScopeQuery.extend({
-  surgicalProcedureId: z.string().uuid().optional(),
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
+  surgicalProcedureId: z.uuid().optional(),
+  from: z.iso.datetime().optional(),
+  to: z.iso.datetime().optional(),
 });
 
 const AssessmentParamsSchema = orgParams.extend({ assessmentId: uuid() });

--- a/apps/backend/src/services/form-assignment.service.ts
+++ b/apps/backend/src/services/form-assignment.service.ts
@@ -28,7 +28,7 @@ export const formAssignmentSignerIdentitySchema = z
   .object({
     userId: z.string().trim().min(1).optional(),
     name: z.string().trim().min(1).optional(),
-    email: z.string().trim().email().optional(),
+    email: z.string().trim().pipe(z.email()).optional(),
     role: z.string().trim().min(1).optional(),
   })
   .strict();

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -113,7 +113,7 @@ const templateContractKindSchema = z.enum([
   "TASK_ASSIGNMENT",
 ]);
 
-const templateStorageKindSchema = z.nativeEnum(TemplateKind);
+const templateStorageKindSchema = z.enum(TemplateKind);
 const templateKindSchema = z.union([
   templateStorageKindSchema,
   templateContractKindSchema,
@@ -151,11 +151,11 @@ export const createTemplateSchema = z
   .object({
     organisationId: z.string().trim().min(1).optional(),
     ownerUserId: z.string().trim().min(1).optional(),
-    ownership: z.nativeEnum(TemplateOwnershipType).default("ORG_TEMPLATE"),
+    ownership: z.enum(TemplateOwnershipType).default("ORG_TEMPLATE"),
     kind: templateKindSchema,
     name: z.string().trim().min(1),
     description: z.string().trim().min(1).optional(),
-    scope: z.nativeEnum(TemplateScope).default("ORGANISATION"),
+    scope: z.enum(TemplateScope).default("ORGANISATION"),
     rules: z.record(z.string(), z.unknown()).optional(),
     schemaSnapshot: templateSchemaSnapshotSchema,
     renderConfigSnapshot: templateConfigSchema.optional(),
@@ -197,9 +197,9 @@ export const createTemplateSchema = z
 export const updateTemplateSchema = z.object({
   name: z.string().trim().min(1).optional(),
   description: z.string().trim().min(1).nullable().optional(),
-  ownership: z.nativeEnum(TemplateOwnershipType).optional(),
-  scope: z.nativeEnum(TemplateScope).optional(),
-  status: z.nativeEnum(TemplateStatus).optional(),
+  ownership: z.enum(TemplateOwnershipType).optional(),
+  scope: z.enum(TemplateScope).optional(),
+  status: z.enum(TemplateStatus).optional(),
   rules: z.record(z.string(), z.unknown()).nullable().optional(),
   schemaSnapshot: templateSchemaSnapshotSchema.optional(),
   renderConfigSnapshot: templateConfigSchema.optional(),
@@ -218,7 +218,7 @@ export const createTemplateInstanceSchema = z.object({
 
 export const updateTemplateInstanceSchema = z.object({
   data: z.record(z.string(), z.unknown()).optional(),
-  status: z.nativeEnum(TemplateInstanceStatus).optional(),
+  status: z.enum(TemplateInstanceStatus).optional(),
   signedBy: z.string().trim().min(1).optional().nullable(),
   signedAt: z.coerce.date().optional().nullable(),
   generatedPdfUrl: z.string().trim().min(1).optional().nullable(),

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -4,6 +4,7 @@
 // it, and v16 exposes live plugin objects, which are circular.
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 import nextTypescript from 'eslint-config-next/typescript';
+import sonarjs from 'eslint-plugin-sonarjs';
 
 const eslintConfig = [
   {
@@ -19,6 +20,87 @@ const eslintConfig = [
   },
   ...nextCoreWebVitals,
   ...nextTypescript,
+  /*
+    Sonar smells, locally (#2565). The plugin was a declared dependency that no
+    config referenced, so the first sight of a smell was a red `sonar` check on
+    the PR - about ten minutes of CI to learn something eslint can say in under a
+    second. The backend gate runs with an issues ceiling of 0, so one MAJOR smell
+    blocks the merge.
+
+    It is a proxy, not SonarCloud. The rules turned off below were each measured
+    against this repo and shown to fire where SonarCloud does not; leaving them on
+    would make `lint` red over findings the gate does not raise, which teaches
+    people to ignore it.
+  */
+  {
+    ...sonarjs.configs.recommended,
+    files: ['**/*.ts', '**/*.tsx'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      // Duplicates @typescript-eslint/no-unused-vars, which is already 'error'
+      // below with this repo's ^_ ignore patterns. Measured 60 duplicate reports.
+      'sonarjs/no-unused-vars': 'off',
+      /* Fires on canonical system URIs, which are identifiers rather than
+         requests: 'http://snomed.info/sct' and 'http://www.whocc.no/atcvet' are
+         fixed strings defined by those standards, and rewriting them to https
+         breaks FHIR conformance. */
+      'sonarjs/no-clear-text-protocols': 'off',
+      /* SonarCloud honours NOSONAR and eslint does not, so this reports the
+         PassKit SHA-1 in wallet-pass.service.ts that is already suppressed and
+         explained there - Apple's manifest format mandates SHA-1. */
+      'sonarjs/hashing': 'off',
+      // The app calls app.disable('x-powered-by') and mounts helmet in app.ts.
+      'sonarjs/x-powered-by': 'off',
+      /* A warning rather than an error, per #2565's own guidance to land the
+         config without blocking on a cleanup. Three call sites exceed the
+         4-level nest, all React callbacks-in-callbacks. SonarCloud's frontend
+         gate is green today, so it is not raising them, and refactoring three
+         unrelated components is its own change rather than part of wiring up a
+         linter. */
+      'sonarjs/no-nested-functions': 'warn',
+    },
+  },
+  {
+    /* Test-file rules. sonar-project.properties sets sonar.test.inclusions, so
+       SonarCloud analyses tests AS tests under a different rule set and raises
+       none of these - measured 123 findings here against 0 on the real scan.
+       Enforcing them locally would mean chasing a backlog the gate never asks
+       for. */
+    files: [
+      '**/__tests__/**',
+      '**/*.test.{ts,tsx}',
+      '**/*.spec.{ts,tsx}',
+      '**/*.stories.{ts,tsx}',
+      'e2e/**',
+      '.storybook/**',
+    ],
+    rules: {
+      'sonarjs/no-skipped-tests': 'off',
+      'sonarjs/hooks-before-test-cases': 'off',
+      'sonarjs/no-invariant-returns': 'off',
+      'sonarjs/no-empty-group': 'off',
+      'sonarjs/reduce-initial-value': 'off',
+      'sonarjs/assertions-in-tests': 'off',
+      'sonarjs/prefer-specific-assertions': 'off',
+      'sonarjs/no-trivial-assertions': 'off',
+      'sonarjs/parameterized-tests': 'off',
+      'sonarjs/no-nested-functions': 'off',
+      'sonarjs/no-identical-functions': 'off',
+      'sonarjs/no-hardcoded-passwords': 'off',
+      'sonarjs/no-floating-point-equality': 'off',
+      'sonarjs/no-extra-arguments': 'off',
+      'sonarjs/void-use': 'off',
+      'sonarjs/super-linear-regex': 'off',
+      'sonarjs/no-nested-conditional': 'off',
+      'sonarjs/no-globals-shadowing': 'off',
+      'sonarjs/no-os-command-from-path': 'off',
+      'sonarjs/cognitive-complexity': 'off',
+      'sonarjs/regex-complexity': 'off',
+      'sonarjs/no-unused-vars': 'off',
+    },
+  },
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',

--- a/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Parent.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Parent.tsx
@@ -319,10 +319,7 @@ function Parent({ setActiveLabel, formData, setFormData, ref }: ParentProps) {
     }
 
     setFormDataErrors(errors);
-    if (Object.keys(errors).length > 0) {
-      return false;
-    }
-    return true;
+    return Object.keys(errors).length === 0;
   };
 
   useImperativeHandle(ref, () => ({

--- a/apps/frontend/src/app/lib/team.ts
+++ b/apps/frontend/src/app/lib/team.ts
@@ -1,8 +1,3 @@
-import { RoleCode } from "@/app/lib/permissions";
+import { RoleCode } from '@/app/lib/permissions';
 
-export const allowDelete = (role: RoleCode) => {
-  if (role === "OWNER") {
-    return false;
-  }
-  return true;
-};
+export const allowDelete = (role: RoleCode) => role !== 'OWNER';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       eslint:
         specifier: ^9.27.0
         version: 9.39.2
+      eslint-plugin-sonarjs:
+        specifier: ^4.2.0
+        version: 4.2.0(eslint@9.39.2)
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.2.0)(ts-node@10.9.2)


### PR DESCRIPTION
Closes #2565. Closes #2652.

Two issues that turned out to be one piece of work — wiring the linter in is what proved the deprecations were still there.

## #2565 — the plugin ran nowhere

`eslint-plugin-sonarjs` was a declared dependency that no eslint config referenced. Sonar smells could not be caught before pushing, so the first sight of one was a red `sonar` check about ten minutes into CI — and the backend gate runs with an issues ceiling of **0**, so a single MAJOR smell blocks the merge.

It is now wired into both configs. The backend also gains the dependency, which it never declared (only the frontend did).

**Self-tested, as the issue asks.** A file containing a nested ternary is rejected by both configs:

```
2:12  error  Extract this nested ternary operation into an independent statement  sonarjs/no-nested-conditional
```

That is the eslint twin of `typescript:S3358`, the single smell that failed PR #2559 and motivated this issue.

## #2652 — and I was wrong about it

Enabling the plugin immediately surfaced **284 `sonarjs/deprecation` hits**, almost all Zod v4 — exactly what #2652 said, and what I had wrongly reported as already done.

My measurement was:

```
git grep -h -o -E "string()\.datetime(" origin/dev -- '...' | wc -l
```

which git rejects outright — `fatal: parentheses not balanced`. It printed nothing to stdout, `wc -l` counted **0**, and because `wc` exited 0 the pipeline looked healthy. I read a command that never ran as evidence that the code was clean, and closed the issue on it. Reopened and corrected.

**283 sites migrated.** Every replacement was checked against the installed zod 4.4.3 by parsing the same inputs through both forms, not taken from the migration guide:

| deprecated | replacement | sites |
|---|---|---|
| `z.string().datetime()` | `z.iso.datetime()` | 148 |
| `z.string().uuid()` | `z.uuid()` | 103 |
| `z.nativeEnum(X)` | `z.enum(X)` | 14 |
| `z.string().url()` | `z.url()` | 5 |
| `z.string().email()` | `z.email()` | 5 |
| `A.merge(B)` | `A.extend(B.shape)` | 4 |
| `z.number().finite()` | `z.number()` | 3 |
| `z.string().date()` | `z.iso.date()` | 1 |

### The ordering trap is real, and it hit four sites

`z.string().trim().email()` trims **then** validates. A bare `z.email()` would validate the untrusted input, so `"  a@b.com  "` would be rejected instead of accepted. Those four became `z.string().trim().pipe(z.email())`, with `.max(254)` moved **inside** the pipe — `ZodPipe` has no `.max`, which `tsc` caught. Verified by parsing padded input through both forms:

```
input "  a@b.com  "   before -> "a@b.com"   after -> "a@b.com"
input " nope "        before -> reject      after -> reject
```

## The config is curated, not wholesale

The plugin is measurably over-broad against this repo, and enabling `recommended` as errors would make `lint` red over findings SonarCloud never raises — which teaches people to ignore the linter. Each rule is off with its measured reason:

- **`no-clear-text-protocols`** — fires on `http://snomed.info/sct` and `http://www.whocc.no/atcvet`, canonical system URIs that are identifiers rather than requests; rewriting them to https breaks FHIR conformance
- **`hashing`** — fires on the PassKit SHA-1 that already carries a `NOSONAR` and an explanation. **SonarCloud honours NOSONAR; eslint does not.** Apple's manifest format mandates SHA-1
- **`x-powered-by`** — `app.ts` already calls `app.disable("x-powered-by")` and mounts helmet
- **`no-unused-vars`** — duplicates `@typescript-eslint/no-unused-vars`, already enforced with this repo's `^_` patterns. Measured 60 duplicate reports
- **test-file rules** — `sonar.test.inclusions` makes SonarCloud analyse tests *as tests* under a different rule set. Measured **123** findings here against **0** on the real scan

Rules SonarCloud does not raise are **warnings**, not errors, per this issue's own guidance to land the config without blocking on a cleanup. The clearest case is `different-types-comparison`, which flags `value === null` where the parameter is `value?: string | number | Date` — by the type `null` is impossible, but these are controllers reading untrusted input, so the check is correct and the type is simply narrower than reality.

## One deprecation is deliberately left

`documenso.documents.createV0` is scoped off for that one file, pointing at #2643. It already carries a NOSONAR, and migrating it cannot be verified without a live Documenso instance. Done as a config-level `files:` exception rather than an inline `eslint-disable`, which CLAUDE.md forbids — the same shape as the existing test-file exception and `sonar-project.properties`' narrow ignores. Delete that block when #2643 lands.

## Validation

- **459 suites / 11079 backend tests pass** after 283 schema edits
- **425 frontend tests pass**
- backend `tsc` **0 errors**, `lint` **exit 0** (25 warnings, 0 errors)
- frontend `tsc` **exit 0**, `lint` **exit 0** (4 warnings, 0 errors)
- both configs self-tested against a deliberately failing probe, and the probes deleted

Also fixed the two genuine `prefer-single-boolean-return` findings the enable surfaced in `lib/team.ts` and `AddCompanion/Sections/Parent.tsx`.