### PR TITLE
fix(desktop): record which key signed each audit entry

### DIFF
--- a/apps/desktop/src/compliance/audit-log.ts
+++ b/apps/desktop/src/compliance/audit-log.ts
@@ -26,9 +26,9 @@ export interface AuditEntry {
    * Which key signed this entry - a truncated HMAC of a fixed label under that
    * key, so it identifies the key without being usable to recover it.
    *
-   * Optional because entries written before this existed carry none. Its
-   * absence means "unknown key", which is treated exactly like a foreign one:
-   * unverifiable, not tampered.
+   * Optional because entries written before this existed carry none. An absent
+   * stamp is NOT treated as foreign: those entries were signed with the stored
+   * key, so they verify normally while it reads.
    *
    * Without it a degraded session was unattributable after the fact. The
    * keychain being unreadable is handled at startup - the stored key is left
@@ -381,8 +381,12 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
   /**
    * Whether this entry was signed by a key other than the one in hand.
    *
-   * An entry with no keyId predates the field, so its key is unknown and it is
-   * treated the same way: unverifiable, never "tampered".
+   * Requires a stamp that is PRESENT and different. An absent stamp means the
+   * entry predates the field, and those were signed with the stored key - so if
+   * that key still reads, they verify normally and belong in `valid`. Treating
+   * absence as foreign would move every entry of every existing install into
+   * `otherKey` and make getIntegrity report ok:false forever, which is a worse
+   * false alarm than the one this exists to remove. A test covers it.
    */
   const signedByAnotherKey = (entry: AuditEntry): boolean =>
     entry.keyId !== undefined && entry.keyId !== currentKeyId;

--- a/apps/desktop/src/compliance/audit-log.ts
+++ b/apps/desktop/src/compliance/audit-log.ts
@@ -22,6 +22,23 @@ export interface AuditEntry {
   // chain (empty string for the genesis entry).
   prevSignature: string;
   signature: string;
+  /**
+   * Which key signed this entry - a truncated HMAC of a fixed label under that
+   * key, so it identifies the key without being usable to recover it.
+   *
+   * Optional because entries written before this existed carry none. Its
+   * absence means "unknown key", which is treated exactly like a foreign one:
+   * unverifiable, not tampered.
+   *
+   * Without it a degraded session was unattributable after the fact. The
+   * keychain being unreadable is handled at startup - the stored key is left
+   * alone and the session signs with a temporary one - but nothing recorded
+   * WHICH entries that applied to, so once the keychain recovered those rows
+   * failed verify() forever and the trail reported "Tampered" with no
+   * explanation. On the controlled-substance register that is a compliance
+   * alarm nobody can clear (#2553).
+   */
+  keyId?: string;
 }
 
 /**
@@ -29,7 +46,10 @@ export interface AuditEntry {
  * only exists in memory is not an audit entry, so this must reach the caller.
  */
 export class AuditWriteError extends Error {
-  constructor(message: string, readonly cause?: unknown) {
+  constructor(
+    message: string,
+    readonly cause?: unknown
+  ) {
     super(message);
     this.name = 'AuditWriteError';
   }
@@ -50,7 +70,9 @@ export interface AuditLog {
   getRange: (start: number, end: number) => AuditEntry[];
   size: () => number;
   verify: (entry: AuditEntry) => boolean;
-  verifyAll: () => { valid: number; tampered: number };
+  /** `otherKey` are entries a different signing key produced - unverifiable
+   *  here, and explicitly not tampered. */
+  verifyAll: () => { valid: number; tampered: number; otherKey: number };
   // Verifies the full hash chain: each entry's stored prevSignature must match
   // the actual prior entry, catching deletion, insertion and reordering.
   //
@@ -123,9 +145,26 @@ const generateId = (): string => `audit-${Date.now()}-${++idCounter}`;
 
 // Keyed HMAC-SHA256 over the entry and the previous signature. Without the key
 // the signature cannot be recomputed, so editing the JSON file is detectable.
+/**
+ * A stable, non-reversible identifier for a signing key.
+ *
+ * An HMAC of a fixed label under the key, truncated to 16 hex characters. The
+ * label is constant so the same key always yields the same id, and the HMAC is
+ * one-way so an id on disk reveals nothing about the key that produced it.
+ */
+const KEY_ID_LABEL = 'yosemite-audit-key-id/v1';
+
+export const computeKeyId = (key: string): string =>
+  crypto.createHmac('sha256', key).update(KEY_ID_LABEL).digest('hex').slice(0, 16);
+
 const computeSignature = (entry: Omit<AuditEntry, 'signature'>, key: string): string => {
   const payload = `${entry.id}|${entry.timestamp}|${entry.action}|${entry.actor}|${entry.resourceType}|${entry.resourceId}|${JSON.stringify(entry.details)}|${entry.prevSignature}`;
-  return crypto.createHmac('sha256', key).update(payload).digest('hex');
+  /* keyId joins the signed payload only when present, so an entry written
+     before this field existed hashes to exactly what it did then and still
+     verifies. A new entry covers it, so the provenance cannot be edited to
+     disguise a foreign key as the current one. */
+  const withProvenance = entry.keyId ? `${payload}|${entry.keyId}` : payload;
+  return crypto.createHmac('sha256', key).update(withProvenance).digest('hex');
 };
 
 export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Promise<AuditLog> => {
@@ -265,6 +304,8 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
     now,
   });
 
+  const currentKeyId = computeKeyId(key);
+
   const load = (): AuditEntry[] => store.readAll();
 
   const append = (
@@ -277,6 +318,9 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
       id: generateId(),
       timestamp: now(),
       prevSignature,
+      // Stamped from the key actually in hand, whether or not it is the stored
+      // one. That is the whole point: a temporary key must leave a trace.
+      keyId: currentKeyId,
     };
     const entry: AuditEntry = {
       ...unsigned,
@@ -334,6 +378,15 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
 
   const size = (): number => load().length;
 
+  /**
+   * Whether this entry was signed by a key other than the one in hand.
+   *
+   * An entry with no keyId predates the field, so its key is unknown and it is
+   * treated the same way: unverifiable, never "tampered".
+   */
+  const signedByAnotherKey = (entry: AuditEntry): boolean =>
+    entry.keyId !== undefined && entry.keyId !== currentKeyId;
+
   const verify = (entry: AuditEntry): boolean => {
     const { signature, ...rest } = entry;
     const candidate = computeSignature(rest, key);
@@ -341,15 +394,23 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
     return crypto.timingSafeEqual(Buffer.from(candidate), Buffer.from(signature));
   };
 
-  const verifyAll = (): { valid: number; tampered: number } => {
+  /**
+   * `otherKey` counts entries a different key signed - during a session where
+   * the stored key was unreadable, for instance. They are NOT tampered, and
+   * counting them as such is the false alarm this exists to prevent. They stay
+   * out of `valid` too, because nothing here can vouch for them.
+   */
+  const verifyAll = (): { valid: number; tampered: number; otherKey: number } => {
     const entries = load();
     let valid = 0;
     let tampered = 0;
+    let otherKey = 0;
     for (const entry of entries) {
-      if (verify(entry)) valid++;
+      if (signedByAnotherKey(entry)) otherKey++;
+      else if (verify(entry)) valid++;
       else tampered++;
     }
-    return { valid, tampered };
+    return { valid, tampered, otherKey };
   };
 
   const verifyChain = (): boolean => {
@@ -357,6 +418,13 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
     let prev = '';
     for (const entry of entries) {
       if (entry.prevSignature !== prev) return false;
+      /* Deliberately NOT skipped for a foreign key. Skipping looks reasonable -
+         the HMAC genuinely cannot be recomputed without that key - but it opens
+         a hole: edit an entry's contents, overwrite its keyId with any other
+         value, and it is excused from verification and the chain walks clean.
+         A test drives exactly that. Without the old key an edit under it is
+         undetectable, so the honest answer is that the chain cannot be attested,
+         never that it is intact. `getIntegrity` explains why. */
       if (!verify(entry)) return false;
       prev = entry.signature;
     }
@@ -373,7 +441,26 @@ export const createAuditLog = async (dirPath: string, deps: AuditDeps = {}): Pro
 
   const getIntegrity = (): AuditIntegrity => {
     const health = store.health();
-    if (keyState.persisted) return { ...health, signingKey: 'persisted' };
+    if (keyState.persisted) {
+      /* Entries a different key signed are unverifiable here even though the
+         stored key is readable again - a window where the keychain was down.
+         Saying so is the point of #2553: the alternative was a permanent
+         "Tampered" with no reason line, which reads as a breach. */
+      const foreign = load().filter(signedByAnotherKey).length;
+      if (foreign > 0) {
+        const foreignReason =
+          `${foreign} ${foreign === 1 ? 'entry was' : 'entries were'} signed with a different key, ` +
+          `recorded while the stored signing key could not be read; their signatures cannot be ` +
+          `re-checked and this is not evidence of tampering`;
+        return {
+          ...health,
+          ok: false,
+          reason: health.reason ? `${health.reason}; ${foreignReason}` : foreignReason,
+          signingKey: 'persisted',
+        };
+      }
+      return { ...health, signingKey: 'persisted' };
+    }
     const keyReason =
       `the audit signing key could not be read (${keyState.reason}), so this session signs with a ` +
       `temporary key; earlier entries cannot be verified until the stored key is readable again`;

--- a/apps/desktop/src/ui/status-dialogs.ts
+++ b/apps/desktop/src/ui/status-dialogs.ts
@@ -77,7 +77,9 @@ export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogS
     const verified = events.filter((e) => e.witnessPinVerified).length;
     const unverified = events.length - verified;
     const line = `Witness-verified waste events: ${verified}`;
-    return unverified > 0 ? `${line}\nWaste events WITHOUT a verified witness: ${unverified}` : line;
+    return unverified > 0
+      ? `${line}\nWaste events WITHOUT a verified witness: ${unverified}`
+      : line;
   };
 
   // A daily log or biennial report built from a register that lost records is
@@ -107,16 +109,25 @@ export const createStatusDialogService = (deps: StatusDialogDeps): StatusDialogS
         infoDialog('Audit Trail', 'The audit log is not initialized.');
         return;
       }
-      const { valid, tampered } = deps.auditLog.verifyAll();
+      const { valid, tampered, otherKey } = deps.auditLog.verifyAll();
       const chainIntact = deps.auditLog.verifyChain();
       const integrity = deps.auditLog.getIntegrity();
       // Without the stored key every historical entry fails its signature check.
       // Reporting that as "Tampered" is indistinguishable from real tampering
       // and sends the practice looking for a breach that did not happen.
+      /* Entries a previous, temporary key signed get their own line and an
+         explanation. Folding them into "Tampered" was a permanent, unexplained
+         compliance alarm on the controlled-substance register once the keychain
+         recovered - the exact false alarm this dialog exists to avoid (#2553). */
+      const otherKeyLine =
+        otherKey > 0
+          ? `\nSigned with a previous key: ${otherKey} (recorded while the signing key was ` +
+            `unreadable - these cannot be re-checked here, and are not evidence of tampering)`
+          : '';
       const signatureLines =
         integrity.signingKey === 'session-only'
           ? 'Signatures: CANNOT BE CHECKED (signing key unreadable)'
-          : `Valid signatures: ${valid}\nTampered: ${tampered}`;
+          : `Valid signatures: ${valid}\nTampered: ${tampered}${otherKeyLine}`;
       // "Hash chain intact: yes" over a log that lost records is an affirmative
       // false compliance statement, so say what is wrong when anything is.
       const problem = integrity.ok ? '' : `\n\nProblem detected: ${integrity.reason}`;

--- a/apps/desktop/tests/audit-key-preservation.test.ts
+++ b/apps/desktop/tests/audit-key-preservation.test.ts
@@ -185,6 +185,143 @@ describe('audit signing key preservation', () => {
   });
 });
 
+describe('a degraded window stays attributable after the keychain recovers', () => {
+  /* The defect this closes (#2553), reproduced end to end over three sessions
+     exactly as the issue describes: healthy keychain, then unreadable while a
+     controlled-substance entry is written, then healthy again.
+
+     Before entries carried a keyId, session 3 reported `{ valid: 1, tampered: 1 }`
+     and `verifyChain() === false`, permanently and with no reason line, because
+     `getIntegrity()` derived the degraded state from the LIVE key state and
+     nothing remembered which rows it had applied to. On the DEA register that is
+     a compliance alarm an operator can neither clear nor account for. */
+  const DEGRADED_DIR = '/audit-degraded';
+
+  test('the entry written on a temporary key is attributed, not called tampered', async () => {
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+    mem.dirs.add(DEGRADED_DIR);
+
+    // Session 1: healthy keychain. E1 is signed with the stored key.
+    const s1 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    s1.append(ENTRY);
+    expect(s1.verifyAll()).toEqual({ valid: 1, tampered: 0, otherKey: 0 });
+
+    // Session 2: keychain unavailable. The stored key is left alone and E2 is
+    // written under a temporary one - the "keep recording" decision above.
+    const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: null });
+    expect(s2.getIntegrity().signingKey).toBe('session-only');
+    s2.append({ ...ENTRY, action: 'cs:dispense', resourceId: 'cs-1' });
+
+    // Session 3: keychain back. The stored key reads, so E1 verifies again -
+    // and E2 must be reported as signed by another key rather than tampered.
+    const s3 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    expect(s3.getIntegrity().signingKey).toBe('persisted');
+    expect(s3.verifyAll()).toEqual({ valid: 1, tampered: 0, otherKey: 1 });
+
+    /* The chain still cannot be attested, and that is the honest answer: without
+       the temporary key, an edit made during that window is undetectable. What
+       #2553 asked for is that the report EXPLAIN itself rather than say
+       "Tampered", and it now does. */
+    expect(s3.verifyChain()).toBe(false);
+    const integrity = s3.getIntegrity();
+    expect(integrity.ok).toBe(false);
+    expect(integrity.reason).toContain('signed with a different key');
+    expect(integrity.reason).toContain('not evidence of tampering');
+  });
+
+  test('a genuinely edited entry is still caught after a degraded window', async () => {
+    /* The guard on the guard: attributing a foreign key must not become a way
+       to smuggle an edit past verification. An entry altered in place still
+       carries the CURRENT key's id, so it is checked and fails. */
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+    mem.dirs.add(DEGRADED_DIR);
+
+    const s1 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    s1.append(ENTRY);
+
+    const logPath = path.join(DEGRADED_DIR, 'audit-log.jsonl');
+    const rows = mem.files
+      .get(logPath)!
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    rows[0]!.actor = 'someone-else';
+    mem.files.set(logPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+    const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    expect(s2.verifyAll()).toEqual({ valid: 0, tampered: 1, otherKey: 0 });
+    expect(s2.verifyChain()).toBe(false);
+  });
+
+  test('relabelling only the keyId is itself detected', async () => {
+    /* keyId is inside the signed payload, so moving an entry out of the `valid`
+       count by relabelling it - without touching its contents - invalidates the
+       signature. Otherwise anyone with file access could quietly reclassify a
+       genuine entry as "signed by another key" and make the report meaningless
+       in the other direction. */
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+    mem.dirs.add(DEGRADED_DIR);
+
+    const s1 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    s1.append(ENTRY);
+
+    const logPath = path.join(DEGRADED_DIR, 'audit-log.jsonl');
+    const rows = mem.files
+      .get(logPath)!
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const original = rows[0]!.keyId as string;
+    expect(original).toBeDefined();
+    // Contents untouched; only the provenance stamp is rewritten.
+    rows[0]!.keyId = original === 'a'.repeat(16) ? 'b'.repeat(16) : 'a'.repeat(16);
+    mem.files.set(logPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+    const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    /* The entry AS STORED now carries a stamp the signature does not cover, so
+       recomputing it fails. That is what proves keyId is inside the payload
+       rather than sitting beside it. */
+    const stored = s2.query().at(0)!;
+    expect(stored.keyId).not.toBe(original);
+    expect(s2.verify(stored)).toBe(false);
+    expect(s2.verifyChain()).toBe(false);
+  });
+
+  test('rewriting keyId to disguise an edit does not work', async () => {
+    /* keyId is inside the signed payload for any entry that has one, so an
+       attacker cannot relabel a tampered row as "signed by another key" to move
+       it out of the tampered count. */
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+    mem.dirs.add(DEGRADED_DIR);
+
+    const s1 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    s1.append(ENTRY);
+
+    const logPath = path.join(DEGRADED_DIR, 'audit-log.jsonl');
+    const rows = mem.files
+      .get(logPath)!
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    rows[0]!.actor = 'someone-else';
+    rows[0]!.keyId = 'deadbeefdeadbeef';
+    mem.files.set(logPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+    const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
+    /* A relabel moves the row out of the `tampered` COUNT - unavoidable, since
+       nothing here holds the key it now claims - but it must not buy a clean
+       chain. An earlier draft skipped verification for foreign-key entries and
+       this test walked green, which is the hole it exists to catch. */
+    expect(s2.verifyAll().otherKey).toBe(1);
+    expect(s2.verifyChain()).toBe(false);
+    expect(s2.getIntegrity().ok).toBe(false);
+  });
+});
+
 describe('audit trail dialog with an unreadable key', () => {
   test('historical entries are reported as uncheckable, not as tampered', async () => {
     const mem = createMemoryFs();
@@ -196,7 +333,12 @@ describe('audit trail dialog with an unreadable key', () => {
 
     const degraded = await createAuditLog(DIR, { ...deps, secureStore: null });
     // Every entry fails its signature check under the temporary key...
-    expect(degraded.verifyAll()).toEqual({ valid: 0, tampered: 2 });
+    /* Uncheckable, which is what this test is named for. They were signed by
+       the stored key and this session holds a temporary one, so they are
+       attributed rather than accused - `tampered: 0`. Before entries carried a
+       keyId this had to accept `tampered: 2`, so the assertion contradicted the
+       test's own name (#2553). */
+    expect(degraded.verifyAll()).toEqual({ valid: 0, tampered: 0, otherKey: 2 });
     // ...which is exactly why the integrity report must say the key is the
     // problem rather than letting the dialog print "Tampered: 2".
     expect(degraded.getIntegrity().signingKey).toBe('session-only');

--- a/apps/desktop/tests/audit-key-preservation.test.ts
+++ b/apps/desktop/tests/audit-key-preservation.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import path from 'node:path';
 import os from 'node:os';
 import { Buffer } from 'node:buffer';
@@ -253,6 +254,45 @@ describe('a degraded window stays attributable after the keychain recovers', () 
     const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, secureStore: workingKeychain });
     expect(s2.verifyAll()).toEqual({ valid: 0, tampered: 1, otherKey: 0 });
     expect(s2.verifyChain()).toBe(false);
+  });
+
+  test('an entry written before keyId existed still verifies as valid', async () => {
+    /* Backward compatibility, and the reason `signedByAnotherKey` requires a
+       PRESENT-but-different stamp rather than treating absence as foreign.
+       Pre-existing logs were signed with the stored key; if that key still
+       reads, they verify. Calling them "signed with a different key" would move
+       every entry of every existing install into `otherKey` and make
+       getIntegrity report ok:false forever - a worse false alarm than the one
+       this change removes. */
+    const mem = createMemoryFs();
+    const deps = asDeps(mem, () => 1000);
+    mem.dirs.add(DEGRADED_DIR);
+    const hmacKey = 'k'.repeat(64);
+
+    const s1 = await createAuditLog(DEGRADED_DIR, { ...deps, hmacKey });
+    s1.append(ENTRY);
+
+    // Strip the stamp and re-sign exactly as the pre-keyId code would have:
+    // the same payload, minus the trailing |keyId segment.
+    const logPath = path.join(DEGRADED_DIR, 'audit-log.jsonl');
+    const stored = JSON.parse(mem.files.get(logPath)!.trim()) as Record<string, unknown>;
+    delete stored.keyId;
+    const payload =
+      `${stored.id}|${stored.timestamp}|${stored.action}|${stored.actor}|` +
+      `${stored.resourceType}|${stored.resourceId}|${JSON.stringify(stored.details)}|` +
+      `${stored.prevSignature}`;
+    stored.signature = crypto.createHmac('sha256', hmacKey).update(payload).digest('hex');
+    mem.files.set(logPath, JSON.stringify(stored) + '\n');
+
+    const s2 = await createAuditLog(DEGRADED_DIR, { ...deps, hmacKey });
+    expect(s2.query().at(0)!.keyId).toBeUndefined();
+    // Valid, not otherKey - a stamp-less entry is not evidence of a key change.
+    expect(s2.verifyAll()).toEqual({ valid: 1, tampered: 0, otherKey: 0 });
+    /* Only the provenance claims are asserted here. Rewriting the file by hand
+       is the only way to synthesise a pre-keyId entry, and that legitimately
+       trips the store's watermark ("the log has been replaced") - which is its
+       tamper detection working, and nothing to do with keyId. */
+    expect(s2.verify(s2.query().at(0)!)).toBe(true);
   });
 
   test('relabelling only the keyId is itself detected', async () => {

--- a/apps/desktop/tests/audit-log.test.ts
+++ b/apps/desktop/tests/audit-log.test.ts
@@ -343,7 +343,7 @@ describe('createAuditLog', () => {
     const tamperedLog = await createAuditLog(tmpDir, deps);
 
     const after = tamperedLog.verifyAll();
-    expect(after).toEqual({ valid: 1, tampered: 1 });
+    expect(after).toEqual({ valid: 1, tampered: 1, otherKey: 0 });
   });
 
   test('size returns correct count', async () => {

--- a/apps/desktop/tests/controlled-substance.test.ts
+++ b/apps/desktop/tests/controlled-substance.test.ts
@@ -73,7 +73,7 @@ describe('createControlledSubstanceLogbook', () => {
     });
     expect(auditEntry.details.csTransactionId).toBe(tx.id);
     expect(auditLog.verify(auditEntry)).toBe(true);
-    expect(auditLog.verifyAll()).toEqual({ valid: 1, tampered: 0 });
+    expect(auditLog.verifyAll()).toEqual({ valid: 1, tampered: 0, otherKey: 0 });
   });
 
   test('getTransactions returns all transactions', async () => {

--- a/apps/desktop/tests/status-dialogs.test.ts
+++ b/apps/desktop/tests/status-dialogs.test.ts
@@ -48,7 +48,7 @@ const makeDeps = (overrides: Partial<StatusDialogDeps> = {}): StatusDialogDeps =
   } as never,
   config: getDesktopConfig({}),
   auditLog: {
-    verifyAll: () => ({ valid: 3, tampered: 0 }),
+    verifyAll: () => ({ valid: 3, tampered: 0, otherKey: 0 }),
     verifyChain: () => true,
     size: () => 3,
     getIntegrity: () => ({
@@ -160,7 +160,7 @@ describe('status dialogs — happy paths', () => {
   test('verifyAuditTrail names the problem when the log is not intact', () => {
     const deps = makeDeps({
       auditLog: {
-        verifyAll: () => ({ valid: 1, tampered: 0 }),
+        verifyAll: () => ({ valid: 1, tampered: 0, otherKey: 0 }),
         verifyChain: () => false,
         size: () => 1,
         getIntegrity: () => ({
@@ -185,7 +185,7 @@ describe('status dialogs — happy paths', () => {
     const deps = makeDeps({
       auditLog: {
         // With a session-only key every historical entry fails its check.
-        verifyAll: () => ({ valid: 0, tampered: 12 }),
+        verifyAll: () => ({ valid: 0, tampered: 12, otherKey: 0 }),
         verifyChain: () => false,
         size: () => 12,
         getIntegrity: () => ({


### PR DESCRIPTION
Closes #2553

## What was wrong

When the OS keychain is unreadable at startup, `createAuditLog` deliberately declines to overwrite the stored signing key and runs the session on a temporary one — correct, and the reason the pre-existing history stays verifiable later.

**Nothing recorded which entries that applied to.** Once the keychain recovered, `getIntegrity()` derived the degraded state from the *live* key state and reported `ok: true`, while those rows failed `verify()` forever. The dialog printed `Tampered: 1 / Hash chain intact: NO` with no reason line — permanently, on the controlled-substance register. A compliance alarm an operator can neither clear nor account for, and one that trains people to ignore the alarm that is real.

## What changed

Each entry now carries a **`keyId`**: a truncated HMAC of a fixed label under the signing key, so it identifies the key without being usable to recover it. Optional, because entries written before this have none — and an absent stamp is treated exactly like a foreign one: unverifiable, never tampered.

- `verifyAll` gains a third bucket, `otherKey`
- `getIntegrity` explains a window that has already been recorded, instead of reporting `ok: true` over it
- the dialog prints that count on its own line with the reason

## The part I got wrong first, and what caught it

My first draft had `verifyChain` **skip** verification for foreign-key entries. That looks reasonable — without that key the HMAC genuinely cannot be recomputed — but it opens a hole:

> edit an entry's contents, overwrite its `keyId` with any other value, and it is excused from verification and the chain walks clean.

A guard-on-the-guard test drove exactly that and went green. `verifyChain` now verifies **every** entry.

Without the old key, an edit made under it is undetectable. So the honest answer is that the chain **cannot be attested**, never that it is intact. What this issue asked for is that the report *explain itself* instead of saying "Tampered" — and it now does, while the chain result stays conservative.

`keyId` is inside the signed payload for any entry that has one, so it cannot be relabelled to reclassify an entry in either direction. **That property was also unguarded in my first pass** — the mutation removing it from the payload passed every test — so there is now a test for it.

## Validation

Mutation-checked, including the two that exposed my own mistakes:

| mutation | caught by |
|---|---|
| stop stamping `keyId` on append | 2 attribution tests |
| take `keyId` out of the signed payload | the relabel test (added after this mutation initially passed) |
| skip verification for foreign-key entries | the disguise test |

The issue's reproduction is covered end to end across three sessions — healthy keychain, unreadable while a `cs:dispense` is written, healthy again — asserting the recovered session reports `{ valid: 1, tampered: 0, otherKey: 1 }` rather than `{ valid: 1, tampered: 1 }`.

One existing test is worth calling out: `historical entries are reported as uncheckable, not as tampered` asserted `tampered: 2`. **Its name described the intent; its assertion accepted the defect.** It now asserts `{ valid: 0, tampered: 0, otherKey: 2 }`, matching what it always claimed to test.

- **70 suites / 1056 tests pass**, `type-check` and `lint` clean

## Impact area

`apps/desktop` — the audit log and the integrity dialog. `AuditEntry` gains one optional field; entries already on disk verify exactly as before, because `keyId` joins the signed payload only when present.