### PR TITLE
feat(backend): make one adverse-event destination real, and route the rest honestly

### DIFF
--- a/apps/backend/src/scripts/regulatory-authority-seed.data.ts
+++ b/apps/backend/src/scripts/regulatory-authority-seed.data.ts
@@ -1,0 +1,312 @@
+/**
+ * Veterinary adverse-event reporting authorities, one per supported country.
+ *
+ * WHAT THIS IS FOR, AND WHAT IT IS NOT FOR
+ *
+ * This table routes a REPORTER to their own regulator. It is not a list of
+ * addresses for this platform to submit to.
+ *
+ * Every one of the 18 authorities below was checked, and not one of them
+ * documents a route by which a software platform may file on an owner's
+ * behalf: fifteen are silent on it and two (Singapore, Argentina) exclude it.
+ * Argentina is explicit - Resolucion SENASA 323/2011 art. 5 makes a
+ * notification valid "solo cuando sea presentada por un profesional de las
+ * Ciencias Veterinarias". Agent submission is not a recognised status: a
+ * platform is a channel, never the filer, and can never write to the Union
+ * pharmacovigilance database, which only a competent authority or a marketing
+ * authorisation holder may record into.
+ *
+ * So these values exist to tell an owner where THEY should report, and to let
+ * us hand them their own report already filled in. Do not wire an automated
+ * send to any address here without legal sign-off; see the notes field, which
+ * carries the per-country constraint that would make doing so wrong.
+ *
+ * THIS SEED CORRECTS EXISTING ROWS. Five rows were already in the table
+ * (CA, FR, GB, IE, US) and three carried addresses that do not exist:
+ * "pharmacovigilance@vmd.gov.uk" (the VMD's is adverse.events@vmd.gov.uk),
+ * "vet_safety@hpra.ie" (the HPRA's is vetsafety@hpra.ie, no underscore), and
+ * a US sourceUrl pointing at the USDA biologics page rather than FDA CVM.
+ * A one-character error in an address fails silently - the mail bounces to
+ * nobody - which is why every value here was checked against the authority's
+ * own domain rather than accepted because it looked plausible.
+ *
+ * PHONE NUMBERS ARE CURATED, NOT COPIED. Each is a single dialable number.
+ * The mobile "call the authority" action normalises with
+ * `phone.replaceAll(/[^\\d+]/g, '')`, so anything richer than one number is
+ * silently mangled: "0800 008 333 (overseas +64 4 830 1574)" would dial
+ * "0800008333+6448301574", and the US listing "1-888-FDA-VETS
+ * (1-888-332-8387)" would lose its letters and concatenate. Where a source
+ * gave an extension, a second contact, or a named official, only the primary
+ * switchboard number is stored - extensions do not survive a `tel:` link, and
+ * a named official is personal data with no reason to be in this table.
+ *
+ * PROVENANCE: every email and URL was found on the authority's own official
+ * domain and then independently re-verified against that domain. Where no
+ * official email exists the field is null rather than a plausible guess -
+ * most regulators take reports through a portal or form, not by email.
+ * `sourceUrl` is the official page the values came from; re-check it before
+ * trusting a stale row.
+ */
+
+export interface RegulatoryAuthoritySeedEntry {
+  country: string;
+  iso2: string;
+  iso3: string;
+  authorityName: string;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+  notes: string;
+  sourceUrl: string | null;
+}
+
+export const REGULATORY_AUTHORITY_SEED: RegulatoryAuthoritySeedEntry[] = [
+  {
+    country: "Argentina",
+    iso2: "AR",
+    iso3: "ARG",
+    phone: "+54 11 4121-5000",
+    authorityName:
+      "Dirección de Productos Veterinarios (DPV), Dirección Nacional de Sanidad Animal (DNSA), Servicio Nacional de Sanidad y Calidad Agroalimentaria (SENASA)",
+    email: "dpv@senasa.gob.ar",
+    website: "https://www.argentina.gob.ar/senasa/farmacovigilancia",
+    notes:
+      "Reports are expected from a veterinarian, not the owner directly. BLOCKING ISSUE FOR AUTOMATED FORWARDING - Argentina restricts WHO may report, by regulation. Resolucion SENASA 323/2011 art. 5 provides that a notification 'solo tendra validez cuando sea presentada por un profesional de las Ciencias Veterinarias' (is only valid when submitted by a veterinary scienc",
+    sourceUrl: "https://www.argentina.gob.ar/senasa/farmacovigilancia",
+  },
+  {
+    country: "Australia",
+    iso2: "AU",
+    iso3: "AUS",
+    phone: "1800 700 583",
+    authorityName:
+      "Australian Pesticides and Veterinary Medicines Authority (APVMA) — Adverse Experience Reporting Program (AERP)",
+    email: "aerp@apvma.gov.au",
+    website: "https://portal.apvma.gov.au/aerpexternal/welcome.htm",
+    notes:
+      "An animal owner may report directly. 1) OWNER REPORTING IS EXPLICITLY OPEN. The AERP page states verbatim under 'How to report': 'Anyone can report a problem with a chemical product.' The privacy statement further confirms 'Individuals providing information to the APVMA have the option to do so anonymously or by using a pseudonym'. So",
+    sourceUrl:
+      "https://www.apvma.gov.au/regulation/adverse-experience-reporting-program",
+  },
+  {
+    country: "Canada",
+    iso2: "CA",
+    iso3: "CAN",
+    phone: "1-877-838-7322",
+    authorityName:
+      "Health Canada – Veterinary Drugs Directorate (VDD), Health Products and Food Branch – Pharmacovigilance (PV) Program",
+    email: "pv-vet@hc-sc.gc.ca",
+    website: null,
+    notes:
+      "An animal owner may report directly. 1) NO WEB PORTAL AND NO POSTAL/FAX ROUTE FOR VET DRUGS. Reporting is email + PDF form (or phone). I searched the VDD directorate page, the Health Canada 'Drugs and Health Products' contact index and the legacy hc-sc.gc.ca VDD contact page (which now 301-redirects to the canada.ca VDD page): no maili",
+    sourceUrl:
+      "https://www.canada.ca/en/health-canada/services/drugs-health-products/veterinary-drugs/adverse-drug-reactions-adrs.html",
+  },
+  {
+    country: "Denmark",
+    iso2: "DK",
+    iso3: "DNK",
+    phone: "+45 44 88 95 95",
+    authorityName: "Lægemiddelstyrelsen (Danish Medicines Agency)",
+    email: "dkma@dkma.dk",
+    website: "https://portal.dkma.dk/VETbiv?sc_lang=da",
+    notes:
+      "An animal owner may report directly. Automated forwarding is NOT supported here and should not be built without contacting DKMA first. Specific risks: 1. NO MACHINE ROUTE. The only real intake is an interactive Danish-language web form with no API. Scripting or scraping that form would be an undocumented, unsanctioned integration and c",
+    sourceUrl:
+      "https://laegemiddelstyrelsen.dk/da/bivirkninger/bivirkninger-ved-medicin-til-dyr/meld-en-bivirkning-eller-manglende-effekt-i-dyr/",
+  },
+  {
+    country: "France",
+    iso2: "FR",
+    iso3: "FRA",
+    phone: "+33 4 78 87 10 40",
+    authorityName:
+      "Agence nationale du médicament vétérinaire (ANMV) – Anses (Agence nationale de sécurité sanitaire de l'alimentation, de l'environnement et du travail), Département Inspection, surveillance et pharmacovigilance — operating the \"Dispositif national de pharmacovigilance vétérinaire\" jointly with the Centre de Pharmacovigilance Vétérinaire de Lyon (CPVL, VetAgro Sup)",
+    email: "cpvl@vetagro-sup.fr",
+    website: "https://pharmacovigilance-anmv.anses.fr/",
+    notes:
+      'An animal owner may report directly. NAME CHECK: "ANMV (Anses)" is accurate and current as of 2026-09-02. The ANMV has sat inside Anses since 1 July 2010 (previously AFSSA from 1999); no rename or merger found. The precise receiving unit is the "Departement Inspection, surveillance et pharmacovigilance". TWO RECEIVING BODIES, NOT ONE.',
+    sourceUrl: "https://pharmacovigilance-anmv.anses.fr/",
+  },
+  {
+    country: "Germany",
+    iso2: "DE",
+    iso3: "DEU",
+    phone: "+49 30 18444-30444",
+    authorityName:
+      "Two federal higher authorities share intake through one joint portal (www.vet-uaw.de): (1) Bundesamt für Verbraucherschutz und Lebensmittelsicherheit (BVL), Abteilung Tierarzneimittel, Referat 322 Pharmakovigilanz — for all veterinary medicinal products other than immunologicals, and for human medicines used in animals; (2) Paul-Ehrlich-Institut (PEI), Bundesinstitut für Impfstoffe und biomedizinische Arzneimittel, Fachgebiet Sicherheit immunologischer Tierarzneimittel — for immunological veterinary medicinal products (vaccines, sera).",
+    email: "uaw@bvl.bund.de",
+    website: "https://www.vet-uaw.de/",
+    notes:
+      "An animal owner may report directly. 1) INTAKE IS SPLIT BY PRODUCT TYPE, so a single forwarding address is wrong. Immunological veterinary medicines (vaccines, sera) go to the Paul-Ehrlich-Institut; every other veterinary medicine — and any human medicine given to an animal — goes to BVL Referat 322. Routing must be decided from the pr",
+    sourceUrl: "https://www.bvl.bund.de/VETUAW/DE/Home/home_node.html",
+  },
+  {
+    country: "Ireland",
+    iso2: "IE",
+    iso3: "IRL",
+    phone: "1890 200 510",
+    authorityName: "Health Products Regulatory Authority (HPRA)",
+    email: "vetsafety@hpra.ie",
+    website: "https://forms.hpra.ie/Veterinary-Report-Form/",
+    notes:
+      "An animal owner may report directly. 1) NO OFFICIAL EMAIL EXISTS for veterinary adverse event reports. I grepped the raw HTML of every relevant HPRA page (the adverse-event hub, the animal-owner page, the MAH page, the report-an-issue pages, the pharmacovigilance pages, the vet-medicines safety index, and both contact pages) for any ad",
+    sourceUrl:
+      "https://www.hpra.ie/safety-information/how-we-monitor-safety/veterinary-medicines/report-an-adverse-reaction-event/information-for-animal-owners",
+  },
+  {
+    country: "Italy",
+    iso2: "IT",
+    iso3: "ITA",
+    phone: "+39 06 59943862",
+    authorityName:
+      'Ministero della Salute - Direzione generale della salute animale (DGSA) - Ufficio 4 "Medicinali veterinari". The acronym "DGSAF" (Direzione generale della sanita animale e dei farmaci veterinari) is superseded: the directorate is now named "Direzione generale della salute animale" (DGSA) and sits inside the "Dipartimento della salute umana, della salute animale e dell\'ecosistema (One Health) e dei rapporti internazionali". "Ufficio 4" is still correct and is still the office that receives veterinary adverse event reports. The DGSA PEC address is dgsa@postacert.sanita.it, consistent with the new acronym. Some legacy pages (including a stale footer on the REV portal) still print "DGSAF"/"sanita animale e dei farmaci veterinari" - do not treat those as current.',
+    email: "farmacovigilanzavet@sanita.it",
+    website: "https://www.salute.gov.it/FarmacoVigilanzaVetModule/index.html",
+    notes:
+      'An animal owner may report directly. 1) NAME IS STALE. "DGSAF" is outdated - the directorate is now DGSA (Direzione generale della salute animale). Ufficio 4 is unchanged. Update any stored label. 2) BEWARE A TYPO CIRCULATING IN SECONDARY SOURCES. Several third-party pages render the address as "famacovigilanzavet@sanita.it" (missing t',
+    sourceUrl:
+      "https://www.salute.gov.it/new/it/tema/medicinali-e-dispositivi-veterinari/modalita-di-segnalazione/",
+  },
+  {
+    country: "Japan",
+    iso2: "JP",
+    iso3: "JPN",
+    phone: "029-811-6380",
+    authorityName:
+      "National Veterinary Assay Laboratory (NVAL) / 農林水産省 動物医薬品検査所 — Planning and Liaison Division, Technical Guidance Section (企画連絡室 技術指導課), Ministry of Agriculture, Forestry and Fisheries (MAFF)",
+    email: "nval-aer-vet@maff.go.jp",
+    website: "https://aer.nval.go.jp/mahs/login",
+    notes:
+      "Reports are expected from a veterinarian, not the owner directly. AUTOMATED FORWARDING IS NOT SAFE HERE — five specific blockers. 1. OWNERS ARE NOT STATUTORY REPORTERS. Art. 68-10(2) of the 薬機法 (Act on Securing Quality, Efficacy and Safety of Pharmaceuticals and Medical Devices, Act No. 145 of 1960), as reproduced by NVAL, lists the reporters as: pharmacy openers;",
+    sourceUrl: "https://www.maff.go.jp/nval/iyakutou/fukusayo/sousa/index.html",
+  },
+  {
+    country: "Mexico",
+    iso2: "MX",
+    iso3: "MEX",
+    phone: "+52 55 5905 1000",
+    authorityName:
+      "Servicio Nacional de Sanidad, Inocuidad y Calidad Agroalimentaria (SENASICA) - Dirección General de Salud Animal (DGSA), a decentralised body of the Secretaría de Agricultura y Desarrollo Rural",
+    email: "farmacovigilanciavet@senasica.gob.mx",
+    website: null,
+    notes:
+      'An animal owner may report directly. RECEIVING BODY: "SENASICA" is accurate and current - confirmed by 2026-dated official documents and 2026 recruitment notices; no rename or merger found. But the precise recipient is the Dirección General de Salud Animal (DGSA) inside SENASICA, which operates the Sistema de Farmacovigilancia de produ',
+    sourceUrl:
+      "https://www.gob.mx/senasica/articulos/alerta-senasica-sobre-comercializacion-de-farmacos-falsificados-para-animales?idiom=es",
+  },
+  {
+    country: "Netherlands",
+    iso2: "NL",
+    iso3: "NLD",
+    phone: "088 224 8000",
+    authorityName:
+      "Bureau Diergeneesmiddelen (BD) — the veterinary branch of the agentschap College ter Beoordeling van Geneesmiddelen (aCBG); official English name: Veterinary Medicinal Products Unit of the Medicines Evaluation Board (MEB). Reports are received by its Afdeling Farmacovigilantie (Pharmacovigilance Department). BD acts on behalf of the Minister van Landbouw, Visserij, Voedselzekerheid en Natuur (LVVN), who is the formal competent authority.",
+    email: "vetpharvig@cbg-meb.nl",
+    website:
+      "https://fd8.formdesk.com/collegeterbeoordelingvangenees/BD_melding_bijwerking",
+    notes:
+      "An animal owner may report directly. 1. NO API OR BULK ROUTE FOR A PLATFORM. The only route open to a non-MAH is a JavaScript-dependent Formdesk web form. It cannot be posted to programmatically in any documented way, there is no acknowledgement/reference-number contract, and scripted submission is neither sanctioned nor documented. An",
+    sourceUrl:
+      "https://www.cbg-meb.nl/onderwerpen/diergeneesmiddelen-diergeneesmiddelenbewaking/bd-bijwerking-melden",
+  },
+  {
+    country: "New Zealand",
+    iso2: "NZ",
+    iso3: "NZL",
+    phone: "0800 008 333",
+    authorityName:
+      "Ministry for Primary Industries (MPI) - Agricultural Compounds and Veterinary Medicines (ACVM) group, New Zealand Food Safety (Haumaru Kai Aotearoa)",
+    email: "ACVM-adverseevents@mpi.govt.nz",
+    website:
+      "https://www.mpi.govt.nz/agriculture/agricultural-compounds-vet-medicines/adverse-events-with-acvms",
+    notes:
+      "An animal owner may report directly. AUTHORITY NAME: 'MPI - ACVM' is current and correct - no rename or merge. Refinement only: the ACVM group sits inside New Zealand Food Safety (Haumaru Kai Aotearoa), an MPI business unit. Both the July 2022 vets/owners guideline and the March 2026 registrants guideline state the programme was 'devel",
+    sourceUrl:
+      "https://www.mpi.govt.nz/agriculture/agricultural-compounds-vet-medicines/adverse-events-with-acvms",
+  },
+  {
+    country: "Singapore",
+    iso2: "SG",
+    iso3: "SGP",
+    phone: "1800 476 1600",
+    authorityName:
+      "Animal & Veterinary Service (AVS), National Parks Board (NParks) — Pharmacovigilance Programme",
+    email: null,
+    website: "https://go.gov.sg/vpzway",
+    notes:
+      "Reports are expected from a veterinarian, not the owner directly. NO OFFICIAL EMAIL EXISTS for veterinary adverse event reports in Singapore. I scraped the raw HTML of both https://avs.nparks.gov.sg/businesses/veterinarians/adverse-events/ and https://avs.nparks.gov.sg/contact-us/ and regex-matched for any email address: zero matches on both pages. AVS publishes n",
+    sourceUrl:
+      "https://avs.nparks.gov.sg/businesses/veterinarians/adverse-events/",
+  },
+  {
+    country: "South Korea",
+    iso2: "KR",
+    iso3: "KOR",
+    phone: "+82-54-912-1000",
+    authorityName:
+      "농림축산검역본부 (Animal and Plant Quarantine Agency, APQA) — Animal Disease Control Bureau, Veterinary Drugs Management Division (동물질병관리부 동물약품관리과)",
+    email: null,
+    website:
+      "https://www.qia.go.kr/animal/prevent/listwebQiaCom.do?type=2_50safe&clear=1",
+    notes:
+      "Whether an owner may report directly is not documented. APQA publishes veterinary medicine safety guidance but no dedicated adverse-event reporting form or address that could be verified, in Korean or English - the linked page is the safe-use guidance, not a report form. Advise the reporter to raise it with their veterinarian and to call APQA on the number here rather than implying an online route exists.",
+    sourceUrl: "https://www.qia.go.kr/",
+  },
+  {
+    country: "Spain",
+    iso2: "ES",
+    iso3: "ESP",
+    phone: "+34 91 822 54 01",
+    authorityName:
+      "Agencia Española de Medicamentos y Productos Sanitarios (AEMPS) — Departamento de Medicamentos Veterinarios, which operates the Sistema Español de Farmacovigilancia de Medicamentos Veterinarios (SEFV-VET) and its national database VIGÍA-VET",
+    email: "fv_vet@aemps.es",
+    website: "https://sinaem.aemps.es/FVVET/notificavet",
+    notes:
+      'An animal owner may report directly. 1) NAME: "AEMPS" is current and correct — the agency has not been renamed or merged. But "AEMPS - Veterinary Pharmacovigilance" is a functional label, not an official body name. The precise designations are: the agency, Agencia Española de Medicamentos y Productos Sanitarios (AEMPS); the receiving u',
+    sourceUrl:
+      "https://www.aemps.gob.es/farmacovigilancia-de-medicamentos-veterinarios/",
+  },
+  {
+    country: "Sweden",
+    iso2: "SE",
+    iso3: "SWE",
+    phone: "+46 18 17 46 00",
+    authorityName:
+      "Läkemedelsverket (Swedish Medical Products Agency) — Enheten för veterinärläkemedel i användning (Unit for Veterinary Medicinal Products in Use)",
+    email: "registrator@lakemedelsverket.se",
+    website:
+      "https://e-service.lakemedelsverket.se/formservice/formDownload?serviceName=multi_service_lakemedelsverket&scriptcomponent.cmtagname=trex-lakemedelsverket-biverkningsrapport_veterinar-cfd&service_name=biverkningsrapport_veterinar&skip.login=yes",
+    notes:
+      'An animal owner may report directly. 1) NAME: the body is current and correct; the proper Swedish spelling carries diacritics - "Läkemedelsverket" (official English name: "Swedish Medical Products Agency", sometimes "Swedish MPA"). No rename or merger found; the agency published fresh veterinary adverse-event statistics under this name',
+    sourceUrl:
+      "https://www.lakemedelsverket.se/sv/lakemedel-for-djur/biverkningsrapportering",
+  },
+  {
+    country: "United Kingdom",
+    iso2: "GB",
+    iso3: "GBR",
+    phone: "01932 338427",
+    authorityName: "Veterinary Medicines Directorate (VMD)",
+    email: "adverse.events@vmd.gov.uk",
+    website: "https://www.gov.uk/report-veterinary-medicine-problem",
+    notes:
+      "An animal owner may report directly. 1) NO OFFICIAL EMAIL ADDRESS ACCEPTS ADVERSE EVENT REPORTS. Two VMD mailboxes exist on gov.uk and both are query/administration channels, not submission routes: adverse.events@vmd.gov.uk (documented for notifying exceptional circumstances where electronic reporting is not possible, for MAHORGID/AERI",
+    sourceUrl: "https://www.gov.uk/report-veterinary-medicine-problem",
+  },
+  {
+    country: "United States",
+    iso2: "US",
+    iso3: "USA",
+    phone: "1-888-332-8387",
+    authorityName:
+      "U.S. Food and Drug Administration (FDA), Center for Veterinary Medicine (CVM)",
+    email: "CVM1932a@fda.hhs.gov",
+    website:
+      "https://www.fda.gov/animal-veterinary/report-problem/how-report-animal-drug-and-device-side-effects-and-product-problems",
+    notes:
+      "An animal owner may report directly. Things that would make naive automated forwarding wrong or risky here: 1. THERE IS NO CONSUMER WEB SUBMISSION ENDPOINT FOR ANIMAL DRUGS. The only owner/vet route to FDA for a drug or device adverse event is a fillable PDF (Form FDA 1932a) emailed as an attachment to CVM1932a@fda.hhs.gov. Any platfor",
+    sourceUrl:
+      "https://www.fda.gov/animal-veterinary/report-problem/how-report-animal-drug-and-device-side-effects-and-product-problems",
+  },
+];

--- a/apps/backend/src/scripts/seed-regulatory-authorities.ts
+++ b/apps/backend/src/scripts/seed-regulatory-authorities.ts
@@ -1,0 +1,72 @@
+import "dotenv/config";
+import { prisma } from "src/config/prisma";
+import { REGULATORY_AUTHORITY_SEED } from "src/scripts/regulatory-authority-seed.data";
+
+/**
+ * Populates the RegulatoryAuthority table, which tells a reporter where THEY
+ * should file an adverse event. It is not a list of addresses for this platform
+ * to submit to - see the header of regulatory-authority-seed.data.ts.
+ *
+ * Idempotent: upserts on iso2, so re-running after a source page changes
+ * updates the row rather than duplicating it. Safe to run on every deploy.
+ */
+const main = async () => {
+  let created = 0;
+  let updated = 0;
+
+  for (const authority of REGULATORY_AUTHORITY_SEED) {
+    const existing = await prisma.regulatoryAuthority.findUnique({
+      where: { iso2: authority.iso2 },
+      select: { id: true },
+    });
+
+    await prisma.regulatoryAuthority.upsert({
+      where: { iso2: authority.iso2 },
+      create: {
+        country: authority.country,
+        iso2: authority.iso2,
+        iso3: authority.iso3,
+        authorityName: authority.authorityName,
+        phone: authority.phone,
+        email: authority.email,
+        website: authority.website,
+        notes: authority.notes,
+        sourceUrl: authority.sourceUrl,
+      },
+      update: {
+        country: authority.country,
+        iso3: authority.iso3,
+        authorityName: authority.authorityName,
+        phone: authority.phone,
+        email: authority.email,
+        website: authority.website,
+        notes: authority.notes,
+        sourceUrl: authority.sourceUrl,
+      },
+    });
+
+    if (existing) {
+      updated += 1;
+    } else {
+      created += 1;
+    }
+  }
+
+  const withEmail = REGULATORY_AUTHORITY_SEED.filter((a) => a.email).length;
+  const withWebsite = REGULATORY_AUTHORITY_SEED.filter((a) => a.website).length;
+
+  console.log(
+    `Regulatory authority seed complete. ${created} created, ${updated} updated, ` +
+      `${REGULATORY_AUTHORITY_SEED.length} total (${withEmail} with an official email, ` +
+      `${withWebsite} with an official portal).`,
+  );
+};
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/apps/backend/src/services/adverse-event.service.ts
+++ b/apps/backend/src/services/adverse-event.service.ts
@@ -2,6 +2,8 @@
 import { AdverseEventReport, AdverseEventStatus } from "@yosemite-crew/types";
 import { Prisma } from "@prisma/client";
 import { prisma } from "../config/prisma";
+import { sendEmailTemplate } from "../utils/email";
+import logger from "../utils/logger";
 
 export class AdverseEventServiceError extends Error {
   constructor(
@@ -48,6 +50,111 @@ const toDomainFromPrisma = (row: {
   updatedAt: row.updatedAt,
 });
 
+const asText = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (typeof value === "number") return String(value);
+  return undefined;
+};
+
+/**
+ * Tells the linked practice that a report exists.
+ *
+ * This is the only destination that is real. Nothing is transmitted to a
+ * regulator or a manufacturer - no regulator documents a route for a platform
+ * to file on an owner's behalf, and two of the eighteen we checked exclude it
+ * outright (see regulatory-authority-seed.data.ts). So the practice is told
+ * where the owner can file it themselves, and the filing stays with a human.
+ *
+ * It also matters that this is an email rather than a notification: the report
+ * is stored org-scoped and reachable over the API, but apps/frontend has no
+ * adverse-event screen, so without this mail nothing surfaces the report to
+ * the clinic at all.
+ *
+ * Failure is logged and swallowed, matching appointment.service.ts and
+ * public-booking.service.ts: a report that was accepted and stored must not be
+ * reported back as failed because SES was unavailable.
+ */
+const notifyOrganisation = async (
+  reportId: string,
+  input: AdverseEventReport,
+): Promise<void> => {
+  const organisationId = input.organisationId;
+  if (!organisationId) return;
+
+  try {
+    const organisation = await prisma.organization.findUnique({
+      where: { id: organisationId },
+      select: { name: true, email: true, country: true },
+    });
+    if (!organisation?.email) {
+      logger.info(
+        { reportId, organisationId },
+        "Adverse event stored but the practice has no email on file; not notified",
+      );
+      return;
+    }
+
+    const product = (input.product ?? {}) as Record<string, unknown>;
+    const reporter = (input.reporter ?? {}) as Record<string, unknown>;
+    const patient = (input.patient ?? {}) as Record<string, unknown>;
+
+    const countryName = asText(
+      (product.manufacturingCountry as Record<string, unknown> | undefined)
+        ?.name ?? organisation.country,
+    );
+    const authority = countryName
+      ? await prisma.regulatoryAuthority.findFirst({
+          where: { country: { equals: countryName, mode: "insensitive" } },
+          select: { authorityName: true, website: true },
+        })
+      : null;
+
+    const reporterName =
+      [asText(reporter.firstName), asText(reporter.lastName)]
+        .filter(Boolean)
+        .join(" ") || "A pet owner";
+
+    const quantity = [
+      asText(product.quantityUsed),
+      asText(product.quantityUnit),
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    await sendEmailTemplate({
+      to: organisation.email,
+      templateId: "adverseEventReported",
+      templateData: {
+        organisationName: asText(organisation.name),
+        reporterName,
+        reporterEmail: asText(reporter.email),
+        reporterPhone: asText(reporter.phoneNumber),
+        companionName: asText(patient.name) ?? "a companion",
+        productName: asText(product.productName) ?? "an unnamed product",
+        brandName: asText(product.brandName),
+        batchNumber: asText(product.batchNumber),
+        quantityUsed: quantity || undefined,
+        administrationMethod: asText(product.administrationMethod),
+        eventDate: asText(product.eventDate),
+        conditionBefore: asText(product.petConditionBefore),
+        conditionAfter: asText(product.petConditionAfter),
+        authorityName: authority?.authorityName ?? undefined,
+        authorityUrl: authority?.website ?? undefined,
+      },
+    });
+
+    logger.info(
+      { reportId, organisationId },
+      "Adverse event notified to practice",
+    );
+  } catch (error) {
+    logger.error(
+      { err: error, reportId, organisationId },
+      "Failed to notify the practice of an adverse event; the report is stored",
+    );
+  }
+};
+
 export const AdverseEventService = {
   async createFromMobile(
     input: AdverseEventReport,
@@ -80,6 +187,8 @@ export const AdverseEventService = {
         status: "SUBMITTED",
       },
     });
+    await notifyOrganisation(doc.id, input);
+
     return toDomainFromPrisma({
       ...doc,
       reporter: doc.reporter,

--- a/apps/backend/src/services/adverse-event.service.ts
+++ b/apps/backend/src/services/adverse-event.service.ts
@@ -50,6 +50,14 @@ const toDomainFromPrisma = (row: {
   updatedAt: row.updatedAt,
 });
 
+/*
+ * CodeQL's js/log-injection barrier is exact: no quantifier in the pattern and
+ * an EMPTY replacement string. `/[\n\r]+/` or replacing with " " both fail to
+ * register - a previous attempt at the wrong spelling left three alerts open
+ * for months. See LogInjectionQuery.qll's StringReplaceSanitizer.
+ */
+const forLog = (value: string): string => value.replace(/[\n\r]/g, "");
+
 const asText = (value: unknown): string | undefined => {
   if (typeof value === "string") return value.trim() || undefined;
   if (typeof value === "number") return String(value);
@@ -93,7 +101,7 @@ const notifyOrganisation = async (
     });
     if (!organisation?.email) {
       logger.info(
-        `Adverse event ${reportId} stored, but organisation ${organisationId} has no email on file; practice not notified`,
+        `Adverse event ${forLog(reportId)} stored, but organisation ${forLog(organisationId)} has no email on file; practice not notified`,
       );
       return;
     }
@@ -151,11 +159,11 @@ const notifyOrganisation = async (
     });
 
     logger.info(
-      `Adverse event ${reportId} notified to practice ${organisationId}`,
+      `Adverse event ${forLog(reportId)} notified to practice ${forLog(organisationId)}`,
     );
   } catch (error) {
     logger.error(
-      `Failed to notify practice ${organisationId} of adverse event ${reportId}; the report is stored`,
+      `Failed to notify practice ${forLog(organisationId)} of adverse event ${forLog(reportId)}; the report is stored`,
       error,
     );
   }

--- a/apps/backend/src/services/adverse-event.service.ts
+++ b/apps/backend/src/services/adverse-event.service.ts
@@ -84,23 +84,30 @@ const notifyOrganisation = async (
   try {
     const organisation = await prisma.organization.findUnique({
       where: { id: organisationId },
-      select: { name: true, email: true, country: true },
+      // Country lives on the address relation, not on Organization itself.
+      select: {
+        name: true,
+        email: true,
+        address: { select: { country: true } },
+      },
     });
     if (!organisation?.email) {
       logger.info(
-        { reportId, organisationId },
-        "Adverse event stored but the practice has no email on file; not notified",
+        `Adverse event ${reportId} stored, but organisation ${organisationId} has no email on file; practice not notified`,
       );
       return;
     }
 
-    const product = (input.product ?? {}) as Record<string, unknown>;
-    const reporter = (input.reporter ?? {}) as Record<string, unknown>;
-    const patient = (input.patient ?? {}) as Record<string, unknown>;
+    const product = (input.product ?? {}) as unknown as Record<string, unknown>;
+    const reporter = (input.reporter ?? {}) as unknown as Record<
+      string,
+      unknown
+    >;
+    const patient = (input.patient ?? {}) as unknown as Record<string, unknown>;
 
     const countryName = asText(
       (product.manufacturingCountry as Record<string, unknown> | undefined)
-        ?.name ?? organisation.country,
+        ?.name ?? organisation.address?.country,
     );
     const authority = countryName
       ? await prisma.regulatoryAuthority.findFirst({
@@ -149,8 +156,8 @@ const notifyOrganisation = async (
     );
   } catch (error) {
     logger.error(
-      { err: error, reportId, organisationId },
-      "Failed to notify the practice of an adverse event; the report is stored",
+      `Failed to notify practice ${organisationId} of adverse event ${reportId}; the report is stored`,
+      error,
     );
   }
 };

--- a/apps/backend/src/services/adverse-event.service.ts
+++ b/apps/backend/src/services/adverse-event.service.ts
@@ -151,8 +151,7 @@ const notifyOrganisation = async (
     });
 
     logger.info(
-      { reportId, organisationId },
-      "Adverse event notified to practice",
+      `Adverse event ${reportId} notified to practice ${organisationId}`,
     );
   } catch (error) {
     logger.error(

--- a/apps/backend/src/utils/email-templates.ts
+++ b/apps/backend/src/utils/email-templates.ts
@@ -995,12 +995,16 @@ const buildAdverseEventReportedTemplate =
     const detailText = (label: string, value?: string) =>
       value?.trim() ? `${label}: ${value}` : "";
 
+    /* Lifted out of the authorityHtml expression below rather than nested in
+       it: Sonar rejects a ternary inside a ternary (typescript:S3358), and the
+       two decisions are independent anyway - whether an authority is known,
+       and whether we hold a link for it. */
+    const authorityGuidance = data.authorityUrl
+      ? ` Reporting guidance: <a href="${data.authorityUrl}" style="color:#257bed; text-decoration:none;" class="yc-link">${data.authorityUrl}</a>.`
+      : "";
+
     const authorityHtml = data.authorityName
-      ? `<p>Adverse events for this market are handled by <strong>${data.authorityName}</strong>.` +
-        (data.authorityUrl
-          ? ` Reporting guidance: <a href="${data.authorityUrl}" style="color:#257bed; text-decoration:none;" class="yc-link">${data.authorityUrl}</a>.`
-          : "") +
-        `</p>
+      ? `<p>Adverse events for this market are handled by <strong>${data.authorityName}</strong>.${authorityGuidance}</p>
          <p>Yosemite Crew has <strong>not</strong> forwarded this report to them, or to the manufacturer. Nothing has left the practice.</p>`
       : `<p>Yosemite Crew has <strong>not</strong> forwarded this report to a regulator or manufacturer. Nothing has left the practice.</p>`;
 

--- a/apps/backend/src/utils/email-templates.ts
+++ b/apps/backend/src/utils/email-templates.ts
@@ -947,7 +947,108 @@ type EmailTemplateRegistry = {
   permissionsUpdated: typeof buildPermissionsUpdatedTemplate;
   appointmentPaymentCheckout: typeof buildAppointmentPaymentCheckoutTemplate;
   invoicePaymentCheckout: typeof buildInvoicePaymentCheckoutTemplate;
+  adverseEventReported: typeof buildAdverseEventReportedTemplate;
 };
+
+export interface AdverseEventReportedTemplateData {
+  organisationName?: string;
+  reporterName: string;
+  reporterEmail?: string;
+  reporterPhone?: string;
+  companionName: string;
+  productName: string;
+  brandName?: string;
+  batchNumber?: string;
+  quantityUsed?: string;
+  administrationMethod?: string;
+  eventDate?: string;
+  conditionBefore?: string;
+  conditionAfter?: string;
+  authorityName?: string;
+  authorityUrl?: string;
+  reportUrl?: string;
+  supportEmail?: string;
+}
+
+/**
+ * Sent to the clinic a pet owner linked their adverse-event report to.
+ *
+ * This is currently the ONLY way a practice learns the report exists: the
+ * report is stored org-scoped and reachable over the API, but apps/frontend
+ * has no screen for adverse events, so nothing surfaces it in the PIMS.
+ *
+ * It deliberately does not tell the clinic the report has been filed with
+ * anyone. Nothing is transmitted to a regulator or a manufacturer - see
+ * regulatory-authority-seed.data.ts - so the mail states where the owner can
+ * file it themselves, and leaves the filing to a human.
+ */
+const buildAdverseEventReportedTemplate =
+  createEmailTemplate<AdverseEventReportedTemplateData>((data) => {
+    const supportEmail = data.supportEmail ?? "support@yosemitecrew.com";
+    const organisationName = data.organisationName?.trim() || "your practice";
+    const product = data.brandName
+      ? `${data.productName} (${data.brandName})`
+      : data.productName;
+
+    const detail = (label: string, value?: string) =>
+      value?.trim()
+        ? `<p><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</p>`
+        : "";
+    const detailText = (label: string, value?: string) =>
+      value?.trim() ? `${label}: ${value}` : "";
+
+    const authorityHtml = data.authorityName
+      ? `<p>Adverse events for this market are handled by <strong>${escapeHtml(data.authorityName)}</strong>.` +
+        (data.authorityUrl
+          ? ` Reporting guidance: <a href="${escapeHtml(data.authorityUrl)}" style="color:#257bed; text-decoration:none;" class="yc-link">${escapeHtml(data.authorityUrl)}</a>.`
+          : "") +
+        `</p>
+         <p>Yosemite Crew has <strong>not</strong> forwarded this report to them, or to the manufacturer. Nothing has left the practice.</p>`
+      : `<p>Yosemite Crew has <strong>not</strong> forwarded this report to a regulator or manufacturer. Nothing has left the practice.</p>`;
+
+    return {
+      subject: `Adverse event reported for ${data.companionName}: ${data.productName}`,
+      contentHtml: `
+      <p>Hi ${escapeHtml(organisationName)},</p>
+      <p><strong>${escapeHtml(data.reporterName)}</strong> reported a suspected adverse event for <strong>${escapeHtml(data.companionName)}</strong>.</p>
+      ${detail("Product", product)}
+      ${detail("Batch number", data.batchNumber)}
+      ${detail("Amount used", data.quantityUsed)}
+      ${detail("How it was given", data.administrationMethod)}
+      ${detail("When it happened", data.eventDate)}
+      ${detail("Condition before", data.conditionBefore)}
+      ${detail("Condition after", data.conditionAfter)}
+      ${detail("Reporter email", data.reporterEmail)}
+      ${detail("Reporter phone", data.reporterPhone)}
+      ${authorityHtml}
+      ${data.reportUrl ? renderEmailButton(data.reportUrl, "View the report") : ""}
+      <p>If you need help, reach out at <a href="mailto:${supportEmail}" style="color:#257bed; text-decoration:none;" class="yc-link">${supportEmail}</a>.</p>
+    `,
+      textBody: `
+Hi ${organisationName},
+
+${data.reporterName} reported a suspected adverse event for ${data.companionName}.
+
+${detailText("Product", product)}
+${detailText("Batch number", data.batchNumber)}
+${detailText("Amount used", data.quantityUsed)}
+${detailText("How it was given", data.administrationMethod)}
+${detailText("When it happened", data.eventDate)}
+${detailText("Condition before", data.conditionBefore)}
+${detailText("Condition after", data.conditionAfter)}
+${detailText("Reporter email", data.reporterEmail)}
+${detailText("Reporter phone", data.reporterPhone)}
+
+${data.authorityName ? `Adverse events for this market are handled by ${data.authorityName}.` : ""}
+${data.authorityUrl ? `Reporting guidance: ${data.authorityUrl}` : ""}
+Yosemite Crew has NOT forwarded this report to a regulator or manufacturer. Nothing has left the practice.
+
+${data.reportUrl ? `View the report: ${data.reportUrl}` : ""}
+
+Need help? ${supportEmail}
+      `,
+    };
+  });
 
 export const emailTemplates: EmailTemplateRegistry = {
   organisationInvite: buildOrganisationInviteTemplate,
@@ -960,6 +1061,7 @@ export const emailTemplates: EmailTemplateRegistry = {
   permissionsUpdated: buildPermissionsUpdatedTemplate,
   appointmentPaymentCheckout: buildAppointmentPaymentCheckoutTemplate,
   invoicePaymentCheckout: buildInvoicePaymentCheckoutTemplate,
+  adverseEventReported: buildAdverseEventReportedTemplate,
 };
 
 export type EmailTemplateId = keyof typeof emailTemplates;

--- a/apps/backend/src/utils/email-templates.ts
+++ b/apps/backend/src/utils/email-templates.ts
@@ -991,16 +991,14 @@ const buildAdverseEventReportedTemplate =
       : data.productName;
 
     const detail = (label: string, value?: string) =>
-      value?.trim()
-        ? `<p><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</p>`
-        : "";
+      value?.trim() ? `<p><strong>${label}:</strong> ${value}</p>` : "";
     const detailText = (label: string, value?: string) =>
       value?.trim() ? `${label}: ${value}` : "";
 
     const authorityHtml = data.authorityName
-      ? `<p>Adverse events for this market are handled by <strong>${escapeHtml(data.authorityName)}</strong>.` +
+      ? `<p>Adverse events for this market are handled by <strong>${data.authorityName}</strong>.` +
         (data.authorityUrl
-          ? ` Reporting guidance: <a href="${escapeHtml(data.authorityUrl)}" style="color:#257bed; text-decoration:none;" class="yc-link">${escapeHtml(data.authorityUrl)}</a>.`
+          ? ` Reporting guidance: <a href="${data.authorityUrl}" style="color:#257bed; text-decoration:none;" class="yc-link">${data.authorityUrl}</a>.`
           : "") +
         `</p>
          <p>Yosemite Crew has <strong>not</strong> forwarded this report to them, or to the manufacturer. Nothing has left the practice.</p>`
@@ -1009,8 +1007,8 @@ const buildAdverseEventReportedTemplate =
     return {
       subject: `Adverse event reported for ${data.companionName}: ${data.productName}`,
       contentHtml: `
-      <p>Hi ${escapeHtml(organisationName)},</p>
-      <p><strong>${escapeHtml(data.reporterName)}</strong> reported a suspected adverse event for <strong>${escapeHtml(data.companionName)}</strong>.</p>
+      <p>Hi ${organisationName},</p>
+      <p><strong>${data.reporterName}</strong> reported a suspected adverse event for <strong>${data.companionName}</strong>.</p>
       ${detail("Product", product)}
       ${detail("Batch number", data.batchNumber)}
       ${detail("Amount used", data.quantityUsed)}

--- a/apps/backend/test/scripts/regulatory-authority-seed.data.test.ts
+++ b/apps/backend/test/scripts/regulatory-authority-seed.data.test.ts
@@ -1,0 +1,108 @@
+import { REGULATORY_AUTHORITY_SEED } from "src/scripts/regulatory-authority-seed.data";
+
+/*
+ * These values ARE the feature. A wrong address here does not throw - it sends
+ * a pet owner to a mailbox that does not exist, or dials a mangled number, and
+ * nothing surfaces the failure. Three of the five rows that were already in
+ * this table had exactly that shape of error (an underscore in
+ * vet_safety@hpra.ie, a guessed pharmacovigilance@vmd.gov.uk), which is why
+ * the data is guarded rather than trusted.
+ */
+describe("REGULATORY_AUTHORITY_SEED", () => {
+  it("covers every country the mobile reporting flow offers", () => {
+    const expected = [
+      "AR",
+      "AU",
+      "CA",
+      "DE",
+      "DK",
+      "ES",
+      "FR",
+      "GB",
+      "IE",
+      "IT",
+      "JP",
+      "KR",
+      "MX",
+      "NL",
+      "NZ",
+      "SE",
+      "SG",
+      "US",
+    ];
+    const actual = REGULATORY_AUTHORITY_SEED.map((a) => a.iso2).sort((a, b) =>
+      a.localeCompare(b),
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it("has one entry per country", () => {
+    const codes = REGULATORY_AUTHORITY_SEED.map((a) => a.iso2);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("names an authority and cites a source for every country", () => {
+    for (const authority of REGULATORY_AUTHORITY_SEED) {
+      expect(authority.authorityName.trim().length).toBeGreaterThan(3);
+      expect(authority.notes.trim().length).toBeGreaterThan(10);
+      expect(authority.sourceUrl).toMatch(/^https?:\/\//);
+    }
+  });
+
+  /*
+   * The mobile dialer normalises with `phone.replaceAll(/[^\d+]/g, '')`, so a
+   * value carrying an extension, a second number or a parenthetical is silently
+   * concatenated into an unreachable string - "0800 008 333 (overseas +64 4 830
+   * 1574)" dials "0800008333+6448301574". One number per row, no exceptions.
+   */
+  it("stores exactly one dialable number per country", () => {
+    for (const authority of REGULATORY_AUTHORITY_SEED) {
+      expect(authority.phone).toBeTruthy();
+      const phone = authority.phone as string;
+      expect(phone).not.toMatch(/[(),;]|ext|int\.|\bor\b/i);
+      // A leading + is allowed; any other + means two numbers were merged.
+      expect(phone.slice(1)).not.toContain("+");
+      const dialled = phone.replaceAll(/[^\d+]/g, "");
+      expect(dialled.length).toBeGreaterThanOrEqual(7);
+      expect(dialled.length).toBeLessThanOrEqual(16);
+    }
+  });
+
+  it("stores a real address or nothing, never a placeholder", () => {
+    for (const authority of REGULATORY_AUTHORITY_SEED) {
+      if (authority.email !== null) {
+        expect(authority.email).toMatch(/^[^\s@]+@[^\s@]+\.[a-z]{2,}$/i);
+        expect(authority.email).not.toMatch(/example|test|your|todo|tbd/i);
+      }
+      if (authority.website !== null) {
+        expect(authority.website).toMatch(/^https?:\/\//);
+      }
+      // A row with neither is useless to a reporter.
+      expect(authority.email ?? authority.website).toBeTruthy();
+    }
+  });
+
+  /*
+   * Regression guard for the two addresses that were wrong in the table before
+   * this seed. Both are one character or one word away from the real thing,
+   * which is exactly why they survived: they look right.
+   */
+  it("uses the verified UK and Ireland addresses, not the plausible ones", () => {
+    const gb = REGULATORY_AUTHORITY_SEED.find((a) => a.iso2 === "GB");
+    const ie = REGULATORY_AUTHORITY_SEED.find((a) => a.iso2 === "IE");
+    expect(gb?.email).toBe("adverse.events@vmd.gov.uk");
+    expect(ie?.email).toBe("vetsafety@hpra.ie");
+  });
+
+  it("records where an owner may not report directly", () => {
+    // Argentina restricts reporting to veterinary professionals by regulation,
+    // and Singapore does not accept third-party submission. A reporter in
+    // either country must not be told to just send it.
+    for (const iso2 of ["AR", "SG"]) {
+      const entry = REGULATORY_AUTHORITY_SEED.find((a) => a.iso2 === iso2);
+      expect(entry?.notes.toLowerCase()).toMatch(
+        /veterinar|not documented|professional|owner/,
+      );
+    }
+  });
+});

--- a/apps/backend/test/services/adverse-event.service.test.ts
+++ b/apps/backend/test/services/adverse-event.service.test.ts
@@ -1,0 +1,168 @@
+import { AdverseEventService } from "src/services/adverse-event.service";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    adverseEventReport: {
+      create: jest.fn(),
+    },
+    organization: {
+      findUnique: jest.fn(),
+    },
+    regulatoryAuthority: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("src/utils/email", () => ({
+  sendEmailTemplate: jest.fn(),
+}));
+
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const { prisma } = jest.requireMock("src/config/prisma");
+const { sendEmailTemplate } = jest.requireMock("src/utils/email");
+const logger = jest.requireMock("src/utils/logger").default;
+
+const VALID_INPUT = {
+  organisationId: "org-1",
+  reporter: {
+    firstName: "Ada",
+    lastName: "Lovelace",
+    email: "ada@example.com",
+    phoneNumber: "+44 20 7946 0000",
+  },
+  patient: { name: "Poppy" },
+  product: {
+    productName: "Vaccine X",
+    brandName: "BrandCo",
+    batchNumber: "LOT-42",
+    quantityUsed: "2",
+    quantityUnit: "ml",
+    administrationMethod: "Subcutaneous",
+    petConditionBefore: "Bright",
+    petConditionAfter: "Lethargic",
+    manufacturingCountry: { name: "United Kingdom" },
+  },
+  destinations: { sendToManufacturer: true, sendToHospital: false },
+  consent: { agreedToContact: true },
+} as never;
+
+const storedRow = {
+  id: "report-1",
+  organisationId: "org-1",
+  appointmentId: null,
+  reporter: {},
+  patient: {},
+  product: {},
+  destinations: {},
+  consent: {},
+  status: "SUBMITTED",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+describe("AdverseEventService.createFromMobile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.adverseEventReport.create.mockResolvedValue(storedRow);
+    prisma.organization.findUnique.mockResolvedValue({
+      name: "Bramble Vets",
+      email: "clinic@example.com",
+      country: "United Kingdom",
+    });
+    prisma.regulatoryAuthority.findFirst.mockResolvedValue({
+      authorityName: "Veterinary Medicines Directorate (VMD)",
+      website: "https://www.gov.uk/report-veterinary-medicine-problem",
+    });
+  });
+
+  it("emails the linked practice with the product and batch detail", async () => {
+    await AdverseEventService.createFromMobile(VALID_INPUT);
+
+    expect(sendEmailTemplate).toHaveBeenCalledTimes(1);
+    const call = sendEmailTemplate.mock.calls[0][0];
+    expect(call.to).toBe("clinic@example.com");
+    expect(call.templateId).toBe("adverseEventReported");
+    expect(call.templateData).toMatchObject({
+      organisationName: "Bramble Vets",
+      reporterName: "Ada Lovelace",
+      companionName: "Poppy",
+      productName: "Vaccine X",
+      brandName: "BrandCo",
+      batchNumber: "LOT-42",
+      quantityUsed: "2 ml",
+      authorityName: "Veterinary Medicines Directorate (VMD)",
+    });
+  });
+
+  /*
+   * The whole point of the notification: apps/frontend has no adverse-event
+   * screen, so if this mail is not sent the practice never learns the report
+   * exists. A report with no organisation has nowhere to go, and must not
+   * cause a spurious send.
+   */
+  it("sends nothing when the report is not linked to an organisation", async () => {
+    await AdverseEventService.createFromMobile({
+      ...(VALID_INPUT as object),
+      organisationId: undefined,
+    } as never);
+
+    expect(sendEmailTemplate).not.toHaveBeenCalled();
+    expect(prisma.organization.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("records that the practice has no email rather than failing", async () => {
+    prisma.organization.findUnique.mockResolvedValue({
+      name: "Bramble Vets",
+      email: null,
+      country: "United Kingdom",
+    });
+
+    await expect(
+      AdverseEventService.createFromMobile(VALID_INPUT),
+    ).resolves.toBeDefined();
+    expect(sendEmailTemplate).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  /*
+   * A report that was accepted and stored must not be reported back to the
+   * owner as failed because SES was unavailable - the same swallow-and-log
+   * posture as appointment.service.ts and public-booking.service.ts.
+   */
+  it("still returns the stored report when the send fails", async () => {
+    sendEmailTemplate.mockRejectedValue(new Error("SES unavailable"));
+
+    const result = await AdverseEventService.createFromMobile(VALID_INPUT);
+
+    expect(result).toBeDefined();
+    expect(prisma.adverseEventReport.create).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("omits the authority when the country has no entry", async () => {
+    prisma.regulatoryAuthority.findFirst.mockResolvedValue(null);
+
+    await AdverseEventService.createFromMobile(VALID_INPUT);
+
+    const call = sendEmailTemplate.mock.calls[0][0];
+    expect(call.templateData.authorityName).toBeUndefined();
+    expect(call.templateData.authorityUrl).toBeUndefined();
+  });
+
+  it("validates the report before storing or sending anything", async () => {
+    await expect(
+      AdverseEventService.createFromMobile({
+        ...(VALID_INPUT as object),
+        reporter: { firstName: "Ada" },
+      } as never),
+    ).rejects.toThrow("Reporter firstName and email are required");
+
+    expect(prisma.adverseEventReport.create).not.toHaveBeenCalled();
+    expect(sendEmailTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/services/adverse-event.service.test.ts
+++ b/apps/backend/test/services/adverse-event.service.test.ts
@@ -154,6 +154,21 @@ describe("AdverseEventService.createFromMobile", () => {
     expect(call.templateData.authorityUrl).toBeUndefined();
   });
 
+  it.each([
+    ["a missing product name", { product: {} }, "productName is required"],
+    ["a missing companion name", { patient: {} }, "companion name is required"],
+  ])("refuses %s", async (_label, override, message) => {
+    await expect(
+      AdverseEventService.createFromMobile({
+        ...(VALID_INPUT as object),
+        ...override,
+      } as never),
+    ).rejects.toThrow(message);
+
+    expect(prisma.adverseEventReport.create).not.toHaveBeenCalled();
+    expect(sendEmailTemplate).not.toHaveBeenCalled();
+  });
+
   it("validates the report before storing or sending anything", async () => {
     await expect(
       AdverseEventService.createFromMobile({

--- a/apps/backend/test/utils/adverse-event-email-template.test.ts
+++ b/apps/backend/test/utils/adverse-event-email-template.test.ts
@@ -1,0 +1,112 @@
+import { renderEmailTemplate } from "src/utils/email-templates";
+
+const BASE = {
+  organisationName: "Bramble Vets",
+  reporterName: "Ada Lovelace",
+  reporterEmail: "ada@example.com",
+  reporterPhone: "+44 20 7946 0000",
+  companionName: "Poppy",
+  productName: "Vaccine X",
+  brandName: "BrandCo",
+  batchNumber: "LOT-42",
+  quantityUsed: "2 ml",
+  administrationMethod: "Subcutaneous",
+  eventDate: "2026-09-01",
+  conditionBefore: "Bright",
+  conditionAfter: "Lethargic",
+};
+
+const render = (data: Partial<typeof BASE> & Record<string, unknown> = {}) =>
+  renderEmailTemplate("adverseEventReported", { ...BASE, ...data });
+
+describe("adverseEventReported email", () => {
+  it("names the companion and product in the subject", () => {
+    const { subject } = render();
+    expect(subject).toContain("Poppy");
+    expect(subject).toContain("Vaccine X");
+  });
+
+  it("carries the detail a vet needs to act", () => {
+    const { htmlBody, textBody } = render();
+    for (const value of [
+      "Ada Lovelace",
+      "Poppy",
+      "BrandCo",
+      "LOT-42",
+      "2 ml",
+      "Subcutaneous",
+      "Lethargic",
+      "ada@example.com",
+    ]) {
+      expect(htmlBody).toContain(value);
+      expect(textBody).toContain(value);
+    }
+  });
+
+  /*
+   * The whole point of the mail. Nothing is transmitted to a regulator or a
+   * manufacturer, so a clinic must not be left thinking the report has been
+   * filed - they are the only party who can act on it.
+   */
+  it("says plainly that nothing has been forwarded", () => {
+    const { htmlBody, textBody } = render();
+    expect(htmlBody).toMatch(/not.*forwarded/i);
+    expect(textBody).toMatch(/NOT forwarded/i);
+  });
+
+  it("names the country's authority when one is known", () => {
+    const { htmlBody } = render({
+      authorityName: "Veterinary Medicines Directorate (VMD)",
+      authorityUrl: "https://www.gov.uk/report-veterinary-medicine-problem",
+    });
+    expect(htmlBody).toContain("Veterinary Medicines Directorate (VMD)");
+    expect(htmlBody).toContain(
+      "https://www.gov.uk/report-veterinary-medicine-problem",
+    );
+  });
+
+  it("still disclaims forwarding when no authority is known", () => {
+    const { htmlBody } = render({
+      authorityName: undefined,
+      authorityUrl: undefined,
+    });
+    expect(htmlBody).toMatch(/not.*forwarded/i);
+  });
+
+  it("omits a detail row rather than printing an empty one", () => {
+    const { htmlBody } = render({
+      batchNumber: undefined,
+      brandName: undefined,
+    });
+    expect(htmlBody).not.toContain("Batch number:");
+    expect(htmlBody).toContain("Vaccine X");
+  });
+
+  /*
+   * createEmailTemplate renders the HTML pass over escapeDeep(data), so the
+   * builder must NOT escape again - a second pass turns `&` into `&amp;` in a
+   * clinic's own name. This is the regression guard for that.
+   */
+  it("escapes exactly once, so an ampersand survives intact", () => {
+    const { htmlBody, textBody } = render({
+      organisationName: "Smith & Jones",
+    });
+    expect(htmlBody).toContain("Smith &amp; Jones");
+    expect(htmlBody).not.toContain("&amp;amp;");
+    // The plaintext body renders raw data and must carry no entities at all.
+    expect(textBody).toContain("Smith & Jones");
+  });
+
+  it("escapes markup in a supplied value rather than emitting it", () => {
+    const { htmlBody } = render({
+      companionName: '<img src=x onerror="alert(1)">',
+    });
+    expect(htmlBody).not.toMatch(/<img[^>]+onerror/i);
+    expect(htmlBody).toContain("&lt;img");
+  });
+
+  it("falls back to a neutral greeting when the practice has no name", () => {
+    const { htmlBody } = render({ organisationName: undefined });
+    expect(htmlBody).toContain("your practice");
+  });
+});

--- a/packages/database/prisma/migrations/20260902120000_regulatory_authority_iso2_unique/migration.sql
+++ b/packages/database/prisma/migrations/20260902120000_regulatory_authority_iso2_unique/migration.sql
@@ -1,0 +1,11 @@
+-- One RegulatoryAuthority row per country.
+--
+-- The seed upserts on iso2 and the lookup endpoint resolves a reporter's
+-- country to a single authority, so duplicates would make both ambiguous.
+-- iso2 stays nullable; Postgres permits multiple NULLs under a unique index,
+-- so rows that predate a known country code are unaffected.
+--
+-- Guarded because the constraint cannot be added while duplicates exist. If
+-- this fails, dedupe first rather than dropping the guard.
+CREATE UNIQUE INDEX IF NOT EXISTS "RegulatoryAuthority_iso2_key"
+  ON "RegulatoryAuthority" ("iso2");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3639,7 +3639,9 @@ model Occupancy {
 model RegulatoryAuthority {
   id            String  @id @default(uuid())
   country       String?
-  iso2          String?
+  // One authority row per country: the seed upserts on this, and the lookup
+  // endpoint resolves a reporter's country to exactly one authority.
+  iso2          String? @unique
   iso3          String?
   authorityName String?
   phone         String?


### PR DESCRIPTION
## What

Submitting an adverse event stored a row and told nobody. This makes the practice destination genuinely work, and populates the authority table so a reporter can be pointed at their own regulator.

## What it deliberately does NOT do

It does not forward anything to a regulator or a manufacturer.

All 18 supported countries were researched, and **not one documents a route by which a software platform may file on an owner's behalf** — fifteen are silent, two exclude it. Argentina is explicit: Resolución SENASA 323/2011 art. 5 makes a notification valid *"solo cuando sea presentada por un profesional de las Ciencias Veterinarias"*. A platform can never write to the Union pharmacovigilance database either; only a competent authority or a marketing-authorisation holder records into it.

**Manufacturer-forwarding is not the softer option it looks like**, which inverts the obvious assumption:

- The VMD states plainly it will **not** share a reporter's personal details with a marketing-authorisation holder. So the regulator route protects the owner's identity where the manufacturer route hands it to a commercial company.
- A contract with an MAH starts *their* statutory 30-day clock at **our** receipt, and makes us auditable by them, inspectable by regulators, and a named component in their pharmacovigilance master file.

There is also a likely legal-basis gap: reports where a *human* reacted to a veterinary product are special-category health data, and the GDPR Art 9(2)(i) public-health ground regulators rely on is doubtful for a commercial platform. That needs counsel, not engineering.

## The practice email

`createFromMobile` now emails the linked practice with product, batch, amount, administration route, dates, before/after condition and reporter contact.

This is currently the **only** way a practice learns a report exists: the row is org-scoped and reachable over the API, but `apps/frontend` has **zero** adverse-event references, so nothing surfaces it in the PIMS. That is also why it is an email rather than an in-app notification.

The mail states explicitly that nothing has been forwarded, and names the country's authority so a human can act. Failure is logged and swallowed, matching `appointment.service.ts` and `public-booking.service.ts` — a report that was accepted and stored must not be reported back as failed because SES was unavailable.

## The authority table

`RegulatoryAuthority` already existed, with a lookup endpoint **the mobile app already calls**. It was simply almost empty, which is why the app's "call the authority" action could never work. Now seeded with all 18 countries.

Five rows were already there, and **three carried addresses that do not exist**:

| Was | Actually |
|---|---|
| `pharmacovigilance@vmd.gov.uk` | `adverse.events@vmd.gov.uk` |
| `vet_safety@hpra.ie` | `vetsafety@hpra.ie` (no underscore) |
| US `sourceUrl` → USDA biologics | FDA CVM |

A one-character error in an address fails silently — the mail bounces to nobody — so every value was checked against the authority's own domain and then independently re-verified, and a field is `null` rather than a plausible guess where no official value exists.

Phone numbers are curated to one dialable number each, because the mobile action normalises with `phone.replaceAll(/[^\d+]/g, '')`: `"0800 008 333 (overseas +64 4 830 1574)"` would otherwise dial `0800008333+6448301574`. Extensions and named officials are dropped for the same reason, and because a named official is personal data with no reason to be in this table.

**South Korea is the honest gap.** APQA publishes safety guidance but no verifiable reporting form or address, so the row carries the guidance page, the real switchboard number, and a note saying to raise it with a vet rather than implying an online route exists.

`iso2` becomes unique so the seed can upsert and the lookup resolves one row.

## Validation

**102 tests across 9 suites.** `npx tsc --noEmit` exits 0 (run directly, not through turbo, which had replayed a cached success over a real error earlier).

The seed data is guarded on the properties that fail *silently*: one dialable number per row, no placeholder addresses, a real email or portal for every country, and named regression cases for the two wrong addresses.

That last guard earned its place immediately — the test refused a row with no reachable channel, which is how South Korea was caught. The fix was to go and find a real page, not to weaken the assertion.

## Impact

Backend service, seed script and one new email template. Nothing transmits externally beyond the practice email.