### PR TITLE
chore(backend): take the backend Sonar smell count to zero

### DIFF
--- a/apps/backend/src/services/documenso.service.ts
+++ b/apps/backend/src/services/documenso.service.ts
@@ -129,16 +129,16 @@ export class DocumensoService {
       logger.info("Creating document with signature placement", {
         placement,
       });
-      const createDocumentResponse = await documenso.documents.createV0({
+      const request = {
         title: title ?? "Form Submission",
         recipients: [
           {
             email: signerEmail,
             name: signerName ?? signerEmail,
-            role: "SIGNER",
+            role: "SIGNER" as const,
             fields: [
               {
-                type: "SIGNATURE",
+                type: "SIGNATURE" as const,
                 pageNumber: placement.pageNumber,
                 pageX: placement.pageX,
                 pageY: placement.pageY,
@@ -148,9 +148,16 @@ export class DocumensoService {
             ],
           },
         ],
-      });
+      };
+      // createV0 is deprecated, but its replacement documents.create() returns
+      // only { envelopeId, id } - no uploadUrl and no recipients. The callers
+      // below read document.recipients[0].token to build the signing URL, so
+      // migrating needs a second documents.get() round-trip and a rewrite of the
+      // upload path. That is a behavioural change on the e-signature flow, so it
+      // is tracked in #2643 and tested there against a live Documenso.
+      const created = await documenso.documents.createV0(request); // NOSONAR
 
-      const { document, uploadUrl } = createDocumentResponse;
+      const { document, uploadUrl } = created;
 
       await uploadPdfBuffer(pdf, uploadUrl);
 

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -964,9 +964,7 @@ export const TemplateService = {
       ? await loadTemplateVersionOrThrow(template.id, targetVersion)
       : null;
     const rawNextSchemaSnapshot =
-      parsed.schemaSnapshot === undefined
-        ? currentVersion?.schemaSnapshot
-        : parsed.schemaSnapshot;
+      parsed.schemaSnapshot ?? currentVersion?.schemaSnapshot;
     const nextSchemaSnapshot =
       rawNextSchemaSnapshot == null
         ? rawNextSchemaSnapshot
@@ -1025,14 +1023,10 @@ export const TemplateService = {
             nextSchemaSnapshot ?? currentVersion.schemaSnapshot,
           ),
           renderConfigSnapshot: toJsonInput(
-            parsed.renderConfigSnapshot === undefined
-              ? currentVersion.renderConfigSnapshot
-              : parsed.renderConfigSnapshot,
+            parsed.renderConfigSnapshot ?? currentVersion.renderConfigSnapshot,
           ),
           validationSnapshot: toJsonInput(
-            parsed.validationSnapshot === undefined
-              ? currentVersion.validationSnapshot
-              : parsed.validationSnapshot,
+            parsed.validationSnapshot ?? currentVersion.validationSnapshot,
           ),
         },
       });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

> Successor to #2661, which was correctly closed as superseded by #2663. That close invited a reopen if a specific hunk differed in substance rather than in path. Two do, and this is them. Everything else from #2661 is already on `dev` and has been dropped.

## What is the current behavior?

#2658, #2659 and #2663 cleared the Zod deprecations and the frontend smells. `apps/backend` has no remaining deprecated Zod call sites. Two SonarCloud findings are still open on `dev`, and either one holds `scripts/ci/sonar-thresholds.mjs --issues 0` red:

**1. Three `typescript:S6606` in `template.service.ts`.** Sonar wants `X === undefined ? Y : X` written as `X ?? Y`. Still present at lines 967, 1028 and 1033 on `dev`.

**2. One `typescript:S1874` in `documenso.service.ts`** - the deprecated `documents.createV0()`.

On the second one there is a gap worth flagging plainly, because it is easy to miss. #2663 turned `sonarjs/deprecation` off for that file with this reasoning:

> The one remaining deprecation is documenso.documents.createV0, which already carries a NOSONAR and an explanation there - SonarCloud honours that comment and eslint does not.

The premise is not true on `dev`. There is no `NOSONAR` in `documenso.service.ts`, and no `sonar.issue.ignore` entry for it in `apps/backend/sonar-project.properties`:

```
$ git show origin/dev:apps/backend/src/services/documenso.service.ts | grep -c NOSONAR
0
$ git show origin/dev:apps/backend/sonar-project.properties | grep -ci 'documenso\|S1874'
0
```

So the eslint side is silenced and the SonarCloud side is not. The finding will still be raised, and the gate will still be red. That is not a criticism of #2663 - its conclusion about *why* `createV0` stays is identical to the one reached independently here. The suppression it assumed existed simply had not landed yet. This PR lands it, which also makes that config comment accurate.

## What is the new behavior?

**The three ternaries become `??`.** Worth reading rather than rubber-stamping, because the file carries a comment warning about exactly this distinction - the concern being a v4 `.default().optional()` resolution writing `{}` over a stored snapshot the caller never mentioned.

`??` is safe here because of the types. `schemaSnapshot`, `renderConfigSnapshot` and `validationSnapshot` are each `.optional()` applied to a non-nullable schema (`z.object({...})` and `z.record(z.string(), z.unknown())`), so each is `T | undefined` and never `null`. `X === undefined ? Y : X` and `X ?? Y` diverge only when `X` can be `null`. The "absent leaves the stored snapshot alone" behaviour the comment protects is preserved exactly.

**The Documenso call gets the `NOSONAR` that #2663 assumed was already there**, with the reasoning inline: `documents.create()` returns only `{ envelopeId, id }` - no `uploadUrl`, no `recipients` - while `workspace-document-packet.service.ts` reads `doc.recipients[0].token` to build the signing URL, and `pet-clinical-records.service.ts` and `rendered-document.service.ts` read `.id`. Migrating needs a second `documents.get()` round-trip plus a rewrite of the upload path, on the flow that produces signed clinical documents, and it cannot be verified without a live instance. That is #2643.

The call is lifted into a `request` variable so it fits on one line. That is not cosmetic. Sonar honours `NOSONAR` only on the line it reported, and Prettier reflows a multi-line call so the marker lands inside the object literal or on the closing paren - suppressing nothing while looking suppressed. A one-line call is the only placement that survives `prettier --write`, which was confirmed by re-reading the line after formatting.

## How this was verified

- `pnpm --filter backend run lint` (including the `eslint-plugin-sonarjs` rules #2663 wired in): exit 0. The 25 warnings it reports are pre-existing and in other files; none are in the two touched here.
- `pnpm --filter backend run type-check`: exit 0
- Targeted Jest for both touched services: 15 suites, 357 tests, all passing
- `prettier --check`: clean, and the `NOSONAR` re-read afterwards to confirm it is still on the `createV0` line

The one thing not checkable locally is whether SonarCloud accepts the marker - eslint does not honour `NOSONAR`, so that is what the `sonar` check on this PR is for.

## Related Issue(s)

Fixes #2652

Follow-up: #2643
