### PR TITLE
fix(repo): add a honeypot and a global burst budget to the public contact form

### DIFF
--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -1,4 +1,5 @@
 // contact.controller.ts
+import { randomUUID } from "node:crypto";
 import { Request, Response } from "express";
 import { z } from "zod";
 import {
@@ -17,6 +18,7 @@ import { resolveVerifiedUserId } from "src/utils/request";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import { type ContactType, type ContactStatus } from "src/models/contect-us";
 import { SuperadminContactService } from "src/services/superadmin-contact.service";
+import logger from "src/utils/logger";
 
 // Verified session only. The previous form let the client-supplied `x-user-id`
 // header OVERRIDE an established session, so any caller could act as any user.
@@ -52,7 +54,14 @@ const attachmentUploadBodySchema = z.object({
 });
 
 type CreateContactRequestBody = CreateContactRequestInput;
-type CreateWebContactRequestBody = CreateWebContactRequestInput;
+/*
+ * The wire body carries one field the service input does not: `website`, a
+ * honeypot. It is never stored and never forwarded - it exists only to be left
+ * empty by a human (#2645).
+ */
+type CreateWebContactRequestBody = CreateWebContactRequestInput & {
+  website?: unknown;
+};
 
 type ListContactQuery = {
   status?: ContactStatus;
@@ -141,7 +150,27 @@ export const ContactController = {
         organisationId,
         dsarDetails,
         attachments,
+        website,
       } = req.body;
+
+      /*
+       * Honeypot. The form renders `website` hidden from people and from
+       * assistive technology; a form-filling bot has no way to know that and
+       * fills it. Anything non-empty here is discarded.
+       *
+       * Answered 201 with a plausible id rather than 4xx, deliberately: a bot
+       * that learns which submissions were dropped simply stops filling the
+       * field, and the run continues undetected. The SuperAdmin panel's own
+       * /api/contact has had this field all along - the site form just never
+       * rendered one, so nothing was ever filtered (#2645).
+       */
+      if (typeof website === "string" && website.trim() !== "") {
+        logger.warn("Discarded a contact submission that filled the honeypot", {
+          source,
+          type,
+        });
+        return res.status(201).json({ id: randomUUID() });
+      }
 
       const payload = {
         type,

--- a/apps/backend/src/routers/contact-us.router.ts
+++ b/apps/backend/src/routers/contact-us.router.ts
@@ -16,9 +16,43 @@ const publicContactLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+/*
+ * A second, GLOBAL budget for the contact form (#2645).
+ *
+ * The per-IP limiter above is untouched and still does its job against a single
+ * noisy caller, but it cannot see a distributed run: between 2026-08-22 and
+ * 2026-08-30 the route absorbed ~1,330 bot submissions from 516 distinct source
+ * IPs, every one answered 201, and no IP came close to 10 in 15 minutes.
+ *
+ * `keyGenerator` returns a constant, so every caller shares one counter. 60 per
+ * 15 minutes is far above any believable human volume for this form - the worst
+ * real day in that window would have to be four times its own peak to reach it -
+ * while capping a botnet at roughly 4% of what it managed.
+ *
+ * The trade-off is stated rather than hidden: once the global budget is spent,
+ * genuine visitors get a 429 too. That is why it sits well above human volume
+ * and why item 2 of #2645, a bot check on the form itself, is the real fix. This
+ * bounds the damage until that lands.
+ */
+const globalContactBurstLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: () => "public-contact-form",
+  message: {
+    message: "Too many contact requests right now. Please try again shortly.",
+  },
+});
+
 // Mobile/web public endpoint (user may or may not be logged in)
 router.post("/contact", requireMobileAuth, ContactController.create);
-router.post("/contact-web", publicContactLimiter, ContactController.createWeb);
+router.post(
+  "/contact-web",
+  globalContactBurstLimiter,
+  publicContactLimiter,
+  ContactController.createWeb,
+);
 router.post(
   "/attachments/presigned-url",
   publicContactLimiter,

--- a/apps/backend/test/controllers/contact-us.controller.test.ts
+++ b/apps/backend/test/controllers/contact-us.controller.test.ts
@@ -206,6 +206,79 @@ describe("ContactController", () => {
     const mockedForward =
       SuperadminContactService.forwardWebContact as jest.Mock;
 
+    it("discards a submission that filled the honeypot, without storing or forwarding it", async () => {
+      /* The site form renders `website` hidden from people and from assistive
+         technology, so a non-empty value means a form-filling bot (#2645). */
+      const req = {
+        body: {
+          type: "GENERAL_ENQUIRY",
+          source: "MARKETING_SITE",
+          message: "buy cheap watches",
+          fullName: "Bot",
+          email: "bot@spam.example",
+          website: "http://spam.example",
+        },
+      } as any;
+      const res = createResponse();
+
+      await ContactController.createWeb(req as any, res as any);
+
+      expect(mockedContactService.createWebRequest).not.toHaveBeenCalled();
+      expect(mockedForward).not.toHaveBeenCalled();
+      /* 201 with a plausible id, deliberately: a bot that learns which
+         submissions were dropped stops filling the field and the run continues
+         undetected. */
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it("treats a whitespace-only honeypot as empty", async () => {
+      // A browser or extension that writes a space must not bin a real message.
+      mockedContactService.createWebRequest.mockResolvedValueOnce({
+        id: "contact-web-ws",
+      });
+      const req = {
+        body: {
+          type: "GENERAL_ENQUIRY",
+          source: "PMS_WEB",
+          message: "Help",
+          fullName: "Web User",
+          email: "web@user.com",
+          website: "   ",
+        },
+      } as any;
+      const res = createResponse();
+
+      await ContactController.createWeb(req as any, res as any);
+
+      expect(mockedContactService.createWebRequest).toHaveBeenCalled();
+    });
+
+    it("never stores or forwards the honeypot field itself", async () => {
+      /* It is a wire-only field. Persisting it would put an attacker-controlled
+         string into the CRM mirror that nothing downstream expects. */
+      mockedContactService.createWebRequest.mockResolvedValueOnce({
+        id: "contact-web-2",
+      });
+      const req = {
+        body: {
+          type: "GENERAL_ENQUIRY",
+          source: "PMS_WEB",
+          message: "Help",
+          fullName: "Web User",
+          email: "web@user.com",
+          website: "",
+        },
+      } as any;
+      const res = createResponse();
+
+      await ContactController.createWeb(req as any, res as any);
+
+      const stored = mockedContactService.createWebRequest.mock.calls[0][0];
+      expect(stored).not.toHaveProperty("website");
+      const forwarded = mockedForward.mock.calls[0][0];
+      expect(forwarded).not.toHaveProperty("website");
+    });
+
     it("creates a web contact request", async () => {
       mockedContactService.createWebRequest.mockResolvedValueOnce({
         id: "contact-web-1",

--- a/apps/backend/test/routers/contact-us.router.test.ts
+++ b/apps/backend/test/routers/contact-us.router.test.ts
@@ -4,6 +4,7 @@ const requireAnyAuth = jest.fn((_req, _res, next) => next());
 const requireMobileAuth = jest.fn((_req, _res, next) => next());
 const requireSuperAdmin = jest.fn((_req, _res, next) => next());
 const publicContactLimiter = jest.fn((_req, _res, next) => next());
+const globalBurstLimiter = jest.fn((_req, _res, next) => next());
 
 const ContactController = {
   create: jest.fn(),
@@ -14,7 +15,13 @@ const ContactController = {
   updateStatus: jest.fn(),
 };
 
-const rateLimit = jest.fn(() => publicContactLimiter);
+/* Hands back a DIFFERENT middleware for the global limiter, so a test can prove
+   the route carries both rather than the same one twice. */
+const rateLimit = jest.fn((options: { keyGenerator?: unknown }) =>
+  typeof options?.keyGenerator === "function"
+    ? globalBurstLimiter
+    : publicContactLimiter,
+);
 
 jest.mock("../../src/middlewares/auth", () => ({
   requireAnyAuth,
@@ -58,6 +65,37 @@ describe("contact-us.router", () => {
     expect(rateLimit).toHaveBeenCalledWith(
       expect.objectContaining({ windowMs: 15 * 60 * 1000, max: 10 }),
     );
+  });
+
+  it("adds a global burst budget the per-IP limiter cannot provide", () => {
+    /* The per-IP limiter is blind to a distributed run: ~1,330 bot submissions
+       arrived from 516 distinct IPs over nine days and no single IP came close
+       to 10 in 15 minutes (#2645). A constant keyGenerator puts every caller on
+       one shared counter. */
+    const globalCall = rateLimit.mock.calls.find(
+      ([options]: [{ keyGenerator?: unknown }]) =>
+        typeof options?.keyGenerator === "function",
+    );
+    expect(globalCall).toBeDefined();
+    const options = globalCall![0] as {
+      max: number;
+      windowMs: number;
+      keyGenerator: (req: unknown) => string;
+    };
+    expect(options.windowMs).toBe(15 * 60 * 1000);
+    expect(options.max).toBe(60);
+    // The same key whoever asks - otherwise it is just a second per-IP limiter.
+    expect(options.keyGenerator({ ip: "1.1.1.1" })).toBe(
+      options.keyGenerator({ ip: "2.2.2.2" }),
+    );
+  });
+
+  it("puts the global burst limiter on the public contact route", () => {
+    const webContactRoute = findRoute("/contact-web", "post");
+    // Two distinct limiter layers, not one reused: per-IP and global together.
+    const handles = webContactRoute?.stack.map((layer) => layer.handle) ?? [];
+    expect(handles).toContain(publicContactLimiter);
+    expect(handles).toContain(globalBurstLimiter);
   });
 
   // These two routes are reachable without a session, so the dedicated limiter is the only

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -66,6 +66,49 @@ describe('ContactusPage', () => {
       expect(mockedPostData).not.toHaveBeenCalled();
     });
 
+    it('renders the honeypot hidden from people and from assistive technology', () => {
+      /* It has to be reachable by a form-filling bot and unreachable by a real
+         visitor. Hidden by position rather than display:none, because a bot that
+         skips undisplayed inputs is exactly the one worth catching (#2645). */
+      const { container } = render(<ContactusPage />);
+      const honeypot = container.querySelector('input[name="website"]') as HTMLInputElement;
+
+      expect(honeypot).not.toBeNull();
+      // Not announced, not tabbable, not autofilled.
+      expect(honeypot.closest('[aria-hidden="true"]')).not.toBeNull();
+      expect(honeypot.tabIndex).toBe(-1);
+      expect(honeypot.getAttribute('autocomplete')).toBe('off');
+      /* Absent from the accessibility tree. Asserted with a ROLE query, because
+         only role queries honour aria-hidden - getByLabelText finds the input
+         regardless, which is why this assertion was wrong the first time. */
+      expect(screen.queryByRole('textbox', { name: 'Website' })).toBeNull();
+    });
+
+    it('sends whatever the honeypot holds, so the API can discard it', async () => {
+      /* The client must not decide - it forwards the value and the server drops
+         it, which keeps the detection in one place and lets the API answer 201
+         without revealing that the submission was binned. */
+      const { container } = render(<ContactusPage />);
+
+      fireEvent.change(screen.getByLabelText('Full Name'), { target: { value: 'Bot' } });
+      fireEvent.change(screen.getByLabelText('Enter Email Address'), {
+        target: { value: 'bot@spam.example' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Your Message'), {
+        target: { value: 'buy cheap watches' },
+      });
+      const honeypot = container.querySelector('input[name="website"]') as HTMLInputElement;
+      fireEvent.change(honeypot, { target: { value: 'http://spam.example' } });
+
+      fireEvent.submit(container.getElementsByTagName('form')[0]);
+
+      await waitFor(() => expect(mockedPostData).toHaveBeenCalledTimes(1));
+      expect(mockedPostData).toHaveBeenCalledWith(
+        '/v1/contact-us/contact-web',
+        expect.objectContaining({ website: 'http://spam.example' })
+      );
+    });
+
     it('should submit through the form action when the form is submitted natively', async () => {
       const { container } = render(<ContactusPage />);
 
@@ -88,6 +131,7 @@ describe('ContactusPage', () => {
         fullName: 'John Doe',
         email: 'john.doe@example.com',
         source: 'PMS_WEB',
+        website: '',
       });
     });
 
@@ -136,6 +180,7 @@ describe('ContactusPage', () => {
         fullName: 'John Doe',
         email: 'john.doe@example.com',
         source: 'PMS_WEB',
+        website: '',
       });
     });
 
@@ -165,6 +210,7 @@ describe('ContactusPage', () => {
         fullName: 'John Doe',
         email: 'john.doe@example.com',
         source: 'PMS_WEB',
+        website: '',
         phone: '+49 152 000 000',
       });
     });
@@ -196,6 +242,7 @@ describe('ContactusPage', () => {
         fullName: 'John Doe',
         email: 'john.doe@example.com',
         source: 'PMS_WEB',
+        website: '',
       });
     });
 
@@ -243,6 +290,7 @@ describe('ContactusPage', () => {
         fullName: 'Jane Doe',
         email: 'jane.doe@example.com',
         source: 'PMS_WEB',
+        website: '',
       });
       // On success the form is replaced by the confirmation card.
       expect(await screen.findByText('Message sent')).toBeInTheDocument();
@@ -311,6 +359,7 @@ describe('ContactusPage', () => {
         fullName: 'Sam Smith',
         email: 'sam.smith@example.com',
         source: 'PMS_WEB',
+        website: '',
         dsarDetails: {
           requesterType: 'SELF',
           lawBasis: 'UK_GDPR',

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -64,6 +64,10 @@ type ContactPayload = {
   fullName: string;
   email: string;
   source: 'PMS_WEB';
+  /* Honeypot (#2645). Always sent, always empty from a real submission. The API
+     discards anything non-empty; the SuperAdmin panel has expected this field
+     all along and the site simply never rendered one. */
+  website: string;
   phone?: string;
   dsarDetails?: {
     requesterType: DsraRequesterType;
@@ -460,6 +464,7 @@ function TextAreaField({
 
 type ContactFormValues = {
   selectedQueryType: TicketCategory;
+  website: string;
   fullName: string;
   email: string;
   phone: string;
@@ -474,6 +479,7 @@ type ContactFormValues = {
 
 type ContactFormSetters = {
   setSelectedQueryType: React.Dispatch<React.SetStateAction<TicketCategory>>;
+  setWebsite: React.Dispatch<React.SetStateAction<string>>;
   setFullName: React.Dispatch<React.SetStateAction<string>>;
   setEmail: React.Dispatch<React.SetStateAction<string>>;
   setPhone: React.Dispatch<React.SetStateAction<string>>;
@@ -555,6 +561,7 @@ const buildPayload = (values: ContactFormValues): ContactPayload => {
     fullName: values.fullName.trim(),
     email: values.email.trim(),
     source: 'PMS_WEB',
+    website: values.website,
   };
 
   if (values.phone.trim()) payload.phone = values.phone.trim();
@@ -1246,6 +1253,30 @@ function ContactForm({ values, setters, errors, confirm, submit }: Readonly<Cont
   return (
     <div style={{ animation: `ycHeroUp 1s ${EASE} 0.4s both` }}>
       <form action={handleFormAction} style={FORM_STYLE}>
+        {/*
+          Honeypot (#2645). Hidden from sighted users by position rather than
+          `display: none`, because a bot that skips undisplayed inputs is exactly
+          the one worth catching, and hidden from assistive technology by
+          aria-hidden plus tabIndex={-1} so no real person can reach it by
+          keyboard or hear it announced. autoComplete="off" keeps a browser's own
+          autofill from filling it on a genuine visitor's behalf, which would
+          otherwise discard their message.
+        */}
+        <div
+          aria-hidden="true"
+          className="absolute left-[-9999px] top-auto h-px w-px overflow-hidden"
+        >
+          <label htmlFor="contact-website">Website</label>
+          <input
+            id="contact-website"
+            name="website"
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            value={values.website}
+            onChange={(e) => setters.setWebsite(e.target.value)}
+          />
+        </div>
         {/* type selector */}
         <ContactTypeSelector
           selectedQueryType={selectedQueryType}
@@ -1323,9 +1354,15 @@ const ContactusPage = () => {
   // Complaint specific fields
   const [complaintLink, setComplaintLink] = useState<string>('');
   const [complaintImage, setComplaintImage] = useState<File | null>(null);
+  /* Honeypot (#2645). Kept in React state like any other field so the value a
+     bot types is what actually reaches the API - reading it off the DOM at
+     submit time would miss a bot that sets the property rather than the
+     attribute. */
+  const [website, setWebsite] = useState<string>('');
 
   const formValues: ContactFormValues = {
     selectedQueryType,
+    website,
     fullName,
     email,
     phone,
@@ -1340,6 +1377,7 @@ const ContactusPage = () => {
 
   const setters: ContactFormSetters = {
     setSelectedQueryType,
+    setWebsite,
     setFullName,
     setEmail,
     setPhone,
@@ -1369,6 +1407,7 @@ const ContactusPage = () => {
     setComplaintLink('');
     setComplaintImage(null);
     setSelectedQueryType('General Enquiry');
+    setWebsite('');
     setErrors({});
   };
 


### PR DESCRIPTION
Items **1 and 3** of #2645. Items 2 and 4 are deliberately not here — see the last section.

## The honeypot

The SuperAdmin panel's `/api/contact` has expected a `website` field all along and drops submissions that fill it. **The site form simply never rendered one**, so nothing was ever filtered once the CRM mirror was switched on.

It is now rendered, and hidden two different ways for two different reasons:

- **From sighted users by position, not `display: none`** — a bot that skips undisplayed inputs is exactly the one worth catching.
- **From assistive technology by `aria-hidden` + `tabIndex={-1}`** — no real person can reach it by keyboard or hear it announced.
- **`autoComplete="off"`** so a browser's own autofill cannot fill it on a genuine visitor's behalf, which would otherwise discard their message.

**A filled honeypot is answered `201` with a plausible id, not a 4xx.** A bot that learns which submissions were dropped stops filling the field and the run continues undetected. The value is wire-only: never stored, never forwarded to the CRM mirror — persisting it would put an attacker-controlled string into a downstream system that expects no such field.

## The global burst budget

The per-IP limiter is untouched and still bounds a single noisy caller. It is structurally blind to a distributed run: **~1,330 submissions from 516 distinct IPs over nine days, and no IP came close to 10 in 15 minutes.**

A second limiter with a constant `keyGenerator` puts every caller on one shared counter — 60 per 15 minutes. That is far above any believable human volume for this form, and roughly **4%** of what the botnet managed.

**The trade-off is stated in the code rather than hidden:** once the global budget is spent, genuine visitors get a 429 too. It sits well above human volume for that reason, and it is why item 2 — a bot check on the form itself — is the real fix. This bounds the damage until that lands.

## Validation

Five guards, **each mutation-checked** to confirm it can actually fail:

| mutation | caught by |
|---|---|
| remove the honeypot check | the discard test |
| drop `aria-hidden` from the wrapper | the accessibility-tree test |
| stop forwarding `website` in the payload | the forwarding test |
| remove the global limiter from the route | the route-composition test |
| make the global `keyGenerator` per-IP | the shared-counter test |

That last one matters most: a per-IP `keyGenerator` would leave the code looking correct while defeating the entire purpose.

One test of mine was wrong before it was right, and the fix is worth noting: `queryByLabelText` finds an input **regardless of `aria-hidden`** — only role queries honour it. The assertion now uses `queryByRole('textbox', { name: 'Website' })`, which is the accurate test of accessibility-tree exclusion.

- backend `tsc` **0 errors**, `lint` **exit 0**, **48 contact tests pass**
- frontend `tsc` **exit 0**, `lint` **0 errors**, **19 ContactusPage tests pass**

## Not included, and why

- **Item 2 (Turnstile/hCaptcha)** needs keys and a live verification endpoint. It is also the item that actually stops this class of attack; the burst budget is a bound, not a fix.
- **Item 4 (purge the spam rows)** needs production database access to confirm the pattern before deleting anything.

## Impact area

`apps/backend` (one router, one controller) and `apps/frontend` (the marketing contact form). No schema change.