### PR TITLE
fix(backend): apply the configured buffer when building public booking slots

### DIFF
--- a/apps/backend/src/services/availability.service.ts
+++ b/apps/backend/src/services/availability.service.ts
@@ -193,8 +193,14 @@ export function generateBookableWindows(
   date: string,
   slots: AvailabilitySlotMongo[],
   windowMinutes: number,
+  bufferMinutes = 0,
 ): AvailabilitySlotMongo[] {
   const results: AvailabilitySlotMongo[] = [];
+  // The buffer is dead time between visits, so it widens the stride to the next
+  // slot but never the visit itself: a window is still `windowMinutes` long, and
+  // the last visit in an availability block may end exactly at `end` with no
+  // trailing buffer wasted. A buffer of 0 reproduces back-to-back tiling.
+  const stride = windowMinutes + Math.max(0, bufferMinutes);
 
   for (const slot of slots) {
     const start = dayjs.utc(`${date}T${slot.startTime}:00`);
@@ -215,7 +221,7 @@ export function generateBookableWindows(
         isAvailable: true,
       });
 
-      cursor = windowEnd;
+      cursor = cursor.add(stride, "minute");
     }
   }
 
@@ -822,6 +828,7 @@ export const AvailabilityService = {
     userId: string,
     windowMinutes: number,
     referenceDate: Date,
+    bufferMinutes = 0,
   ) {
     const safeReferenceDate = ensureValidDate(referenceDate, "referenceDate");
 
@@ -836,7 +843,12 @@ export const AvailabilityService = {
     const slots = finalForDate.slots;
 
     // 2. Generate bookable windows
-    const windows = generateBookableWindows(dateStr, slots, windowMinutes);
+    const windows = generateBookableWindows(
+      dateStr,
+      slots,
+      windowMinutes,
+      bufferMinutes,
+    );
 
     return {
       date: dateStr,

--- a/apps/backend/src/services/catalog.service.ts
+++ b/apps/backend/src/services/catalog.service.ts
@@ -2533,6 +2533,7 @@ export const CatalogService = {
     productItemId: string,
     organisationId: string,
     referenceDate: Date,
+    bufferMinutes = 0,
   ) {
     const context = await resolveCatalogSchedulingContext(
       productItemId,
@@ -2544,6 +2545,7 @@ export const CatalogService = {
       vetIds: context.vetIds,
       durationMinutes: context.durationMinutes,
       referenceDate,
+      bufferMinutes,
       getBookableSlotsForDate: (...args) =>
         AvailabilityService.getBookableSlotsForDate(...args),
     });

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -326,10 +326,17 @@ export const PublicBookingService = {
     // answer as asking for one that does not exist.
     if (!service) throw notFound();
 
+    // "Buffer between visits" is a public-booking setting: it spaces the offered
+    // slots so anonymous requests cannot be booked back to back. It applies only
+    // here - the signed-in scheduling paths call getBookableSlotsService without
+    // it and keep tiling with no gap.
+    const bufferMinutes = Math.max(0, practice.settings?.bufferMinutes ?? 0);
+
     const result = await CatalogService.getBookableSlotsService(
       serviceId,
       practice.organizationId,
       date.toDate(),
+      bufferMinutes,
     );
 
     return {

--- a/apps/backend/src/utils/scheduling.ts
+++ b/apps/backend/src/utils/scheduling.ts
@@ -254,14 +254,19 @@ export const buildBookableWindowsForVets = async <
   vetIds: string[];
   durationMinutes: number;
   referenceDate: Date;
+  bufferMinutes?: number;
   slotCache?: Map<string, Promise<BookableWindowResult<TSlot>>>;
   getBookableSlotsForDate: (
     organisationId: string,
     vetId: string,
     durationMinutes: number,
     referenceDate: Date,
+    bufferMinutes: number,
   ) => Promise<BookableWindowResult<TSlot>>;
 }): Promise<BookableWindowSet<TSlot>> => {
+  // Empty gap between visits by default: callers that do not set a buffer (the
+  // signed-in scheduling paths) tile back to back exactly as before.
+  const bufferMinutes = Math.max(0, params.bufferMinutes ?? 0);
   if (params.vetIds.length === 0) {
     return {
       date: dayjs(params.referenceDate).utc().format("YYYY-MM-DD"),
@@ -277,6 +282,7 @@ export const buildBookableWindowsForVets = async <
       params.organisationId,
       vetId,
       params.durationMinutes,
+      bufferMinutes,
       dayjs(params.referenceDate).utc().format("YYYY-MM-DD"),
     ].join("|");
 
@@ -288,6 +294,7 @@ export const buildBookableWindowsForVets = async <
         vetId,
         params.durationMinutes,
         params.referenceDate,
+        bufferMinutes,
       );
 
     if (!cachedResult && params.slotCache) {

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -73,6 +73,48 @@ describe("AvailabilityService", () => {
       const windows = generateBookableWindows("2026-03-09", slots, 30);
       expect(windows).toHaveLength(0);
     });
+
+    it("spaces windows by the buffer without lengthening the visit", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "11:00", isAvailable: true },
+      ];
+      // 30-minute visits with a 15-minute buffer: each visit stays 30 minutes,
+      // the next one starts 15 minutes after the previous ends, and the last
+      // visit may end exactly at the slot boundary with no trailing buffer.
+      const windows = generateBookableWindows("2026-03-09", slots, 30, 15);
+
+      expect(windows).toEqual([
+        { startTime: "09:00", endTime: "09:30", isAvailable: true },
+        { startTime: "09:45", endTime: "10:15", isAvailable: true },
+        { startTime: "10:30", endTime: "11:00", isAvailable: true },
+      ]);
+    });
+
+    it("tiles back to back when the buffer is zero", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "10:00", isAvailable: true },
+      ];
+      // Guard on the guard: an explicit zero buffer must reproduce the
+      // no-argument tiling exactly, so the buffer thread cannot regress the
+      // signed-in scheduling paths that never pass one.
+      expect(generateBookableWindows("2026-03-09", slots, 30, 0)).toEqual(
+        generateBookableWindows("2026-03-09", slots, 30),
+      );
+    });
+
+    it("drops a trailing visit that no longer fits once the buffer shifts it", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "10:00", isAvailable: true },
+      ];
+      // Back to back this is two 30-minute windows. A 15-minute buffer pushes
+      // the second start to 09:45, whose visit would end at 10:15, past the
+      // slot - so only the first window survives.
+      const windows = generateBookableWindows("2026-03-09", slots, 30, 15);
+
+      expect(windows).toEqual([
+        { startTime: "09:00", endTime: "09:30", isAvailable: true },
+      ]);
+    });
   });
 
   describe("Base Availability", () => {

--- a/apps/backend/test/services/public-booking.service.test.ts
+++ b/apps/backend/test/services/public-booking.service.test.ts
@@ -335,6 +335,52 @@ describe("public-booking.service", () => {
       expect(JSON.stringify(result)).not.toContain("staff-1");
     });
 
+    it("passes the practice's configured buffer to the slot generator", async () => {
+      await PublicBookingService.getSlots(
+        "park-veterinary",
+        SERVICE_ID,
+        tomorrow(),
+      );
+
+      // The 4th argument is the buffer, read from bookingSettings (10 in the
+      // fixture). Without the wiring it defaults to 0 and public slots tile back
+      // to back regardless of the "Buffer between visits" setting.
+      expect(slotsMock).toHaveBeenCalledWith(
+        SERVICE_ID,
+        "org-1",
+        expect.any(Date),
+        10,
+      );
+    });
+
+    it("passes a zero buffer when the setting is unset", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [SERVICE_ID],
+            bookingWindowDays: 28,
+            bufferMinutes: 0,
+            autoConfirm: false,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      await PublicBookingService.getSlots(
+        "park-veterinary",
+        SERVICE_ID,
+        tomorrow(),
+      );
+
+      expect(slotsMock).toHaveBeenCalledWith(
+        SERVICE_ID,
+        "org-1",
+        expect.any(Date),
+        0,
+      );
+    });
+
     it("refuses a date beyond the practice's booking window", async () => {
       const far = new Date();
       far.setUTCDate(far.getUTCDate() + 400);


### PR DESCRIPTION
Closes #2552.

## What was wrong

The public booking page exposes a **"Buffer between visits"** setting. It is validated, persisted, and read back into the setup wizard — but nothing in the scheduling path ever consumed it. `bufferMinutes` appeared exactly twice in `public-booking.service.ts` (the `ResolvedPractice` type and the Prisma `select`) and was dead after the select, so public slots tiled back to back whether a practice picked 0, 10, 15 or 30 minutes.

## The fix

Thread the buffer from the setting down to the tiler, **defaulting to 0 the whole way** so the signed-in scheduling paths are byte-for-byte unchanged:

- **`generateBookableWindows`** widens the *stride* to the next slot by the buffer, never the visit itself. A window stays `durationMinutes` long, and the last visit in an availability block may still end exactly at the block boundary — a buffer is dead time *between* visits, not a trailing pad. Buffer 0 reproduces the old back-to-back tiling.
- **`getBookableSlotsForDate`** and **`buildBookableWindowsForVets`** forward it; the latter also keys its per-vet slot cache on the buffer so two different buffers can't collide.
- **`getBookableSlotsService`** accepts it (4th arg, default 0).
- **`PublicBookingService.getSlots`** passes `bookingSettings.bufferMinutes`. The two signed-in callers (`catalog.controller`, `service.controller`) pass nothing and keep tiling with no gap.

Only the anonymous public path changes.

## Worked example

A 30-minute service in a 09:00–11:00 availability block, buffer 15:

| | start | end |
|--|--|--|
| visit 1 | 09:00 | 09:30 |
| visit 2 | 09:45 | 10:15 |
| visit 3 | 10:30 | 11:00 |

Visits stay 30 minutes; each next start is 15 minutes after the previous end; no trailing buffer is wasted.

## Tests (all mutation-checked)

- Tiler: spaces 30-min visits by a 15-min buffer to exactly the table above; reproduces back-to-back tiling at buffer 0 (guard-on-the-guard, equality against the no-arg call); drops a trailing visit the buffer no longer leaves room for.
- Service: `getSlots` forwards the configured buffer (10) and forwards 0 when the setting is unset.

Reverting the stride to ignore the buffer fails the two spacing tests; dropping the argument from `getSlots` fails the two wiring tests. **265/265 across the five affected suites** (availability, scheduling, public-booking, catalog, service), `tsc` 0 errors.

## Not in scope

Sibling issues #2554 (200-row cap) and #2550 (autoConfirm) are separate and untouched here.