### PR TITLE
fix(dev-docs): declare x-org-id, and gate the spec against the routers

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,80 @@
+name: OpenAPI Drift
+
+# The published spec calls itself "generated from backend routers" but has no
+# generator, so it drifts silently. This walks the LIVE Express stack and fails
+# when an organisation-scoped route's operation does not declare `x-org-id` -
+# the header `withOrgPermissions()` needs, whose absence made every org-scoped
+# call from the rendered reference fail with a 400 (#2573).
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/backend/src/routers/**'
+      - 'apps/backend/src/middlewares/rbac.ts'
+      - 'apps/dev-docs/static/openapi.yaml'
+      - 'scripts/ci/openapi-drift.mjs'
+      - '.github/workflows/openapi-drift.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'apps/backend/src/routers/**'
+      - 'apps/backend/src/middlewares/rbac.ts'
+      - 'apps/dev-docs/static/openapi.yaml'
+      - 'scripts/ci/openapi-drift.mjs'
+      - '.github/workflows/openapi-drift.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: openapi-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  drift:
+    name: OpenAPI spec matches the routers
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The router graph imports services whose types come from these, and the
+      # Prisma client. Without them the import fails long before any route is
+      # walked.
+      - name: Build shared packages
+        run: pnpm --filter "@yosemite-crew/*" run build
+
+      - name: Generate Prisma client
+        run: pnpm --filter @yosemite-crew/database run prisma:generate
+
+      # Importing the routers runs module-level code that refuses to load
+      # without these. They are placeholders and are never used to reach any
+      # service - the script only walks the Express stack and exits.
+      - name: Check the spec against the mounted routes
+        working-directory: apps/backend
+        env:
+          STREAM_API_KEY: placeholder-for-route-introspection
+          STREAM_API_SECRET: placeholder-for-route-introspection
+          ENCRYPTION_KEY: not-a-real-key-route-introspection-only
+        run: pnpm exec tsx ../../scripts/ci/openapi-drift.mjs

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -59,14 +59,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # The router graph imports services whose types come from these, and the
-      # Prisma client. Without them the import fails long before any route is
-      # walked.
-      - name: Build shared packages
-        run: pnpm --filter "@yosemite-crew/*" run build
-
+      # Prisma first: packages/database compiles against the generated client,
+      # so building ahead of this fails on Prisma.JsonValue and Prisma.sql.
       - name: Generate Prisma client
         run: pnpm --filter @yosemite-crew/database run prisma:generate
+
+      # The router graph imports services whose types come from these. Without
+      # them the import fails long before any route is walked.
+      - name: Build shared packages
+        run: pnpm --filter "@yosemite-crew/*" run build
 
       # Importing the routers runs module-level code that refuses to load
       # without these. They are placeholders and are never used to reach any

--- a/apps/backend/src/middlewares/rbac.ts
+++ b/apps/backend/src/middlewares/rbac.ts
@@ -86,8 +86,24 @@ function extractOrgIdFromBody(body: unknown): string | null {
   return normalizeOrgId((body as Record<string, unknown>).organisationId);
 }
 
+/**
+ * Marks the middleware `withOrgPermissions()` returns, so tooling can tell which
+ * routes are organisation-scoped by walking the router stack.
+ *
+ * The returned closure is anonymous, so there is nothing else to match on -
+ * name-matching would break the moment it were renamed, and parsing the router
+ * source would miss anything composed indirectly. scripts/ci/openapi-drift.mjs
+ * reads this to decide which operations must declare the `x-org-id` header
+ * (#2573).
+ */
+export const REQUIRES_ORG = Symbol.for("yosemite.requiresOrgPermissions");
+
 export function withOrgPermissions() {
-  return async (req: Request, res: Response, next: NextFunction) => {
+  const middleware = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
     const typedReq = req as OrgRequest;
 
     const userId = typedReq.userId;
@@ -150,6 +166,10 @@ export function withOrgPermissions() {
       });
     }
   };
+
+  // Read by scripts/ci/openapi-drift.mjs when walking the router stack.
+  (middleware as unknown as Record<symbol, boolean>)[REQUIRES_ORG] = true;
+  return middleware;
 }
 
 /**

--- a/apps/dev-docs/static/openapi.yaml
+++ b/apps/dev-docs/static/openapi.yaml
@@ -112,6 +112,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -366,6 +372,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -396,6 +408,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -452,6 +470,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -483,6 +507,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -508,6 +538,12 @@ paths:
         - name: appointmentId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -672,6 +708,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -708,6 +750,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -727,6 +775,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -744,6 +798,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -771,6 +831,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -789,6 +855,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -810,6 +882,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -827,6 +905,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -849,6 +933,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -866,6 +956,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -888,6 +984,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -908,6 +1010,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -926,6 +1034,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -1525,6 +1639,13 @@ paths:
                 properties:
                   message:
                     type: string
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/companion-organisation/pms/reject':
     post:
       tags:
@@ -1561,6 +1682,13 @@ paths:
                 properties:
                   message:
                     type: string
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/companion-organisation/pms/{organisationId}/{companionId}/link':
     post:
       tags:
@@ -1638,6 +1766,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -1833,6 +1967,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -1936,6 +2076,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -1985,6 +2131,12 @@ paths:
           description: Identifies the organisation.
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -2041,6 +2193,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -2313,6 +2471,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         500:
           description: Response
@@ -2342,6 +2506,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         500:
           description: Response
@@ -2369,6 +2539,12 @@ paths:
         - name: months
           in: query
           required: false
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -2405,6 +2581,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         500:
           description: Response
@@ -2437,6 +2619,12 @@ paths:
         - name: range
           in: query
           required: false
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -2473,6 +2661,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         500:
           description: Response
@@ -2505,6 +2699,12 @@ paths:
         - name: year
           in: query
           required: false
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -2561,6 +2761,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -2959,6 +3165,13 @@ paths:
                 properties:
                   message:
                     type: string
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/document/pms/{companionId}':
     post:
       tags:
@@ -3003,6 +3216,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -3022,6 +3241,12 @@ paths:
         - name: documentId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       requestBody:
@@ -3081,6 +3306,12 @@ paths:
         - name: documentId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -3151,6 +3382,13 @@ paths:
                 properties:
                   message:
                     type: string
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/document/pms/appointments/{appointmentId}':
     post:
       tags:
@@ -3345,6 +3583,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         401:
           description: Response
@@ -3389,6 +3633,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -3427,6 +3677,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -3462,6 +3718,12 @@ paths:
         - name: formId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -3508,6 +3770,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         401:
           description: Response
@@ -3550,6 +3818,12 @@ paths:
         - name: formId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -3596,6 +3870,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         401:
           description: Response
@@ -3638,6 +3918,12 @@ paths:
         - name: formId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -3754,6 +4040,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -3785,6 +4077,12 @@ paths:
         - name: submissionId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -4130,6 +4428,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/inventory/items/{itemId}':
     patch:
       tags:
@@ -4259,6 +4564,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -4289,6 +4600,12 @@ paths:
         - name: to
           in: query
           required: false
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -4328,6 +4645,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -4358,6 +4681,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -4385,6 +4714,12 @@ paths:
         - name: batchId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -4419,6 +4754,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   /v1/inventory/stock/consume/bulk:
     post:
       tags:
@@ -4443,6 +4785,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/inventory/items/{itemId}/adjust':
     post:
       tags:
@@ -4455,6 +4804,12 @@ paths:
         - name: itemId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       requestBody:
@@ -4487,6 +4842,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -4515,6 +4876,12 @@ paths:
         - name: itemId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       requestBody:
@@ -4549,6 +4916,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/inventory/organisation/{organisationId}/vendors':
     get:
       tags:
@@ -4561,6 +4935,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -4585,6 +4965,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -4606,6 +4992,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -4625,6 +5017,12 @@ paths:
         - name: vendorId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -4651,6 +5049,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
     get:
       tags:
         - 'Non-FHIR'
@@ -4666,6 +5071,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/inventory/meta-fields/{fieldId}':
     patch:
       tags:
@@ -4678,6 +5090,12 @@ paths:
         - name: fieldId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -4699,6 +5117,12 @@ paths:
         - name: fieldId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -4723,6 +5147,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -4743,6 +5173,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -4897,6 +5333,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -5276,6 +5718,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/observation-tools/pms/submissions/{submissionId}':
     get:
       tags:
@@ -5288,6 +5737,12 @@ paths:
         - name: submissionId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -5310,6 +5765,12 @@ paths:
         - name: submissionId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -5422,6 +5883,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -5466,6 +5933,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -5495,6 +5968,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -5520,6 +5999,12 @@ paths:
         - name: documentId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       requestBody:
@@ -5556,6 +6041,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -5582,6 +6073,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -5602,6 +6099,12 @@ paths:
         - name: orgId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       requestBody:
@@ -5821,6 +6324,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -5869,6 +6378,12 @@ paths:
         - name: id
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -5920,6 +6435,12 @@ paths:
         - name: organizationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -6209,6 +6730,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -6259,6 +6786,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -6307,6 +6840,12 @@ paths:
         - name: organizationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -6360,6 +6899,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -6400,6 +6945,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -6460,6 +7011,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -6979,6 +7536,13 @@ paths:
                 properties:
                   message:
                     type: string
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/fhir/v1/parent/pms/parents/{id}':
     put:
       tags:
@@ -6991,6 +7555,12 @@ paths:
         - name: id
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -7161,6 +7731,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -7211,6 +7787,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -7251,6 +7833,12 @@ paths:
           description: Identifies the speciality being updated.
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
           schema:
             type: string
       responses:
@@ -7307,6 +7895,12 @@ paths:
         - name: specialityId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -7490,6 +8084,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -7523,6 +8123,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -7560,6 +8166,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -7593,6 +8205,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -7630,6 +8248,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -7665,6 +8289,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         200:
           description: Response
@@ -7698,6 +8328,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -7865,6 +8501,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/task/pms/from-template':
     post:
       tags:
@@ -7889,6 +8532,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   /v1/task/pms/custom:
     post:
       tags:
@@ -7913,6 +8563,13 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+      parameters:
+        - name: x-org-id
+          in: header
+          required: true
+          description: 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.'
+          schema:
+            type: string
   '/v1/task/pms/organisation/{organisationId}':
     get:
       tags:
@@ -7925,6 +8582,12 @@ paths:
         - name: organisationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -8208,6 +8871,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         400:
           description: Response
@@ -8327,6 +8996,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         201:
           description: Response
@@ -8359,6 +9034,12 @@ paths:
         - name: organizationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -8402,6 +9083,12 @@ paths:
         - name: organizationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:
@@ -8453,6 +9140,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
+          schema:
+            type: string
       responses:
         404:
           description: Response
@@ -8495,6 +9188,12 @@ paths:
         - name: organizationId
           in: path
           required: true
+          schema:
+            type: string
+        - name: x-org-id
+          in: header
+          required: false
+          description: Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.
           schema:
             type: string
       responses:

--- a/scripts/ci/openapi-add-org-header.mjs
+++ b/scripts/ci/openapi-add-org-header.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * One-off repair: adds the `x-org-id` header parameter to every organisation-
+ * scoped operation in apps/dev-docs/static/openapi.yaml that lacks it (#2573).
+ *
+ * Which operations are org-scoped comes from the LIVE router stack, via the same
+ * walk scripts/ci/openapi-drift.mjs uses, so this cannot disagree with the check
+ * that gates it.
+ *
+ * `required` is decided per route rather than blanket-set, because
+ * `extractOrgId` (middlewares/rbac.ts) reads the path params `orgId`,
+ * `organisationId` and `organizationId` BEFORE the header. Where the path
+ * already carries the organisation the header is genuinely optional, and
+ * marking it required there would send generated clients a header they do not
+ * need and make the spec wrong in the other direction.
+ *
+ * Edits through yaml's document API, which round-trips this file byte-identically,
+ * so the 424 hand-refined component schemas and every $ref into them survive.
+ *
+ *   node scripts/ci/openapi-add-org-header.mjs [--dry-run]
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parseDocument } from 'yaml';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SPEC_PATH = path.join(REPO_ROOT, 'apps/dev-docs/static/openapi.yaml');
+const REQUIRES_ORG = Symbol.for('yosemite.requiresOrgPermissions');
+
+/** The path params extractOrgId consults before falling back to the header. */
+const ORG_PATH_PARAMS = ['orgId', 'organisationId', 'organizationId'];
+
+const toOpenApiPath = (p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
+const joinPath = (base, route) => {
+  const joined = `${base}${route}`.replace(/\/{2,}/g, '/');
+  return joined.length > 1 ? joined.replace(/\/$/, '') : joined;
+};
+
+const collectOrgScoped = (registerRoutes) => {
+  const orgScoped = new Set();
+  const isRouter = (v) =>
+    v != null && (typeof v === 'object' || typeof v === 'function') && Array.isArray(v.stack);
+
+  const readRouter = (base, router) => {
+    for (const layer of router.stack ?? []) {
+      if (!layer.route) continue;
+      if (!(layer.route.stack ?? []).some((h) => h.handle && h.handle[REQUIRES_ORG] === true))
+        continue;
+      for (const method of Object.keys(layer.route.methods ?? {})) {
+        orgScoped.add(`${method.toUpperCase()} ${toOpenApiPath(joinPath(base, layer.route.path))}`);
+      }
+    }
+  };
+
+  const app = new Proxy(
+    {
+      use: (...args) => {
+        const base = typeof args[0] === 'string' ? args[0] : '';
+        for (const arg of args) if (isRouter(arg)) readRouter(base, arg);
+      },
+    },
+    {
+      get: (target, prop) =>
+        prop in target
+          ? target[prop]
+          : (routePath, ...handlers) => {
+              if (typeof routePath !== 'string') return;
+              if (!handlers.some((h) => h && h[REQUIRES_ORG] === true)) return;
+              orgScoped.add(`${String(prop).toUpperCase()} ${toOpenApiPath(routePath)}`);
+            },
+    }
+  );
+
+  registerRoutes(app);
+  return orgScoped;
+};
+
+const main = async () => {
+  const { registerRoutes } = await import(
+    path.join(REPO_ROOT, 'apps/backend/src/routers/index.ts')
+  );
+  const orgScoped = collectOrgScoped(registerRoutes);
+
+  const doc = parseDocument(readFileSync(SPEC_PATH, 'utf8'));
+  const paths = doc.get('paths');
+  const added = [];
+
+  for (const pathItem of paths.items) {
+    const rawPath = String(pathItem.key.value);
+    const suppliedByPath = ORG_PATH_PARAMS.some((p) => rawPath.includes(`{${p}}`));
+
+    for (const opEntry of pathItem.value.items ?? []) {
+      const verb = String(opEntry.key.value).toUpperCase();
+      if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(verb)) continue;
+      if (!orgScoped.has(`${verb} ${rawPath}`)) continue;
+
+      const op = opEntry.value;
+      const params = op.get('parameters');
+      const already = (params?.items ?? []).some((p) => {
+        const name = p.get?.('name');
+        const location = p.get?.('in');
+        return location === 'header' && String(name).toLowerCase() === 'x-org-id';
+      });
+      if (already) continue;
+
+      const header = doc.createNode({
+        name: 'x-org-id',
+        in: 'header',
+        required: !suppliedByPath,
+        description: suppliedByPath
+          ? 'Organisation the request acts on. Optional here because the path already carries it; sent otherwise it is ignored in favour of the path.'
+          : 'Organisation the request acts on. Required: this route has no organisation in its path, and the request is rejected with 400 without it.',
+        schema: { type: 'string' },
+      });
+
+      if (params) params.add(header);
+      else op.set('parameters', doc.createNode([header]));
+      added.push(`${verb} ${rawPath}${suppliedByPath ? ' (optional)' : ' (required)'}`);
+    }
+  }
+
+  if (process.argv.includes('--dry-run')) {
+    console.log(`would add x-org-id to ${added.length} operation(s)`);
+    for (const a of added.slice(0, 20)) console.log('  ', a);
+    process.exit(0);
+  }
+
+  writeFileSync(SPEC_PATH, doc.toString({ lineWidth: 0 }));
+  console.log(`added x-org-id to ${added.length} operation(s)`);
+  process.exit(0);
+};
+
+main().catch((err) => {
+  console.error('openapi-add-org-header failed:', err);
+  process.exit(2);
+});

--- a/scripts/ci/openapi-add-org-header.mjs
+++ b/scripts/ci/openapi-add-org-header.mjs
@@ -29,6 +29,12 @@ const SPEC_PATH = path.join(REPO_ROOT, 'apps/dev-docs/static/openapi.yaml');
 const REQUIRES_ORG = Symbol.for('yosemite.requiresOrgPermissions');
 
 /** The path params extractOrgId consults before falling back to the header. */
+/* Matches the verb list the drift gate checks, so "every organisation-scoped
+   operation" above means the same set in both scripts. The spec carries no
+   HEAD or OPTIONS operations today; including them keeps the two in step if
+   one is ever added. */
+const HTTP_VERBS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+
 const ORG_PATH_PARAMS = ['orgId', 'organisationId', 'organizationId'];
 
 const toOpenApiPath = (p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
@@ -92,7 +98,7 @@ const main = async () => {
 
     for (const opEntry of pathItem.value.items ?? []) {
       const verb = String(opEntry.key.value).toUpperCase();
-      if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(verb)) continue;
+      if (!HTTP_VERBS.includes(verb)) continue;
       if (!orgScoped.has(`${verb} ${rawPath}`)) continue;
 
       const op = opEntry.value;

--- a/scripts/ci/openapi-drift.mjs
+++ b/scripts/ci/openapi-drift.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Fails when apps/dev-docs/static/openapi.yaml has drifted from the routers.
+ *
+ * The published spec calls itself "generated from backend routers", but there is
+ * no generator in the repo - it was produced once and committed, so it cannot
+ * track what it claims to describe. The visible symptom was that 276 operations
+ * declared `x-org-id` zero times, while `withOrgPermissions()` answers 400 when
+ * no organisation can be extracted and the header is the only source on many
+ * routes. A client generated from the spec sent requests that could not succeed
+ * (#2573).
+ *
+ * This checks rather than regenerates, deliberately. The spec carries 424
+ * hand-refined `components.schemas` entries and `$ref`s into them; rewriting it
+ * from a router walk would produce mechanically correct paths and throw all of
+ * that away. So the routers stay the source of truth for WHICH routes exist and
+ * which are org-scoped, and the spec stays the source of truth for their shapes.
+ *
+ * Route facts come from the live Express stack rather than from parsing source:
+ * a router composed indirectly, or a middleware applied through a helper, is
+ * invisible to a grep and present here.
+ *
+ *   node scripts/ci/openapi-drift.mjs            # report and exit non-zero on drift
+ *   node scripts/ci/openapi-drift.mjs --json     # machine-readable
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parse } from 'yaml';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SPEC_PATH = path.join(REPO_ROOT, 'apps/dev-docs/static/openapi.yaml');
+const ORG_HEADER = 'x-org-id';
+const REQUIRES_ORG = Symbol.for('yosemite.requiresOrgPermissions');
+
+/** Express path params (`:id`) to OpenAPI templates (`{id}`). */
+const toOpenApiPath = (p) => p.replace(/:([A-Za-z0-9_]+)/g, '{$1}');
+
+const joinPath = (base, route) => {
+  const joined = `${base}${route}`.replace(/\/{2,}/g, '/');
+  return joined.length > 1 ? joined.replace(/\/$/, '') : joined;
+};
+
+/**
+ * Records what `registerRoutes` mounts. Only the verbs and `use` are needed;
+ * anything else an Express app is asked for is a no-op so the import does not
+ * die on a method this stub does not model.
+ */
+const collectRoutes = (registerRoutes) => {
+  const found = [];
+
+  const readRouter = (base, router) => {
+    for (const layer of router.stack ?? []) {
+      if (!layer.route) continue;
+      const handlers = layer.route.stack ?? [];
+      const orgScoped = handlers.some((h) => h.handle && h.handle[REQUIRES_ORG] === true);
+      for (const method of Object.keys(layer.route.methods ?? {})) {
+        found.push({
+          method: method.toUpperCase(),
+          path: toOpenApiPath(joinPath(base, layer.route.path)),
+          orgScoped,
+        });
+      }
+    }
+  };
+
+  /* An Express Router is a FUNCTION carrying a `stack`, not a plain object, so
+     a `typeof === 'object'` test silently matches nothing and the walk reports
+     one route. */
+  const isRouter = (v) =>
+    v != null && (typeof v === 'object' || typeof v === 'function') && Array.isArray(v.stack);
+
+  const app = new Proxy(
+    {
+      use: (...args) => {
+        const base = typeof args[0] === 'string' ? args[0] : '';
+        for (const arg of args) if (isRouter(arg)) readRouter(base, arg);
+      },
+    },
+    {
+      get(target, prop) {
+        if (prop in target) return target[prop];
+        // A verb registered straight on the app rather than through a router.
+        return (routePath, ...handlers) => {
+          if (typeof routePath !== 'string') return;
+          const orgScoped = handlers.some((h) => h && h[REQUIRES_ORG] === true);
+          found.push({
+            method: String(prop).toUpperCase(),
+            path: toOpenApiPath(routePath),
+            orgScoped,
+          });
+        };
+      },
+    }
+  );
+
+  registerRoutes(app);
+  return found;
+};
+
+const specOperations = (spec) => {
+  const ops = new Map();
+  for (const [rawPath, item] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(item ?? {})) {
+      const verb = method.toUpperCase();
+      if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].includes(verb)) continue;
+      const params = [...(item.parameters ?? []), ...(op?.parameters ?? [])];
+      const declaresOrgHeader = params.some(
+        (p) => p && p.in === 'header' && String(p.name).toLowerCase() === ORG_HEADER
+      );
+      ops.set(`${verb} ${rawPath}`, { declaresOrgHeader });
+    }
+  }
+  return ops;
+};
+
+const main = async () => {
+  const { registerRoutes } = await import(
+    path.join(REPO_ROOT, 'apps/backend/src/routers/index.ts')
+  );
+
+  const routes = collectRoutes(registerRoutes);
+  const spec = parse(readFileSync(SPEC_PATH, 'utf8'));
+  const ops = specOperations(spec);
+
+  const missingFromSpec = [];
+  const missingOrgHeader = [];
+
+  for (const route of routes) {
+    const key = `${route.method} ${route.path}`;
+    const op = ops.get(key);
+    if (!op) {
+      missingFromSpec.push(key);
+      continue;
+    }
+    if (route.orgScoped && !op.declaresOrgHeader) missingOrgHeader.push(key);
+  }
+
+  const mounted = new Set(routes.map((r) => `${r.method} ${r.path}`));
+  const staleInSpec = [...ops.keys()].filter((k) => !mounted.has(k));
+
+  const report = {
+    mountedRoutes: routes.length,
+    orgScopedRoutes: routes.filter((r) => r.orgScoped).length,
+    specOperations: ops.size,
+    missingFromSpec,
+    missingOrgHeader,
+    staleInSpec,
+  };
+
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(
+      `openapi-drift: ${report.mountedRoutes} mounted routes, ` +
+        `${report.orgScopedRoutes} organisation-scoped, ${report.specOperations} spec operations`
+    );
+    const show = (label, list) => {
+      if (list.length === 0) return;
+      console.log(`\n${label} (${list.length}):`);
+      for (const k of list.slice(0, 40)) console.log(`  ${k}`);
+      if (list.length > 40) console.log(`  ... and ${list.length - 40} more`);
+    };
+    show('Mounted but absent from the spec', missingFromSpec);
+    show(`Organisation-scoped but missing the ${ORG_HEADER} header`, missingOrgHeader);
+    show('In the spec but no longer mounted', staleInSpec);
+  }
+
+  /* Only the org-header check is fatal for now. The route-coverage counts are
+     reported so the gap is visible, but failing on them today would block every
+     PR on a backlog this change does not attempt to clear - the header is the
+     defect #2573 is about, and it is the one that makes generated clients send
+     requests that cannot succeed. */
+  /* A guard on the guard. If the REQUIRES_ORG marker ever stops being applied -
+     renamed, dropped in a refactor, or lost because a router composes the
+     middleware some new way - every route reads as unscoped, `missingOrgHeader`
+     is empty and this check passes while verifying nothing. There are 745
+     org-scoped routes today; zero means the detection broke, not that the
+     codebase changed. */
+  if (report.orgScopedRoutes === 0) {
+    console.error(
+      '\nopenapi-drift: no organisation-scoped routes were detected, which cannot be right. ' +
+        'The REQUIRES_ORG marker set in middlewares/rbac.ts is probably no longer reaching the ' +
+        'router stack, so this check is verifying nothing.'
+    );
+    process.exit(1);
+  }
+
+  if (missingOrgHeader.length > 0) {
+    console.error(
+      `\nopenapi-drift: ${missingOrgHeader.length} organisation-scoped operation(s) do not ` +
+        `declare the ${ORG_HEADER} header, so a client generated from this spec would be ` +
+        `rejected with 400 before reaching a controller.`
+    );
+    process.exit(1);
+  }
+
+  /* Importing the routers pulls in clients and timers that keep the loop alive,
+     so the process is ended explicitly rather than left to hang in CI. */
+  process.exit(0);
+};
+
+main().catch((err) => {
+  console.error('openapi-drift failed to run:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes #2573

## The header

The published spec omitted `x-org-id` on every operation. `withOrgPermissions()` answers **400** when no organisation can be extracted, and on many routes the header is the only source — so a client generated from the spec sent requests that could not succeed.

It is now declared on the **114** organisation-scoped operations the spec describes.

**`required` is decided per route rather than blanket-set.** `extractOrgId` reads the path params `orgId`, `organisationId` and `organizationId` *before* the header, so where the path already carries the organisation the header is genuinely optional — marking it required there would make the spec wrong in the other direction.

```
POST /fhir/v1/appointment/pms                              (required)
GET  /fhir/v1/appointment/pms/organisation/{organisationId} (optional)
```

## The header was a symptom

The spec calls itself *"generated from backend routers"* and there is no generator, so it cannot track what it claims to describe. `scripts/ci/openapi-drift.mjs` now walks the **live Express stack** — not the source, so a router composed indirectly or a middleware applied through a helper is still seen — and fails when an org-scoped route's operation does not declare the header. Wired into CI.

**It checks rather than regenerates, deliberately.** The spec carries **424** refined `components.schemas` and `$ref`s into them. Rebuilding from a router walk would produce mechanically correct paths and throw all of that away. So the routers stay the source of truth for *which* routes exist and which are org-scoped; the spec stays the source of truth for their *shapes*. The repair added 699 lines and **deleted none**.

## Detection needed a marker, and the marker needed a guard

`withOrgPermissions()` returns an anonymous closure — there is nothing to match on. It now carries a `REQUIRES_ORG` symbol, read off the router stack.

That creates a way for the check to pass while verifying nothing: if the marker ever stops being applied, every route reads as unscoped and the check goes green over a broken detector. **So the script also fails when it detects zero org-scoped routes** — there are 745 today, and zero means the marker broke, not that the codebase changed.

Both guards mutation-verified:

| mutation | result |
|---|---|
| remove one `x-org-id` block from the spec | exit 1, names the operation |
| remove the `REQUIRES_ORG` marker from `rbac.ts` | exit 1, "no organisation-scoped routes were detected" |

## The scale is worse than the issue recorded

The issue measured 276 operations with 0 mentions of the header. Walking the live stack:

| | |
|---|---|
| routes actually mounted | **1029** |
| organisation-scoped | **745** |
| operations in the spec | **274** |
| mounted but absent from the spec | **790** |
| in the spec but no longer mounted | **35** |

**The spec describes about a quarter of the API.** The script reports all of this but only *fails* on the header, because failing on coverage today would block every PR on a backlog this change does not attempt to clear. The header is the defect #2573 is about and the one that makes generated clients send requests that cannot succeed.

## One note for whoever runs this

Importing the router graph runs module-level code that throws without `STREAM_API_KEY`, `STREAM_API_SECRET` and `ENCRYPTION_KEY`. The workflow supplies obvious placeholders; they are never used to reach a service, since the script only walks the stack and exits. My first version used a hex-looking placeholder for `ENCRYPTION_KEY` and the staged-secret scanner correctly flagged it — it is now plainly not a key.

## Validation

- **459 suites / 11096 backend tests pass**; `tsc` **0 errors**, `lint` **exit 0**
- YAML round-trip through `yaml`'s document API is **byte-identical** on this file, which is what makes the targeted edit safe
- The checker was run before and after the repair: 114 missing → 0