### PR TITLE
fix(backend): stop metering developer API calls made with a test key

### DIFF
--- a/apps/backend/src/middlewares/api-key-auth.ts
+++ b/apps/backend/src/middlewares/api-key-auth.ts
@@ -57,6 +57,7 @@ export const authorizeApiKey = async (
 
   const usage = await DeveloperUsageService.incrementAndCheck(
     verified.ownerUserId,
+    verified.environment,
   );
   if (!usage.allowed) {
     return res.status(429).json({

--- a/apps/backend/src/services/developer-usage.service.ts
+++ b/apps/backend/src/services/developer-usage.service.ts
@@ -1,3 +1,4 @@
+import type { DeveloperApiKeyEnvironment } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { DeveloperBillingService } from "./developer-billing.service";
 import logger from "../utils/logger";
@@ -15,11 +16,31 @@ const currentBillingPeriod = (): string => {
 };
 
 export const DeveloperUsageService = {
-  // Increments call count atomically and checks quota.
-  // Returns { allowed: boolean, callCount: number } — caller should 429 when !allowed.
+  /*
+   * Increments call count atomically and checks quota.
+   * Returns { allowed: boolean, callCount: number } - caller should 429 when !allowed.
+   *
+   * `environment` is required rather than optional so a caller cannot meter a
+   * key by forgetting to pass it. A `test` key never consumes quota, never
+   * triggers a 429 and never produces a Stripe meter event - which is what the
+   * billing UI already promises in two places ("Test-environment calls are
+   * always free", DeveloperBilling.tsx; "Test-environment calls are not
+   * counted", UsageMeter.tsx). The code was silent on test keys rather than
+   * deliberate about them: `verified.environment` existed and was attached to
+   * the request, but nothing consulted it, and this service could not have
+   * discriminated even if a caller wanted it to (#2549).
+   */
   async incrementAndCheck(
     ownerUserId: string,
+    environment: DeveloperApiKeyEnvironment,
   ): Promise<{ allowed: boolean; callCount: number }> {
+    /* Returns the count it did not record. A test key is unmetered, so there is
+       no meaningful running total to report, and 0 keeps callers that log or
+       surface this from implying a quota was consumed. */
+    if (environment === "test") {
+      return { allowed: true, callCount: 0 };
+    }
+
     const period = currentBillingPeriod();
 
     const record = await prisma.developerApiUsage.upsert({

--- a/apps/backend/test/middlewares/api-key-auth.test.ts
+++ b/apps/backend/test/middlewares/api-key-auth.test.ts
@@ -122,7 +122,7 @@ describe("authorizeApiKey", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("calls incrementAndCheck with the ownerUserId", async () => {
+  it("calls incrementAndCheck with the ownerUserId and the key's environment", async () => {
     verifyMock.mockResolvedValue(verifiedKey);
     const res = buildRes();
     await authorizeApiKey(
@@ -130,7 +130,23 @@ describe("authorizeApiKey", () => {
       res,
       next,
     );
-    expect(incrementMock).toHaveBeenCalledWith("org-9");
+    expect(incrementMock).toHaveBeenCalledWith("org-9", "live");
+  });
+
+  it("forwards a test key's environment so it is not metered", async () => {
+    /* `verified.environment` was populated and attached to the request but never
+       consulted, so a yc_test_... key consumed quota and could produce a Stripe
+       meter event (#2549). The middleware is the only thing that knows which
+       environment authenticated; the service cannot discriminate unless this
+       passes it on. */
+    verifyMock.mockResolvedValue({ ...verifiedKey, environment: "test" });
+    const res = buildRes();
+    await authorizeApiKey(
+      buildReq({ authorization: "Bearer yc_test_good" }),
+      res,
+      next,
+    );
+    expect(incrementMock).toHaveBeenCalledWith("org-9", "test");
   });
 });
 

--- a/apps/backend/test/services/developer-usage.service.test.ts
+++ b/apps/backend/test/services/developer-usage.service.test.ts
@@ -55,6 +55,63 @@ describe("DeveloperUsageService", () => {
   });
 
   describe("incrementAndCheck", () => {
+    it("a test key consumes no quota, is never blocked and is never metered", async () => {
+      /* The billing UI promises this in two places - "Test-environment calls are
+         always free" and "Test-environment calls are not counted" - while the
+         code metered a test key exactly like a live one (#2549). A test key
+         must not touch the usage row at all, not merely be forgiven at the
+         quota check, or the count itself would still climb toward the limit. */
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "test",
+      );
+
+      expect(result).toEqual({ allowed: true, callCount: 0 });
+      expect(mockPrisma.developerApiUsage.upsert).not.toHaveBeenCalled();
+      expect(
+        mockPrisma.developerSubscription.findUnique,
+      ).not.toHaveBeenCalled();
+      expect(mockReportUsage).not.toHaveBeenCalled();
+    });
+
+    it("a test key on a pro plan produces no Stripe meter event", async () => {
+      /* Pro is the branch that meters rather than blocks, so it is where an
+         unscreened test key costs the developer money instead of a 429. */
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({
+        callCount: 5000,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "pro",
+        stripeCustomerId: "cus_1",
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "test",
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(mockReportUsage).not.toHaveBeenCalled();
+    });
+
+    it("a test key past the free-tier limit is still allowed", async () => {
+      // The 429 path: a test key must never be the thing that blocks a caller.
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({
+        callCount: 1001,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+        stripeCustomerId: null,
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "test",
+      );
+
+      expect(result.allowed).toBe(true);
+    });
+
     it("free plan, first call — returns allowed:true and callCount:1", async () => {
       mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 1 });
       mockPrisma.developerSubscription.findUnique.mockResolvedValue({
@@ -62,7 +119,10 @@ describe("DeveloperUsageService", () => {
         stripeCustomerId: null,
       });
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: true, callCount: 1 });
       expect(mockReportUsage).not.toHaveBeenCalled();
@@ -77,7 +137,10 @@ describe("DeveloperUsageService", () => {
         stripeCustomerId: null,
       });
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: false, callCount: 1001 });
     });
@@ -91,7 +154,10 @@ describe("DeveloperUsageService", () => {
         stripeCustomerId: null,
       });
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: true, callCount: 1000 });
     });
@@ -105,7 +171,10 @@ describe("DeveloperUsageService", () => {
       mockReportUsage.mockResolvedValue(undefined);
       mockPrisma.developerApiUsage.update.mockResolvedValue({});
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: true, callCount: 42 });
 
@@ -135,7 +204,7 @@ describe("DeveloperUsageService", () => {
         mockReportUsage.mockResolvedValue(undefined);
         mockPrisma.developerApiUsage.update.mockResolvedValue({});
 
-        await DeveloperUsageService.incrementAndCheck("org-1");
+        await DeveloperUsageService.incrementAndCheck("org-1", "live");
         await Promise.resolve();
         await Promise.resolve();
 
@@ -158,11 +227,11 @@ describe("DeveloperUsageService", () => {
       mockPrisma.developerApiUsage.upsert.mockResolvedValueOnce({
         callCount: 7,
       });
-      await DeveloperUsageService.incrementAndCheck("org-1");
+      await DeveloperUsageService.incrementAndCheck("org-1", "live");
       mockPrisma.developerApiUsage.upsert.mockResolvedValueOnce({
         callCount: 8,
       });
-      await DeveloperUsageService.incrementAndCheck("org-1");
+      await DeveloperUsageService.incrementAndCheck("org-1", "live");
 
       await Promise.resolve();
       await Promise.resolve();
@@ -177,7 +246,10 @@ describe("DeveloperUsageService", () => {
       mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 5 });
       mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: true, callCount: 5 });
       expect(mockReportUsage).not.toHaveBeenCalled();
@@ -190,7 +262,10 @@ describe("DeveloperUsageService", () => {
         stripeCustomerId: null,
       });
 
-      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+      const result = await DeveloperUsageService.incrementAndCheck(
+        "org-1",
+        "live",
+      );
 
       expect(result).toEqual({ allowed: true, callCount: 10 });
 


### PR DESCRIPTION
Closes #2549

## What was wrong

`authorizeApiKey` verified a key and then metered the call without ever looking at its environment. A `yc_test_...` key consumed free-tier quota, could trigger a 429, and on the Pro plan produced a Stripe meter event.

`verified.environment` existed on the type, was populated by `verify()`, and was attached to the request — nothing consulted it. And `DeveloperUsageService.incrementAndCheck` could not have discriminated even if a caller wanted it to, because it took no environment argument.

**The billing UI already promises the opposite**, in two places on a live route:

- `DeveloperBilling.tsx`: "Test-environment calls are always free"
- `UsageMeter.tsx`: "Test-environment calls are not counted"

This makes the code match what the product tells developers.

## What changed

A test key returns early: **no usage row is touched, no subscription is read, no Stripe event is sent.**

Short-circuiting rather than forgiving it at the quota check, because otherwise the stored count still climbs toward a limit the key is exempt from — the row would be wrong even though the caller was allowed through. `callCount` comes back as `0`: there is no meaningful running total for an unmetered key, and `0` stops any caller that logs or surfaces it from implying quota was consumed.

**`environment` is required, not optional.** A caller cannot meter a key by forgetting to pass it. `tsc` then listed all nine existing call sites — each was describing live behaviour, and now says so explicitly.

## Validation

Both halves **mutation-checked**:

| mutation | caught by |
|---|---|
| remove the test-key short circuit | all three new service tests |
| middleware hardcodes `"live"` instead of forwarding | the new forwarding test |

The Pro case has its own test, because Pro is the branch that *meters* rather than blocks — where an unscreened test key costs the developer money instead of returning a 429, which is the worse of the two outcomes.

- **459 suites / 11088 backend tests pass**
- backend `tsc` **0 errors**, `lint` **exit 0**

## Scope, from the issue

`authorizeApiKey` is mounted on **zero** routes today — the three developer routers are session-authed via `requireWebAuth`. So `DeveloperApiUsage.callCount` never increments in production and **nobody is being wrongly billed right now**. This is a latent defect that becomes a live billing bug the moment the middleware is mounted on a public route, which is the point at which it would be expensive to discover.

## Impact area

`apps/backend` — one service method and one middleware call. No schema change, no route change.