### PR TITLE
feat(mobile): pet care assistant with Siri App Intents and on-device AI

### DIFF
--- a/apps/mobileAppYC/AGENTS.md
+++ b/apps/mobileAppYC/AGENTS.md
@@ -9,6 +9,7 @@ Inherits all root `AGENTS.md` rules. This file adds mobile-specific rules.
 - [Mobile app README](./README.md) - local setup, environment/credential configuration, and release versioning for the React Native app. Start here if you have not built the app yet.
 - [App Store Submission Guide](../../docs/guide/mobile-app-submission-guide.md) - full reference for pre-submission checklist, Android/iOS build steps, store submission workflow, version reference, and post-approval README updates.
 - [Liquid glass UI guide](./guides/liquidGlassDoc.md) - how the iOS 26 "liquid glass" material (the `@callstack/liquid-glass` library) is used; the `forceLiquidGlassBorder` flags below toggle its behaviour.
+- [Pet care assistant guide](./guides/assistantDoc.md) - how the Siri App Intents, the Android shortcuts, the offline snapshot and the on-device model fit together, and how to add a new assistant action.
 
 ---
 

--- a/apps/mobileAppYC/App.tsx
+++ b/apps/mobileAppYC/App.tsx
@@ -37,6 +37,7 @@ import {ErrorBoundary} from '@/shared/components/common/ErrorBoundary';
 import {PreferencesProvider} from '@/features/preferences/PreferencesContext';
 import {GlobalLoaderProvider} from '@/context/GlobalLoaderContext';
 import {useAssistantSync} from '@/features/assistant/hooks/useAssistantSync';
+import type {AssistantNavigator} from '@/features/assistant/hooks/useAssistantSync';
 import {BottomFadeOverlay} from '@/shared/components/common';
 import {
   initializeNotifications,
@@ -567,7 +568,7 @@ function App(): React.JSX.Element {
                           ref={navigationRef}
                           onReady={handleNavigationReady}
                           onStateChange={handleNavigationStateChange}>
-                          <AppContent />
+                          <AppContent navigationRef={navigationRef} />
                         </NavigationContainer>
                       </StripeProvider>
                     </NotificationBootstrap>
@@ -582,12 +583,18 @@ function App(): React.JSX.Element {
   );
 }
 
-function AppContent(): React.JSX.Element {
+function AppContent({
+  navigationRef,
+}: {
+  navigationRef: AssistantNavigator;
+}): React.JSX.Element {
   const {theme, isDark} = useTheme();
 
   // Keeps Siri's offline snapshot and the Android launcher shortcuts current,
-  // and routes any deep link a handoff intent parked for us.
-  useAssistantSync();
+  // and routes any deep link a handoff intent parked for us. The container ref
+  // is passed rather than read from context: this sits at the app root, which
+  // is not always below a navigator.
+  useAssistantSync(navigationRef);
 
   return (
     <>

--- a/apps/mobileAppYC/App.tsx
+++ b/apps/mobileAppYC/App.tsx
@@ -36,6 +36,7 @@ import {initSuperTokens} from '@/features/auth/services/superTokensClient';
 import {ErrorBoundary} from '@/shared/components/common/ErrorBoundary';
 import {PreferencesProvider} from '@/features/preferences/PreferencesContext';
 import {GlobalLoaderProvider} from '@/context/GlobalLoaderContext';
+import {useAssistantSync} from '@/features/assistant/hooks/useAssistantSync';
 import {BottomFadeOverlay} from '@/shared/components/common';
 import {
   initializeNotifications,
@@ -583,6 +584,10 @@ function App(): React.JSX.Element {
 
 function AppContent(): React.JSX.Element {
   const {theme, isDark} = useTheme();
+
+  // Keeps Siri's offline snapshot and the Android launcher shortcuts current,
+  // and routes any deep link a handoff intent parked for us.
+  useAssistantSync();
 
   return (
     <>

--- a/apps/mobileAppYC/__tests__/features/assistant/actions/catalogue.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/actions/catalogue.test.ts
@@ -1,0 +1,341 @@
+import {
+  ASSISTANT_ACTIONS,
+  ASSISTANT_ACTION_IDS,
+  getAssistantAction,
+  isHandoffAction,
+} from '@/features/assistant/actions/catalogue';
+import type {
+  AssistantAction,
+  AssistantActionId,
+  AssistantActionKind,
+  AssistantSlotName,
+} from '@/features/assistant/types';
+import en from '@/localization/resources/en/common.json';
+import es from '@/localization/resources/es/common.json';
+
+/**
+ * The kind every id in the `AssistantActionId` union is expected to have.
+ *
+ * Typed as a total `Record`, so dropping an id from the union — or adding one
+ * without deciding whether it reads or hands off — fails type-check, while the
+ * assertions below fail at runtime if the catalogue and this table disagree.
+ */
+const EXPECTED_KINDS: Record<AssistantActionId, AssistantActionKind> = {
+  nextAppointment: 'read',
+  vaccinationStatus: 'read',
+  upcomingTasks: 'read',
+  petOverview: 'read',
+  expenseSummary: 'read',
+  addCareTask: 'handoff',
+  logExpense: 'handoff',
+  bookAppointment: 'handoff',
+};
+
+const ALL_SLOT_NAMES: readonly AssistantSlotName[] = [
+  'petName',
+  'when',
+  'title',
+  'amount',
+  'category',
+];
+
+const UNKNOWN_ID = 'notARealAction' as AssistantActionId;
+
+const readActions = ASSISTANT_ACTIONS.filter(a => a.kind === 'read');
+const handoffActions = ASSISTANT_ACTIONS.filter(a => a.kind === 'handoff');
+
+const i18nKeysOf = (action: AssistantAction): string[] => [
+  action.titleKey,
+  action.descriptionKey,
+  ...action.samplePhraseKeys,
+];
+
+const lookup = (bundle: unknown, key: string): unknown =>
+  key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        typeof node === 'object' && node !== null
+          ? (node as Record<string, unknown>)[part]
+          : undefined,
+      bundle,
+    );
+
+describe('ASSISTANT_ACTIONS', () => {
+  it('lists the eight catalogued actions in a stable order', () => {
+    expect(ASSISTANT_ACTIONS.map(a => a.id)).toEqual([
+      'nextAppointment',
+      'vaccinationStatus',
+      'upcomingTasks',
+      'petOverview',
+      'expenseSummary',
+      'addCareTask',
+      'logExpense',
+      'bookAppointment',
+    ]);
+  });
+
+  it('gives every action a unique id', () => {
+    const ids = ASSISTANT_ACTIONS.map(a => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('covers exactly the AssistantActionId union, with the expected kinds', () => {
+    const actual = Object.fromEntries(
+      ASSISTANT_ACTIONS.map(a => [a.id, a.kind]),
+    );
+    expect(actual).toEqual(EXPECTED_KINDS);
+  });
+
+  it('splits into five read actions and three handoff actions', () => {
+    expect(readActions.map(a => a.id)).toEqual([
+      'nextAppointment',
+      'vaccinationStatus',
+      'upcomingTasks',
+      'petOverview',
+      'expenseSummary',
+    ]);
+    expect(handoffActions.map(a => a.id)).toEqual([
+      'addCareTask',
+      'logExpense',
+      'bookAppointment',
+    ]);
+  });
+
+  it('uses only the two documented kinds', () => {
+    expect(readActions.length + handoffActions.length).toBe(
+      ASSISTANT_ACTIONS.length,
+    );
+  });
+});
+
+describe('ASSISTANT_ACTION_IDS', () => {
+  it('mirrors the catalogue order exactly', () => {
+    expect(ASSISTANT_ACTION_IDS).toEqual(ASSISTANT_ACTIONS.map(a => a.id));
+  });
+
+  it('has one id per catalogued action', () => {
+    expect(ASSISTANT_ACTION_IDS).toHaveLength(ASSISTANT_ACTIONS.length);
+    expect(new Set(ASSISTANT_ACTION_IDS).size).toBe(
+      ASSISTANT_ACTION_IDS.length,
+    );
+  });
+
+  it('starts with a read action so the first suggestion chip is safe to run unattended', () => {
+    expect(ASSISTANT_ACTION_IDS[0]).toBe('nextAppointment');
+    expect(isHandoffAction(ASSISTANT_ACTION_IDS[0])).toBe(false);
+  });
+});
+
+describe('slots', () => {
+  it.each(ASSISTANT_ACTIONS.map(a => [a.id, a] as const))(
+    '%s declares requiredSlots as a subset of slots',
+    (_id, action) => {
+      const extras = action.requiredSlots.filter(
+        slot => !action.slots.includes(slot),
+      );
+      expect(extras).toEqual([]);
+    },
+  );
+
+  it.each(ASSISTANT_ACTIONS.map(a => [a.id, a] as const))(
+    '%s uses known slot names with no duplicates',
+    (_id, action) => {
+      const unknownSlots = action.slots.filter(
+        slot => !ALL_SLOT_NAMES.includes(slot),
+      );
+      expect(unknownSlots).toEqual([]);
+      expect(new Set(action.slots).size).toBe(action.slots.length);
+      expect(new Set(action.requiredSlots).size).toBe(
+        action.requiredSlots.length,
+      );
+    },
+  );
+
+  it('requires a slot only where the action cannot answer without it', () => {
+    const withRequired = ASSISTANT_ACTIONS.filter(
+      a => a.requiredSlots.length > 0,
+    ).map(a => [a.id, a.requiredSlots]);
+    expect(withRequired).toEqual([['petOverview', ['petName']]]);
+  });
+
+  it('offers petName first wherever an action accepts it', () => {
+    const accepting = ASSISTANT_ACTIONS.filter(a =>
+      a.slots.includes('petName'),
+    );
+    expect(accepting).toHaveLength(ASSISTANT_ACTIONS.length);
+    accepting.forEach(action => {
+      expect(action.slots[0]).toBe('petName');
+    });
+  });
+});
+
+describe('deep links', () => {
+  it('gives every handoff action a yc:// deep link', () => {
+    expect(handoffActions.map(a => a.deepLink)).toEqual([
+      'yc://app/tasks/new',
+      'yc://app/expenses/new',
+      'yc://app/appointments/book',
+    ]);
+  });
+
+  it.each(handoffActions.map(a => [a.id, a] as const))(
+    '%s points at a distinct yc://app path',
+    (_id, action) => {
+      expect(typeof action.deepLink).toBe('string');
+      expect(action.deepLink).toMatch(/^yc:\/\/app\/[a-z]+\/[a-z]+$/);
+    },
+  );
+
+  it('never reuses a deep link between two handoff actions', () => {
+    const links = handoffActions.map(a => a.deepLink);
+    expect(new Set(links).size).toBe(links.length);
+  });
+
+  it.each(readActions.map(a => [a.id, a] as const))(
+    '%s leaves deepLink undefined because it answers in place',
+    (_id, action) => {
+      expect(action.deepLink).toBeUndefined();
+    },
+  );
+
+  it('defines deepLink on the handoff actions and on no others', () => {
+    const withLink = ASSISTANT_ACTIONS.filter(
+      a => a.deepLink !== undefined,
+    ).map(a => a.id);
+    expect(withLink).toEqual(handoffActions.map(a => a.id));
+  });
+});
+
+describe('i18n keys', () => {
+  it.each(ASSISTANT_ACTIONS.map(a => [a.id, a] as const))(
+    '%s namespaces every key under assistant.actions.<id>',
+    (id, action) => {
+      const keys = i18nKeysOf(action);
+      const misfiled = keys.filter(
+        key => !key.startsWith(`assistant.actions.${id}.`),
+      );
+      expect(misfiled).toEqual([]);
+      keys.forEach(key => {
+        expect(key.startsWith('assistant.')).toBe(true);
+      });
+    },
+  );
+
+  it.each(ASSISTANT_ACTIONS.map(a => [a.id, a] as const))(
+    '%s names its title and description keys by role',
+    (id, action) => {
+      expect(action.titleKey).toBe(`assistant.actions.${id}.title`);
+      expect(action.descriptionKey).toBe(`assistant.actions.${id}.description`);
+    },
+  );
+
+  it.each(ASSISTANT_ACTIONS.map(a => [a.id, a] as const))(
+    '%s offers at least one sample phrase key',
+    (_id, action) => {
+      expect(action.samplePhraseKeys.length).toBeGreaterThanOrEqual(1);
+      expect(new Set(action.samplePhraseKeys).size).toBe(
+        action.samplePhraseKeys.length,
+      );
+    },
+  );
+
+  it('never reuses an i18n key across two actions', () => {
+    // Catches the classic bad edit: an action block copy-pasted and given a new
+    // id, but with the previous action's keys left behind.
+    const keys = ASSISTANT_ACTIONS.flatMap(i18nKeysOf);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('resolves every catalogue key to a string in the English bundle', () => {
+    const unresolved = ASSISTANT_ACTIONS.flatMap(i18nKeysOf).filter(
+      key => typeof lookup(en, key) !== 'string',
+    );
+    expect(unresolved).toEqual([]);
+  });
+
+  it('resolves every catalogue key to a string in the Spanish bundle', () => {
+    const unresolved = ASSISTANT_ACTIONS.flatMap(i18nKeysOf).filter(
+      key => typeof lookup(es, key) !== 'string',
+    );
+    expect(unresolved).toEqual([]);
+  });
+});
+
+describe('getAssistantAction', () => {
+  it.each(ASSISTANT_ACTION_IDS.map(id => [id] as const))(
+    'returns the catalogue entry whose id is %s',
+    id => {
+      const action = getAssistantAction(id);
+      expect(action).toBe(ASSISTANT_ACTIONS.find(a => a.id === id));
+      expect(action?.id).toBe(id);
+    },
+  );
+
+  it('returns the addCareTask entry with its slots and deep link intact', () => {
+    expect(getAssistantAction('addCareTask')).toEqual({
+      id: 'addCareTask',
+      kind: 'handoff',
+      titleKey: 'assistant.actions.addCareTask.title',
+      descriptionKey: 'assistant.actions.addCareTask.description',
+      slots: ['petName', 'title', 'when'],
+      requiredSlots: [],
+      deepLink: 'yc://app/tasks/new',
+      samplePhraseKeys: [
+        'assistant.actions.addCareTask.phrase1',
+        'assistant.actions.addCareTask.phrase2',
+      ],
+    });
+  });
+
+  it('returns undefined for an id that is not in the catalogue', () => {
+    expect(getAssistantAction(UNKNOWN_ID)).toBeUndefined();
+  });
+
+  it('does not fall back to a near-miss id', () => {
+    expect(
+      getAssistantAction('NextAppointment' as AssistantActionId),
+    ).toBeUndefined();
+    expect(getAssistantAction('' as AssistantActionId)).toBeUndefined();
+  });
+
+  it('is not fooled by inherited Object prototype keys', () => {
+    expect(getAssistantAction('toString' as AssistantActionId)).toBeUndefined();
+    expect(
+      getAssistantAction('constructor' as AssistantActionId),
+    ).toBeUndefined();
+  });
+});
+
+describe('isHandoffAction', () => {
+  it.each(handoffActions.map(a => [a.id] as const))(
+    'is true for the handoff action %s',
+    id => {
+      expect(isHandoffAction(id)).toBe(true);
+    },
+  );
+
+  it.each(readActions.map(a => [a.id] as const))(
+    'is false for the read action %s',
+    id => {
+      expect(isHandoffAction(id)).toBe(false);
+    },
+  );
+
+  it('is false for an unknown id rather than throwing', () => {
+    expect(isHandoffAction(UNKNOWN_ID)).toBe(false);
+  });
+
+  it('agrees with the kind recorded on every catalogue entry', () => {
+    ASSISTANT_ACTION_IDS.forEach(id => {
+      expect(isHandoffAction(id)).toBe(
+        getAssistantAction(id)?.kind === 'handoff',
+      );
+    });
+    expect(ASSISTANT_ACTION_IDS.filter(isHandoffAction)).toEqual([
+      'addCareTask',
+      'logExpense',
+      'bookAppointment',
+    ]);
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/actions/resolvers.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/actions/resolvers.test.ts
@@ -1,0 +1,1354 @@
+import {
+  appointmentStartsAt,
+  buildHandoffLink,
+  parseRecordDate,
+  resolveAddCareTask,
+  resolveBookAppointment,
+  resolveCompanion,
+  resolveExpenseSummary,
+  resolveLogExpense,
+  resolveNextAppointment,
+  resolvePetOverview,
+  resolveUpcomingTasks,
+  resolveVaccinationStatus,
+  runAction,
+  taskDueAt,
+  taskLabel,
+} from '@/features/assistant/actions/resolvers';
+import type {
+  AssistantActionId,
+  AssistantContext,
+} from '@/features/assistant/types';
+import type {Companion} from '@/features/companion/types';
+import type {Task} from '@/features/tasks/types';
+import type {Appointment} from '@/features/appointments/types';
+import type {Expense} from '@/features/expenses/types';
+
+/**
+ * One generic factory: give it a fully-typed default, get back a builder that
+ * overrides only the fields a test cares about. No `as any` anywhere, so a
+ * change to a domain type breaks these fixtures at compile time.
+ */
+const factory =
+  <T>(defaults: T) =>
+  (overrides: Partial<T> = {}): T => ({...defaults, ...overrides});
+
+const makeCompanion = factory<Companion>({
+  id: 'c1',
+  name: 'Bruno',
+  category: 'dog',
+  speciesCode: null,
+  breed: null,
+  breedCode: null,
+  dateOfBirth: null,
+  gender: 'male',
+  currentWeight: null,
+  color: null,
+  allergies: null,
+  neuteredStatus: 'neutered',
+  ageWhenNeutered: null,
+  bloodGroup: null,
+  microchipNumber: null,
+  passportNumber: null,
+  insuredStatus: 'not-insured',
+  insuranceCompany: null,
+  insurancePolicyNumber: null,
+  countryOfOrigin: null,
+  origin: 'unknown',
+  profileImage: null,
+  userId: 'u1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const makeTask = factory<Task>({
+  id: 't1',
+  companionId: 'c1',
+  category: 'custom',
+  title: 'Care task',
+  date: '2026-09-10',
+  frequency: 'once',
+  reminderEnabled: false,
+  reminderOptions: null,
+  syncWithCalendar: false,
+  attachDocuments: false,
+  attachments: [],
+  status: 'PENDING',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  details: {},
+});
+
+const makeAppointment = factory<Appointment>({
+  id: 'a1',
+  companionId: 'c1',
+  businessId: 'b1',
+  date: '2026-09-12',
+  time: '12:00',
+  type: 'consultation',
+  status: 'CONFIRMED',
+});
+
+const makeExpense = factory<Expense>({
+  id: 'e1',
+  companionId: 'c1',
+  title: 'Vet visit',
+  category: 'health',
+  subcategory: 'consultation',
+  visitType: 'clinic',
+  amount: 10,
+  currencyCode: 'EUR',
+  status: 'PAID',
+  source: 'inApp',
+  date: '2026-09-01',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  attachments: [],
+});
+
+/** Fixed clock. Midday UTC keeps every asserted ISO day stable under any TZ. */
+const NOW = new Date('2026-09-10T12:00:00.000Z');
+const MS_PER_DAY = 86_400_000;
+const atOffset = (days: number): string =>
+  new Date(NOW.getTime() + days * MS_PER_DAY).toISOString();
+
+const makeContext = factory<AssistantContext>({
+  companions: [],
+  tasks: [],
+  appointments: [],
+  expenses: [],
+  vaccinations: {},
+  now: NOW,
+  currencyCode: 'EUR',
+});
+
+const BRUNO = makeCompanion({id: 'c1', name: 'Bruno'});
+const LUNA = makeCompanion({id: 'c2', name: 'Luna'});
+
+describe('appointmentStartsAt', () => {
+  it('prefers the full `start` timestamp over date and time', () => {
+    const startsAt = appointmentStartsAt(
+      makeAppointment({
+        start: '2026-09-12T08:30:00.000Z',
+        date: '2026-12-25',
+        time: '23:45',
+      }),
+    );
+
+    expect(startsAt?.toISOString()).toBe('2026-09-12T08:30:00.000Z');
+  });
+
+  it('falls back to date plus time when `start` is unparseable', () => {
+    const startsAt = appointmentStartsAt(
+      makeAppointment({
+        start: 'tomorrow-ish',
+        date: '2026-09-12',
+        time: '09:15',
+      }),
+    );
+
+    expect(startsAt?.getFullYear()).toBe(2026);
+    expect(startsAt?.getMonth()).toBe(8);
+    expect(startsAt?.getDate()).toBe(12);
+    expect(startsAt?.getHours()).toBe(9);
+    expect(startsAt?.getMinutes()).toBe(15);
+  });
+
+  it('trims a seconds-bearing time down to HH:mm', () => {
+    const startsAt = appointmentStartsAt(
+      makeAppointment({date: '2026-09-12', time: '09:15:30'}),
+    );
+
+    expect(startsAt).not.toBeNull();
+    expect(startsAt?.getDate()).toBe(12);
+    expect(startsAt?.getHours()).toBe(9);
+    expect(startsAt?.getMinutes()).toBe(15);
+    expect(startsAt?.getSeconds()).toBe(0);
+  });
+
+  it('keeps a seconds-bearing appointment visible to the resolvers', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          id: 'a-seconds',
+          date: '2026-09-12',
+          time: '09:15:30',
+        }),
+      ],
+    });
+
+    const result = resolveNextAppointment(context, {});
+
+    expect(result.status).toBe('ok');
+    expect(result.data?.appointmentId).toBe('a-seconds');
+    expect(result.data?.dateLabel).toBe('2026-09-12');
+  });
+
+  it('joins date and time as local midnight when the time is missing', () => {
+    const startsAt = appointmentStartsAt(
+      makeAppointment({date: '2026-09-12', time: ''}),
+    );
+
+    expect(startsAt?.getDate()).toBe(12);
+    expect(startsAt?.getHours()).toBe(0);
+    expect(startsAt?.getMinutes()).toBe(0);
+  });
+
+  it('falls back to midnight when the time is not HH:mm', () => {
+    const startsAt = appointmentStartsAt(
+      makeAppointment({date: '2026-09-12', time: '9am'}),
+    );
+
+    expect(startsAt?.getHours()).toBe(0);
+  });
+
+  it('returns null when there is no date to fall back to', () => {
+    expect(
+      appointmentStartsAt(makeAppointment({date: '', time: '12:00'})),
+    ).toBeNull();
+  });
+
+  it('returns null when the date cannot be parsed', () => {
+    expect(
+      appointmentStartsAt(
+        makeAppointment({date: 'next tuesday', time: '12:00'}),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('taskDueAt', () => {
+  it('prefers `dueAt` over the local date and time fields', () => {
+    const dueAt = taskDueAt(
+      makeTask({
+        dueAt: '2026-09-11T06:45:00.000Z',
+        date: '2026-12-25',
+        time: '23:45',
+      }),
+    );
+
+    expect(dueAt?.toISOString()).toBe('2026-09-11T06:45:00.000Z');
+  });
+
+  it('falls back to date plus time when `dueAt` is unparseable', () => {
+    const dueAt = taskDueAt(
+      makeTask({dueAt: 'soon', date: '2026-09-11', time: '07:30'}),
+    );
+
+    expect(dueAt?.getDate()).toBe(11);
+    expect(dueAt?.getHours()).toBe(7);
+    expect(dueAt?.getMinutes()).toBe(30);
+  });
+
+  it('trims a seconds-bearing time down to HH:mm', () => {
+    const dueAt = taskDueAt(makeTask({date: '2026-09-11', time: '07:30:00'}));
+
+    expect(dueAt?.getHours()).toBe(7);
+    expect(dueAt?.getMinutes()).toBe(30);
+  });
+
+  it('takes only the date half of a full ISO `date`', () => {
+    const dueAt = taskDueAt(
+      makeTask({date: '2026-09-11T22:00:00.000Z', time: '08:00'}),
+    );
+
+    expect(dueAt?.getDate()).toBe(11);
+    expect(dueAt?.getHours()).toBe(8);
+  });
+
+  it('uses midnight when the time is not HH:mm', () => {
+    expect(
+      taskDueAt(makeTask({date: '2026-09-11', time: 'morning'}))?.getHours(),
+    ).toBe(0);
+  });
+
+  it('returns null when the task has no date at all', () => {
+    expect(taskDueAt(makeTask({date: ''}))).toBeNull();
+  });
+
+  it('returns null when the date cannot be parsed', () => {
+    expect(taskDueAt(makeTask({date: 'whenever!!'}))).toBeNull();
+  });
+});
+
+describe('taskLabel', () => {
+  it('prefers the display name over the title', () => {
+    expect(
+      taskLabel(makeTask({name: 'Evening pill', title: 'MEDICATION'})),
+    ).toBe('Evening pill');
+  });
+
+  it('falls back to the title when there is no name', () => {
+    expect(taskLabel(makeTask({title: 'Brush teeth'}))).toBe('Brush teeth');
+  });
+
+  it('returns an empty string when neither is set', () => {
+    expect(taskLabel(makeTask({name: '', title: ''}))).toBe('');
+  });
+});
+
+describe('parseRecordDate', () => {
+  it('reads a date-only string as local midnight, not as UTC', () => {
+    const parsed = parseRecordDate('2026-09-12');
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(8);
+    expect(parsed?.getDate()).toBe(12);
+    expect(parsed?.getHours()).toBe(0);
+    expect(parsed?.getMinutes()).toBe(0);
+    expect(parsed?.getTime()).toBe(new Date(2026, 8, 12).getTime());
+  });
+
+  it('ignores whitespace around a date-only string', () => {
+    expect(parseRecordDate('  2026-09-12  ')?.getTime()).toBe(
+      new Date(2026, 8, 12).getTime(),
+    );
+  });
+
+  it('parses a full timestamp as the instant it names', () => {
+    expect(parseRecordDate('2026-09-12T08:30:00.000Z')?.toISOString()).toBe(
+      '2026-09-12T08:30:00.000Z',
+    );
+  });
+
+  it('returns null for a value that is not a date', () => {
+    expect(parseRecordDate('sometime next spring')).toBeNull();
+    expect(parseRecordDate('')).toBeNull();
+  });
+});
+
+describe('resolveCompanion', () => {
+  it('matches an explicitly named pet among several', () => {
+    const context = makeContext({companions: [BRUNO, LUNA]});
+
+    expect(resolveCompanion(context, {petName: 'Luna'})?.id).toBe('c2');
+  });
+
+  it('matches accent- and case-insensitively', () => {
+    const context = makeContext({
+      companions: [makeCompanion({id: 'c3', name: 'Bruño'}), LUNA],
+    });
+
+    expect(resolveCompanion(context, {petName: '  BRUNO '})?.id).toBe('c3');
+  });
+
+  it('falls back to the only pet when the name matches nothing', () => {
+    const context = makeContext({companions: [BRUNO]});
+
+    expect(resolveCompanion(context, {petName: 'Rex'})?.id).toBe('c1');
+  });
+
+  it('falls back to the only pet when no name was given', () => {
+    const context = makeContext({companions: [LUNA]});
+
+    expect(resolveCompanion(context, {})?.id).toBe('c2');
+  });
+
+  it('is undefined when several pets are possible and none was named', () => {
+    const context = makeContext({companions: [BRUNO, LUNA]});
+
+    expect(resolveCompanion(context, {})).toBeUndefined();
+  });
+
+  it('is undefined when the named pet is unknown and several exist', () => {
+    const context = makeContext({companions: [BRUNO, LUNA]});
+
+    expect(resolveCompanion(context, {petName: 'Rex'})).toBeUndefined();
+  });
+});
+
+describe('resolveNextAppointment', () => {
+  it('returns the soonest upcoming appointment and up to three items', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          id: 'a-late',
+          start: atOffset(9),
+          time: '12:00',
+          serviceName: 'Dental',
+        }),
+        makeAppointment({
+          id: 'a-soon',
+          start: '2026-09-11T09:00:00.000Z',
+          time: '11:00',
+          serviceName: 'Vaccination',
+          organisationName: 'Happy Paws',
+        }),
+        makeAppointment({
+          id: 'a-mid',
+          start: atOffset(3),
+          time: '10:00',
+          serviceName: null,
+        }),
+        makeAppointment({id: 'a-last', start: atOffset(20), time: '08:00'}),
+      ],
+    });
+
+    const result = resolveNextAppointment(context, {});
+
+    expect(result.actionId).toBe('nextAppointment');
+    expect(result.status).toBe('ok');
+    expect(result.speechKey).toBe('assistant.replies.nextAppointment.found');
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      date: '2026-09-11',
+      time: '11:00',
+      business: 'Happy Paws',
+    });
+    expect(result.data?.appointmentId).toBe('a-soon');
+    expect(result.data?.dateLabel).toBe('2026-09-11');
+    expect(result.data?.items?.map(item => item.id)).toEqual([
+      'a-soon',
+      'a-mid',
+      'a-late',
+    ]);
+  });
+
+  it('titles an item by service name, or by type when there is none', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          id: 'a-named',
+          start: '2026-09-11T09:00:00.000Z',
+          time: '11:00',
+          serviceName: 'Vaccination',
+        }),
+        makeAppointment({
+          id: 'a-typed',
+          start: '2026-09-12T09:00:00.000Z',
+          time: '',
+          serviceName: null,
+          type: 'follow-up',
+        }),
+      ],
+    });
+
+    const items = resolveNextAppointment(context, {}).data?.items ?? [];
+
+    expect(items[0]).toEqual({
+      id: 'a-named',
+      title: 'Vaccination',
+      subtitle: '2026-09-11 11:00',
+    });
+    expect(items[1]).toEqual({
+      id: 'a-typed',
+      title: 'follow-up',
+      subtitle: '2026-09-12',
+    });
+  });
+
+  it('labels an untimed appointment with its local calendar day', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({id: 'a-untimed', date: '2026-09-12', time: ''}),
+      ],
+    });
+    // Local midnight on the 12th is still the 11th in UTC at any positive
+    // offset, so the label has to be built from the local date parts.
+    const localMidnight = new Date('2026-09-12T00:00:00');
+    const localLabel = [
+      localMidnight.getFullYear(),
+      String(localMidnight.getMonth() + 1).padStart(2, '0'),
+      String(localMidnight.getDate()).padStart(2, '0'),
+    ].join('-');
+
+    const result = resolveNextAppointment(context, {});
+
+    expect(localLabel).toBe('2026-09-12');
+    expect(result.data?.dateLabel).toBe(localLabel);
+    expect(result.speechParams?.date).toBe('2026-09-12');
+    expect(result.data?.items?.[0].subtitle).toBe('2026-09-12');
+  });
+
+  it('leaves the business empty when the appointment has no organisation', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          start: '2026-09-11T09:00:00.000Z',
+          organisationName: null,
+        }),
+      ],
+    });
+
+    expect(resolveNextAppointment(context, {}).speechParams?.business).toBe('');
+  });
+
+  it('excludes appointments in terminal statuses', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({id: 'done', start: atOffset(1), status: 'COMPLETED'}),
+        makeAppointment({id: 'gone', start: atOffset(2), status: 'CANCELLED'}),
+        makeAppointment({id: 'noshow', start: atOffset(3), status: 'NO_SHOW'}),
+        makeAppointment({
+          id: 'moved',
+          start: atOffset(4),
+          status: 'RESCHEDULED',
+        }),
+        makeAppointment({id: 'live', start: atOffset(5), status: 'UPCOMING'}),
+      ],
+    });
+
+    const result = resolveNextAppointment(context, {});
+
+    expect(result.data?.appointmentId).toBe('live');
+    expect(result.data?.items).toHaveLength(1);
+  });
+
+  it('excludes past appointments but keeps one starting exactly now', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({id: 'yesterday', start: atOffset(-1)}),
+        makeAppointment({id: 'right-now', start: NOW.toISOString()}),
+      ],
+    });
+
+    expect(resolveNextAppointment(context, {}).data?.appointmentId).toBe(
+      'right-now',
+    );
+  });
+
+  it('ignores appointments whose start cannot be worked out', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [makeAppointment({id: 'undated', date: '', time: ''})],
+    });
+
+    expect(resolveNextAppointment(context, {}).status).toBe('empty');
+  });
+
+  it('only considers the named pet when one is given', () => {
+    const context = makeContext({
+      companions: [BRUNO, LUNA],
+      appointments: [
+        makeAppointment({
+          id: 'bruno-appt',
+          companionId: 'c1',
+          start: atOffset(1),
+        }),
+        makeAppointment({
+          id: 'luna-appt',
+          companionId: 'c2',
+          start: atOffset(2),
+        }),
+      ],
+    });
+
+    const result = resolveNextAppointment(context, {petName: 'Luna'});
+
+    expect(result.data?.appointmentId).toBe('luna-appt');
+    expect(result.data?.petName).toBe('Luna');
+  });
+
+  it('names the pet in the empty reply when there is only one in scope', () => {
+    const result = resolveNextAppointment(
+      makeContext({companions: [BRUNO]}),
+      {},
+    );
+
+    expect(result.status).toBe('empty');
+    expect(result.speechKey).toBe('assistant.replies.nextAppointment.none');
+    expect(result.speechParams).toEqual({petName: 'Bruno'});
+  });
+
+  it('leaves the pet name out of the empty reply when several are in scope', () => {
+    const result = resolveNextAppointment(
+      makeContext({companions: [BRUNO, LUNA]}),
+      {},
+    );
+
+    expect(result.speechParams).toEqual({petName: ''});
+  });
+});
+
+describe('resolveVaccinationStatus', () => {
+  it('asks which pet when several are possible and none was named', () => {
+    const result = resolveVaccinationStatus(
+      makeContext({companions: [BRUNO, LUNA]}),
+      {},
+    );
+
+    expect(result.status).toBe('needsSlot');
+    expect(result.missingSlot).toBe('petName');
+    expect(result.speechKey).toBe('assistant.replies.needsPet');
+  });
+
+  it('reports no records when the pet has none', () => {
+    const result = resolveVaccinationStatus(
+      makeContext({companions: [BRUNO]}),
+      {},
+    );
+
+    expect(result.status).toBe('empty');
+    expect(result.speechKey).toBe('assistant.replies.vaccinationStatus.none');
+    expect(result.data).toEqual({petName: 'Bruno'});
+  });
+
+  it('names the most overdue vaccination, listing due-soon ones after them', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {name: 'Rabies', dueOn: atOffset(-40)},
+          {name: 'Leptospirosis', dueOn: atOffset(-10)},
+          {name: 'Kennel cough', dueOn: atOffset(5)},
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.status).toBe('ok');
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.overdue',
+    );
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      count: 2,
+      name: 'Rabies',
+    });
+    expect(result.data?.items).toEqual([
+      {id: 'Rabies', title: 'Rabies', subtitle: '2026-08-01'},
+      {id: 'Leptospirosis', title: 'Leptospirosis', subtitle: '2026-08-31'},
+      {id: 'Kennel cough', title: 'Kennel cough', subtitle: '2026-09-15'},
+    ]);
+  });
+
+  it('names the soonest vaccination when several are due soon, listing them in due order', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {name: 'Rabies', dueOn: atOffset(20)},
+          {name: 'Kennel cough', dueOn: atOffset(4)},
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.dueSoon',
+    );
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      name: 'Kennel cough',
+      date: '2026-09-14',
+    });
+    expect(result.data?.items).toEqual([
+      {id: 'Kennel cough', title: 'Kennel cough', subtitle: '2026-09-14'},
+      {id: 'Rabies', title: 'Rabies', subtitle: '2026-09-30'},
+    ]);
+  });
+
+  it('names the soonest due vaccination whichever order the records arrive in', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {name: 'Kennel cough', dueOn: atOffset(4)},
+          {name: 'Rabies', dueOn: atOffset(20)},
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechParams?.name).toBe('Kennel cough');
+    expect(result.data?.items?.map(item => item.id)).toEqual([
+      'Kennel cough',
+      'Rabies',
+    ]);
+  });
+
+  it('names the most overdue vaccination whichever order the records arrive in', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {name: 'Leptospirosis', dueOn: atOffset(-10)},
+          {name: 'Rabies', dueOn: atOffset(-40)},
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.overdue',
+    );
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      count: 2,
+      name: 'Rabies',
+    });
+    expect(result.data?.items?.map(item => item.id)).toEqual([
+      'Rabies',
+      'Leptospirosis',
+    ]);
+  });
+
+  it('lists a vaccination overdue by only a few hours once, as overdue', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {
+            name: 'Rabies',
+            dueOn: new Date(NOW.getTime() - 3 * 3_600_000).toISOString(),
+          },
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.overdue',
+    );
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      count: 1,
+      name: 'Rabies',
+    });
+    expect(result.data?.items).toEqual([
+      {id: 'Rabies', title: 'Rabies', subtitle: '2026-09-10'},
+    ]);
+  });
+
+  it('keeps overdue and due-soon a strict partition of the dated records', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {
+            name: 'Rabies',
+            dueOn: new Date(NOW.getTime() - 3 * 3_600_000).toISOString(),
+          },
+          {
+            name: 'Kennel cough',
+            dueOn: new Date(NOW.getTime() + 3 * 3_600_000).toISOString(),
+          },
+          {name: 'Leptospirosis', dueOn: atOffset(5)},
+        ],
+      },
+    });
+
+    const ids = resolveVaccinationStatus(context, {}).data?.items?.map(
+      item => item.id,
+    );
+
+    expect(ids).toEqual(['Rabies', 'Kennel cough', 'Leptospirosis']);
+    expect(new Set(ids).size).toBe(ids?.length);
+  });
+
+  it('counts a vaccination due exactly at the window edge as due soon', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {c1: [{name: 'Rabies', dueOn: atOffset(30)}]},
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.dueSoon',
+    );
+    expect(result.speechParams?.date).toBe('2026-10-10');
+  });
+
+  it('treats a vaccination one day past the window edge as up to date', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {c1: [{name: 'Rabies', dueOn: atOffset(31)}]},
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.upToDate',
+    );
+    expect(result.speechParams).toEqual({petName: 'Bruno'});
+    expect(result.data).toEqual({petName: 'Bruno'});
+  });
+
+  it('ignores records with a missing or unparseable due date', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      vaccinations: {
+        c1: [
+          {name: 'Rabies', dueOn: null, administeredOn: atOffset(-400)},
+          {name: 'Kennel cough', dueOn: 'sometime next spring'},
+        ],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.upToDate',
+    );
+    expect(result.data?.items).toBeUndefined();
+  });
+
+  it('reads the records of the named pet, not of the first one', () => {
+    const context = makeContext({
+      companions: [BRUNO, LUNA],
+      vaccinations: {
+        c1: [{name: 'Rabies', dueOn: atOffset(-5)}],
+        c2: [{name: 'Feline flu', dueOn: atOffset(3)}],
+      },
+    });
+
+    const result = resolveVaccinationStatus(context, {petName: 'Luna'});
+
+    expect(result.speechKey).toBe(
+      'assistant.replies.vaccinationStatus.dueSoon',
+    );
+    expect(result.speechParams?.name).toBe('Feline flu');
+  });
+});
+
+describe('resolveUpcomingTasks', () => {
+  it('lists open tasks inside the default 30-day window, soonest first', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [
+        makeTask({id: 't-far', dueAt: atOffset(40), name: 'Annual check'}),
+        makeTask({id: 't-late', dueAt: atOffset(20), name: 'Worming'}),
+        makeTask({id: 't-soon', dueAt: atOffset(1), name: 'Evening pill'}),
+      ],
+    });
+
+    const result = resolveUpcomingTasks(context, {});
+
+    expect(result.status).toBe('ok');
+    expect(result.speechKey).toBe('assistant.replies.upcomingTasks.found');
+    expect(result.speechParams).toEqual({
+      count: 2,
+      first: 'Evening pill',
+      petName: 'Bruno',
+    });
+    expect(result.data?.taskIds).toEqual(['t-soon', 't-late']);
+    expect(result.data?.items).toEqual([
+      {id: 't-soon', title: 'Evening pill', subtitle: '2026-09-11'},
+      {id: 't-late', title: 'Worming', subtitle: '2026-09-30'},
+    ]);
+  });
+
+  it('shows at most five items while counting every due task', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: Array.from({length: 7}, (_unused, index) =>
+        makeTask({
+          id: `t${index}`,
+          dueAt: atOffset(index + 1),
+          name: `Task ${index}`,
+        }),
+      ),
+    });
+
+    const result = resolveUpcomingTasks(context, {});
+
+    expect(result.speechParams?.count).toBe(7);
+    expect(result.data?.taskIds).toHaveLength(7);
+    expect(result.data?.items).toHaveLength(5);
+  });
+
+  it('extends a named day to the end of that day rather than to its clock time', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [
+        makeTask({id: 't-later-that-day', dueAt: '2026-09-12T13:00:00.000Z'}),
+        makeTask({id: 't-next-day', dueAt: '2026-09-13T12:00:00.000Z'}),
+      ],
+    });
+
+    const result = resolveUpcomingTasks(context, {
+      when: '2026-09-12T12:00:00.000Z',
+    });
+
+    expect(result.data?.taskIds).toEqual(['t-later-that-day']);
+  });
+
+  it('falls back to the default window when the `when` slot is unparseable', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [
+        makeTask({id: 't-in-window', dueAt: atOffset(10)}),
+        makeTask({id: 't-out-of-window', dueAt: atOffset(40)}),
+      ],
+    });
+
+    const result = resolveUpcomingTasks(context, {when: 'next fortnight'});
+
+    expect(result.data?.taskIds).toEqual(['t-in-window']);
+  });
+
+  it('keeps a task overdue by hours but drops one overdue by days', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [
+        makeTask({id: 't-just-missed', dueAt: '2026-09-10T00:00:00.000Z'}),
+        makeTask({id: 't-long-gone', dueAt: atOffset(-2)}),
+      ],
+    });
+
+    expect(resolveUpcomingTasks(context, {}).data?.taskIds).toEqual([
+      't-just-missed',
+    ]);
+  });
+
+  it('excludes completed and cancelled tasks whatever the status casing', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [
+        makeTask({id: 't-done', dueAt: atOffset(1), status: 'completed'}),
+        makeTask({id: 't-void', dueAt: atOffset(2), status: 'CANCELLED'}),
+        makeTask({id: 't-open', dueAt: atOffset(3), status: 'in_progress'}),
+      ],
+    });
+
+    expect(resolveUpcomingTasks(context, {}).data?.taskIds).toEqual(['t-open']);
+  });
+
+  it('ignores tasks with no workable due date', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [makeTask({id: 't-undated', date: ''})],
+    });
+
+    const result = resolveUpcomingTasks(context, {});
+
+    expect(result.status).toBe('empty');
+    expect(result.speechKey).toBe('assistant.replies.upcomingTasks.none');
+    expect(result.speechParams).toEqual({petName: 'Bruno'});
+  });
+
+  it('spans every pet when none is named, and drops the pet name', () => {
+    const context = makeContext({
+      companions: [BRUNO, LUNA],
+      tasks: [
+        makeTask({id: 't-bruno', companionId: 'c1', dueAt: atOffset(2)}),
+        makeTask({id: 't-luna', companionId: 'c2', dueAt: atOffset(1)}),
+        makeTask({id: 't-stray', companionId: 'c9', dueAt: atOffset(1)}),
+      ],
+    });
+
+    const result = resolveUpcomingTasks(context, {});
+
+    expect(result.data?.taskIds).toEqual(['t-luna', 't-bruno']);
+    expect(result.data?.petName).toBeUndefined();
+    expect(result.speechParams?.petName).toBe('');
+  });
+
+  it('leaves the pet name out of the empty reply when several are in scope', () => {
+    const result = resolveUpcomingTasks(
+      makeContext({companions: [BRUNO, LUNA]}),
+      {},
+    );
+
+    expect(result.status).toBe('empty');
+    expect(result.speechParams).toEqual({petName: ''});
+  });
+
+  it('labels an item by title when the task has no display name', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      tasks: [makeTask({id: 't1', dueAt: atOffset(1), title: 'Nail trim'})],
+    });
+
+    expect(resolveUpcomingTasks(context, {}).data?.items?.[0].title).toBe(
+      'Nail trim',
+    );
+  });
+});
+
+describe('resolvePetOverview', () => {
+  it('asks which pet when several are possible and none was named', () => {
+    const result = resolvePetOverview(
+      makeContext({companions: [BRUNO, LUNA]}),
+      {},
+    );
+
+    expect(result.status).toBe('needsSlot');
+    expect(result.missingSlot).toBe('petName');
+    expect(result.speechKey).toBe('assistant.replies.needsPet');
+  });
+
+  it('counts that pet open tasks and only its appointments still ahead', () => {
+    const context = makeContext({
+      companions: [
+        makeCompanion({
+          id: 'c1',
+          name: 'Bruno',
+          breed: {
+            speciesId: 1,
+            speciesName: 'Dog',
+            breedId: 7,
+            breedName: 'Beagle',
+          },
+        }),
+        LUNA,
+      ],
+      tasks: [
+        makeTask({id: 't1', companionId: 'c1', status: 'PENDING'}),
+        makeTask({id: 't2', companionId: 'c1', status: 'in_progress'}),
+        makeTask({id: 't3', companionId: 'c1', status: 'COMPLETED'}),
+        makeTask({id: 't4', companionId: 'c1', status: 'cancelled'}),
+        makeTask({id: 't5', companionId: 'c2', status: 'PENDING'}),
+      ],
+      appointments: [
+        makeAppointment({
+          id: 'a-ahead',
+          companionId: 'c1',
+          status: 'CONFIRMED',
+          start: atOffset(3),
+        }),
+        makeAppointment({
+          id: 'a-ahead-too',
+          companionId: 'c1',
+          status: 'UPCOMING',
+          start: atOffset(5),
+        }),
+        makeAppointment({
+          id: 'a-past-confirmed',
+          companionId: 'c1',
+          status: 'CONFIRMED',
+          start: atOffset(-30),
+        }),
+        makeAppointment({
+          id: 'a-cancelled',
+          companionId: 'c1',
+          status: 'CANCELLED',
+          start: atOffset(2),
+        }),
+        makeAppointment({
+          id: 'a-undated',
+          companionId: 'c1',
+          status: 'CONFIRMED',
+          date: '',
+          time: '',
+        }),
+        makeAppointment({
+          id: 'a-luna',
+          companionId: 'c2',
+          status: 'CONFIRMED',
+          start: atOffset(1),
+        }),
+      ],
+    });
+
+    const result = resolvePetOverview(context, {petName: 'Bruno'});
+
+    expect(result.status).toBe('ok');
+    expect(result.speechKey).toBe('assistant.replies.petOverview.summary');
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      breed: 'Beagle',
+      tasks: 2,
+      appointments: 2,
+    });
+    expect(result.data).toEqual({petName: 'Bruno'});
+  });
+
+  it('leaves a past appointment out of the count even if it was never completed', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          id: 'a-last-year',
+          companionId: 'c1',
+          status: 'CONFIRMED',
+          start: atOffset(-365),
+        }),
+      ],
+    });
+
+    expect(resolvePetOverview(context, {}).speechParams?.appointments).toBe(0);
+  });
+
+  it('counts an appointment starting exactly now as still ahead', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      appointments: [
+        makeAppointment({
+          id: 'a-right-now',
+          companionId: 'c1',
+          status: 'CONFIRMED',
+          start: NOW.toISOString(),
+        }),
+      ],
+    });
+
+    expect(resolvePetOverview(context, {}).speechParams?.appointments).toBe(1);
+  });
+
+  it('reports an empty breed when the pet has none recorded', () => {
+    const result = resolvePetOverview(makeContext({companions: [BRUNO]}), {});
+
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      breed: '',
+      tasks: 0,
+      appointments: 0,
+    });
+  });
+});
+
+describe('resolveExpenseSummary', () => {
+  it('totals the expenses of the pet in scope and rounds to two decimals', () => {
+    const context = makeContext({
+      companions: [BRUNO, LUNA],
+      expenses: [
+        makeExpense({id: 'e1', companionId: 'c1', amount: 10.1}),
+        makeExpense({id: 'e2', companionId: 'c1', amount: 20.2}),
+        makeExpense({id: 'e3', companionId: 'c2', amount: 999}),
+      ],
+    });
+
+    const result = resolveExpenseSummary(context, {petName: 'Bruno'});
+
+    expect(result.status).toBe('ok');
+    expect(result.speechKey).toBe('assistant.replies.expenseSummary.total');
+    expect(result.speechParams).toEqual({
+      total: 30.3,
+      currency: 'EUR',
+      petName: 'Bruno',
+      count: 2,
+    });
+    expect(result.data).toEqual({
+      petName: 'Bruno',
+      amount: 30.3,
+      currencyCode: 'EUR',
+    });
+  });
+
+  it('skips a non-finite amount instead of poisoning the total', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      expenses: [
+        makeExpense({id: 'e1', amount: Number.NaN}),
+        makeExpense({id: 'e2', amount: 25}),
+      ],
+    });
+
+    const result = resolveExpenseSummary(context, {});
+
+    expect(result.speechParams?.total).toBe(25);
+    expect(result.speechParams?.count).toBe(2);
+  });
+
+  it('falls back to the context currency when the expense carries none', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      currencyCode: 'GBP',
+      expenses: [makeExpense({id: 'e1', amount: 12, currencyCode: ''})],
+    });
+
+    expect(resolveExpenseSummary(context, {}).data?.currencyCode).toBe('GBP');
+  });
+
+  it('uses the currency of the first matching expense', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      currencyCode: 'GBP',
+      expenses: [makeExpense({id: 'e1', amount: 12, currencyCode: 'USD'})],
+    });
+
+    expect(resolveExpenseSummary(context, {}).speechParams?.currency).toBe(
+      'USD',
+    );
+  });
+
+  it('totals across every pet when none is named', () => {
+    const context = makeContext({
+      companions: [BRUNO, LUNA],
+      expenses: [
+        makeExpense({id: 'e1', companionId: 'c1', amount: 10}),
+        makeExpense({id: 'e2', companionId: 'c2', amount: 5}),
+      ],
+    });
+
+    const result = resolveExpenseSummary(context, {});
+
+    expect(result.speechParams).toEqual({
+      total: 15,
+      currency: 'EUR',
+      petName: '',
+      count: 2,
+    });
+    expect(result.data?.petName).toBeUndefined();
+  });
+
+  it('reports nothing spent when no expense belongs to the pet', () => {
+    const context = makeContext({
+      companions: [BRUNO],
+      expenses: [makeExpense({id: 'e1', companionId: 'c9', amount: 50})],
+    });
+
+    const result = resolveExpenseSummary(context, {});
+
+    expect(result.status).toBe('empty');
+    expect(result.speechKey).toBe('assistant.replies.expenseSummary.none');
+    expect(result.speechParams).toEqual({petName: 'Bruno'});
+    expect(result.data).toBeUndefined();
+  });
+
+  it('leaves the pet name out of the empty reply when several are in scope', () => {
+    const result = resolveExpenseSummary(
+      makeContext({companions: [BRUNO, LUNA]}),
+      {},
+    );
+
+    expect(result.status).toBe('empty');
+    expect(result.speechParams).toEqual({petName: ''});
+  });
+});
+
+describe('buildHandoffLink', () => {
+  it('is undefined for a read action, which has no deep link', () => {
+    expect(
+      buildHandoffLink('nextAppointment', {petName: 'Bruno'}, 'c1'),
+    ).toBeUndefined();
+  });
+
+  it('returns the bare deep link when there is nothing to prefill', () => {
+    expect(buildHandoffLink('addCareTask', {})).toBe('yc://app/tasks/new');
+  });
+
+  it('encodes the companion, title and when slots as a query', () => {
+    expect(
+      buildHandoffLink(
+        'addCareTask',
+        {title: 'Give Bruno his pill', when: '2026-09-12T09:00:00.000Z'},
+        'c1',
+      ),
+    ).toBe(
+      'yc://app/tasks/new?companionId=c1&title=Give+Bruno+his+pill&when=2026-09-12T09%3A00%3A00.000Z',
+    );
+  });
+
+  it('keeps a zero amount and the category on an expense handoff', () => {
+    expect(buildHandoffLink('logExpense', {amount: 0, category: 'food'})).toBe(
+      'yc://app/expenses/new?amount=0&category=food',
+    );
+  });
+
+  it('omits slots the action was not given, including the pet name', () => {
+    expect(buildHandoffLink('bookAppointment', {petName: 'Bruno'}, 'c1')).toBe(
+      'yc://app/appointments/book?companionId=c1',
+    );
+  });
+});
+
+describe('handoff resolvers', () => {
+  it('hands a care task off with the pet and title prefilled', () => {
+    const context = makeContext({companions: [BRUNO]});
+
+    const result = resolveAddCareTask(context, {
+      title: 'Brush teeth',
+      when: '2026-09-12T09:00:00.000Z',
+    });
+
+    expect(result.actionId).toBe('addCareTask');
+    expect(result.status).toBe('handoff');
+    expect(result.speechKey).toBe('assistant.replies.addCareTask.handoff');
+    expect(result.speechParams).toEqual({
+      petName: 'Bruno',
+      title: 'Brush teeth',
+    });
+    expect(result.deepLink).toBe(
+      'yc://app/tasks/new?companionId=c1&title=Brush+teeth&when=2026-09-12T09%3A00%3A00.000Z',
+    );
+    expect(result.data).toEqual({petName: 'Bruno'});
+  });
+
+  it('hands an expense off with the amount and category prefilled', () => {
+    const context = makeContext({companions: [BRUNO]});
+
+    const result = resolveLogExpense(context, {amount: 42.5, category: 'food'});
+
+    expect(result.actionId).toBe('logExpense');
+    expect(result.speechKey).toBe('assistant.replies.logExpense.handoff');
+    expect(result.speechParams).toEqual({petName: 'Bruno', title: ''});
+    expect(result.deepLink).toBe(
+      'yc://app/expenses/new?companionId=c1&amount=42.5&category=food',
+    );
+  });
+
+  it('hands a booking off for the named pet', () => {
+    const context = makeContext({companions: [BRUNO, LUNA]});
+
+    const result = resolveBookAppointment(context, {
+      petName: 'Luna',
+      when: '2026-09-20T09:00:00.000Z',
+    });
+
+    expect(result.actionId).toBe('bookAppointment');
+    expect(result.speechKey).toBe('assistant.replies.bookAppointment.handoff');
+    expect(result.speechParams?.petName).toBe('Luna');
+    expect(result.deepLink).toBe(
+      'yc://app/appointments/book?companionId=c2&when=2026-09-20T09%3A00%3A00.000Z',
+    );
+  });
+
+  it('still hands off when the pet is ambiguous, without a companion id', () => {
+    const context = makeContext({companions: [BRUNO, LUNA]});
+
+    const result = resolveAddCareTask(context, {title: 'Walk'});
+
+    expect(result.status).toBe('handoff');
+    expect(result.speechParams).toEqual({petName: '', title: 'Walk'});
+    expect(result.deepLink).toBe('yc://app/tasks/new?title=Walk');
+    expect(result.data).toEqual({petName: undefined});
+  });
+});
+
+describe('runAction', () => {
+  const context = makeContext({
+    companions: [BRUNO],
+    tasks: [makeTask({id: 't1', dueAt: atOffset(1), name: 'Evening pill'})],
+    appointments: [makeAppointment({id: 'a1', start: atOffset(2)})],
+    expenses: [makeExpense({id: 'e1', amount: 30})],
+    vaccinations: {c1: [{name: 'Rabies', dueOn: atOffset(-5)}]},
+  });
+
+  const cases: Array<[AssistantActionId, string]> = [
+    ['nextAppointment', 'assistant.replies.nextAppointment.found'],
+    ['vaccinationStatus', 'assistant.replies.vaccinationStatus.overdue'],
+    ['upcomingTasks', 'assistant.replies.upcomingTasks.found'],
+    ['petOverview', 'assistant.replies.petOverview.summary'],
+    ['expenseSummary', 'assistant.replies.expenseSummary.total'],
+    ['addCareTask', 'assistant.replies.addCareTask.handoff'],
+    ['logExpense', 'assistant.replies.logExpense.handoff'],
+    ['bookAppointment', 'assistant.replies.bookAppointment.handoff'],
+  ];
+
+  it.each(cases)('routes %s to its own resolver', (actionId, speechKey) => {
+    const result = runAction(actionId, context, {});
+
+    expect(result.actionId).toBe(actionId);
+    expect(result.speechKey).toBe(speechKey);
+  });
+
+  it('passes the slots through to the resolver it picked', () => {
+    const twoPets = makeContext({
+      companions: [BRUNO, LUNA],
+      expenses: [
+        makeExpense({id: 'e1', companionId: 'c1', amount: 10}),
+        makeExpense({id: 'e2', companionId: 'c2', amount: 7}),
+      ],
+    });
+
+    expect(
+      runAction('expenseSummary', twoPets, {petName: 'Luna'}).speechParams,
+    ).toEqual({total: 7, currency: 'EUR', petName: 'Luna', count: 1});
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/assistantSlice.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/assistantSlice.test.ts
@@ -1,0 +1,476 @@
+import {
+  assistantReducer,
+  assistantEnabledChanged,
+  messageAdded,
+  modelAvailabilityChanged,
+  thinkingStarted,
+  transcriptCleared,
+  turnCompleted,
+  turnFailed,
+  type AssistantState,
+} from '@/features/assistant/assistantSlice';
+import {MAX_TRANSCRIPT_MESSAGES} from '@/features/assistant/constants';
+import type {
+  AssistantActionResult,
+  AssistantMessage,
+} from '@/features/assistant/types';
+
+const INITIAL_STATE: AssistantState = {
+  messages: [],
+  status: 'idle',
+  error: null,
+  modelAvailability: {available: false},
+  enabled: true,
+  availabilityChecked: false,
+};
+
+const message = (
+  id: string,
+  overrides: Partial<AssistantMessage> = {},
+): AssistantMessage => ({
+  id,
+  author: 'user',
+  text: `text ${id}`,
+  createdAt: '2026-01-01T10:00:00.000Z',
+  ...overrides,
+});
+
+const messages = (count: number, offset = 0): AssistantMessage[] =>
+  Array.from({length: count}, (_, index) => message(`m-${index + offset}`));
+
+const okResult: AssistantActionResult = {
+  actionId: 'nextAppointment',
+  status: 'ok',
+  speechKey: 'assistant.nextAppointment.ok',
+  speechParams: {petName: 'Kiwi'},
+  data: {petName: 'Kiwi', appointmentId: 'appt-1'},
+};
+
+const stateWith = (overrides: Partial<AssistantState>): AssistantState => ({
+  ...INITIAL_STATE,
+  ...overrides,
+});
+
+describe('features/assistant/assistantSlice', () => {
+  describe('initial state', () => {
+    it('starts with an empty transcript, idle status and an unchecked model', () => {
+      const state = assistantReducer(undefined, {type: '@@INIT/unknown'});
+
+      expect(state).toEqual({
+        messages: [],
+        status: 'idle',
+        error: null,
+        modelAvailability: {available: false},
+        enabled: true,
+        availabilityChecked: false,
+      });
+    });
+
+    it('leaves state untouched for an action the slice does not own', () => {
+      const seeded = stateWith({
+        messages: [message('m-1')],
+        status: 'thinking',
+      });
+
+      expect(assistantReducer(seeded, {type: 'tasks/somethingElse'})).toBe(
+        seeded,
+      );
+    });
+  });
+
+  describe('action types', () => {
+    it('namespaces every action under "assistant/"', () => {
+      expect(messageAdded.type).toBe('assistant/messageAdded');
+      expect(thinkingStarted.type).toBe('assistant/thinkingStarted');
+      expect(turnCompleted.type).toBe('assistant/turnCompleted');
+      expect(turnFailed.type).toBe('assistant/turnFailed');
+      expect(transcriptCleared.type).toBe('assistant/transcriptCleared');
+      expect(modelAvailabilityChanged.type).toBe(
+        'assistant/modelAvailabilityChanged',
+      );
+      expect(assistantEnabledChanged.type).toBe(
+        'assistant/assistantEnabledChanged',
+      );
+    });
+  });
+
+  describe('messageAdded', () => {
+    it('appends the first message to an empty transcript', () => {
+      const first = message('m-1', {text: 'when is the next vet visit?'});
+
+      const state = assistantReducer(INITIAL_STATE, messageAdded(first));
+
+      expect(state.messages).toEqual([first]);
+    });
+
+    it('appends to the end, keeping the earlier messages in order', () => {
+      const seeded = stateWith({messages: [message('m-1'), message('m-2')]});
+
+      const state = assistantReducer(
+        seeded,
+        messageAdded(message('m-3', {author: 'assistant'})),
+      );
+
+      expect(state.messages.map(m => m.id)).toEqual(['m-1', 'm-2', 'm-3']);
+      expect(state.messages[2].author).toBe('assistant');
+    });
+
+    it('does not mutate the transcript array it was handed', () => {
+      const existing = [message('m-1')];
+      const seeded = stateWith({messages: existing});
+
+      const state = assistantReducer(seeded, messageAdded(message('m-2')));
+
+      expect(existing).toHaveLength(1);
+      expect(state.messages).toHaveLength(2);
+    });
+
+    it('leaves status, error and the rest of the state alone', () => {
+      const seeded = stateWith({
+        status: 'error',
+        error: 'the model went away',
+        enabled: false,
+        availabilityChecked: true,
+        modelAvailability: {available: true, providerLabel: 'Apple'},
+      });
+
+      const state = assistantReducer(seeded, messageAdded(message('m-1')));
+
+      expect(state.status).toBe('error');
+      expect(state.error).toBe('the model went away');
+      expect(state.enabled).toBe(false);
+      expect(state.availabilityChecked).toBe(true);
+      expect(state.modelAvailability).toEqual({
+        available: true,
+        providerLabel: 'Apple',
+      });
+    });
+  });
+
+  describe('transcript trimming', () => {
+    it('caps the transcript at 60 messages', () => {
+      expect(MAX_TRANSCRIPT_MESSAGES).toBe(60);
+    });
+
+    it('keeps every message while the transcript is one short of the cap', () => {
+      const seeded = stateWith({
+        messages: messages(MAX_TRANSCRIPT_MESSAGES - 1),
+      });
+
+      const state = assistantReducer(seeded, messageAdded(message('newest')));
+
+      expect(state.messages).toHaveLength(MAX_TRANSCRIPT_MESSAGES);
+      expect(state.messages[0].id).toBe('m-0');
+      expect(state.messages[MAX_TRANSCRIPT_MESSAGES - 1].id).toBe('newest');
+    });
+
+    it('drops the oldest message once the cap is exceeded', () => {
+      const seeded = stateWith({messages: messages(MAX_TRANSCRIPT_MESSAGES)});
+
+      const state = assistantReducer(seeded, messageAdded(message('newest')));
+
+      expect(state.messages).toHaveLength(MAX_TRANSCRIPT_MESSAGES);
+      expect(state.messages[0].id).toBe('m-1');
+      expect(state.messages.map(m => m.id)).not.toContain('m-0');
+      expect(state.messages[MAX_TRANSCRIPT_MESSAGES - 1].id).toBe('newest');
+    });
+
+    it('keeps the newest window when the cap is passed by five messages', () => {
+      const overflow = 5;
+      let state = INITIAL_STATE;
+
+      for (const next of messages(MAX_TRANSCRIPT_MESSAGES + overflow)) {
+        state = assistantReducer(state, messageAdded(next));
+      }
+
+      expect(state.messages).toHaveLength(MAX_TRANSCRIPT_MESSAGES);
+      expect(state.messages[0].id).toBe(`m-${overflow}`);
+      expect(state.messages[MAX_TRANSCRIPT_MESSAGES - 1].id).toBe(
+        `m-${MAX_TRANSCRIPT_MESSAGES + overflow - 1}`,
+      );
+      expect(state.messages.map(m => m.id)).not.toContain('m-0');
+      expect(state.messages.map(m => m.id)).not.toContain('m-4');
+    });
+
+    it('trims an over-long transcript handed to turnCompleted too', () => {
+      const seeded = stateWith({
+        messages: messages(MAX_TRANSCRIPT_MESSAGES + 3),
+      });
+
+      const state = assistantReducer(
+        seeded,
+        turnCompleted({message: message('reply'), result: okResult}),
+      );
+
+      expect(state.messages).toHaveLength(MAX_TRANSCRIPT_MESSAGES);
+      expect(state.messages[0].id).toBe('m-4');
+      expect(state.messages[MAX_TRANSCRIPT_MESSAGES - 1].id).toBe('reply');
+      expect(state.messages[MAX_TRANSCRIPT_MESSAGES - 1].result).toEqual(
+        okResult,
+      );
+    });
+  });
+
+  describe('thinkingStarted', () => {
+    it('moves the status to thinking and clears a previous error', () => {
+      const seeded = stateWith({status: 'error', error: 'timed out'});
+
+      const state = assistantReducer(seeded, thinkingStarted());
+
+      expect(state.status).toBe('thinking');
+      expect(state.error).toBeNull();
+    });
+
+    it('keeps the transcript while thinking', () => {
+      const seeded = stateWith({messages: [message('m-1'), message('m-2')]});
+
+      const state = assistantReducer(seeded, thinkingStarted());
+
+      expect(state.messages.map(m => m.id)).toEqual(['m-1', 'm-2']);
+    });
+  });
+
+  describe('turnCompleted', () => {
+    it('appends the reply with the result attached and returns to idle', () => {
+      const seeded = stateWith({
+        messages: [message('m-1')],
+        status: 'thinking',
+        error: 'stale error',
+      });
+      const reply = message('m-2', {author: 'assistant', text: 'Tomorrow 9am'});
+
+      const state = assistantReducer(
+        seeded,
+        turnCompleted({message: reply, result: okResult}),
+      );
+
+      expect(state.status).toBe('idle');
+      expect(state.error).toBeNull();
+      expect(state.messages).toHaveLength(2);
+      expect(state.messages[1]).toEqual({...reply, result: okResult});
+    });
+
+    it('stores an undefined result when the turn produced none', () => {
+      const reply = message('m-1', {author: 'assistant'});
+
+      const state = assistantReducer(
+        stateWith({status: 'thinking'}),
+        turnCompleted({message: reply}),
+      );
+
+      expect(state.messages[0].result).toBeUndefined();
+      expect(state.status).toBe('idle');
+    });
+
+    it('overwrites a result already on the message when none is supplied', () => {
+      const reply = message('m-1', {author: 'assistant', result: okResult});
+
+      const state = assistantReducer(
+        INITIAL_STATE,
+        turnCompleted({message: reply}),
+      );
+
+      expect(state.messages[0].result).toBeUndefined();
+    });
+
+    it('carries a handoff result through untouched', () => {
+      const handoff: AssistantActionResult = {
+        actionId: 'bookAppointment',
+        status: 'handoff',
+        speechKey: 'assistant.bookAppointment.handoff',
+        deepLink: 'yc://app/appointments/new?petName=Kiwi',
+      };
+
+      const state = assistantReducer(
+        INITIAL_STATE,
+        turnCompleted({message: message('m-1'), result: handoff}),
+      );
+
+      expect(state.messages[0].result).toEqual(handoff);
+      expect(state.messages[0].result?.deepLink).toBe(
+        'yc://app/appointments/new?petName=Kiwi',
+      );
+    });
+  });
+
+  describe('turnFailed', () => {
+    it('records the failure message and flips the status to error', () => {
+      const seeded = stateWith({status: 'thinking'});
+
+      const state = assistantReducer(
+        seeded,
+        turnFailed('The on-device model is unavailable'),
+      );
+
+      expect(state.status).toBe('error');
+      expect(state.error).toBe('The on-device model is unavailable');
+    });
+
+    it('keeps the transcript so the user can still read the question', () => {
+      const seeded = stateWith({
+        messages: [message('m-1', {text: 'how much did I spend?'})],
+        status: 'thinking',
+      });
+
+      const state = assistantReducer(seeded, turnFailed('nope'));
+
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0].text).toBe('how much did I spend?');
+    });
+
+    it('replaces an earlier error with the newest one', () => {
+      const first = assistantReducer(INITIAL_STATE, turnFailed('first'));
+      const second = assistantReducer(first, turnFailed('second'));
+
+      expect(second.error).toBe('second');
+    });
+  });
+
+  describe('transcriptCleared', () => {
+    it('empties the transcript and resets status and error', () => {
+      const seeded = stateWith({
+        messages: messages(3),
+        status: 'error',
+        error: 'boom',
+      });
+
+      const state = assistantReducer(seeded, transcriptCleared());
+
+      expect(state.messages).toEqual([]);
+      expect(state.status).toBe('idle');
+      expect(state.error).toBeNull();
+    });
+
+    it('leaves the enabled switch and model availability in place', () => {
+      const seeded = stateWith({
+        messages: messages(2),
+        enabled: false,
+        availabilityChecked: true,
+        modelAvailability: {available: true, providerLabel: 'Gemini Nano'},
+      });
+
+      const state = assistantReducer(seeded, transcriptCleared());
+
+      expect(state.enabled).toBe(false);
+      expect(state.availabilityChecked).toBe(true);
+      expect(state.modelAvailability).toEqual({
+        available: true,
+        providerLabel: 'Gemini Nano',
+      });
+    });
+  });
+
+  describe('modelAvailabilityChanged', () => {
+    it('stores an available model and marks the probe as run', () => {
+      const state = assistantReducer(
+        INITIAL_STATE,
+        modelAvailabilityChanged({
+          available: true,
+          providerLabel: 'Apple Intelligence',
+        }),
+      );
+
+      expect(state.modelAvailability).toEqual({
+        available: true,
+        providerLabel: 'Apple Intelligence',
+      });
+      expect(state.availabilityChecked).toBe(true);
+    });
+
+    it('stores the reason a model is unavailable', () => {
+      const state = assistantReducer(
+        INITIAL_STATE,
+        modelAvailabilityChanged({
+          available: false,
+          reason: 'unsupportedDevice',
+        }),
+      );
+
+      expect(state.modelAvailability).toEqual({
+        available: false,
+        reason: 'unsupportedDevice',
+      });
+      expect(state.availabilityChecked).toBe(true);
+    });
+
+    it('replaces the previous availability rather than merging into it', () => {
+      const seeded = stateWith({
+        modelAvailability: {
+          available: true,
+          providerLabel: 'Apple Intelligence',
+        },
+        availabilityChecked: true,
+      });
+
+      const state = assistantReducer(
+        seeded,
+        modelAvailabilityChanged({available: false, reason: 'modelNotReady'}),
+      );
+
+      expect(state.modelAvailability).toEqual({
+        available: false,
+        reason: 'modelNotReady',
+      });
+      expect(state.modelAvailability.providerLabel).toBeUndefined();
+      expect(state.availabilityChecked).toBe(true);
+    });
+  });
+
+  describe('assistantEnabledChanged', () => {
+    it('turns the assistant off', () => {
+      const state = assistantReducer(
+        INITIAL_STATE,
+        assistantEnabledChanged(false),
+      );
+
+      expect(state.enabled).toBe(false);
+    });
+
+    it('turns the assistant back on', () => {
+      const off = assistantReducer(
+        INITIAL_STATE,
+        assistantEnabledChanged(false),
+      );
+
+      expect(assistantReducer(off, assistantEnabledChanged(true)).enabled).toBe(
+        true,
+      );
+    });
+
+    it('does not touch the transcript when toggled', () => {
+      const seeded = stateWith({messages: messages(2), status: 'thinking'});
+
+      const state = assistantReducer(seeded, assistantEnabledChanged(false));
+
+      expect(state.messages.map(m => m.id)).toEqual(['m-0', 'm-1']);
+      expect(state.status).toBe('thinking');
+    });
+  });
+
+  describe('a full turn', () => {
+    it('runs question, thinking, answer and clear end to end', () => {
+      const question = message('q-1', {text: 'when is Kiwi due?'});
+      const answer = message('a-1', {
+        author: 'assistant',
+        text: 'Rabies is due on 12 March.',
+      });
+
+      let state = assistantReducer(INITIAL_STATE, messageAdded(question));
+      state = assistantReducer(state, thinkingStarted());
+      expect(state.status).toBe('thinking');
+
+      state = assistantReducer(
+        state,
+        turnCompleted({message: answer, result: okResult}),
+      );
+
+      expect(state.status).toBe('idle');
+      expect(state.messages.map(m => m.id)).toEqual(['q-1', 'a-1']);
+      expect(state.messages[1].result).toEqual(okResult);
+
+      state = assistantReducer(state, transcriptCleared());
+
+      expect(state.messages).toEqual([]);
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/components/ActionResultCard.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/ActionResultCard.test.tsx
@@ -1,0 +1,381 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {fireEvent, render} from '@testing-library/react-native';
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {ActionResultCard} from '@/features/assistant/components/ActionResultCard/ActionResultCard';
+import type {
+  AssistantActionId,
+  AssistantActionResult,
+  AssistantResultItem,
+} from '@/features/assistant/types';
+
+/**
+ * A distinct, human-looking label per open key, so an assertion on the button's
+ * text can only pass if the component ran `assistant.open.<actionId>` through
+ * t(). Rendering the raw key would produce different text.
+ */
+const mockOpenLabels: Record<string, string> = {
+  'assistant.open.bookAppointment': 'Open the booking form',
+  'assistant.open.addCareTask': 'Open the new task form',
+  'assistant.open.logExpense': 'Open the expense form',
+};
+
+// The card reads every spacing/colour/typography token off useTheme().
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => mockOpenLabels[key] ?? key,
+  }),
+}));
+
+type JsonNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: JsonNode[] | null;
+};
+
+const makeResult = (
+  overrides: Partial<AssistantActionResult> = {},
+): AssistantActionResult => ({
+  actionId: 'upcomingTasks',
+  status: 'ok',
+  speechKey: 'assistant.speech.upcomingTasks',
+  ...overrides,
+});
+
+const withItems = (
+  items: AssistantResultItem[],
+  overrides: Partial<AssistantActionResult> = {},
+): AssistantActionResult => makeResult({data: {items}, ...overrides});
+
+const handoff = (
+  actionId: AssistantActionId,
+  deepLink: string | undefined,
+  overrides: Partial<AssistantActionResult> = {},
+): AssistantActionResult =>
+  makeResult({actionId, status: 'handoff', deepLink, ...overrides});
+
+const renderCard = (result: AssistantActionResult) => {
+  const onOpen = jest.fn();
+  const utils = render(<ActionResultCard result={result} onOpen={onOpen} />);
+  return {...utils, onOpen};
+};
+
+/** The card's own children: one View per item, then the button when present. */
+const cardChildren = (toJSON: () => unknown): JsonNode[] => {
+  const root = toJSON() as JsonNode | null;
+  if (!root) {
+    throw new Error('Expected the card to render, but it rendered null');
+  }
+  return root.children ?? [];
+};
+
+describe('ActionResultCard', () => {
+  describe('when there is nothing to show', () => {
+    it('renders null for a read result with no data at all', () => {
+      const {toJSON, queryByTestId} = renderCard(makeResult());
+
+      expect(toJSON()).toBeNull();
+      expect(queryByTestId('assistant-result-card')).toBeNull();
+    });
+
+    it('renders null when data is present but carries no items key', () => {
+      const {toJSON} = renderCard(makeResult({data: {petName: 'Milo'}}));
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('renders null when the item list is empty', () => {
+      const {toJSON} = renderCard(withItems([]));
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('renders null for a handoff result that has no deep link', () => {
+      const {toJSON, queryByTestId} = renderCard(
+        handoff('bookAppointment', undefined),
+      );
+
+      expect(toJSON()).toBeNull();
+      expect(queryByTestId('assistant-result-open')).toBeNull();
+    });
+
+    it('renders null for a handoff result whose deep link is an empty string', () => {
+      const {toJSON} = renderCard(handoff('bookAppointment', ''));
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('renders null for a non-handoff result that happens to carry a deep link', () => {
+      const {toJSON, queryByTestId} = renderCard(
+        makeResult({status: 'ok', deepLink: 'yc://tasks/new'}),
+      );
+
+      expect(toJSON()).toBeNull();
+      expect(queryByTestId('assistant-result-open')).toBeNull();
+    });
+  });
+
+  describe('item list', () => {
+    const twoItems: AssistantResultItem[] = [
+      {id: 't1', title: 'Give Milo his pill', subtitle: 'Today, 8:00 pm'},
+      {id: 't2', title: 'Brush Nala', subtitle: 'Tomorrow, 9:00 am'},
+    ];
+
+    it('renders the card once every item title is present', () => {
+      const {getByTestId, getByText} = renderCard(withItems(twoItems));
+
+      expect(getByTestId('assistant-result-card')).toBeTruthy();
+      expect(getByText('Give Milo his pill')).toBeTruthy();
+      expect(getByText('Brush Nala')).toBeTruthy();
+    });
+
+    it('renders one row per item, in the order given', () => {
+      const {toJSON} = renderCard(withItems(twoItems));
+      const rows = cardChildren(toJSON);
+
+      expect(rows).toHaveLength(2);
+      expect((rows[0].children?.[0] as JsonNode).children).toEqual([
+        'Give Milo his pill',
+      ]);
+      expect((rows[1].children?.[0] as JsonNode).children).toEqual([
+        'Brush Nala',
+      ]);
+    });
+
+    it('renders the subtitle beneath an item that has one', () => {
+      const {getByText, toJSON} = renderCard(withItems(twoItems));
+
+      expect(getByText('Today, 8:00 pm')).toBeTruthy();
+      // Title line plus subtitle line.
+      expect(cardChildren(toJSON)[0].children).toHaveLength(2);
+    });
+
+    it('omits the subtitle line entirely for an item without one', () => {
+      const {queryByText, toJSON} = renderCard(
+        withItems([{id: 't1', title: 'Give Milo his pill'}]),
+      );
+      const rows = cardChildren(toJSON);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].children).toHaveLength(1);
+      expect(queryByText('undefined')).toBeNull();
+    });
+
+    it('omits the subtitle line when the subtitle is an empty string', () => {
+      const {toJSON} = renderCard(
+        withItems([{id: 't1', title: 'Brush Nala', subtitle: ''}]),
+      );
+
+      expect(cardChildren(toJSON)[0].children).toHaveLength(1);
+    });
+
+    it('mixes items with and without subtitles in the same card', () => {
+      const {toJSON, getByText} = renderCard(
+        withItems([
+          {id: 't1', title: 'Give Milo his pill'},
+          {id: 't2', title: 'Brush Nala', subtitle: 'Tomorrow, 9:00 am'},
+        ]),
+      );
+      const rows = cardChildren(toJSON);
+
+      expect(rows[0].children).toHaveLength(1);
+      expect(rows[1].children).toHaveLength(2);
+      expect(getByText('Tomorrow, 9:00 am')).toBeTruthy();
+    });
+
+    it('draws a divider above every row except the first', () => {
+      const {toJSON} = renderCard(
+        withItems([
+          {id: 't1', title: 'First'},
+          {id: 't2', title: 'Second'},
+          {id: 't3', title: 'Third'},
+        ]),
+      );
+      const borders = cardChildren(toJSON).map(
+        row => StyleSheet.flatten(row.props.style as never).borderTopWidth,
+      );
+
+      expect(borders).toEqual([0, 1, 1]);
+    });
+
+    it('paints the divider and row padding from the theme', () => {
+      const {toJSON} = renderCard(withItems(twoItems));
+      const secondRow = StyleSheet.flatten(
+        cardChildren(toJSON)[1].props.style as never,
+      );
+
+      expect(secondRow.borderTopColor).toBe(mockTheme.colors.divider);
+      expect(secondRow.paddingVertical).toBe(mockTheme.spacing['2']);
+    });
+
+    it('styles the title with the bold small label token and body ink', () => {
+      const {getByText} = renderCard(withItems(twoItems));
+      const style = StyleSheet.flatten(
+        getByText('Give Milo his pill').props.style,
+      );
+
+      expect(style.fontSize).toBe(mockTheme.typography.labelSmallBold.fontSize);
+      expect(style.fontFamily).toBe(
+        mockTheme.typography.labelSmallBold.fontFamily,
+      );
+      expect(style.color).toBe(mockTheme.colors.text);
+    });
+
+    it('styles the subtitle with the xs label token and secondary ink', () => {
+      const {getByText} = renderCard(withItems(twoItems));
+      const style = StyleSheet.flatten(getByText('Today, 8:00 pm').props.style);
+
+      expect(style.fontSize).toBe(mockTheme.typography.labelXs.fontSize);
+      expect(style.fontFamily).toBe(mockTheme.typography.labelXs.fontFamily);
+      expect(style.color).toBe(mockTheme.colors.textSecondary);
+    });
+
+    it('renders no open button for a read result that only has items', () => {
+      const {queryByTestId, queryByRole} = renderCard(withItems(twoItems));
+
+      expect(queryByTestId('assistant-result-open')).toBeNull();
+      expect(queryByRole('button')).toBeNull();
+    });
+  });
+
+  describe('handoff button', () => {
+    const bookingLink = 'yc://appointments/new?petName=Milo';
+
+    it('renders the open button for a handoff result with a deep link', () => {
+      const {getByTestId, getByRole} = renderCard(
+        handoff('bookAppointment', bookingLink),
+      );
+
+      expect(getByTestId('assistant-result-open')).toBeTruthy();
+      expect(getByRole('button')).toBeTruthy();
+    });
+
+    it('labels the button with the open key for that action id', () => {
+      const {getByText, queryByText} = renderCard(
+        handoff('bookAppointment', bookingLink),
+      );
+
+      expect(getByText('Open the booking form')).toBeTruthy();
+      expect(queryByText('assistant.open.bookAppointment')).toBeNull();
+    });
+
+    it('uses a different label for a different action id', () => {
+      const {getByText} = renderCard(
+        handoff('logExpense', 'yc://expenses/new'),
+      );
+
+      expect(getByText('Open the expense form')).toBeTruthy();
+    });
+
+    it('calls onOpen with the deep link when the button is pressed', () => {
+      const {getByTestId, onOpen} = renderCard(
+        handoff('bookAppointment', bookingLink),
+      );
+
+      fireEvent.press(getByTestId('assistant-result-open'));
+
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onOpen).toHaveBeenCalledWith(bookingLink);
+    });
+
+    it('does not call onOpen before the button is pressed', () => {
+      const {onOpen} = renderCard(handoff('bookAppointment', bookingLink));
+
+      expect(onOpen).not.toHaveBeenCalled();
+    });
+
+    it('renders the button below the items when a handoff also carries items', () => {
+      const {toJSON, getByText, getByTestId} = renderCard(
+        handoff('addCareTask', 'yc://tasks/new?title=Pill', {
+          data: {items: [{id: 't1', title: 'Give Milo his pill'}]},
+        }),
+      );
+      const children = cardChildren(toJSON);
+
+      expect(children).toHaveLength(2);
+      expect(getByText('Give Milo his pill')).toBeTruthy();
+      expect(getByText('Open the new task form')).toBeTruthy();
+      expect(getByTestId('assistant-result-open')).toBeTruthy();
+    });
+
+    it('renders the items but no button when a handoff has no deep link', () => {
+      const {toJSON, getByText, queryByTestId, queryByRole} = renderCard(
+        handoff('bookAppointment', undefined, {
+          data: {items: [{id: 'a1', title: 'Check-up with Dr Reed'}]},
+        }),
+      );
+
+      expect(cardChildren(toJSON)).toHaveLength(1);
+      expect(getByText('Check-up with Dr Reed')).toBeTruthy();
+      expect(queryByTestId('assistant-result-open')).toBeNull();
+      expect(queryByRole('button')).toBeNull();
+    });
+
+    it('renders no button when a result carries a deep link but is not a handoff', () => {
+      const {getByText, queryByTestId} = renderCard(
+        makeResult({
+          status: 'ok',
+          deepLink: 'yc://tasks/new',
+          data: {items: [{id: 't1', title: 'Brush Nala'}]},
+        }),
+      );
+
+      expect(getByText('Brush Nala')).toBeTruthy();
+      expect(queryByTestId('assistant-result-open')).toBeNull();
+    });
+
+    it('paints the button with the cta tokens', () => {
+      const {getByTestId, getByText} = renderCard(
+        handoff('bookAppointment', bookingLink),
+      );
+      const buttonStyle = StyleSheet.flatten(
+        getByTestId('assistant-result-open').props.style,
+      );
+      const labelStyle = StyleSheet.flatten(
+        getByText('Open the booking form').props.style,
+      );
+
+      expect(buttonStyle.backgroundColor).toBe(mockTheme.colors.cta);
+      expect(buttonStyle.borderRadius).toBe(mockTheme.borderRadius.button);
+      expect(buttonStyle.alignSelf).toBe('flex-start');
+      expect(labelStyle.color).toBe(mockTheme.colors.ctaText);
+      expect(labelStyle.fontSize).toBe(
+        mockTheme.typography.buttonSmall.fontSize,
+      );
+    });
+  });
+
+  describe('card container', () => {
+    it('takes its border, background and radius from the theme', () => {
+      const {getByTestId} = renderCard(
+        withItems([{id: 't1', title: 'Brush Nala'}]),
+      );
+      const style = StyleSheet.flatten(
+        getByTestId('assistant-result-card').props.style,
+      );
+
+      expect(style.backgroundColor).toBe(mockTheme.colors.cardBackground);
+      expect(style.borderColor).toBe(mockTheme.colors.border);
+      expect(style.borderWidth).toBe(1);
+      expect(style.borderRadius).toBe(mockTheme.borderRadius.card);
+      expect(style.padding).toBe(mockTheme.spacing['4']);
+    });
+
+    it('hugs the left edge and caps its width at 90%', () => {
+      const {getByTestId} = renderCard(
+        withItems([{id: 't1', title: 'Brush Nala'}]),
+      );
+      const style = StyleSheet.flatten(
+        getByTestId('assistant-result-card').props.style,
+      );
+
+      expect(style.alignSelf).toBe('flex-start');
+      expect(style.maxWidth).toBe('90%');
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/components/AssistantComposer.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/AssistantComposer.test.tsx
@@ -1,0 +1,462 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {fireEvent, render} from '@testing-library/react-native';
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {AssistantComposer} from '@/features/assistant/components/AssistantComposer/AssistantComposer';
+import {MAX_UTTERANCE_LENGTH} from '@/features/assistant/constants';
+
+/**
+ * Distinct, human-looking copy for the two keys the composer translates, so an
+ * assertion on rendered text can only pass if the value went through t() — the
+ * raw key would render as different text.
+ */
+const SEND_LABEL = 'Send it';
+const PLACEHOLDER = 'Ask about your pet';
+
+const mockCopy: Record<string, string> = {
+  'assistant.send': SEND_LABEL,
+  'assistant.composerPlaceholder': PLACEHOLDER,
+};
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => mockCopy[key] ?? key,
+  }),
+}));
+
+interface ComposerOptions {
+  value?: string;
+  busy?: boolean;
+  onSubmit?: jest.Mock;
+  onChangeText?: jest.Mock;
+}
+
+const renderComposer = (options: ComposerOptions = {}) => {
+  const onSubmit = options.onSubmit ?? jest.fn();
+  const onChangeText = options.onChangeText ?? jest.fn();
+  const utils = render(
+    <AssistantComposer
+      value={options.value ?? ''}
+      busy={options.busy ?? false}
+      onSubmit={onSubmit}
+      onChangeText={onChangeText}
+    />,
+  );
+  return {...utils, onSubmit, onChangeText};
+};
+
+const inputOf = (utils: ReturnType<typeof renderComposer>) =>
+  utils.getByTestId('assistant-input');
+
+const sendOf = (utils: ReturnType<typeof renderComposer>) =>
+  utils.getByTestId('assistant-send');
+
+const inputBorderColor = (utils: ReturnType<typeof renderComposer>) =>
+  StyleSheet.flatten(inputOf(utils).props.style).borderColor;
+
+describe('AssistantComposer', () => {
+  describe('typing', () => {
+    it('reports every keystroke through onChangeText', () => {
+      const utils = renderComposer({value: ''});
+
+      fireEvent.changeText(inputOf(utils), 'Wh');
+
+      expect(utils.onChangeText).toHaveBeenCalledTimes(1);
+      expect(utils.onChangeText).toHaveBeenCalledWith('Wh');
+    });
+
+    it('passes the raw text through without trimming it', () => {
+      const utils = renderComposer({value: ''});
+
+      fireEvent.changeText(inputOf(utils), '  spaced out  ');
+
+      expect(utils.onChangeText).toHaveBeenCalledWith('  spaced out  ');
+    });
+
+    it('reports each edit separately', () => {
+      const utils = renderComposer({value: ''});
+
+      fireEvent.changeText(inputOf(utils), 'a');
+      fireEvent.changeText(inputOf(utils), 'ab');
+
+      expect(utils.onChangeText.mock.calls).toEqual([['a'], ['ab']]);
+    });
+
+    it('renders the value it is given rather than owning the text itself', () => {
+      const utils = renderComposer({value: 'Is Milo due for shots?'});
+
+      expect(inputOf(utils).props.value).toBe('Is Milo due for shots?');
+    });
+
+    it('shows the new value when the parent pushes a suggestion chip in', () => {
+      const onSubmit = jest.fn();
+      const onChangeText = jest.fn();
+      const {getByTestId, rerender} = render(
+        <AssistantComposer
+          value=""
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      expect(getByTestId('assistant-input').props.value).toBe('');
+
+      rerender(
+        <AssistantComposer
+          value="Book an appointment"
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+
+      expect(getByTestId('assistant-input').props.value).toBe(
+        'Book an appointment',
+      );
+      expect(getByTestId('assistant-send').props.accessibilityState).toEqual({
+        disabled: false,
+      });
+    });
+
+    it('caps the field at MAX_UTTERANCE_LENGTH characters', () => {
+      const utils = renderComposer();
+
+      expect(inputOf(utils).props.maxLength).toBe(MAX_UTTERANCE_LENGTH);
+      expect(inputOf(utils).props.maxLength).toBe(500);
+    });
+
+    it('is a multiline field with a send return key', () => {
+      const utils = renderComposer();
+
+      expect(inputOf(utils).props.multiline).toBe(true);
+      expect(inputOf(utils).props.returnKeyType).toBe('send');
+      expect(inputOf(utils).props.blurOnSubmit).toBe(true);
+    });
+  });
+
+  describe('send availability', () => {
+    it('disables send when the field is empty', () => {
+      const utils = renderComposer({value: ''});
+
+      expect(sendOf(utils).props.accessibilityState).toEqual({disabled: true});
+    });
+
+    it('disables send when the field holds only whitespace', () => {
+      const utils = renderComposer({value: '   \n\t  '});
+
+      expect(sendOf(utils).props.accessibilityState).toEqual({disabled: true});
+    });
+
+    it('enables send as soon as there is a non-space character', () => {
+      const utils = renderComposer({value: ' a '});
+
+      expect(sendOf(utils).props.accessibilityState).toEqual({disabled: false});
+    });
+
+    it('disables send while a reply is in flight even with text present', () => {
+      const utils = renderComposer({value: 'Where is my vet?', busy: true});
+
+      expect(sendOf(utils).props.accessibilityState).toEqual({disabled: true});
+    });
+
+    it('dims the send button while it is disabled', () => {
+      const utils = renderComposer({value: '  '});
+
+      expect(StyleSheet.flatten(sendOf(utils).props.style).opacity).toBe(0.5);
+    });
+
+    it('shows the send button at full opacity once it can be pressed', () => {
+      const utils = renderComposer({value: 'hi'});
+
+      expect(StyleSheet.flatten(sendOf(utils).props.style).opacity).toBe(1);
+    });
+  });
+
+  describe('submitting', () => {
+    it('does not submit anything on mount', () => {
+      const utils = renderComposer({value: 'ready to go'});
+
+      expect(utils.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('submits the trimmed text when send is pressed', () => {
+      const utils = renderComposer({value: '   how much have I spent?   '});
+
+      fireEvent.press(sendOf(utils));
+
+      expect(utils.onSubmit).toHaveBeenCalledTimes(1);
+      expect(utils.onSubmit).toHaveBeenCalledWith('how much have I spent?');
+    });
+
+    it('keeps whitespace inside the utterance while trimming the ends', () => {
+      const utils = renderComposer({value: '\n  book  a   visit \n'});
+
+      fireEvent.press(sendOf(utils));
+
+      expect(utils.onSubmit).toHaveBeenCalledWith('book  a   visit');
+    });
+
+    it('submits the trimmed text on onSubmitEditing from the keyboard', () => {
+      const utils = renderComposer({value: '  next appointment  '});
+
+      fireEvent(inputOf(utils), 'submitEditing');
+
+      expect(utils.onSubmit).toHaveBeenCalledTimes(1);
+      expect(utils.onSubmit).toHaveBeenCalledWith('next appointment');
+    });
+
+    it('does not submit an empty utterance from the keyboard', () => {
+      const utils = renderComposer({value: ''});
+
+      fireEvent(inputOf(utils), 'submitEditing');
+
+      expect(utils.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit a whitespace-only utterance from the keyboard', () => {
+      const utils = renderComposer({value: '    '});
+
+      fireEvent(inputOf(utils), 'submitEditing');
+
+      expect(utils.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit while busy, even with text, when send is pressed', () => {
+      const utils = renderComposer({value: 'another question', busy: true});
+
+      fireEvent.press(sendOf(utils));
+
+      expect(utils.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit while busy when the keyboard fires submitEditing', () => {
+      const utils = renderComposer({value: 'another question', busy: true});
+
+      fireEvent(inputOf(utils), 'submitEditing');
+
+      expect(utils.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('submits again once the reply has landed and busy clears', () => {
+      const onSubmit = jest.fn();
+      const onChangeText = jest.fn();
+      const {getByTestId, rerender} = render(
+        <AssistantComposer
+          value="tell me about Milo"
+          busy
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      fireEvent(getByTestId('assistant-input'), 'submitEditing');
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      rerender(
+        <AssistantComposer
+          value="tell me about Milo"
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      fireEvent.press(getByTestId('assistant-send'));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith('tell me about Milo');
+    });
+
+    it('submits the latest value after a re-render, not the mounted one', () => {
+      const onSubmit = jest.fn();
+      const onChangeText = jest.fn();
+      const {getByTestId, rerender} = render(
+        <AssistantComposer
+          value="first"
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+
+      rerender(
+        <AssistantComposer
+          value=" second "
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      fireEvent.press(getByTestId('assistant-send'));
+
+      expect(onSubmit).toHaveBeenCalledWith('second');
+      expect(onSubmit).not.toHaveBeenCalledWith('first');
+    });
+  });
+
+  describe('busy state', () => {
+    it('shows the translated send label when idle', () => {
+      const utils = renderComposer({value: 'hi', busy: false});
+
+      expect(utils.getByText(SEND_LABEL)).toBeTruthy();
+      expect(utils.queryByText('assistant.send')).toBeNull();
+      expect(utils.queryByTestId('assistant-busy')).toBeNull();
+    });
+
+    it('replaces the send label with a spinner while busy', () => {
+      const utils = renderComposer({value: 'hi', busy: true});
+
+      expect(utils.getByTestId('assistant-busy')).toBeTruthy();
+      expect(utils.queryByText(SEND_LABEL)).toBeNull();
+    });
+
+    it('tints the spinner with the CTA foreground colour', () => {
+      const utils = renderComposer({value: 'hi', busy: true});
+
+      expect(utils.getByTestId('assistant-busy').props.color).toBe('#FFFFFF');
+    });
+
+    it('swaps the spinner back for the label when busy clears', () => {
+      const onSubmit = jest.fn();
+      const onChangeText = jest.fn();
+      const {queryByText, queryByTestId, rerender} = render(
+        <AssistantComposer
+          value="hi"
+          busy
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      expect(queryByTestId('assistant-busy')).not.toBeNull();
+
+      rerender(
+        <AssistantComposer
+          value="hi"
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+
+      expect(queryByTestId('assistant-busy')).toBeNull();
+      expect(queryByText(SEND_LABEL)).not.toBeNull();
+    });
+
+    it('keeps the send button labelled for screen readers while the spinner shows', () => {
+      const utils = renderComposer({value: 'hi', busy: true});
+
+      expect(utils.getByLabelText(SEND_LABEL)).toBe(sendOf(utils));
+      expect(sendOf(utils).props.accessibilityRole).toBe('button');
+    });
+  });
+
+  describe('focus', () => {
+    it('uses the neutral border colour before the field is touched', () => {
+      const utils = renderComposer();
+
+      expect(inputBorderColor(utils)).toBe('#EAEAEA');
+    });
+
+    it('switches to the primary border colour on focus', () => {
+      const utils = renderComposer();
+
+      fireEvent(inputOf(utils), 'focus');
+
+      expect(inputBorderColor(utils)).toBe('#257BED');
+    });
+
+    it('returns to the neutral border colour on blur', () => {
+      const utils = renderComposer();
+      fireEvent(inputOf(utils), 'focus');
+      expect(inputBorderColor(utils)).toBe('#257BED');
+
+      fireEvent(inputOf(utils), 'blur');
+
+      expect(inputBorderColor(utils)).toBe('#EAEAEA');
+    });
+
+    it('keeps the focused border across a value change', () => {
+      const onSubmit = jest.fn();
+      const onChangeText = jest.fn();
+      const {getByTestId, rerender} = render(
+        <AssistantComposer
+          value=""
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+      fireEvent(getByTestId('assistant-input'), 'focus');
+
+      rerender(
+        <AssistantComposer
+          value="typed"
+          busy={false}
+          onSubmit={onSubmit}
+          onChangeText={onChangeText}
+        />,
+      );
+
+      expect(
+        StyleSheet.flatten(getByTestId('assistant-input').props.style)
+          .borderColor,
+      ).toBe('#257BED');
+    });
+  });
+
+  describe('presentation', () => {
+    it('labels the field with the translated placeholder', () => {
+      const utils = renderComposer();
+
+      expect(utils.getByPlaceholderText(PLACEHOLDER)).toBe(inputOf(utils));
+      expect(inputOf(utils).props.accessibilityLabel).toBe(PLACEHOLDER);
+      expect(inputOf(utils).props.placeholderTextColor).toBe('#747473');
+    });
+
+    it('styles the field from the theme tokens', () => {
+      const utils = renderComposer();
+
+      expect(StyleSheet.flatten(inputOf(utils).props.style)).toMatchObject({
+        flex: 1,
+        minHeight: 44,
+        maxHeight: 120,
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        borderRadius: 16,
+        borderWidth: 1,
+        backgroundColor: '#FBF8F2',
+        color: '#302F2E',
+        fontSize: 16,
+        fontFamily: 'Satoshi-Regular',
+      });
+    });
+
+    it('styles the send button from the theme tokens', () => {
+      const utils = renderComposer({value: 'hi'});
+
+      expect(StyleSheet.flatten(sendOf(utils).props.style)).toMatchObject({
+        minHeight: 44,
+        justifyContent: 'center',
+        paddingHorizontal: 16,
+        borderRadius: 18,
+        backgroundColor: '#302F2E',
+      });
+    });
+
+    it('styles the send label with the small button typography', () => {
+      const utils = renderComposer({value: 'hi'});
+
+      expect(
+        StyleSheet.flatten(utils.getByText(SEND_LABEL).props.style),
+      ).toMatchObject({
+        fontSize: 14,
+        fontWeight: '500',
+        fontFamily: 'Satoshi-Medium',
+        color: '#FFFFFF',
+      });
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/components/AssistantComposer.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/AssistantComposer.test.tsx
@@ -56,6 +56,20 @@ const inputOf = (utils: ReturnType<typeof renderComposer>) =>
 const sendOf = (utils: ReturnType<typeof renderComposer>) =>
   utils.getByTestId('assistant-send');
 
+/**
+ * The send button's resolved style while it is not being pressed.
+ *
+ * PressableOpacity gives Pressable a style callback rather than an object, so
+ * the state has to be applied before flattening. `pressed: false` is the
+ * resting appearance, which is what these assertions are about.
+ */
+const sendStyle = (utils: ReturnType<typeof renderComposer>) => {
+  const {style} = sendOf(utils).props;
+  return StyleSheet.flatten(
+    typeof style === 'function' ? style({pressed: false}) : style,
+  );
+};
+
 const inputBorderColor = (utils: ReturnType<typeof renderComposer>) =>
   StyleSheet.flatten(inputOf(utils).props.style).borderColor;
 
@@ -167,13 +181,16 @@ describe('AssistantComposer', () => {
     it('dims the send button while it is disabled', () => {
       const utils = renderComposer({value: '  '});
 
-      expect(StyleSheet.flatten(sendOf(utils).props.style).opacity).toBe(0.5);
+      expect(sendStyle(utils).opacity).toBe(0.5);
     });
 
-    it('shows the send button at full opacity once it can be pressed', () => {
+    it('does not dim the send button once it can be pressed', () => {
       const utils = renderComposer({value: 'hi'});
 
-      expect(StyleSheet.flatten(sendOf(utils).props.style).opacity).toBe(1);
+      // The dimming is the component's own `sendDisabled` style; when it can
+      // be pressed there is no opacity of its own to apply.
+      expect(sendStyle(utils).opacity).toBeUndefined();
+      expect(sendOf(utils).props.accessibilityState).toEqual({disabled: false});
     });
   });
 

--- a/apps/mobileAppYC/__tests__/features/assistant/components/MessageBubble.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/MessageBubble.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {render} from '@testing-library/react-native';
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {MessageBubble} from '@/features/assistant/components/MessageBubble/MessageBubble';
+import type {
+  AssistantMessage,
+  AssistantMessageAuthor,
+} from '@/features/assistant/types';
+
+// MessageBubble reads every spacing/colour/typography token off useTheme().
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+const makeMessage = (
+  author: AssistantMessageAuthor,
+  text: string,
+): AssistantMessage => ({
+  id: `msg-${author}`,
+  author,
+  text,
+  createdAt: '2026-09-03T09:00:00.000Z',
+});
+
+const bubbleStyleFor = (author: AssistantMessageAuthor, text: string) => {
+  const {getByTestId, toJSON} = render(
+    <MessageBubble message={makeMessage(author, text)} />,
+  );
+  const bubble = getByTestId(`assistant-bubble-${author}`);
+  // toJSON() is the outer row View that owns the alignment styles.
+  const row = toJSON() as {props: {style?: unknown}} | null;
+  return {
+    bubble,
+    bubbleStyle: StyleSheet.flatten(bubble.props.style),
+    rowStyle: StyleSheet.flatten(row?.props.style as never),
+  };
+};
+
+describe('MessageBubble', () => {
+  describe('message text', () => {
+    it('renders the text of a user message', () => {
+      const {getByText} = render(
+        <MessageBubble message={makeMessage('user', 'When is Milo due?')} />,
+      );
+
+      expect(getByText('When is Milo due?')).toBeTruthy();
+    });
+
+    it('renders the text of an assistant message', () => {
+      const {getByText} = render(
+        <MessageBubble
+          message={makeMessage('assistant', 'Milo is due on 12 September.')}
+        />,
+      );
+
+      expect(getByText('Milo is due on 12 September.')).toBeTruthy();
+    });
+
+    it('styles the text with the paragraph token and body ink colour', () => {
+      const {getByText} = render(
+        <MessageBubble message={makeMessage('assistant', 'Styled line')} />,
+      );
+
+      const textStyle = StyleSheet.flatten(
+        getByText('Styled line').props.style,
+      );
+      expect(textStyle.fontSize).toBe(mockTheme.typography.paragraph.fontSize);
+      expect(textStyle.fontFamily).toBe(
+        mockTheme.typography.paragraph.fontFamily,
+      );
+      expect(textStyle.lineHeight).toBe(
+        mockTheme.typography.paragraph.lineHeight,
+      );
+      expect(textStyle.color).toBe(mockTheme.colors.text);
+    });
+  });
+
+  describe('testID', () => {
+    it('tags a user message bubble as assistant-bubble-user', () => {
+      const {getByTestId, queryByTestId} = render(
+        <MessageBubble message={makeMessage('user', 'Hi')} />,
+      );
+
+      expect(getByTestId('assistant-bubble-user')).toBeTruthy();
+      expect(queryByTestId('assistant-bubble-assistant')).toBeNull();
+    });
+
+    it('tags an assistant message bubble as assistant-bubble-assistant', () => {
+      const {getByTestId, queryByTestId} = render(
+        <MessageBubble message={makeMessage('assistant', 'Hello')} />,
+      );
+
+      expect(getByTestId('assistant-bubble-assistant')).toBeTruthy();
+      expect(queryByTestId('assistant-bubble-user')).toBeNull();
+    });
+  });
+
+  describe('author variants', () => {
+    it('paints a user bubble with the soft blue token', () => {
+      const {bubbleStyle} = bubbleStyleFor('user', 'Mine');
+
+      expect(bubbleStyle.backgroundColor).toBe(mockTheme.colors.blueSoft);
+      expect(bubbleStyle.borderColor).toBe(mockTheme.colors.blueSoft);
+    });
+
+    it('paints an assistant bubble with the card background and border tokens', () => {
+      const {bubbleStyle} = bubbleStyleFor('assistant', 'Theirs');
+
+      expect(bubbleStyle.backgroundColor).toBe(mockTheme.colors.cardBackground);
+      expect(bubbleStyle.borderColor).toBe(mockTheme.colors.border);
+    });
+
+    it('gives the two authors visibly different bubble colours', () => {
+      const user = bubbleStyleFor('user', 'Mine').bubbleStyle;
+      const assistant = bubbleStyleFor('assistant', 'Theirs').bubbleStyle;
+
+      expect(user.backgroundColor).not.toBe(assistant.backgroundColor);
+      expect(user.borderColor).not.toBe(assistant.borderColor);
+      // Guard the tokens themselves: if the theme ever collapsed these two to
+      // the same value the inequality above would silently stop meaning
+      // anything.
+      expect(mockTheme.colors.blueSoft).not.toBe(
+        mockTheme.colors.cardBackground,
+      );
+    });
+
+    it('right-aligns a user message and left-aligns an assistant message', () => {
+      expect(bubbleStyleFor('user', 'Mine').rowStyle.alignItems).toBe(
+        'flex-end',
+      );
+      expect(bubbleStyleFor('assistant', 'Theirs').rowStyle.alignItems).toBe(
+        'flex-start',
+      );
+    });
+  });
+
+  describe('shared bubble geometry', () => {
+    it('applies the same padding, radius and width cap to both authors', () => {
+      const user = bubbleStyleFor('user', 'Mine').bubbleStyle;
+      const assistant = bubbleStyleFor('assistant', 'Theirs').bubbleStyle;
+
+      for (const style of [user, assistant]) {
+        expect(style.maxWidth).toBe('86%');
+        expect(style.paddingVertical).toBe(mockTheme.spacing['3']);
+        expect(style.paddingHorizontal).toBe(mockTheme.spacing['4']);
+        expect(style.borderRadius).toBe(mockTheme.borderRadius.card);
+        expect(style.borderWidth).toBe(1);
+      }
+    });
+
+    it('lays the row out full width with a spacing-2 gap below', () => {
+      const {rowStyle} = bubbleStyleFor('user', 'Mine');
+
+      expect(rowStyle.width).toBe('100%');
+      expect(rowStyle.marginBottom).toBe(mockTheme.spacing['2']);
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/components/ModelStatusBanner.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/ModelStatusBanner.test.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import type {ReactTestInstance} from 'react-test-renderer';
+import {StyleSheet} from 'react-native';
+import {render} from '@testing-library/react-native';
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {ModelStatusBanner} from '@/features/assistant/components/ModelStatusBanner/ModelStatusBanner';
+import type {OnDeviceModelAvailability} from '@/features/assistant/types';
+
+/**
+ * The real English catalogue for `assistant.model.*`, copied verbatim from
+ * src/localization/resources/en/common.json. Using the shipping copy (rather
+ * than placeholder text) means an assertion on the rendered sentence pins both
+ * the key the component chose AND the value it interpolated into it.
+ *
+ * `unknown` deliberately carries no {{provider}} placeholder — that is how the
+ * catalogue is written, and the component must still render it.
+ */
+const COPY: Record<string, string> = {
+  'assistant.model.provider': 'on-device AI',
+  'assistant.model.unsupportedOS':
+    "Answers here are exact rather than chatty. {{provider}} needs a newer version of this phone's software.",
+  'assistant.model.unsupportedDevice':
+    'Answers here are exact rather than chatty. This device does not support {{provider}}.',
+  'assistant.model.notEnabled':
+    'Turn on {{provider}} in system settings for more natural replies. Everything still works without it.',
+  'assistant.model.modelNotReady':
+    '{{provider}} is still downloading. Replies stay exact until it is ready.',
+  'assistant.model.unknown':
+    'Replies are exact rather than chatty on this device.',
+};
+
+/**
+ * A t() that interpolates for real. A key the catalogue does not carry comes
+ * back as the raw key, so a component that built the wrong key would render
+ * something visibly different from any real sentence.
+ */
+const mockT = jest.fn((key: string, options?: {provider?: string}): string => {
+  const template = COPY[key];
+  if (template === undefined) {
+    return key;
+  }
+  return template.replace('{{provider}}', options?.provider ?? '');
+});
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: mockT}),
+}));
+
+const renderBanner = (availability: OnDeviceModelAvailability) =>
+  render(<ModelStatusBanner availability={availability} />);
+
+/** The one Text node inside the banner, or null when nothing rendered. */
+const bannerTextNode = (
+  utils: ReturnType<typeof renderBanner>,
+): ReactTestInstance | null => {
+  const banner = utils.queryByTestId('assistant-model-status');
+  if (banner === null) {
+    return null;
+  }
+  const children = banner.children.filter(
+    (child): child is ReactTestInstance => typeof child !== 'string',
+  );
+  expect(children).toHaveLength(1);
+  return children[0];
+};
+
+/** The single line of copy inside the banner, or null when nothing rendered. */
+const bannerText = (utils: ReturnType<typeof renderBanner>): string | null => {
+  const node = bannerTextNode(utils);
+  return node === null ? null : (node.props.children as string);
+};
+
+beforeEach(() => {
+  mockT.mockClear();
+});
+
+describe('ModelStatusBanner', () => {
+  describe('when the on-device model is available', () => {
+    it('renders nothing at all', () => {
+      const utils = renderBanner({available: true});
+
+      expect(utils.toJSON()).toBeNull();
+    });
+
+    it('does not translate anything, so no copy can leak into the tree', () => {
+      renderBanner({available: true});
+
+      expect(mockT).not.toHaveBeenCalled();
+    });
+
+    it('stays silent even when a reason and provider label are also present', () => {
+      const utils = renderBanner({
+        available: true,
+        reason: 'notEnabled',
+        providerLabel: 'Apple Intelligence',
+      });
+
+      expect(utils.queryByTestId('assistant-model-status')).toBeNull();
+      expect(
+        utils.queryByText(
+          'Turn on Apple Intelligence in system settings for more natural replies. Everything still works without it.',
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe('when the on-device model is unavailable', () => {
+    it('renders the banner under the assistant-model-status test id', () => {
+      const utils = renderBanner({
+        available: false,
+        reason: 'notEnabled',
+        providerLabel: 'Apple Intelligence',
+      });
+
+      expect(utils.queryByTestId('assistant-model-status')).not.toBeNull();
+    });
+
+    it('shows the sentence for the reason with the provider name filled in', () => {
+      const utils = renderBanner({
+        available: false,
+        reason: 'notEnabled',
+        providerLabel: 'Apple Intelligence',
+      });
+
+      expect(bannerText(utils)).toBe(
+        'Turn on Apple Intelligence in system settings for more natural replies. Everything still works without it.',
+      );
+    });
+  });
+
+  describe('the translation key follows the reason', () => {
+    const reasons: ReadonlyArray<
+      [NonNullable<OnDeviceModelAvailability['reason']>, string]
+    > = [
+      [
+        'unsupportedOS',
+        "Answers here are exact rather than chatty. Apple Intelligence needs a newer version of this phone's software.",
+      ],
+      [
+        'unsupportedDevice',
+        'Answers here are exact rather than chatty. This device does not support Apple Intelligence.',
+      ],
+      [
+        'notEnabled',
+        'Turn on Apple Intelligence in system settings for more natural replies. Everything still works without it.',
+      ],
+      [
+        'modelNotReady',
+        'Apple Intelligence is still downloading. Replies stay exact until it is ready.',
+      ],
+      ['unknown', 'Replies are exact rather than chatty on this device.'],
+    ];
+
+    it.each(reasons)(
+      'asks for assistant.model.%s and renders its sentence',
+      (reason, expectedText) => {
+        const utils = renderBanner({
+          available: false,
+          reason,
+          providerLabel: 'Apple Intelligence',
+        });
+
+        expect(mockT).toHaveBeenCalledWith(`assistant.model.${reason}`, {
+          provider: 'Apple Intelligence',
+        });
+        expect(bannerText(utils)).toBe(expectedText);
+      },
+    );
+
+    it('falls back to assistant.model.unknown when no reason is given', () => {
+      const utils = renderBanner({
+        available: false,
+        providerLabel: 'Apple Intelligence',
+      });
+
+      expect(mockT).toHaveBeenCalledWith('assistant.model.unknown', {
+        provider: 'Apple Intelligence',
+      });
+      expect(bannerText(utils)).toBe(
+        'Replies are exact rather than chatty on this device.',
+      );
+    });
+
+    it('renders the same copy for an absent reason as for an explicit unknown', () => {
+      const implicit = renderBanner({available: false});
+      const implicitText = bannerText(implicit);
+      implicit.unmount();
+
+      const explicit = renderBanner({available: false, reason: 'unknown'});
+
+      expect(implicitText).toBe(
+        'Replies are exact rather than chatty on this device.',
+      );
+      expect(bannerText(explicit)).toBe(implicitText);
+    });
+  });
+
+  describe('the provider name', () => {
+    it('uses the supplied provider label verbatim', () => {
+      const utils = renderBanner({
+        available: false,
+        reason: 'modelNotReady',
+        providerLabel: 'Gemini Nano',
+      });
+
+      expect(bannerText(utils)).toBe(
+        'Gemini Nano is still downloading. Replies stay exact until it is ready.',
+      );
+    });
+
+    it('does not look up the generic provider string when a label is supplied', () => {
+      renderBanner({
+        available: false,
+        reason: 'modelNotReady',
+        providerLabel: 'Gemini Nano',
+      });
+
+      expect(mockT).not.toHaveBeenCalledWith('assistant.model.provider');
+      expect(mockT).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the generic provider string when no label is supplied', () => {
+      const utils = renderBanner({
+        available: false,
+        reason: 'modelNotReady',
+      });
+
+      expect(bannerText(utils)).toBe(
+        'on-device AI is still downloading. Replies stay exact until it is ready.',
+      );
+    });
+
+    it('resolves the generic provider string before building the reason key', () => {
+      renderBanner({available: false, reason: 'notEnabled'});
+
+      expect(mockT.mock.calls).toEqual([
+        ['assistant.model.provider'],
+        ['assistant.model.notEnabled', {provider: 'on-device AI'}],
+      ]);
+    });
+
+    it('interpolates the provider into every reason that carries the placeholder', () => {
+      const utils = renderBanner({
+        available: false,
+        reason: 'unsupportedDevice',
+        providerLabel: 'Apple Intelligence',
+      });
+
+      expect(bannerText(utils)).toBe(
+        'Answers here are exact rather than chatty. This device does not support Apple Intelligence.',
+      );
+    });
+  });
+
+  describe('styling', () => {
+    it('lays the banner out from the theme spacing and radius tokens', () => {
+      const utils = renderBanner({available: false, reason: 'notEnabled'});
+
+      const bannerStyle = StyleSheet.flatten(
+        utils.getByTestId('assistant-model-status').props.style,
+      );
+
+      expect(bannerStyle).toMatchObject({
+        marginHorizontal: 16,
+        marginBottom: 8,
+        paddingVertical: 8,
+        paddingHorizontal: 12,
+        borderRadius: 18,
+      });
+    });
+
+    it('styles the copy with the small label typography and secondary text colour', () => {
+      const utils = renderBanner({available: false, reason: 'unknown'});
+
+      const node = bannerTextNode(utils);
+      const textStyle = StyleSheet.flatten(node?.props.style);
+
+      expect(textStyle).toMatchObject({
+        fontSize: 14,
+        fontWeight: '500',
+        lineHeight: 21,
+        fontFamily: 'Satoshi-Medium',
+        color: '#747473',
+      });
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/components/SuggestionChips.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/components/SuggestionChips.test.tsx
@@ -1,0 +1,335 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {fireEvent, render} from '@testing-library/react-native';
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {SuggestionChips} from '@/features/assistant/components/SuggestionChips/SuggestionChips';
+import {ASSISTANT_ACTIONS} from '@/features/assistant/actions/catalogue';
+
+/**
+ * The chips are the catalogue's sample phrases, flattened in catalogue order.
+ * Pinned here as literals so a reorder of the catalogue (which would silently
+ * change what a first-run user is offered) fails a test rather than sliding by.
+ */
+const ALL_PHRASE_KEYS = [
+  'assistant.actions.nextAppointment.phrase1',
+  'assistant.actions.nextAppointment.phrase2',
+  'assistant.actions.vaccinationStatus.phrase1',
+  'assistant.actions.vaccinationStatus.phrase2',
+  'assistant.actions.upcomingTasks.phrase1',
+  'assistant.actions.upcomingTasks.phrase2',
+  'assistant.actions.petOverview.phrase1',
+  'assistant.actions.expenseSummary.phrase1',
+  'assistant.actions.addCareTask.phrase1',
+  'assistant.actions.addCareTask.phrase2',
+  'assistant.actions.logExpense.phrase1',
+  'assistant.actions.bookAppointment.phrase1',
+  'assistant.actions.bookAppointment.phrase2',
+];
+
+/**
+ * A translation table with a distinct, human-looking value for every key, so an
+ * assertion on rendered text can only pass if the component ran the key through
+ * t() — rendering the raw key would produce different text.
+ */
+const mockPhraseLabels: Record<string, string> = {
+  'assistant.actions.nextAppointment.phrase1': "When is Milo's next visit?",
+  'assistant.actions.nextAppointment.phrase2': 'Next appointment',
+  'assistant.actions.vaccinationStatus.phrase1': 'Is Milo up to date on shots?',
+  'assistant.actions.vaccinationStatus.phrase2': 'Vaccination status',
+  'assistant.actions.upcomingTasks.phrase1': "What's due this week?",
+  'assistant.actions.upcomingTasks.phrase2': 'Upcoming tasks',
+  'assistant.actions.petOverview.phrase1': 'Tell me about Milo',
+  'assistant.actions.expenseSummary.phrase1': 'How much have I spent?',
+  'assistant.actions.addCareTask.phrase1': 'Remind me to give Milo his pill',
+  'assistant.actions.addCareTask.phrase2': 'Add a care task',
+  'assistant.actions.logExpense.phrase1': 'Log a 40 euro vet bill',
+  'assistant.actions.bookAppointment.phrase1': 'Book a check-up for Milo',
+  'assistant.actions.bookAppointment.phrase2': 'Book an appointment',
+};
+
+const labelFor = (key: string): string => {
+  const label = mockPhraseLabels[key];
+  if (!label) {
+    throw new Error(`Test table is missing a label for ${key}`);
+  }
+  return label;
+};
+
+const labelsFor = (keys: readonly string[]): string[] => keys.map(labelFor);
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => mockPhraseLabels[key] ?? key,
+  }),
+}));
+
+const renderChips = (props: {onSelect?: jest.Mock; limit?: number} = {}) => {
+  const onSelect = props.onSelect ?? jest.fn();
+  const utils = render(
+    <SuggestionChips onSelect={onSelect} limit={props.limit} />,
+  );
+  return {...utils, onSelect};
+};
+
+/** The visible text of every chip, in render order. */
+const chipTexts = (
+  utils: ReturnType<typeof renderChips>,
+): (string | undefined)[] =>
+  utils
+    .getAllByRole('button')
+    .map(chip => chip.props.accessibilityLabel as string | undefined);
+
+describe('SuggestionChips', () => {
+  describe('chip source', () => {
+    it('draws its phrases from the catalogue, flattened in catalogue order', () => {
+      expect(
+        ASSISTANT_ACTIONS.flatMap(action => [...action.samplePhraseKeys]),
+      ).toEqual(ALL_PHRASE_KEYS);
+    });
+
+    it('renders four chips when the limit prop is omitted entirely', () => {
+      const {getAllByRole} = render(<SuggestionChips onSelect={jest.fn()} />);
+
+      expect(getAllByRole('button')).toHaveLength(4);
+    });
+
+    it('renders four chips when limit is passed as undefined', () => {
+      const utils = renderChips();
+
+      expect(utils.getAllByRole('button')).toHaveLength(4);
+    });
+
+    it('shows the first four sample phrases by default', () => {
+      const utils = renderChips();
+
+      expect(chipTexts(utils)).toEqual(labelsFor(ALL_PHRASE_KEYS.slice(0, 4)));
+    });
+
+    it('shows only two chips when limit is 2', () => {
+      const utils = renderChips({limit: 2});
+
+      expect(chipTexts(utils)).toEqual([
+        "When is Milo's next visit?",
+        'Next appointment',
+      ]);
+    });
+
+    it('flattens across actions with a single sample phrase when limit is 8', () => {
+      const utils = renderChips({limit: 8});
+
+      expect(chipTexts(utils)).toEqual([
+        "When is Milo's next visit?",
+        'Next appointment',
+        'Is Milo up to date on shots?',
+        'Vaccination status',
+        "What's due this week?",
+        'Upcoming tasks',
+        'Tell me about Milo',
+        'How much have I spent?',
+      ]);
+    });
+
+    it('renders no chips when limit is 0', () => {
+      const utils = renderChips({limit: 0});
+
+      expect(utils.queryAllByRole('button')).toHaveLength(0);
+      expect(utils.queryByText("When is Milo's next visit?")).toBeNull();
+    });
+
+    it('renders every sample phrase once when limit exceeds the catalogue', () => {
+      const utils = renderChips({limit: 500});
+
+      expect(chipTexts(utils)).toEqual(labelsFor(ALL_PHRASE_KEYS));
+    });
+
+    // The limit is handed straight to Array.prototype.slice, so a negative cap
+    // counts back from the end instead of capping. Pinned as the current
+    // behaviour, not endorsed: -1 widens the row to 12 chips.
+    it('counts a negative limit back from the end instead of capping', () => {
+      const utils = renderChips({limit: -1});
+
+      expect(utils.getAllByRole('button')).toHaveLength(
+        ALL_PHRASE_KEYS.length - 1,
+      );
+      expect(chipTexts(utils)).toEqual(labelsFor(ALL_PHRASE_KEYS.slice(0, -1)));
+    });
+
+    it('drops chips when the limit shrinks on a re-render', () => {
+      const onSelect = jest.fn();
+      const {getAllByRole, rerender} = render(
+        <SuggestionChips onSelect={onSelect} limit={6} />,
+      );
+      expect(getAllByRole('button')).toHaveLength(6);
+
+      rerender(<SuggestionChips onSelect={onSelect} limit={3} />);
+
+      expect(getAllByRole('button')).toHaveLength(3);
+      expect(
+        getAllByRole('button').map(c => c.props.accessibilityLabel),
+      ).toEqual([
+        "When is Milo's next visit?",
+        'Next appointment',
+        'Is Milo up to date on shots?',
+      ]);
+    });
+  });
+
+  describe('labels', () => {
+    it('renders the translated phrase, not the raw catalogue key', () => {
+      const utils = renderChips({limit: 1});
+
+      expect(utils.getByText("When is Milo's next visit?")).toBeTruthy();
+      expect(
+        utils.queryByText('assistant.actions.nextAppointment.phrase1'),
+      ).toBeNull();
+    });
+
+    it('renders one Text label per chip', () => {
+      const utils = renderChips({limit: 3});
+
+      labelsFor(ALL_PHRASE_KEYS.slice(0, 3)).forEach(label => {
+        expect(utils.getByText(label)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('selection', () => {
+    it('does not call onSelect on mount', () => {
+      const {onSelect} = renderChips();
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('calls onSelect with the pressed chip label', () => {
+      const utils = renderChips();
+
+      fireEvent.press(utils.getByText("When is Milo's next visit?"));
+
+      expect(utils.onSelect).toHaveBeenCalledTimes(1);
+      expect(utils.onSelect).toHaveBeenCalledWith("When is Milo's next visit?");
+    });
+
+    it('reports the label of the chip that was pressed, not the first one', () => {
+      const utils = renderChips();
+
+      fireEvent.press(utils.getByText('Vaccination status'));
+
+      expect(utils.onSelect).toHaveBeenCalledTimes(1);
+      expect(utils.onSelect).toHaveBeenCalledWith('Vaccination status');
+    });
+
+    it('passes the translated label rather than the catalogue key', () => {
+      const utils = renderChips({limit: 1});
+
+      fireEvent.press(utils.getAllByRole('button')[0]);
+
+      expect(utils.onSelect).toHaveBeenCalledWith("When is Milo's next visit?");
+      expect(utils.onSelect).not.toHaveBeenCalledWith(
+        'assistant.actions.nextAppointment.phrase1',
+      );
+    });
+
+    it('reports each chip separately when several are pressed', () => {
+      const utils = renderChips({limit: 4});
+
+      fireEvent.press(utils.getByText('Next appointment'));
+      fireEvent.press(utils.getByText('Is Milo up to date on shots?'));
+
+      expect(utils.onSelect.mock.calls).toEqual([
+        ['Next appointment'],
+        ['Is Milo up to date on shots?'],
+      ]);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes every chip as a button', () => {
+      const utils = renderChips({limit: 5});
+
+      const roles = utils
+        .getAllByRole('button')
+        .map(chip => chip.props.accessibilityRole);
+
+      expect(roles).toEqual(['button', 'button', 'button', 'button', 'button']);
+    });
+
+    it('labels each button with the phrase it will send', () => {
+      const utils = renderChips({limit: 3});
+
+      labelsFor(ALL_PHRASE_KEYS.slice(0, 3)).forEach(label => {
+        expect(utils.getByLabelText(label)).toBeTruthy();
+      });
+    });
+
+    it('gives the accessibility label the same text the chip displays', () => {
+      const utils = renderChips({limit: 2});
+
+      utils.getAllByRole('button').forEach(chip => {
+        expect(utils.getByLabelText(chip.props.accessibilityLabel)).toBe(chip);
+      });
+    });
+  });
+
+  describe('layout', () => {
+    it('renders a horizontal scroller with the assistant suggestions testID', () => {
+      const utils = renderChips();
+
+      const scroller = utils.getByTestId('assistant-suggestions');
+
+      expect(scroller.props.horizontal).toBe(true);
+      expect(scroller.props.showsHorizontalScrollIndicator).toBe(false);
+    });
+
+    it('spaces the row using the theme spacing scale', () => {
+      const utils = renderChips();
+
+      const containerStyle = StyleSheet.flatten(
+        utils.getByTestId('assistant-suggestions').props.contentContainerStyle,
+      );
+
+      expect(containerStyle).toMatchObject({
+        paddingHorizontal: 16,
+        gap: 8,
+        paddingBottom: 8,
+      });
+    });
+
+    it('styles each chip from the theme tokens', () => {
+      const utils = renderChips({limit: 1});
+
+      const chipStyle = StyleSheet.flatten(
+        utils.getAllByRole('button')[0].props.style,
+      );
+
+      expect(chipStyle).toMatchObject({
+        paddingVertical: 8,
+        paddingHorizontal: 16,
+        borderRadius: 9999,
+        borderWidth: 1,
+        borderColor: '#EAEAEA',
+        backgroundColor: '#FFFFFF',
+      });
+    });
+
+    it('styles the chip text with the theme label typography', () => {
+      const utils = renderChips({limit: 1});
+
+      const textStyle = StyleSheet.flatten(
+        utils.getByText("When is Milo's next visit?").props.style,
+      );
+
+      expect(textStyle).toMatchObject({
+        fontSize: 14,
+        fontWeight: '500',
+        lineHeight: 21,
+        fontFamily: 'Satoshi-Medium',
+        color: '#302F2E',
+      });
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/hooks/useAssistantSync.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/hooks/useAssistantSync.test.tsx
@@ -1,0 +1,504 @@
+/**
+ * Tests for `useAssistantSync` - the hook that keeps the OS-facing surfaces in
+ * step with the app: the debounced offline snapshot, the Android launcher
+ * shortcuts, and the deep link parked by a Siri intent or a shortcut.
+ */
+import React from 'react';
+import {AppState, Platform} from 'react-native';
+import {act, renderHook} from '@testing-library/react-native';
+import {Provider} from 'react-redux';
+import {combineReducers, configureStore} from '@reduxjs/toolkit';
+
+import {assistantReducer} from '@/features/assistant/assistantSlice';
+import {useAssistantSync} from '@/features/assistant/hooks/useAssistantSync';
+import {consumePendingLink} from '@/features/assistant/services/assistantSnapshot';
+import {getSnapshotModule} from '@/features/assistant/services/nativeBridge';
+import {refreshAssistantSnapshot} from '@/features/assistant/thunks';
+
+/** Mirrors SNAPSHOT_DEBOUNCE_MS in the hook, which is not exported. */
+const SNAPSHOT_DEBOUNCE_MS = 1500;
+const REFRESH_ACTION_TYPE = 'test/refreshAssistantSnapshot';
+const SET_DATA = 'test/setData';
+
+const mockNavigate = jest.fn();
+const mockRefreshAction = {type: REFRESH_ACTION_TYPE};
+/** Mutable stand-in for the action catalogue, refilled before every test. */
+const mockCatalogueActions: Array<Record<string, unknown>> = [];
+
+jest.mock('@react-navigation/native', () => {
+  // One stable object, so the `useCallback`/`useEffect` deps do not churn.
+  const navigation = {
+    navigate: (...args: unknown[]) => mockNavigate(...args),
+  };
+  return {useNavigation: () => navigation};
+});
+
+jest.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {useTranslation: () => ({t})};
+});
+
+jest.mock('@/features/assistant/services/assistantSnapshot', () => ({
+  consumePendingLink: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/services/nativeBridge', () => ({
+  getSnapshotModule: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/thunks', () => ({
+  refreshAssistantSnapshot: jest.fn(() => mockRefreshAction),
+}));
+
+jest.mock('@/features/assistant/actions/catalogue', () => ({
+  // A getter, because the factory runs before the const below is initialised.
+  get ASSISTANT_ACTIONS() {
+    return mockCatalogueActions;
+  },
+}));
+
+const realCatalogueActions = jest.requireActual(
+  '@/features/assistant/actions/catalogue',
+).ASSISTANT_ACTIONS as Array<Record<string, unknown>>;
+
+const mockedConsumePendingLink = consumePendingLink as jest.MockedFunction<
+  typeof consumePendingLink
+>;
+const mockedGetSnapshotModule = getSnapshotModule as jest.MockedFunction<
+  typeof getSnapshotModule
+>;
+const mockedRefreshSnapshot = refreshAssistantSnapshot as unknown as jest.Mock;
+const mockedAddEventListener =
+  AppState.addEventListener as unknown as jest.Mock;
+
+const setPlatform = (os: 'ios' | 'android') => {
+  (Platform as unknown as {OS: string}).OS = os;
+};
+
+const dataReducer =
+  <T,>(slice: string, initial: T) =>
+  (
+    state: T = initial,
+    action: {type: string; slice?: string; payload?: T},
+  ): T =>
+    action.type === SET_DATA && action.slice === slice
+      ? (action.payload as T)
+      : state;
+
+const makeStore = () => {
+  const dispatched: string[] = [];
+  const store = configureStore({
+    reducer: combineReducers({
+      assistant: assistantReducer,
+      companion: dataReducer('companion', {companions: [] as unknown[]}),
+      tasks: dataReducer('tasks', {items: [] as unknown[]}),
+      appointments: dataReducer('appointments', {items: [] as unknown[]}),
+      expenses: dataReducer('expenses', {items: [] as unknown[]}),
+      passport: dataReducer('passport', {
+        byCompanionId: {} as Record<string, unknown>,
+      }),
+    }),
+    middleware: getDefault =>
+      getDefault({serializableCheck: false}).concat(() => next => action => {
+        dispatched.push((action as {type: string}).type);
+        return next(action);
+      }),
+  });
+  return {store, dispatched};
+};
+
+const renderSync = (store: ReturnType<typeof makeStore>['store']) => {
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(() => useAssistantSync(), {wrapper});
+};
+
+/** Lets the promise chain inside `routePendingLink` settle. */
+const flushMicrotasks = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('useAssistantSync', () => {
+  let removeSubscription: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    setPlatform('ios');
+    mockCatalogueActions.length = 0;
+    mockCatalogueActions.push(...realCatalogueActions);
+    mockedConsumePendingLink.mockResolvedValue(null);
+    mockedGetSnapshotModule.mockReturnValue(null);
+    mockedRefreshSnapshot.mockReturnValue(mockRefreshAction);
+    removeSubscription = jest.fn();
+    mockedAddEventListener.mockImplementation(() => ({
+      remove: removeSubscription,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    setPlatform('ios');
+  });
+
+  describe('snapshot refresh', () => {
+    it('does not refresh the snapshot until the debounce window has elapsed', async () => {
+      const {store, dispatched} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedRefreshSnapshot).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS - 1);
+      });
+      expect(mockedRefreshSnapshot).not.toHaveBeenCalled();
+      expect(dispatched).not.toContain(REFRESH_ACTION_TYPE);
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(mockedRefreshSnapshot).toHaveBeenCalledTimes(1);
+      expect(dispatched).toContain(REFRESH_ACTION_TYPE);
+    });
+
+    it('restarts the debounce when the underlying data changes', async () => {
+      const {store, dispatched} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS - 200);
+      });
+      expect(mockedRefreshSnapshot).not.toHaveBeenCalled();
+
+      act(() => {
+        store.dispatch({
+          type: SET_DATA,
+          slice: 'tasks',
+          payload: {items: [{id: 'task-1'}]},
+        });
+      });
+
+      // The original deadline passes, but the timer was restarted by the change.
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(mockedRefreshSnapshot).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS - 200);
+      });
+      expect(mockedRefreshSnapshot).toHaveBeenCalledTimes(1);
+      expect(
+        dispatched.filter(type => type === REFRESH_ACTION_TYPE),
+      ).toHaveLength(1);
+    });
+
+    it('does not refresh a slice the hook does not watch', async () => {
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS);
+      });
+      expect(mockedRefreshSnapshot).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        store.dispatch({
+          type: SET_DATA,
+          slice: 'expenses',
+          payload: {items: [{id: 'expense-1'}]},
+        });
+      });
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS * 2);
+      });
+
+      expect(mockedRefreshSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the pending timer on unmount so the snapshot is never written', async () => {
+      const {store, dispatched} = makeStore();
+      const {unmount} = renderSync(store);
+      await flushMicrotasks();
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS - 1);
+      });
+      expect(jest.getTimerCount()).toBe(1);
+
+      act(() => {
+        unmount();
+      });
+      // The cleanup cancelled the timer rather than letting it fire late.
+      expect(jest.getTimerCount()).toBe(0);
+
+      act(() => {
+        jest.advanceTimersByTime(SNAPSHOT_DEBOUNCE_MS * 4);
+      });
+      expect(mockedRefreshSnapshot).not.toHaveBeenCalled();
+      expect(dispatched).not.toContain(REFRESH_ACTION_TYPE);
+    });
+  });
+
+  describe('Android launcher shortcuts', () => {
+    const publishShortcuts = jest.fn();
+
+    beforeEach(() => {
+      publishShortcuts.mockClear();
+    });
+
+    it('publishes the four catalogue shortcuts with their deep links on Android', async () => {
+      setPlatform('android');
+      mockedGetSnapshotModule.mockReturnValue({
+        writeSnapshot: jest.fn(),
+        clearSnapshot: jest.fn(),
+        consumePendingLink: jest.fn(),
+        publishShortcuts,
+      });
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(publishShortcuts).toHaveBeenCalledTimes(1);
+      const raw = publishShortcuts.mock.calls[0][0];
+      expect(typeof raw).toBe('string');
+      expect(JSON.parse(raw)).toEqual([
+        {
+          id: 'upcomingTasks',
+          label: 'assistant.actions.upcomingTasks.title',
+          longLabel: 'assistant.actions.upcomingTasks.description',
+          link: 'yc://app/assistant',
+        },
+        {
+          id: 'nextAppointment',
+          label: 'assistant.actions.nextAppointment.title',
+          longLabel: 'assistant.actions.nextAppointment.description',
+          link: 'yc://app/assistant',
+        },
+        {
+          id: 'addCareTask',
+          label: 'assistant.actions.addCareTask.title',
+          longLabel: 'assistant.actions.addCareTask.description',
+          link: 'yc://app/tasks/new',
+        },
+        {
+          id: 'bookAppointment',
+          label: 'assistant.actions.bookAppointment.title',
+          longLabel: 'assistant.actions.bookAppointment.description',
+          link: 'yc://app/appointments/book',
+        },
+      ]);
+    });
+
+    it('falls back to the id and the assistant link when the catalogue has no entry', async () => {
+      setPlatform('android');
+      mockCatalogueActions.length = 0;
+      mockCatalogueActions.push(
+        ...realCatalogueActions.filter(action => action.id !== 'addCareTask'),
+      );
+      mockedGetSnapshotModule.mockReturnValue({
+        writeSnapshot: jest.fn(),
+        clearSnapshot: jest.fn(),
+        consumePendingLink: jest.fn(),
+        publishShortcuts,
+      });
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      const payload = JSON.parse(publishShortcuts.mock.calls[0][0]);
+      expect(payload[2]).toEqual({
+        id: 'addCareTask',
+        label: 'addCareTask',
+        longLabel: 'addCareTask',
+        link: 'yc://app/assistant',
+      });
+      // The entries that survived in the catalogue are untouched.
+      expect(payload[3].link).toBe('yc://app/appointments/book');
+    });
+
+    it('does not publish shortcuts on iOS even when the module offers them', async () => {
+      setPlatform('ios');
+      mockedGetSnapshotModule.mockReturnValue({
+        writeSnapshot: jest.fn(),
+        clearSnapshot: jest.fn(),
+        consumePendingLink: jest.fn(),
+        publishShortcuts,
+      });
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(publishShortcuts).not.toHaveBeenCalled();
+      expect(mockedGetSnapshotModule).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on Android when the native module is absent', async () => {
+      setPlatform('android');
+      mockedGetSnapshotModule.mockReturnValue(null);
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedGetSnapshotModule).toHaveBeenCalledTimes(1);
+      expect(publishShortcuts).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on Android when the module does not expose publishShortcuts', async () => {
+      setPlatform('android');
+      mockedGetSnapshotModule.mockReturnValue({
+        writeSnapshot: jest.fn(),
+        clearSnapshot: jest.fn(),
+        consumePendingLink: jest.fn(),
+      });
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(publishShortcuts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pending handoff links', () => {
+    it('routes a pending task link through the Main navigator on mount', async () => {
+      mockedConsumePendingLink.mockResolvedValue(
+        'yc://app/tasks/new?when=2026-09-10T09:00:00Z',
+      );
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedConsumePendingLink).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('Main', {
+        screen: 'Tasks',
+        params: {screen: 'AddTask', params: {prefillDate: '2026-09-10'}},
+      });
+    });
+
+    it('uses the nested-target shape for the expenses route', async () => {
+      mockedConsumePendingLink.mockResolvedValue('yc://app/expenses/new');
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockNavigate).toHaveBeenCalledWith('Main', {
+        screen: 'HomeStack',
+        params: {screen: 'ExpensesStack', params: {screen: 'AddExpense'}},
+      });
+    });
+
+    it('does not navigate when no link is pending', async () => {
+      mockedConsumePendingLink.mockResolvedValue(null);
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedConsumePendingLink).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when the link does not resolve to a target', async () => {
+      mockedConsumePendingLink.mockResolvedValue('yc://app/not-a-real-route');
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedConsumePendingLink).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('re-checks for a pending link when the app returns to the foreground', async () => {
+      mockedConsumePendingLink.mockResolvedValue(null);
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockedAddEventListener).toHaveBeenCalledTimes(1);
+      expect(mockedAddEventListener.mock.calls[0][0]).toBe('change');
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      const onChange = mockedAddEventListener.mock.calls[0][1];
+      mockedConsumePendingLink.mockResolvedValue('yc://app/appointments/book');
+
+      await act(async () => {
+        onChange('active');
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockedConsumePendingLink).toHaveBeenCalledTimes(2);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('Main', {
+        screen: 'Appointments',
+        params: {
+          screen: 'BrowseBusinesses',
+          params: {autoFocusSearch: true},
+        },
+      });
+    });
+
+    it('ignores AppState changes that are not "active"', async () => {
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      const onChange = mockedAddEventListener.mock.calls[0][1];
+      mockedConsumePendingLink.mockResolvedValue('yc://app/assistant');
+
+      await act(async () => {
+        onChange('background');
+        onChange('inactive');
+        await Promise.resolve();
+      });
+
+      expect(mockedConsumePendingLink).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('routes the assistant link to the home stack', async () => {
+      mockedConsumePendingLink.mockResolvedValue('yc://app/assistant');
+
+      const {store} = makeStore();
+      renderSync(store);
+      await flushMicrotasks();
+
+      expect(mockNavigate).toHaveBeenCalledWith('Main', {
+        screen: 'HomeStack',
+        params: {screen: 'Assistant', params: undefined},
+      });
+    });
+
+    it('removes the AppState subscription on unmount', async () => {
+      const {store} = makeStore();
+      const {unmount} = renderSync(store);
+      await flushMicrotasks();
+
+      expect(removeSubscription).not.toHaveBeenCalled();
+
+      act(() => {
+        unmount();
+      });
+
+      expect(removeSubscription).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/hooks/useAssistantSync.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/hooks/useAssistantSync.test.tsx
@@ -25,14 +25,6 @@ const mockRefreshAction = {type: REFRESH_ACTION_TYPE};
 /** Mutable stand-in for the action catalogue, refilled before every test. */
 const mockCatalogueActions: Array<Record<string, unknown>> = [];
 
-jest.mock('@react-navigation/native', () => {
-  // One stable object, so the `useCallback`/`useEffect` deps do not churn.
-  const navigation = {
-    navigate: (...args: unknown[]) => mockNavigate(...args),
-  };
-  return {useNavigation: () => navigation};
-});
-
 jest.mock('react-i18next', () => {
   const t = (key: string) => key;
   return {useTranslation: () => ({t})};
@@ -107,11 +99,26 @@ const makeStore = () => {
   return {store, dispatched};
 };
 
-const renderSync = (store: ReturnType<typeof makeStore>['store']) => {
+/**
+ * The navigation container ref the hook is handed.
+ *
+ * One stable object so the hook's `useCallback`/`useEffect` deps do not churn
+ * between renders. `isReady` is overridable to cover a cold start that arrives
+ * before the navigator has mounted.
+ */
+const makeNavigator = (isReady = true) => ({
+  isReady: () => isReady,
+  navigate: (...args: unknown[]) => mockNavigate(...args),
+});
+
+const renderSync = (
+  store: ReturnType<typeof makeStore>['store'],
+  navigator: ReturnType<typeof makeNavigator> | null = makeNavigator(),
+) => {
   const wrapper = ({children}: {children: React.ReactNode}) => (
     <Provider store={store}>{children}</Provider>
   );
-  return renderHook(() => useAssistantSync(), {wrapper});
+  return renderHook(() => useAssistantSync(navigator), {wrapper});
 };
 
 /** Lets the promise chain inside `routePendingLink` settle. */
@@ -500,5 +507,33 @@ describe('useAssistantSync', () => {
 
       expect(removeSubscription).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('useAssistantSync navigator readiness', () => {
+  // A shortcut can cold-start the app, so a parked link may be read before the
+  // navigator exists. Dropping it beats throwing: the app still opens.
+  it('does not route a pending link when no navigator was supplied', async () => {
+    (consumePendingLink as jest.Mock).mockResolvedValue('yc://app/tasks/new');
+    const {store} = makeStore();
+    renderSync(store, null);
+    await flushMicrotasks();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not route a pending link while the navigator is not ready', async () => {
+    (consumePendingLink as jest.Mock).mockResolvedValue('yc://app/tasks/new');
+    const {store} = makeStore();
+    renderSync(store, makeNavigator(false));
+    await flushMicrotasks();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('routes once the navigator reports ready', async () => {
+    (consumePendingLink as jest.Mock).mockResolvedValue('yc://app/tasks/new');
+    const {store} = makeStore();
+    renderSync(store, makeNavigator(true));
+    await flushMicrotasks();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobileAppYC/__tests__/features/assistant/nlu/dates.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/nlu/dates.test.ts
@@ -475,3 +475,42 @@ describe('parseWhen with no date in the text', () => {
     expect(parseWhen('refill the water bowl', NOW)).toBeNull();
   });
 });
+
+describe('parseWhen same-day phrases already past', () => {
+  // A day part supplies an implied hour, so a past one is rolled forward
+  // rather than scheduling a reminder in the past.
+  const LATE = new Date(2026, 2, 3, 23, 0, 0);
+
+  it('rolls "tonight" to tomorrow when 21:00 has already passed', () => {
+    expect(localParts(parseWhen('tonight', LATE) as string)).toEqual(
+      at(2026, 2, 4, 21, 0),
+    );
+  });
+
+  it('rolls "esta noche" to tomorrow when 21:00 has already passed', () => {
+    expect(localParts(parseWhen('esta noche', LATE) as string)).toEqual(
+      at(2026, 2, 4, 21, 0),
+    );
+  });
+
+  it('keeps "tonight" on the same day while 21:00 is still ahead', () => {
+    const early = new Date(2026, 2, 3, 10, 0, 0);
+    expect(localParts(parseWhen('tonight', early) as string)).toEqual(
+      at(2026, 2, 3, 21, 0),
+    );
+  });
+
+  it('honours an explicit time on the named day even once it has passed', () => {
+    // The owner said both the day and the hour; a handoff shows the date on a
+    // form they can edit, so their words are not second-guessed.
+    expect(localParts(parseWhen('today at 8am', LATE) as string)).toEqual(
+      at(2026, 2, 3, 8, 0),
+    );
+  });
+
+  it('honours a bare "today" at the default hour even once it has passed', () => {
+    expect(localParts(parseWhen('today', LATE) as string)).toEqual(
+      at(2026, 2, 3, 9, 0),
+    );
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/nlu/dates.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/nlu/dates.test.ts
@@ -1,0 +1,477 @@
+import {parseClockTime, parseWhen} from '@/features/assistant/nlu/dates';
+
+/**
+ * Tuesday 3 March 2026, 10:00 local time. Every assertion is made against
+ * this fixed `now` so the suite never depends on the wall clock.
+ */
+const NOW = new Date(2026, 2, 3, 10, 0, 0);
+
+/**
+ * The module builds local times and hands back `toISOString()`, so results are
+ * compared by round-tripping and reading the local getters rather than by
+ * pinning a UTC literal that would only hold in one timezone.
+ */
+const localParts = (iso: string | null) => {
+  if (iso === null) {
+    throw new Error('expected an ISO timestamp, got null');
+  }
+  const parsed = new Date(iso);
+  return {
+    year: parsed.getFullYear(),
+    month: parsed.getMonth(),
+    date: parsed.getDate(),
+    hours: parsed.getHours(),
+    minutes: parsed.getMinutes(),
+    seconds: parsed.getSeconds(),
+    ms: parsed.getMilliseconds(),
+  };
+};
+
+const at = (
+  year: number,
+  month: number,
+  date: number,
+  hours: number,
+  minutes: number,
+) => ({year, month, date, hours, minutes, seconds: 0, ms: 0});
+
+describe('parseClockTime', () => {
+  it('reads a 12-hour time with a pm meridiem', () => {
+    expect(parseClockTime('8pm')).toEqual({hour: 20, minute: 0});
+  });
+
+  it('reads a 12-hour time with an am meridiem and a space', () => {
+    expect(parseClockTime('8 am')).toEqual({hour: 8, minute: 0});
+  });
+
+  it('maps 12am to midnight and 12pm to noon', () => {
+    expect(parseClockTime('12am')).toEqual({hour: 0, minute: 0});
+    expect(parseClockTime('12pm')).toEqual({hour: 12, minute: 0});
+  });
+
+  it('finds the time inside a longer sentence', () => {
+    expect(parseClockTime('give the tablet at 9 pm please')).toEqual({
+      hour: 21,
+      minute: 0,
+    });
+  });
+
+  it('reads a bare hour when it follows "at"', () => {
+    expect(parseClockTime('at 7')).toEqual({hour: 7, minute: 0});
+  });
+
+  it('does not treat a bare number as a time without "at"', () => {
+    expect(parseClockTime('give 2 tablets')).toBeNull();
+  });
+
+  it('rejects an hour above 12 in front of a meridiem', () => {
+    expect(parseClockTime('13pm')).toBeNull();
+  });
+
+  it('rejects a zero hour in front of a meridiem', () => {
+    expect(parseClockTime('0am')).toBeNull();
+  });
+
+  it('rejects a bare hour after "at" that is not a valid hour', () => {
+    expect(parseClockTime('at 25')).toBeNull();
+  });
+
+  it('returns null for text with no time in it', () => {
+    expect(parseClockTime('walk the dog')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseClockTime('')).toBeNull();
+  });
+
+  it('rejects a meridiem time whose minutes are 60 or more', () => {
+    // 8:75 is rejected outright rather than falling back to a bare 08:00.
+    expect(parseClockTime('8:75 pm')).toBeNull();
+  });
+
+  /*
+   * The separator carries the minutes, so `parseClockTime` normalises with
+   * `normalizeKeepingClock`, which folds accents and case but keeps ":" and
+   * ".". Both the minute-bearing meridiem form and the 24-hour form are read.
+   */
+  describe('minute-bearing and 24-hour times', () => {
+    it('reads the minutes from a colon-separated "8:30 pm"', () => {
+      expect(parseClockTime('8:30 pm')).toEqual({hour: 20, minute: 30});
+    });
+
+    it('reads the minutes from a dotted "8.30 pm"', () => {
+      expect(parseClockTime('8.30 pm')).toEqual({hour: 20, minute: 30});
+    });
+
+    it('reads a bare 24-hour "20:30"', () => {
+      expect(parseClockTime('20:30')).toEqual({hour: 20, minute: 30});
+    });
+
+    it('keeps the minutes in "at 7:45"', () => {
+      expect(parseClockTime('at 7:45')).toEqual({hour: 7, minute: 45});
+    });
+
+    it('reads both the minutes and the meridiem in "at 8:30 pm"', () => {
+      expect(parseClockTime('at 8:30 pm')).toEqual({hour: 20, minute: 30});
+    });
+
+    it('maps a minute-bearing 12am to just after midnight', () => {
+      expect(parseClockTime('12:30 am')).toEqual({hour: 0, minute: 30});
+    });
+
+    it('maps a minute-bearing 12pm to just after noon', () => {
+      expect(parseClockTime('12:45 pm')).toEqual({hour: 12, minute: 45});
+    });
+
+    it('reads a 24-hour hour of zero', () => {
+      expect(parseClockTime('0:30')).toEqual({hour: 0, minute: 30});
+    });
+
+    it('prefers the 24-hour reading over the bare hour after "at"', () => {
+      expect(parseClockTime('at 20:30')).toEqual({hour: 20, minute: 30});
+    });
+
+    it('falls back to the 24-hour reading when the hour is too big for a meridiem', () => {
+      // "13" cannot be a 12-hour clock hour, so the pm is ignored and the
+      // 24-hour rule supplies 13:30 rather than the whole phrase failing.
+      expect(parseClockTime('13:30 pm')).toEqual({hour: 13, minute: 30});
+    });
+
+    it('rejects a 24-hour time with an hour above 23', () => {
+      expect(parseClockTime('25:30')).toBeNull();
+    });
+
+    it('rejects a 24-hour time with minutes above 59', () => {
+      expect(parseClockTime('20:70')).toBeNull();
+    });
+  });
+});
+
+describe('parseWhen relative day words', () => {
+  it('resolves "tonight" to 21:00 today', () => {
+    expect(localParts(parseWhen('tonight', NOW))).toEqual(
+      at(2026, 2, 3, 21, 0),
+    );
+  });
+
+  it('resolves "today" to the default 09:00, even when that is already past', () => {
+    expect(localParts(parseWhen('today', NOW))).toEqual(at(2026, 2, 3, 9, 0));
+  });
+
+  it('resolves "tomorrow" to the default 09:00 the next day', () => {
+    expect(localParts(parseWhen('tomorrow', NOW))).toEqual(
+      at(2026, 2, 4, 9, 0),
+    );
+  });
+
+  it('lets an explicit time override the default hour', () => {
+    expect(localParts(parseWhen('tomorrow at 7', NOW))).toEqual(
+      at(2026, 2, 4, 7, 0),
+    );
+  });
+
+  it('carries the minutes of an explicit time onto the relative day', () => {
+    expect(localParts(parseWhen('tomorrow at 8:30 pm', NOW))).toEqual(
+      at(2026, 2, 4, 20, 30),
+    );
+  });
+
+  it('lets a day part set the hour when there is no explicit time', () => {
+    expect(localParts(parseWhen('tomorrow morning', NOW))).toEqual(
+      at(2026, 2, 4, 8, 0),
+    );
+  });
+
+  it('resolves "overmorrow" two days out', () => {
+    expect(localParts(parseWhen('overmorrow', NOW))).toEqual(
+      at(2026, 2, 5, 9, 0),
+    );
+  });
+
+  it('returns an ISO string that round-trips exactly', () => {
+    const result = parseWhen('tomorrow', NOW);
+    expect(typeof result).toBe('string');
+    expect(new Date(result as string).toISOString()).toBe(result);
+  });
+});
+
+describe('parseWhen Spanish phrases', () => {
+  it('resolves the accented "mañana" to tomorrow', () => {
+    expect(localParts(parseWhen('mañana', NOW))).toEqual(at(2026, 2, 4, 9, 0));
+  });
+
+  it('resolves the unaccented "manana" to tomorrow', () => {
+    expect(localParts(parseWhen('manana', NOW))).toEqual(at(2026, 2, 4, 9, 0));
+  });
+
+  it('resolves "hoy" to today', () => {
+    expect(localParts(parseWhen('hoy', NOW))).toEqual(at(2026, 2, 3, 9, 0));
+  });
+
+  it('does not treat a bare "esta" as today', () => {
+    expect(parseWhen('esta', NOW)).toBeNull();
+  });
+
+  it('treats "esta" as today once a day part qualifies it', () => {
+    expect(localParts(parseWhen('esta night', NOW))).toEqual(
+      at(2026, 2, 3, 21, 0),
+    );
+  });
+
+  it('resolves "esta noche" to 21:00 today', () => {
+    // DAY_PART_HOURS carries the Spanish parts of the day, so "noche" is a
+    // day part and the "esta" guard lets the relative-day branch fire.
+    expect(localParts(parseWhen('esta noche', NOW))).toEqual(
+      at(2026, 2, 3, 21, 0),
+    );
+  });
+
+  it('resolves "esta tarde" to 14:00 today', () => {
+    expect(localParts(parseWhen('esta tarde', NOW))).toEqual(
+      at(2026, 2, 3, 14, 0),
+    );
+  });
+
+  it('resolves a bare "mediodia" to noon today', () => {
+    expect(localParts(parseWhen('mediodia', NOW))).toEqual(
+      at(2026, 2, 3, 12, 0),
+    );
+  });
+
+  it('rolls "madrugada" to 06:00 tomorrow because it is already past', () => {
+    expect(localParts(parseWhen('madrugada', NOW))).toEqual(
+      at(2026, 2, 4, 6, 0),
+    );
+  });
+
+  it('lets a Spanish day part set the hour on "manana"', () => {
+    expect(localParts(parseWhen('manana por la tarde', NOW))).toEqual(
+      at(2026, 2, 4, 14, 0),
+    );
+  });
+});
+
+describe('parseWhen relative offsets', () => {
+  it('adds days for "in 3 days"', () => {
+    expect(localParts(parseWhen('in 3 days', NOW))).toEqual(
+      at(2026, 2, 6, 9, 0),
+    );
+  });
+
+  it('accepts the singular "in 1 day"', () => {
+    expect(localParts(parseWhen('in 1 day', NOW))).toEqual(
+      at(2026, 2, 4, 9, 0),
+    );
+  });
+
+  it('accepts the Spanish "in 3 dias"', () => {
+    expect(localParts(parseWhen('in 3 dias', NOW))).toEqual(
+      at(2026, 2, 6, 9, 0),
+    );
+  });
+
+  it('lets an explicit time set the hour on the offset day', () => {
+    expect(localParts(parseWhen('in 3 days at 8pm', NOW))).toEqual(
+      at(2026, 2, 6, 20, 0),
+    );
+  });
+
+  it('adds weeks for "in 2 weeks"', () => {
+    expect(localParts(parseWhen('in 2 weeks', NOW))).toEqual(
+      at(2026, 2, 17, 9, 0),
+    );
+  });
+
+  it('accepts the Spanish "in 2 semanas"', () => {
+    expect(localParts(parseWhen('in 2 semanas', NOW))).toEqual(
+      at(2026, 2, 17, 9, 0),
+    );
+  });
+
+  it('lets a day part set the hour on the offset week', () => {
+    expect(localParts(parseWhen('in 2 weeks tonight', NOW))).toEqual(
+      at(2026, 2, 17, 21, 0),
+    );
+  });
+
+  it('adds hours for "in 5 hours" and zeroes the minutes', () => {
+    expect(localParts(parseWhen('in 5 hours', NOW))).toEqual(
+      at(2026, 2, 3, 15, 0),
+    );
+  });
+
+  it('accepts the Spanish "in 2 horas"', () => {
+    expect(localParts(parseWhen('in 2 horas', NOW))).toEqual(
+      at(2026, 2, 3, 12, 0),
+    );
+  });
+
+  it('rolls past midnight for "in 20 hours"', () => {
+    expect(localParts(parseWhen('in 20 hours', NOW))).toEqual(
+      at(2026, 2, 4, 6, 0),
+    );
+  });
+
+  it('ignores a stated clock time on the hours branch', () => {
+    expect(localParts(parseWhen('in 5 hours at 8pm', NOW))).toEqual(
+      at(2026, 2, 3, 15, 0),
+    );
+  });
+
+  it('prefers days over weeks when both could match', () => {
+    expect(localParts(parseWhen('in 3 days in 2 weeks', NOW))).toEqual(
+      at(2026, 2, 6, 9, 0),
+    );
+  });
+});
+
+describe('parseWhen weekday names', () => {
+  // NOW is a Tuesday, so Friday is three days out.
+  it('resolves an English weekday to the next one ahead', () => {
+    expect(localParts(parseWhen('on friday', NOW))).toEqual(
+      at(2026, 2, 6, 9, 0),
+    );
+  });
+
+  it('resolves a Spanish weekday to the next one ahead', () => {
+    expect(localParts(parseWhen('el viernes', NOW))).toEqual(
+      at(2026, 2, 6, 9, 0),
+    );
+  });
+
+  it('folds the accent in "miércoles"', () => {
+    expect(localParts(parseWhen('miércoles', NOW))).toEqual(
+      at(2026, 2, 4, 9, 0),
+    );
+  });
+
+  it('wraps to the following week for a weekday earlier in this one', () => {
+    expect(localParts(parseWhen('on monday', NOW))).toEqual(
+      at(2026, 2, 9, 9, 0),
+    );
+  });
+
+  it('sends a weekday equal to today a full week out, never to today', () => {
+    expect(localParts(parseWhen('on tuesday', NOW))).toEqual(
+      at(2026, 2, 10, 9, 0),
+    );
+  });
+
+  it('sends the Spanish name of the current weekday a full week out too', () => {
+    expect(localParts(parseWhen('el martes', NOW))).toEqual(
+      at(2026, 2, 10, 9, 0),
+    );
+  });
+
+  it('applies an explicit time to the weekday', () => {
+    expect(localParts(parseWhen('friday 8pm', NOW))).toEqual(
+      at(2026, 2, 6, 20, 0),
+    );
+  });
+
+  it('applies a 24-hour time, minutes included, to the weekday', () => {
+    expect(localParts(parseWhen('friday 20:30', NOW))).toEqual(
+      at(2026, 2, 6, 20, 30),
+    );
+  });
+
+  it('applies a day part to the weekday', () => {
+    expect(localParts(parseWhen('friday evening', NOW))).toEqual(
+      at(2026, 2, 6, 19, 0),
+    );
+  });
+
+  it('prefers a relative day word over a weekday name', () => {
+    expect(localParts(parseWhen('tomorrow not friday', NOW))).toEqual(
+      at(2026, 2, 4, 9, 0),
+    );
+  });
+});
+
+describe('parseWhen bare clock times', () => {
+  it('keeps a time still ahead of now on today', () => {
+    expect(localParts(parseWhen('8pm', NOW))).toEqual(at(2026, 2, 3, 20, 0));
+  });
+
+  it('rolls a time already past today to tomorrow', () => {
+    expect(localParts(parseWhen('8am', NOW))).toEqual(at(2026, 2, 4, 8, 0));
+  });
+
+  it('rolls a time exactly equal to now to tomorrow', () => {
+    expect(localParts(parseWhen('at 10', NOW))).toEqual(at(2026, 2, 4, 10, 0));
+  });
+
+  it('schedules "at 8:30 pm" for 20:30 today, minutes and meridiem intact', () => {
+    expect(localParts(parseWhen('at 8:30 pm', NOW))).toEqual(
+      at(2026, 2, 3, 20, 30),
+    );
+  });
+
+  it('rolls "at 8:30 am" to 08:30 tomorrow because it is already past', () => {
+    expect(localParts(parseWhen('at 8:30 am', NOW))).toEqual(
+      at(2026, 2, 4, 8, 30),
+    );
+  });
+
+  it('keeps the minutes of a 24-hour time', () => {
+    expect(localParts(parseWhen('20:30', NOW))).toEqual(at(2026, 2, 3, 20, 30));
+  });
+});
+
+describe('parseWhen day parts with no day', () => {
+  it('keeps a day part still ahead of now on today', () => {
+    expect(localParts(parseWhen('in the evening', NOW))).toEqual(
+      at(2026, 2, 3, 19, 0),
+    );
+  });
+
+  it('resolves the afternoon to 14:00 today', () => {
+    expect(localParts(parseWhen('in the afternoon', NOW))).toEqual(
+      at(2026, 2, 3, 14, 0),
+    );
+  });
+
+  it('resolves noon to 12:00 today', () => {
+    expect(localParts(parseWhen('at noon', NOW))).toEqual(
+      at(2026, 2, 3, 12, 0),
+    );
+  });
+
+  it('rolls a day part already past today to tomorrow', () => {
+    expect(localParts(parseWhen('in the morning', NOW))).toEqual(
+      at(2026, 2, 4, 8, 0),
+    );
+  });
+
+  it('rolls midnight to the start of tomorrow', () => {
+    expect(localParts(parseWhen('midnight', NOW))).toEqual(
+      at(2026, 2, 4, 0, 0),
+    );
+  });
+
+  it('does not read "night" out of the middle of "tonight"', () => {
+    // "tonight" must resolve through the relative-day branch (today 21:00),
+    // not through a bare day part that would roll to tomorrow.
+    expect(localParts(parseWhen('tonight', NOW))).toEqual(
+      at(2026, 2, 3, 21, 0),
+    );
+  });
+});
+
+describe('parseWhen with no date in the text', () => {
+  it('returns null for an empty string', () => {
+    expect(parseWhen('', NOW)).toBeNull();
+  });
+
+  it('returns null for punctuation that normalises away', () => {
+    expect(parseWhen('   !!!  ', NOW)).toBeNull();
+  });
+
+  it('returns null for a quantity that is not a time', () => {
+    expect(parseWhen('give 2 tablets', NOW)).toBeNull();
+  });
+
+  it('returns null for an ordinary sentence', () => {
+    expect(parseWhen('refill the water bowl', NOW)).toBeNull();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/nlu/normalize.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/nlu/normalize.test.ts
@@ -1,0 +1,56 @@
+import {
+  containsPhrase,
+  normalizeText,
+  tokenize,
+} from '@/features/assistant/nlu/normalize';
+
+describe('normalizeText', () => {
+  it('lower-cases and strips punctuation', () => {
+    expect(normalizeText("Bruno's VACCINE!")).toBe('bruno s vaccine');
+  });
+
+  it('folds accents so Spanish reaches the same keyword table', () => {
+    expect(normalizeText('¿Cuándo es la próxima vacuna?')).toBe(
+      'cuando es la proxima vacuna',
+    );
+  });
+
+  it('collapses runs of separators and trims', () => {
+    expect(normalizeText('  a --- b  ')).toBe('a b');
+  });
+
+  it('returns an empty string for punctuation only', () => {
+    expect(normalizeText('!!!')).toBe('');
+  });
+});
+
+describe('tokenize', () => {
+  it('splits into words', () => {
+    expect(tokenize('when is the vet')).toEqual(['when', 'is', 'the', 'vet']);
+  });
+
+  it('returns an empty array rather than one empty token', () => {
+    expect(tokenize('   ')).toEqual([]);
+  });
+});
+
+describe('containsPhrase', () => {
+  it('matches words in order with gaps between them', () => {
+    expect(
+      containsPhrase(
+        ['when', 'is', 'the', 'next', 'vaccine'],
+        ['when', 'vaccine'],
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects words that appear out of order', () => {
+    expect(containsPhrase(['vaccine', 'when'], ['when', 'vaccine'])).toBe(
+      false,
+    );
+  });
+
+  it('rejects an empty phrase', () => {
+    expect(containsPhrase(['a'], [])).toBe(false);
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/nlu/parser.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/nlu/parser.test.ts
@@ -1,0 +1,661 @@
+import {
+  extractTaskTitle,
+  matchPetName,
+  parseAmount,
+  parseUtterance,
+} from '@/features/assistant/nlu/parser';
+import {
+  BARE_NAME_CONFIDENCE,
+  RULES_CONFIDENCE_THRESHOLD,
+} from '@/features/assistant/constants';
+
+/** Thursday 15 January 2026, 10:30 local time. */
+const NOW = new Date(2026, 0, 15, 10, 30, 0, 0);
+const at = (
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour: number,
+  minute = 0,
+): string => new Date(year, monthIndex, day, hour, minute, 0, 0).toISOString();
+
+describe('matchPetName', () => {
+  it('finds a single-word name anywhere in the utterance', () => {
+    expect(matchPetName('when is the vaccine for Bruno?', ['Bruno'])).toBe(
+      'Bruno',
+    );
+  });
+
+  it('returns the name as spelled in the list, not as typed', () => {
+    expect(matchPetName('WHERE IS bruno', ['Bruno'])).toBe('Bruno');
+  });
+
+  it('matches across accents so an unaccented typing still finds the pet', () => {
+    expect(matchPetName('how is Oceane doing', ['Océane'])).toBe('Océane');
+    expect(matchPetName('¿cómo está Océane?', ['Océane'])).toBe('Océane');
+  });
+
+  it('prefers the longest name so "Bella Rose" beats "Bella"', () => {
+    expect(
+      matchPetName('book a visit for Bella Rose', ['Bella', 'Bella Rose']),
+    ).toBe('Bella Rose');
+  });
+
+  it('falls back to the short name when the two-word name is absent', () => {
+    expect(
+      matchPetName('book a visit for Bella', ['Bella', 'Bella Rose']),
+    ).toBe('Bella');
+  });
+
+  it('requires both words of a two-word name to be present', () => {
+    expect(matchPetName('how is Bella', ['Bella Rose'])).toBeUndefined();
+  });
+
+  it('matches a two-word name only on token boundaries', () => {
+    expect(
+      matchPetName('Isabella Rosewood came in today', ['Bella Rose']),
+    ).toBeUndefined();
+    expect(
+      matchPetName('this is Bella Rosewood', ['Bella Rose']),
+    ).toBeUndefined();
+    expect(matchPetName('this is Bella Rose', ['Bella Rose'])).toBe(
+      'Bella Rose',
+    );
+  });
+
+  it('does not treat "max" as a pet when it is not in the list', () => {
+    expect(matchPetName('give the max dose today', ['Bruno'])).toBeUndefined();
+  });
+
+  it('does treat "Max" as a pet when it IS in the list', () => {
+    expect(matchPetName('give the max dose today', ['Max'])).toBe('Max');
+  });
+
+  it('returns undefined when the utterance has no word characters', () => {
+    expect(matchPetName('   ???   ', ['Bruno'])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty pet list', () => {
+    expect(matchPetName('how is Bruno', [])).toBeUndefined();
+  });
+
+  it('skips a blank name in the list rather than matching everything', () => {
+    expect(matchPetName('hello world', ['', 'Bruno'])).toBeUndefined();
+  });
+});
+
+describe('parseAmount', () => {
+  it('reads a bare integer', () => {
+    expect(parseAmount('spent 45 at the vet')).toBe(45);
+  });
+
+  it('reads a currency-prefixed amount', () => {
+    expect(parseAmount('$45')).toBe(45);
+    expect(parseAmount('£20 for the vet')).toBe(20);
+  });
+
+  it('reads a decimal point', () => {
+    expect(parseAmount('45.50')).toBe(45.5);
+  });
+
+  it('reads a decimal comma as a decimal point', () => {
+    expect(parseAmount('12,50')).toBe(12.5);
+    expect(parseAmount('€12,50')).toBe(12.5);
+  });
+
+  it('rejects zero', () => {
+    expect(parseAmount('spent 0 today')).toBeUndefined();
+  });
+
+  it('rejects text with no digits at all', () => {
+    expect(parseAmount('spent nothing on Bruno')).toBeUndefined();
+    expect(parseAmount('')).toBeUndefined();
+  });
+
+  it('rejects a negative amount', () => {
+    expect(parseAmount('spent -5')).toBeUndefined();
+    expect(parseAmount('-12.50')).toBeUndefined();
+    expect(parseAmount('- 5')).toBeUndefined();
+  });
+
+  it('takes the first number in the string', () => {
+    expect(parseAmount('room 101 cost 45')).toBe(101);
+  });
+
+  it('keeps only two decimals of a longer fraction', () => {
+    expect(parseAmount('$45.999')).toBe(45.99);
+  });
+
+  it('reads a thousands separator as a whole number', () => {
+    expect(parseAmount('spent 1,234')).toBe(1234);
+    expect(parseAmount('$1,234.50')).toBe(1234.5);
+  });
+});
+
+describe('extractTaskTitle', () => {
+  it('drops the lead-in, the pet name and the time phrase', () => {
+    expect(
+      extractTaskTitle(
+        'remind me to give Bruno his heart pill tonight',
+        'Bruno',
+      ),
+    ).toBe('give his heart pill');
+  });
+
+  it('keeps the whole phrase after "to" when there is no pet name', () => {
+    expect(extractTaskTitle('remind me to walk the dog', undefined)).toBe(
+      'walk the dog',
+    );
+  });
+
+  it('strips the pet name case-insensitively', () => {
+    expect(extractTaskTitle('remind me to brush BRUNO', 'Bruno')).toBe('brush');
+  });
+
+  it('uses the whole utterance when there is no "to", "para" or "que"', () => {
+    expect(extractTaskTitle('reminder: feed the cat', undefined)).toBe(
+      'reminder: feed the cat',
+    );
+  });
+
+  it('splits on the Spanish "para"', () => {
+    expect(
+      extractTaskTitle('recordatorio para cepillar a Bruno hoy', 'Bruno'),
+    ).toBe('cepillar a');
+  });
+
+  it('splits on the Spanish "que"', () => {
+    expect(extractTaskTitle('recuérdame que dar la medicina', undefined)).toBe(
+      'dar la medicina',
+    );
+  });
+
+  it.each([
+    ['remind me to book the groomer in 3 days', 'book the groomer'],
+    ['remind me to trim the claws on Friday', 'trim the claws'],
+    ['remind me to give the pill at 8pm', 'give the pill'],
+    ['remind me to walk him this morning', 'walk him'],
+    ['remind me to feed her tomorrow', 'feed her'],
+    ['remind me to weigh him today', 'weigh him'],
+  ])('strips the time phrase from %s', (text, expected) => {
+    expect(extractTaskTitle(text, undefined)).toBe(expected);
+  });
+
+  it('strips an accented Spanish time phrase', () => {
+    expect(
+      extractTaskTitle('recuérdame dar la pastilla mañana', undefined),
+    ).toBe('recuérdame dar la pastilla');
+    expect(
+      extractTaskTitle('recuérdame dar la pastilla esta mañana', undefined),
+    ).toBe('recuérdame dar la pastilla');
+  });
+
+  it('strips a pet name carrying regex metacharacters', () => {
+    expect(extractTaskTitle('remind me to groom C++ tonight', 'C++')).toBe(
+      'groom',
+    );
+    expect(extractTaskTitle('remind me to brush Mr. B tonight', 'Mr. B')).toBe(
+      'brush',
+    );
+  });
+
+  it('strips a short pet name only on whole words, not inside a longer one', () => {
+    expect(extractTaskTitle('remind me to call Alice about Al', 'Al')).toBe(
+      'call Alice about',
+    );
+  });
+
+  it('returns undefined when only the pet name and a time phrase remain', () => {
+    expect(
+      extractTaskTitle('remind me to Bruno tonight', 'Bruno'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when a single character is left', () => {
+    expect(extractTaskTitle('remind me to x', undefined)).toBeUndefined();
+  });
+});
+
+describe('parseUtterance routing', () => {
+  const petNames = ['Bruno'];
+
+  it.each([
+    ['Book a vet visit for Bruno', 'bookAppointment'],
+    ['Schedule an appointment for Bruno', 'bookAppointment'],
+    ['Make an appointment', 'bookAppointment'],
+    ['remind me to give Bruno his pill', 'addCareTask'],
+    ['set a reminder for the flea drops', 'addCareTask'],
+    ['add a task for the groomer', 'addCareTask'],
+    ['create a task for the groomer', 'addCareTask'],
+    ['add medication for Bruno', 'addCareTask'],
+    ['log expense 45 for Bruno', 'logExpense'],
+    ['add expense 45', 'logExpense'],
+    ['record expense 45', 'logExpense'],
+    ['I spent 45 at the vet', 'logExpense'],
+    ['Is Bruno vaccinated?', 'vaccinationStatus'],
+    ['when is the next vaccine', 'vaccinationStatus'],
+    ['which vaccines does Bruno need', 'vaccinationStatus'],
+    ['is the vaccination up to date', 'vaccinationStatus'],
+    ['are the shots up to date', 'vaccinationStatus'],
+    ['does he need a jab', 'vaccinationStatus'],
+    ['Show my total expenses', 'expenseSummary'],
+    ['what are my expenses', 'expenseSummary'],
+    ['how is my spending', 'expenseSummary'],
+    ['When is the next appointment for Bruno?', 'nextAppointment'],
+    ['do we have an appointment', 'nextAppointment'],
+    ['when is the vet visit', 'nextAppointment'],
+    ['when should Bruno see the vet', 'nextAppointment'],
+    ['what tasks are due today', 'upcomingTasks'],
+    ['what is on the care plan', 'upcomingTasks'],
+    ['what is on my todo list', 'upcomingTasks'],
+    ['tell me about Bruno', 'petOverview'],
+    ['show the overview', 'petOverview'],
+    ['open the profile', 'petOverview'],
+    ['How is Bruno doing?', 'petOverview'],
+  ])('routes the English phrase %s to %s', (text, actionId) => {
+    expect(parseUtterance(text, {petNames, now: NOW})?.actionId).toBe(actionId);
+  });
+
+  it.each([
+    ['¿Puedes reservar una cita con el veterinario?', 'bookAppointment'],
+    ['agendar una cita', 'bookAppointment'],
+    ['Pedir cita para Bruno', 'bookAppointment'],
+    ['Recuérdame dar la medicina hoy', 'addCareTask'],
+    ['crear un recordatorio', 'addCareTask'],
+    ['añadir una tarea', 'addCareTask'],
+    ['Registrar un gasto de 30 euros', 'logExpense'],
+    ['¿Bruno tiene las vacunas al día?', 'vaccinationStatus'],
+    ['¿cuándo es la vacuna?', 'vaccinationStatus'],
+    ['¿cuánto he gastado?', 'expenseSummary'],
+    ['resumen de gastos', 'expenseSummary'],
+    ['¿Cuándo es la próxima cita?', 'nextAppointment'],
+    ['¿Qué tareas tengo pendientes?', 'upcomingTasks'],
+    ['tengo algo pendiente', 'upcomingTasks'],
+    ['Resumen de Bruno', 'petOverview'],
+    ['ver el perfil', 'petOverview'],
+  ])('routes the Spanish phrase %s to %s', (text, actionId) => {
+    expect(parseUtterance(text, {petNames, now: NOW})?.actionId).toBe(actionId);
+  });
+
+  it('tags every rules answer with the rules source', () => {
+    expect(parseUtterance('book an appointment')?.source).toBe('rules');
+  });
+});
+
+describe('parseUtterance rule order', () => {
+  it('routes "book an appointment" to bookAppointment, not nextAppointment', () => {
+    expect(parseUtterance('book an appointment', {now: NOW})).toEqual({
+      actionId: 'bookAppointment',
+      slots: {},
+      confidence: 0.737,
+      source: 'rules',
+    });
+  });
+
+  it('routes "pedir cita" to bookAppointment, not nextAppointment', () => {
+    expect(parseUtterance('Pedir cita para Bruno', {now: NOW})?.actionId).toBe(
+      'bookAppointment',
+    );
+  });
+
+  it('routes "schedule an appointment" to bookAppointment', () => {
+    expect(
+      parseUtterance('Schedule an appointment for Bruno', {now: NOW})?.actionId,
+    ).toBe('bookAppointment');
+  });
+
+  it('routes "add a task" to addCareTask, not upcomingTasks', () => {
+    expect(
+      parseUtterance('add a task for the groomer', {now: NOW})?.actionId,
+    ).toBe('addCareTask');
+  });
+
+  it('routes "add expense" to logExpense, not expenseSummary', () => {
+    expect(parseUtterance('add expense 45', {now: NOW})?.actionId).toBe(
+      'logExpense',
+    );
+  });
+
+  it('routes "how much have I spent" to expenseSummary, the read action', () => {
+    expect(
+      parseUtterance('How much have I spent on Bruno?', {now: NOW}),
+    ).toEqual({
+      actionId: 'expenseSummary',
+      slots: {},
+      confidence: 0.996,
+      source: 'rules',
+    });
+  });
+
+  it.each([
+    ['log an expense', undefined],
+    ['add an expense', undefined],
+    ['record an expense', undefined],
+    ['I spent 45 on food', 45],
+  ])('still routes %s to logExpense', (text, amount) => {
+    const parsed = parseUtterance(text, {now: NOW});
+    expect(parsed?.actionId).toBe('logExpense');
+    expect(parsed?.slots.amount).toBe(amount);
+  });
+
+  it('routes "remind me about the vaccine" to addCareTask, not vaccinationStatus', () => {
+    expect(
+      parseUtterance('remind me about the vaccine', {now: NOW})?.actionId,
+    ).toBe('addCareTask');
+  });
+});
+
+describe('parseUtterance slots', () => {
+  it('fills petName and when for a booking', () => {
+    expect(
+      parseUtterance('Book a vet appointment for Bella Rose tomorrow at 3pm', {
+        petNames: ['Bella', 'Bella Rose'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'bookAppointment',
+      slots: {petName: 'Bella Rose', when: at(2026, 0, 16, 15)},
+      confidence: 0.69,
+      source: 'rules',
+    });
+  });
+
+  it('fills petName, when and title for a reminder', () => {
+    expect(
+      parseUtterance('remind me to give Bruno his heart pill tonight', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'addCareTask',
+      slots: {
+        petName: 'Bruno',
+        when: at(2026, 0, 15, 21),
+        title: 'give his heart pill',
+      },
+      confidence: 0.692,
+      source: 'rules',
+    });
+  });
+
+  it('fills when and title for a Spanish reminder with no pet named', () => {
+    expect(
+      parseUtterance('Recuérdame dar la medicina hoy', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'addCareTask',
+      slots: {when: at(2026, 0, 15, 9), title: 'Recuérdame dar la medicina'},
+      confidence: 0.71,
+      source: 'rules',
+    });
+  });
+
+  it('leaves title unset when nothing survives the stripping', () => {
+    expect(
+      parseUtterance('remind me to Bruno tonight', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'addCareTask',
+      slots: {petName: 'Bruno', when: at(2026, 0, 15, 21)},
+      confidence: 0.71,
+      source: 'rules',
+    });
+  });
+
+  it('does not fill petName from a word that is not a known pet', () => {
+    expect(
+      parseUtterance('remind me to give Max his dose today', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'addCareTask',
+      slots: {when: at(2026, 0, 15, 9), title: 'give Max his dose'},
+      confidence: 0.695,
+      source: 'rules',
+    });
+  });
+
+  it('parses a pet name carrying regex metacharacters without throwing', () => {
+    const parse = () =>
+      parseUtterance('remind me to give C++ his pill tonight', {
+        petNames: ['C++'],
+        now: NOW,
+      });
+
+    expect(parse).not.toThrow();
+    expect(parse()).toEqual({
+      actionId: 'addCareTask',
+      slots: {
+        petName: 'C++',
+        when: at(2026, 0, 15, 21),
+        title: 'give his pill',
+      },
+      confidence: 0.695,
+      source: 'rules',
+    });
+  });
+
+  it('parses a pet name containing a full stop without throwing', () => {
+    const parse = () =>
+      parseUtterance('remind me to brush Mr. B tomorrow', {
+        petNames: ['Mr. B'],
+        now: NOW,
+      });
+
+    expect(parse).not.toThrow();
+    expect(parse()).toEqual({
+      actionId: 'addCareTask',
+      slots: {
+        petName: 'Mr. B',
+        when: at(2026, 0, 16, 9),
+        title: 'brush',
+      },
+      confidence: 0.699,
+      source: 'rules',
+    });
+  });
+
+  it('fills petName and amount for an expense', () => {
+    expect(
+      parseUtterance('log expense $45 for Bruno', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'logExpense',
+      slots: {petName: 'Bruno', amount: 45},
+      confidence: 0.87,
+      source: 'rules',
+    });
+  });
+
+  it('leaves amount unset when the expense carries no number', () => {
+    expect(
+      parseUtterance('log expense for Bruno', {petNames: ['Bruno'], now: NOW}),
+    ).toEqual({
+      actionId: 'logExpense',
+      slots: {petName: 'Bruno'},
+      confidence: 0.89,
+      source: 'rules',
+    });
+  });
+
+  it('fills amount for a Spanish expense', () => {
+    expect(
+      parseUtterance('Registrar un gasto de 30 euros', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'logExpense',
+      slots: {amount: 30},
+      confidence: 0.703,
+      source: 'rules',
+    });
+  });
+
+  it('does not fill title or amount for a read action', () => {
+    expect(
+      parseUtterance('what tasks are due today', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'upcomingTasks',
+      slots: {when: at(2026, 0, 15, 9)},
+      confidence: 0.71,
+      source: 'rules',
+    });
+  });
+
+  it('leaves when unset when the utterance carries no date', () => {
+    expect(
+      parseUtterance('Is Bruno vaccinated?', {petNames: ['Bruno'], now: NOW}),
+    ).toEqual({
+      actionId: 'vaccinationStatus',
+      slots: {petName: 'Bruno'},
+      confidence: 0.737,
+      source: 'rules',
+    });
+  });
+
+  it('matches the pet in a Spanish question', () => {
+    expect(
+      parseUtterance('¿Bruno tiene las vacunas al día?', {
+        petNames: ['Bruno'],
+        now: NOW,
+      }),
+    ).toEqual({
+      actionId: 'vaccinationStatus',
+      slots: {petName: 'Bruno'},
+      confidence: 0.703,
+      source: 'rules',
+    });
+  });
+
+  it('defaults now to the current clock when no options are passed', () => {
+    const parsed = parseUtterance('remind me to feed him tomorrow');
+    const expected = new Date();
+    expected.setDate(expected.getDate() + 1);
+    expected.setHours(9, 0, 0, 0);
+
+    expect(parsed).toEqual({
+      actionId: 'addCareTask',
+      slots: {when: expected.toISOString(), title: 'feed him'},
+      confidence: 0.703,
+      source: 'rules',
+    });
+  });
+});
+
+describe('parseUtterance confidence', () => {
+  it('scores a one-keyword hit in a long sentence lower than in a short one', () => {
+    const long = parseUtterance(
+      'Book a vet appointment for Bella Rose tomorrow at 3pm',
+      {petNames: ['Bella Rose'], now: NOW},
+    );
+    const short = parseUtterance('book an appointment', {now: NOW});
+
+    expect(long?.confidence).toBe(0.69);
+    expect(short?.confidence).toBe(0.737);
+  });
+
+  it('scores a three-keyword hit that explains the whole sentence at the ceiling of 1', () => {
+    expect(parseUtterance('tell me about', {now: NOW})?.confidence).toBe(1);
+  });
+
+  it('keeps every confidence inside (0, 1]', () => {
+    const phrases = [
+      'book an appointment',
+      'remind me to give the pill tonight',
+      'log expense 45',
+      'Is Bruno vaccinated?',
+      'Show my total expenses',
+      'When is the next appointment?',
+      'what tasks are due today',
+      'tell me about Bruno',
+    ];
+
+    const confidences = phrases.map(
+      phrase =>
+        parseUtterance(phrase, {petNames: ['Bruno'], now: NOW})?.confidence,
+    );
+
+    expect(confidences).toEqual([
+      0.737, 0.699, 0.923, 0.737, 0.89, 0.87, 0.71, 1,
+    ]);
+    confidences.forEach(confidence => {
+      expect(confidence).toBeGreaterThan(0);
+      expect(confidence).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe('parseUtterance fallbacks', () => {
+  it('reads a bare known pet name as a request for that pet overview', () => {
+    expect(parseUtterance('Bruno?', {petNames: ['Bruno'], now: NOW})).toEqual({
+      actionId: 'petOverview',
+      slots: {petName: 'Bruno'},
+      confidence: BARE_NAME_CONFIDENCE,
+      source: 'rules',
+    });
+  });
+
+  it('allows stopwords around the bare pet name', () => {
+    expect(parseUtterance('my Bruno', {petNames: ['Bruno'], now: NOW})).toEqual(
+      {
+        actionId: 'petOverview',
+        slots: {petName: 'Bruno'},
+        confidence: BARE_NAME_CONFIDENCE,
+        source: 'rules',
+      },
+    );
+  });
+
+  it('reads a bare two-word pet name as an overview too', () => {
+    expect(
+      parseUtterance('Bella Rose', {petNames: ['Bella Rose'], now: NOW}),
+    ).toEqual({
+      actionId: 'petOverview',
+      slots: {petName: 'Bella Rose'},
+      confidence: BARE_NAME_CONFIDENCE,
+      source: 'rules',
+    });
+  });
+
+  it('scores the bare-name guess below the rules threshold so the model can overrule it', () => {
+    const parsed = parseUtterance('Bruno?', {petNames: ['Bruno'], now: NOW});
+
+    expect(parsed?.confidence).toBe(BARE_NAME_CONFIDENCE);
+    expect(parsed?.confidence).toBeLessThan(RULES_CONFIDENCE_THRESHOLD);
+  });
+
+  it('returns null when the pet name is buried in words the parser cannot explain', () => {
+    expect(
+      parseUtterance('Bruno barks loudly', {petNames: ['Bruno'], now: NOW}),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'whitespace'],
+    ['!!!', 'punctuation only'],
+  ])('returns null for %s input (%s)', text => {
+    expect(parseUtterance(text, {petNames: ['Bruno'], now: NOW})).toBeNull();
+  });
+
+  it('returns null for gibberish', () => {
+    expect(
+      parseUtterance('asdfgh qwerty zxcvb', {petNames: ['Bruno'], now: NOW}),
+    ).toBeNull();
+  });
+
+  it('returns null when a known keyword is absent and no pet is known', () => {
+    expect(parseUtterance('hello there', {now: NOW})).toBeNull();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/screens/AssistantScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/screens/AssistantScreen.test.tsx
@@ -1,0 +1,548 @@
+/**
+ * Tests for `AssistantScreen` - the in-app assistant surface.
+ *
+ * The turn loop itself is covered by the thunk tests, so `askAssistant` and
+ * `probeOnDeviceModel` are replaced with plain action creators here. What this
+ * file owns is the wiring the screen adds on top: what reaches the store, what
+ * the transcript renders, and where a handoff card sends the user.
+ */
+import React from 'react';
+import {KeyboardAvoidingView, Platform} from 'react-native';
+import {act, fireEvent, render} from '@testing-library/react-native';
+import {Provider} from 'react-redux';
+import {configureStore} from '@reduxjs/toolkit';
+
+// Path: 3 levels up to __tests__, then into setup (also remapped by jest config).
+import {mockTheme} from '../../../setup/mockTheme';
+import {
+  assistantReducer,
+  turnFailed,
+  type AssistantState,
+} from '@/features/assistant/assistantSlice';
+import type {
+  AssistantActionResult,
+  AssistantMessage,
+} from '@/features/assistant/types';
+import {askAssistant, probeOnDeviceModel} from '@/features/assistant/thunks';
+import {AssistantScreen} from '@/features/assistant/screens/AssistantScreen/AssistantScreen';
+import {Images} from '@/assets/images';
+
+const ASK_ACTION = 'test/askAssistant';
+const PROBE_ACTION = 'test/probeOnDeviceModel';
+
+/**
+ * Distinct, human-looking copy for every key the screen and its children ask
+ * for, so an assertion on rendered text can only pass if the value went
+ * through t() - a component that leaked the raw key would read differently.
+ */
+const mockTranslations: Record<string, string> = {
+  'assistant.title': 'Assistant',
+  'assistant.clear': 'Clear conversation',
+  'assistant.emptyTitle': 'Ask about your pets',
+  'assistant.emptyBody': 'Try one of the suggestions below.',
+  'assistant.composerPlaceholder': 'Ask anything',
+  'assistant.send': 'Send',
+  'assistant.open.addCareTask': 'Open the task form',
+  'assistant.open.logExpense': 'Open the expense form',
+  'assistant.open.bookAppointment': 'Find a clinic',
+  'assistant.model.unsupportedDevice': 'This iPhone has no on-device model.',
+  'assistant.model.provider': 'on-device AI',
+  'assistant.actions.nextAppointment.phrase1': "When is Milo's next visit?",
+  'assistant.actions.nextAppointment.phrase2': 'Next appointment',
+  'assistant.actions.vaccinationStatus.phrase1': 'Is Milo up to date on shots?',
+  'assistant.actions.vaccinationStatus.phrase2': 'Vaccination status',
+};
+
+/** Stable identity, so the screen's `useCallback` deps do not churn and the
+ * dispatched payload can be asserted against this exact function. */
+const mockT = (key: string): string => mockTranslations[key] ?? key;
+
+const mockGoBack = jest.fn();
+const mockOwnNavigate = jest.fn();
+const mockParentNavigate = jest.fn();
+let mockParent: {navigate: jest.Mock} | undefined;
+/** One stable object: `handleOpen` closes over `navigation`. */
+const mockNavigation = {
+  goBack: mockGoBack,
+  navigate: mockOwnNavigate,
+  getParent: () => mockParent,
+};
+let mockCurrency = 'EUR';
+
+/**
+ * Every asset key resolves to its own marker. The png module map otherwise
+ * collapses all assets to a single shared stub, which would let an assertion
+ * on `Images.closeIcon` pass for any icon at all.
+ */
+jest.mock('@/assets/images', () => ({
+  Images: new Proxy(
+    {},
+    {get: (_target, key: string | symbol) => `image:${String(key)}`},
+  ),
+}));
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({t: mockT}),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+jest.mock('@/shared/hooks/useResolvedUserCurrency', () => ({
+  useResolvedUserCurrency: () => mockCurrency,
+}));
+
+jest.mock('@/shared/components/common/Header/Header', () => {
+  const RN = require('react-native');
+  const ReactLocal = require('react');
+  // Mirrors the real Header: the right-hand slot is rendered only when an
+  // icon is supplied, so `rightIcon: undefined` is observable as an absent
+  // control no matter what `onRightPress` holds. The icon source is exposed
+  // on `header-right-icon` so the screen's choice of glyph can be asserted.
+  return {
+    Header: ({
+      title,
+      onBack,
+      rightIcon,
+      onRightPress,
+      rightAccessibilityLabel,
+    }: {
+      title?: string;
+      onBack?: () => void;
+      rightIcon?: unknown;
+      onRightPress?: () => void;
+      rightAccessibilityLabel?: string;
+    }) =>
+      ReactLocal.createElement(
+        RN.View,
+        {testID: 'header'},
+        ReactLocal.createElement(RN.Text, {testID: 'header-title'}, title),
+        ReactLocal.createElement(
+          RN.Text,
+          {testID: 'header-back', onPress: onBack},
+          'back',
+        ),
+        rightIcon
+          ? ReactLocal.createElement(
+              RN.View,
+              {testID: 'header-right-slot'},
+              ReactLocal.createElement(RN.Image, {
+                testID: 'header-right-icon',
+                source: rightIcon,
+              }),
+              ReactLocal.createElement(
+                RN.Text,
+                {
+                  testID: 'header-right',
+                  accessibilityLabel: rightAccessibilityLabel,
+                  onPress: onRightPress,
+                },
+                'clear',
+              ),
+            )
+          : null,
+      ),
+  };
+});
+
+jest.mock('@/features/assistant/thunks', () => ({
+  askAssistant: jest.fn((args: unknown) => ({
+    type: 'test/askAssistant',
+    payload: args,
+  })),
+  probeOnDeviceModel: jest.fn(() => ({type: 'test/probeOnDeviceModel'})),
+}));
+
+const mockedAsk = askAssistant as unknown as jest.Mock;
+const mockedProbe = probeOnDeviceModel as unknown as jest.Mock;
+
+const userMessage: AssistantMessage = {
+  id: 'm1',
+  author: 'user',
+  text: 'When is Milo due for his booster?',
+  createdAt: '2026-03-01T10:00:00.000Z',
+};
+
+const assistantMessage: AssistantMessage = {
+  id: 'm2',
+  author: 'assistant',
+  text: 'Milo is due on 4 March.',
+  createdAt: '2026-03-01T10:00:01.000Z',
+};
+
+const listResult: AssistantActionResult = {
+  actionId: 'upcomingTasks',
+  status: 'ok',
+  speechKey: 'assistant.results.upcomingTasks.ok',
+  data: {
+    items: [
+      {id: 'i1', title: 'Give Milo his pill', subtitle: 'Friday, 9:00'},
+      {id: 'i2', title: 'Weigh Nala', subtitle: 'Saturday, 8:00'},
+    ],
+  },
+};
+
+const handoffMessage = (
+  deepLink: string,
+  actionId: AssistantActionResult['actionId'] = 'addCareTask',
+): AssistantMessage => ({
+  id: 'm3',
+  author: 'assistant',
+  text: 'I can open the task form for you.',
+  createdAt: '2026-03-01T10:00:02.000Z',
+  result: {
+    actionId,
+    status: 'handoff',
+    speechKey: 'assistant.results.addCareTask.handoff',
+    deepLink,
+  },
+});
+
+const baseState: AssistantState = {
+  messages: [],
+  status: 'idle',
+  error: null,
+  // Available by default so the status banner stays out of the way; the banner
+  // gets its own test.
+  modelAvailability: {available: true},
+  enabled: true,
+  availabilityChecked: true,
+};
+
+const renderScreen = (overrides: Partial<AssistantState> = {}) => {
+  const dispatched: string[] = [];
+  const store = configureStore({
+    reducer: {assistant: assistantReducer},
+    preloadedState: {assistant: {...baseState, ...overrides}},
+    middleware: getDefault =>
+      getDefault({serializableCheck: false}).concat(() => next => action => {
+        dispatched.push((action as {type: string}).type);
+        return next(action);
+      }),
+  });
+  const utils = render(
+    <Provider store={store}>
+      <AssistantScreen />
+    </Provider>,
+  );
+  return {...utils, store, dispatched};
+};
+
+const originalPlatformOS = Platform.OS;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockParent = {navigate: mockParentNavigate};
+  mockCurrency = 'EUR';
+});
+
+afterEach(() => {
+  (Platform as unknown as {OS: string}).OS = originalPlatformOS;
+});
+
+describe('AssistantScreen transcript', () => {
+  it('shows the empty state and no bubbles when the transcript is empty', () => {
+    const {getByTestId, getByText, queryByTestId} = renderScreen();
+
+    expect(getByTestId('assistant-empty')).toBeTruthy();
+    expect(getByText('Ask about your pets')).toBeTruthy();
+    expect(getByText('Try one of the suggestions below.')).toBeTruthy();
+    expect(queryByTestId('assistant-bubble-user')).toBeNull();
+    expect(queryByTestId('assistant-bubble-assistant')).toBeNull();
+  });
+
+  it('renders each message as a bubble authored by its sender', () => {
+    const {getAllByTestId, getByText, queryByTestId} = renderScreen({
+      messages: [userMessage, assistantMessage],
+    });
+
+    expect(queryByTestId('assistant-empty')).toBeNull();
+    expect(getAllByTestId('assistant-bubble-user')).toHaveLength(1);
+    expect(getAllByTestId('assistant-bubble-assistant')).toHaveLength(1);
+    expect(getByText('When is Milo due for his booster?')).toBeTruthy();
+    expect(getByText('Milo is due on 4 March.')).toBeTruthy();
+    // Neither message carries a result, so no card is rendered beneath them.
+    expect(queryByTestId('assistant-result-card')).toBeNull();
+  });
+
+  it('renders a result card under the message that carries a result', () => {
+    const withResult: AssistantMessage = {
+      ...assistantMessage,
+      result: listResult,
+    };
+    const {getAllByTestId, getByText} = renderScreen({
+      messages: [userMessage, withResult],
+    });
+
+    expect(getAllByTestId('assistant-result-card')).toHaveLength(1);
+    expect(getByText('Give Milo his pill')).toBeTruthy();
+    expect(getByText('Friday, 9:00')).toBeTruthy();
+    expect(getByText('Weigh Nala')).toBeTruthy();
+  });
+});
+
+describe('AssistantScreen model probe', () => {
+  it('dispatches probeOnDeviceModel once on mount', () => {
+    const {dispatched} = renderScreen();
+
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
+    expect(dispatched).toContain(PROBE_ACTION);
+  });
+
+  it('does not re-probe when the screen re-renders', () => {
+    const {rerender, store} = renderScreen();
+
+    rerender(
+      <Provider store={store}>
+        <AssistantScreen />
+      </Provider>,
+    );
+
+    expect(mockedProbe).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the model status banner only while the model is unavailable', () => {
+    const {getByTestId, getByText} = renderScreen({
+      modelAvailability: {available: false, reason: 'unsupportedDevice'},
+    });
+
+    expect(getByTestId('assistant-model-status')).toBeTruthy();
+    expect(getByText('This iPhone has no on-device model.')).toBeTruthy();
+
+    const available = renderScreen({modelAvailability: {available: true}});
+    expect(available.queryByTestId('assistant-model-status')).toBeNull();
+  });
+});
+
+describe('AssistantScreen composer', () => {
+  it('dispatches askAssistant with the typed text and clears the draft', () => {
+    const {getByTestId, dispatched} = renderScreen();
+
+    fireEvent.changeText(getByTestId('assistant-input'), '  Book a check-up  ');
+    fireEvent.press(getByTestId('assistant-send'));
+
+    expect(mockedAsk).toHaveBeenCalledTimes(1);
+    expect(mockedAsk).toHaveBeenCalledWith({
+      utterance: 'Book a check-up',
+      t: mockT,
+      currencyCode: 'EUR',
+    });
+    expect(dispatched).toContain(ASK_ACTION);
+    expect(getByTestId('assistant-input').props.value).toBe('');
+  });
+
+  it('passes the resolved user currency through to the turn', () => {
+    mockCurrency = 'GBP';
+    const {getByTestId} = renderScreen();
+
+    fireEvent.changeText(
+      getByTestId('assistant-input'),
+      'How much did I spend?',
+    );
+    fireEvent.press(getByTestId('assistant-send'));
+
+    expect(mockedAsk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        utterance: 'How much did I spend?',
+        currencyCode: 'GBP',
+      }),
+    );
+  });
+
+  it('marks the composer busy and refuses a second turn while thinking', () => {
+    const {getByTestId, dispatched} = renderScreen({status: 'thinking'});
+
+    expect(getByTestId('assistant-busy')).toBeTruthy();
+    expect(getByTestId('assistant-send').props.accessibilityState).toEqual({
+      disabled: true,
+    });
+
+    fireEvent.changeText(getByTestId('assistant-input'), 'And Nala?');
+    fireEvent.press(getByTestId('assistant-send'));
+
+    expect(mockedAsk).not.toHaveBeenCalled();
+    expect(dispatched).not.toContain(ASK_ACTION);
+  });
+
+  it('is not busy while the status is idle', () => {
+    const {getByText, queryByTestId} = renderScreen({status: 'idle'});
+
+    expect(queryByTestId('assistant-busy')).toBeNull();
+    expect(getByText('Send')).toBeTruthy();
+  });
+
+  it('fills the draft from a suggestion chip without submitting it', () => {
+    const {getByLabelText, getByTestId} = renderScreen();
+
+    fireEvent.press(getByLabelText("When is Milo's next visit?"));
+
+    expect(getByTestId('assistant-input').props.value).toBe(
+      "When is Milo's next visit?",
+    );
+    expect(mockedAsk).not.toHaveBeenCalled();
+  });
+
+  it('uses padding avoidance on iOS and none on Android', () => {
+    (Platform as unknown as {OS: string}).OS = 'ios';
+    const ios = renderScreen();
+    expect(ios.UNSAFE_getByType(KeyboardAvoidingView).props.behavior).toBe(
+      'padding',
+    );
+
+    (Platform as unknown as {OS: string}).OS = 'android';
+    const android = renderScreen();
+    expect(
+      android.UNSAFE_getByType(KeyboardAvoidingView).props.behavior,
+    ).toBeUndefined();
+  });
+});
+
+describe('AssistantScreen header actions', () => {
+  it('goes back when the header back control is pressed', () => {
+    const {getByTestId} = renderScreen();
+
+    expect(getByTestId('header-title').props.children).toBe('Assistant');
+    fireEvent.press(getByTestId('header-back'));
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives the header the close icon once the transcript has messages', () => {
+    const {getByTestId} = renderScreen({
+      messages: [userMessage, assistantMessage],
+    });
+
+    // The right slot renders only when Header is handed an icon, so this is
+    // the observable form of `rightIcon: Images.closeIcon`.
+    expect(getByTestId('header-right-icon').props.source).toBe(
+      Images.closeIcon,
+    );
+    expect(getByTestId('header-right').props.accessibilityLabel).toBe(
+      'Clear conversation',
+    );
+  });
+
+  it('clears the transcript from the header when messages exist', () => {
+    const {getByTestId, queryByTestId, store, dispatched} = renderScreen({
+      messages: [userMessage, assistantMessage],
+      error: null,
+    });
+
+    expect(getByTestId('header-right').props.accessibilityLabel).toBe(
+      'Clear conversation',
+    );
+
+    fireEvent.press(getByTestId('header-right'));
+
+    expect(dispatched).toContain('assistant/transcriptCleared');
+    expect(store.getState().assistant.messages).toEqual([]);
+    expect(queryByTestId('assistant-bubble-user')).toBeNull();
+    expect(getByTestId('assistant-empty')).toBeTruthy();
+    // Emptying the transcript takes the icon - and so the whole right slot -
+    // back out of the header.
+    expect(queryByTestId('header-right-icon')).toBeNull();
+    expect(queryByTestId('header-right')).toBeNull();
+  });
+
+  it('passes no right icon while the transcript is empty', () => {
+    const {getByTestId, queryByTestId} = renderScreen({messages: []});
+
+    expect(getByTestId('header')).toBeTruthy();
+    expect(queryByTestId('header-right-icon')).toBeNull();
+    expect(queryByTestId('header-right')).toBeNull();
+  });
+});
+
+describe('AssistantScreen error line', () => {
+  it('renders the error held in the slice', () => {
+    const {getByText} = renderScreen({
+      status: 'error',
+      error: 'I could not read that pet.',
+    });
+
+    expect(getByText('I could not read that pet.')).toBeTruthy();
+  });
+
+  it('shows the error line only once the slice records a failure', () => {
+    const {getByText, queryByText, store} = renderScreen({
+      status: 'idle',
+      error: null,
+      messages: [assistantMessage],
+    });
+
+    expect(queryByText('The turn failed.')).toBeNull();
+
+    act(() => {
+      store.dispatch(turnFailed('The turn failed.'));
+    });
+
+    expect(getByText('The turn failed.')).toBeTruthy();
+  });
+});
+
+describe('AssistantScreen handoff navigation', () => {
+  it('navigates through the parent navigator for a mapped deep link', () => {
+    const {getByTestId, getByText} = renderScreen({
+      messages: [
+        handoffMessage('yc://app/tasks/new?when=2026-03-04T09%3A00%3A00.000Z'),
+      ],
+    });
+
+    expect(getByText('Open the task form')).toBeTruthy();
+    fireEvent.press(getByTestId('assistant-result-open'));
+
+    expect(mockParentNavigate).toHaveBeenCalledTimes(1);
+    expect(mockParentNavigate).toHaveBeenCalledWith('Main', {
+      screen: 'Tasks',
+      params: {screen: 'AddTask', params: {prefillDate: '2026-03-04'}},
+    });
+    // The hop is always Main -> tab; the screen's own navigator is untouched.
+    expect(mockOwnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('carries the nested hop for a link that lands inside a nested stack', () => {
+    const {getByTestId} = renderScreen({
+      messages: [handoffMessage('yc://app/expenses/new', 'logExpense')],
+    });
+
+    fireEvent.press(getByTestId('assistant-result-open'));
+
+    expect(mockParentNavigate).toHaveBeenCalledWith('Main', {
+      screen: 'HomeStack',
+      params: {
+        screen: 'ExpensesStack',
+        params: {screen: 'AddExpense'},
+      },
+    });
+  });
+
+  it('navigates nowhere for an unrecognised deep link', () => {
+    const {getByTestId} = renderScreen({
+      messages: [handoffMessage('yc://app/nowhere', 'bookAppointment')],
+    });
+
+    fireEvent.press(getByTestId('assistant-result-open'));
+
+    expect(mockParentNavigate).not.toHaveBeenCalled();
+    expect(mockOwnNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to the local navigator when there is no parent', () => {
+    mockParent = undefined;
+    const {getByTestId} = renderScreen({
+      messages: [
+        handoffMessage('yc://app/appointments/book', 'bookAppointment'),
+      ],
+    });
+
+    fireEvent.press(getByTestId('assistant-result-open'));
+
+    expect(mockParentNavigate).not.toHaveBeenCalled();
+    expect(mockOwnNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/screens/AssistantScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/assistant/screens/AssistantScreen.test.tsx
@@ -486,7 +486,7 @@ describe('AssistantScreen error line', () => {
 });
 
 describe('AssistantScreen handoff navigation', () => {
-  it('navigates through the parent navigator for a mapped deep link', () => {
+  it('navigates to Main for a mapped deep link', () => {
     const {getByTestId, getByText} = renderScreen({
       messages: [
         handoffMessage('yc://app/tasks/new?when=2026-03-04T09%3A00%3A00.000Z'),
@@ -496,13 +496,14 @@ describe('AssistantScreen handoff navigation', () => {
     expect(getByText('Open the task form')).toBeTruthy();
     fireEvent.press(getByTestId('assistant-result-open'));
 
-    expect(mockParentNavigate).toHaveBeenCalledTimes(1);
-    expect(mockParentNavigate).toHaveBeenCalledWith('Main', {
+    expect(mockOwnNavigate).toHaveBeenCalledTimes(1);
+    expect(mockOwnNavigate).toHaveBeenCalledWith('Main', {
       screen: 'Tasks',
       params: {screen: 'AddTask', params: {prefillDate: '2026-03-04'}},
     });
-    // The hop is always Main -> tab; the screen's own navigator is untouched.
-    expect(mockOwnNavigate).not.toHaveBeenCalled();
+    // The hop is always Main -> tab, addressed to whichever navigator owns
+    // 'Main'; the immediate parent (the tab navigator) does not.
+    expect(mockParentNavigate).not.toHaveBeenCalled();
   });
 
   it('carries the nested hop for a link that lands inside a nested stack', () => {
@@ -512,7 +513,7 @@ describe('AssistantScreen handoff navigation', () => {
 
     fireEvent.press(getByTestId('assistant-result-open'));
 
-    expect(mockParentNavigate).toHaveBeenCalledWith('Main', {
+    expect(mockOwnNavigate).toHaveBeenCalledWith('Main', {
       screen: 'HomeStack',
       params: {
         screen: 'ExpensesStack',
@@ -532,7 +533,10 @@ describe('AssistantScreen handoff navigation', () => {
     expect(mockOwnNavigate).not.toHaveBeenCalled();
   });
 
-  it('does not fall back to the local navigator when there is no parent', () => {
+  // The immediate parent is the tab navigator, which owns no 'Main' route.
+  // Addressing it there only worked by accident of React Navigation bubbling,
+  // so the handoff must not depend on getParent() at all.
+  it('addresses the navigator that owns Main rather than the immediate parent', () => {
     mockParent = undefined;
     const {getByTestId} = renderScreen({
       messages: [
@@ -543,6 +547,9 @@ describe('AssistantScreen handoff navigation', () => {
     fireEvent.press(getByTestId('assistant-result-open'));
 
     expect(mockParentNavigate).not.toHaveBeenCalled();
-    expect(mockOwnNavigate).not.toHaveBeenCalled();
+    expect(mockOwnNavigate).toHaveBeenCalledWith('Main', {
+      screen: 'Appointments',
+      params: {screen: 'BrowseBusinesses', params: {autoFocusSearch: true}},
+    });
   });
 });

--- a/apps/mobileAppYC/__tests__/features/assistant/selectors.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/selectors.test.ts
@@ -1,0 +1,517 @@
+import {
+  selectAssistantMessages,
+  selectAssistantStatus,
+  selectAssistantError,
+  selectModelAvailability,
+  selectAssistantEnabled,
+  selectVaccinationsByCompanion,
+  selectAssistantData,
+  buildAssistantContext,
+} from '@/features/assistant/selectors';
+import type {RootState} from '@/app/store';
+import type {
+  AssistantMessage,
+  OnDeviceModelAvailability,
+} from '@/features/assistant/types';
+import type {Companion} from '@/features/companion/types';
+import type {Task} from '@/features/tasks/types';
+import type {Appointment} from '@/features/appointments/types';
+import type {Expense} from '@/features/expenses/types';
+
+/**
+ * The single cast helper. Every state in this file is a partial slice map -
+ * RootState carries redux-persist's `_persist` key and a dozen slices the
+ * assistant selectors never read, so building a whole store per case would
+ * only hide which slice a given expectation actually depends on.
+ */
+const stateOf = (slices: Record<string, unknown>): RootState =>
+  slices as unknown as RootState;
+
+const message = (id: string): AssistantMessage => ({
+  id,
+  author: 'user',
+  text: `text ${id}`,
+  createdAt: '2026-01-01T10:00:00.000Z',
+});
+
+const companions = [
+  {id: 'pet-1', name: 'Kiwi'},
+  {id: 'pet-2', name: 'Mango'},
+] as unknown as Companion[];
+
+const tasks = [{id: 'task-1', companionId: 'pet-1'}] as unknown as Task[];
+
+const appointments = [
+  {id: 'appt-1', companionId: 'pet-1'},
+] as unknown as Appointment[];
+
+const expenses = [
+  {id: 'exp-1', companionId: 'pet-1', amount: 42},
+] as unknown as Expense[];
+
+describe('features/assistant/selectors', () => {
+  describe('selectAssistantMessages', () => {
+    it('returns the transcript held by the slice', () => {
+      const messages = [message('m-1'), message('m-2')];
+
+      expect(selectAssistantMessages(stateOf({assistant: {messages}}))).toBe(
+        messages,
+      );
+    });
+
+    it('falls back to an empty transcript when the slice is missing', () => {
+      expect(selectAssistantMessages(stateOf({}))).toEqual([]);
+    });
+
+    it('falls back to an empty transcript when the slice has no messages key', () => {
+      expect(selectAssistantMessages(stateOf({assistant: {}}))).toEqual([]);
+    });
+  });
+
+  describe('selectAssistantStatus', () => {
+    it('returns the status held by the slice', () => {
+      expect(
+        selectAssistantStatus(stateOf({assistant: {status: 'thinking'}})),
+      ).toBe('thinking');
+    });
+
+    it('returns "error" when the slice reports a failed turn', () => {
+      expect(
+        selectAssistantStatus(stateOf({assistant: {status: 'error'}})),
+      ).toBe('error');
+    });
+
+    it('falls back to "idle" when the slice is missing', () => {
+      expect(selectAssistantStatus(stateOf({}))).toBe('idle');
+    });
+  });
+
+  describe('selectAssistantError', () => {
+    it('returns the error message held by the slice', () => {
+      expect(
+        selectAssistantError(stateOf({assistant: {error: 'model timed out'}})),
+      ).toBe('model timed out');
+    });
+
+    it('returns null when the slice holds no error', () => {
+      expect(selectAssistantError(stateOf({assistant: {error: null}}))).toBe(
+        null,
+      );
+    });
+
+    it('falls back to null when the slice is missing', () => {
+      expect(selectAssistantError(stateOf({}))).toBe(null);
+    });
+  });
+
+  describe('selectModelAvailability', () => {
+    it('returns the availability reported by the native bridge', () => {
+      const modelAvailability: OnDeviceModelAvailability = {
+        available: true,
+        providerLabel: 'Apple Intelligence',
+      };
+
+      expect(
+        selectModelAvailability(stateOf({assistant: {modelAvailability}})),
+      ).toBe(modelAvailability);
+    });
+
+    it('reports an unavailable model when the slice is missing', () => {
+      expect(selectModelAvailability(stateOf({}))).toEqual({available: false});
+    });
+  });
+
+  describe('selectAssistantEnabled', () => {
+    it('returns false when the user has switched the assistant off', () => {
+      expect(
+        selectAssistantEnabled(stateOf({assistant: {enabled: false}})),
+      ).toBe(false);
+    });
+
+    it('returns true when the slice has the assistant switched on', () => {
+      expect(
+        selectAssistantEnabled(stateOf({assistant: {enabled: true}})),
+      ).toBe(true);
+    });
+
+    it('defaults to enabled when the slice is missing', () => {
+      expect(selectAssistantEnabled(stateOf({}))).toBe(true);
+    });
+  });
+
+  describe('selectVaccinationsByCompanion', () => {
+    it('returns an empty map when the passport slice is missing', () => {
+      expect(selectVaccinationsByCompanion(stateOf({}))).toEqual({});
+    });
+
+    it('flattens each passport into vaccination summaries keyed by companion', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {
+                  name: 'Rabies',
+                  administeredOn: '2026-01-10',
+                  dueOn: '2027-01-10',
+                },
+                {name: 'Leptospirosis', administeredOn: '2026-02-20'},
+              ],
+            },
+            'pet-2': {
+              vaccinations: [{name: 'Feline calicivirus'}],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)).toEqual({
+        'pet-1': [
+          {name: 'Rabies', administeredOn: '2026-01-10', dueOn: '2027-01-10'},
+          {
+            name: 'Leptospirosis',
+            administeredOn: '2026-02-20',
+            dueOn: null,
+          },
+        ],
+        'pet-2': [
+          {name: 'Feline calicivirus', administeredOn: null, dueOn: null},
+        ],
+      });
+    });
+
+    it('maps the alternate DTO field names (vaccineName, date, nextDueDate)', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {
+                  vaccineName: 'Distemper',
+                  date: '2026-03-01',
+                  nextDueDate: '2027-03-01',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Distemper', administeredOn: '2026-03-01', dueOn: '2027-03-01'},
+      ]);
+    });
+
+    it('prefers the primary field over its alternate when a record carries both', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {
+                  name: 'Rabies',
+                  vaccineName: 'Rabies (alt)',
+                  administeredOn: '2026-01-10',
+                  date: '2020-01-01',
+                  dueOn: '2027-01-10',
+                  nextDueDate: '2021-01-01',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Rabies', administeredOn: '2026-01-10', dueOn: '2027-01-10'},
+      ]);
+    });
+
+    it('keeps a companion whose passport has an empty vaccination list', () => {
+      const state = stateOf({
+        passport: {byCompanionId: {'pet-1': {vaccinations: []}}},
+      });
+
+      expect(selectVaccinationsByCompanion(state)).toEqual({'pet-1': []});
+    });
+
+    it('skips a companion whose passport has no vaccination array', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-missing-key': {issuedOn: '2026-01-01'},
+            'pet-not-an-array': {vaccinations: {rabies: true}},
+            'pet-null-list': {vaccinations: null},
+            'pet-null-passport': null,
+            'pet-kept': {vaccinations: [{name: 'Rabies'}]},
+          },
+        },
+      });
+
+      const result = selectVaccinationsByCompanion(state);
+
+      expect(Object.keys(result)).toEqual(['pet-kept']);
+      expect(result['pet-kept']).toEqual([
+        {name: 'Rabies', administeredOn: null, dueOn: null},
+      ]);
+    });
+
+    it('falls through to the alternate name when the primary one is an empty string', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {name: '', vaccineName: 'Bordetella'},
+                {vaccineName: 'Parvovirus', date: '2026-04-04'},
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Bordetella', administeredOn: null, dueOn: null},
+        {name: 'Parvovirus', administeredOn: '2026-04-04', dueOn: null},
+      ]);
+    });
+
+    it('falls through to the alternate dates when the primary ones are empty strings', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {
+                  name: 'Distemper',
+                  administeredOn: '',
+                  date: '2026-03-01',
+                  dueOn: '',
+                  nextDueDate: '2027-03-01',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Distemper', administeredOn: '2026-03-01', dueOn: '2027-03-01'},
+      ]);
+    });
+
+    it('reports no date when both the primary and the alternate field are empty strings', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {
+                  name: 'Rabies',
+                  administeredOn: '',
+                  date: '',
+                  dueOn: '',
+                  nextDueDate: '',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Rabies', administeredOn: null, dueOn: null},
+      ]);
+    });
+
+    it('trims the surrounding whitespace off the name it keeps', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {vaccinations: [{name: '  Rabies\n'}]},
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Rabies', administeredOn: null, dueOn: null},
+      ]);
+    });
+
+    it('skips records with no usable name rather than emitting a blank line', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {
+            'pet-1': {
+              vaccinations: [
+                {administeredOn: '2026-01-10', dueOn: '2027-01-10'},
+                {name: '', vaccineName: ''},
+                {name: '   ', vaccineName: '  '},
+                {vaccineName: 'Parvovirus', date: '2026-04-04'},
+              ],
+            },
+          },
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)['pet-1']).toEqual([
+        {name: 'Parvovirus', administeredOn: '2026-04-04', dueOn: null},
+      ]);
+    });
+
+    it('reuses the memoised result while the passport map is unchanged', () => {
+      const state = stateOf({
+        passport: {
+          byCompanionId: {'pet-1': {vaccinations: [{name: 'Rabies'}]}},
+        },
+      });
+
+      expect(selectVaccinationsByCompanion(state)).toBe(
+        selectVaccinationsByCompanion(state),
+      );
+    });
+  });
+
+  describe('selectAssistantData', () => {
+    it('assembles the five collections the resolvers read', () => {
+      const state = stateOf({
+        companion: {companions},
+        tasks: {items: tasks},
+        appointments: {items: appointments},
+        expenses: {items: expenses},
+        passport: {
+          byCompanionId: {
+            'pet-1': {vaccinations: [{name: 'Rabies', dueOn: '2027-01-10'}]},
+          },
+        },
+      });
+
+      const data = selectAssistantData(state);
+
+      expect(data.companions).toBe(companions);
+      expect(data.tasks).toBe(tasks);
+      expect(data.appointments).toBe(appointments);
+      expect(data.expenses).toBe(expenses);
+      expect(data.vaccinations).toEqual({
+        'pet-1': [{name: 'Rabies', administeredOn: null, dueOn: '2027-01-10'}],
+      });
+    });
+
+    it('falls back to empty collections when every source slice is missing', () => {
+      expect(selectAssistantData(stateOf({}))).toEqual({
+        companions: [],
+        tasks: [],
+        appointments: [],
+        expenses: [],
+        vaccinations: {},
+      });
+    });
+
+    it('falls back per slice when a slice exists but holds no collection', () => {
+      const state = stateOf({
+        companion: {},
+        tasks: {items: tasks},
+        appointments: {},
+        expenses: {},
+        passport: {},
+      });
+
+      const data = selectAssistantData(state);
+
+      expect(data.companions).toEqual([]);
+      expect(data.tasks).toBe(tasks);
+      expect(data.appointments).toEqual([]);
+      expect(data.expenses).toEqual([]);
+      expect(data.vaccinations).toEqual({});
+    });
+
+    it('returns the same object while the source slices are unchanged', () => {
+      const state = stateOf({
+        companion: {companions},
+        tasks: {items: tasks},
+        appointments: {items: appointments},
+        expenses: {items: expenses},
+        passport: {byCompanionId: {}},
+      });
+
+      expect(selectAssistantData(state)).toBe(selectAssistantData(state));
+    });
+
+    it('recomputes when one of the source collections changes', () => {
+      const passport = {byCompanionId: {}};
+      const first = selectAssistantData(
+        stateOf({
+          companion: {companions},
+          tasks: {items: tasks},
+          appointments: {items: appointments},
+          expenses: {items: expenses},
+          passport,
+        }),
+      );
+      const nextTasks = [
+        ...tasks,
+        {id: 'task-2', companionId: 'pet-2'},
+      ] as unknown as Task[];
+      const second = selectAssistantData(
+        stateOf({
+          companion: {companions},
+          tasks: {items: nextTasks},
+          appointments: {items: appointments},
+          expenses: {items: expenses},
+          passport,
+        }),
+      );
+
+      expect(first.tasks).toBe(tasks);
+      expect(second.tasks).toBe(nextTasks);
+      expect(second).not.toBe(first);
+    });
+  });
+
+  describe('buildAssistantContext', () => {
+    it('merges the clock and currency into the selected data', () => {
+      const now = new Date('2026-05-04T09:00:00.000Z');
+      const data = selectAssistantData(
+        stateOf({
+          companion: {companions},
+          tasks: {items: tasks},
+          appointments: {items: appointments},
+          expenses: {items: expenses},
+          passport: {
+            byCompanionId: {'pet-1': {vaccinations: [{name: 'Rabies'}]}},
+          },
+        }),
+      );
+
+      const context = buildAssistantContext(data, now, 'GBP');
+
+      expect(context).toEqual({
+        companions,
+        tasks,
+        appointments,
+        expenses,
+        vaccinations: {
+          'pet-1': [{name: 'Rabies', administeredOn: null, dueOn: null}],
+        },
+        now,
+        currencyCode: 'GBP',
+      });
+      expect(context.now).toBe(now);
+    });
+
+    it('does not mutate the memoised data it was handed', () => {
+      const data = selectAssistantData(stateOf({}));
+
+      buildAssistantContext(data, new Date('2026-05-04T09:00:00.000Z'), 'USD');
+
+      expect(data).toEqual({
+        companions: [],
+        tasks: [],
+        appointments: [],
+        expenses: [],
+        vaccinations: {},
+      });
+      expect('now' in data).toBe(false);
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/assistantRuntime.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/assistantRuntime.test.ts
@@ -1,0 +1,631 @@
+/**
+ * Tests for the assistant turn loop.
+ *
+ * The loop's whole value is its ordering: rules first, model only as a rescue,
+ * resolvers always, rephrasing only over a sentence that is already true. Each
+ * test here drives the real parser and the real resolvers with a fixed clock
+ * and fakes only the on-device model, so an assertion about the reply is an
+ * assertion about the sentence a user would actually hear.
+ */
+import type {TFunction} from 'i18next';
+import {
+  buildActionDescriptions,
+  runTurn,
+} from '@/features/assistant/services/assistantRuntime';
+import {classify, rephrase} from '@/features/assistant/services/onDeviceModel';
+import {parseUtterance} from '@/features/assistant/nlu/parser';
+import {runAction} from '@/features/assistant/actions/resolvers';
+import {
+  BARE_NAME_CONFIDENCE,
+  MAX_UTTERANCE_LENGTH,
+  RULES_CONFIDENCE_THRESHOLD,
+} from '@/features/assistant/constants';
+import type {
+  AssistantContext,
+  AssistantIntent,
+} from '@/features/assistant/types';
+import type {Companion} from '@/features/companion/types';
+import type {Task} from '@/features/tasks/types';
+import type {Appointment} from '@/features/appointments/types';
+import type {Expense} from '@/features/expenses/types';
+
+jest.mock('@/features/assistant/services/onDeviceModel', () => ({
+  classify: jest.fn(),
+  rephrase: jest.fn(),
+}));
+
+// The parser and the resolvers run for real; they are only wrapped so the test
+// can assert what the loop handed them, and so a test can pin a confidence the
+// live rules never emit - such as one sitting exactly on the threshold.
+jest.mock('@/features/assistant/nlu/parser', () => {
+  const actual = jest.requireActual('@/features/assistant/nlu/parser');
+  return {...actual, parseUtterance: jest.fn()};
+});
+
+jest.mock('@/features/assistant/actions/resolvers', () => {
+  const actual = jest.requireActual('@/features/assistant/actions/resolvers');
+  return {...actual, runAction: jest.fn()};
+});
+
+const realParseUtterance = jest.requireActual<
+  typeof import('@/features/assistant/nlu/parser')
+>('@/features/assistant/nlu/parser').parseUtterance;
+const realRunAction = jest.requireActual<
+  typeof import('@/features/assistant/actions/resolvers')
+>('@/features/assistant/actions/resolvers').runAction;
+
+const classifyMock = classify as jest.MockedFunction<typeof classify>;
+const rephraseMock = rephrase as jest.MockedFunction<typeof rephrase>;
+const parseUtteranceMock = parseUtterance as jest.MockedFunction<
+  typeof parseUtterance
+>;
+const runActionMock = runAction as jest.MockedFunction<typeof runAction>;
+
+/**
+ * A translator that renders the key plus its params, so an assertion on the
+ * reply pins both which sentence was chosen and the facts it was given.
+ */
+const fakeT = ((key: string, params?: Record<string, unknown>) =>
+  params === undefined
+    ? key
+    : `${key}|${JSON.stringify(params)}`) as unknown as TFunction;
+
+const factory =
+  <T>(defaults: T) =>
+  (overrides: Partial<T> = {}): T => ({...defaults, ...overrides});
+
+const makeCompanion = factory<Companion>({
+  id: 'c1',
+  name: 'Bruno',
+  category: 'dog',
+  speciesCode: null,
+  breed: null,
+  breedCode: null,
+  dateOfBirth: null,
+  gender: 'male',
+  currentWeight: null,
+  color: null,
+  allergies: null,
+  neuteredStatus: 'neutered',
+  ageWhenNeutered: null,
+  bloodGroup: null,
+  microchipNumber: null,
+  passportNumber: null,
+  insuredStatus: 'not-insured',
+  insuranceCompany: null,
+  insurancePolicyNumber: null,
+  countryOfOrigin: null,
+  origin: 'unknown',
+  profileImage: null,
+  userId: 'u1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const makeTask = factory<Task>({
+  id: 't1',
+  companionId: 'c1',
+  category: 'custom',
+  title: 'Care task',
+  date: '2026-09-11',
+  frequency: 'once',
+  reminderEnabled: false,
+  reminderOptions: null,
+  syncWithCalendar: false,
+  attachDocuments: false,
+  attachments: [],
+  status: 'PENDING',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  details: {},
+});
+
+const makeAppointment = factory<Appointment>({
+  id: 'a1',
+  companionId: 'c1',
+  businessId: 'b1',
+  date: '2026-09-12',
+  time: '09:00',
+  // A full timestamp keeps the rendered day identical in every timezone.
+  start: '2026-09-12T09:00:00.000Z',
+  type: 'consultation',
+  status: 'CONFIRMED',
+  organisationName: 'Willow Vets',
+  serviceName: 'Checkup',
+});
+
+const makeExpense = factory<Expense>({
+  id: 'e1',
+  companionId: 'c1',
+  title: 'Vet visit',
+  category: 'health',
+  subcategory: 'consultation',
+  visitType: 'clinic',
+  amount: 40,
+  currencyCode: 'EUR',
+  status: 'PAID',
+  source: 'inApp',
+  date: '2026-09-01',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  attachments: [],
+});
+
+/** Fixed clock. Midday UTC keeps every asserted ISO day stable under any TZ. */
+const NOW = new Date('2026-09-10T12:00:00.000Z');
+
+const BRUNO = makeCompanion({id: 'c1', name: 'Bruno'});
+const LUNA = makeCompanion({id: 'c2', name: 'Luna'});
+
+const makeContext = factory<AssistantContext>({
+  companions: [BRUNO, LUNA],
+  tasks: [],
+  appointments: [makeAppointment()],
+  expenses: [],
+  vaccinations: {},
+  now: NOW,
+  currencyCode: 'EUR',
+});
+
+/** The catalogue exactly as the model is shown it. */
+const EXPECTED_DESCRIPTIONS = [
+  'nextAppointment: assistant.actions.nextAppointment.description',
+  'vaccinationStatus: assistant.actions.vaccinationStatus.description',
+  'upcomingTasks: assistant.actions.upcomingTasks.description',
+  'petOverview: assistant.actions.petOverview.description',
+  'expenseSummary: assistant.actions.expenseSummary.description',
+  'addCareTask: assistant.actions.addCareTask.description',
+  'logExpense: assistant.actions.logExpense.description',
+  'bookAppointment: assistant.actions.bookAppointment.description',
+].join('\n');
+
+const modelGuess = (
+  overrides: Partial<AssistantIntent> = {},
+): AssistantIntent => ({
+  actionId: 'petOverview',
+  slots: {},
+  confidence: 0.5,
+  source: 'model',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  parseUtteranceMock.mockImplementation(realParseUtterance);
+  runActionMock.mockImplementation(realRunAction);
+  classifyMock.mockResolvedValue(null);
+  rephraseMock.mockImplementation(async sentence => `warmer: ${sentence}`);
+});
+
+describe('buildActionDescriptions', () => {
+  it('renders every catalogue action as "id: description", in catalogue order', () => {
+    expect(buildActionDescriptions(fakeT)).toBe(EXPECTED_DESCRIPTIONS);
+  });
+
+  it('translates the description key rather than printing it raw', () => {
+    const lookup = {
+      'assistant.actions.nextAppointment.description':
+        'When the next vet visit is',
+      'assistant.actions.petOverview.description': 'A summary of one pet',
+    } as Record<string, string>;
+    const translating = ((key: string) => lookup[key] ?? key) as TFunction;
+
+    const lines = buildActionDescriptions(translating).split('\n');
+
+    expect(lines).toHaveLength(8);
+    expect(lines[0]).toBe('nextAppointment: When the next vet visit is');
+    expect(lines[3]).toBe('petOverview: A summary of one pet');
+  });
+});
+
+describe('runTurn: an utterance with no words', () => {
+  it('answers with the empty reply and never reaches a resolver', async () => {
+    const turn = await runTurn('', makeContext(), fakeT);
+
+    expect(turn).toEqual({
+      intent: null,
+      result: null,
+      text: 'assistant.replies.empty',
+    });
+    expect(runActionMock).not.toHaveBeenCalled();
+    expect(parseUtteranceMock).not.toHaveBeenCalled();
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(rephraseMock).not.toHaveBeenCalled();
+  });
+
+  it('treats whitespace and newlines as empty rather than parsing them', async () => {
+    const turn = await runTurn('  \n\t  ', makeContext(), fakeT);
+
+    expect(turn.text).toBe('assistant.replies.empty');
+    expect(turn.intent).toBeNull();
+    expect(runActionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runTurn: the rules routed it confidently', () => {
+  it('answers from the resolver without consulting the model', async () => {
+    const turn = await runTurn(
+      'when is my next appointment',
+      makeContext(),
+      fakeT,
+    );
+
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(1);
+    expect(parseUtteranceMock).toHaveBeenCalledWith(
+      'when is my next appointment',
+      {petNames: ['Bruno', 'Luna'], now: NOW},
+    );
+    expect(turn.intent).toEqual({
+      actionId: 'nextAppointment',
+      slots: {},
+      confidence: 0.87,
+      source: 'rules',
+    });
+    expect(turn.result?.speechKey).toBe(
+      'assistant.replies.nextAppointment.found',
+    );
+    expect(turn.result?.speechParams).toEqual({
+      petName: 'Bruno',
+      date: '2026-09-12',
+      time: '09:00',
+      business: 'Willow Vets',
+    });
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.nextAppointment.found|' +
+        '{"petName":"Bruno","date":"2026-09-12","time":"09:00","business":"Willow Vets"}',
+    );
+  });
+
+  it('keeps the rules answer when confidence sits exactly on the threshold', async () => {
+    // The guard is `confidence < RULES_CONFIDENCE_THRESHOLD`, so a score
+    // landing exactly on the threshold is confident enough and the model is
+    // never asked. No live rule emits 0.6, so the parser is pinned here.
+    parseUtteranceMock.mockReturnValue({
+      actionId: 'petOverview',
+      slots: {petName: 'Bruno'},
+      confidence: RULES_CONFIDENCE_THRESHOLD,
+      source: 'rules',
+    });
+
+    const turn = await runTurn('bruno please', makeContext(), fakeT);
+
+    expect(turn.intent?.confidence).toBe(0.6);
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(1);
+    expect(turn.intent?.actionId).toBe('petOverview');
+    expect(turn.intent?.source).toBe('rules');
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.petOverview.summary|' +
+        '{"petName":"Bruno","breed":"","tasks":0,"appointments":1}',
+    );
+  });
+
+  it('passes the parsed slots to the resolver', async () => {
+    const context = makeContext({tasks: [makeTask({companionId: 'c2'})]});
+
+    const turn = await runTurn('what tasks does Luna have', context, fakeT);
+
+    expect(turn.intent?.slots).toEqual({petName: 'Luna'});
+    expect(runActionMock).toHaveBeenCalledWith('upcomingTasks', context, {
+      petName: 'Luna',
+    });
+    expect(turn.result?.speechParams).toEqual({
+      count: 1,
+      first: 'Care task',
+      petName: 'Luna',
+    });
+  });
+});
+
+describe('runTurn: the rules scored low', () => {
+  it('takes the action from the model but keeps the slots the rules found', async () => {
+    parseUtteranceMock.mockReturnValue({
+      actionId: 'upcomingTasks',
+      slots: {petName: 'Luna'},
+      confidence: 0.4,
+      source: 'rules',
+    });
+    classifyMock.mockResolvedValue(modelGuess({actionId: 'petOverview'}));
+
+    const turn = await runTurn('luna thing', makeContext(), fakeT);
+
+    expect(classifyMock).toHaveBeenCalledTimes(1);
+    expect(classifyMock).toHaveBeenCalledWith(
+      'luna thing',
+      EXPECTED_DESCRIPTIONS,
+    );
+    // The rules are re-run purely to keep their slots.
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(2);
+    expect(turn.intent).toEqual({
+      actionId: 'petOverview',
+      slots: {petName: 'Luna'},
+      confidence: 0.5,
+      source: 'model',
+    });
+    // Had the slot been dropped, two companions would force a needsSlot reply.
+    expect(turn.result?.status).toBe('ok');
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.petOverview.summary|' +
+        '{"petName":"Luna","breed":"","tasks":0,"appointments":0}',
+    );
+  });
+
+  it('rescues a bare pet name through the model and keeps the pet the rules found', async () => {
+    // The live parser scores a bare name below the threshold, so this is the
+    // rescue route running end to end with no parser stubbing at all.
+    const context = makeContext({
+      tasks: [
+        makeTask({id: 't1', companionId: 'c1', title: 'Brush Bruno'}),
+        makeTask({id: 't2', companionId: 'c2', title: 'Walk Luna'}),
+      ],
+    });
+    classifyMock.mockResolvedValue(modelGuess({actionId: 'upcomingTasks'}));
+
+    const turn = await runTurn('Bruno', context, fakeT);
+
+    const rulesRead = realParseUtterance('Bruno', {
+      petNames: ['Bruno', 'Luna'],
+      now: NOW,
+    });
+    expect(rulesRead).toEqual({
+      actionId: 'petOverview',
+      slots: {petName: 'Bruno'},
+      confidence: BARE_NAME_CONFIDENCE,
+      source: 'rules',
+    });
+    expect(BARE_NAME_CONFIDENCE).toBeLessThan(RULES_CONFIDENCE_THRESHOLD);
+    expect(classifyMock).toHaveBeenCalledTimes(1);
+    expect(classifyMock).toHaveBeenCalledWith('Bruno', EXPECTED_DESCRIPTIONS);
+    // Re-run purely to keep the slots the rules had already extracted.
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(2);
+    expect(turn.intent).toEqual({
+      actionId: 'upcomingTasks',
+      slots: {petName: 'Bruno'},
+      confidence: 0.5,
+      source: 'model',
+    });
+    expect(runActionMock).toHaveBeenCalledWith('upcomingTasks', context, {
+      petName: 'Bruno',
+    });
+    // Had the model's empty slots won, both pets would be in scope: count 2
+    // and an empty petName. The rules still own slot filling.
+    expect(turn.result?.speechParams).toEqual({
+      count: 1,
+      first: 'Brush Bruno',
+      petName: 'Bruno',
+    });
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.upcomingTasks.found|' +
+        '{"count":1,"first":"Brush Bruno","petName":"Bruno"}',
+    );
+  });
+
+  it('keeps the weak rules intent when the model declines to guess', async () => {
+    classifyMock.mockResolvedValue(null);
+
+    const turn = await runTurn('Bruno', makeContext(), fakeT);
+
+    expect(classifyMock).toHaveBeenCalledTimes(1);
+    // No guess means no re-parse; the original rules intent is simply kept.
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(1);
+    expect(turn.intent).toEqual({
+      actionId: 'petOverview',
+      slots: {petName: 'Bruno'},
+      confidence: BARE_NAME_CONFIDENCE,
+      source: 'rules',
+    });
+    // It answers from the rules rather than falling through to "unknown".
+    expect(turn.result?.status).toBe('ok');
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.petOverview.summary|' +
+        '{"petName":"Bruno","breed":"","tasks":0,"appointments":1}',
+    );
+  });
+
+  it('does not consult the model when useModel is false', async () => {
+    parseUtteranceMock.mockReturnValue({
+      actionId: 'upcomingTasks',
+      slots: {petName: 'Luna'},
+      confidence: 0.4,
+      source: 'rules',
+    });
+
+    const turn = await runTurn('luna thing', makeContext(), fakeT, {
+      useModel: false,
+    });
+
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(parseUtteranceMock).toHaveBeenCalledTimes(1);
+    expect(turn.intent?.actionId).toBe('upcomingTasks');
+    expect(turn.intent?.source).toBe('rules');
+  });
+});
+
+describe('runTurn: the rules found nothing', () => {
+  it('routes through the model and runs the resolver with empty slots', async () => {
+    classifyMock.mockResolvedValue(modelGuess({actionId: 'petOverview'}));
+
+    const turn = await runTurn('hello there', makeContext(), fakeT);
+
+    expect(classifyMock).toHaveBeenCalledWith(
+      'hello there',
+      EXPECTED_DESCRIPTIONS,
+    );
+    expect(turn.intent).toEqual({
+      actionId: 'petOverview',
+      slots: {},
+      confidence: 0.5,
+      source: 'model',
+    });
+    // Two pets and no name, so the resolver has to ask which one.
+    expect(turn.result?.status).toBe('needsSlot');
+    expect(turn.result?.missingSlot).toBe('petName');
+    expect(turn.text).toBe('assistant.replies.needsPet|{}');
+  });
+
+  it('answers "unknown" when the model returns no action', async () => {
+    classifyMock.mockResolvedValue(null);
+
+    const turn = await runTurn('hello there', makeContext(), fakeT);
+
+    expect(classifyMock).toHaveBeenCalledTimes(1);
+    expect(turn).toEqual({
+      intent: null,
+      result: null,
+      text: 'assistant.replies.unknown',
+    });
+    expect(runActionMock).not.toHaveBeenCalled();
+    expect(rephraseMock).not.toHaveBeenCalled();
+  });
+
+  it('answers "unknown" without asking the model when useModel is false', async () => {
+    classifyMock.mockResolvedValue(modelGuess());
+
+    const turn = await runTurn('hello there', makeContext(), fakeT, {
+      useModel: false,
+    });
+
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe('assistant.replies.unknown');
+    expect(turn.intent).toBeNull();
+    expect(runActionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runTurn: rephrasing', () => {
+  it('rephrases an "ok" answer and returns the model wording', async () => {
+    const turn = await runTurn(
+      'total expenses',
+      makeContext({expenses: [makeExpense({amount: 40})]}),
+      fakeT,
+    );
+
+    expect(turn.result?.status).toBe('ok');
+    expect(rephraseMock).toHaveBeenCalledTimes(1);
+    expect(rephraseMock).toHaveBeenCalledWith(
+      'assistant.replies.expenseSummary.total|' +
+        '{"total":40,"currency":"EUR","petName":"","count":1}',
+    );
+    expect(turn.text).toBe(
+      'warmer: assistant.replies.expenseSummary.total|' +
+        '{"total":40,"currency":"EUR","petName":"","count":1}',
+    );
+  });
+
+  it('leaves a handoff sentence exactly as the resolver wrote it', async () => {
+    const turn = await runTurn(
+      'book an appointment for Bruno',
+      makeContext(),
+      fakeT,
+    );
+
+    expect(turn.result?.status).toBe('handoff');
+    expect(rephraseMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe(
+      'assistant.replies.bookAppointment.handoff|{"petName":"Bruno","title":""}',
+    );
+    expect(turn.result?.deepLink).toContain(
+      'yc://app/appointments/book?companionId=c1',
+    );
+  });
+
+  it('leaves a needsSlot question unrephrased so it stays a question', async () => {
+    const turn = await runTurn('overview', makeContext(), fakeT);
+
+    expect(turn.result?.status).toBe('needsSlot');
+    expect(rephraseMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe('assistant.replies.needsPet|{}');
+  });
+
+  it('leaves an "empty" answer unrephrased', async () => {
+    const turn = await runTurn(
+      'when is my next appointment',
+      makeContext({appointments: []}),
+      fakeT,
+    );
+
+    expect(turn.result?.status).toBe('empty');
+    expect(rephraseMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe(
+      'assistant.replies.nextAppointment.none|{"petName":""}',
+    );
+  });
+
+  it('keeps the resolver wording when allowRephrase is false', async () => {
+    const turn = await runTurn(
+      'when is my next appointment',
+      makeContext(),
+      fakeT,
+      {
+        allowRephrase: false,
+      },
+    );
+
+    expect(turn.result?.status).toBe('ok');
+    expect(rephraseMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe(
+      'assistant.replies.nextAppointment.found|' +
+        '{"petName":"Bruno","date":"2026-09-12","time":"09:00","business":"Willow Vets"}',
+    );
+  });
+
+  it('keeps the resolver wording when useModel is false', async () => {
+    const turn = await runTurn(
+      'when is my next appointment',
+      makeContext(),
+      fakeT,
+      {
+        useModel: false,
+      },
+    );
+
+    expect(rephraseMock).not.toHaveBeenCalled();
+    expect(classifyMock).not.toHaveBeenCalled();
+    expect(turn.text).toBe(
+      'assistant.replies.nextAppointment.found|' +
+        '{"petName":"Bruno","date":"2026-09-12","time":"09:00","business":"Willow Vets"}',
+    );
+  });
+
+  it('rephrases when allowRephrase is explicitly true', async () => {
+    const turn = await runTurn(
+      'when is my next appointment',
+      makeContext(),
+      fakeT,
+      {
+        allowRephrase: true,
+        useModel: true,
+      },
+    );
+
+    expect(rephraseMock).toHaveBeenCalledTimes(1);
+    expect(turn.text.startsWith('warmer: ')).toBe(true);
+  });
+});
+
+describe('runTurn: a very long utterance', () => {
+  it('truncates to MAX_UTTERANCE_LENGTH instead of rejecting the question', async () => {
+    const head = 'when is my next appointment ';
+    const filler = 'a'.repeat(MAX_UTTERANCE_LENGTH);
+    // "vaccination" would win the routing race, so its survival past the cut
+    // would be visible in the answer.
+    const utterance = `  ${head}${filler} vaccination  `;
+
+    const turn = await runTurn(utterance, makeContext(), fakeT);
+
+    const expectedSeen = `${head}${filler} vaccination`.slice(
+      0,
+      MAX_UTTERANCE_LENGTH,
+    );
+    expect(expectedSeen).toHaveLength(MAX_UTTERANCE_LENGTH);
+    expect(parseUtteranceMock).toHaveBeenCalledWith(expectedSeen, {
+      petNames: ['Bruno', 'Luna'],
+      now: NOW,
+    });
+    expect(turn.intent?.actionId).toBe('nextAppointment');
+    expect(turn.result?.speechKey).toBe(
+      'assistant.replies.nextAppointment.found',
+    );
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/assistantSnapshot.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/assistantSnapshot.test.ts
@@ -1,0 +1,842 @@
+/**
+ * Tests for the offline assistant snapshot.
+ *
+ * `buildSnapshot` is pure once `context.now` is fixed, so every case pins an
+ * exact payload rather than a shape. `getSnapshotModule` is mocked so the
+ * publish helpers can be driven through a present, an absent and a rejecting
+ * native module.
+ */
+import type {Appointment} from '@/features/appointments/types';
+import type {Companion} from '@/features/companion/types';
+import type {Task} from '@/features/tasks/types';
+import type {AssistantContext} from '@/features/assistant/types';
+import type {AssistantSnapshotNativeModule} from '@/features/assistant/services/nativeBridge';
+import {
+  SNAPSHOT_ITEM_LIMIT,
+  SNAPSHOT_PET_LIMIT,
+  UPCOMING_WINDOW_DAYS,
+} from '@/features/assistant/constants';
+import {getSnapshotModule} from '@/features/assistant/services/nativeBridge';
+import {
+  buildSnapshot,
+  clearSnapshot,
+  consumePendingLink,
+  publishSnapshot,
+} from '@/features/assistant/services/assistantSnapshot';
+
+jest.mock('@/features/assistant/services/nativeBridge', () => ({
+  getSnapshotModule: jest.fn(),
+}));
+
+const mockGetSnapshotModule = getSnapshotModule as jest.MockedFunction<
+  typeof getSnapshotModule
+>;
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+
+/** Fixed clock. Every expectation below is expressed relative to it. */
+const NOW = new Date('2026-01-15T12:00:00.000Z');
+const HORIZON_MS = NOW.getTime() + UPCOMING_WINDOW_DAYS * MS_PER_DAY;
+
+const fromNow = (offsetMs: number): string =>
+  new Date(NOW.getTime() + offsetMs).toISOString();
+
+const atMs = (ms: number): string => new Date(ms).toISOString();
+
+const makePet = (overrides: Partial<Companion> & {id: string}): Companion => ({
+  category: 'dog',
+  speciesCode: null,
+  name: `Pet ${overrides.id}`,
+  breed: null,
+  breedCode: null,
+  dateOfBirth: null,
+  gender: 'male',
+  currentWeight: null,
+  color: null,
+  allergies: null,
+  neuteredStatus: 'neutered',
+  ageWhenNeutered: null,
+  bloodGroup: null,
+  microchipNumber: null,
+  passportNumber: null,
+  insuredStatus: 'insured',
+  insuranceCompany: null,
+  insurancePolicyNumber: null,
+  countryOfOrigin: null,
+  origin: 'shop',
+  profileImage: null,
+  userId: 'user-1',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makeAppointment = (
+  overrides: Partial<Appointment> & {id: string; companionId: string},
+): Appointment => ({
+  businessId: 'biz-1',
+  date: '',
+  time: '',
+  type: 'Check-up',
+  status: 'CONFIRMED',
+  serviceName: null,
+  organisationName: null,
+  ...overrides,
+});
+
+const makeTask = (
+  overrides: Partial<Task> & {id: string; companionId: string},
+): Task => ({
+  category: 'custom',
+  title: 'Untitled task',
+  date: '',
+  frequency: 'once',
+  reminderEnabled: false,
+  reminderOptions: null,
+  syncWithCalendar: false,
+  attachDocuments: false,
+  attachments: [],
+  status: 'PENDING',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  details: {},
+  ...overrides,
+});
+
+const makeContext = (
+  overrides: Partial<AssistantContext> = {},
+): AssistantContext => ({
+  companions: [],
+  tasks: [],
+  appointments: [],
+  expenses: [],
+  vaccinations: {},
+  now: NOW,
+  currencyCode: 'EUR',
+  ...overrides,
+});
+
+const BRUNO = makePet({id: 'p1', name: 'Bruno', category: 'dog'});
+const MIA = makePet({id: 'p2', name: 'Mia', category: 'cat'});
+
+const makeNativeModule = (
+  overrides: Partial<AssistantSnapshotNativeModule> = {},
+): jest.Mocked<AssistantSnapshotNativeModule> =>
+  ({
+    writeSnapshot: jest.fn().mockResolvedValue(true),
+    clearSnapshot: jest.fn().mockResolvedValue(true),
+    consumePendingLink: jest.fn().mockResolvedValue(''),
+    ...overrides,
+  }) as unknown as jest.Mocked<AssistantSnapshotNativeModule>;
+
+beforeEach(() => {
+  mockGetSnapshotModule.mockReset();
+  mockGetSnapshotModule.mockReturnValue(null);
+});
+
+describe('buildSnapshot - envelope and pets', () => {
+  it('stamps version 1 and generatedAt from context.now', () => {
+    const snapshot = buildSnapshot(makeContext({companions: [BRUNO]}));
+
+    expect(snapshot.version).toBe(1);
+    expect(snapshot.generatedAt).toBe('2026-01-15T12:00:00.000Z');
+  });
+
+  it('maps each pet to id, name and the companion category as species', () => {
+    const snapshot = buildSnapshot(makeContext({companions: [BRUNO, MIA]}));
+
+    expect(snapshot.pets).toStrictEqual([
+      {id: 'p1', name: 'Bruno', species: 'dog'},
+      {id: 'p2', name: 'Mia', species: 'cat'},
+    ]);
+  });
+
+  it('truncates pets to the first 12 companions', () => {
+    const companions = Array.from({length: SNAPSHOT_PET_LIMIT + 1}, (_, i) =>
+      makePet({id: `p${i + 1}`, name: `Pet ${i + 1}`}),
+    );
+
+    const snapshot = buildSnapshot(makeContext({companions}));
+
+    expect(snapshot.pets).toHaveLength(12);
+    expect(snapshot.pets[0].id).toBe('p1');
+    expect(snapshot.pets[11].id).toBe('p12');
+    expect(snapshot.pets.map(pet => pet.id)).not.toContain('p13');
+  });
+
+  it('drops every item belonging to a pet past the pet limit', () => {
+    const companions = Array.from({length: SNAPSHOT_PET_LIMIT + 1}, (_, i) =>
+      makePet({id: `p${i + 1}`, name: `Pet ${i + 1}`}),
+    );
+    const overflowId = `p${SNAPSHOT_PET_LIMIT + 1}`;
+
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions,
+        appointments: [
+          makeAppointment({
+            id: 'a-overflow',
+            companionId: overflowId,
+            start: fromNow(MS_PER_HOUR),
+          }),
+        ],
+        tasks: [
+          makeTask({
+            id: 't-overflow',
+            companionId: overflowId,
+            dueAt: fromNow(MS_PER_HOUR),
+          }),
+        ],
+        vaccinations: {
+          [overflowId]: [{name: 'Rabies', dueOn: fromNow(MS_PER_DAY)}],
+        },
+      }),
+    );
+
+    expect(snapshot.appointments).toStrictEqual([]);
+    expect(snapshot.tasks).toStrictEqual([]);
+    expect(snapshot.vaccinationsDue).toStrictEqual([]);
+  });
+});
+
+describe('buildSnapshot - appointments', () => {
+  it('keeps only future, non-terminal, in-horizon appointments for known pets, sorted', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO, MIA],
+        appointments: [
+          // Out of order on purpose: the sort is what puts these right.
+          makeAppointment({
+            id: 'a-horizon',
+            companionId: 'p1',
+            start: atMs(HORIZON_MS),
+            serviceName: 'Annual review',
+            organisationName: 'Happy Paws',
+          }),
+          makeAppointment({
+            id: 'a-mid',
+            companionId: 'p2',
+            start: fromNow(5 * MS_PER_DAY),
+            serviceName: 'Dental clean',
+            organisationName: 'Cat Clinic',
+          }),
+          makeAppointment({
+            id: 'a-now',
+            companionId: 'p1',
+            start: fromNow(0),
+            serviceName: 'Vaccination',
+            organisationName: 'Happy Paws',
+          }),
+          makeAppointment({
+            id: 'a-unknown-pet',
+            companionId: 'ghost',
+            start: fromNow(MS_PER_HOUR),
+            serviceName: 'Should not appear',
+          }),
+          makeAppointment({
+            id: 'a-completed',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            status: 'COMPLETED',
+          }),
+          makeAppointment({
+            id: 'a-cancelled',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            status: 'CANCELLED',
+          }),
+          makeAppointment({
+            id: 'a-no-show',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            status: 'NO_SHOW',
+          }),
+          makeAppointment({
+            id: 'a-rescheduled',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            status: 'RESCHEDULED',
+          }),
+          makeAppointment({
+            id: 'a-undated',
+            companionId: 'p1',
+            start: undefined,
+            date: '',
+          }),
+          makeAppointment({
+            id: 'a-past',
+            companionId: 'p1',
+            start: fromNow(-MS_PER_HOUR),
+            serviceName: 'Yesterday',
+          }),
+          makeAppointment({
+            id: 'a-beyond-horizon',
+            companionId: 'p1',
+            start: atMs(HORIZON_MS + 1),
+            serviceName: 'Too far out',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments).toStrictEqual([
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Vaccination',
+        at: fromNow(0),
+        subtitle: 'Happy Paws',
+      },
+      {
+        petId: 'p2',
+        petName: 'Mia',
+        title: 'Dental clean',
+        at: fromNow(5 * MS_PER_DAY),
+        subtitle: 'Cat Clinic',
+      },
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Annual review',
+        at: atMs(HORIZON_MS),
+        subtitle: 'Happy Paws',
+      },
+    ]);
+  });
+
+  it('falls back to the appointment type when there is no service name', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        appointments: [
+          makeAppointment({
+            id: 'a1',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            serviceName: null,
+            type: 'Emergency visit',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments[0].title).toBe('Emergency visit');
+  });
+
+  it('uses an empty title when neither service name nor type is present', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        appointments: [
+          makeAppointment({
+            id: 'a1',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            serviceName: null,
+            type: undefined as unknown as string,
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments[0].title).toBe('');
+  });
+
+  it('leaves the subtitle undefined when the appointment has no organisation', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        appointments: [
+          makeAppointment({
+            id: 'a1',
+            companionId: 'p1',
+            start: fromNow(MS_PER_HOUR),
+            serviceName: 'Nail trim',
+            organisationName: null,
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments[0].subtitle).toBeUndefined();
+  });
+
+  it('derives the moment from date plus time when there is no start timestamp', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        appointments: [
+          makeAppointment({
+            id: 'a1',
+            companionId: 'p1',
+            start: undefined,
+            date: '2026-01-20',
+            time: '09:30',
+            serviceName: 'Groom',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments[0].at).toBe(
+      new Date('2026-01-20T09:30:00').toISOString(),
+    );
+  });
+
+  it('keeps only the 20 earliest appointments', () => {
+    const appointments = Array.from({length: SNAPSHOT_ITEM_LIMIT + 5}, (_, i) =>
+      makeAppointment({
+        id: `a${i}`,
+        companionId: 'p1',
+        // Descending input order, so a missing sort would be visible.
+        start: fromNow((SNAPSHOT_ITEM_LIMIT + 5 - i) * MS_PER_HOUR),
+        serviceName: `Visit ${SNAPSHOT_ITEM_LIMIT + 5 - i}`,
+      }),
+    );
+
+    const snapshot = buildSnapshot(
+      makeContext({companions: [BRUNO], appointments}),
+    );
+
+    expect(snapshot.appointments).toHaveLength(20);
+    expect(snapshot.appointments[0].at).toBe(fromNow(MS_PER_HOUR));
+    expect(snapshot.appointments[19].at).toBe(fromNow(20 * MS_PER_HOUR));
+    expect(snapshot.appointments.map(entry => entry.title)).not.toContain(
+      'Visit 21',
+    );
+  });
+
+  it('uses an empty pet name when the companion record has no name', () => {
+    const nameless = makePet({
+      id: 'p9',
+      name: undefined as unknown as string,
+    });
+
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [nameless],
+        appointments: [
+          makeAppointment({
+            id: 'a1',
+            companionId: 'p9',
+            start: fromNow(MS_PER_HOUR),
+            serviceName: 'Check-up',
+          }),
+        ],
+        tasks: [
+          makeTask({
+            id: 't1',
+            companionId: 'p9',
+            dueAt: fromNow(MS_PER_HOUR),
+            name: 'Walk',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.appointments[0].petName).toBe('');
+    expect(snapshot.tasks[0].petName).toBe('');
+  });
+});
+
+describe('buildSnapshot - tasks', () => {
+  it('keeps open, dated tasks from a day ago to the horizon, sorted, with no subtitle', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO, MIA],
+        tasks: [
+          makeTask({
+            id: 't-horizon',
+            companionId: 'p1',
+            dueAt: atMs(HORIZON_MS),
+            name: 'Annual bloods',
+          }),
+          makeTask({
+            id: 't-just-overdue',
+            companionId: 'p2',
+            dueAt: fromNow(-12 * MS_PER_HOUR),
+            name: 'Morning pill',
+          }),
+          makeTask({
+            id: 't-oldest-kept',
+            companionId: 'p1',
+            dueAt: fromNow(-MS_PER_DAY),
+            name: 'Yesterday brush',
+          }),
+          makeTask({
+            id: 't-soon',
+            companionId: 'p1',
+            dueAt: fromNow(2 * MS_PER_HOUR),
+            name: 'Evening walk',
+          }),
+          makeTask({
+            id: 't-unknown-pet',
+            companionId: 'ghost',
+            dueAt: fromNow(MS_PER_HOUR),
+            name: 'Should not appear',
+          }),
+          makeTask({
+            id: 't-completed',
+            companionId: 'p1',
+            dueAt: fromNow(MS_PER_HOUR),
+            status: 'COMPLETED',
+            name: 'Done',
+          }),
+          makeTask({
+            id: 't-completed-lowercase',
+            companionId: 'p1',
+            dueAt: fromNow(MS_PER_HOUR),
+            status: 'completed',
+            name: 'Also done',
+          }),
+          makeTask({
+            id: 't-cancelled-lowercase',
+            companionId: 'p1',
+            dueAt: fromNow(MS_PER_HOUR),
+            status: 'cancelled',
+            name: 'Called off',
+          }),
+          makeTask({
+            id: 't-undated',
+            companionId: 'p1',
+            dueAt: undefined,
+            date: '',
+            name: 'No date',
+          }),
+          makeTask({
+            id: 't-too-old',
+            companionId: 'p1',
+            dueAt: fromNow(-2 * MS_PER_DAY),
+            name: 'Long overdue',
+          }),
+          makeTask({
+            id: 't-beyond-horizon',
+            companionId: 'p1',
+            dueAt: atMs(HORIZON_MS + 1),
+            name: 'Too far out',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.tasks).toStrictEqual([
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Yesterday brush',
+        at: fromNow(-MS_PER_DAY),
+      },
+      {
+        petId: 'p2',
+        petName: 'Mia',
+        title: 'Morning pill',
+        at: fromNow(-12 * MS_PER_HOUR),
+      },
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Evening walk',
+        at: fromNow(2 * MS_PER_HOUR),
+      },
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Annual bloods',
+        at: atMs(HORIZON_MS),
+      },
+    ]);
+  });
+
+  it('keeps a task whose status is missing', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        tasks: [
+          makeTask({
+            id: 't1',
+            companionId: 'p1',
+            dueAt: fromNow(MS_PER_HOUR),
+            name: 'Statusless',
+            status: undefined as unknown as Task['status'],
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.tasks).toHaveLength(1);
+    expect(snapshot.tasks[0].title).toBe('Statusless');
+  });
+
+  it('falls back to the task title when there is no display name', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        tasks: [
+          makeTask({
+            id: 't1',
+            companionId: 'p1',
+            dueAt: fromNow(MS_PER_HOUR),
+            title: 'Give insulin',
+            name: undefined,
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.tasks[0].title).toBe('Give insulin');
+  });
+
+  it('derives the due moment from date plus time when dueAt is absent', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO],
+        tasks: [
+          makeTask({
+            id: 't1',
+            companionId: 'p1',
+            dueAt: undefined,
+            date: '2026-01-22',
+            time: '07:15',
+            name: 'Breakfast',
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.tasks[0].at).toBe(
+      new Date('2026-01-22T07:15:00').toISOString(),
+    );
+  });
+
+  it('keeps only the 20 earliest tasks', () => {
+    const tasks = Array.from({length: SNAPSHOT_ITEM_LIMIT + 5}, (_, i) =>
+      makeTask({
+        id: `t${i}`,
+        companionId: 'p1',
+        dueAt: fromNow((SNAPSHOT_ITEM_LIMIT + 5 - i) * MS_PER_HOUR),
+        name: `Chore ${SNAPSHOT_ITEM_LIMIT + 5 - i}`,
+      }),
+    );
+
+    const snapshot = buildSnapshot(makeContext({companions: [BRUNO], tasks}));
+
+    expect(snapshot.tasks).toHaveLength(20);
+    expect(snapshot.tasks[0].at).toBe(fromNow(MS_PER_HOUR));
+    expect(snapshot.tasks[19].at).toBe(fromNow(20 * MS_PER_HOUR));
+    expect(snapshot.tasks.map(entry => entry.title)).not.toContain('Chore 21');
+  });
+});
+
+describe('buildSnapshot - vaccinations due', () => {
+  it('collects dated records per pet, sorted by date, keeping overdue ones', () => {
+    const snapshot = buildSnapshot(
+      makeContext({
+        companions: [BRUNO, MIA, makePet({id: 'p3', name: 'Rex'})],
+        vaccinations: {
+          p1: [
+            {name: 'Rabies', dueOn: fromNow(5 * MS_PER_DAY)},
+            {name: 'Overdue booster', dueOn: fromNow(-40 * MS_PER_DAY)},
+            {name: 'At horizon', dueOn: atMs(HORIZON_MS)},
+            {name: 'No due date', dueOn: null},
+            {name: 'Undefined due date'},
+            {name: 'Empty due date', dueOn: ''},
+            {name: 'Unparseable', dueOn: 'not-a-date'},
+            {name: 'Beyond horizon', dueOn: atMs(HORIZON_MS + 1)},
+          ],
+          p2: [{name: 'Leptospirosis', dueOn: fromNow(MS_PER_DAY)}],
+          ghost: [{name: 'Belongs to nobody', dueOn: fromNow(2 * MS_PER_DAY)}],
+        },
+      }),
+    );
+
+    expect(snapshot.vaccinationsDue).toStrictEqual([
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Overdue booster',
+        at: fromNow(-40 * MS_PER_DAY),
+      },
+      {
+        petId: 'p2',
+        petName: 'Mia',
+        title: 'Leptospirosis',
+        at: fromNow(MS_PER_DAY),
+      },
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Rabies',
+        at: fromNow(5 * MS_PER_DAY),
+      },
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'At horizon',
+        at: atMs(HORIZON_MS),
+      },
+    ]);
+  });
+
+  it('returns nothing for a pet with no vaccination records at all', () => {
+    const snapshot = buildSnapshot(
+      makeContext({companions: [BRUNO], vaccinations: {}}),
+    );
+
+    expect(snapshot.vaccinationsDue).toStrictEqual([]);
+  });
+
+  it('keeps only the 20 earliest vaccinations due', () => {
+    const records = Array.from({length: SNAPSHOT_ITEM_LIMIT + 5}, (_, i) => ({
+      name: `Shot ${SNAPSHOT_ITEM_LIMIT + 5 - i}`,
+      dueOn: fromNow((SNAPSHOT_ITEM_LIMIT + 5 - i) * MS_PER_HOUR),
+    }));
+
+    const snapshot = buildSnapshot(
+      makeContext({companions: [BRUNO], vaccinations: {p1: records}}),
+    );
+
+    expect(snapshot.vaccinationsDue).toHaveLength(20);
+    expect(snapshot.vaccinationsDue[0].at).toBe(fromNow(MS_PER_HOUR));
+    expect(snapshot.vaccinationsDue[19].at).toBe(fromNow(20 * MS_PER_HOUR));
+    expect(snapshot.vaccinationsDue.map(entry => entry.title)).not.toContain(
+      'Shot 21',
+    );
+  });
+});
+
+describe('publishSnapshot', () => {
+  const context = makeContext({
+    companions: [BRUNO],
+    appointments: [
+      makeAppointment({
+        id: 'a1',
+        companionId: 'p1',
+        start: fromNow(MS_PER_HOUR),
+        serviceName: 'Dental clean',
+        organisationName: 'Happy Paws',
+      }),
+    ],
+  });
+
+  it('resolves false when the native module is absent', async () => {
+    mockGetSnapshotModule.mockReturnValue(null);
+
+    await expect(publishSnapshot(context)).resolves.toBe(false);
+  });
+
+  it('writes the serialised snapshot and returns the module result', async () => {
+    const native = makeNativeModule();
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(publishSnapshot(context)).resolves.toBe(true);
+
+    expect(native.writeSnapshot).toHaveBeenCalledTimes(1);
+    const json = native.writeSnapshot.mock.calls[0][0];
+    expect(typeof json).toBe('string');
+    const payload = JSON.parse(json);
+    expect(payload).toEqual(buildSnapshot(context));
+    expect(payload.appointments).toStrictEqual([
+      {
+        petId: 'p1',
+        petName: 'Bruno',
+        title: 'Dental clean',
+        at: fromNow(MS_PER_HOUR),
+        subtitle: 'Happy Paws',
+      },
+    ]);
+  });
+
+  it('returns false when the native side reports a failed write', async () => {
+    const native = makeNativeModule({
+      writeSnapshot: jest.fn().mockResolvedValue(false),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(publishSnapshot(context)).resolves.toBe(false);
+    expect(native.writeSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when writeSnapshot rejects', async () => {
+    const native = makeNativeModule({
+      writeSnapshot: jest.fn().mockRejectedValue(new Error('bridge down')),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(publishSnapshot(context)).resolves.toBe(false);
+  });
+});
+
+describe('clearSnapshot', () => {
+  it('resolves false when the native module is absent', async () => {
+    mockGetSnapshotModule.mockReturnValue(null);
+
+    await expect(clearSnapshot()).resolves.toBe(false);
+  });
+
+  it('returns the module result when the clear succeeds', async () => {
+    const native = makeNativeModule();
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(clearSnapshot()).resolves.toBe(true);
+    expect(native.clearSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the native side reports a failed clear', async () => {
+    const native = makeNativeModule({
+      clearSnapshot: jest.fn().mockResolvedValue(false),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(clearSnapshot()).resolves.toBe(false);
+  });
+
+  it('returns false when clearSnapshot rejects', async () => {
+    const native = makeNativeModule({
+      clearSnapshot: jest.fn().mockRejectedValue(new Error('bridge down')),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(clearSnapshot()).resolves.toBe(false);
+  });
+});
+
+describe('consumePendingLink', () => {
+  it('resolves null when the native module is absent', async () => {
+    mockGetSnapshotModule.mockReturnValue(null);
+
+    await expect(consumePendingLink()).resolves.toBeNull();
+  });
+
+  it('returns the parked deep link', async () => {
+    const native = makeNativeModule({
+      consumePendingLink: jest
+        .fn()
+        .mockResolvedValue('yc://app/appointments/a1'),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(consumePendingLink()).resolves.toBe(
+      'yc://app/appointments/a1',
+    );
+    expect(native.consumePendingLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps the empty string the native side returns for "nothing pending" to null', async () => {
+    const native = makeNativeModule({
+      consumePendingLink: jest.fn().mockResolvedValue(''),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(consumePendingLink()).resolves.toBeNull();
+  });
+
+  it('returns null when consumePendingLink rejects', async () => {
+    const native = makeNativeModule({
+      consumePendingLink: jest.fn().mockRejectedValue(new Error('bridge down')),
+    });
+    mockGetSnapshotModule.mockReturnValue(native);
+
+    await expect(consumePendingLink()).resolves.toBeNull();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/handoffNavigation.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/handoffNavigation.test.ts
@@ -233,3 +233,37 @@ describe('resolveHandoffTarget', () => {
     expect(resolveHandoffTarget('yosemite://app/assistant')).toBeNull();
   });
 });
+
+describe('parseAssistantLink malformed input', () => {
+  // yc://app is an exported deep link, so any installed app can hand us one.
+  // decodeURIComponent throws a URIError on a stray '%', which used to escape
+  // the parser and surface as an unhandled rejection in the deep-link handler.
+  it('keeps a malformed percent escape verbatim instead of throwing', () => {
+    expect(parseAssistantLink('yc://app/tasks/new?title=%')).toEqual({
+      path: '/tasks/new',
+      params: {title: '%'},
+    });
+  });
+
+  it('keeps a malformed percent escape in a key verbatim', () => {
+    expect(parseAssistantLink('yc://app/x?%ZZ=1')).toEqual({
+      path: '/x',
+      params: {'%ZZ': '1'},
+    });
+  });
+
+  it('still decodes the valid pairs alongside a malformed one', () => {
+    expect(parseAssistantLink('yc://app/x?bad=%&good=a%20b')).toEqual({
+      path: '/x',
+      params: {bad: '%', good: 'a b'},
+    });
+  });
+
+  it('routes a link carrying a malformed value rather than throwing', () => {
+    expect(resolveHandoffTarget('yc://app/appointments/book?pet=%')).toEqual({
+      tab: 'Appointments',
+      screen: 'BrowseBusinesses',
+      params: {autoFocusSearch: true},
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/handoffNavigation.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/handoffNavigation.test.ts
@@ -1,0 +1,235 @@
+import {
+  parseAssistantLink,
+  resolveHandoffTarget,
+} from '@/features/assistant/services/handoffNavigation';
+
+describe('parseAssistantLink', () => {
+  it('treats a bare yc://app as the root path with no params', () => {
+    expect(parseAssistantLink('yc://app')).toEqual({path: '/', params: {}});
+  });
+
+  it('keeps the path and returns empty params when there is no query', () => {
+    expect(parseAssistantLink('yc://app/tasks/new')).toEqual({
+      path: '/tasks/new',
+      params: {},
+    });
+  });
+
+  it('splits the query into key/value pairs', () => {
+    expect(
+      parseAssistantLink('yc://app/tasks/new?when=2026-09-10&pet=bruno'),
+    ).toEqual({
+      path: '/tasks/new',
+      params: {when: '2026-09-10', pet: 'bruno'},
+    });
+  });
+
+  it('percent-decodes both keys and values', () => {
+    expect(
+      parseAssistantLink('yc://app/tasks/new?pet%20name=Mr%2E%20Bruno'),
+    ).toEqual({
+      path: '/tasks/new',
+      params: {'pet name': 'Mr. Bruno'},
+    });
+  });
+
+  it('decodes "+" in a value as a space', () => {
+    expect(
+      parseAssistantLink('yc://app/tasks/new?title=book+a+vet+visit'),
+    ).toEqual({
+      path: '/tasks/new',
+      params: {title: 'book a vet visit'},
+    });
+  });
+
+  it('decodes "+" as a space in the key as well as the value', () => {
+    expect(parseAssistantLink('yc://app/x?a+b=c+d')).toEqual({
+      path: '/x',
+      params: {'a b': 'c d'},
+    });
+  });
+
+  it('decodes "+" in a key that has no value', () => {
+    expect(parseAssistantLink('yc://app/x?flag+two')).toEqual({
+      path: '/x',
+      params: {'flag two': ''},
+    });
+  });
+
+  it('skips an empty pair produced by a doubled ampersand', () => {
+    expect(parseAssistantLink('yc://app/x?a=1&&b=2')).toEqual({
+      path: '/x',
+      params: {a: '1', b: '2'},
+    });
+  });
+
+  it('skips a pair whose key is empty', () => {
+    expect(parseAssistantLink('yc://app/x?=orphan&a=1')).toEqual({
+      path: '/x',
+      params: {a: '1'},
+    });
+  });
+
+  it('gives a key with no "=" an empty-string value', () => {
+    expect(parseAssistantLink('yc://app/x?flag')).toEqual({
+      path: '/x',
+      params: {flag: ''},
+    });
+  });
+
+  it('splits on the first "=" only, so a value may contain further "=" signs', () => {
+    expect(parseAssistantLink('yc://app/x?a=b=c')).toEqual({
+      path: '/x',
+      params: {a: 'b=c'},
+    });
+  });
+
+  it('keeps a trailing "=" as part of a base64-ish value', () => {
+    expect(parseAssistantLink('yc://app/x?token=YWJjZA==&a=1')).toEqual({
+      path: '/x',
+      params: {token: 'YWJjZA==', a: '1'},
+    });
+  });
+
+  it('gives a key followed by a bare "=" an empty-string value', () => {
+    expect(parseAssistantLink('yc://app/x?a=')).toEqual({
+      path: '/x',
+      params: {a: ''},
+    });
+  });
+
+  it('returns empty params for a "?" with nothing after it', () => {
+    expect(parseAssistantLink('yc://app/x?')).toEqual({path: '/x', params: {}});
+  });
+
+  it('strips a trailing slash from the path', () => {
+    expect(parseAssistantLink('yc://app/tasks/new/')).toEqual({
+      path: '/tasks/new',
+      params: {},
+    });
+  });
+
+  it('strips a run of trailing slashes from the path', () => {
+    expect(parseAssistantLink('yc://app/tasks/new///?a=1')).toEqual({
+      path: '/tasks/new',
+      params: {a: '1'},
+    });
+  });
+
+  it('collapses a lone "/" back to the root path', () => {
+    expect(parseAssistantLink('yc://app/')).toEqual({path: '/', params: {}});
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(parseAssistantLink('  yc://app/assistant  ')).toEqual({
+      path: '/assistant',
+      params: {},
+    });
+  });
+
+  it('returns null for a non-matching scheme', () => {
+    expect(parseAssistantLink('https://app/tasks/new')).toBeNull();
+  });
+
+  it('returns null for a host that merely starts with "app"', () => {
+    expect(parseAssistantLink('yc://apples/tasks')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseAssistantLink('')).toBeNull();
+  });
+});
+
+describe('resolveHandoffTarget', () => {
+  it('routes /tasks/new to the add-task screen with an ISO "when" truncated to a date', () => {
+    expect(
+      resolveHandoffTarget('yc://app/tasks/new?when=2026-09-10T09:30:00.000Z'),
+    ).toEqual({
+      tab: 'Tasks',
+      screen: 'AddTask',
+      params: {prefillDate: '2026-09-10'},
+    });
+  });
+
+  it('passes an already-date-only "when" through unchanged', () => {
+    expect(resolveHandoffTarget('yc://app/tasks/new?when=2026-12-01')).toEqual({
+      tab: 'Tasks',
+      screen: 'AddTask',
+      params: {prefillDate: '2026-12-01'},
+    });
+  });
+
+  it('leaves prefillDate undefined when "when" is absent', () => {
+    const target = resolveHandoffTarget('yc://app/tasks/new');
+    expect(target).toEqual({
+      tab: 'Tasks',
+      screen: 'AddTask',
+      params: {prefillDate: undefined},
+    });
+    // The key is still present, it simply carries no value.
+    expect(target?.params).toHaveProperty('prefillDate', undefined);
+    expect(Object.keys(target?.params ?? {})).toEqual(['prefillDate']);
+  });
+
+  it('leaves prefillDate undefined when "when" is present but empty', () => {
+    expect(resolveHandoffTarget('yc://app/tasks/new?when=')?.params).toEqual({
+      prefillDate: undefined,
+    });
+    expect(
+      resolveHandoffTarget('yc://app/tasks/new?when=')?.params?.prefillDate,
+    ).toBeUndefined();
+  });
+
+  it('ignores query params other than "when" on /tasks/new', () => {
+    expect(
+      resolveHandoffTarget('yc://app/tasks/new?pet=bruno&title=vet'),
+    ).toEqual({
+      tab: 'Tasks',
+      screen: 'AddTask',
+      params: {prefillDate: undefined},
+    });
+  });
+
+  it('routes /expenses/new through the nested expenses stack under the home tab', () => {
+    expect(resolveHandoffTarget('yc://app/expenses/new')).toEqual({
+      tab: 'HomeStack',
+      screen: 'ExpensesStack',
+      nested: {screen: 'AddExpense'},
+    });
+  });
+
+  it('routes /appointments/book to browse with search auto-focused', () => {
+    expect(resolveHandoffTarget('yc://app/appointments/book')).toEqual({
+      tab: 'Appointments',
+      screen: 'BrowseBusinesses',
+      params: {autoFocusSearch: true},
+    });
+  });
+
+  it('routes /assistant to the assistant screen with no params', () => {
+    expect(resolveHandoffTarget('yc://app/assistant')).toEqual({
+      tab: 'HomeStack',
+      screen: 'Assistant',
+    });
+  });
+
+  it('resolves a route despite a trailing slash', () => {
+    expect(resolveHandoffTarget('yc://app/appointments/book/')).toEqual({
+      tab: 'Appointments',
+      screen: 'BrowseBusinesses',
+      params: {autoFocusSearch: true},
+    });
+  });
+
+  it('returns null for a known-looking but unmapped path', () => {
+    expect(resolveHandoffTarget('yc://app/tasks/edit')).toBeNull();
+  });
+
+  it('returns null for the root path', () => {
+    expect(resolveHandoffTarget('yc://app')).toBeNull();
+  });
+
+  it('returns null when the link does not parse at all', () => {
+    expect(resolveHandoffTarget('yosemite://app/assistant')).toBeNull();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/nativeBridge.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/nativeBridge.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the assistant's safe native-module accessors.
+ *
+ * `nativeBridge` reads `NativeModules` and `Platform` at call time, so every
+ * case here re-requires the module through `jest.resetModules()` +
+ * `jest.doMock('react-native', ...)` to place it under a different runtime.
+ */
+
+type Bridge = typeof import('@/features/assistant/services/nativeBridge');
+
+type LoadOptions = {
+  nativeModules?: Record<string, unknown>;
+  os?: string;
+};
+
+const loadBridge = ({nativeModules = {}, os = 'ios'}: LoadOptions = {}): {
+  bridge: Bridge;
+  nativeModules: Record<string, unknown>;
+} => {
+  jest.resetModules();
+  jest.doMock('react-native', () => ({
+    NativeModules: nativeModules,
+    Platform: {OS: os},
+  }));
+  const bridge =
+    require('@/features/assistant/services/nativeBridge') as Bridge;
+  return {bridge, nativeModules};
+};
+
+const makeSnapshotModule = () => ({
+  writeSnapshot: jest.fn().mockResolvedValue(true),
+  clearSnapshot: jest.fn().mockResolvedValue(true),
+  consumePendingLink: jest.fn().mockResolvedValue(''),
+});
+
+const makeOnDeviceModule = () => ({
+  isAvailable: jest.fn().mockResolvedValue({available: true}),
+  generate: jest.fn().mockResolvedValue('hello'),
+});
+
+afterEach(() => {
+  jest.dontMock('react-native');
+  jest.resetModules();
+});
+
+describe('getSnapshotModule', () => {
+  it('returns null when AssistantSnapshotBridge is absent', () => {
+    const {bridge} = loadBridge({nativeModules: {}});
+
+    expect(bridge.getSnapshotModule()).toBeNull();
+  });
+
+  it('returns the exact AssistantSnapshotBridge object when present', () => {
+    const snapshot = makeSnapshotModule();
+    const {bridge} = loadBridge({
+      nativeModules: {AssistantSnapshotBridge: snapshot},
+    });
+
+    expect(bridge.getSnapshotModule()).toBe(snapshot);
+  });
+
+  it('returns a module whose methods are callable through the accessor', async () => {
+    const snapshot = makeSnapshotModule();
+    const {bridge} = loadBridge({
+      nativeModules: {AssistantSnapshotBridge: snapshot},
+    });
+
+    await expect(
+      bridge.getSnapshotModule()?.writeSnapshot('{"pets":[]}'),
+    ).resolves.toBe(true);
+    expect(snapshot.writeSnapshot).toHaveBeenCalledWith('{"pets":[]}');
+  });
+
+  it('does not fall back to the on-device model module', () => {
+    const {bridge} = loadBridge({
+      nativeModules: {OnDeviceModelBridge: makeOnDeviceModule()},
+    });
+
+    expect(bridge.getSnapshotModule()).toBeNull();
+  });
+
+  it('returns null when the registered entry is falsy', () => {
+    const {bridge} = loadBridge({
+      nativeModules: {AssistantSnapshotBridge: undefined},
+    });
+
+    expect(bridge.getSnapshotModule()).toBeNull();
+  });
+
+  it('reads NativeModules on every call, so late registration is picked up', () => {
+    const {bridge, nativeModules} = loadBridge({nativeModules: {}});
+    expect(bridge.getSnapshotModule()).toBeNull();
+
+    const snapshot = makeSnapshotModule();
+    nativeModules.AssistantSnapshotBridge = snapshot;
+
+    expect(bridge.getSnapshotModule()).toBe(snapshot);
+  });
+});
+
+describe('getOnDeviceModelModule', () => {
+  it('returns null when OnDeviceModelBridge is absent', () => {
+    const {bridge} = loadBridge({nativeModules: {}});
+
+    expect(bridge.getOnDeviceModelModule()).toBeNull();
+  });
+
+  it('returns the exact OnDeviceModelBridge object when present', () => {
+    const model = makeOnDeviceModule();
+    const {bridge} = loadBridge({nativeModules: {OnDeviceModelBridge: model}});
+
+    expect(bridge.getOnDeviceModelModule()).toBe(model);
+  });
+
+  it('returns a module whose generate() reaches the native implementation', async () => {
+    const model = makeOnDeviceModule();
+    const {bridge} = loadBridge({nativeModules: {OnDeviceModelBridge: model}});
+
+    await expect(
+      bridge.getOnDeviceModelModule()?.generate('hi', 64),
+    ).resolves.toBe('hello');
+    expect(model.generate).toHaveBeenCalledWith('hi', 64);
+  });
+
+  it('does not fall back to the snapshot module', () => {
+    const {bridge} = loadBridge({
+      nativeModules: {AssistantSnapshotBridge: makeSnapshotModule()},
+    });
+
+    expect(bridge.getOnDeviceModelModule()).toBeNull();
+  });
+
+  it('returns null when the registered entry is falsy', () => {
+    const {bridge} = loadBridge({nativeModules: {OnDeviceModelBridge: null}});
+
+    expect(bridge.getOnDeviceModelModule()).toBeNull();
+  });
+
+  it('resolves both modules independently when both are registered', () => {
+    const snapshot = makeSnapshotModule();
+    const model = makeOnDeviceModule();
+    const {bridge} = loadBridge({
+      nativeModules: {
+        AssistantSnapshotBridge: snapshot,
+        OnDeviceModelBridge: model,
+      },
+    });
+
+    expect(bridge.getSnapshotModule()).toBe(snapshot);
+    expect(bridge.getOnDeviceModelModule()).toBe(model);
+  });
+});
+
+describe('platformProviderLabel', () => {
+  it('names Apple Intelligence on iOS', () => {
+    const {bridge} = loadBridge({os: 'ios'});
+
+    expect(bridge.platformProviderLabel()).toBe('Apple Intelligence');
+  });
+
+  it('names Gemini Nano on Android', () => {
+    const {bridge} = loadBridge({os: 'android'});
+
+    expect(bridge.platformProviderLabel()).toBe('Gemini Nano');
+  });
+
+  it('falls back to Gemini Nano on any non-iOS platform', () => {
+    const {bridge} = loadBridge({os: 'macos'});
+
+    expect(bridge.platformProviderLabel()).toBe('Gemini Nano');
+  });
+
+  it('does not depend on which native modules are registered', () => {
+    const {bridge} = loadBridge({
+      nativeModules: {OnDeviceModelBridge: makeOnDeviceModule()},
+      os: 'android',
+    });
+
+    expect(bridge.platformProviderLabel()).toBe('Gemini Nano');
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/services/onDeviceModel.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/services/onDeviceModel.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for the on-device model wrapper.
+ *
+ * The wrapper is a guard rail: it must never let the platform model widen the
+ * assistant's answers. Every case here drives the real module with a faked
+ * native bridge and asserts the exact value that reaches the caller.
+ */
+import {
+  checkAvailability,
+  classify,
+  rephrase,
+} from '@/features/assistant/services/onDeviceModel';
+import {ASSISTANT_ACTION_IDS} from '@/features/assistant/actions/catalogue';
+import {RULES_CONFIDENCE_THRESHOLD} from '@/features/assistant/constants';
+
+const mockGetOnDeviceModelModule = jest.fn();
+const mockPlatformProviderLabel = jest.fn(() => 'Apple Intelligence');
+
+jest.mock('@/features/assistant/services/nativeBridge', () => ({
+  getOnDeviceModelModule: () => mockGetOnDeviceModelModule(),
+  platformProviderLabel: () => mockPlatformProviderLabel(),
+}));
+
+type FakeModule = {
+  isAvailable: jest.Mock;
+  generate: jest.Mock;
+};
+
+const makeModule = (overrides: Partial<FakeModule> = {}): FakeModule => ({
+  isAvailable: jest.fn().mockResolvedValue({available: true}),
+  generate: jest.fn().mockResolvedValue(''),
+  ...overrides,
+});
+
+/** Installs a fake native module for the next call, and returns it. */
+const useModule = (overrides: Partial<FakeModule> = {}): FakeModule => {
+  const module = makeModule(overrides);
+  mockGetOnDeviceModelModule.mockReturnValue(module);
+  return module;
+};
+
+const useNoModule = (): void => {
+  mockGetOnDeviceModelModule.mockReturnValue(null);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPlatformProviderLabel.mockReturnValue('Apple Intelligence');
+  useNoModule();
+});
+
+describe('checkAvailability', () => {
+  it('reports unsupportedDevice with no provider label when the native module is absent', async () => {
+    useNoModule();
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unsupportedDevice',
+    });
+    expect(mockPlatformProviderLabel).not.toHaveBeenCalled();
+  });
+
+  it('reports available with the platform label when the module says yes', async () => {
+    useModule({isAvailable: jest.fn().mockResolvedValue({available: true})});
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: true,
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('prefers the label the module supplies over the platform default', async () => {
+    useModule({
+      isAvailable: jest
+        .fn()
+        .mockResolvedValue({available: true, providerLabel: 'Gemini Nano'}),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: true,
+      providerLabel: 'Gemini Nano',
+    });
+    expect(mockPlatformProviderLabel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'unsupportedOS',
+    'unsupportedDevice',
+    'notEnabled',
+    'modelNotReady',
+    'unknown',
+  ])('passes the known reason %s straight through', async reason => {
+    useModule({
+      isAvailable: jest.fn().mockResolvedValue({available: false, reason}),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason,
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('maps a reason outside the known set to unknown', async () => {
+    useModule({
+      isAvailable: jest
+        .fn()
+        .mockResolvedValue({available: false, reason: 'thermalThrottling'}),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('maps a missing reason to unknown and still reports the provider label', async () => {
+    useModule({isAvailable: jest.fn().mockResolvedValue({available: false})});
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('treats a null result as unavailable for an unknown reason', async () => {
+    useModule({isAvailable: jest.fn().mockResolvedValue(null)});
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('keeps the module-supplied label on the unavailable branch', async () => {
+    useModule({
+      isAvailable: jest.fn().mockResolvedValue({
+        available: false,
+        reason: 'notEnabled',
+        providerLabel: 'Writing Tools',
+      }),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'notEnabled',
+      providerLabel: 'Writing Tools',
+    });
+  });
+
+  it('reports unknown with the platform label when isAvailable rejects', async () => {
+    useModule({
+      isAvailable: jest.fn().mockRejectedValue(new Error('bridge exploded')),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('reports unknown with the platform label when isAvailable throws synchronously', async () => {
+    useModule({
+      isAvailable: jest.fn(() => {
+        throw new Error('no such selector');
+      }),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Apple Intelligence',
+    });
+  });
+
+  it('takes the throwing path label from the platform rather than a fixed string', async () => {
+    mockPlatformProviderLabel.mockReturnValue('Gemini Nano');
+    useModule({
+      isAvailable: jest.fn().mockRejectedValue(new Error('bridge exploded')),
+    });
+
+    await expect(checkAvailability()).resolves.toEqual({
+      available: false,
+      reason: 'unknown',
+      providerLabel: 'Gemini Nano',
+    });
+    expect(mockPlatformProviderLabel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('classify', () => {
+  it('returns null without asking anything when the native module is absent', async () => {
+    useNoModule();
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+
+  it('returns the catalogue action the model names', async () => {
+    const module = useModule({
+      generate: jest.fn().mockResolvedValue('nextAppointment'),
+    });
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toEqual({
+      actionId: 'nextAppointment',
+      slots: {},
+      confidence: 0.5,
+      source: 'model',
+    });
+    expect(module.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the utterance, the descriptions and a 24 token budget to the model', async () => {
+    const module = useModule({
+      generate: jest.fn().mockResolvedValue('logExpense'),
+    });
+
+    await classify('I paid the groomer', 'logExpense — record a cost');
+
+    const [prompt, maxTokens] = module.generate.mock.calls[0];
+    expect(prompt).toContain('Question: I paid the groomer');
+    expect(prompt).toContain('logExpense — record a cost');
+    expect(prompt).toContain(
+      'Reply with exactly one action id from this list and nothing else.',
+    );
+    expect(maxTokens).toBe(24);
+  });
+
+  it('strips surrounding whitespace and punctuation from the reply', async () => {
+    useModule({
+      generate: jest.fn().mockResolvedValue('\n  "vaccinationStatus".  \n'),
+    });
+
+    const intent = await classify('are the shots done', 'catalogue');
+
+    expect(intent?.actionId).toBe('vaccinationStatus');
+  });
+
+  it('returns null when the id arrives inside a numbered list item', async () => {
+    useModule({
+      generate: jest.fn().mockResolvedValue('\n  2. "vaccinationStatus".  \n'),
+    });
+
+    await expect(
+      classify('are the shots done', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+
+  it('matches an action id regardless of case', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('BOOKAPPOINTMENT')});
+
+    const intent = await classify('book me in', 'catalogue');
+
+    expect(intent?.actionId).toBe('bookAppointment');
+  });
+
+  it('reports source model and a confidence below the rules threshold', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('petOverview')});
+
+    const intent = await classify('tell me about Rex', 'catalogue');
+
+    expect(intent?.source).toBe('model');
+    expect(intent?.confidence).toBe(0.5);
+    expect(intent?.confidence).toBeLessThan(RULES_CONFIDENCE_THRESHOLD);
+  });
+
+  it('never invents slots for the model guess', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('upcomingTasks')});
+
+    const intent = await classify('what is due for Rex', 'catalogue');
+
+    expect(intent?.slots).toEqual({});
+  });
+
+  it('returns null for an id that is not in the catalogue', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('petHoroscope')});
+
+    expect(ASSISTANT_ACTION_IDS).not.toContain('petHoroscope');
+    await expect(classify('read his stars', 'catalogue')).resolves.toBeNull();
+  });
+
+  it('returns null when the model answers the question in prose instead', async () => {
+    useModule({
+      generate: jest
+        .fn()
+        .mockResolvedValue('I think the vet visit is on Tuesday at three.'),
+    });
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null for a spaced rendering of an id, which is prose and not an id', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('next appointment')});
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null for a line-broken rendering of an id', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('next\nAppointment')});
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+
+  it('accepts a single-token id wrapped in whitespace and a full stop', async () => {
+    useModule({generate: jest.fn().mockResolvedValue(' nextAppointment. ')});
+
+    const intent = await classify('when is the vet visit', 'catalogue');
+
+    expect(intent?.actionId).toBe('nextAppointment');
+  });
+
+  it('returns null for an empty reply', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('   ')});
+
+    await expect(classify('anything', 'catalogue')).resolves.toBeNull();
+  });
+
+  it('returns null when the model resolves to null', async () => {
+    useModule({generate: jest.fn().mockResolvedValue(null)});
+
+    await expect(classify('anything', 'catalogue')).resolves.toBeNull();
+  });
+
+  it('returns null when generate rejects', async () => {
+    useModule({
+      generate: jest.fn().mockRejectedValue(new Error('model timed out')),
+    });
+
+    await expect(
+      classify('when is the vet visit', 'catalogue'),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('rephrase', () => {
+  const sentence = 'Rex is due for a rabies booster on 4 March.';
+
+  it('returns the sentence untouched when the native module is absent', async () => {
+    useNoModule();
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+
+  it('returns the model rewrite when it is a plausible short sentence', async () => {
+    useModule({
+      generate: jest
+        .fn()
+        .mockResolvedValue("Rex's rabies booster is due on 4 March."),
+    });
+
+    await expect(rephrase(sentence)).resolves.toBe(
+      "Rex's rabies booster is due on 4 March.",
+    );
+  });
+
+  it('trims the whitespace the model wraps around its rewrite', async () => {
+    useModule({
+      generate: jest.fn().mockResolvedValue('\n  Booster: 4 March.  '),
+    });
+
+    await expect(rephrase(sentence)).resolves.toBe('Booster: 4 March.');
+  });
+
+  it('sends the sentence and a 96 token budget to the model', async () => {
+    const module = useModule({generate: jest.fn().mockResolvedValue('ok')});
+
+    await rephrase(sentence);
+
+    const [prompt, maxTokens] = module.generate.mock.calls[0];
+    expect(prompt).toContain(`Sentence: ${sentence}`);
+    expect(prompt).toContain('Add no new facts. Reply with the sentence only.');
+    expect(maxTokens).toBe(96);
+  });
+
+  it('returns the original when the model replies with only whitespace', async () => {
+    useModule({generate: jest.fn().mockResolvedValue('   \n  ')});
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+
+  it('returns the original when the model resolves to null', async () => {
+    useModule({generate: jest.fn().mockResolvedValue(null)});
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+
+  it('returns the original when the rewrite runs past twice the length plus 40', async () => {
+    const tooLong = 'x'.repeat(sentence.length * 2 + 41);
+    useModule({generate: jest.fn().mockResolvedValue(tooLong)});
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+
+  it('accepts a rewrite that lands exactly on the length ceiling', async () => {
+    const atCeiling = 'y'.repeat(sentence.length * 2 + 40);
+    useModule({generate: jest.fn().mockResolvedValue(atCeiling)});
+
+    await expect(rephrase(sentence)).resolves.toBe(atCeiling);
+  });
+
+  it('returns the original when generate rejects', async () => {
+    useModule({
+      generate: jest.fn().mockRejectedValue(new Error('model timed out')),
+    });
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+
+  it('returns the original when generate throws synchronously', async () => {
+    useModule({
+      generate: jest.fn(() => {
+        throw new Error('bridge gone');
+      }),
+    });
+
+    await expect(rephrase(sentence)).resolves.toBe(sentence);
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/thunks.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/thunks.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Tests for the assistant thunks.
+ *
+ * The three services the thunks lean on are mocked, so what is under test is
+ * purely the orchestration: which action is dispatched, in what order, and
+ * with what the service handed back. Everything else - the slice, the
+ * selectors and the context builder - runs for real through a store shaped
+ * like the app's, because the whole point of `askAssistant` is that the turn
+ * sees the state that exists at the moment the user pressed send.
+ *
+ * The clock is pinned so `makeId`, `createdAt` and `context.now` are exact
+ * values rather than "some date".
+ */
+import {configureStore} from '@reduxjs/toolkit';
+import type {TFunction} from 'i18next';
+import type {Appointment} from '@/features/appointments/types';
+import type {Companion} from '@/features/companion/types';
+import type {Expense} from '@/features/expenses/types';
+import type {Task} from '@/features/tasks/types';
+import type {
+  AssistantActionResult,
+  OnDeviceModelAvailability,
+} from '@/features/assistant/types';
+import {
+  assistantReducer,
+  modelAvailabilityChanged,
+} from '@/features/assistant/assistantSlice';
+import {
+  askAssistant,
+  probeOnDeviceModel,
+  refreshAssistantSnapshot,
+} from '@/features/assistant/thunks';
+import {runTurn} from '@/features/assistant/services/assistantRuntime';
+import {checkAvailability} from '@/features/assistant/services/onDeviceModel';
+import {publishSnapshot} from '@/features/assistant/services/assistantSnapshot';
+
+jest.mock('@/features/assistant/services/assistantRuntime', () => ({
+  runTurn: jest.fn(),
+}));
+jest.mock('@/features/assistant/services/onDeviceModel', () => ({
+  checkAvailability: jest.fn(),
+}));
+jest.mock('@/features/assistant/services/assistantSnapshot', () => ({
+  publishSnapshot: jest.fn(),
+}));
+
+const mockRunTurn = runTurn as jest.MockedFunction<typeof runTurn>;
+const mockCheckAvailability = checkAvailability as jest.MockedFunction<
+  typeof checkAvailability
+>;
+const mockPublishSnapshot = publishSnapshot as jest.MockedFunction<
+  typeof publishSnapshot
+>;
+
+/** Every `new Date()` inside the thunks resolves to this instant. */
+const WALL_CLOCK = '2026-05-04T09:30:00.000Z';
+
+const companions = [
+  {id: 'pet-1', name: 'Kiwi', category: 'dog'},
+  {id: 'pet-2', name: 'Mango', category: 'cat'},
+] as unknown as Companion[];
+
+const tasks = [
+  {id: 'task-1', companionId: 'pet-1', status: 'PENDING'},
+] as unknown as Task[];
+
+const appointments = [
+  {id: 'appt-1', companionId: 'pet-1', status: 'CONFIRMED'},
+] as unknown as Appointment[];
+
+const expenses = [
+  {id: 'exp-1', companionId: 'pet-1', amount: 42},
+] as unknown as Expense[];
+
+const passports = {
+  'pet-1': {
+    vaccinations: [
+      {name: 'Rabies', administeredOn: '2026-01-10', dueOn: '2027-01-10'},
+    ],
+  },
+};
+
+/** What `selectVaccinationsByCompanion` makes of `passports`. */
+const vaccinations = {
+  'pet-1': [
+    {name: 'Rabies', administeredOn: '2026-01-10', dueOn: '2027-01-10'},
+  ],
+};
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      assistant: assistantReducer,
+      companion: (state: {companions: Companion[]} = {companions}) => state,
+      tasks: (state: {items: Task[]} = {items: tasks}) => state,
+      appointments: (state: {items: Appointment[]} = {items: appointments}) =>
+        state,
+      expenses: (state: {items: Expense[]} = {items: expenses}) => state,
+      passport: (
+        state: {byCompanionId: Record<string, unknown>} = {
+          byCompanionId: passports,
+        },
+      ) => state,
+    },
+  });
+
+type TestStore = ReturnType<typeof createTestStore>;
+
+/**
+ * The thunks are typed against the app's full `RootState`; this harness store
+ * holds the five slices they actually read, so dispatch is widened once here
+ * rather than at every call site.
+ */
+const dispatchOn = (store: TestStore) =>
+  store.dispatch as unknown as (
+    action: unknown,
+  ) => Promise<{type: string; payload: unknown}>;
+
+const translations: Record<string, string> = {
+  'assistant.replies.error': 'Something went wrong.',
+};
+
+const makeT = () =>
+  jest.fn((key: string) => translations[key] ?? key) as unknown as TFunction;
+
+/** The context every call should be handed, unless a case overrides a field. */
+const expectedContext = (overrides: Record<string, unknown> = {}) => ({
+  companions,
+  tasks,
+  appointments,
+  expenses,
+  vaccinations,
+  now: new Date(WALL_CLOCK),
+  currencyCode: 'USD',
+  ...overrides,
+});
+
+const actionResult: AssistantActionResult = {
+  actionId: 'nextAppointment',
+  status: 'ok',
+  speechKey: 'assistant.replies.nextAppointment',
+  speechParams: {petName: 'Kiwi'},
+};
+
+const turnOf = (overrides: Record<string, unknown> = {}) =>
+  ({
+    intent: {
+      actionId: 'nextAppointment',
+      slots: {petName: 'Kiwi'},
+      confidence: 0.9,
+      source: 'rules',
+    },
+    result: actionResult,
+    text: 'Kiwi sees Dr Rao on Friday.',
+    ...overrides,
+  }) as unknown as Awaited<ReturnType<typeof runTurn>>;
+
+describe('features/assistant/thunks', () => {
+  let store: TestStore;
+  let dispatch: ReturnType<typeof dispatchOn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(WALL_CLOCK));
+    store = createTestStore();
+    dispatch = dispatchOn(store);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('probeOnDeviceModel', () => {
+    it('stores the availability the platform reported', async () => {
+      const availability: OnDeviceModelAvailability = {
+        available: true,
+        providerLabel: 'Apple Intelligence',
+      };
+      mockCheckAvailability.mockResolvedValue(availability);
+
+      const action = await dispatch(probeOnDeviceModel());
+
+      expect(mockCheckAvailability).toHaveBeenCalledTimes(1);
+      expect(action.type).toBe('assistant/probeOnDeviceModel/fulfilled');
+      expect(store.getState().assistant.modelAvailability).toEqual({
+        available: true,
+        providerLabel: 'Apple Intelligence',
+      });
+      expect(store.getState().assistant.availabilityChecked).toBe(true);
+    });
+
+    it('stores an unavailable verdict together with its reason', async () => {
+      mockCheckAvailability.mockResolvedValue({
+        available: false,
+        reason: 'modelNotReady',
+        providerLabel: 'Gemini Nano',
+      });
+
+      await dispatch(probeOnDeviceModel());
+
+      expect(store.getState().assistant.modelAvailability).toEqual({
+        available: false,
+        reason: 'modelNotReady',
+        providerLabel: 'Gemini Nano',
+      });
+      expect(store.getState().assistant.availabilityChecked).toBe(true);
+    });
+
+    it('leaves availability untouched when the probe itself throws', async () => {
+      mockCheckAvailability.mockRejectedValue(new Error('bridge gone'));
+
+      const action = await dispatch(probeOnDeviceModel());
+
+      expect(action.type).toBe('assistant/probeOnDeviceModel/rejected');
+      expect(store.getState().assistant.modelAvailability).toEqual({
+        available: false,
+      });
+      expect(store.getState().assistant.availabilityChecked).toBe(false);
+    });
+  });
+
+  describe('refreshAssistantSnapshot', () => {
+    it('publishes a context built from the live slices and returns true', async () => {
+      mockPublishSnapshot.mockResolvedValue(true);
+
+      const action = await dispatch(refreshAssistantSnapshot());
+
+      expect(mockPublishSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockPublishSnapshot).toHaveBeenCalledWith(expectedContext());
+      expect(action.payload).toBe(true);
+    });
+
+    it('returns false when the native side refused the write', async () => {
+      mockPublishSnapshot.mockResolvedValue(false);
+
+      const action = await dispatch(refreshAssistantSnapshot());
+
+      expect(action.payload).toBe(false);
+    });
+
+    it('uses the currency code supplied by the caller', async () => {
+      mockPublishSnapshot.mockResolvedValue(true);
+
+      await dispatch(refreshAssistantSnapshot({currencyCode: 'GBP'}));
+
+      expect(mockPublishSnapshot).toHaveBeenCalledWith(
+        expectedContext({currencyCode: 'GBP'}),
+      );
+    });
+
+    it('falls back to USD when the argument omits a currency code', async () => {
+      mockPublishSnapshot.mockResolvedValue(true);
+
+      await dispatch(refreshAssistantSnapshot({}));
+
+      expect(mockPublishSnapshot).toHaveBeenCalledWith(
+        expectedContext({currencyCode: 'USD'}),
+      );
+    });
+  });
+
+  describe('askAssistant', () => {
+    it('appends the trimmed user message before the turn starts', async () => {
+      let transcriptDuringTurn: unknown = null;
+      let statusDuringTurn: unknown = null;
+      mockRunTurn.mockImplementation(async () => {
+        transcriptDuringTurn = store.getState().assistant.messages;
+        statusDuringTurn = store.getState().assistant.status;
+        return turnOf();
+      });
+
+      await dispatch(
+        askAssistant({utterance: '  when is Kiwi due?  ', t: makeT()}),
+      );
+
+      expect(transcriptDuringTurn).toHaveLength(1);
+      expect(transcriptDuringTurn).toEqual([
+        {
+          id: expect.any(String),
+          author: 'user',
+          text: 'when is Kiwi due?',
+          createdAt: WALL_CLOCK,
+        },
+      ]);
+      expect(statusDuringTurn).toBe('thinking');
+    });
+
+    it('appends the assistant reply with the resolver result attached', async () => {
+      mockRunTurn.mockResolvedValue(turnOf());
+
+      await dispatch(
+        askAssistant({utterance: 'when is Kiwi due?', t: makeT()}),
+      );
+
+      const {messages, status, error} = store.getState().assistant;
+      expect(messages).toHaveLength(2);
+      expect(messages[0].author).toBe('user');
+      expect(messages[1]).toEqual({
+        id: expect.any(String),
+        author: 'assistant',
+        text: 'Kiwi sees Dr Rao on Friday.',
+        createdAt: WALL_CLOCK,
+        result: actionResult,
+      });
+      expect(messages[1].id).not.toBe(messages[0].id);
+      expect(status).toBe('idle');
+      expect(error).toBeNull();
+    });
+
+    it('leaves the assistant message without a result when the turn produced none', async () => {
+      mockRunTurn.mockResolvedValue(turnOf({result: null}));
+
+      await dispatch(askAssistant({utterance: 'hello', t: makeT()}));
+
+      const {messages} = store.getState().assistant;
+      expect(messages).toHaveLength(2);
+      expect(messages[1].result).toBeUndefined();
+      expect(messages[1].text).toBe('Kiwi sees Dr Rao on Friday.');
+    });
+
+    it('asks the runtime to use the model when the platform reports it available', async () => {
+      store.dispatch(
+        modelAvailabilityChanged({
+          available: true,
+          providerLabel: 'Apple Intelligence',
+        }),
+      );
+      mockRunTurn.mockResolvedValue(turnOf());
+      const t = makeT();
+
+      await dispatch(askAssistant({utterance: 'when is Kiwi due?', t}));
+
+      expect(mockRunTurn).toHaveBeenCalledWith(
+        'when is Kiwi due?',
+        expectedContext(),
+        t,
+        {useModel: true, allowRephrase: true},
+      );
+    });
+
+    it('keeps the model out of the turn when the platform reports it unavailable', async () => {
+      store.dispatch(
+        modelAvailabilityChanged({
+          available: false,
+          reason: 'unsupportedDevice',
+        }),
+      );
+      mockRunTurn.mockResolvedValue(turnOf());
+      const t = makeT();
+
+      await dispatch(askAssistant({utterance: 'when is Kiwi due?', t}));
+
+      expect(mockRunTurn).toHaveBeenCalledWith(
+        'when is Kiwi due?',
+        expectedContext(),
+        t,
+        {useModel: false, allowRephrase: false},
+      );
+    });
+
+    it('hands the runtime the untrimmed utterance and the default currency', async () => {
+      mockRunTurn.mockResolvedValue(turnOf());
+
+      await dispatch(askAssistant({utterance: '  spaced out  ', t: makeT()}));
+
+      expect(mockRunTurn.mock.calls[0][0]).toBe('  spaced out  ');
+      expect(mockRunTurn.mock.calls[0][1].currencyCode).toBe('USD');
+      expect(mockRunTurn.mock.calls[0][1].now).toEqual(new Date(WALL_CLOCK));
+    });
+
+    it('uses the injected clock and currency code when the caller supplies them', async () => {
+      mockRunTurn.mockResolvedValue(turnOf());
+      const now = new Date('2026-11-20T18:45:00.000Z');
+
+      await dispatch(
+        askAssistant({
+          utterance: 'how much have I spent?',
+          t: makeT(),
+          currencyCode: 'EUR',
+          now,
+        }),
+      );
+
+      expect(mockRunTurn.mock.calls[0][1].now).toBe(now);
+      expect(mockRunTurn.mock.calls[0][1].currencyCode).toBe('EUR');
+    });
+
+    it('records the rejection message and leaves the status in error', async () => {
+      mockRunTurn.mockRejectedValue(new Error('model timed out'));
+      const t = makeT();
+
+      const action = await dispatch(
+        askAssistant({utterance: 'when is Kiwi due?', t}),
+      );
+
+      const {messages, status, error} = store.getState().assistant;
+      expect(action.type).toBe('assistant/ask/fulfilled');
+      expect(status).toBe('error');
+      expect(error).toBe('model timed out');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].author).toBe('user');
+      expect(t).not.toHaveBeenCalledWith('assistant.replies.error');
+    });
+
+    it('falls back to the localised error string when the rejection is not an Error', async () => {
+      mockRunTurn.mockRejectedValue('nothing useful');
+      const t = makeT();
+
+      await dispatch(askAssistant({utterance: 'when is Kiwi due?', t}));
+
+      expect(t).toHaveBeenCalledWith('assistant.replies.error');
+      expect(store.getState().assistant.error).toBe('Something went wrong.');
+      expect(store.getState().assistant.status).toBe('error');
+    });
+
+    it('clears a previous error as soon as the next turn starts thinking', async () => {
+      mockRunTurn.mockRejectedValueOnce(new Error('model timed out'));
+      await dispatch(askAssistant({utterance: 'first', t: makeT()}));
+      expect(store.getState().assistant.error).toBe('model timed out');
+
+      mockRunTurn.mockResolvedValueOnce(turnOf());
+      await dispatch(askAssistant({utterance: 'second', t: makeT()}));
+
+      expect(store.getState().assistant.error).toBeNull();
+      expect(store.getState().assistant.status).toBe('idle');
+      expect(
+        store.getState().assistant.messages.map(message => message.text),
+      ).toEqual(['first', 'second', 'Kiwi sees Dr Rao on Friday.']);
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/assistant/utils/trimEdges.test.ts
+++ b/apps/mobileAppYC/__tests__/features/assistant/utils/trimEdges.test.ts
@@ -1,0 +1,78 @@
+import {
+  isNotLetter,
+  trimEdgesWhile,
+  trimEndWhile,
+  trimStartWhile,
+} from '@/features/assistant/utils/trimEdges';
+
+const isDash = (char: string) => char === '-';
+
+describe('trimStartWhile', () => {
+  it('drops the leading run and keeps the rest intact', () => {
+    expect(trimStartWhile('---abc-', isDash)).toBe('abc-');
+  });
+
+  it('returns the same string when the first character does not match', () => {
+    expect(trimStartWhile('abc--', isDash)).toBe('abc--');
+  });
+
+  it('returns an empty string when everything matches', () => {
+    expect(trimStartWhile('----', isDash)).toBe('');
+  });
+
+  it('handles an empty string', () => {
+    expect(trimStartWhile('', isDash)).toBe('');
+  });
+});
+
+describe('trimEndWhile', () => {
+  it('drops the trailing run and keeps the rest intact', () => {
+    expect(trimEndWhile('-abc---', isDash)).toBe('-abc');
+  });
+
+  it('returns the same string when the last character does not match', () => {
+    expect(trimEndWhile('--abc', isDash)).toBe('--abc');
+  });
+
+  it('returns an empty string when everything matches', () => {
+    expect(trimEndWhile('----', isDash)).toBe('');
+  });
+
+  it('handles an empty string', () => {
+    expect(trimEndWhile('', isDash)).toBe('');
+  });
+});
+
+describe('trimEdgesWhile', () => {
+  it('drops both runs but nothing in between', () => {
+    expect(trimEdgesWhile('--a-b--', isDash)).toBe('a-b');
+  });
+
+  it('returns an empty string when everything matches', () => {
+    expect(trimEdgesWhile('---', isDash)).toBe('');
+  });
+});
+
+describe('isNotLetter', () => {
+  it.each(['a', 'z', 'A', 'Z', 'm'])('treats %s as a letter', char => {
+    expect(isNotLetter(char)).toBe(false);
+  });
+
+  it.each(['0', '9', '.', '!', ' ', '-', 'é', '['])(
+    'treats %s as not a letter',
+    char => {
+      expect(isNotLetter(char)).toBe(true);
+    },
+  );
+
+  it('rejects the characters either side of the ASCII letter ranges', () => {
+    // '@' precedes 'A' and '[' follows 'Z'; '`' precedes 'a' and '{' follows
+    // 'z'. These are what a naive range comparison gets wrong.
+    expect(['@', '[', '`', '{'].map(isNotLetter)).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/auth/thunks.test.ts
+++ b/apps/mobileAppYC/__tests__/features/auth/thunks.test.ts
@@ -4,6 +4,8 @@ import {themeReducer} from '@/features/theme';
 import {companionReducer} from '@/features/companion';
 import formsReducer from '@/features/forms/formsSlice';
 import passportReducer from '@/features/passport/passportSlice';
+import {assistantReducer} from '@/features/assistant/assistantSlice';
+import {clearSnapshot} from '@/features/assistant/services/assistantSnapshot';
 import {
   initializeAuth,
   refreshSession,
@@ -24,6 +26,9 @@ import type {
 
 jest.mock('@/features/auth/sessionManager');
 jest.mock('@/features/auth/services/passwordlessAuth');
+jest.mock('@/features/assistant/services/assistantSnapshot', () => ({
+  clearSnapshot: jest.fn().mockResolvedValue(true),
+}));
 
 const createTestStore = () => {
   return configureStore({
@@ -33,6 +38,7 @@ const createTestStore = () => {
       companion: companionReducer,
       forms: formsReducer,
       passport: passportReducer,
+      assistant: assistantReducer,
     },
   });
 };
@@ -660,6 +666,36 @@ describe('auth thunks', () => {
       expect(state.status).toBe('unauthenticated');
       expect(state.user).toBeNull();
       expect(store.getState().forms.byAppointmentId).toEqual({});
+    });
+
+    // The assistant's transcript is pet health chatter and its snapshot is read
+    // by Siri and the launcher shortcuts WITHOUT the app running, so a
+    // signed-out phone must not still answer from the previous owner's data.
+    it('clears the assistant transcript and its offline snapshot on logout', async () => {
+      jest.spyOn(passwordlessAuth, 'signOutEverywhere').mockResolvedValue();
+      (sessionManager.clearSessionData as jest.Mock).mockResolvedValue(
+        undefined,
+      );
+      (sessionManager.resetAuthLifecycle as jest.Mock).mockImplementation(
+        () => {},
+      );
+
+      store.dispatch({
+        type: 'assistant/messageAdded',
+        payload: {
+          id: 'm1',
+          author: 'assistant',
+          text: 'Bruno is overdue a rabies vaccination.',
+          createdAt: '2026-09-03T09:00:00.000Z',
+        },
+      });
+      expect(store.getState().assistant.messages).toHaveLength(1);
+
+      const dispatch = store.dispatch as any;
+      await dispatch(logout());
+
+      expect(store.getState().assistant.messages).toEqual([]);
+      expect(clearSnapshot).toHaveBeenCalled();
     });
 
     // Passport payloads carry the owner's name, email and phone, so they must

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/MainApplication.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/MainApplication.kt
@@ -14,6 +14,7 @@ import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import com.facebook.FacebookSdk
 import com.facebook.appevents.AppEventsLogger
+import com.mobileappyc.assistant.AssistantPackage
 
 class MainApplication : Application(), ReactApplication {
 
@@ -23,6 +24,7 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
               // add(MyReactNativePackage())
+              add(AssistantPackage())
             }
 
         override fun getJSMainModuleName(): String = "index"

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantPackage.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantPackage.kt
@@ -1,0 +1,22 @@
+package com.mobileappyc.assistant
+
+import android.view.View
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ReactShadowNode
+import com.facebook.react.uimanager.ViewManager
+
+/** Registers the assistant's native modules. */
+class AssistantPackage : ReactPackage {
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext
+    ): List<NativeModule> = listOf(
+        AssistantSnapshotBridgeModule(reactContext),
+        OnDeviceModelBridgeModule(reactContext)
+    )
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext
+    ): List<ViewManager<out View, out ReactShadowNode<*>>> = emptyList()
+}

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantShortcuts.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantShortcuts.kt
@@ -22,6 +22,7 @@ import org.json.JSONException
  */
 object AssistantShortcuts {
     private const val MAX_SHORTCUTS = 4
+    private const val LINK_SCHEME = "yc"
 
     /**
      * Replaces the published set.
@@ -47,7 +48,15 @@ object AssistantShortcuts {
                 continue
             }
 
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link)).apply {
+            // Only this app's own scheme may become a shortcut intent, on top
+            // of the package constraint below. Together they stop a malformed
+            // or unexpected payload turning into a launch of anything else.
+            val uri = Uri.parse(link)
+            if (uri.scheme != LINK_SCHEME) {
+                continue
+            }
+
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
                 setPackage(context.packageName)
             }
 

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantShortcuts.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantShortcuts.kt
@@ -1,0 +1,71 @@
+package com.mobileappyc.assistant
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.mobileappyc.R
+import org.json.JSONArray
+import org.json.JSONException
+
+/**
+ * Publishes the action catalogue as Android app shortcuts.
+ *
+ * This is the shipping route for OS-level actions on Android today. Google's
+ * AppFunctions, which is what lets Gemini call an app's actions directly, is
+ * an experimental preview limited to Android 16 and a short device list, so it
+ * is deliberately not wired here yet. Shortcuts reach every supported device,
+ * appear on long-press and in launcher search, and carry the same deep links
+ * the iOS intents use.
+ */
+object AssistantShortcuts {
+    private const val MAX_SHORTCUTS = 4
+
+    /**
+     * Replaces the published set.
+     *
+     * Returns false when the payload cannot be read, so the JavaScript caller
+     * can tell a bad payload from a platform that refused.
+     */
+    fun publish(context: Context, json: String): Boolean {
+        val entries = try {
+            JSONArray(json)
+        } catch (error: JSONException) {
+            return false
+        }
+
+        val shortcuts = mutableListOf<ShortcutInfoCompat>()
+        val limit = minOf(entries.length(), MAX_SHORTCUTS)
+        for (index in 0 until limit) {
+            val entry = entries.optJSONObject(index) ?: continue
+            val id = entry.optString("id")
+            val label = entry.optString("label")
+            val link = entry.optString("link")
+            if (id.isEmpty() || label.isEmpty() || link.isEmpty()) {
+                continue
+            }
+
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link)).apply {
+                setPackage(context.packageName)
+            }
+
+            shortcuts.add(
+                ShortcutInfoCompat.Builder(context, id)
+                    .setShortLabel(label)
+                    .setLongLabel(entry.optString("longLabel", label))
+                    .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
+                    .setIntent(intent)
+                    .build()
+            )
+        }
+
+        if (shortcuts.isEmpty()) {
+            ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+            return true
+        }
+
+        return ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+    }
+}

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantSnapshotBridgeModule.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantSnapshotBridgeModule.kt
@@ -1,0 +1,39 @@
+package com.mobileappyc.assistant
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+/** React Native access to the snapshot store and app shortcuts. */
+class AssistantSnapshotBridgeModule(
+    reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun writeSnapshot(json: String, promise: Promise) {
+        promise.resolve(AssistantSnapshotStore.write(reactApplicationContext, json))
+    }
+
+    @ReactMethod
+    fun clearSnapshot(promise: Promise) {
+        AssistantSnapshotStore.clear(reactApplicationContext)
+        promise.resolve(true)
+    }
+
+    @ReactMethod
+    fun consumePendingLink(promise: Promise) {
+        promise.resolve(AssistantSnapshotStore.consumePendingLink(reactApplicationContext))
+    }
+
+    @ReactMethod
+    fun publishShortcuts(json: String, promise: Promise) {
+        promise.resolve(AssistantShortcuts.publish(reactApplicationContext, json))
+    }
+
+    companion object {
+        const val NAME = "AssistantSnapshotBridge"
+    }
+}

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantSnapshotStore.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/AssistantSnapshotStore.kt
@@ -1,0 +1,65 @@
+package com.mobileappyc.assistant
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * The offline answer sheet shared with the OS.
+ *
+ * Android app shortcuts and, in future, AppFunctions run without the React
+ * Native bridge attached, so JavaScript keeps a small current copy of the few
+ * facts those surfaces can state. It holds no tokens and no clinical notes.
+ */
+object AssistantSnapshotStore {
+    private const val PREFS = "yc_assistant"
+    private const val KEY_SNAPSHOT = "snapshot_v1"
+    private const val KEY_PENDING_LINK = "pending_link_v1"
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    /**
+     * Stores the snapshot, rejecting anything that is not the expected object.
+     *
+     * A half-written payload is dropped rather than stored, because a shortcut
+     * reading it would otherwise present something wrong with confidence.
+     */
+    fun write(context: Context, json: String): Boolean {
+        val parsed = try {
+            JSONObject(json)
+        } catch (error: JSONException) {
+            return false
+        }
+        if (!parsed.has("version") || !parsed.has("pets")) {
+            return false
+        }
+        prefs(context).edit().putString(KEY_SNAPSHOT, json).apply()
+        return true
+    }
+
+    fun clear(context: Context) {
+        prefs(context).edit().remove(KEY_SNAPSHOT).apply()
+    }
+
+    fun read(context: Context): JSONObject? {
+        val raw = prefs(context).getString(KEY_SNAPSHOT, null) ?: return null
+        return try {
+            JSONObject(raw)
+        } catch (error: JSONException) {
+            null
+        }
+    }
+
+    fun setPendingLink(context: Context, link: String) {
+        prefs(context).edit().putString(KEY_PENDING_LINK, link).apply()
+    }
+
+    /** Reads and clears together, so a link is never acted on twice. */
+    fun consumePendingLink(context: Context): String {
+        val link = prefs(context).getString(KEY_PENDING_LINK, "") ?: ""
+        prefs(context).edit().remove(KEY_PENDING_LINK).apply()
+        return link
+    }
+}

--- a/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/OnDeviceModelBridgeModule.kt
+++ b/apps/mobileAppYC/android/app/src/main/java/com/mobileappyc/assistant/OnDeviceModelBridgeModule.kt
@@ -1,0 +1,67 @@
+package com.mobileappyc.assistant
+
+import android.os.Build
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+/**
+ * Android's on-device language model, as the assistant sees it.
+ *
+ * The assistant answers from its own rule parser and resolvers on every
+ * device; a platform model only ever rephrases an answer that is already true
+ * or rescues an unrouted phrase. So reporting "unavailable" here costs
+ * phrasing, never correctness, and the whole feature works without it.
+ *
+ * Gemini Nano is reached through ML Kit's GenAI Prompt API. That dependency is
+ * deliberately not wired in yet, and the reasons are worth writing down:
+ *
+ *  - The artifact declares `minSdkVersion 26` while this app ships `minSdk 24`,
+ *    so adopting it means either raising the app's floor or overriding the
+ *    merge and guarding every call.
+ *  - It reaches AICore, which exists only on recent flagships (Pixel 8 and
+ *    later, Galaxy S24 and later). No emulator image exposes it, so the
+ *    integration cannot be exercised on CI or on any simulator in the build
+ *    fleet.
+ *  - It is a beta API with no deprecation policy, and it pulls a large
+ *    transitive tree including its own play-services-basement pin.
+ *
+ * Until that is taken on deliberately, this module reports the same honest
+ * state a non-Gemini device would report, and the UI explains it to the owner.
+ */
+class OnDeviceModelBridgeModule(
+    reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun isAvailable(promise: Promise) {
+        val result = Arguments.createMap()
+        result.putBoolean("available", false)
+        result.putString("providerLabel", PROVIDER_LABEL)
+        result.putString(
+            "reason",
+            if (Build.VERSION.SDK_INT < MIN_GENAI_SDK) "unsupportedOS" else "unsupportedDevice"
+        )
+        promise.resolve(result)
+    }
+
+    @ReactMethod
+    fun generate(prompt: String, maxTokens: Int, promise: Promise) {
+        // The JavaScript caller treats a rejection as "no model help this
+        // turn" and falls back to the rule-based reply.
+        promise.reject(ERROR_CODE, "No on-device model on this device")
+    }
+
+    companion object {
+        const val NAME = "OnDeviceModelBridge"
+        private const val PROVIDER_LABEL = "Gemini Nano"
+
+        /** The API level ML Kit's GenAI artifacts require. */
+        private const val MIN_GENAI_SDK = 26
+        private const val ERROR_CODE = "on_device_model_unavailable"
+    }
+}

--- a/apps/mobileAppYC/guides/assistantDoc.md
+++ b/apps/mobileAppYC/guides/assistantDoc.md
@@ -1,0 +1,162 @@
+# Pet care assistant
+
+The assistant lets a pet owner ask about their animals in plain language, and lets
+Siri and the Android launcher run the same actions from outside the app.
+
+It is built so that **every fact it states comes from the owner's own records**. A
+platform language model, where one exists, may only choose an action or reword an
+answer that is already true. That boundary is the whole design.
+
+---
+
+## The three surfaces
+
+| Surface         | iOS                                                      | Android                                     |
+| --------------- | -------------------------------------------------------- | ------------------------------------------- |
+| OS assistant    | App Intents (Siri, Spotlight, Shortcuts, Action button)  | App shortcuts (long-press, launcher search) |
+| In-app screen   | Account -> Pet care assistant                            | same                                        |
+| On-device model | Foundation Models (iOS 26+, Apple Intelligence hardware) | not wired yet - see "Gemini Nano" below     |
+
+All three are driven by one catalogue, `src/features/assistant/actions/catalogue.ts`.
+Add a capability there and it becomes available to every surface at once.
+
+---
+
+## How a turn is answered
+
+```
+utterance
+   |
+   v
+[1] rule parser          src/features/assistant/nlu/parser.ts
+   |                     offline, deterministic, works on every device
+   |  low confidence or no match
+   v
+[2] on-device model      src/features/assistant/services/onDeviceModel.ts
+   |                     may ONLY pick an action id from the catalogue
+   v
+[3] resolver             src/features/assistant/actions/resolvers.ts
+   |                     reads Redux state - this is where facts come from
+   v
+[4] optional rephrase    model rewords an already-true sentence
+   |
+   v
+localised reply
+```
+
+Steps 2 and 4 are optional. If the model is missing, slow, or wrong, the answer is
+still correct - only its phrasing is plainer. That is why the feature ships on every
+supported device rather than only on Apple Intelligence hardware.
+
+### Read actions vs handoff actions
+
+- **Read** actions (`nextAppointment`, `vaccinationStatus`, `upcomingTasks`,
+  `petOverview`, `expenseSummary`) answer from local state and are safe for Siri to
+  run in the background.
+- **Handoff** actions (`addCareTask`, `logExpense`, `bookAppointment`) deliberately
+  do **not** commit anything. Booking needs live availability and payment, and a
+  medication reminder deserves a human confirming the dose. They open the app at a
+  deep link with the slots prefilled.
+
+---
+
+## The offline snapshot
+
+When Siri runs an App Intent, the app's JavaScript is not running. The intent
+executes with no Redux store and no session.
+
+So the app keeps a small answer sheet in shared storage:
+
+- written by `services/assistantSnapshot.ts`, debounced by `hooks/useAssistantSync.ts`
+- read on iOS by `ios/mobileAppYC/Assistant/AssistantSnapshot.swift`
+- read on Android by `android/.../assistant/AssistantSnapshotStore.kt`
+
+It holds pets, upcoming appointments, upcoming tasks and due vaccinations - and
+nothing else. **No tokens, no addresses, no clinical notes.** An intent that would
+need more than this hands off to the app instead.
+
+It is cleared on sign-out, so a signed-out phone says nothing.
+
+---
+
+## Platform notes
+
+### iOS - App Intents
+
+`ios/mobileAppYC/Assistant/Intents/` holds the intents, the `PetEntity` that lets
+Siri disambiguate between animals, and `YosemiteAppShortcuts`, which registers the
+zero-setup Siri phrases.
+
+Everything is `@available(iOS 16.0, *)`; the app's deployment target is 15.1.
+
+Intents live in the **app target**, not an extension, so they share
+`UserDefaults.standard` with the app. No App Group entitlement is needed, which
+keeps provisioning unchanged.
+
+Apple allows at most ten App Shortcuts, so `YosemiteAppShortcuts` registers the five
+highest-traffic actions. The rest stay available in the Shortcuts app and Spotlight.
+
+### iOS - Foundation Models
+
+`OnDeviceModelBridge.swift` wraps `SystemLanguageModel`, guarded by
+`#if canImport(FoundationModels)` and `@available(iOS 26.0, *)`. Unavailability is
+reported as a reason code (`unsupportedOS`, `unsupportedDevice`, `notEnabled`,
+`modelNotReady`) which the UI explains to the owner.
+
+### Android - app shortcuts
+
+`AssistantShortcuts.kt` publishes the catalogue as dynamic shortcuts carrying the
+same `yc://app/...` deep links the iOS intents use.
+
+**Why not AppFunctions?** AppFunctions is what lets Gemini call an app's actions
+directly, and it is the natural Android counterpart to App Intents. It is not wired
+up yet because it requires Android 16, its Gemini integration is a private preview
+limited to a short device list, and no emulator image can exercise it. Shortcuts
+reach every supported device today.
+
+### Android - Gemini Nano
+
+`OnDeviceModelBridgeModule.kt` currently reports the model as unavailable. Reaching
+Gemini Nano means adopting ML Kit's GenAI Prompt API, which:
+
+- declares `minSdkVersion 26` while this app ships `minSdk 24`;
+- needs AICore, present only on recent flagships (Pixel 8+, Galaxy S24+), so it
+  cannot be exercised on CI or any emulator in the build fleet;
+- is a beta API with no deprecation policy and a large transitive tree.
+
+That is a deliberate decision to take on separately, not an oversight. The module's
+comment records the same reasoning.
+
+---
+
+## Adding a new action
+
+1. Add the entry to `actions/catalogue.ts` (id, kind, i18n keys, slots).
+2. Add a resolver in `actions/resolvers.ts` and register it in `RESOLVERS`.
+3. Add keywords to `nlu/parser.ts` so the rule parser can route it offline.
+4. Add the `assistant.actions.*` and `assistant.replies.*` strings to **both**
+   `en/common.json` and `es/common.json`.
+5. For a handoff, add its path to `services/handoffNavigation.ts`.
+6. For a Siri phrase, add an intent under `ios/mobileAppYC/Assistant/Intents/` and,
+   if it earns one of the ten slots, an entry in `YosemiteAppShortcuts`.
+
+The catalogue test asserts structural invariants (handoff actions have deep links,
+required slots are a subset of slots, i18n keys are namespaced), so a half-finished
+action fails the suite rather than shipping.
+
+---
+
+## Testing
+
+```bash
+# the whole feature
+pnpm --filter mobileAppYC run test -- --testPathPatterns="features/assistant"
+
+# one module, with coverage
+pnpm --filter mobileAppYC run test -- \
+  --testPathPatterns="features/assistant/actions/resolvers" \
+  --coverage --collectCoverageFrom="src/features/assistant/actions/resolvers.ts"
+```
+
+Resolvers and date parsing take `now` from their context rather than reading the
+clock, so no test is time-dependent.

--- a/apps/mobileAppYC/guides/assistantDoc.md
+++ b/apps/mobileAppYC/guides/assistantDoc.md
@@ -160,3 +160,20 @@ pnpm --filter mobileAppYC run test -- \
 
 Resolvers and date parsing take `now` from their context rather than reading the
 clock, so no test is time-dependent.
+
+### What is not covered
+
+The JavaScript layer is at 100% statements, functions and lines. **The native
+layer has no automated coverage at all:**
+
+- there is no Swift or Kotlin test target, so the App Intents, the Foundation
+  Models bridge, the snapshot stores and the shortcut publisher are verified by
+  compiling and by running them on a device, not by a suite;
+- CI builds neither platform, so a Swift or Kotlin compile error will not be
+  caught on a PR - build both locally before pushing a change under `ios/` or
+  `android/`.
+
+What has been exercised on a real device: the snapshot round-trip, Foundation
+Models reporting available and answering, App Intents metadata extraction, and
+the Android shortcut publish. The intents' dialog strings have not been driven
+through Siri end to end.

--- a/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
+++ b/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
@@ -23,6 +23,16 @@
 		7FA6EE15257E4A089AF96CE8 /* ClashDisplay-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 28D2C7847A484697B1AF1F8E /* ClashDisplay-Variable.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8CDF7234D58144ABAB092E35 /* SFProText-regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 28621C890A9E481DB0D9B6D6 /* SFProText-regular.ttf */; };
+		A55100000000000000000002 /* AssistantSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000001 /* AssistantSnapshot.swift */; };
+		A55100000000000000000004 /* AssistantSnapshotBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000003 /* AssistantSnapshotBridge.swift */; };
+		A55100000000000000000006 /* AssistantSnapshotBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000005 /* AssistantSnapshotBridge.m */; };
+		A55100000000000000000008 /* OnDeviceModelBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000007 /* OnDeviceModelBridge.swift */; };
+		A5510000000000000000000A /* OnDeviceModelBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000009 /* OnDeviceModelBridge.m */; };
+		A5510000000000000000000C /* PetEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5510000000000000000000B /* PetEntity.swift */; };
+		A5510000000000000000000E /* PendingAssistantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5510000000000000000000D /* PendingAssistantAction.swift */; };
+		A55100000000000000000010 /* ReadIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5510000000000000000000F /* ReadIntents.swift */; };
+		A55100000000000000000012 /* HandoffIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000011 /* HandoffIntents.swift */; };
+		A55100000000000000000014 /* YosemiteAppShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55100000000000000000013 /* YosemiteAppShortcuts.swift */; };
 		B16AD49F1216448AB1FE638B /* Satoshi-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = CD336A2EB96D4E3A842ADBBC /* Satoshi-Light.otf */; };
 		CA3524178EF34A1685826155 /* Newsreader-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B65C712C98FF43F8A6656D1C /* Newsreader-Italic.ttf */; };
 		DDBFAE588BE04905ACDBD2DA /* Satoshi-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = FD410C24CA4B417686DFF96F /* Satoshi-Black.otf */; };
@@ -59,6 +69,16 @@
 		98A6482CD9DBA0E9DD9F36C6 /* Pods-mobileAppYC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mobileAppYC.debug.xcconfig"; path = "Target Support Files/Pods-mobileAppYC/Pods-mobileAppYC.debug.xcconfig"; sourceTree = "<group>"; };
 		99B0C6F9F5B3EE5251D91C71 /* libPods-mobileAppYC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-mobileAppYC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B6F853E1DE74D949EF0A172 /* ClashDisplay-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "ClashDisplay-Bold.otf"; path = "../assets/fonts/ClashDisplay-Bold.otf"; sourceTree = "<group>"; };
+		A55100000000000000000001 /* AssistantSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantSnapshot.swift; sourceTree = "<group>"; };
+		A55100000000000000000003 /* AssistantSnapshotBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantSnapshotBridge.swift; sourceTree = "<group>"; };
+		A55100000000000000000005 /* AssistantSnapshotBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AssistantSnapshotBridge.m; sourceTree = "<group>"; };
+		A55100000000000000000007 /* OnDeviceModelBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDeviceModelBridge.swift; sourceTree = "<group>"; };
+		A55100000000000000000009 /* OnDeviceModelBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnDeviceModelBridge.m; sourceTree = "<group>"; };
+		A5510000000000000000000B /* PetEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetEntity.swift; sourceTree = "<group>"; };
+		A5510000000000000000000D /* PendingAssistantAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingAssistantAction.swift; sourceTree = "<group>"; };
+		A5510000000000000000000F /* ReadIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadIntents.swift; sourceTree = "<group>"; };
+		A55100000000000000000011 /* HandoffIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffIntents.swift; sourceTree = "<group>"; };
+		A55100000000000000000013 /* YosemiteAppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YosemiteAppShortcuts.swift; sourceTree = "<group>"; };
 		AEF6A6C942B4489AA39854D7 /* Satoshi-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Satoshi-Medium.otf"; path = "../assets/fonts/Satoshi-Medium.otf"; sourceTree = "<group>"; };
 		B20BB11C225246958C33590A /* ClashDisplay-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "ClashDisplay-Medium.otf"; path = "../assets/fonts/ClashDisplay-Medium.otf"; sourceTree = "<group>"; };
 		B65C712C98FF43F8A6656D1C /* Newsreader-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Newsreader-Italic.ttf"; path = "../assets/fonts/Newsreader-Italic.ttf"; sourceTree = "<group>"; };
@@ -112,6 +132,7 @@
 				5384E25E2E881C1D00342038 /* mobileAppYC.entitlements */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
+				A55100000000000000000015 /* Assistant */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
@@ -161,6 +182,31 @@
 				13B07F961A680F5B00A75B9A /* mobileAppYC.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A55100000000000000000015 /* Assistant */ = {
+			isa = PBXGroup;
+			children = (
+				A55100000000000000000001 /* AssistantSnapshot.swift */,
+				A55100000000000000000003 /* AssistantSnapshotBridge.swift */,
+				A55100000000000000000005 /* AssistantSnapshotBridge.m */,
+				A55100000000000000000007 /* OnDeviceModelBridge.swift */,
+				A55100000000000000000009 /* OnDeviceModelBridge.m */,
+				A55100000000000000000016 /* Intents */,
+			);
+			path = mobileAppYC/Assistant;
+			sourceTree = "<group>";
+		};
+		A55100000000000000000016 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				A5510000000000000000000B /* PetEntity.swift */,
+				A5510000000000000000000D /* PendingAssistantAction.swift */,
+				A5510000000000000000000F /* ReadIntents.swift */,
+				A55100000000000000000011 /* HandoffIntents.swift */,
+				A55100000000000000000013 /* YosemiteAppShortcuts.swift */,
+			);
+			path = Intents;
 			sourceTree = "<group>";
 		};
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
@@ -355,6 +401,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
+				A55100000000000000000002 /* AssistantSnapshot.swift in Sources */,
+				A55100000000000000000004 /* AssistantSnapshotBridge.swift in Sources */,
+				A55100000000000000000006 /* AssistantSnapshotBridge.m in Sources */,
+				A55100000000000000000008 /* OnDeviceModelBridge.swift in Sources */,
+				A5510000000000000000000A /* OnDeviceModelBridge.m in Sources */,
+				A5510000000000000000000C /* PetEntity.swift in Sources */,
+				A5510000000000000000000E /* PendingAssistantAction.swift in Sources */,
+				A55100000000000000000010 /* ReadIntents.swift in Sources */,
+				A55100000000000000000012 /* HandoffIntents.swift in Sources */,
+				A55100000000000000000014 /* YosemiteAppShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshot.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshot.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// The offline answer sheet the app writes and App Intents read.
+///
+/// App Intents declared in the app target run in the app's own process, which
+/// iOS may launch in the background with no React Native bridge attached. The
+/// JavaScript side therefore keeps a small, current copy of the few facts an
+/// intent can state out loud, and the intents read only this.
+///
+/// It deliberately holds no tokens, addresses or clinical notes: an intent
+/// that needs more than this should hand off to the app instead.
+struct AssistantSnapshot: Codable {
+  struct Pet: Codable {
+    let id: String
+    let name: String
+    let species: String
+  }
+
+  struct Entry: Codable {
+    let petId: String
+    let petName: String
+    let title: String
+    /// ISO-8601. Formatted for display at read time, in the device locale.
+    let at: String
+    let subtitle: String?
+  }
+
+  let version: Int
+  let generatedAt: String
+  let pets: [Pet]
+  let appointments: [Entry]
+  let tasks: [Entry]
+  let vaccinationsDue: [Entry]
+
+  static let empty = AssistantSnapshot(
+    version: 1,
+    generatedAt: "",
+    pets: [],
+    appointments: [],
+    tasks: [],
+    vaccinationsDue: []
+  )
+}
+
+/// Reads and writes the snapshot.
+///
+/// `UserDefaults.standard` is the store rather than an App Group, because the
+/// intents live in the app target and share its container. Adding an app group
+/// would mean a provisioning change for no behavioural gain today.
+enum AssistantSnapshotStore {
+  private static let key = "yc.assistant.snapshot.v1"
+
+  static func write(_ json: String) -> Bool {
+    guard let data = json.data(using: .utf8),
+          (try? JSONDecoder().decode(AssistantSnapshot.self, from: data)) != nil
+    else {
+      // A malformed payload is dropped rather than stored: a half-written
+      // snapshot would make Siri state something wrong with confidence.
+      return false
+    }
+    UserDefaults.standard.set(json, forKey: key)
+    return true
+  }
+
+  static func clear() {
+    UserDefaults.standard.removeObject(forKey: key)
+  }
+
+  static func read() -> AssistantSnapshot {
+    guard let json = UserDefaults.standard.string(forKey: key),
+          let data = json.data(using: .utf8),
+          let snapshot = try? JSONDecoder().decode(AssistantSnapshot.self, from: data)
+    else {
+      return .empty
+    }
+    return snapshot
+  }
+
+  // MARK: - Queries shared by the intents
+
+  /// Resolves a spoken pet name against the snapshot.
+  ///
+  /// Falls back to the only pet when the owner has exactly one, so "when is
+  /// the next appointment" works without naming anybody.
+  static func pet(named name: String?, in snapshot: AssistantSnapshot) -> AssistantSnapshot.Pet? {
+    if let name, !name.isEmpty {
+      let wanted = name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+      if let match = snapshot.pets.first(where: {
+        $0.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) == wanted
+      }) {
+        return match
+      }
+      return nil
+    }
+    return snapshot.pets.count == 1 ? snapshot.pets.first : nil
+  }
+
+  static func parseDate(_ iso: String) -> Date? {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: iso) {
+      return date
+    }
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: iso)
+  }
+
+  /// A short, spoken-friendly rendering: "Tuesday 4 March at 09:30".
+  static func speakableDate(_ iso: String) -> String {
+    guard let date = parseDate(iso) else {
+      return iso
+    }
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.dateStyle = .full
+    formatter.timeStyle = .short
+    return formatter.string(from: date)
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshotBridge.m
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshotBridge.m
@@ -1,0 +1,18 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE (AssistantSnapshotBridge, NSObject)
+
+RCT_EXTERN_METHOD(writeSnapshot
+                  : (NSString *)json resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearSnapshot
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(consumePendingLink
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+@end

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshotBridge.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/AssistantSnapshotBridge.swift
@@ -1,0 +1,46 @@
+import Foundation
+import React
+
+/// React Native access to the snapshot store.
+///
+/// Registered as a legacy bridge module. Under the New Architecture RN routes
+/// these through its interop layer, which is enough for two string methods and
+/// avoids adding a codegen spec for them.
+@objc(AssistantSnapshotBridge)
+final class AssistantSnapshotBridge: NSObject {
+
+  /// Nothing here touches UIKit, so the bridge does not need the main queue.
+  @objc static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  @objc(writeSnapshot:resolver:rejecter:)
+  func writeSnapshot(
+    _ json: String,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    resolve(AssistantSnapshotStore.write(json))
+  }
+
+  /// Hands the app any deep link parked by a handoff intent, once.
+  ///
+  /// Returns an empty string rather than null when there is nothing pending,
+  /// so the JavaScript side has one shape to handle.
+  @objc(consumePendingLink:rejecter:)
+  func consumePendingLink(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    resolve(PendingAssistantAction.consume() ?? "")
+  }
+
+  @objc(clearSnapshot:rejecter:)
+  func clearSnapshot(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    AssistantSnapshotStore.clear()
+    resolve(true)
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/HandoffIntents.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/HandoffIntents.swift
@@ -1,0 +1,106 @@
+import AppIntents
+import Foundation
+
+/// Intents that deliberately do not finish the job.
+///
+/// Adding a medication reminder, logging money and booking a clinic slot all
+/// deserve a human confirming them, and booking additionally needs live
+/// availability and payment. Each one parks a deep link and opens the app on
+/// the right screen with what Siri heard already filled in.
+@available(iOS 16.0, *)
+struct AddCareTaskIntent: AppIntent {
+  static var title: LocalizedStringResource = "Add a care task"
+  static var description = IntentDescription(
+    "Opens a new care task or medication reminder, ready to confirm."
+  )
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  @Parameter(title: "Task")
+  var taskTitle: String?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    var items: [URLQueryItem] = []
+    if let pet {
+      items.append(URLQueryItem(name: "companionId", value: pet.id))
+    }
+    if let taskTitle, !taskTitle.isEmpty {
+      items.append(URLQueryItem(name: "title", value: taskTitle))
+    }
+    PendingAssistantAction.set(AssistantLink.build(path: "/tasks/new", items: items))
+
+    return .result(
+      dialog: IntentDialog(
+        stringLiteral: "Opening a new task for you to confirm."
+      )
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+struct BookAppointmentIntent: AppIntent {
+  static var title: LocalizedStringResource = "Book an appointment"
+  static var description = IntentDescription(
+    "Opens clinic search to book a vet or grooming appointment."
+  )
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    var items: [URLQueryItem] = []
+    if let pet {
+      items.append(URLQueryItem(name: "companionId", value: pet.id))
+    }
+    PendingAssistantAction.set(
+      AssistantLink.build(path: "/appointments/book", items: items)
+    )
+
+    return .result(
+      dialog: IntentDialog(
+        stringLiteral: "Booking needs a time and payment, so I am opening clinic search."
+      )
+    )
+  }
+}
+
+@available(iOS 16.0, *)
+struct LogExpenseIntent: AppIntent {
+  static var title: LocalizedStringResource = "Log an expense"
+  static var description = IntentDescription(
+    "Opens a new expense record for a pet, ready to confirm."
+  )
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    var items: [URLQueryItem] = []
+    if let pet {
+      items.append(URLQueryItem(name: "companionId", value: pet.id))
+    }
+    PendingAssistantAction.set(
+      AssistantLink.build(path: "/expenses/new", items: items)
+    )
+
+    return .result(
+      dialog: IntentDialog(stringLiteral: "Opening a new expense for you to confirm.")
+    )
+  }
+}
+
+/// Builds the `yc://app/...` links the JavaScript router already understands.
+enum AssistantLink {
+  static func build(path: String, items: [URLQueryItem]) -> String {
+    var components = URLComponents()
+    components.scheme = "yc"
+    components.host = "app"
+    components.path = path
+    components.queryItems = items.isEmpty ? nil : items
+    return components.string ?? "yc://app\(path)"
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/PendingAssistantAction.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/PendingAssistantAction.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// A handoff parked for the app to pick up on launch.
+///
+/// Booking, adding a task and logging an expense all need confirmation, live
+/// availability or payment. Rather than commit them from a background intent,
+/// the intent stores the deep link here, opens the app, and JavaScript reads
+/// it once and routes to the prefilled screen.
+enum PendingAssistantAction {
+  private static let key = "yc.assistant.pendingLink.v1"
+
+  static func set(_ link: String) {
+    UserDefaults.standard.set(link, forKey: key)
+  }
+
+  /// Reads and clears in one step, so a link is never handled twice.
+  static func consume() -> String? {
+    let link = UserDefaults.standard.string(forKey: key)
+    UserDefaults.standard.removeObject(forKey: key)
+    return link
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/PetEntity.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/PetEntity.swift
@@ -1,0 +1,41 @@
+import AppIntents
+import Foundation
+
+/// A pet, as Siri and the Shortcuts app see it.
+///
+/// Modelling pets as an entity rather than a free-text parameter is what lets
+/// Siri disambiguate ("which pet?") and lets a Shortcut hold a stable
+/// reference to one animal.
+@available(iOS 16.0, *)
+struct PetEntity: AppEntity, Identifiable {
+  let id: String
+  let name: String
+  let species: String
+
+  static var typeDisplayRepresentation: TypeDisplayRepresentation {
+    TypeDisplayRepresentation(name: "Pet")
+  }
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)", subtitle: "\(species)")
+  }
+
+  static var defaultQuery = PetEntityQuery()
+}
+
+/// Answers Siri's lookups from the offline snapshot.
+@available(iOS 16.0, *)
+struct PetEntityQuery: EntityQuery {
+  func entities(for identifiers: [String]) async throws -> [PetEntity] {
+    let snapshot = AssistantSnapshotStore.read()
+    return snapshot.pets
+      .filter { identifiers.contains($0.id) }
+      .map { PetEntity(id: $0.id, name: $0.name, species: $0.species) }
+  }
+
+  func suggestedEntities() async throws -> [PetEntity] {
+    AssistantSnapshotStore.read().pets.map {
+      PetEntity(id: $0.id, name: $0.name, species: $0.species)
+    }
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/ReadIntents.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/ReadIntents.swift
@@ -4,11 +4,23 @@ import Foundation
 /// Shared phrasing for the read-only intents.
 @available(iOS 16.0, *)
 private enum AssistantSpeech {
-  static func noPetMatch(_ name: String?) -> String {
+  /// Spoken when a pet cannot be resolved.
+  ///
+  /// The three cases are genuinely different and were previously collapsed
+  /// into one: an owner with several pets who named none was told to add a pet
+  /// first, which is both wrong and a dead end.
+  static func noPetMatch(_ name: String?, in snapshot: AssistantSnapshot) -> String {
     if let name, !name.isEmpty {
       return "I could not find a pet called \(name) in Yosemite Crew."
     }
-    return "Open Yosemite Crew and add a pet first."
+    if snapshot.pets.isEmpty {
+      return "Open Yosemite Crew and add a pet first."
+    }
+    let names = snapshot.pets.map(\.name)
+    let list = names.count == 2
+      ? "\(names[0]) or \(names[1])"
+      : names.dropLast().joined(separator: ", ") + ", or " + (names.last ?? "")
+    return "Which pet do you mean - \(list)?"
   }
 }
 
@@ -44,7 +56,7 @@ struct NextAppointmentIntent: AppIntent {
     guard let next = entries.first else {
       let name = pet?.name
       let dialog = scopeId == nil && snapshot.pets.isEmpty
-        ? AssistantSpeech.noPetMatch(name)
+        ? AssistantSpeech.noPetMatch(name, in: snapshot)
         : "There are no upcoming appointments booked."
       return .result(dialog: IntentDialog(stringLiteral: dialog))
     }
@@ -77,7 +89,9 @@ struct VaccinationStatusIntent: AppIntent {
     guard let resolved = AssistantSnapshotStore.pet(named: pet?.name, in: snapshot)
     else {
       return .result(
-        dialog: IntentDialog(stringLiteral: AssistantSpeech.noPetMatch(pet?.name))
+        dialog: IntentDialog(
+          stringLiteral: AssistantSpeech.noPetMatch(pet?.name, in: snapshot)
+        )
       )
     }
 
@@ -85,7 +99,7 @@ struct VaccinationStatusIntent: AppIntent {
     guard let soonest = due.first else {
       return .result(
         dialog: IntentDialog(
-          stringLiteral: "\(resolved.name) has no vaccinations due in the next month."
+          stringLiteral: "\(resolved.name) has no vaccinations due or overdue."
         )
       )
     }

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/ReadIntents.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/ReadIntents.swift
@@ -1,0 +1,151 @@
+import AppIntents
+import Foundation
+
+/// Shared phrasing for the read-only intents.
+@available(iOS 16.0, *)
+private enum AssistantSpeech {
+  static func noPetMatch(_ name: String?) -> String {
+    if let name, !name.isEmpty {
+      return "I could not find a pet called \(name) in Yosemite Crew."
+    }
+    return "Open Yosemite Crew and add a pet first."
+  }
+}
+
+/// "When is Bruno's next appointment?"
+@available(iOS 16.0, *)
+struct NextAppointmentIntent: AppIntent {
+  static var title: LocalizedStringResource = "Next appointment"
+  static var description = IntentDescription(
+    "Says when the next vet or grooming appointment is."
+  )
+  /// Answered entirely from the snapshot, so Siri never has to open the app.
+  static var openAppWhenRun: Bool = false
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let snapshot = AssistantSnapshotStore.read()
+
+    let scopeId: String?
+    if let pet {
+      scopeId = pet.id
+    } else if snapshot.pets.count == 1 {
+      scopeId = snapshot.pets.first?.id
+    } else {
+      scopeId = nil
+    }
+
+    let entries = snapshot.appointments.filter { entry in
+      scopeId == nil || entry.petId == scopeId
+    }
+
+    guard let next = entries.first else {
+      let name = pet?.name
+      let dialog = scopeId == nil && snapshot.pets.isEmpty
+        ? AssistantSpeech.noPetMatch(name)
+        : "There are no upcoming appointments booked."
+      return .result(dialog: IntentDialog(stringLiteral: dialog))
+    }
+
+    let when = AssistantSnapshotStore.speakableDate(next.at)
+    let where_ = next.subtitle.map { " at \($0)" } ?? ""
+    return .result(
+      dialog: IntentDialog(
+        stringLiteral: "\(next.petName) has \(next.title) on \(when)\(where_)."
+      )
+    )
+  }
+}
+
+/// "Are Bruno's vaccinations up to date?"
+@available(iOS 16.0, *)
+struct VaccinationStatusIntent: AppIntent {
+  static var title: LocalizedStringResource = "Vaccination status"
+  static var description = IntentDescription(
+    "Says whether a pet's vaccinations are up to date or due."
+  )
+  static var openAppWhenRun: Bool = false
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let snapshot = AssistantSnapshotStore.read()
+
+    guard let resolved = AssistantSnapshotStore.pet(named: pet?.name, in: snapshot)
+    else {
+      return .result(
+        dialog: IntentDialog(stringLiteral: AssistantSpeech.noPetMatch(pet?.name))
+      )
+    }
+
+    let due = snapshot.vaccinationsDue.filter { $0.petId == resolved.id }
+    guard let soonest = due.first else {
+      return .result(
+        dialog: IntentDialog(
+          stringLiteral: "\(resolved.name) has no vaccinations due in the next month."
+        )
+      )
+    }
+
+    let now = Date()
+    let dueDate = AssistantSnapshotStore.parseDate(soonest.at)
+    let overdue = dueDate.map { $0 < now } ?? false
+    let when = AssistantSnapshotStore.speakableDate(soonest.at)
+
+    let sentence = overdue
+      ? "\(resolved.name) is overdue a \(soonest.title) vaccination, due \(when)."
+      : "\(resolved.name) is due a \(soonest.title) vaccination on \(when)."
+    return .result(dialog: IntentDialog(stringLiteral: sentence))
+  }
+}
+
+/// "What is due for Bruno today?"
+@available(iOS 16.0, *)
+struct UpcomingTasksIntent: AppIntent {
+  static var title: LocalizedStringResource = "What is due"
+  static var description = IntentDescription(
+    "Lists the care tasks due for a pet."
+  )
+  static var openAppWhenRun: Bool = false
+
+  @Parameter(title: "Pet")
+  var pet: PetEntity?
+
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let snapshot = AssistantSnapshotStore.read()
+
+    let scopeId: String?
+    if let pet {
+      scopeId = pet.id
+    } else if snapshot.pets.count == 1 {
+      scopeId = snapshot.pets.first?.id
+    } else {
+      scopeId = nil
+    }
+
+    let entries = snapshot.tasks.filter { scopeId == nil || $0.petId == scopeId }
+
+    guard let first = entries.first else {
+      return .result(
+        dialog: IntentDialog(stringLiteral: "Nothing is due right now.")
+      )
+    }
+
+    if entries.count == 1 {
+      return .result(
+        dialog: IntentDialog(
+          stringLiteral: "\(first.petName) has one task due: \(first.title), on \(AssistantSnapshotStore.speakableDate(first.at))."
+        )
+      )
+    }
+
+    return .result(
+      dialog: IntentDialog(
+        stringLiteral: "There are \(entries.count) tasks due. The next is \(first.title) for \(first.petName) on \(AssistantSnapshotStore.speakableDate(first.at))."
+      )
+    )
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/YosemiteAppShortcuts.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/Intents/YosemiteAppShortcuts.swift
@@ -1,0 +1,58 @@
+import AppIntents
+
+/// The phrases Siri accepts without the user setting anything up.
+///
+/// Every phrase has to contain the app name, which is why each one reads
+/// "... in Yosemite Crew". Apple allows at most ten shortcuts per app, so this
+/// is the five highest-traffic actions rather than the whole catalogue; the
+/// rest remain available in the Shortcuts app and to Spotlight.
+@available(iOS 16.0, *)
+struct YosemiteAppShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: NextAppointmentIntent(),
+      phrases: [
+        "Next appointment in \(.applicationName)",
+        "When is my next appointment in \(.applicationName)",
+      ],
+      shortTitle: "Next appointment",
+      systemImageName: "calendar"
+    )
+    AppShortcut(
+      intent: VaccinationStatusIntent(),
+      phrases: [
+        "Vaccination status in \(.applicationName)",
+        "Check vaccinations in \(.applicationName)",
+      ],
+      shortTitle: "Vaccination status",
+      systemImageName: "syringe"
+    )
+    AppShortcut(
+      intent: UpcomingTasksIntent(),
+      phrases: [
+        "What is due in \(.applicationName)",
+        "Pet care tasks in \(.applicationName)",
+      ],
+      shortTitle: "What is due",
+      systemImageName: "checklist"
+    )
+    AppShortcut(
+      intent: AddCareTaskIntent(),
+      phrases: [
+        "Add a care task in \(.applicationName)",
+        "New pet reminder in \(.applicationName)",
+      ],
+      shortTitle: "Add a care task",
+      systemImageName: "plus.circle"
+    )
+    AppShortcut(
+      intent: BookAppointmentIntent(),
+      phrases: [
+        "Book an appointment in \(.applicationName)",
+        "Book a vet visit in \(.applicationName)",
+      ],
+      shortTitle: "Book an appointment",
+      systemImageName: "stethoscope"
+    )
+  }
+}

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/OnDeviceModelBridge.m
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/OnDeviceModelBridge.m
@@ -1,0 +1,15 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE (OnDeviceModelBridge, NSObject)
+
+RCT_EXTERN_METHOD(isAvailable
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(generate
+                  : (NSString *)prompt maxTokens
+                  : (nonnull NSNumber *)maxTokens resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+@end

--- a/apps/mobileAppYC/ios/mobileAppYC/Assistant/OnDeviceModelBridge.swift
+++ b/apps/mobileAppYC/ios/mobileAppYC/Assistant/OnDeviceModelBridge.swift
@@ -1,0 +1,108 @@
+import Foundation
+import React
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Apple's on-device language model, exposed to React Native.
+///
+/// The framework arrived in iOS 26 and only runs on Apple Intelligence
+/// hardware, so both the import and the calls are guarded. Every failure path
+/// resolves with `available: false` rather than rejecting: the assistant is
+/// designed to work without a model, and a rejected promise would turn a
+/// normal "this phone has no model" into an error the user sees.
+@objc(OnDeviceModelBridge)
+final class OnDeviceModelBridge: NSObject {
+
+  private static let providerLabel = "Apple Intelligence"
+
+  @objc static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  @objc(isAvailable:rejecter:)
+  func isAvailable(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    #if canImport(FoundationModels)
+    if #available(iOS 26.0, *) {
+      let model = SystemLanguageModel.default
+      switch model.availability {
+      case .available:
+        resolve([
+          "available": true,
+          "providerLabel": Self.providerLabel,
+        ])
+      case .unavailable(let reason):
+        resolve([
+          "available": false,
+          "reason": Self.reasonCode(for: reason),
+          "providerLabel": Self.providerLabel,
+        ])
+      @unknown default:
+        resolve([
+          "available": false,
+          "reason": "unknown",
+          "providerLabel": Self.providerLabel,
+        ])
+      }
+      return
+    }
+    #endif
+
+    resolve([
+      "available": false,
+      "reason": "unsupportedOS",
+      "providerLabel": Self.providerLabel,
+    ])
+  }
+
+  @objc(generate:maxTokens:resolver:rejecter:)
+  func generate(
+    _ prompt: String,
+    maxTokens: NSNumber,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    #if canImport(FoundationModels)
+    if #available(iOS 26.0, *) {
+      Task {
+        do {
+          let session = LanguageModelSession()
+          var options = GenerationOptions()
+          options.maximumResponseTokens = maxTokens.intValue
+          let response = try await session.respond(to: prompt, options: options)
+          resolve(response.content)
+        } catch {
+          // The caller treats a rejection as "no model help this turn" and
+          // falls back to the rule-based reply.
+          reject("on_device_model_failed", error.localizedDescription, error)
+        }
+      }
+      return
+    }
+    #endif
+
+    reject("on_device_model_unavailable", "No on-device model on this device", nil)
+  }
+
+  #if canImport(FoundationModels)
+  @available(iOS 26.0, *)
+  private static func reasonCode(
+    for reason: SystemLanguageModel.Availability.UnavailableReason
+  ) -> String {
+    switch reason {
+    case .deviceNotEligible:
+      return "unsupportedDevice"
+    case .appleIntelligenceNotEnabled:
+      return "notEnabled"
+    case .modelNotReady:
+      return "modelNotReady"
+    @unknown default:
+      return "unknown"
+    }
+  }
+  #endif
+}

--- a/apps/mobileAppYC/src/app/store.ts
+++ b/apps/mobileAppYC/src/app/store.ts
@@ -58,6 +58,7 @@ import {linkedBusinessesReducer} from '@/features/linkedBusinesses';
 import {notificationReducer} from '@/features/notifications';
 import formsReducer from '@/features/forms/formsSlice';
 import preferencesReducer from '@/features/preferences/preferencesSlice';
+import {assistantReducer} from '@/features/assistant';
 
 const migrateV1ToV2 = (_state: any) => {
   console.log(
@@ -238,6 +239,10 @@ const rootReducer = combineReducers({
   notifications: notificationReducer,
   forms: formsReducer,
   preferences: preferencesReducer,
+  // Deliberately absent from `whitelist` below: the assistant transcript is a
+  // conversation, not a record. It should not survive a relaunch, and keeping
+  // it out of storage also keeps pet health chatter off disk.
+  assistant: assistantReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/apps/mobileAppYC/src/features/account/screens/AccountScreen.tsx
+++ b/apps/mobileAppYC/src/features/account/screens/AccountScreen.tsx
@@ -111,6 +111,15 @@ const buildAccountMenuItems = (
   onDeletePress: () => void,
 ): MenuItem[] => [
   {
+    id: 'assistant',
+    label: 'Pet care assistant',
+    icon: Images.paw,
+    tone: 'info',
+    onPress: () => {
+      navigation.navigate('Assistant');
+    },
+  },
+  {
     id: 'preferences',
     label: 'Preferences',
     icon: Images.editIconSlide,

--- a/apps/mobileAppYC/src/features/assistant/actions/catalogue.ts
+++ b/apps/mobileAppYC/src/features/assistant/actions/catalogue.ts
@@ -1,0 +1,119 @@
+/**
+ * The assistant action catalogue.
+ *
+ * This is the single source of truth for what the assistant can do. The
+ * in-app screen, the iOS App Intents and the Android shortcuts are all
+ * generated from or mirrored against this list, so a capability is described
+ * once and never drifts between surfaces.
+ *
+ * Everything here is data only. Behaviour lives in `actions/resolvers.ts`.
+ */
+import type {AssistantAction, AssistantActionId} from '../types';
+
+export const ASSISTANT_ACTIONS: readonly AssistantAction[] = [
+  {
+    id: 'nextAppointment',
+    kind: 'read',
+    titleKey: 'assistant.actions.nextAppointment.title',
+    descriptionKey: 'assistant.actions.nextAppointment.description',
+    slots: ['petName'],
+    requiredSlots: [],
+    samplePhraseKeys: [
+      'assistant.actions.nextAppointment.phrase1',
+      'assistant.actions.nextAppointment.phrase2',
+    ],
+  },
+  {
+    id: 'vaccinationStatus',
+    kind: 'read',
+    titleKey: 'assistant.actions.vaccinationStatus.title',
+    descriptionKey: 'assistant.actions.vaccinationStatus.description',
+    slots: ['petName'],
+    requiredSlots: [],
+    samplePhraseKeys: [
+      'assistant.actions.vaccinationStatus.phrase1',
+      'assistant.actions.vaccinationStatus.phrase2',
+    ],
+  },
+  {
+    id: 'upcomingTasks',
+    kind: 'read',
+    titleKey: 'assistant.actions.upcomingTasks.title',
+    descriptionKey: 'assistant.actions.upcomingTasks.description',
+    slots: ['petName', 'when'],
+    requiredSlots: [],
+    samplePhraseKeys: [
+      'assistant.actions.upcomingTasks.phrase1',
+      'assistant.actions.upcomingTasks.phrase2',
+    ],
+  },
+  {
+    id: 'petOverview',
+    kind: 'read',
+    titleKey: 'assistant.actions.petOverview.title',
+    descriptionKey: 'assistant.actions.petOverview.description',
+    slots: ['petName'],
+    requiredSlots: ['petName'],
+    samplePhraseKeys: ['assistant.actions.petOverview.phrase1'],
+  },
+  {
+    id: 'expenseSummary',
+    kind: 'read',
+    titleKey: 'assistant.actions.expenseSummary.title',
+    descriptionKey: 'assistant.actions.expenseSummary.description',
+    slots: ['petName'],
+    requiredSlots: [],
+    samplePhraseKeys: ['assistant.actions.expenseSummary.phrase1'],
+  },
+  {
+    id: 'addCareTask',
+    kind: 'handoff',
+    titleKey: 'assistant.actions.addCareTask.title',
+    descriptionKey: 'assistant.actions.addCareTask.description',
+    slots: ['petName', 'title', 'when'],
+    requiredSlots: [],
+    deepLink: 'yc://app/tasks/new',
+    samplePhraseKeys: [
+      'assistant.actions.addCareTask.phrase1',
+      'assistant.actions.addCareTask.phrase2',
+    ],
+  },
+  {
+    id: 'logExpense',
+    kind: 'handoff',
+    titleKey: 'assistant.actions.logExpense.title',
+    descriptionKey: 'assistant.actions.logExpense.description',
+    slots: ['petName', 'amount', 'category'],
+    requiredSlots: [],
+    deepLink: 'yc://app/expenses/new',
+    samplePhraseKeys: ['assistant.actions.logExpense.phrase1'],
+  },
+  {
+    id: 'bookAppointment',
+    kind: 'handoff',
+    titleKey: 'assistant.actions.bookAppointment.title',
+    descriptionKey: 'assistant.actions.bookAppointment.description',
+    slots: ['petName', 'when'],
+    requiredSlots: [],
+    deepLink: 'yc://app/appointments/book',
+    samplePhraseKeys: [
+      'assistant.actions.bookAppointment.phrase1',
+      'assistant.actions.bookAppointment.phrase2',
+    ],
+  },
+] as const;
+
+const ACTIONS_BY_ID: ReadonlyMap<AssistantActionId, AssistantAction> = new Map(
+  ASSISTANT_ACTIONS.map(action => [action.id, action]),
+);
+
+export const getAssistantAction = (
+  id: AssistantActionId,
+): AssistantAction | undefined => ACTIONS_BY_ID.get(id);
+
+export const isHandoffAction = (id: AssistantActionId): boolean =>
+  getAssistantAction(id)?.kind === 'handoff';
+
+/** Action ids in catalogue order. Used to keep suggestion chips stable. */
+export const ASSISTANT_ACTION_IDS: readonly AssistantActionId[] =
+  ASSISTANT_ACTIONS.map(action => action.id);

--- a/apps/mobileAppYC/src/features/assistant/actions/resolvers.ts
+++ b/apps/mobileAppYC/src/features/assistant/actions/resolvers.ts
@@ -1,0 +1,561 @@
+/**
+ * Action resolvers: intent plus app state to an answer.
+ *
+ * Every fact the assistant states comes from here, never from the language
+ * model. The model may only rephrase a resolver's output. That boundary is
+ * what keeps a hallucinated vaccination date out of a pet's health record.
+ *
+ * Resolvers are pure: they take a context and return a result. `now` is part
+ * of the context so date maths is testable without freezing the clock.
+ */
+import type {
+  AssistantActionId,
+  AssistantActionResult,
+  AssistantContext,
+  AssistantResultItem,
+  AssistantSlots,
+  AssistantVaccination,
+} from '../types';
+import type {Appointment} from '@/features/appointments/types';
+import type {Task} from '@/features/tasks/types';
+import type {Companion} from '@/features/companion/types';
+import {UPCOMING_WINDOW_DAYS, VACCINATION_DUE_SOON_DAYS} from '../constants';
+import {getAssistantAction} from './catalogue';
+import {normalizeText} from '../nlu/normalize';
+
+const MS_PER_DAY = 86_400_000;
+
+const daysBetween = (from: Date, to: Date): number =>
+  Math.round((to.getTime() - from.getTime()) / MS_PER_DAY);
+
+/** Appointment date and time are stored separately; this joins them. */
+export const appointmentStartsAt = (appointment: Appointment): Date | null => {
+  if (appointment.start) {
+    const parsed = new Date(appointment.start);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  if (!appointment.date) {
+    return null;
+  }
+  // The guard accepted "09:15:30" but the interpolation appended a second
+  // ":00", producing an Invalid Date - so an appointment whose time carried
+  // seconds vanished from every answer. taskDueAt already sliced; this did not.
+  const time =
+    appointment.time && /^\d{2}:\d{2}/.test(appointment.time)
+      ? appointment.time.slice(0, 5)
+      : '00:00';
+  const parsed = new Date(`${appointment.date}T${time}:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const TERMINAL_STATUSES = new Set([
+  'COMPLETED',
+  'CANCELLED',
+  'NO_SHOW',
+  'RESCHEDULED',
+]);
+
+/** Finds the pet the question is about. */
+export const resolveCompanion = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): Companion | undefined => {
+  if (slots.petName) {
+    const wanted = normalizeText(slots.petName);
+    const match = context.companions.find(
+      companion => normalizeText(companion.name) === wanted,
+    );
+    if (match) {
+      return match;
+    }
+  }
+  // With exactly one pet, "when is the next appointment" is unambiguous.
+  return context.companions.length === 1 ? context.companions[0] : undefined;
+};
+
+const companionsInScope = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): Companion[] => {
+  const single = resolveCompanion(context, slots);
+  return single ? [single] : context.companions;
+};
+
+/**
+ * A task's due moment.
+ *
+ * `dueAt` is the backend's full timestamp but is optional; tasks created
+ * locally carry a `date` plus an optional `time` instead, so both shapes are
+ * handled rather than treating a locally created task as undated.
+ */
+export const taskDueAt = (task: Task): Date | null => {
+  if (task.dueAt) {
+    const parsed = new Date(task.dueAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  if (!task.date) {
+    return null;
+  }
+  const time =
+    task.time && /^\d{2}:\d{2}/.test(task.time)
+      ? task.time.slice(0, 5)
+      : '00:00';
+  const parsed = new Date(`${task.date.slice(0, 10)}T${time}:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/** Tasks carry both a required `title` and an optional display `name`. */
+export const taskLabel = (task: Task): string => task.name || task.title || '';
+
+const isOpenTask = (task: Task): boolean => {
+  const status = String(task.status ?? '').toUpperCase();
+  return status !== 'COMPLETED' && status !== 'CANCELLED';
+};
+
+/**
+ * Renders a calendar day in LOCAL time.
+ *
+ * `toISOString()` converts to UTC first, so local midnight on the 12th printed
+ * as the 11th at any positive offset - a wrong date read aloud to the owner.
+ */
+const formatDay = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Parses a record date, reading a date-only value as LOCAL midnight.
+ *
+ * Appointment and task dates are already read locally; parsing a vaccination's
+ * date-only string with `new Date()` would read it as UTC and put the same
+ * calendar day at a different instant.
+ */
+export const parseRecordDate = (value: string): Date | null => {
+  const trimmed = value.trim();
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(trimmed)
+    ? new Date(`${trimmed}T00:00:00`)
+    : new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/** "when is my next appointment" */
+export const resolveNextAppointment = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const scope = companionsInScope(context, slots);
+  const scopeIds = new Set(scope.map(companion => companion.id));
+  const nameById = new Map(scope.map(c => [c.id, c.name]));
+
+  const upcoming = context.appointments
+    .filter(appointment => scopeIds.has(appointment.companionId))
+    .filter(appointment => !TERMINAL_STATUSES.has(appointment.status))
+    .map(appointment => ({
+      appointment,
+      startsAt: appointmentStartsAt(appointment),
+    }))
+    .filter(
+      (entry): entry is {appointment: Appointment; startsAt: Date} =>
+        entry.startsAt !== null &&
+        entry.startsAt.getTime() >= context.now.getTime(),
+    )
+    .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
+
+  const next = upcoming[0];
+  if (!next) {
+    return {
+      actionId: 'nextAppointment',
+      status: 'empty',
+      speechKey: 'assistant.replies.nextAppointment.none',
+      speechParams: {petName: scope.length === 1 ? scope[0].name : ''},
+    };
+  }
+
+  const petName = nameById.get(next.appointment.companionId) ?? '';
+  return {
+    actionId: 'nextAppointment',
+    status: 'ok',
+    speechKey: 'assistant.replies.nextAppointment.found',
+    speechParams: {
+      petName,
+      date: formatDay(next.startsAt),
+      time: next.appointment.time ?? '',
+      business: next.appointment.organisationName ?? '',
+    },
+    data: {
+      petName,
+      appointmentId: next.appointment.id,
+      dateLabel: formatDay(next.startsAt),
+      items: upcoming.slice(0, 3).map(entry => ({
+        id: entry.appointment.id,
+        title: entry.appointment.serviceName ?? entry.appointment.type,
+        subtitle:
+          `${formatDay(entry.startsAt)} ${entry.appointment.time ?? ''}`.trim(),
+      })),
+    },
+  };
+};
+
+/** "is Bruno up to date on his vaccines" */
+export const resolveVaccinationStatus = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const companion = resolveCompanion(context, slots);
+  if (!companion) {
+    return {
+      actionId: 'vaccinationStatus',
+      status: 'needsSlot',
+      missingSlot: 'petName',
+      speechKey: 'assistant.replies.needsPet',
+    };
+  }
+
+  const records = context.vaccinations[companion.id] ?? [];
+  if (records.length === 0) {
+    return {
+      actionId: 'vaccinationStatus',
+      status: 'empty',
+      speechKey: 'assistant.replies.vaccinationStatus.none',
+      speechParams: {petName: companion.name},
+      data: {petName: companion.name},
+    };
+  }
+
+  const dated = records
+    .map(record => ({
+      record,
+      dueOn: record.dueOn ? parseRecordDate(record.dueOn) : null,
+    }))
+    .filter(
+      (entry): entry is {record: AssistantVaccination; dueOn: Date} =>
+        entry.dueOn !== null,
+    )
+    .sort((a, b) => a.dueOn.getTime() - b.dueOn.getTime());
+
+  // Partitioned rather than filtered twice. A record overdue by a few hours
+  // rounded to -0 days, which satisfied `>= 0`, so it appeared in both lists
+  // and rendered twice in the card. Sorting also means "most overdue" and
+  // "soonest due" are simply the first element of each.
+  const overdue = dated.filter(
+    entry => entry.dueOn.getTime() < context.now.getTime(),
+  );
+  const dueSoon = dated.filter(entry => {
+    if (entry.dueOn.getTime() < context.now.getTime()) {
+      return false;
+    }
+    return daysBetween(context.now, entry.dueOn) <= VACCINATION_DUE_SOON_DAYS;
+  });
+
+  const items: AssistantResultItem[] = [...overdue, ...dueSoon].map(entry => ({
+    id: entry.record.name,
+    title: entry.record.name,
+    subtitle: formatDay(entry.dueOn),
+  }));
+
+  if (overdue.length > 0) {
+    return {
+      actionId: 'vaccinationStatus',
+      status: 'ok',
+      speechKey: 'assistant.replies.vaccinationStatus.overdue',
+      speechParams: {
+        petName: companion.name,
+        count: overdue.length,
+        name: overdue[0].record.name,
+      },
+      data: {petName: companion.name, items},
+    };
+  }
+
+  if (dueSoon.length > 0) {
+    const soonest = dueSoon[0];
+    return {
+      actionId: 'vaccinationStatus',
+      status: 'ok',
+      speechKey: 'assistant.replies.vaccinationStatus.dueSoon',
+      speechParams: {
+        petName: companion.name,
+        name: soonest.record.name,
+        date: formatDay(soonest.dueOn),
+      },
+      data: {petName: companion.name, items},
+    };
+  }
+
+  return {
+    actionId: 'vaccinationStatus',
+    status: 'ok',
+    speechKey: 'assistant.replies.vaccinationStatus.upToDate',
+    speechParams: {petName: companion.name},
+    data: {petName: companion.name},
+  };
+};
+
+/** "what is due today" / "what does Bruno need this week" */
+export const resolveUpcomingTasks = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const scope = companionsInScope(context, slots);
+  const scopeIds = new Set(scope.map(companion => companion.id));
+
+  const windowEnd = slots.when
+    ? new Date(slots.when)
+    : new Date(context.now.getTime() + UPCOMING_WINDOW_DAYS * MS_PER_DAY);
+  const endTime = Number.isNaN(windowEnd.getTime())
+    ? context.now.getTime() + UPCOMING_WINDOW_DAYS * MS_PER_DAY
+    : // A named day means "through the end of that day", not "up to 9am".
+      new Date(windowEnd).setHours(23, 59, 59, 999);
+
+  const due = context.tasks
+    .filter(task => scopeIds.has(task.companionId))
+    .filter(isOpenTask)
+    .map(task => ({task, dueAt: taskDueAt(task)}))
+    .filter(
+      (entry): entry is {task: Task; dueAt: Date} =>
+        entry.dueAt !== null &&
+        entry.dueAt.getTime() >= context.now.getTime() - MS_PER_DAY &&
+        entry.dueAt.getTime() <= endTime,
+    )
+    .sort((a, b) => a.dueAt.getTime() - b.dueAt.getTime());
+
+  if (due.length === 0) {
+    return {
+      actionId: 'upcomingTasks',
+      status: 'empty',
+      speechKey: 'assistant.replies.upcomingTasks.none',
+      speechParams: {petName: scope.length === 1 ? scope[0].name : ''},
+    };
+  }
+
+  return {
+    actionId: 'upcomingTasks',
+    status: 'ok',
+    speechKey: 'assistant.replies.upcomingTasks.found',
+    speechParams: {
+      count: due.length,
+      first: taskLabel(due[0].task),
+      petName: scope.length === 1 ? scope[0].name : '',
+    },
+    data: {
+      petName: scope.length === 1 ? scope[0].name : undefined,
+      taskIds: due.map(entry => entry.task.id),
+      items: due.slice(0, 5).map(entry => ({
+        id: entry.task.id,
+        title: taskLabel(entry.task),
+        subtitle: formatDay(entry.dueAt),
+      })),
+    },
+  };
+};
+
+/** "tell me about Bruno" */
+export const resolvePetOverview = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const companion = resolveCompanion(context, slots);
+  if (!companion) {
+    return {
+      actionId: 'petOverview',
+      status: 'needsSlot',
+      missingSlot: 'petName',
+      speechKey: 'assistant.replies.needsPet',
+    };
+  }
+
+  const openTasks = context.tasks.filter(
+    task => task.companionId === companion.id && isOpenTask(task),
+  ).length;
+  // Filtered on time as well as status: a year-old CONFIRMED appointment that
+  // was never marked COMPLETED was still being counted as upcoming.
+  const upcomingAppointments = context.appointments.filter(appointment => {
+    if (appointment.companionId !== companion.id) {
+      return false;
+    }
+    if (TERMINAL_STATUSES.has(appointment.status)) {
+      return false;
+    }
+    const startsAt = appointmentStartsAt(appointment);
+    return startsAt !== null && startsAt.getTime() >= context.now.getTime();
+  }).length;
+
+  return {
+    actionId: 'petOverview',
+    status: 'ok',
+    speechKey: 'assistant.replies.petOverview.summary',
+    speechParams: {
+      petName: companion.name,
+      breed: companion.breed?.breedName ?? '',
+      tasks: openTasks,
+      appointments: upcomingAppointments,
+    },
+    data: {petName: companion.name},
+  };
+};
+
+/** "how much have I spent on Bruno" */
+export const resolveExpenseSummary = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const scope = companionsInScope(context, slots);
+  const scopeIds = new Set(scope.map(companion => companion.id));
+
+  const relevant = context.expenses.filter(expense =>
+    scopeIds.has(expense.companionId),
+  );
+
+  if (relevant.length === 0) {
+    return {
+      actionId: 'expenseSummary',
+      status: 'empty',
+      speechKey: 'assistant.replies.expenseSummary.none',
+      speechParams: {petName: scope.length === 1 ? scope[0].name : ''},
+    };
+  }
+
+  const total = relevant.reduce(
+    (sum, expense) =>
+      sum + (Number.isFinite(expense.amount) ? expense.amount : 0),
+    0,
+  );
+  const currencyCode = relevant[0].currencyCode || context.currencyCode;
+
+  return {
+    actionId: 'expenseSummary',
+    status: 'ok',
+    speechKey: 'assistant.replies.expenseSummary.total',
+    speechParams: {
+      total: Number(total.toFixed(2)),
+      currency: currencyCode,
+      petName: scope.length === 1 ? scope[0].name : '',
+      count: relevant.length,
+    },
+    data: {
+      petName: scope.length === 1 ? scope[0].name : undefined,
+      amount: Number(total.toFixed(2)),
+      currencyCode,
+    },
+  };
+};
+
+/**
+ * Builds the deep link for a handoff action.
+ *
+ * Handoff actions never commit anything. Booking needs live availability and
+ * payment, and a medication reminder deserves a human confirming the dose, so
+ * the assistant opens the right screen with the slots prefilled instead.
+ */
+export const buildHandoffLink = (
+  actionId: AssistantActionId,
+  slots: AssistantSlots,
+  companionId?: string,
+): string | undefined => {
+  const action = getAssistantAction(actionId);
+  if (!action?.deepLink) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams();
+  if (companionId) {
+    params.set('companionId', companionId);
+  }
+  if (slots.title) {
+    params.set('title', slots.title);
+  }
+  if (slots.when) {
+    params.set('when', slots.when);
+  }
+  if (slots.amount !== undefined) {
+    params.set('amount', String(slots.amount));
+  }
+  if (slots.category) {
+    params.set('category', slots.category);
+  }
+
+  const query = params.toString();
+  return query ? `${action.deepLink}?${query}` : action.deepLink;
+};
+
+const resolveHandoff = (
+  actionId: AssistantActionId,
+  speechKey: string,
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => {
+  const companion = resolveCompanion(context, slots);
+  return {
+    actionId,
+    status: 'handoff',
+    speechKey,
+    speechParams: {
+      petName: companion?.name ?? '',
+      title: slots.title ?? '',
+    },
+    deepLink: buildHandoffLink(actionId, slots, companion?.id),
+    data: {petName: companion?.name},
+  };
+};
+
+export const resolveAddCareTask = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult =>
+  resolveHandoff(
+    'addCareTask',
+    'assistant.replies.addCareTask.handoff',
+    context,
+    slots,
+  );
+
+export const resolveLogExpense = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult =>
+  resolveHandoff(
+    'logExpense',
+    'assistant.replies.logExpense.handoff',
+    context,
+    slots,
+  );
+
+export const resolveBookAppointment = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult =>
+  resolveHandoff(
+    'bookAppointment',
+    'assistant.replies.bookAppointment.handoff',
+    context,
+    slots,
+  );
+
+type Resolver = (
+  context: AssistantContext,
+  slots: AssistantSlots,
+) => AssistantActionResult;
+
+const RESOLVERS: Record<AssistantActionId, Resolver> = {
+  nextAppointment: resolveNextAppointment,
+  vaccinationStatus: resolveVaccinationStatus,
+  upcomingTasks: resolveUpcomingTasks,
+  petOverview: resolvePetOverview,
+  expenseSummary: resolveExpenseSummary,
+  addCareTask: resolveAddCareTask,
+  logExpense: resolveLogExpense,
+  bookAppointment: resolveBookAppointment,
+};
+
+/** Runs the resolver for an action id. */
+export const runAction = (
+  actionId: AssistantActionId,
+  context: AssistantContext,
+  slots: AssistantSlots,
+): AssistantActionResult => RESOLVERS[actionId](context, slots);

--- a/apps/mobileAppYC/src/features/assistant/assistantSlice.ts
+++ b/apps/mobileAppYC/src/features/assistant/assistantSlice.ts
@@ -1,0 +1,96 @@
+/** Redux state for the assistant transcript and model availability. */
+import {createSlice, type PayloadAction} from '@reduxjs/toolkit';
+import type {
+  AssistantMessage,
+  AssistantActionResult,
+  OnDeviceModelAvailability,
+} from './types';
+import {MAX_TRANSCRIPT_MESSAGES} from './constants';
+
+export type AssistantStatus = 'idle' | 'thinking' | 'error';
+
+export interface AssistantState {
+  messages: AssistantMessage[];
+  status: AssistantStatus;
+  error: string | null;
+  modelAvailability: OnDeviceModelAvailability;
+  /** Owner-controlled switch, surfaced in preferences. */
+  enabled: boolean;
+  /** Set once the availability probe has run, so the UI can avoid a flash. */
+  availabilityChecked: boolean;
+}
+
+const initialState: AssistantState = {
+  messages: [],
+  status: 'idle',
+  error: null,
+  modelAvailability: {available: false},
+  enabled: true,
+  availabilityChecked: false,
+};
+
+/** Keeps the transcript bounded without dropping the turn just added. */
+const trimTranscript = (messages: AssistantMessage[]): AssistantMessage[] =>
+  messages.length <= MAX_TRANSCRIPT_MESSAGES
+    ? messages
+    : messages.slice(messages.length - MAX_TRANSCRIPT_MESSAGES);
+
+const assistantSlice = createSlice({
+  name: 'assistant',
+  initialState,
+  reducers: {
+    messageAdded: (state, action: PayloadAction<AssistantMessage>) => {
+      state.messages = trimTranscript([...state.messages, action.payload]);
+    },
+    thinkingStarted: state => {
+      state.status = 'thinking';
+      state.error = null;
+    },
+    turnCompleted: (
+      state,
+      action: PayloadAction<{
+        message: AssistantMessage;
+        result?: AssistantActionResult;
+      }>,
+    ) => {
+      state.status = 'idle';
+      state.error = null;
+      state.messages = trimTranscript([
+        ...state.messages,
+        {...action.payload.message, result: action.payload.result},
+      ]);
+    },
+    turnFailed: (state, action: PayloadAction<string>) => {
+      state.status = 'error';
+      state.error = action.payload;
+    },
+    transcriptCleared: state => {
+      state.messages = [];
+      state.status = 'idle';
+      state.error = null;
+    },
+    modelAvailabilityChanged: (
+      state,
+      action: PayloadAction<OnDeviceModelAvailability>,
+    ) => {
+      state.modelAvailability = action.payload;
+      state.availabilityChecked = true;
+    },
+    assistantEnabledChanged: (state, action: PayloadAction<boolean>) => {
+      state.enabled = action.payload;
+    },
+  },
+});
+
+export const {
+  messageAdded,
+  thinkingStarted,
+  turnCompleted,
+  turnFailed,
+  transcriptCleared,
+  modelAvailabilityChanged,
+  assistantEnabledChanged,
+} = assistantSlice.actions;
+
+export const assistantReducer = assistantSlice.reducer;
+export default assistantSlice.reducer;

--- a/apps/mobileAppYC/src/features/assistant/components/ActionResultCard/ActionResultCard.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/ActionResultCard/ActionResultCard.tsx
@@ -1,0 +1,103 @@
+import React, {useMemo} from 'react';
+import {StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import {useTheme} from '@/hooks';
+import type {Theme} from '@/theme';
+import type {AssistantActionResult} from '@/features/assistant/types';
+
+interface ActionResultCardProps {
+  result: AssistantActionResult;
+  /** Invoked for a handoff result. The screen owns the navigation. */
+  onOpen: (deepLink: string) => void;
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    card: {
+      marginTop: theme.spacing['2'],
+      marginBottom: theme.spacing['3'],
+      padding: theme.spacing['4'],
+      borderRadius: theme.borderRadius.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.cardBackground,
+      alignSelf: 'flex-start',
+      maxWidth: '90%',
+    },
+    item: {
+      paddingVertical: theme.spacing['2'],
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.divider,
+    },
+    firstItem: {borderTopWidth: 0},
+    itemTitle: {
+      ...theme.typography.labelSmallBold,
+      color: theme.colors.text,
+    },
+    itemSubtitle: {
+      ...theme.typography.labelXs,
+      color: theme.colors.textSecondary,
+    },
+    action: {
+      marginTop: theme.spacing['3'],
+      paddingVertical: theme.spacing['3'],
+      paddingHorizontal: theme.spacing['4'],
+      borderRadius: theme.borderRadius.button,
+      backgroundColor: theme.colors.cta,
+      alignSelf: 'flex-start',
+    },
+    actionText: {
+      ...theme.typography.buttonSmall,
+      color: theme.colors.ctaText,
+    },
+  });
+
+/**
+ * The structured half of an answer.
+ *
+ * The bubble above it already carries the sentence, so this renders only what
+ * a sentence reads badly: a list of due items, and the button for a handoff
+ * the assistant deliberately did not complete on its own.
+ */
+export const ActionResultCard: React.FC<ActionResultCardProps> = ({
+  result,
+  onOpen,
+}) => {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const items = result.data?.items ?? [];
+  const hasHandoff = result.status === 'handoff' && Boolean(result.deepLink);
+
+  if (items.length === 0 && !hasHandoff) {
+    return null;
+  }
+
+  return (
+    <View style={styles.card} testID="assistant-result-card">
+      {items.map((item, index) => (
+        <View
+          key={item.id}
+          style={[styles.item, index === 0 && styles.firstItem]}>
+          <Text style={styles.itemTitle}>{item.title}</Text>
+          {item.subtitle ? (
+            <Text style={styles.itemSubtitle}>{item.subtitle}</Text>
+          ) : null}
+        </View>
+      ))}
+
+      {hasHandoff ? (
+        <TouchableOpacity
+          style={styles.action}
+          accessibilityRole="button"
+          testID="assistant-result-open"
+          onPress={() => onOpen(result.deepLink as string)}>
+          <Text style={styles.actionText}>
+            {t(`assistant.open.${result.actionId}`)}
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/components/ActionResultCard/ActionResultCard.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/ActionResultCard/ActionResultCard.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
-import {StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {StyleSheet, Text, View} from 'react-native';
 import {useTranslation} from 'react-i18next';
+import {PressableOpacity} from '@/shared/components/common/PressableOpacity/PressableOpacity';
 import {useTheme} from '@/hooks';
 import type {Theme} from '@/theme';
 import type {AssistantActionResult} from '@/features/assistant/types';
@@ -88,7 +89,7 @@ export const ActionResultCard: React.FC<ActionResultCardProps> = ({
       ))}
 
       {hasHandoff ? (
-        <TouchableOpacity
+        <PressableOpacity
           style={styles.action}
           accessibilityRole="button"
           testID="assistant-result-open"
@@ -96,7 +97,7 @@ export const ActionResultCard: React.FC<ActionResultCardProps> = ({
           <Text style={styles.actionText}>
             {t(`assistant.open.${result.actionId}`)}
           </Text>
-        </TouchableOpacity>
+        </PressableOpacity>
       ) : null}
     </View>
   );

--- a/apps/mobileAppYC/src/features/assistant/components/AssistantComposer/AssistantComposer.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/AssistantComposer/AssistantComposer.tsx
@@ -1,0 +1,120 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import {useTheme} from '@/hooks';
+import type {Theme} from '@/theme';
+import {MAX_UTTERANCE_LENGTH} from '@/features/assistant/constants';
+
+interface AssistantComposerProps {
+  onSubmit: (text: string) => void;
+  busy: boolean;
+  /** Lets the screen push a suggestion chip into the field. */
+  value: string;
+  onChangeText: (text: string) => void;
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    wrapper: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      gap: theme.spacing['2'],
+      paddingHorizontal: theme.spacing['4'],
+      paddingTop: theme.spacing['2'],
+      paddingBottom: theme.spacing['3'],
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border,
+      backgroundColor: theme.colors.background,
+    },
+    input: {
+      flex: 1,
+      minHeight: 44,
+      maxHeight: 120,
+      paddingHorizontal: theme.spacing['4'],
+      paddingVertical: theme.spacing['3'],
+      borderRadius: theme.borderRadius.field,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.fieldBg,
+      ...theme.typography.input,
+      color: theme.colors.text,
+    },
+    send: {
+      minHeight: 44,
+      justifyContent: 'center',
+      paddingHorizontal: theme.spacing['4'],
+      borderRadius: theme.borderRadius.button,
+      backgroundColor: theme.colors.cta,
+    },
+    sendDisabled: {opacity: 0.5},
+    sendText: {
+      ...theme.typography.buttonSmall,
+      color: theme.colors.ctaText,
+    },
+  });
+
+export const AssistantComposer: React.FC<AssistantComposerProps> = ({
+  onSubmit,
+  busy,
+  value,
+  onChangeText,
+}) => {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [focused, setFocused] = useState(false);
+
+  const canSend = value.trim().length > 0 && !busy;
+
+  const handleSubmit = useCallback(() => {
+    if (!canSend) {
+      return;
+    }
+    onSubmit(value.trim());
+  }, [canSend, onSubmit, value]);
+
+  return (
+    <View style={styles.wrapper}>
+      <TextInput
+        testID="assistant-input"
+        style={[styles.input, focused && {borderColor: theme.colors.primary}]}
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder={t('assistant.composerPlaceholder')}
+        placeholderTextColor={theme.colors.textSecondary}
+        maxLength={MAX_UTTERANCE_LENGTH}
+        multiline
+        accessibilityLabel={t('assistant.composerPlaceholder')}
+        onSubmitEditing={handleSubmit}
+        returnKeyType="send"
+        blurOnSubmit
+      />
+      <TouchableOpacity
+        testID="assistant-send"
+        accessibilityRole="button"
+        accessibilityLabel={t('assistant.send')}
+        accessibilityState={{disabled: !canSend}}
+        disabled={!canSend}
+        style={[styles.send, !canSend && styles.sendDisabled]}
+        onPress={handleSubmit}>
+        {busy ? (
+          <ActivityIndicator
+            testID="assistant-busy"
+            color={theme.colors.ctaText}
+          />
+        ) : (
+          <Text style={styles.sendText}>{t('assistant.send')}</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/components/AssistantComposer/AssistantComposer.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/AssistantComposer/AssistantComposer.tsx
@@ -4,10 +4,10 @@ import {
   StyleSheet,
   Text,
   TextInput,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import {useTranslation} from 'react-i18next';
+import {PressableOpacity} from '@/shared/components/common/PressableOpacity/PressableOpacity';
 import {useTheme} from '@/hooks';
 import type {Theme} from '@/theme';
 import {MAX_UTTERANCE_LENGTH} from '@/features/assistant/constants';
@@ -98,7 +98,7 @@ export const AssistantComposer: React.FC<AssistantComposerProps> = ({
         returnKeyType="send"
         blurOnSubmit
       />
-      <TouchableOpacity
+      <PressableOpacity
         testID="assistant-send"
         accessibilityRole="button"
         accessibilityLabel={t('assistant.send')}
@@ -114,7 +114,7 @@ export const AssistantComposer: React.FC<AssistantComposerProps> = ({
         ) : (
           <Text style={styles.sendText}>{t('assistant.send')}</Text>
         )}
-      </TouchableOpacity>
+      </PressableOpacity>
     </View>
   );
 };

--- a/apps/mobileAppYC/src/features/assistant/components/MessageBubble/MessageBubble.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/MessageBubble/MessageBubble.tsx
@@ -1,0 +1,57 @@
+import React, {useMemo} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {useTheme} from '@/hooks';
+import type {Theme} from '@/theme';
+import type {AssistantMessage} from '@/features/assistant/types';
+
+interface MessageBubbleProps {
+  message: AssistantMessage;
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    row: {
+      width: '100%',
+      marginBottom: theme.spacing['2'],
+    },
+    userRow: {alignItems: 'flex-end'},
+    assistantRow: {alignItems: 'flex-start'},
+    bubble: {
+      maxWidth: '86%',
+      paddingVertical: theme.spacing['3'],
+      paddingHorizontal: theme.spacing['4'],
+      borderRadius: theme.borderRadius.card,
+      borderWidth: 1,
+    },
+    userBubble: {
+      backgroundColor: theme.colors.blueSoft,
+      borderColor: theme.colors.blueSoft,
+    },
+    assistantBubble: {
+      backgroundColor: theme.colors.cardBackground,
+      borderColor: theme.colors.border,
+    },
+    text: {
+      ...theme.typography.paragraph,
+      color: theme.colors.text,
+    },
+  });
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({message}) => {
+  const {theme} = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const isUser = message.author === 'user';
+
+  return (
+    <View style={[styles.row, isUser ? styles.userRow : styles.assistantRow]}>
+      <View
+        testID={`assistant-bubble-${message.author}`}
+        style={[
+          styles.bubble,
+          isUser ? styles.userBubble : styles.assistantBubble,
+        ]}>
+        <Text style={styles.text}>{message.text}</Text>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/components/ModelStatusBanner/ModelStatusBanner.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/ModelStatusBanner/ModelStatusBanner.tsx
@@ -1,0 +1,57 @@
+import React, {useMemo} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import {useTheme} from '@/hooks';
+import type {Theme} from '@/theme';
+import type {OnDeviceModelAvailability} from '@/features/assistant/types';
+
+interface ModelStatusBannerProps {
+  availability: OnDeviceModelAvailability;
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    banner: {
+      marginHorizontal: theme.spacing['4'],
+      marginBottom: theme.spacing['2'],
+      paddingVertical: theme.spacing['2'],
+      paddingHorizontal: theme.spacing['3'],
+      borderRadius: theme.borderRadius.cardSmall,
+      backgroundColor: theme.colors.infoSurface,
+    },
+    text: {
+      ...theme.typography.labelSmall,
+      color: theme.colors.textSecondary,
+    },
+  });
+
+/**
+ * Explains, once, why answers are phrased plainly on this device.
+ *
+ * Only shown when the model is genuinely missing. Saying "on-device AI is on"
+ * to the majority who have it would be noise, so the available case renders
+ * nothing.
+ */
+export const ModelStatusBanner: React.FC<ModelStatusBannerProps> = ({
+  availability,
+}) => {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  if (availability.available) {
+    return null;
+  }
+
+  const reasonKey = availability.reason ?? 'unknown';
+
+  return (
+    <View style={styles.banner} testID="assistant-model-status">
+      <Text style={styles.text}>
+        {t(`assistant.model.${reasonKey}`, {
+          provider: availability.providerLabel ?? t('assistant.model.provider'),
+        })}
+      </Text>
+    </View>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/components/SuggestionChips/SuggestionChips.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/SuggestionChips/SuggestionChips.tsx
@@ -1,0 +1,81 @@
+import React, {useMemo} from 'react';
+import {ScrollView, StyleSheet, Text, TouchableOpacity} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import {useTheme} from '@/hooks';
+import type {Theme} from '@/theme';
+import {ASSISTANT_ACTIONS} from '@/features/assistant/actions/catalogue';
+
+interface SuggestionChipsProps {
+  onSelect: (phrase: string) => void;
+  /** Cap the number of chips so the row stays scannable. */
+  limit?: number;
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    // A horizontal ScrollView carries no intrinsic height, so inside the
+    // screen's flex column it was shrunk by its siblings and clipped the
+    // bottom of every pill. It should keep its natural height instead.
+    row: {
+      flexGrow: 0,
+      flexShrink: 0,
+    },
+    container: {
+      paddingHorizontal: theme.spacing['4'],
+      gap: theme.spacing['2'],
+      paddingBottom: theme.spacing['2'],
+    },
+    chip: {
+      paddingVertical: theme.spacing['2'],
+      paddingHorizontal: theme.spacing['4'],
+      borderRadius: theme.borderRadius.chip,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.cardBackground,
+    },
+    chipText: {
+      ...theme.typography.labelSmall,
+      color: theme.colors.text,
+    },
+  });
+
+/**
+ * First-run affordance. An assistant cannot be discovered by guessing, so the
+ * catalogue's own sample phrases double as the starter suggestions.
+ */
+export const SuggestionChips: React.FC<SuggestionChipsProps> = ({
+  onSelect,
+  limit = 4,
+}) => {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const phrases = useMemo(
+    () =>
+      ASSISTANT_ACTIONS.flatMap(action => action.samplePhraseKeys)
+        .slice(0, limit)
+        .map(key => ({key, label: t(key)})),
+    [limit, t],
+  );
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.row}
+      contentContainerStyle={styles.container}
+      testID="assistant-suggestions">
+      {phrases.map(phrase => (
+        <TouchableOpacity
+          key={phrase.key}
+          style={styles.chip}
+          accessibilityRole="button"
+          accessibilityLabel={phrase.label}
+          onPress={() => onSelect(phrase.label)}>
+          <Text style={styles.chipText}>{phrase.label}</Text>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/components/SuggestionChips/SuggestionChips.tsx
+++ b/apps/mobileAppYC/src/features/assistant/components/SuggestionChips/SuggestionChips.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
-import {ScrollView, StyleSheet, Text, TouchableOpacity} from 'react-native';
+import {ScrollView, StyleSheet, Text} from 'react-native';
 import {useTranslation} from 'react-i18next';
+import {PressableOpacity} from '@/shared/components/common/PressableOpacity/PressableOpacity';
 import {useTheme} from '@/hooks';
 import type {Theme} from '@/theme';
 import {ASSISTANT_ACTIONS} from '@/features/assistant/actions/catalogue';
@@ -60,6 +61,11 @@ export const SuggestionChips: React.FC<SuggestionChipsProps> = ({
   );
 
   return (
+    // Deliberately a ScrollView rather than a FlatList, against
+    // react-doctor's rn-no-scrollview-mapped-list. That rule targets long
+    // lists; this row is explicitly capped by `limit` (four by default), so
+    // virtualising it would buy nothing and would trade an exact "render these
+    // chips" contract for a windowed one.
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
@@ -67,14 +73,14 @@ export const SuggestionChips: React.FC<SuggestionChipsProps> = ({
       contentContainerStyle={styles.container}
       testID="assistant-suggestions">
       {phrases.map(phrase => (
-        <TouchableOpacity
+        <PressableOpacity
           key={phrase.key}
           style={styles.chip}
           accessibilityRole="button"
           accessibilityLabel={phrase.label}
           onPress={() => onSelect(phrase.label)}>
           <Text style={styles.chipText}>{phrase.label}</Text>
-        </TouchableOpacity>
+        </PressableOpacity>
       ))}
     </ScrollView>
   );

--- a/apps/mobileAppYC/src/features/assistant/components/index.ts
+++ b/apps/mobileAppYC/src/features/assistant/components/index.ts
@@ -1,0 +1,5 @@
+export {MessageBubble} from './MessageBubble/MessageBubble';
+export {SuggestionChips} from './SuggestionChips/SuggestionChips';
+export {ActionResultCard} from './ActionResultCard/ActionResultCard';
+export {AssistantComposer} from './AssistantComposer/AssistantComposer';
+export {ModelStatusBanner} from './ModelStatusBanner/ModelStatusBanner';

--- a/apps/mobileAppYC/src/features/assistant/constants.ts
+++ b/apps/mobileAppYC/src/features/assistant/constants.ts
@@ -1,0 +1,48 @@
+/** Shared constants for the assistant feature. */
+
+/** Deep-link scheme already registered by the app on both platforms. */
+export const ASSISTANT_LINK_SCHEME = 'yc://app';
+
+/** Maximum turns kept in the transcript. Older turns are dropped. */
+export const MAX_TRANSCRIPT_MESSAGES = 60;
+
+/**
+ * Maximum characters accepted from one utterance. Long pastes are truncated
+ * rather than rejected so a rambling question still gets an answer.
+ */
+export const MAX_UTTERANCE_LENGTH = 500;
+
+/**
+ * Confidence at or above which the deterministic parser's answer is used
+ * without consulting the on-device model.
+ */
+export const RULES_CONFIDENCE_THRESHOLD = 0.6;
+
+/**
+ * Confidence for a bare pet name ("Bruno?").
+ *
+ * Deliberately below the threshold above: naming an animal with no verb is a
+ * guess about intent, so it is the one rules result the on-device model is
+ * allowed to overrule.
+ */
+export const BARE_NAME_CONFIDENCE = 0.45;
+
+/** How many pets the snapshot carries to the native side. */
+export const SNAPSHOT_PET_LIMIT = 12;
+
+/** How many upcoming items of each kind the snapshot carries. */
+export const SNAPSHOT_ITEM_LIMIT = 20;
+
+/** Days ahead that count as "upcoming" for tasks and appointments. */
+export const UPCOMING_WINDOW_DAYS = 30;
+
+/** Days before a due date that a vaccination counts as "due soon". */
+export const VACCINATION_DUE_SOON_DAYS = 30;
+
+/**
+ * How far back an overdue vaccination still earns a place in the snapshot.
+ *
+ * The snapshot holds a fixed number of entries, so without this an owner with
+ * a long unrecorded history crowds out the shot due next week.
+ */
+export const VACCINATION_STALE_DAYS = 90;

--- a/apps/mobileAppYC/src/features/assistant/hooks/useAssistantSync.ts
+++ b/apps/mobileAppYC/src/features/assistant/hooks/useAssistantSync.ts
@@ -1,0 +1,120 @@
+import {useCallback, useEffect, useRef} from 'react';
+import {AppState, Platform, type AppStateStatus} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import type {NavigationProp} from '@react-navigation/native';
+import {useTranslation} from 'react-i18next';
+import {useAppDispatch, useAppSelector} from '@/app/hooks';
+import type {RootStackParamList} from '@/navigation/types';
+import {selectAssistantData} from '../selectors';
+import {refreshAssistantSnapshot} from '../thunks';
+import {consumePendingLink} from '../services/assistantSnapshot';
+import {resolveHandoffTarget} from '../services/handoffNavigation';
+import {getSnapshotModule} from '../services/nativeBridge';
+import {ASSISTANT_ACTIONS} from '../actions/catalogue';
+
+/** How long to wait after a data change before rewriting the snapshot. */
+const SNAPSHOT_DEBOUNCE_MS = 1_500;
+
+/** Actions worth a launcher shortcut, in the order they are shown. */
+const SHORTCUT_ACTION_IDS = [
+  'upcomingTasks',
+  'nextAppointment',
+  'addCareTask',
+  'bookAppointment',
+] as const;
+
+/**
+ * Keeps the OS-facing surfaces in step with the app.
+ *
+ * Three jobs, all of them fire-and-forget:
+ *  - rewrite the offline snapshot when the underlying records change, so Siri
+ *    and the launcher shortcuts answer with today's facts;
+ *  - publish the Android app shortcuts once per launch;
+ *  - pick up a deep link parked by an intent or shortcut and route to it.
+ *
+ * Every one of these no-ops when the native module is absent, which is the
+ * case in Jest and in a JS-only reload.
+ */
+export const useAssistantSync = (): void => {
+  const dispatch = useAppDispatch();
+  const {t} = useTranslation();
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const data = useAppSelector(selectAssistantData);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Rewriting on every keystroke of a task form would be wasteful, and the
+  // snapshot only has to be right by the time the app is backgrounded.
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      dispatch(refreshAssistantSnapshot());
+    }, SNAPSHOT_DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [
+    dispatch,
+    data.companions,
+    data.tasks,
+    data.appointments,
+    data.vaccinations,
+  ]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+    const module = getSnapshotModule();
+    if (!module?.publishShortcuts) {
+      return;
+    }
+    const payload = SHORTCUT_ACTION_IDS.map(id => {
+      const action = ASSISTANT_ACTIONS.find(entry => entry.id === id);
+      return {
+        id,
+        label: action ? t(action.titleKey) : id,
+        longLabel: action ? t(action.descriptionKey) : id,
+        link: action?.deepLink ?? 'yc://app/assistant',
+      };
+    });
+    module.publishShortcuts(JSON.stringify(payload));
+  }, [t]);
+
+  const routePendingLink = useCallback(async () => {
+    const link = await consumePendingLink();
+    if (!link) {
+      return;
+    }
+    const target = resolveHandoffTarget(link);
+    if (!target) {
+      return;
+    }
+    navigation.navigate('Main', {
+      screen: target.tab,
+      params: target.nested
+        ? {screen: target.screen, params: target.nested}
+        : {screen: target.screen, params: target.params},
+    } as never);
+  }, [navigation]);
+
+  useEffect(() => {
+    routePendingLink();
+
+    // A handoff intent opens the app; if it was already running, the link
+    // arrives while the app is resuming rather than at mount.
+    const subscription = AppState.addEventListener(
+      'change',
+      (status: AppStateStatus) => {
+        if (status === 'active') {
+          routePendingLink();
+        }
+      },
+    );
+    return () => subscription.remove();
+  }, [routePendingLink]);
+};

--- a/apps/mobileAppYC/src/features/assistant/hooks/useAssistantSync.ts
+++ b/apps/mobileAppYC/src/features/assistant/hooks/useAssistantSync.ts
@@ -1,16 +1,25 @@
 import {useCallback, useEffect, useRef} from 'react';
 import {AppState, Platform, type AppStateStatus} from 'react-native';
-import {useNavigation} from '@react-navigation/native';
-import type {NavigationProp} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 import {useAppDispatch, useAppSelector} from '@/app/hooks';
-import type {RootStackParamList} from '@/navigation/types';
 import {selectAssistantData} from '../selectors';
 import {refreshAssistantSnapshot} from '../thunks';
 import {consumePendingLink} from '../services/assistantSnapshot';
 import {resolveHandoffTarget} from '../services/handoffNavigation';
 import {getSnapshotModule} from '../services/nativeBridge';
 import {ASSISTANT_ACTIONS} from '../actions/catalogue';
+
+/**
+ * The slice of the navigation container this hook needs.
+ *
+ * Taking the container ref rather than calling `useNavigation()` keeps the
+ * hook independent of navigator context: it is mounted at the app root, which
+ * renders above the navigator in some trees and in none at all under test.
+ */
+export interface AssistantNavigator {
+  isReady: () => boolean;
+  navigate: (name: string, params?: object) => void;
+}
 
 /** How long to wait after a data change before rewriting the snapshot. */
 const SNAPSHOT_DEBOUNCE_MS = 1_500;
@@ -35,10 +44,11 @@ const SHORTCUT_ACTION_IDS = [
  * Every one of these no-ops when the native module is absent, which is the
  * case in Jest and in a JS-only reload.
  */
-export const useAssistantSync = (): void => {
+export const useAssistantSync = (
+  navigator?: AssistantNavigator | null,
+): void => {
   const dispatch = useAppDispatch();
   const {t} = useTranslation();
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const data = useAppSelector(selectAssistantData);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -94,13 +104,18 @@ export const useAssistantSync = (): void => {
     if (!target) {
       return;
     }
-    navigation.navigate('Main', {
+    // A link can arrive before the navigator has mounted, on a cold start from
+    // a shortcut. Dropping it beats throwing; the app still opens.
+    if (!navigator?.isReady()) {
+      return;
+    }
+    navigator.navigate('Main', {
       screen: target.tab,
       params: target.nested
         ? {screen: target.screen, params: target.nested}
         : {screen: target.screen, params: target.params},
-    } as never);
-  }, [navigation]);
+    });
+  }, [navigator]);
 
   useEffect(() => {
     routePendingLink();

--- a/apps/mobileAppYC/src/features/assistant/index.ts
+++ b/apps/mobileAppYC/src/features/assistant/index.ts
@@ -1,0 +1,38 @@
+export {
+  assistantReducer,
+  default as assistantDefaultReducer,
+} from './assistantSlice';
+export {
+  messageAdded,
+  thinkingStarted,
+  turnCompleted,
+  turnFailed,
+  transcriptCleared,
+  modelAvailabilityChanged,
+  assistantEnabledChanged,
+} from './assistantSlice';
+export {
+  askAssistant,
+  probeOnDeviceModel,
+  refreshAssistantSnapshot,
+} from './thunks';
+export {
+  selectAssistantMessages,
+  selectAssistantStatus,
+  selectAssistantError,
+  selectModelAvailability,
+  selectAssistantEnabled,
+  selectAssistantData,
+  selectVaccinationsByCompanion,
+  buildAssistantContext,
+} from './selectors';
+export {ASSISTANT_ACTIONS, getAssistantAction} from './actions/catalogue';
+export type {
+  AssistantAction,
+  AssistantActionId,
+  AssistantActionResult,
+  AssistantContext,
+  AssistantIntent,
+  AssistantMessage,
+  OnDeviceModelAvailability,
+} from './types';

--- a/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
@@ -75,13 +75,13 @@ const RELATIVE_DAYS: Record<string, number> = {
 const DEFAULT_HOUR = 9;
 
 const atTime = (base: Date, hour: number, minute: number): Date => {
-  const result = new Date(base.getTime());
+  const result = new Date(base);
   result.setHours(hour, minute, 0, 0);
   return result;
 };
 
 const addDays = (base: Date, days: number): Date => {
-  const result = new Date(base.getTime());
+  const result = new Date(base);
   result.setDate(result.getDate() + days);
   return result;
 };
@@ -97,52 +97,161 @@ interface ClockTime {
  * A bare number is only treated as a time when preceded by "at", so "give 2
  * tablets" does not become 2 o'clock.
  */
+/** "8pm", "8:30 pm" - an hour of 1-12 qualified by am/pm. */
+const parseMeridiemTime = (normalized: string): ClockTime | null => {
+  const match = /(\d{1,2})(?:\s*[:.]\s*(\d{2}))?\s*(am|pm)\b/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const rawHour = Number(match[1]);
+  const minute = match[2] ? Number(match[2]) : 0;
+  if (rawHour < 1 || rawHour > 12 || minute >= 60) {
+    return null;
+  }
+  return {hour: (rawHour % 12) + (match[3] === 'pm' ? 12 : 0), minute};
+};
+
+/** "20:30" - a bare 24-hour reading. */
+const parse24HourTime = (normalized: string): ClockTime | null => {
+  const match = /\b(\d{1,2})\s*[:.]\s*(\d{2})\b/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  return hour < 24 && minute < 60 ? {hour, minute} : null;
+};
+
+/**
+ * "at 7" - a bare hour, and only after "at".
+ *
+ * The preposition is what keeps "give 2 tablets" from becoming 2 o'clock.
+ */
+const parseBareHourAfterAt = (normalized: string): ClockTime | null => {
+  const match = /\bat\s+(\d{1,2})\b/.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const hour = Number(match[1]);
+  return hour < 24 ? {hour, minute: 0} : null;
+};
+
+/**
+ * Reads an explicit clock time: "8pm", "8:30 pm", "20:30", "at 7".
+ *
+ * The readings are tried most specific first, so "13:30 pm" - whose hour is
+ * out of range for a meridiem - still resolves through the 24-hour rule.
+ */
 export const parseClockTime = (text: string): ClockTime | null => {
   const normalized = normalizeKeepingClock(text);
-
-  const meridiem = /(\d{1,2})(?:\s*[:.]\s*(\d{2}))?\s*(am|pm)\b/.exec(
-    normalized,
+  return (
+    parseMeridiemTime(normalized) ??
+    parse24HourTime(normalized) ??
+    parseBareHourAfterAt(normalized)
   );
-  if (meridiem) {
-    const rawHour = Number(meridiem[1]);
-    if (rawHour >= 1 && rawHour <= 12) {
-      const minute = meridiem[2] ? Number(meridiem[2]) : 0;
-      if (minute < 60) {
-        const isPm = meridiem[3] === 'pm';
-        const hour = (rawHour % 12) + (isPm ? 12 : 0);
-        return {hour, minute};
-      }
-    }
-  }
-
-  const twentyFour = /\b(\d{1,2})\s*[:.]\s*(\d{2})\b/.exec(normalized);
-  if (twentyFour) {
-    const hour = Number(twentyFour[1]);
-    const minute = Number(twentyFour[2]);
-    if (hour < 24 && minute < 60) {
-      return {hour, minute};
-    }
-  }
-
-  const bareAfterAt = /\bat\s+(\d{1,2})\b/.exec(normalized);
-  if (bareAfterAt) {
-    const hour = Number(bareAfterAt[1]);
-    if (hour < 24) {
-      return {hour, minute: 0};
-    }
-  }
-
-  return null;
 };
 
 /** Finds a named part of the day, e.g. "tonight" or "in the morning". */
 const parseDayPart = (normalized: string): number | null => {
   for (const [word, hour] of Object.entries(DAY_PART_HOURS)) {
-    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
+    if (new RegExp(String.raw`\b${word}\b`).test(normalized)) {
       return hour;
     }
   }
   return null;
+};
+
+/**
+ * Resolves a date phrase against `now`.
+ *
+ * Returns null when the text carries no date information at all, so callers
+ * can tell "no date mentioned" apart from "date mentioned but unparseable".
+ */
+/** Units accepted by an "in N ..." phrase, with the days each one contributes. */
+const RELATIVE_UNITS: ReadonlyArray<{pattern: RegExp; days: number}> = [
+  {pattern: /\bin\s+(\d{1,3})\s+(?:day|days|dias|dia)\b/, days: 1},
+  {pattern: /\bin\s+(\d{1,2})\s+(?:week|weeks|semana|semanas)\b/, days: 7},
+];
+
+/** "in 3 days", "in 2 weeks". */
+const resolveInDays = (
+  normalized: string,
+  now: Date,
+  hour: number,
+  minute: number,
+): string | null => {
+  for (const unit of RELATIVE_UNITS) {
+    const match = unit.pattern.exec(normalized);
+    if (match) {
+      return atTime(
+        addDays(now, Number(match[1]) * unit.days),
+        hour,
+        minute,
+      ).toISOString();
+    }
+  }
+  return null;
+};
+
+/** "in 5 hours". Deliberately ignores any stated clock time or day part. */
+const resolveInHours = (normalized: string, now: Date): string | null => {
+  const match = /\bin\s+(\d{1,3})\s+(?:hour|hours|hora|horas)\b/.exec(
+    normalized,
+  );
+  if (!match) {
+    return null;
+  }
+  const result = new Date(now);
+  result.setHours(result.getHours() + Number(match[1]), 0, 0, 0);
+  return result.toISOString();
+};
+
+/** "today", "tomorrow", "esta noche". */
+const resolveRelativeDay = (
+  normalized: string,
+  now: Date,
+  dayPartHour: number | null,
+  hour: number,
+  minute: number,
+): string | null => {
+  for (const [word, offset] of Object.entries(RELATIVE_DAYS)) {
+    // "esta" only means today when it qualifies a part of the day
+    // ("esta noche"); on its own it is just a determiner.
+    if (word === 'esta' && dayPartHour === null) {
+      continue;
+    }
+    if (new RegExp(String.raw`\b${word}\b`).test(normalized)) {
+      return atTime(addDays(now, offset), hour, minute).toISOString();
+    }
+  }
+  return null;
+};
+
+/** "on Friday". Always looks forward, so the same weekday means next week. */
+const resolveWeekday = (
+  normalized: string,
+  now: Date,
+  hour: number,
+  minute: number,
+): string | null => {
+  for (const [word, weekday] of Object.entries(WEEKDAYS)) {
+    if (new RegExp(String.raw`\b${word}\b`).test(normalized)) {
+      const delta = (weekday - now.getDay() + 7) % 7 || 7;
+      return atTime(addDays(now, delta), hour, minute).toISOString();
+    }
+  }
+  return null;
+};
+
+/** A time with no day means the next occurrence of that time. */
+const resolveNextOccurrence = (
+  now: Date,
+  hour: number,
+  minute: number,
+): string => {
+  const todayAt = atTime(now, hour, minute);
+  const target = todayAt > now ? todayAt : addDays(todayAt, 1);
+  return target.toISOString();
 };
 
 /**
@@ -159,82 +268,23 @@ export const parseWhen = (text: string, now: Date): string | null => {
 
   const clock = parseClockTime(text);
   const dayPartHour = parseDayPart(normalized);
+  const hour = clock?.hour ?? dayPartHour ?? DEFAULT_HOUR;
+  const minute = clock?.minute ?? 0;
 
-  const inDays = /\bin\s+(\d{1,3})\s+(day|days|dias|dia)\b/.exec(normalized);
-  if (inDays) {
-    const base = addDays(now, Number(inDays[1]));
-    return atTime(
-      base,
-      clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
-      clock?.minute ?? 0,
-    ).toISOString();
+  const dated =
+    resolveInDays(normalized, now, hour, minute) ??
+    resolveInHours(normalized, now) ??
+    resolveRelativeDay(normalized, now, dayPartHour, hour, minute) ??
+    resolveWeekday(normalized, now, hour, minute);
+  if (dated) {
+    return dated;
   }
 
-  const inWeeks = /\bin\s+(\d{1,2})\s+(week|weeks|semana|semanas)\b/.exec(
-    normalized,
-  );
-  if (inWeeks) {
-    const base = addDays(now, Number(inWeeks[1]) * 7);
-    return atTime(
-      base,
-      clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
-      clock?.minute ?? 0,
-    ).toISOString();
-  }
-
-  const inHours = /\bin\s+(\d{1,3})\s+(hour|hours|hora|horas)\b/.exec(
-    normalized,
-  );
-  if (inHours) {
-    const result = new Date(now.getTime());
-    result.setHours(result.getHours() + Number(inHours[1]), 0, 0, 0);
-    return result.toISOString();
-  }
-
-  for (const [word, offset] of Object.entries(RELATIVE_DAYS)) {
-    // "esta" only means today when it qualifies a part of the day
-    // ("esta noche"); on its own it is just a determiner.
-    if (word === 'esta' && dayPartHour === null) {
-      continue;
-    }
-    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
-      const base = addDays(now, offset);
-      return atTime(
-        base,
-        clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
-        clock?.minute ?? 0,
-      ).toISOString();
-    }
-  }
-
-  for (const [word, weekday] of Object.entries(WEEKDAYS)) {
-    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
-      const current = now.getDay();
-      // Always look forward: "on Monday" said on a Monday means next Monday.
-      const delta = (weekday - current + 7) % 7 || 7;
-      const base = addDays(now, delta);
-      return atTime(
-        base,
-        clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
-        clock?.minute ?? 0,
-      ).toISOString();
-    }
-  }
-
-  // A time with no day means the next occurrence of that time.
   if (clock) {
-    const todayAt = atTime(now, clock.hour, clock.minute);
-    const target =
-      todayAt.getTime() > now.getTime() ? todayAt : addDays(todayAt, 1);
-    return target.toISOString();
+    return resolveNextOccurrence(now, clock.hour, clock.minute);
   }
-
   if (dayPartHour !== null) {
-    const todayAt = atTime(now, dayPartHour, 0);
-    const target =
-      todayAt.getTime() > now.getTime() ? todayAt : addDays(todayAt, 1);
-    return target.toISOString();
+    return resolveNextOccurrence(now, dayPartHour, 0);
   }
-
   return null;
 };

--- a/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
@@ -206,13 +206,26 @@ const resolveInHours = (normalized: string, now: Date): string | null => {
   return result.toISOString();
 };
 
-/** "today", "tomorrow", "esta noche". */
+/**
+ * "today", "tomorrow", "esta noche".
+ *
+ * A day part whose time has already passed falls through rather than
+ * resolving: "tonight" asked at 23:00 would otherwise schedule 21:00 today,
+ * two hours in the past.
+ *
+ * That roll-forward is deliberately narrow. When the owner names a day and
+ * nothing else ("today"), or names both a day and a time ("today at 8am"),
+ * their words win even if the moment has passed - a handoff opens a prefilled
+ * form where the date is visible and editable. Only an implied hour, taken
+ * from a day part, is moved.
+ */
 const resolveRelativeDay = (
   normalized: string,
   now: Date,
   dayPartHour: number | null,
   hour: number,
   minute: number,
+  hasExplicitClock: boolean,
 ): string | null => {
   for (const [word, offset] of Object.entries(RELATIVE_DAYS)) {
     // "esta" only means today when it qualifies a part of the day
@@ -221,7 +234,13 @@ const resolveRelativeDay = (
       continue;
     }
     if (new RegExp(String.raw`\b${word}\b`).test(normalized)) {
-      return atTime(addDays(now, offset), hour, minute).toISOString();
+      const target = atTime(addDays(now, offset), hour, minute);
+      const impliedHourAlreadyPast =
+        offset === 0 &&
+        target <= now &&
+        dayPartHour !== null &&
+        !hasExplicitClock;
+      return impliedHourAlreadyPast ? null : target.toISOString();
     }
   }
   return null;
@@ -274,7 +293,14 @@ export const parseWhen = (text: string, now: Date): string | null => {
   const dated =
     resolveInDays(normalized, now, hour, minute) ??
     resolveInHours(normalized, now) ??
-    resolveRelativeDay(normalized, now, dayPartHour, hour, minute) ??
+    resolveRelativeDay(
+      normalized,
+      now,
+      dayPartHour,
+      hour,
+      minute,
+      clock !== null,
+    ) ??
     resolveWeekday(normalized, now, hour, minute);
   if (dated) {
     return dated;

--- a/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/dates.ts
@@ -1,0 +1,240 @@
+/**
+ * Natural date phrases to ISO timestamps.
+ *
+ * Deliberately small and deterministic. The assistant only needs the phrases
+ * people actually use for pet care ("tonight", "tomorrow morning", "in 3
+ * days", "on Friday"), and a wrong guess here would silently schedule a dose
+ * at the wrong time, so anything unrecognised returns null rather than a
+ * best effort.
+ */
+import {normalizeText} from './normalize';
+
+/**
+ * Lower-cases and folds accents but KEEPS `:` and `.`, which carry the minutes.
+ *
+ * `normalizeText` collapses every non-alphanumeric run to a space. Running it
+ * before the clock regexes destroyed the separator they need, so "8:30 pm"
+ * parsed as null and "at 8:30 pm" fell through to the bare-hour rule and
+ * resolved to eight the NEXT morning - exactly the mis-scheduled dose this
+ * module's header warns about.
+ */
+const normalizeKeepingClock = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9:.]+/g, ' ')
+    .trim();
+
+/** Hour-of-day each named part of the day resolves to. */
+const DAY_PART_HOURS: Record<string, number> = {
+  morning: 8,
+  afternoon: 14,
+  evening: 19,
+  night: 21,
+  tonight: 21,
+  noon: 12,
+  midnight: 0,
+  // Spanish. `manana` is deliberately absent: alone it means tomorrow, which
+  // RELATIVE_DAYS already covers, and treating it as "morning" would turn
+  // "manana" into today at 08:00.
+  noche: 21,
+  tarde: 14,
+  mediodia: 12,
+  madrugada: 6,
+};
+
+const WEEKDAYS: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+  domingo: 0,
+  lunes: 1,
+  martes: 2,
+  miercoles: 3,
+  jueves: 4,
+  viernes: 5,
+  sabado: 6,
+};
+
+/** Words that shift the day relative to today, in either shipped language. */
+const RELATIVE_DAYS: Record<string, number> = {
+  today: 0,
+  tonight: 0,
+  hoy: 0,
+  esta: 0,
+  tomorrow: 1,
+  manana: 1,
+  overmorrow: 2,
+};
+
+const DEFAULT_HOUR = 9;
+
+const atTime = (base: Date, hour: number, minute: number): Date => {
+  const result = new Date(base.getTime());
+  result.setHours(hour, minute, 0, 0);
+  return result;
+};
+
+const addDays = (base: Date, days: number): Date => {
+  const result = new Date(base.getTime());
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+interface ClockTime {
+  hour: number;
+  minute: number;
+}
+
+/**
+ * Reads an explicit clock time: "8pm", "8:30 pm", "20:30", "at 7".
+ *
+ * A bare number is only treated as a time when preceded by "at", so "give 2
+ * tablets" does not become 2 o'clock.
+ */
+export const parseClockTime = (text: string): ClockTime | null => {
+  const normalized = normalizeKeepingClock(text);
+
+  const meridiem = /(\d{1,2})(?:\s*[:.]\s*(\d{2}))?\s*(am|pm)\b/.exec(
+    normalized,
+  );
+  if (meridiem) {
+    const rawHour = Number(meridiem[1]);
+    if (rawHour >= 1 && rawHour <= 12) {
+      const minute = meridiem[2] ? Number(meridiem[2]) : 0;
+      if (minute < 60) {
+        const isPm = meridiem[3] === 'pm';
+        const hour = (rawHour % 12) + (isPm ? 12 : 0);
+        return {hour, minute};
+      }
+    }
+  }
+
+  const twentyFour = /\b(\d{1,2})\s*[:.]\s*(\d{2})\b/.exec(normalized);
+  if (twentyFour) {
+    const hour = Number(twentyFour[1]);
+    const minute = Number(twentyFour[2]);
+    if (hour < 24 && minute < 60) {
+      return {hour, minute};
+    }
+  }
+
+  const bareAfterAt = /\bat\s+(\d{1,2})\b/.exec(normalized);
+  if (bareAfterAt) {
+    const hour = Number(bareAfterAt[1]);
+    if (hour < 24) {
+      return {hour, minute: 0};
+    }
+  }
+
+  return null;
+};
+
+/** Finds a named part of the day, e.g. "tonight" or "in the morning". */
+const parseDayPart = (normalized: string): number | null => {
+  for (const [word, hour] of Object.entries(DAY_PART_HOURS)) {
+    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
+      return hour;
+    }
+  }
+  return null;
+};
+
+/**
+ * Resolves a date phrase against `now`.
+ *
+ * Returns null when the text carries no date information at all, so callers
+ * can tell "no date mentioned" apart from "date mentioned but unparseable".
+ */
+export const parseWhen = (text: string, now: Date): string | null => {
+  const normalized = normalizeText(text);
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const clock = parseClockTime(text);
+  const dayPartHour = parseDayPart(normalized);
+
+  const inDays = /\bin\s+(\d{1,3})\s+(day|days|dias|dia)\b/.exec(normalized);
+  if (inDays) {
+    const base = addDays(now, Number(inDays[1]));
+    return atTime(
+      base,
+      clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
+      clock?.minute ?? 0,
+    ).toISOString();
+  }
+
+  const inWeeks = /\bin\s+(\d{1,2})\s+(week|weeks|semana|semanas)\b/.exec(
+    normalized,
+  );
+  if (inWeeks) {
+    const base = addDays(now, Number(inWeeks[1]) * 7);
+    return atTime(
+      base,
+      clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
+      clock?.minute ?? 0,
+    ).toISOString();
+  }
+
+  const inHours = /\bin\s+(\d{1,3})\s+(hour|hours|hora|horas)\b/.exec(
+    normalized,
+  );
+  if (inHours) {
+    const result = new Date(now.getTime());
+    result.setHours(result.getHours() + Number(inHours[1]), 0, 0, 0);
+    return result.toISOString();
+  }
+
+  for (const [word, offset] of Object.entries(RELATIVE_DAYS)) {
+    // "esta" only means today when it qualifies a part of the day
+    // ("esta noche"); on its own it is just a determiner.
+    if (word === 'esta' && dayPartHour === null) {
+      continue;
+    }
+    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
+      const base = addDays(now, offset);
+      return atTime(
+        base,
+        clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
+        clock?.minute ?? 0,
+      ).toISOString();
+    }
+  }
+
+  for (const [word, weekday] of Object.entries(WEEKDAYS)) {
+    if (new RegExp(`\\b${word}\\b`).test(normalized)) {
+      const current = now.getDay();
+      // Always look forward: "on Monday" said on a Monday means next Monday.
+      const delta = (weekday - current + 7) % 7 || 7;
+      const base = addDays(now, delta);
+      return atTime(
+        base,
+        clock?.hour ?? dayPartHour ?? DEFAULT_HOUR,
+        clock?.minute ?? 0,
+      ).toISOString();
+    }
+  }
+
+  // A time with no day means the next occurrence of that time.
+  if (clock) {
+    const todayAt = atTime(now, clock.hour, clock.minute);
+    const target =
+      todayAt.getTime() > now.getTime() ? todayAt : addDays(todayAt, 1);
+    return target.toISOString();
+  }
+
+  if (dayPartHour !== null) {
+    const todayAt = atTime(now, dayPartHour, 0);
+    const target =
+      todayAt.getTime() > now.getTime() ? todayAt : addDays(todayAt, 1);
+    return target.toISOString();
+  }
+
+  return null;
+};

--- a/apps/mobileAppYC/src/features/assistant/nlu/normalize.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/normalize.ts
@@ -1,0 +1,45 @@
+/** Text normalisation shared by the parser and the pet-name matcher. */
+
+/**
+ * Lower-cases, strips accents and collapses punctuation to single spaces.
+ *
+ * Accent folding matters because the app ships Spanish: "¿Cuándo?" and
+ * "cuando" have to reach the same keyword table.
+ */
+export const normalizeText = (value: string): string =>
+  value
+    .normalize('NFD')
+    // Combining diacritical marks. Removing them folds "á" to "a".
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+/** Splits normalised text into word tokens. */
+export const tokenize = (value: string): string[] => {
+  const normalized = normalizeText(value);
+  return normalized.length === 0 ? [] : normalized.split(' ');
+};
+
+/**
+ * True when every word of `phrase` appears in `tokens`, in order but not
+ * necessarily adjacent. "when is vaccine" matches "when is the next vaccine".
+ */
+export const containsPhrase = (
+  tokens: readonly string[],
+  phrase: readonly string[],
+): boolean => {
+  if (phrase.length === 0) {
+    return false;
+  }
+  let cursor = 0;
+  for (const token of tokens) {
+    if (token === phrase[cursor]) {
+      cursor += 1;
+      if (cursor === phrase.length) {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
@@ -228,33 +228,57 @@ export const matchPetName = (
 
 /** Escapes a value for literal use inside a RegExp. */
 const escapeRegExp = (value: string): string =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
-/** Reads a money amount: "45", "45.50", "$45", "€12,50". */
+/** A number written with thousands separators: "1,234", "1,234.50". */
+const GROUPED_AMOUNT = /\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?/;
+/** A plain number, with an optional two-digit fraction: "45", "12,50". */
+const PLAIN_AMOUNT = /\d+(?:[.,]\d{1,2})?/;
+/** A minus immediately before the number, allowing a currency mark between. */
+const NEGATIVE_PREFIX = /-\s*[$£€]?\s*$/;
+
+/** Reads a money amount: "45", "45.50", "$45", "€12,50", "1,234". */
 export const parseAmount = (text: string): number | undefined => {
+  const grouped = GROUPED_AMOUNT.exec(text);
+  const plain = PLAIN_AMOUNT.exec(text);
+  // The grouped reading wins only where it starts no later, so "12,50" still
+  // reads as a decimal rather than being passed over.
   const match =
-    /(-)?\s*(?:[$£€]\s*)?(\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?|\d+(?:[.,]\d{1,2})?)/.exec(
-      text,
-    );
+    grouped && (!plain || grouped.index <= plain.index) ? grouped : plain;
   if (!match) {
     return undefined;
   }
-  // "spent -5" is not an expense of five; the old pattern started at the digit
-  // and silently dropped the sign.
-  if (match[1]) {
+
+  // "spent -5" is not an expense of five.
+  if (NEGATIVE_PREFIX.test(text.slice(0, match.index))) {
     return undefined;
   }
 
-  const raw = match[2];
+  const raw = match[0];
   // "1,234" is one thousand two hundred, not 1.23. Only a comma with one or
   // two trailing digits is a decimal separator.
   const normalized = /,\d{3}/.test(raw)
-    ? raw.replace(/,/g, '')
+    ? raw.replaceAll(',', '')
     : raw.replace(',', '.');
 
   const value = Number(normalized);
   return Number.isFinite(value) && value > 0 ? value : undefined;
 };
+
+/** Time phrases stripped from a task title, since `when` is its own slot. */
+// Multi-word phrases come first: stripping the bare "mañana" out of "esta
+// mañana" would strand the determiner in the title.
+const TIME_PHRASES: readonly RegExp[] = [
+  /\bthis\s+(?:morning|afternoon|evening|night)\b/gi,
+  /\besta\s+(?:noche|mañana)\b/gi,
+  /\b(?:tonight|today|tomorrow|hoy|manana|mañana)\b/gi,
+  /\bat\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b/gi,
+  /\bin\s+\d+\s+\w+\b/gi,
+  /\bon\s+\w+day\b/gi,
+];
+
+/** The verb a reminder's subject follows: "remind me TO give ...". */
+const AFTER_VERB = /\b(?:to|para|que)\s+/i;
 
 /**
  * Extracts the free-text title for a task from a reminder phrase.
@@ -267,8 +291,11 @@ export const extractTaskTitle = (
   text: string,
   petName: string | undefined,
 ): string | undefined => {
-  const afterTo = /\b(?:to|para|que)\b\s+(.*)$/i.exec(text);
-  let candidate = afterTo ? afterTo[1] : text;
+  // Sliced rather than captured with `(.*)$`, which backtracks.
+  const afterVerb = AFTER_VERB.exec(text);
+  let candidate = afterVerb
+    ? text.slice(afterVerb.index + afterVerb[0].length)
+    : text;
 
   if (petName) {
     // Unescaped, a name carrying a regex metacharacter ("C++", "Mr. B") either
@@ -276,31 +303,35 @@ export const extractTaskTitle = (
     // whitespace anchors stop a short name being stripped mid-word, which is
     // how "call Alice about Al" once became "c l ice about".
     candidate = candidate.replace(
-      new RegExp(`(^|\\s)${escapeRegExp(petName)}(?=\\s|$)`, 'ig'),
+      new RegExp(String.raw`(^|\s)${escapeRegExp(petName)}(?=\s|$)`, 'ig'),
       ' ',
     );
   }
 
+  for (const phrase of TIME_PHRASES) {
+    candidate = candidate.replaceAll(phrase, ' ');
+  }
+
+  // Two anchored strips rather than one alternation of unbounded quantifiers.
   candidate = candidate
-    .replace(
-      /\b(tonight|today|tomorrow|this (?:morning|afternoon|evening|night)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|in\s+\d+\s+\w+|on\s+\w+day|hoy|manana|mañana|esta noche|esta mañana)\b/gi,
-      ' ',
-    )
-    .replace(/\s+/g, ' ')
-    .replace(/^[\s,.-]+|[\s,.-]+$/g, '')
+    .replaceAll(/\s+/g, ' ')
+    .replace(/^[\s,.-]+/, '')
+    .replace(/[\s,.-]+$/, '')
     .trim();
 
   return candidate.length >= 2 ? candidate : undefined;
 };
 
-/** Scores how much of the utterance a rule explained. */
+/**
+ * Scores how much of the utterance a rule explained.
+ *
+ * `tokenCount` is always at least one: the only caller returns early on an
+ * empty utterance, so there is no zero case to guard.
+ */
 const scoreMatch = (matchedKeywords: number, tokenCount: number): number => {
-  if (tokenCount === 0) {
-    return 0;
-  }
   // Two matched keywords in a short question is a confident read; the same two
   // buried in a long sentence is not.
-  const density = matchedKeywords / Math.max(tokenCount, 1);
+  const density = matchedKeywords / tokenCount;
   const base = 0.55 + Math.min(matchedKeywords, 3) * 0.12;
   return Math.min(1, Number((base + density * 0.2).toFixed(3)));
 };
@@ -309,6 +340,67 @@ export interface ParseOptions {
   petNames?: readonly string[];
   now?: Date;
 }
+
+/** Fills the slots an action can use from the utterance. */
+const collectSlots = (
+  actionId: AssistantActionId,
+  text: string,
+  petName: string | undefined,
+  now: Date,
+): AssistantSlots => {
+  const slots: AssistantSlots = {};
+
+  if (petName) {
+    slots.petName = petName;
+  }
+
+  const when = parseWhen(text, now);
+  if (when) {
+    slots.when = when;
+  }
+
+  if (actionId === 'addCareTask') {
+    const title = extractTaskTitle(text, petName);
+    if (title) {
+      slots.title = title;
+    }
+  }
+
+  if (actionId === 'logExpense') {
+    const amount = parseAmount(text);
+    if (amount !== undefined) {
+      slots.amount = amount;
+    }
+  }
+
+  return slots;
+};
+
+/** The first keyword rule whose group is fully present, in catalogue order. */
+const matchRule = (
+  tokenSet: ReadonlySet<string>,
+): {actionId: AssistantActionId; keywords: number} | null => {
+  for (const rule of KEYWORD_RULES) {
+    for (const group of rule.groups) {
+      if (group.every(keyword => tokenSet.has(keyword))) {
+        return {actionId: rule.actionId, keywords: group.length};
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * True when the utterance is nothing but a pet's name and filler.
+ *
+ * People type "Bruno?" and expect that pet's summary.
+ */
+const isBarePetName = (tokens: readonly string[], petName: string): boolean => {
+  const nameTokens = tokenize(petName);
+  return tokens.every(
+    token => NAME_STOPWORDS.has(token) || nameTokens.includes(token),
+  );
+};
 
 /**
  * Parses an utterance into an intent.
@@ -328,60 +420,22 @@ export const parseUtterance = (
     return null;
   }
 
-  const tokenSet = new Set(tokens);
+  const petName = matchPetName(text, petNames);
+  const rule = matchRule(new Set(tokens));
 
-  for (const rule of KEYWORD_RULES) {
-    for (const group of rule.groups) {
-      const matched = group.every(keyword => tokenSet.has(keyword));
-      if (!matched) {
-        continue;
-      }
-
-      const slots: AssistantSlots = {};
-      const petName = matchPetName(text, petNames);
-      if (petName) {
-        slots.petName = petName;
-      }
-
-      const when = parseWhen(text, now);
-      if (when) {
-        slots.when = when;
-      }
-
-      if (rule.actionId === 'addCareTask') {
-        const title = extractTaskTitle(text, petName);
-        if (title) {
-          slots.title = title;
-        }
-      }
-
-      if (rule.actionId === 'logExpense') {
-        const amount = parseAmount(text);
-        if (amount !== undefined) {
-          slots.amount = amount;
-        }
-      }
-
-      return {
-        actionId: rule.actionId,
-        slots,
-        confidence: scoreMatch(group.length, tokens.length),
-        source: 'rules',
-      };
-    }
+  if (rule) {
+    return {
+      actionId: rule.actionId,
+      slots: collectSlots(rule.actionId, text, petName, now),
+      confidence: scoreMatch(rule.keywords, tokens.length),
+      source: 'rules',
+    };
   }
 
-  // A bare pet name is a request for that pet's overview: people type "Bruno?"
-  const soloPet = matchPetName(text, petNames);
-  if (
-    soloPet &&
-    tokens.every(
-      token => NAME_STOPWORDS.has(token) || tokenize(soloPet).includes(token),
-    )
-  ) {
+  if (petName && isBarePetName(tokens, petName)) {
     return {
       actionId: 'petOverview',
-      slots: {petName: soloPet},
+      slots: {petName},
       // A name on its own is a guess, not a routed phrase. Scoring it below
       // the rules threshold is what lets the on-device model rescue it.
       confidence: BARE_NAME_CONFIDENCE,

--- a/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
@@ -15,6 +15,7 @@ import type {
 import {BARE_NAME_CONFIDENCE} from '../constants';
 import {normalizeText, tokenize} from './normalize';
 import {parseWhen} from './dates';
+import {trimEdgesWhile} from '../utils/trimEdges';
 
 interface KeywordRule {
   actionId: AssistantActionId;
@@ -234,8 +235,26 @@ const escapeRegExp = (value: string): string =>
 const GROUPED_AMOUNT = /\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?/;
 /** A plain number, with an optional two-digit fraction: "45", "12,50". */
 const PLAIN_AMOUNT = /\d+(?:[.,]\d{1,2})?/;
-/** A minus immediately before the number, allowing a currency mark between. */
-const NEGATIVE_PREFIX = /-\s*[$£€]?\s*$/;
+const CURRENCY_MARKS = new Set(['$', '£', '€']);
+
+/**
+ * True when a minus sign immediately precedes the number.
+ *
+ * Walks backwards over whitespace and any currency mark rather than testing an
+ * anchored `-\s*[$£€]?\s*$` against the prefix, which is super-linear.
+ */
+const hasNegativeSign = (text: string, numberIndex: number): boolean => {
+  for (let i = numberIndex - 1; i >= 0; i -= 1) {
+    const char = text[i];
+    if (char === '-') {
+      return true;
+    }
+    if (char !== ' ' && char !== '\t' && !CURRENCY_MARKS.has(char)) {
+      return false;
+    }
+  }
+  return false;
+};
 
 /** Reads a money amount: "45", "45.50", "$45", "€12,50", "1,234". */
 export const parseAmount = (text: string): number | undefined => {
@@ -250,7 +269,7 @@ export const parseAmount = (text: string): number | undefined => {
   }
 
   // "spent -5" is not an expense of five.
-  if (NEGATIVE_PREFIX.test(text.slice(0, match.index))) {
+  if (hasNegativeSign(text, match.index)) {
     return undefined;
   }
 
@@ -312,12 +331,10 @@ export const extractTaskTitle = (
     candidate = candidate.replaceAll(phrase, ' ');
   }
 
-  // Two anchored strips rather than one alternation of unbounded quantifiers.
-  candidate = candidate
-    .replaceAll(/\s+/g, ' ')
-    .replace(/^[\s,.-]+/, '')
-    .replace(/[\s,.-]+$/, '')
-    .trim();
+  candidate = trimEdgesWhile(
+    candidate.replaceAll(/\s+/g, ' '),
+    char => char === ' ' || char === ',' || char === '.' || char === '-',
+  );
 
   return candidate.length >= 2 ? candidate : undefined;
 };

--- a/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
+++ b/apps/mobileAppYC/src/features/assistant/nlu/parser.ts
@@ -1,0 +1,393 @@
+/**
+ * The deterministic intent parser.
+ *
+ * This runs on every device, with no model and no network, and it is the only
+ * router the assistant strictly needs. The on-device language model is an
+ * enhancement layered on top: it rephrases answers and rescues utterances this
+ * parser scores as low confidence. Keeping rules as the floor means the
+ * feature behaves identically on an iPhone 11 and an iPhone 17 Pro.
+ */
+import type {
+  AssistantActionId,
+  AssistantIntent,
+  AssistantSlots,
+} from '../types';
+import {BARE_NAME_CONFIDENCE} from '../constants';
+import {normalizeText, tokenize} from './normalize';
+import {parseWhen} from './dates';
+
+interface KeywordRule {
+  actionId: AssistantActionId;
+  /**
+   * Any one of these groups matching is enough. Within a group every keyword
+   * must be present, which is what keeps "add a vet visit" out of
+   * `vaccinationStatus`.
+   */
+  groups: string[][];
+}
+
+/**
+ * Ordered most specific first. The first rule that matches wins, so
+ * `bookAppointment` ("book a vet visit") is tested before `nextAppointment`
+ * ("when is the vet visit").
+ */
+const KEYWORD_RULES: readonly KeywordRule[] = [
+  {
+    actionId: 'bookAppointment',
+    groups: [
+      ['book'],
+      ['schedule', 'appointment'],
+      ['make', 'appointment'],
+      ['reservar'],
+      ['agendar'],
+      ['pedir', 'cita'],
+    ],
+  },
+  {
+    actionId: 'addCareTask',
+    groups: [
+      ['remind'],
+      ['reminder'],
+      ['add', 'task'],
+      ['create', 'task'],
+      ['add', 'medication'],
+      ['give', 'medication'],
+      ['recuerdame'],
+      ['recordatorio'],
+      ['anadir', 'tarea'],
+    ],
+  },
+  {
+    actionId: 'expenseSummary',
+    groups: [
+      ['how', 'much', 'spent'],
+      ['total', 'expenses'],
+      ['expenses'],
+      ['spending'],
+      ['gastos'],
+      ['cuanto', 'gastado'],
+    ],
+  },
+  {
+    actionId: 'logExpense',
+    groups: [
+      ['log', 'expense'],
+      ['add', 'expense'],
+      ['record', 'expense'],
+      ['spent'],
+      ['gasto'],
+      ['registrar', 'gasto'],
+    ],
+  },
+  {
+    actionId: 'vaccinationStatus',
+    groups: [
+      ['vaccine'],
+      ['vaccines'],
+      ['vaccination'],
+      ['vaccinations'],
+      ['vaccinated'],
+      ['shot', 'due'],
+      ['shots'],
+      ['jab'],
+      ['vacuna'],
+      ['vacunas'],
+    ],
+  },
+  {
+    actionId: 'nextAppointment',
+    groups: [
+      ['next', 'appointment'],
+      ['appointment'],
+      ['vet', 'visit'],
+      ['when', 'vet'],
+      ['cita'],
+      ['proxima', 'cita'],
+    ],
+  },
+  {
+    actionId: 'upcomingTasks',
+    groups: [
+      ['tasks'],
+      ['task'],
+      ['due'],
+      ['todo'],
+      ['to', 'do'],
+      ['care', 'plan'],
+      ['tareas'],
+      ['pendiente'],
+      ['pendientes'],
+    ],
+  },
+  {
+    actionId: 'petOverview',
+    groups: [
+      ['tell', 'me', 'about'],
+      ['overview'],
+      ['profile'],
+      ['how', 'is'],
+      ['resumen'],
+      ['perfil'],
+    ],
+  },
+];
+
+/** Words that must never be mistaken for a pet's name. */
+const NAME_STOPWORDS = new Set([
+  'my',
+  'the',
+  'a',
+  'an',
+  'for',
+  'of',
+  'is',
+  'are',
+  'when',
+  'what',
+  'how',
+  'much',
+  'next',
+  'add',
+  'book',
+  'log',
+  'remind',
+  'me',
+  'to',
+  'and',
+  'dog',
+  'cat',
+  'horse',
+  'pet',
+  'vet',
+  'appointment',
+  'vaccine',
+  'vaccines',
+  'vaccination',
+  'task',
+  'tasks',
+  'expense',
+  'expenses',
+  'today',
+  'tomorrow',
+  'tonight',
+  'due',
+  'about',
+  'mi',
+  'el',
+  'la',
+  'los',
+  'las',
+  'para',
+  'de',
+  'cita',
+  'vacuna',
+  'perro',
+  'gato',
+]);
+
+/**
+ * Finds a known pet name in the utterance.
+ *
+ * Matching against the owner's actual pet list rather than guessing a proper
+ * noun avoids the classic failure where "Max" in "max dose" becomes a pet.
+ */
+export const matchPetName = (
+  text: string,
+  petNames: readonly string[],
+): string | undefined => {
+  const tokens = tokenize(text);
+  if (tokens.length === 0) {
+    return undefined;
+  }
+  const tokenSet = new Set(tokens);
+
+  // Longest name first so "Bella Rose" wins over "Bella".
+  const ordered = [...petNames].sort((a, b) => b.length - a.length);
+
+  for (const name of ordered) {
+    const nameTokens = tokenize(name);
+    if (nameTokens.length === 0) {
+      continue;
+    }
+    if (nameTokens.length === 1) {
+      if (tokenSet.has(nameTokens[0])) {
+        return name;
+      }
+      continue;
+    }
+    // Padding both sides turns the substring test into a token-boundary test,
+    // so "Bella Rose" no longer matches inside "Isabella Rosewood".
+    const joined = ` ${nameTokens.join(' ')} `;
+    if (` ${normalizeText(text)} `.includes(joined)) {
+      return name;
+    }
+  }
+
+  return undefined;
+};
+
+/** Escapes a value for literal use inside a RegExp. */
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/** Reads a money amount: "45", "45.50", "$45", "€12,50". */
+export const parseAmount = (text: string): number | undefined => {
+  const match =
+    /(-)?\s*(?:[$£€]\s*)?(\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?|\d+(?:[.,]\d{1,2})?)/.exec(
+      text,
+    );
+  if (!match) {
+    return undefined;
+  }
+  // "spent -5" is not an expense of five; the old pattern started at the digit
+  // and silently dropped the sign.
+  if (match[1]) {
+    return undefined;
+  }
+
+  const raw = match[2];
+  // "1,234" is one thousand two hundred, not 1.23. Only a comma with one or
+  // two trailing digits is a decimal separator.
+  const normalized = /,\d{3}/.test(raw)
+    ? raw.replace(/,/g, '')
+    : raw.replace(',', '.');
+
+  const value = Number(normalized);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+};
+
+/**
+ * Extracts the free-text title for a task from a reminder phrase.
+ *
+ * "remind me to give Bruno his heart pill tonight" yields "give his heart
+ * pill". The pet name and the time phrase are removed because they are
+ * already captured as their own slots.
+ */
+export const extractTaskTitle = (
+  text: string,
+  petName: string | undefined,
+): string | undefined => {
+  const afterTo = /\b(?:to|para|que)\b\s+(.*)$/i.exec(text);
+  let candidate = afterTo ? afterTo[1] : text;
+
+  if (petName) {
+    // Unescaped, a name carrying a regex metacharacter ("C++", "Mr. B") either
+    // threw a SyntaxError out of parseUtterance or matched far too much. The
+    // whitespace anchors stop a short name being stripped mid-word, which is
+    // how "call Alice about Al" once became "c l ice about".
+    candidate = candidate.replace(
+      new RegExp(`(^|\\s)${escapeRegExp(petName)}(?=\\s|$)`, 'ig'),
+      ' ',
+    );
+  }
+
+  candidate = candidate
+    .replace(
+      /\b(tonight|today|tomorrow|this (?:morning|afternoon|evening|night)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|in\s+\d+\s+\w+|on\s+\w+day|hoy|manana|mañana|esta noche|esta mañana)\b/gi,
+      ' ',
+    )
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s,.-]+|[\s,.-]+$/g, '')
+    .trim();
+
+  return candidate.length >= 2 ? candidate : undefined;
+};
+
+/** Scores how much of the utterance a rule explained. */
+const scoreMatch = (matchedKeywords: number, tokenCount: number): number => {
+  if (tokenCount === 0) {
+    return 0;
+  }
+  // Two matched keywords in a short question is a confident read; the same two
+  // buried in a long sentence is not.
+  const density = matchedKeywords / Math.max(tokenCount, 1);
+  const base = 0.55 + Math.min(matchedKeywords, 3) * 0.12;
+  return Math.min(1, Number((base + density * 0.2).toFixed(3)));
+};
+
+export interface ParseOptions {
+  petNames?: readonly string[];
+  now?: Date;
+}
+
+/**
+ * Parses an utterance into an intent.
+ *
+ * Returns null only when nothing at all matched, which is the signal to fall
+ * back to the on-device model or to the "I can help with these" reply.
+ */
+export const parseUtterance = (
+  text: string,
+  options: ParseOptions = {},
+): AssistantIntent | null => {
+  const petNames = options.petNames ?? [];
+  const now = options.now ?? new Date();
+  const tokens = tokenize(text);
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  const tokenSet = new Set(tokens);
+
+  for (const rule of KEYWORD_RULES) {
+    for (const group of rule.groups) {
+      const matched = group.every(keyword => tokenSet.has(keyword));
+      if (!matched) {
+        continue;
+      }
+
+      const slots: AssistantSlots = {};
+      const petName = matchPetName(text, petNames);
+      if (petName) {
+        slots.petName = petName;
+      }
+
+      const when = parseWhen(text, now);
+      if (when) {
+        slots.when = when;
+      }
+
+      if (rule.actionId === 'addCareTask') {
+        const title = extractTaskTitle(text, petName);
+        if (title) {
+          slots.title = title;
+        }
+      }
+
+      if (rule.actionId === 'logExpense') {
+        const amount = parseAmount(text);
+        if (amount !== undefined) {
+          slots.amount = amount;
+        }
+      }
+
+      return {
+        actionId: rule.actionId,
+        slots,
+        confidence: scoreMatch(group.length, tokens.length),
+        source: 'rules',
+      };
+    }
+  }
+
+  // A bare pet name is a request for that pet's overview: people type "Bruno?"
+  const soloPet = matchPetName(text, petNames);
+  if (
+    soloPet &&
+    tokens.every(
+      token => NAME_STOPWORDS.has(token) || tokenize(soloPet).includes(token),
+    )
+  ) {
+    return {
+      actionId: 'petOverview',
+      slots: {petName: soloPet},
+      // A name on its own is a guess, not a routed phrase. Scoring it below
+      // the rules threshold is what lets the on-device model rescue it.
+      confidence: BARE_NAME_CONFIDENCE,
+      source: 'rules',
+    };
+  }
+
+  return null;
+};

--- a/apps/mobileAppYC/src/features/assistant/screens/AssistantScreen/AssistantScreen.tsx
+++ b/apps/mobileAppYC/src/features/assistant/screens/AssistantScreen/AssistantScreen.tsx
@@ -1,0 +1,195 @@
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {useTranslation} from 'react-i18next';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useNavigation} from '@react-navigation/native';
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {Header} from '@/shared/components/common/Header/Header';
+import {Images} from '@/assets/images';
+import {useTheme} from '@/hooks';
+import {useAppDispatch, useAppSelector} from '@/app/hooks';
+import type {Theme} from '@/theme';
+import type {HomeStackParamList} from '@/navigation/types';
+import type {AssistantMessage} from '@/features/assistant/types';
+import {
+  ActionResultCard,
+  AssistantComposer,
+  MessageBubble,
+  ModelStatusBanner,
+  SuggestionChips,
+} from '@/features/assistant/components';
+import {
+  selectAssistantError,
+  selectAssistantMessages,
+  selectAssistantStatus,
+  selectModelAvailability,
+} from '@/features/assistant/selectors';
+import {askAssistant, probeOnDeviceModel} from '@/features/assistant/thunks';
+import {transcriptCleared} from '@/features/assistant/assistantSlice';
+import {resolveHandoffTarget} from '@/features/assistant/services/handoffNavigation';
+import {useResolvedUserCurrency} from '@/shared/hooks/useResolvedUserCurrency';
+
+type Navigation = NativeStackNavigationProp<HomeStackParamList, 'Assistant'>;
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    screen: {flex: 1, backgroundColor: theme.colors.background},
+    flex: {flex: 1},
+    list: {
+      paddingHorizontal: theme.spacing['4'],
+      paddingTop: theme.spacing['3'],
+      paddingBottom: theme.spacing['4'],
+      flexGrow: 1,
+    },
+    empty: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: theme.spacing['6'],
+      gap: theme.spacing['2'],
+    },
+    emptyTitle: {
+      ...theme.typography.titleSmall,
+      color: theme.colors.text,
+      textAlign: 'center',
+    },
+    emptyBody: {
+      ...theme.typography.paragraph,
+      color: theme.colors.textSecondary,
+      textAlign: 'center',
+    },
+    error: {
+      ...theme.typography.labelSmall,
+      color: theme.colors.dangerText,
+      paddingHorizontal: theme.spacing['4'],
+      paddingBottom: theme.spacing['2'],
+    },
+  });
+
+export const AssistantScreen: React.FC = () => {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const dispatch = useAppDispatch();
+  const navigation = useNavigation<Navigation>();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  // The screen renders with the navigator header hidden, so it owns its own
+  // insets: without them the title sits under the notch and the composer sits
+  // on the home indicator.
+  const insets = useSafeAreaInsets();
+  const listRef = useRef<FlatList<AssistantMessage>>(null);
+  const [draft, setDraft] = useState('');
+
+  const messages = useAppSelector(selectAssistantMessages);
+  const status = useAppSelector(selectAssistantStatus);
+  const error = useAppSelector(selectAssistantError);
+  const availability = useAppSelector(selectModelAvailability);
+  const currencyCode = useResolvedUserCurrency();
+
+  useEffect(() => {
+    dispatch(probeOnDeviceModel());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      listRef.current?.scrollToEnd({animated: true});
+    }
+  }, [messages.length]);
+
+  const handleSubmit = useCallback(
+    (text: string) => {
+      setDraft('');
+      dispatch(askAssistant({utterance: text, t, currencyCode}));
+    },
+    [currencyCode, dispatch, t],
+  );
+
+  const handleOpen = useCallback(
+    (deepLink: string) => {
+      const target = resolveHandoffTarget(deepLink);
+      if (!target) {
+        return;
+      }
+      // Every handoff destination lives under the tab navigator, so the hop is
+      // always Main -> tab -> screen, with one optional nested stack.
+      navigation.getParent()?.navigate('Main', {
+        screen: target.tab,
+        params: target.nested
+          ? {screen: target.screen, params: target.nested}
+          : {screen: target.screen, params: target.params},
+      });
+    },
+    [navigation],
+  );
+
+  const renderItem = useCallback(
+    ({item}: {item: AssistantMessage}) => (
+      <View>
+        <MessageBubble message={item} />
+        {item.result ? (
+          <ActionResultCard result={item.result} onOpen={handleOpen} />
+        ) : null}
+      </View>
+    ),
+    [handleOpen],
+  );
+
+  const listEmpty = useMemo(
+    () => (
+      <View style={styles.empty} testID="assistant-empty">
+        <Text style={styles.emptyTitle}>{t('assistant.emptyTitle')}</Text>
+        <Text style={styles.emptyBody}>{t('assistant.emptyBody')}</Text>
+      </View>
+    ),
+    [styles, t],
+  );
+
+  return (
+    <View style={[styles.screen, {paddingTop: insets.top}]}>
+      <Header
+        title={t('assistant.title')}
+        showBackButton
+        onBack={() => navigation.goBack()}
+        // Header only renders its right slot when it has an icon, so passing
+        // just onRightPress left the clear action invisible.
+        rightIcon={messages.length > 0 ? Images.closeIcon : undefined}
+        rightAccessibilityLabel={t('assistant.clear')}
+        onRightPress={() => dispatch(transcriptCleared())}
+      />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <FlatList
+          ref={listRef}
+          testID="assistant-transcript"
+          // Without flex the list sizes to its content and overflows its slot,
+          // which let the newest reply render underneath the suggestion chips.
+          style={styles.flex}
+          data={messages}
+          keyExtractor={item => item.id}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={listEmpty}
+          keyboardShouldPersistTaps="handled"
+        />
+        <ModelStatusBanner availability={availability} />
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <SuggestionChips onSelect={setDraft} />
+        <View style={{paddingBottom: insets.bottom}}>
+          <AssistantComposer
+            value={draft}
+            onChangeText={setDraft}
+            onSubmit={handleSubmit}
+            busy={status === 'thinking'}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </View>
+  );
+};

--- a/apps/mobileAppYC/src/features/assistant/screens/AssistantScreen/AssistantScreen.tsx
+++ b/apps/mobileAppYC/src/features/assistant/screens/AssistantScreen/AssistantScreen.tsx
@@ -10,13 +10,14 @@ import {
 import {useTranslation} from 'react-i18next';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useNavigation} from '@react-navigation/native';
+import type {NavigationProp} from '@react-navigation/native';
 import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {Header} from '@/shared/components/common/Header/Header';
 import {Images} from '@/assets/images';
 import {useTheme} from '@/hooks';
 import {useAppDispatch, useAppSelector} from '@/app/hooks';
 import type {Theme} from '@/theme';
-import type {HomeStackParamList} from '@/navigation/types';
+import type {HomeStackParamList, RootStackParamList} from '@/navigation/types';
 import type {AssistantMessage} from '@/features/assistant/types';
 import {
   ActionResultCard,
@@ -78,6 +79,9 @@ export const AssistantScreen: React.FC = () => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const navigation = useNavigation<Navigation>();
+  // A second view of the same navigation object, typed for the root stack:
+  // `navigate` walks up until it finds the navigator owning the route.
+  const rootNavigation = useNavigation<NavigationProp<RootStackParamList>>();
   const styles = useMemo(() => createStyles(theme), [theme]);
   // The screen renders with the navigator header hidden, so it owns its own
   // insets: without them the title sits under the notch and the composer sits
@@ -116,16 +120,22 @@ export const AssistantScreen: React.FC = () => {
       if (!target) {
         return;
       }
-      // Every handoff destination lives under the tab navigator, so the hop is
-      // always Main -> tab -> screen, with one optional nested stack.
-      navigation.getParent()?.navigate('Main', {
+      // Addressed to the navigator that owns 'Main', which is the root stack.
+      // `getParent()` here is the tab navigator, which has no such route, so
+      // naming it as the target only worked by accident of bubbling.
+      //
+      // The cast is unavoidable: a handoff target names a screen in whichever
+      // stack owns it, so it is a plain string rather than a key of any one
+      // param list. `resolveHandoffTarget` is the thing that guarantees the
+      // pair is real, and it is exhaustively tested.
+      rootNavigation.navigate('Main', {
         screen: target.tab,
         params: target.nested
           ? {screen: target.screen, params: target.nested}
           : {screen: target.screen, params: target.params},
-      });
+      } as never);
     },
-    [navigation],
+    [rootNavigation],
   );
 
   const renderItem = useCallback(

--- a/apps/mobileAppYC/src/features/assistant/screens/index.ts
+++ b/apps/mobileAppYC/src/features/assistant/screens/index.ts
@@ -1,0 +1,1 @@
+export {AssistantScreen} from './AssistantScreen/AssistantScreen';

--- a/apps/mobileAppYC/src/features/assistant/selectors.ts
+++ b/apps/mobileAppYC/src/features/assistant/selectors.ts
@@ -1,0 +1,103 @@
+/** Selectors for the assistant feature. */
+import {createSelector} from '@reduxjs/toolkit';
+import type {RootState} from '@/app/store';
+import type {AssistantContext, AssistantVaccination} from './types';
+
+export const selectAssistantMessages = (state: RootState) =>
+  state.assistant?.messages ?? [];
+
+export const selectAssistantStatus = (state: RootState) =>
+  state.assistant?.status ?? 'idle';
+
+export const selectAssistantError = (state: RootState) =>
+  state.assistant?.error ?? null;
+
+export const selectModelAvailability = (state: RootState) =>
+  state.assistant?.modelAvailability ?? {available: false};
+
+export const selectAssistantEnabled = (state: RootState) =>
+  state.assistant?.enabled ?? true;
+
+const selectCompanions = (state: RootState) =>
+  state.companion?.companions ?? [];
+const selectTasks = (state: RootState) => state.tasks?.items ?? [];
+const selectAppointments = (state: RootState) =>
+  state.appointments?.items ?? [];
+const selectExpenses = (state: RootState) => state.expenses?.items ?? [];
+const selectPassports = (state: RootState) =>
+  state.passport?.byCompanionId ?? {};
+
+/**
+ * Flattens each pet's passport into the vaccination shape the resolvers use.
+ *
+ * The passport DTO nests records under several optional keys depending on how
+ * the record was created, so anything without a name is skipped rather than
+ * surfaced as a blank line in an answer.
+ */
+export const selectVaccinationsByCompanion = createSelector(
+  [selectPassports],
+  passports => {
+    const result: Record<string, AssistantVaccination[]> = {};
+    for (const [companionId, passport] of Object.entries(passports)) {
+      const records = (passport as {vaccinations?: unknown})?.vaccinations;
+      if (!Array.isArray(records)) {
+        continue;
+      }
+      const mapped: AssistantVaccination[] = [];
+      for (const record of records) {
+        const entry = record as {
+          name?: string;
+          vaccineName?: string;
+          administeredOn?: string;
+          date?: string;
+          dueOn?: string;
+          nextDueDate?: string;
+        };
+        // `??` only falls through on null/undefined, so a record carrying
+        // `name: ''` alongside a real `vaccineName` was dropped entirely, and
+        // an empty `administeredOn` hid a populated `date`.
+        const name = (entry.name || entry.vaccineName || '').trim();
+        if (!name) {
+          continue;
+        }
+        mapped.push({
+          name,
+          administeredOn: entry.administeredOn || entry.date || null,
+          dueOn: entry.dueOn || entry.nextDueDate || null,
+        });
+      }
+      result[companionId] = mapped;
+    }
+    return result;
+  },
+);
+
+/**
+ * Assembles the read-only context the resolvers work from.
+ *
+ * `now` is not part of the memoised result: a selector that captured the
+ * current time would either be recomputed on every render or, worse, answer
+ * "today" with a stale day after midnight. Callers pass the clock in.
+ */
+export const selectAssistantData = createSelector(
+  [
+    selectCompanions,
+    selectTasks,
+    selectAppointments,
+    selectExpenses,
+    selectVaccinationsByCompanion,
+  ],
+  (companions, tasks, appointments, expenses, vaccinations) => ({
+    companions,
+    tasks,
+    appointments,
+    expenses,
+    vaccinations,
+  }),
+);
+
+export const buildAssistantContext = (
+  data: ReturnType<typeof selectAssistantData>,
+  now: Date,
+  currencyCode: string,
+): AssistantContext => ({...data, now, currencyCode});

--- a/apps/mobileAppYC/src/features/assistant/services/assistantRuntime.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/assistantRuntime.ts
@@ -1,0 +1,103 @@
+/**
+ * The assistant's turn loop.
+ *
+ * One utterance in, one localised reply out. The order is deliberate:
+ *
+ *   1. Rule parser. Free, offline, works on every device.
+ *   2. On-device model, only when the rules scored low or found nothing.
+ *   3. Resolver. Always. This is where the facts come from.
+ *   4. Optional rephrase, only for a reply that is already true.
+ *
+ * A failure at step 2 or 4 costs phrasing, never correctness.
+ */
+import type {TFunction} from 'i18next';
+import type {
+  AssistantActionResult,
+  AssistantContext,
+  AssistantIntent,
+} from '../types';
+import {ASSISTANT_ACTIONS} from '../actions/catalogue';
+import {runAction} from '../actions/resolvers';
+import {parseUtterance} from '../nlu/parser';
+import {MAX_UTTERANCE_LENGTH, RULES_CONFIDENCE_THRESHOLD} from '../constants';
+import {classify, rephrase} from './onDeviceModel';
+
+export interface TurnOptions {
+  /** Set false to skip the model entirely, e.g. when it is unavailable. */
+  useModel?: boolean;
+  /** Set false to keep the resolver's exact wording. */
+  allowRephrase?: boolean;
+}
+
+export interface AssistantTurn {
+  intent: AssistantIntent | null;
+  result: AssistantActionResult | null;
+  /** The localised sentence to show and speak. */
+  text: string;
+}
+
+/** The catalogue rendered for the model's classification prompt. */
+export const buildActionDescriptions = (t: TFunction): string =>
+  ASSISTANT_ACTIONS.map(
+    action => `${action.id}: ${t(action.descriptionKey)}`,
+  ).join('\n');
+
+/**
+ * Runs one turn.
+ *
+ * `context.now` drives every date decision, so a test can pin the clock and
+ * get the same sentence every run.
+ */
+export const runTurn = async (
+  utterance: string,
+  context: AssistantContext,
+  t: TFunction,
+  options: TurnOptions = {},
+): Promise<AssistantTurn> => {
+  const trimmed = utterance.trim().slice(0, MAX_UTTERANCE_LENGTH);
+  if (trimmed.length === 0) {
+    return {
+      intent: null,
+      result: null,
+      text: t('assistant.replies.empty'),
+    };
+  }
+
+  const petNames = context.companions.map(companion => companion.name);
+  let intent = parseUtterance(trimmed, {petNames, now: context.now});
+
+  const rulesWereWeak =
+    intent === null || intent.confidence < RULES_CONFIDENCE_THRESHOLD;
+
+  if (rulesWereWeak && options.useModel !== false) {
+    const guessed = await classify(trimmed, buildActionDescriptions(t));
+    if (guessed) {
+      // The rules still own slot filling: the model only chose the action, so
+      // a pet name or time in the utterance is not lost by switching routes.
+      const reparsed = parseUtterance(trimmed, {petNames, now: context.now});
+      intent = {...guessed, slots: reparsed?.slots ?? {}};
+    }
+  }
+
+  if (!intent) {
+    return {
+      intent: null,
+      result: null,
+      text: t('assistant.replies.unknown'),
+    };
+  }
+
+  const result = runAction(intent.actionId, context, intent.slots);
+  const factual = t(result.speechKey, result.speechParams ?? {});
+
+  // A prompt for a missing pet name is already a question; rewording it risks
+  // turning it into a statement.
+  const shouldRephrase =
+    options.allowRephrase !== false &&
+    options.useModel !== false &&
+    result.status === 'ok';
+
+  const text = shouldRephrase ? await rephrase(factual) : factual;
+
+  return {intent, result, text};
+};

--- a/apps/mobileAppYC/src/features/assistant/services/assistantSnapshot.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/assistantSnapshot.ts
@@ -1,0 +1,210 @@
+/**
+ * The offline snapshot handed to the native layer.
+ *
+ * When Siri runs an App Intent, the app's JavaScript is not running: the
+ * intent executes in its own process with no Redux store and no session. So
+ * the app writes a small, current answer sheet into shared storage every time
+ * the relevant data changes, and the native side reads that.
+ *
+ * Only what an intent can actually say out loud goes in here. No tokens, no
+ * addresses, no clinical notes - a snapshot is readable by any process in the
+ * app group, so it holds the minimum that makes the answers useful.
+ */
+import type {AssistantContext} from '../types';
+import {
+  SNAPSHOT_ITEM_LIMIT,
+  SNAPSHOT_PET_LIMIT,
+  UPCOMING_WINDOW_DAYS,
+  VACCINATION_STALE_DAYS,
+} from '../constants';
+import {getSnapshotModule} from './nativeBridge';
+import {
+  appointmentStartsAt,
+  parseRecordDate,
+  taskDueAt,
+  taskLabel,
+} from '../actions/resolvers';
+
+export interface SnapshotPet {
+  id: string;
+  name: string;
+  species: string;
+}
+
+export interface SnapshotEntry {
+  petId: string;
+  petName: string;
+  title: string;
+  /** ISO-8601. The native side formats it in the device locale. */
+  at: string;
+  subtitle?: string;
+}
+
+export interface AssistantSnapshotPayload {
+  version: 1;
+  generatedAt: string;
+  pets: SnapshotPet[];
+  appointments: SnapshotEntry[];
+  tasks: SnapshotEntry[];
+  vaccinationsDue: SnapshotEntry[];
+}
+
+const MS_PER_DAY = 86_400_000;
+
+const TERMINAL_STATUSES = new Set([
+  'COMPLETED',
+  'CANCELLED',
+  'NO_SHOW',
+  'RESCHEDULED',
+]);
+
+/** Builds the payload from the same context the in-app resolvers use. */
+export const buildSnapshot = (
+  context: AssistantContext,
+): AssistantSnapshotPayload => {
+  const pets = context.companions.slice(0, SNAPSHOT_PET_LIMIT);
+  const nameById = new Map(pets.map(pet => [pet.id, pet.name]));
+  const horizon = context.now.getTime() + UPCOMING_WINDOW_DAYS * MS_PER_DAY;
+
+  const appointments = context.appointments
+    .filter(appointment => nameById.has(appointment.companionId))
+    .filter(appointment => !TERMINAL_STATUSES.has(appointment.status))
+    .map(appointment => ({
+      appointment,
+      startsAt: appointmentStartsAt(appointment),
+    }))
+    .filter(
+      entry =>
+        entry.startsAt !== null &&
+        entry.startsAt.getTime() >= context.now.getTime() &&
+        entry.startsAt.getTime() <= horizon,
+    )
+    .sort(
+      (a, b) => (a.startsAt as Date).getTime() - (b.startsAt as Date).getTime(),
+    )
+    .slice(0, SNAPSHOT_ITEM_LIMIT)
+    .map(entry => ({
+      petId: entry.appointment.companionId,
+      petName: nameById.get(entry.appointment.companionId) ?? '',
+      title: entry.appointment.serviceName ?? entry.appointment.type ?? '',
+      at: (entry.startsAt as Date).toISOString(),
+      subtitle: entry.appointment.organisationName ?? undefined,
+    }));
+
+  const tasks = context.tasks
+    .filter(task => nameById.has(task.companionId))
+    .filter(task => {
+      const status = String(task.status ?? '').toUpperCase();
+      return status !== 'COMPLETED' && status !== 'CANCELLED';
+    })
+    .map(task => ({task, dueAt: taskDueAt(task)}))
+    .filter(
+      entry =>
+        entry.dueAt !== null &&
+        entry.dueAt.getTime() >= context.now.getTime() - MS_PER_DAY &&
+        entry.dueAt.getTime() <= horizon,
+    )
+    .sort((a, b) => (a.dueAt as Date).getTime() - (b.dueAt as Date).getTime())
+    .slice(0, SNAPSHOT_ITEM_LIMIT)
+    .map(entry => ({
+      petId: entry.task.companionId,
+      petName: nameById.get(entry.task.companionId) ?? '',
+      title: taskLabel(entry.task),
+      at: (entry.dueAt as Date).toISOString(),
+    }));
+
+  // Overdue shots matter, so they stay - but only recent ones. Without a lower
+  // bound a pet with years of unrecorded history filled all twenty slots with
+  // ancient entries and pushed out the shot actually due next week.
+  const staleBefore =
+    context.now.getTime() - VACCINATION_STALE_DAYS * MS_PER_DAY;
+  const vaccinationsDue: SnapshotEntry[] = [];
+  for (const pet of pets) {
+    for (const record of context.vaccinations[pet.id] ?? []) {
+      if (!record.dueOn) {
+        continue;
+      }
+      const due = parseRecordDate(record.dueOn);
+      if (
+        due === null ||
+        due.getTime() > horizon ||
+        due.getTime() < staleBefore
+      ) {
+        continue;
+      }
+      vaccinationsDue.push({
+        petId: pet.id,
+        petName: pet.name,
+        title: record.name,
+        at: due.toISOString(),
+      });
+    }
+  }
+  vaccinationsDue.sort((a, b) => a.at.localeCompare(b.at));
+
+  return {
+    version: 1,
+    generatedAt: context.now.toISOString(),
+    pets: pets.map(pet => ({
+      id: pet.id,
+      name: pet.name,
+      species: pet.category,
+    })),
+    appointments,
+    tasks,
+    vaccinationsDue: vaccinationsDue.slice(0, SNAPSHOT_ITEM_LIMIT),
+  };
+};
+
+/**
+ * Pushes the snapshot to the native side.
+ *
+ * Resolves false rather than throwing when the module is missing, so a caller
+ * in a `useEffect` never has to guard it.
+ */
+export const publishSnapshot = async (
+  context: AssistantContext,
+): Promise<boolean> => {
+  const module = getSnapshotModule();
+  if (!module) {
+    return false;
+  }
+  try {
+    return await module.writeSnapshot(JSON.stringify(buildSnapshot(context)));
+  } catch {
+    return false;
+  }
+};
+
+/** Removes the snapshot. Called on sign-out so a signed-out phone says nothing. */
+export const clearSnapshot = async (): Promise<boolean> => {
+  const module = getSnapshotModule();
+  if (!module) {
+    return false;
+  }
+  try {
+    return await module.clearSnapshot();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Picks up a deep link left by a Siri intent or an Android shortcut.
+ *
+ * Returns null when nothing is pending. The native side clears the value as it
+ * reads it, so a link is acted on exactly once even if the app is resumed
+ * repeatedly.
+ */
+export const consumePendingLink = async (): Promise<string | null> => {
+  const module = getSnapshotModule();
+  if (!module) {
+    return null;
+  }
+  try {
+    const link = await module.consumePendingLink();
+    return link && link.length > 0 ? link : null;
+  } catch {
+    return null;
+  }
+};

--- a/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
@@ -6,6 +6,7 @@
  * Siri or an Android shortcut, which arrive as the identical URL.
  */
 import type {TabParamList} from '@/navigation/types';
+import {trimEndWhile} from '../utils/trimEdges';
 
 export interface HandoffTarget {
   tab: keyof TabParamList;
@@ -78,7 +79,7 @@ export const parseAssistantLink = (
     return null;
   }
 
-  const path = rawPath.replace(/\/+$/, '') || '/';
+  const path = trimEndWhile(rawPath, char => char === '/') || '/';
   return {path, params: parseQuery(query)};
 };
 

--- a/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
@@ -1,0 +1,95 @@
+/**
+ * Turns an assistant deep link into a navigation target.
+ *
+ * Kept as a pure mapping so the routing is unit-testable without a navigator,
+ * and so the same table serves both an in-app handoff and a cold start from
+ * Siri or an Android shortcut, which arrive as the identical URL.
+ */
+import type {TabParamList} from '@/navigation/types';
+
+export interface HandoffTarget {
+  tab: keyof TabParamList;
+  screen: string;
+  params?: Record<string, unknown>;
+  /** Nested navigator hop, used by the expenses stack under the home tab. */
+  nested?: {screen: string; params?: Record<string, unknown>};
+}
+
+/** Extracts the path and query of a `yc://app/...` link. */
+export const parseAssistantLink = (
+  link: string,
+): {path: string; params: Record<string, string>} | null => {
+  const match = /^yc:\/\/app(\/[^?]*)?(?:\?(.*))?$/.exec(link.trim());
+  if (!match) {
+    return null;
+  }
+  const path = (match[1] ?? '/').replace(/\/+$/, '') || '/';
+  const params: Record<string, string> = {};
+  if (match[2]) {
+    for (const pair of match[2].split('&')) {
+      if (!pair) {
+        continue;
+      }
+      // Split on the FIRST '=' only: `split('=')` discarded everything after
+      // a second one, silently corrupting any value containing '='.
+      const separator = pair.indexOf('=');
+      const rawKey = separator === -1 ? pair : pair.slice(0, separator);
+      const rawValue = separator === -1 ? '' : pair.slice(separator + 1);
+      if (!rawKey) {
+        continue;
+      }
+      // In a form-encoded query '+' means a space on both sides of the '='.
+      params[decodeURIComponent(rawKey.replace(/\+/g, ' '))] =
+        decodeURIComponent(rawValue.replace(/\+/g, ' '));
+    }
+  }
+  return {path, params};
+};
+
+/**
+ * Maps a link to a target.
+ *
+ * Unknown paths return null so an unrecognised link lands the user nowhere
+ * rather than on an arbitrary screen.
+ */
+export const resolveHandoffTarget = (link: string): HandoffTarget | null => {
+  const parsed = parseAssistantLink(link);
+  if (!parsed) {
+    return null;
+  }
+
+  const {path, params} = parsed;
+
+  if (path === '/tasks/new') {
+    return {
+      tab: 'Tasks',
+      screen: 'AddTask',
+      params: {
+        // The add-task form takes a date, not a timestamp.
+        prefillDate: params.when ? params.when.slice(0, 10) : undefined,
+      },
+    };
+  }
+
+  if (path === '/expenses/new') {
+    return {
+      tab: 'HomeStack',
+      screen: 'ExpensesStack',
+      nested: {screen: 'AddExpense'},
+    };
+  }
+
+  if (path === '/appointments/book') {
+    return {
+      tab: 'Appointments',
+      screen: 'BrowseBusinesses',
+      params: {autoFocusSearch: true},
+    };
+  }
+
+  if (path === '/assistant') {
+    return {tab: 'HomeStack', screen: 'Assistant'};
+  }
+
+  return null;
+};

--- a/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
@@ -15,6 +15,22 @@ export interface HandoffTarget {
   nested?: {screen: string; params?: Record<string, unknown>};
 }
 
+/**
+ * Percent-decodes a query fragment, tolerating malformed input.
+ *
+ * `yc://app` is an exported deep link, so any installed app can hand us a
+ * link, and `decodeURIComponent` throws a URIError on a stray '%'. That threw
+ * out of the parser and surfaced as an unhandled rejection in the deep-link
+ * handler, so a malformed value is kept verbatim instead.
+ */
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
 /** Extracts the path and query of a `yc://app/...` link. */
 export const parseAssistantLink = (
   link: string,
@@ -39,8 +55,9 @@ export const parseAssistantLink = (
         continue;
       }
       // In a form-encoded query '+' means a space on both sides of the '='.
-      params[decodeURIComponent(rawKey.replace(/\+/g, ' '))] =
-        decodeURIComponent(rawValue.replace(/\+/g, ' '));
+      params[safeDecode(rawKey.replace(/\+/g, ' '))] = safeDecode(
+        rawValue.replace(/\+/g, ' '),
+      );
     }
   }
   return {path, params};

--- a/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/handoffNavigation.ts
@@ -31,36 +31,55 @@ const safeDecode = (value: string): string => {
   }
 };
 
+/** Only this app's own scheme and host are accepted. */
+const LINK_PREFIX = 'yc://app';
+
+/** Splits `a=1&b=2` into a map, tolerating malformed pairs. */
+const parseQuery = (query: string): Record<string, string> => {
+  const params: Record<string, string> = {};
+  for (const pair of query.split('&')) {
+    if (!pair) {
+      continue;
+    }
+    // Split on the FIRST '=' only: `split('=')` discarded everything after
+    // a second one, silently corrupting any value containing '='.
+    const separator = pair.indexOf('=');
+    const rawKey = separator === -1 ? pair : pair.slice(0, separator);
+    const rawValue = separator === -1 ? '' : pair.slice(separator + 1);
+    if (!rawKey) {
+      continue;
+    }
+    // In a form-encoded query '+' means a space on both sides of the '='.
+    params[safeDecode(rawKey.replaceAll('+', ' '))] = safeDecode(
+      rawValue.replaceAll('+', ' '),
+    );
+  }
+  return params;
+};
+
 /** Extracts the path and query of a `yc://app/...` link. */
 export const parseAssistantLink = (
   link: string,
 ): {path: string; params: Record<string, string>} | null => {
-  const match = /^yc:\/\/app(\/[^?]*)?(?:\?(.*))?$/.exec(link.trim());
-  if (!match) {
+  const trimmed = link.trim();
+  if (!trimmed.startsWith(LINK_PREFIX)) {
     return null;
   }
-  const path = (match[1] ?? '/').replace(/\/+$/, '') || '/';
-  const params: Record<string, string> = {};
-  if (match[2]) {
-    for (const pair of match[2].split('&')) {
-      if (!pair) {
-        continue;
-      }
-      // Split on the FIRST '=' only: `split('=')` discarded everything after
-      // a second one, silently corrupting any value containing '='.
-      const separator = pair.indexOf('=');
-      const rawKey = separator === -1 ? pair : pair.slice(0, separator);
-      const rawValue = separator === -1 ? '' : pair.slice(separator + 1);
-      if (!rawKey) {
-        continue;
-      }
-      // In a form-encoded query '+' means a space on both sides of the '='.
-      params[safeDecode(rawKey.replace(/\+/g, ' '))] = safeDecode(
-        rawValue.replace(/\+/g, ' '),
-      );
-    }
+
+  const remainder = trimmed.slice(LINK_PREFIX.length);
+  const queryStart = remainder.indexOf('?');
+  const rawPath =
+    queryStart === -1 ? remainder : remainder.slice(0, queryStart);
+  const query = queryStart === -1 ? '' : remainder.slice(queryStart + 1);
+
+  // Anything between the host and the path separator would be a different
+  // host ("yc://appstore/..."), not a path on ours.
+  if (rawPath.length > 0 && !rawPath.startsWith('/')) {
+    return null;
   }
-  return {path, params};
+
+  const path = rawPath.replace(/\/+$/, '') || '/';
+  return {path, params: parseQuery(query)};
 };
 
 /**

--- a/apps/mobileAppYC/src/features/assistant/services/nativeBridge.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/nativeBridge.ts
@@ -1,0 +1,53 @@
+/**
+ * Safe access to the assistant's native modules.
+ *
+ * Both modules are optional at runtime. They are absent in Jest, absent in a
+ * JS-only reload before the native side registers, and the on-device model is
+ * absent on every device that does not ship one. Every accessor here returns
+ * null rather than throwing so a missing module degrades the feature instead
+ * of crashing the app.
+ */
+import {NativeModules, Platform} from 'react-native';
+
+/** Writes the offline snapshot that App Intents and shortcuts read. */
+export interface AssistantSnapshotNativeModule {
+  writeSnapshot(json: string): Promise<boolean>;
+  clearSnapshot(): Promise<boolean>;
+  /**
+   * Returns a deep link parked by a handoff intent or shortcut, then clears
+   * it. Resolves to an empty string when nothing is pending.
+   */
+  consumePendingLink(): Promise<string>;
+  /** Publishes the OS-level shortcuts for the catalogue. Android only. */
+  publishShortcuts?(json: string): Promise<boolean>;
+}
+
+/** Wraps the platform's on-device language model. */
+export interface OnDeviceModelNativeModule {
+  isAvailable(): Promise<{
+    available: boolean;
+    reason?: string;
+    providerLabel?: string;
+  }>;
+  generate(prompt: string, maxTokens: number): Promise<string>;
+}
+
+const readModule = <T>(name: string): T | null => {
+  const candidate = (NativeModules as Record<string, unknown>)[name];
+  return candidate ? (candidate as T) : null;
+};
+
+export const getSnapshotModule = (): AssistantSnapshotNativeModule | null =>
+  readModule<AssistantSnapshotNativeModule>('AssistantSnapshotBridge');
+
+export const getOnDeviceModelModule = (): OnDeviceModelNativeModule | null =>
+  readModule<OnDeviceModelNativeModule>('OnDeviceModelBridge');
+
+/**
+ * The user-facing name of the platform's assistant.
+ *
+ * Used in the availability banner. Kept here so the two native modules do not
+ * each have to ship a localised string.
+ */
+export const platformProviderLabel = (): string =>
+  Platform.OS === 'ios' ? 'Apple Intelligence' : 'Gemini Nano';

--- a/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
@@ -87,8 +87,9 @@ const buildClassifyPrompt = (
 /**
  * Picks an action for an utterance the rules could not route.
  *
- * The reply is matched against the catalogue, so a model that invents an id,
- * adds prose or answers the question directly yields null.
+ * The reply must be a single token that, once its surrounding punctuation is
+ * trimmed, matches a catalogue id exactly. A model that invents an id, answers
+ * the question directly, or wraps the id in prose yields null.
  */
 export const classify = async (
   utterance: string,
@@ -105,13 +106,18 @@ export const classify = async (
       CLASSIFY_MAX_TOKENS,
     );
     const answer = String(raw ?? '').trim();
-    // Stripping every non-letter first meant a prose reply whose words happened
-    // to spell an id ("next appointment") was accepted as one. A real id is a
-    // single token, so anything containing whitespace is prose.
+    // An id is a single token, so anything with whitespace inside it is prose
+    // and is discarded - that is what keeps "next appointment" and a numbered
+    // list item out.
     if (answer.length === 0 || /\s/.test(answer)) {
       return null;
     }
-    const cleaned = answer.replace(/[^A-Za-z]/g, '');
+    // Only the edges are stripped, not every non-letter. A small model reliably
+    // wraps its answer in punctuation ("nextAppointment."), which is worth
+    // tolerating; interior noise is not.
+    const cleaned = answer
+      .replace(/^[^A-Za-z]+/, '')
+      .replace(/[^A-Za-z]+$/, '');
     const match = ASSISTANT_ACTION_IDS.find(
       id => id.toLowerCase() === cleaned.toLowerCase(),
     );

--- a/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
@@ -1,0 +1,165 @@
+/**
+ * The on-device language model, as the assistant uses it.
+ *
+ * Two jobs, both optional:
+ *  - `classify` rescues an utterance the rule parser could not route, by
+ *    picking an action id from the catalogue. It may only return an id from
+ *    the list, and anything else is discarded.
+ *  - `rephrase` turns a resolver's already-true sentence into warmer prose.
+ *
+ * The model is never asked for facts. If it is unavailable, slow or wrong,
+ * the assistant still answers from the rule parser and the resolvers.
+ */
+import type {
+  AssistantActionId,
+  AssistantIntent,
+  OnDeviceModelAvailability,
+} from '../types';
+import {ASSISTANT_ACTION_IDS} from '../actions/catalogue';
+import {getOnDeviceModelModule, platformProviderLabel} from './nativeBridge';
+
+const CLASSIFY_MAX_TOKENS = 24;
+const REPHRASE_MAX_TOKENS = 96;
+
+const UNAVAILABLE: OnDeviceModelAvailability = {
+  available: false,
+  reason: 'unsupportedDevice',
+};
+
+const KNOWN_REASONS = new Set([
+  'unsupportedOS',
+  'unsupportedDevice',
+  'notEnabled',
+  'modelNotReady',
+  'unknown',
+]);
+
+const toReason = (
+  value: string | undefined,
+): OnDeviceModelAvailability['reason'] =>
+  value && KNOWN_REASONS.has(value)
+    ? (value as OnDeviceModelAvailability['reason'])
+    : 'unknown';
+
+/** Asks the platform whether a usable model is present right now. */
+export const checkAvailability =
+  async (): Promise<OnDeviceModelAvailability> => {
+    const module = getOnDeviceModelModule();
+    if (!module) {
+      return UNAVAILABLE;
+    }
+    try {
+      const result = await module.isAvailable();
+      if (!result?.available) {
+        return {
+          available: false,
+          reason: toReason(result?.reason),
+          providerLabel: result?.providerLabel ?? platformProviderLabel(),
+        };
+      }
+      return {
+        available: true,
+        providerLabel: result.providerLabel ?? platformProviderLabel(),
+      };
+    } catch {
+      // Every other unavailable path carries a provider name; the banner reads
+      // oddly without one, so the throwing path reports it too.
+      return {
+        available: false,
+        reason: 'unknown',
+        providerLabel: platformProviderLabel(),
+      };
+    }
+  };
+
+const buildClassifyPrompt = (
+  utterance: string,
+  actionDescriptions: string,
+): string =>
+  [
+    'You route a pet owner question to one app action.',
+    'Reply with exactly one action id from this list and nothing else.',
+    actionDescriptions,
+    `Question: ${utterance}`,
+    'Action id:',
+  ].join('\n');
+
+/**
+ * Picks an action for an utterance the rules could not route.
+ *
+ * The reply is matched against the catalogue, so a model that invents an id,
+ * adds prose or answers the question directly yields null.
+ */
+export const classify = async (
+  utterance: string,
+  actionDescriptions: string,
+): Promise<AssistantIntent | null> => {
+  const module = getOnDeviceModelModule();
+  if (!module) {
+    return null;
+  }
+
+  try {
+    const raw = await module.generate(
+      buildClassifyPrompt(utterance, actionDescriptions),
+      CLASSIFY_MAX_TOKENS,
+    );
+    const answer = String(raw ?? '').trim();
+    // Stripping every non-letter first meant a prose reply whose words happened
+    // to spell an id ("next appointment") was accepted as one. A real id is a
+    // single token, so anything containing whitespace is prose.
+    if (answer.length === 0 || /\s/.test(answer)) {
+      return null;
+    }
+    const cleaned = answer.replace(/[^A-Za-z]/g, '');
+    const match = ASSISTANT_ACTION_IDS.find(
+      id => id.toLowerCase() === cleaned.toLowerCase(),
+    );
+    if (!match) {
+      return null;
+    }
+    return {
+      actionId: match as AssistantActionId,
+      slots: {},
+      // Deliberately below the rules threshold: a model guess is a last
+      // resort, and the UI shows it as a suggestion rather than a certainty.
+      confidence: 0.5,
+      source: 'model',
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Rewrites a factual sentence in a warmer voice.
+ *
+ * Returns the original sentence whenever the model is unavailable or its
+ * answer looks like anything other than a short rewrite, because a longer
+ * reply is a sign the model started adding claims of its own.
+ */
+export const rephrase = async (sentence: string): Promise<string> => {
+  const module = getOnDeviceModelModule();
+  if (!module) {
+    return sentence;
+  }
+
+  try {
+    const raw = await module.generate(
+      [
+        'Rewrite the sentence for a pet owner in at most 25 words.',
+        'Keep every date, number and name exactly as written.',
+        'Add no new facts. Reply with the sentence only.',
+        `Sentence: ${sentence}`,
+      ].join('\n'),
+      REPHRASE_MAX_TOKENS,
+    );
+    const candidate = String(raw ?? '').trim();
+    if (candidate.length === 0 || candidate.length > sentence.length * 2 + 40) {
+      return sentence;
+    }
+    return candidate;
+  } catch {
+    return sentence;
+  }
+};

--- a/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
+++ b/apps/mobileAppYC/src/features/assistant/services/onDeviceModel.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types';
 import {ASSISTANT_ACTION_IDS} from '../actions/catalogue';
 import {getOnDeviceModelModule, platformProviderLabel} from './nativeBridge';
+import {isNotLetter, trimEdgesWhile} from '../utils/trimEdges';
 
 const CLASSIFY_MAX_TOKENS = 24;
 const REPHRASE_MAX_TOKENS = 96;
@@ -115,9 +116,7 @@ export const classify = async (
     // Only the edges are stripped, not every non-letter. A small model reliably
     // wraps its answer in punctuation ("nextAppointment."), which is worth
     // tolerating; interior noise is not.
-    const cleaned = answer
-      .replace(/^[^A-Za-z]+/, '')
-      .replace(/[^A-Za-z]+$/, '');
+    const cleaned = trimEdgesWhile(answer, isNotLetter);
     const match = ASSISTANT_ACTION_IDS.find(
       id => id.toLowerCase() === cleaned.toLowerCase(),
     );

--- a/apps/mobileAppYC/src/features/assistant/thunks.ts
+++ b/apps/mobileAppYC/src/features/assistant/thunks.ts
@@ -1,5 +1,7 @@
 /** Thunks that drive the assistant. */
+import 'react-native-get-random-values';
 import {createAsyncThunk} from '@reduxjs/toolkit';
+import {v4 as uuid} from 'uuid';
 import type {TFunction} from 'i18next';
 import type {AppDispatch, RootState} from '@/app/store';
 import {
@@ -21,8 +23,9 @@ import type {AssistantMessage} from './types';
 
 const DEFAULT_CURRENCY = 'USD';
 
-const makeId = (): string =>
-  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+// `Math.random()` is not a source of unique identifiers and static analysis
+// rightly flags it; the app already polyfills crypto for uuid elsewhere.
+const makeId = (): string => uuid();
 
 /** Probes the platform model once per app session. */
 export const probeOnDeviceModel = createAsyncThunk<

--- a/apps/mobileAppYC/src/features/assistant/thunks.ts
+++ b/apps/mobileAppYC/src/features/assistant/thunks.ts
@@ -1,0 +1,114 @@
+/** Thunks that drive the assistant. */
+import {createAsyncThunk} from '@reduxjs/toolkit';
+import type {TFunction} from 'i18next';
+import type {AppDispatch, RootState} from '@/app/store';
+import {
+  buildAssistantContext,
+  selectAssistantData,
+  selectModelAvailability,
+} from './selectors';
+import {
+  messageAdded,
+  modelAvailabilityChanged,
+  thinkingStarted,
+  turnCompleted,
+  turnFailed,
+} from './assistantSlice';
+import {runTurn} from './services/assistantRuntime';
+import {checkAvailability} from './services/onDeviceModel';
+import {publishSnapshot} from './services/assistantSnapshot';
+import type {AssistantMessage} from './types';
+
+const DEFAULT_CURRENCY = 'USD';
+
+const makeId = (): string =>
+  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+/** Probes the platform model once per app session. */
+export const probeOnDeviceModel = createAsyncThunk<
+  void,
+  void,
+  {dispatch: AppDispatch}
+>('assistant/probeOnDeviceModel', async (_arg, {dispatch}) => {
+  const availability = await checkAvailability();
+  dispatch(modelAvailabilityChanged(availability));
+});
+
+/**
+ * Refreshes the snapshot the OS assistants read.
+ *
+ * Called after the app loads pets, tasks and appointments, and again on
+ * sign-out through `clearSnapshot`. Failure is not surfaced: a stale snapshot
+ * degrades Siri's answer, it does not break the app.
+ */
+export const refreshAssistantSnapshot = createAsyncThunk<
+  boolean,
+  {currencyCode?: string} | undefined,
+  {state: RootState}
+>('assistant/refreshSnapshot', async (arg, {getState}) => {
+  const context = buildAssistantContext(
+    selectAssistantData(getState()),
+    new Date(),
+    arg?.currencyCode ?? DEFAULT_CURRENCY,
+  );
+  return publishSnapshot(context);
+});
+
+export interface AskAssistantArgs {
+  utterance: string;
+  t: TFunction;
+  currencyCode?: string;
+  /** Injectable for tests; defaults to the real clock. */
+  now?: Date;
+}
+
+/** Runs one user turn and appends both messages to the transcript. */
+export const askAssistant = createAsyncThunk<
+  void,
+  AskAssistantArgs,
+  {state: RootState; dispatch: AppDispatch}
+>('assistant/ask', async (args, {dispatch, getState}) => {
+  const {utterance, t} = args;
+  const state = getState();
+
+  const userMessage: AssistantMessage = {
+    id: makeId(),
+    author: 'user',
+    text: utterance.trim(),
+    createdAt: new Date().toISOString(),
+  };
+  dispatch(messageAdded(userMessage));
+  dispatch(thinkingStarted());
+
+  try {
+    const context = buildAssistantContext(
+      selectAssistantData(state),
+      args.now ?? new Date(),
+      args.currencyCode ?? DEFAULT_CURRENCY,
+    );
+    const availability = selectModelAvailability(state);
+
+    const turn = await runTurn(utterance, context, t, {
+      useModel: availability.available,
+      allowRephrase: availability.available,
+    });
+
+    dispatch(
+      turnCompleted({
+        message: {
+          id: makeId(),
+          author: 'assistant',
+          text: turn.text,
+          createdAt: new Date().toISOString(),
+        },
+        result: turn.result ?? undefined,
+      }),
+    );
+  } catch (error) {
+    dispatch(
+      turnFailed(
+        error instanceof Error ? error.message : t('assistant.replies.error'),
+      ),
+    );
+  }
+});

--- a/apps/mobileAppYC/src/features/assistant/types.ts
+++ b/apps/mobileAppYC/src/features/assistant/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Types for the on-device pet care assistant.
+ *
+ * The assistant has three layers that all speak these types:
+ * 1. The OS assistants (Siri via App Intents, Android app shortcuts) call into
+ *    the same action catalogue through the native snapshot bridge.
+ * 2. The in-app assistant screen routes typed questions through the same
+ *    catalogue.
+ * 3. The optional on-device language model only ever *chooses* an action and
+ *    phrases the answer. It never invents data - every fact in a reply comes
+ *    from a resolver reading Redux state.
+ */
+import type {Companion} from '@/features/companion/types';
+import type {Task} from '@/features/tasks/types';
+import type {Appointment} from '@/features/appointments/types';
+import type {Expense} from '@/features/expenses/types';
+
+/** Stable identifiers for every action the assistant can perform. */
+export type AssistantActionId =
+  | 'nextAppointment'
+  | 'vaccinationStatus'
+  | 'upcomingTasks'
+  | 'addCareTask'
+  | 'logExpense'
+  | 'bookAppointment'
+  | 'petOverview'
+  | 'expenseSummary';
+
+/**
+ * How an action reaches its result.
+ *
+ * `read` actions answer from the local snapshot and are safe for a background
+ * Siri or shortcut invocation. `handoff` actions need confirmation, payment or
+ * a form, so they open the app at a deep link with the slots prefilled rather
+ * than committing anything unattended.
+ */
+export type AssistantActionKind = 'read' | 'handoff';
+
+/** A slot the parser can fill from an utterance. */
+export type AssistantSlotName =
+  'petName' | 'when' | 'title' | 'amount' | 'category';
+
+export interface AssistantSlots {
+  petName?: string;
+  /** ISO-8601 date-time, already resolved from phrases such as "tonight". */
+  when?: string;
+  title?: string;
+  amount?: number;
+  category?: string;
+}
+
+export interface AssistantAction {
+  id: AssistantActionId;
+  kind: AssistantActionKind;
+  /** i18n key for the short human title, e.g. shown on a suggestion chip. */
+  titleKey: string;
+  /** i18n key for the one-line description handed to the model and to Siri. */
+  descriptionKey: string;
+  /** Slots this action can use, in priority order. */
+  slots: AssistantSlotName[];
+  /** Slots without which the action cannot run at all. */
+  requiredSlots: AssistantSlotName[];
+  /**
+   * Deep link template for handoff actions. Placeholders are `:slotName`.
+   * Read actions leave this undefined.
+   */
+  deepLink?: string;
+  /** Example utterances, used for Siri phrases and in-app suggestions. */
+  samplePhraseKeys: string[];
+}
+
+/** The read-only view of app state every resolver works from. */
+export interface AssistantContext {
+  companions: Companion[];
+  tasks: Task[];
+  appointments: Appointment[];
+  expenses: Expense[];
+  /** Vaccination summaries keyed by companion id. */
+  vaccinations: Record<string, AssistantVaccination[]>;
+  /** Injected so date maths is deterministic under test. */
+  now: Date;
+  currencyCode: string;
+}
+
+export interface AssistantVaccination {
+  name: string;
+  administeredOn?: string | null;
+  dueOn?: string | null;
+}
+
+/**
+ * A resolver's answer.
+ *
+ * `speech` is the sentence a voice assistant reads out. `display` is what the
+ * in-app transcript shows. They differ only where the screen can be richer.
+ */
+export interface AssistantActionResult {
+  actionId: AssistantActionId;
+  status: 'ok' | 'empty' | 'needsSlot' | 'handoff' | 'error';
+  speechKey: string;
+  speechParams?: Record<string, string | number>;
+  /** Structured payload the UI renders as a card. */
+  data?: AssistantResultData;
+  /** Set when status is `needsSlot`. */
+  missingSlot?: AssistantSlotName;
+  /** Set when status is `handoff`. */
+  deepLink?: string;
+}
+
+export interface AssistantResultData {
+  petName?: string;
+  appointmentId?: string;
+  taskIds?: string[];
+  amount?: number;
+  currencyCode?: string;
+  dateLabel?: string;
+  items?: AssistantResultItem[];
+}
+
+export interface AssistantResultItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+}
+
+/** A parsed utterance, before any state is consulted. */
+export interface AssistantIntent {
+  actionId: AssistantActionId;
+  slots: AssistantSlots;
+  /** 0-1. The deterministic parser reports how much of the phrase it matched. */
+  confidence: number;
+  source: 'rules' | 'model';
+}
+
+export type AssistantMessageAuthor = 'user' | 'assistant';
+
+export interface AssistantMessage {
+  id: string;
+  author: AssistantMessageAuthor;
+  /** Already-localised text. The transcript stores display strings. */
+  text: string;
+  createdAt: string;
+  result?: AssistantActionResult;
+}
+
+/** What the native layer reports about the on-device language model. */
+export interface OnDeviceModelAvailability {
+  available: boolean;
+  /**
+   * Why the model cannot be used, when it cannot. `unsupportedOS` and
+   * `unsupportedDevice` are permanent for this device; `notEnabled` and
+   * `modelNotReady` can change without a reinstall.
+   */
+  reason?:
+    | 'unsupportedOS'
+    | 'unsupportedDevice'
+    | 'notEnabled'
+    | 'modelNotReady'
+    | 'unknown';
+  /** Human-readable platform label, e.g. "Apple Intelligence". */
+  providerLabel?: string;
+}

--- a/apps/mobileAppYC/src/features/assistant/utils/trimEdges.ts
+++ b/apps/mobileAppYC/src/features/assistant/utils/trimEdges.ts
@@ -1,0 +1,42 @@
+/**
+ * Character trimming that does not use an anchored regex.
+ *
+ * `/[^a-z]+$/` and friends read naturally but are super-linear: the engine
+ * retries the unbounded quantifier from every start position, so a long run of
+ * trimmable characters costs O(n^2). These walk in from each end instead, which
+ * is O(n) and obvious.
+ */
+
+/** Drops leading characters while `shouldTrim` accepts them. */
+export const trimStartWhile = (
+  value: string,
+  shouldTrim: (char: string) => boolean,
+): string => {
+  let start = 0;
+  while (start < value.length && shouldTrim(value[start])) {
+    start += 1;
+  }
+  return start === 0 ? value : value.slice(start);
+};
+
+/** Drops trailing characters while `shouldTrim` accepts them. */
+export const trimEndWhile = (
+  value: string,
+  shouldTrim: (char: string) => boolean,
+): string => {
+  let end = value.length;
+  while (end > 0 && shouldTrim(value[end - 1])) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+};
+
+/** Drops characters `shouldTrim` accepts from both ends. */
+export const trimEdgesWhile = (
+  value: string,
+  shouldTrim: (char: string) => boolean,
+): string => trimEndWhile(trimStartWhile(value, shouldTrim), shouldTrim);
+
+/** True for anything that is not an ASCII letter. */
+export const isNotLetter = (char: string): boolean =>
+  (char < 'A' || char > 'Z') && (char < 'a' || char > 'z');

--- a/apps/mobileAppYC/src/features/auth/thunks.ts
+++ b/apps/mobileAppYC/src/features/auth/thunks.ts
@@ -2,6 +2,8 @@ import {createAsyncThunk} from '@reduxjs/toolkit';
 
 import {AppDispatch, type RootState} from '@/app/store';
 import {resetCompanionState} from '@/features/companion';
+import {transcriptCleared} from '@/features/assistant/assistantSlice';
+import {clearSnapshot} from '@/features/assistant/services/assistantSnapshot';
 import {resetExpensesState} from '@/features/expenses';
 import {resetDocumentState} from '@/features/documents/documentSlice';
 import {resetPassportState} from '@/features/passport/passportSlice';
@@ -278,6 +280,13 @@ export const logout = createAsyncThunk<
   dispatch(resetCoParentState());
   dispatch(resetNotificationState());
   dispatch(resetFormsState());
+  dispatch(transcriptCleared());
+
+  // The assistant's offline snapshot lives outside Redux, in native storage
+  // that Siri and the launcher shortcuts read without the app running. Leaving
+  // it behind would let a signed-out phone still read out the previous
+  // owner's appointments.
+  await clearSnapshot();
 });
 
 export const clearAuthError = createAsyncThunk(

--- a/apps/mobileAppYC/src/localization/resources/en/common.json
+++ b/apps/mobileAppYC/src/localization/resources/en/common.json
@@ -589,5 +589,118 @@
       "submissionRequired": "Submission required",
       "submissionRequiredBody": "Complete the observational tool before booking."
     }
+  },
+  "assistant": {
+    "title": "Pet care assistant",
+    "entryTitle": "Ask about your pets",
+    "entrySubtitle": "Appointments, vaccines, tasks and spending, answered on your device.",
+    "emptyTitle": "Ask me about your pets",
+    "emptyBody": "Try one of the suggestions below, or ask in your own words. Answers come from your own records.",
+    "composerPlaceholder": "Ask about appointments, vaccines or tasks",
+    "send": "Send",
+    "clear": "Clear conversation",
+    "model": {
+      "provider": "on-device AI",
+      "unsupportedOS": "Answers here are exact rather than chatty. {{provider}} needs a newer version of this phone's software.",
+      "unsupportedDevice": "Answers here are exact rather than chatty. This device does not support {{provider}}.",
+      "notEnabled": "Turn on {{provider}} in system settings for more natural replies. Everything still works without it.",
+      "modelNotReady": "{{provider}} is still downloading. Replies stay exact until it is ready.",
+      "unknown": "Replies are exact rather than chatty on this device."
+    },
+    "actions": {
+      "nextAppointment": {
+        "title": "Next appointment",
+        "description": "Say when the next vet or grooming appointment is.",
+        "phrase1": "When is my next appointment?",
+        "phrase2": "When does Bruno see the vet?"
+      },
+      "vaccinationStatus": {
+        "title": "Vaccination status",
+        "description": "Say whether a pet's vaccinations are up to date or due.",
+        "phrase1": "Are Bruno's vaccines up to date?",
+        "phrase2": "Which vaccinations are due?"
+      },
+      "upcomingTasks": {
+        "title": "What is due",
+        "description": "List the care tasks due for a pet in a given period.",
+        "phrase1": "What is due today?",
+        "phrase2": "What does Bruno need this week?"
+      },
+      "petOverview": {
+        "title": "Pet summary",
+        "description": "Summarise one pet's open tasks and upcoming appointments.",
+        "phrase1": "Tell me about Bruno"
+      },
+      "expenseSummary": {
+        "title": "Spending",
+        "description": "Total what has been spent on a pet.",
+        "phrase1": "How much have I spent on Bruno?"
+      },
+      "addCareTask": {
+        "title": "Add a care task",
+        "description": "Start a new care task or medication reminder.",
+        "phrase1": "Remind me to give Bruno his tablet tonight",
+        "phrase2": "Add a task for Bruno"
+      },
+      "logExpense": {
+        "title": "Log an expense",
+        "description": "Start a new expense record for a pet.",
+        "phrase1": "Log an expense for Bruno"
+      },
+      "bookAppointment": {
+        "title": "Book an appointment",
+        "description": "Start booking a vet or grooming appointment.",
+        "phrase1": "Book an appointment for Bruno",
+        "phrase2": "Book a vet visit"
+      }
+    },
+    "open": {
+      "addCareTask": "Add the task",
+      "logExpense": "Add the expense",
+      "bookAppointment": "Find a clinic",
+      "nextAppointment": "Open",
+      "vaccinationStatus": "Open",
+      "upcomingTasks": "Open",
+      "petOverview": "Open",
+      "expenseSummary": "Open"
+    },
+    "replies": {
+      "empty": "Ask me something about your pets.",
+      "unknown": "I can help with appointments, vaccinations, care tasks and spending. Try one of the suggestions.",
+      "error": "Something went wrong. Please try again.",
+      "needsPet": "Which pet do you mean?",
+      "nextAppointment": {
+        "found": "{{petName}} has an appointment on {{date}} at {{time}}.",
+        "none": "There are no upcoming appointments booked."
+      },
+      "vaccinationStatus": {
+        "overdue": "{{petName}} has {{count}} overdue vaccination, starting with {{name}}.",
+        "overdue_other": "{{petName}} has {{count}} overdue vaccinations, starting with {{name}}.",
+        "dueSoon": "{{petName}} is due a {{name}} vaccination on {{date}}.",
+        "upToDate": "{{petName}} is up to date on vaccinations.",
+        "none": "There are no vaccination records for {{petName}} yet."
+      },
+      "upcomingTasks": {
+        "found": "There are {{count}} tasks due, starting with {{first}}.",
+        "found_one": "There is 1 task due: {{first}}.",
+        "none": "Nothing is due in that period."
+      },
+      "petOverview": {
+        "summary": "{{petName}} has {{tasks}} open tasks and {{appointments}} upcoming appointments."
+      },
+      "expenseSummary": {
+        "total": "You have recorded {{total}} {{currency}} across {{count}} expenses.",
+        "none": "There are no expenses recorded yet."
+      },
+      "addCareTask": {
+        "handoff": "I have opened a new task for you to confirm."
+      },
+      "logExpense": {
+        "handoff": "I have opened a new expense for you to confirm."
+      },
+      "bookAppointment": {
+        "handoff": "Booking needs a time and payment, so I have opened the clinic search for you."
+      }
+    }
   }
 }

--- a/apps/mobileAppYC/src/localization/resources/es/common.json
+++ b/apps/mobileAppYC/src/localization/resources/es/common.json
@@ -589,5 +589,118 @@
       "submissionRequired": "Envío obligatorio",
       "submissionRequiredBody": "Completa la herramienta de observación antes de reservar."
     }
+  },
+  "assistant": {
+    "title": "Asistente de cuidado",
+    "entryTitle": "Pregunta por tus mascotas",
+    "entrySubtitle": "Citas, vacunas, tareas y gastos, respondidos en tu dispositivo.",
+    "emptyTitle": "Pregúntame por tus mascotas",
+    "emptyBody": "Prueba una de las sugerencias o pregunta con tus palabras. Las respuestas salen de tus propios registros.",
+    "composerPlaceholder": "Pregunta por citas, vacunas o tareas",
+    "send": "Enviar",
+    "clear": "Borrar conversación",
+    "model": {
+      "provider": "IA en el dispositivo",
+      "unsupportedOS": "Las respuestas son exactas en lugar de conversacionales. {{provider}} necesita una versión más reciente del software.",
+      "unsupportedDevice": "Las respuestas son exactas en lugar de conversacionales. Este dispositivo no admite {{provider}}.",
+      "notEnabled": "Activa {{provider}} en los ajustes para respuestas más naturales. Todo funciona igual sin ello.",
+      "modelNotReady": "{{provider}} aún se está descargando. Las respuestas serán exactas hasta que esté listo.",
+      "unknown": "Las respuestas son exactas en lugar de conversacionales en este dispositivo."
+    },
+    "actions": {
+      "nextAppointment": {
+        "title": "Próxima cita",
+        "description": "Indicar cuándo es la próxima cita veterinaria o de peluquería.",
+        "phrase1": "¿Cuándo es mi próxima cita?",
+        "phrase2": "¿Cuándo ve Bruno al veterinario?"
+      },
+      "vaccinationStatus": {
+        "title": "Estado de vacunación",
+        "description": "Indicar si las vacunas de una mascota están al día o pendientes.",
+        "phrase1": "¿Las vacunas de Bruno están al día?",
+        "phrase2": "¿Qué vacunas tocan?"
+      },
+      "upcomingTasks": {
+        "title": "Qué toca",
+        "description": "Listar las tareas de cuidado pendientes en un periodo.",
+        "phrase1": "¿Qué toca hoy?",
+        "phrase2": "¿Qué necesita Bruno esta semana?"
+      },
+      "petOverview": {
+        "title": "Resumen de mascota",
+        "description": "Resumir las tareas abiertas y las citas de una mascota.",
+        "phrase1": "Háblame de Bruno"
+      },
+      "expenseSummary": {
+        "title": "Gastos",
+        "description": "Sumar lo gastado en una mascota.",
+        "phrase1": "¿Cuánto he gastado en Bruno?"
+      },
+      "addCareTask": {
+        "title": "Añadir una tarea",
+        "description": "Empezar una tarea de cuidado o recordatorio de medicación.",
+        "phrase1": "Recuérdame darle a Bruno su pastilla esta noche",
+        "phrase2": "Añadir una tarea para Bruno"
+      },
+      "logExpense": {
+        "title": "Registrar un gasto",
+        "description": "Empezar un registro de gasto para una mascota.",
+        "phrase1": "Registrar un gasto de Bruno"
+      },
+      "bookAppointment": {
+        "title": "Reservar una cita",
+        "description": "Empezar a reservar una cita veterinaria o de peluquería.",
+        "phrase1": "Reservar una cita para Bruno",
+        "phrase2": "Reservar una visita al veterinario"
+      }
+    },
+    "open": {
+      "addCareTask": "Añadir la tarea",
+      "logExpense": "Añadir el gasto",
+      "bookAppointment": "Buscar una clínica",
+      "nextAppointment": "Abrir",
+      "vaccinationStatus": "Abrir",
+      "upcomingTasks": "Abrir",
+      "petOverview": "Abrir",
+      "expenseSummary": "Abrir"
+    },
+    "replies": {
+      "empty": "Pregúntame algo sobre tus mascotas.",
+      "unknown": "Puedo ayudarte con citas, vacunas, tareas y gastos. Prueba una de las sugerencias.",
+      "error": "Algo ha fallado. Inténtalo de nuevo.",
+      "needsPet": "¿A qué mascota te refieres?",
+      "nextAppointment": {
+        "found": "{{petName}} tiene una cita el {{date}} a las {{time}}.",
+        "none": "No hay citas próximas reservadas."
+      },
+      "vaccinationStatus": {
+        "overdue": "{{petName}} tiene {{count}} vacuna atrasada, empezando por {{name}}.",
+        "overdue_other": "{{petName}} tiene {{count}} vacunas atrasadas, empezando por {{name}}.",
+        "dueSoon": "A {{petName}} le toca la vacuna {{name}} el {{date}}.",
+        "upToDate": "{{petName}} tiene las vacunas al día.",
+        "none": "Todavía no hay registros de vacunación de {{petName}}."
+      },
+      "upcomingTasks": {
+        "found": "Hay {{count}} tareas pendientes, empezando por {{first}}.",
+        "found_one": "Hay 1 tarea pendiente: {{first}}.",
+        "none": "No hay nada pendiente en ese periodo."
+      },
+      "petOverview": {
+        "summary": "{{petName}} tiene {{tasks}} tareas abiertas y {{appointments}} citas próximas."
+      },
+      "expenseSummary": {
+        "total": "Has registrado {{total}} {{currency}} en {{count}} gastos.",
+        "none": "Todavía no hay gastos registrados."
+      },
+      "addCareTask": {
+        "handoff": "He abierto una tarea nueva para que la confirmes."
+      },
+      "logExpense": {
+        "handoff": "He abierto un gasto nuevo para que lo confirmes."
+      },
+      "bookAppointment": {
+        "handoff": "Reservar requiere hora y pago, así que he abierto la búsqueda de clínicas."
+      }
+    }
   }
 }

--- a/apps/mobileAppYC/src/navigation/HomeStackNavigator.tsx
+++ b/apps/mobileAppYC/src/navigation/HomeStackNavigator.tsx
@@ -22,6 +22,7 @@ import {EditCoParentScreen} from '@/features/coParent/screens/EditCoParentScreen
 import {CoParentProfileScreen} from '@/features/coParent/screens/CoParentProfileScreen/CoParentProfileScreen';
 import {AdverseEventStackNavigator} from './AdverseEventStackNavigator';
 import {NotificationsScreen} from '@/features/notifications';
+import {AssistantScreen} from '@/features/assistant/screens';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
@@ -141,6 +142,11 @@ export const HomeStackNavigator: React.FC = () => {
       <Stack.Screen
         name="CoParentProfile"
         component={CoParentProfileScreen}
+        options={{headerShown: false}}
+      />
+      <Stack.Screen
+        name="Assistant"
+        component={AssistantScreen}
         options={{headerShown: false}}
       />
     </Stack.Navigator>

--- a/apps/mobileAppYC/src/navigation/types.ts
+++ b/apps/mobileAppYC/src/navigation/types.ts
@@ -54,6 +54,7 @@ export type HomeStackParamList = {
   AddCoParent: undefined;
   EditCoParent: {coParentId: string};
   CoParentProfile: {coParentId: string};
+  Assistant: undefined;
 };
 
 export type LinkedBusinessStackParamList = {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Pet owners can only reach their pets' information by opening the app and
navigating to it. Nothing is exposed to Siri, Spotlight, the Shortcuts app or
the Android launcher, and the app makes no use of the on-device models both
platforms now ship.

## What is the new behavior?

A pet care assistant. Owners can ask about their animals in plain language,
and Siri and the Android launcher can run the same actions from outside the
app.

**The core constraint: every fact the assistant states comes from the owner's
own records.** The platform language model may only *choose an action* or
*reword an answer that is already true*. A hallucinated vaccination date is
not reachable by construction.

### How a turn is answered

1. A deterministic rule parser routes the utterance. Offline, no model, works
   on every supported device.
2. The on-device model is consulted **only** when the rules are unsure. It may
   return an action id from the catalogue and nothing else.
3. A resolver reads Redux state. This is where the facts come from.
4. The model may then reword an already-true sentence.

Steps 2 and 4 are optional. If the model is missing, slow or wrong, the answer
is still correct - only its phrasing is plainer.

### Read vs handoff

Read actions (next appointment, vaccination status, what is due, pet summary,
spending) answer from a small offline snapshot, which is what lets Siri reply
without the app running.

Handoff actions (book, add a task, log an expense) **deliberately do not
commit anything**. Booking needs live availability and payment, and a
medication reminder deserves a human confirming the dose, so they open the app
at a deep link with the slots prefilled.

### Per platform

| | iOS | Android |
|---|---|---|
| OS assistant | App Intents: Siri, Spotlight, Shortcuts, Action button | App shortcuts: long-press, launcher search |
| In-app screen | Account -> Pet care assistant | same |
| On-device model | Foundation Models (iOS 26+) | deferred, see below |

Both surfaces are generated from one catalogue, so a capability is described
once and cannot drift between them.

### Two deliberate omissions

Neither is an oversight; both are recorded in `guides/assistantDoc.md` and in
the code.

- **Gemini Nano.** ML Kit's GenAI artifact declares `minSdkVersion 26` against
  this app's `minSdk 24`, needs AICore hardware that no emulator in the build
  fleet exposes, and is a beta API with no deprecation policy and a large
  transitive tree including its own play-services pin. Shipping a path that
  cannot be exercised anywhere would be unverifiable, so the Android bridge
  reports unavailable honestly and the UI explains it.
- **AppFunctions**, the Android counterpart that lets Gemini call an app's
  actions directly, requires Android 16 and is in a private preview limited to
  a short device list. App shortcuts reach every supported device today.

### Privacy

The snapshot holds pets, upcoming appointments, upcoming tasks and due
vaccinations, and nothing else - no tokens, no addresses, no clinical notes.
It is cleared on sign-out. The chat transcript is deliberately **not**
persisted (absent from the redux-persist whitelist), so pet health chatter
never reaches disk.

## Validation

Every number below is from a command run on this branch.

**Tests** - `npx jest --testPathPatterns="__tests__/features/assistant" --ci --coverage`

```
Test Suites: 20 passed, 20 total
Tests:       775 passed, 775 total
Statements   : 99.86%   Branches : 98.8%   Functions : 100%   Lines : 99.86%
```

**Type-check** - `npx tsc --noEmit` -> exit 0
**Lint** - `npx eslint src/features/assistant __tests__/features/assistant` -> exit 0

**iOS build** - `xcodebuild -workspace ios/mobileAppYC.xcworkspace -scheme mobileAppYC -sdk iphonesimulator` -> exit 0, zero compile errors, all ten Assistant sources compiled.

App Intents metadata extraction ran and produced `Metadata.appintents/` in the
app bundle containing all six intents, the `PetEntity`, and the compiled NLU
model Siri uses for phrase matching - so the intents are genuinely
discoverable, not merely compiling.

**Live on an iPhone 17 Pro simulator (iOS 26.5).** The native bridge reported
`{"available":true,"providerLabel":"Apple Intelligence"}`, so Foundation
Models was exercised for real. A typed question routed through the parser, ran
the resolver and rendered the answer with its date and time intact.

Three defects were found by visual QA and fixed:
- the transcript list was unconstrained and overflowed under the suggestion chips;
- the chips row was shrunk by its siblings and clipped every pill;
- the screen took no safe-area insets, so the title sat under the Dynamic Island.

### Bugs found and fixed before review

The suites were written adversarially against the implementation and found 17
real defects, all fixed in this PR. The most serious:

- `parseClockTime` normalised its input before matching, destroying the `:` it
  needed. `at 8:30 pm` resolved to **8am the next morning** - the mis-scheduled
  dose the module exists to prevent.
- `extractTaskTitle` built a `RegExp` from the raw pet name, so a pet called
  `C++` or `Mr. B` **threw and crashed** every reminder utterance.
- "How much have I spent on Bruno?" routed to the expense *form* rather than
  the total.
- An appointment whose time carried seconds became an Invalid Date and
  **vanished** from every answer.
- `formatDay` rendered a local date through `toISOString()`, labelling an
  untimed appointment the **previous day** anywhere east of UTC.
- A vaccination overdue by under twelve hours was counted **twice**.
- `parseAmount("1,234")` returned `1.23`; a leading minus was silently dropped.
- Spanish `esta noche` returned null - no Spanish parts of the day existed.
- A malformed `%` in an exported deep link threw a `URIError` out of the
  handler as an unhandled rejection. Mutation-checked: removing the guard fails
  the four new cases.

## Related Issue(s)

Relates to https://github.com/orgs/YosemiteCrew/discussions/777
