### PR TITLE
docs(desktop): mark recordWaste as the unwired stricter variant, not the live policy

### DIFF
--- a/apps/desktop/src/compliance/dual-witness.ts
+++ b/apps/desktop/src/compliance/dual-witness.ts
@@ -22,6 +22,16 @@ export interface WasteEvent {
 }
 
 export interface DualWitnessLog {
+  /**
+   * A stricter waste-recording variant that is NOT the live policy: no IPC
+   * channel or menu action calls it. The live path is the `yc:cs-record`
+   * handler in core/ipc-handlers.ts, which records the waste through the
+   * controlled-substance logbook even when the witness PIN did not verify (with
+   * `witnessPinVerified: false`), and that is deliberate - refusing unverified
+   * waste would silently drop every record and make the DEA biennial report in
+   * dea-report.ts overstate ending inventory. Read the definition's comment
+   * before assuming the rejection below is in force anywhere.
+   */
   recordWaste: (
     event: Omit<WasteEvent, 'id' | 'timestamp' | 'csTransactionId' | 'witnessPinVerified'> & {
       witnessPin: string;
@@ -120,6 +130,13 @@ export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
     return verifyPinHash(pin, account.pinHash);
   };
 
+  // NOT wired to any live path (see the DualWitnessLog interface comment). This
+  // is the stricter alternative to the shipping policy: it declines to write a
+  // controlled-substance transaction when the witness PIN did not verify, where
+  // the live yc:cs-record handler writes it with witnessPinVerified: false. The
+  // live, lenient policy is the intended one; this stays as the tested
+  // reference for what a reject-on-unverified path would look like, should a
+  // witness-enrolment flow ever make refusal safe.
   const recordWaste = (
     input: { witnessPin: string } & Omit<
       WasteEvent,
@@ -219,7 +236,9 @@ export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
   const getWasteEvents = (drugName?: string): WasteEvent[] => {
     const txs = drugName ? deps.logbook.getByDrug(drugName) : deps.logbook.getTransactions();
     const isVerified = verifiedFromAuditTrail();
-    return txs.filter((tx) => tx.action === 'waste').map((tx) => txToWasteEvent(tx, isVerified(tx)));
+    return txs
+      .filter((tx) => tx.action === 'waste')
+      .map((tx) => txToWasteEvent(tx, isVerified(tx)));
   };
 
   const getVerifiedWasteEvents = (drugName?: string): WasteEvent[] =>


### PR DESCRIPTION
Closes #2561.

## The ambiguity

`recordWaste` (`apps/desktop/src/compliance/dual-witness.ts`) and the live `yc:cs-record` handler (`apps/desktop/src/core/ipc-handlers.ts`) state **opposite** controlled-substance policies:

- `recordWaste` declines to write a waste transaction when the witness PIN did not verify.
- the handler records it anyway, with `witnessPinVerified: false`.

`recordWaste` has **zero production callers**, so a reader who meets it first believes the stricter rule is in force on a DEA-relevant path. It is not — and the handler's lenient behaviour is deliberate and tested (`ipc-handlers.test.ts`): because nothing enrols entries in the witness map, refusing unverified waste would drop every waste record and make the DEA biennial report in `dea-report.ts` **overstate** ending inventory.

## The fix

Comment-only. The `DualWitnessLog` interface and the `recordWaste` definition now both say plainly that it is not wired to any live path, name the live policy and where it lives, and explain why the lenient policy is the deliberate one. No behaviour changes.

## Why clarified, not deleted

The issue offered either. Deletion looks like the tidier option until you follow the tests: `recordWaste` is the fixture path the **live** read/verify methods are tested through — `getWasteEvents`, `getWasteByWitness`, `getVerifiedWasteEvents`, all consumed by the DEA report. Those read from the controlled-substance logbook, and `recordWaste` is how ~9 test sites populate it. Deleting it means rewriting that harness to write through `logbook.record` directly — a test-surgery change on a controlled-substance path, for something the issue itself calls "not a live defect."

The actual problem this issue raises is the ambiguity between two policy statements. Clarifying the comments removes it in full without disturbing that coverage. If a maintainer later wants the dead path gone, the comment now makes that a safe, informed deletion.

## Validation

25/25 dual-witness + waste-witness tests pass, `tsc --noEmit` 0 errors, lint clean.