### PR TITLE
fix(backend): stop history from hiding actionable public booking requests

### DIFF
--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -488,6 +488,28 @@ const practiceNotificationEmail = (request: StoredRequest) => {
   };
 };
 
+/** One page of requests. History gets a smaller slice: it is context, not work. */
+const REQUEST_PAGE_SIZE = 200;
+const HISTORY_PAGE_SIZE = 50;
+
+/** The fields the practice queue and its history rows both render. */
+const BOOKING_REQUEST_SELECT = {
+  id: true,
+  serviceName: true,
+  requestedStart: true,
+  requestedEnd: true,
+  durationMinutes: true,
+  ownerName: true,
+  ownerEmail: true,
+  ownerPhone: true,
+  petName: true,
+  petSpecies: true,
+  concern: true,
+  status: true,
+  confirmedAt: true,
+  createdAt: true,
+} as const;
+
 export const PublicBookingRequestService = {
   /**
    * Accept a booking request and email the requester a confirmation link.
@@ -669,30 +691,42 @@ export const PublicBookingRequestService = {
       "organisationId",
     );
 
-    return prisma.publicBookingRequest.findMany({
-      where: {
-        organizationId: safeOrganisationId,
-        status: status ?? { in: ["CONFIRMED", "DECLINED", "BOOKED"] },
-      },
-      orderBy: { requestedStart: "asc" },
-      take: 200,
-      select: {
-        id: true,
-        serviceName: true,
-        requestedStart: true,
-        requestedEnd: true,
-        durationMinutes: true,
-        ownerName: true,
-        ownerEmail: true,
-        ownerPhone: true,
-        petName: true,
-        petSpecies: true,
-        concern: true,
-        status: true,
-        confirmedAt: true,
-        createdAt: true,
-      },
-    });
+    // An explicit status is one capped page of that single status.
+    if (status) {
+      return prisma.publicBookingRequest.findMany({
+        where: { organizationId: safeOrganisationId, status },
+        orderBy: { requestedStart: "asc" },
+        take: REQUEST_PAGE_SIZE,
+        select: BOOKING_REQUEST_SELECT,
+      });
+    }
+
+    // Default view: actionable requests must never be crowded out of the page by
+    // history. CONFIRMED is the only status the practice acts on; BOOKED and
+    // DECLINED are already dealt with. A single `requestedStart`-ordered page
+    // capped at 200 let past-dated history sort to the front and push future
+    // actionable requests off the end. Querying the two sets separately makes
+    // that impossible - every actionable request up to the cap is returned,
+    // followed by a bounded, most-recent slice of history for context.
+    const [actionable, history] = await Promise.all([
+      prisma.publicBookingRequest.findMany({
+        where: { organizationId: safeOrganisationId, status: "CONFIRMED" },
+        orderBy: { requestedStart: "asc" },
+        take: REQUEST_PAGE_SIZE,
+        select: BOOKING_REQUEST_SELECT,
+      }),
+      prisma.publicBookingRequest.findMany({
+        where: {
+          organizationId: safeOrganisationId,
+          status: { in: ["BOOKED", "DECLINED"] },
+        },
+        orderBy: { requestedStart: "desc" },
+        take: HISTORY_PAGE_SIZE,
+        select: BOOKING_REQUEST_SELECT,
+      }),
+    ]);
+
+    return [...actionable, ...history];
   },
 
   /**

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc.js";
 import customParseFormat from "dayjs/plugin/customParseFormat.js";
+import { Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { CatalogService } from "./catalog.service";
 import { resolveBookingPageUrl } from "./booking-page.service";
@@ -708,23 +709,33 @@ export const PublicBookingRequestService = {
     // actionable requests off the end. Querying the two sets separately makes
     // that impossible - every actionable request up to the cap is returned,
     // followed by a bounded, most-recent slice of history for context.
-    const [actionable, history] = await Promise.all([
-      prisma.publicBookingRequest.findMany({
-        where: { organizationId: safeOrganisationId, status: "CONFIRMED" },
-        orderBy: { requestedStart: "asc" },
-        take: REQUEST_PAGE_SIZE,
-        select: BOOKING_REQUEST_SELECT,
-      }),
-      prisma.publicBookingRequest.findMany({
-        where: {
-          organizationId: safeOrganisationId,
-          status: { in: ["BOOKED", "DECLINED"] },
-        },
-        orderBy: { requestedStart: "desc" },
-        take: HISTORY_PAGE_SIZE,
-        select: BOOKING_REQUEST_SELECT,
-      }),
-    ]);
+    // Both reads must see one snapshot. Run separately (outside a transaction),
+    // a status change committed between them - a colleague marking a request
+    // booked - could let the actionable query still return a row that the
+    // history query also returns under its new status, putting a duplicate id
+    // in the merged list (the queue renders by id), or drop it from both.
+    // RepeatableRead pins a single snapshot for the pair; it is read-only, so it
+    // cannot hit a serialization failure.
+    const [actionable, history] = await prisma.$transaction(
+      [
+        prisma.publicBookingRequest.findMany({
+          where: { organizationId: safeOrganisationId, status: "CONFIRMED" },
+          orderBy: { requestedStart: "asc" },
+          take: REQUEST_PAGE_SIZE,
+          select: BOOKING_REQUEST_SELECT,
+        }),
+        prisma.publicBookingRequest.findMany({
+          where: {
+            organizationId: safeOrganisationId,
+            status: { in: ["BOOKED", "DECLINED"] },
+          },
+          orderBy: { requestedStart: "desc" },
+          take: HISTORY_PAGE_SIZE,
+          select: BOOKING_REQUEST_SELECT,
+        }),
+      ],
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+    );
 
     return [...actionable, ...history];
   },

--- a/apps/backend/test/services/public-booking.service.test.ts
+++ b/apps/backend/test/services/public-booking.service.test.ts
@@ -737,17 +737,46 @@ describe("public-booking.service", () => {
   });
 
   describe("practice queue", () => {
-    it("never lists unconfirmed requests", async () => {
+    it("queries actionable and history separately so history cannot hide actionable", async () => {
       pm.publicBookingRequest.findMany.mockResolvedValue([]);
 
       await PublicBookingRequestService.listForOrganisation("org-1");
 
-      const where = pm.publicBookingRequest.findMany.mock.calls[0][0].where;
-      expect(where.status).toEqual({ in: ["CONFIRMED", "DECLINED", "BOOKED"] });
-      expect(where.organizationId).toBe("org-1");
+      // Two queries, not one shared capped page: a past-dated backlog of
+      // BOOKED/DECLINED can never push a future CONFIRMED request off the end.
+      expect(pm.publicBookingRequest.findMany).toHaveBeenCalledTimes(2);
+      const [actionableCall, historyCall] =
+        pm.publicBookingRequest.findMany.mock.calls;
+
+      expect(actionableCall[0].where).toEqual({
+        organizationId: "org-1",
+        status: "CONFIRMED",
+      });
+      expect(actionableCall[0].take).toBe(200);
+
+      expect(historyCall[0].where).toEqual({
+        organizationId: "org-1",
+        status: { in: ["BOOKED", "DECLINED"] },
+      });
+      // History is context, so it gets a smaller slice than actionable.
+      expect(historyCall[0].take).toBe(50);
     });
 
-    it("honours an explicit status filter", async () => {
+    it("returns actionable requests ahead of history", async () => {
+      pm.publicBookingRequest.findMany
+        .mockResolvedValueOnce([{ id: "c1", status: "CONFIRMED" }])
+        .mockResolvedValueOnce([
+          { id: "b1", status: "BOOKED" },
+          { id: "d1", status: "DECLINED" },
+        ]);
+
+      const result =
+        await PublicBookingRequestService.listForOrganisation("org-1");
+
+      expect(result.map((request) => request.id)).toEqual(["c1", "b1", "d1"]);
+    });
+
+    it("honours an explicit status filter with a single query", async () => {
       pm.publicBookingRequest.findMany.mockResolvedValue([]);
 
       await PublicBookingRequestService.listForOrganisation(
@@ -755,6 +784,7 @@ describe("public-booking.service", () => {
         "DECLINED",
       );
 
+      expect(pm.publicBookingRequest.findMany).toHaveBeenCalledTimes(1);
       expect(
         pm.publicBookingRequest.findMany.mock.calls[0][0].where.status,
       ).toBe("DECLINED");

--- a/apps/backend/test/services/public-booking.service.test.ts
+++ b/apps/backend/test/services/public-booking.service.test.ts
@@ -11,6 +11,9 @@ import { sendEmail } from "src/utils/email";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    // The array form runs the batched queries and returns their results in
+    // order, which is all the list path needs from a transaction here.
+    $transaction: jest.fn((operations) => Promise.all(operations)),
     organization: { findUnique: jest.fn(), update: jest.fn() },
     bookingSlugReservation: { findUnique: jest.fn() },
     productItem: { findMany: jest.fn(), count: jest.fn() },
@@ -38,6 +41,7 @@ jest.mock("src/utils/logger", () => ({
 }));
 
 const pm = prisma as unknown as {
+  $transaction: jest.Mock;
   organization: { findUnique: jest.Mock; update: jest.Mock };
   bookingSlugReservation: { findUnique: jest.Mock };
   productItem: { findMany: jest.Mock; count: jest.Mock };
@@ -760,6 +764,19 @@ describe("public-booking.service", () => {
       });
       // History is context, so it gets a smaller slice than actionable.
       expect(historyCall[0].take).toBe(50);
+    });
+
+    it("reads both buckets in one RepeatableRead snapshot", async () => {
+      pm.publicBookingRequest.findMany.mockResolvedValue([]);
+
+      await PublicBookingRequestService.listForOrganisation("org-1");
+
+      // A status change committed between two independent reads could duplicate
+      // a row's id across the buckets or drop it; a single snapshot cannot.
+      expect(pm.$transaction).toHaveBeenCalledTimes(1);
+      expect(pm.$transaction.mock.calls[0][1]).toEqual({
+        isolationLevel: "RepeatableRead",
+      });
     });
 
     it("returns actionable requests ahead of history", async () => {


### PR DESCRIPTION
Closes #2554.

## The bug

`PublicBookingRequestService.listForOrganisation` returned actionable and already-processed requests from **one** query, sorted them together by `requestedStart` ascending, and capped the result at **200**:

```ts
where: { organizationId, status: status ?? { in: ["CONFIRMED", "DECLINED", "BOOKED"] } },
orderBy: { requestedStart: "asc" },
take: 200,
```

`CONFIRMED` is the only status a practice acts on. `BOOKED` and `DECLINED` are history. Because rows are retained until 30 days **after** their appointment, past-dated history sorts to the front of an ascending `requestedStart` order and consumes cap slots ahead of every future actionable request. At sustained volume the entire `CONFIRMED` set can sit behind retained history and never render — the practice silently stops seeing new booking requests.

## The fix

For the default view, query the two sets separately and concatenate:

- **actionable** — every `CONFIRMED` request up to the full 200 page, soonest first;
- **history** — a bounded most-recent slice (50) of `BOOKED`/`DECLINED`, for context.

A history backlog can no longer push an actionable request off the end, because they no longer share a page. An explicit `?status=` filter still returns one capped page of that single status.

## No frontend or API change

The queue component (`BookingRequests.tsx`) renders the returned order as before — now actionable-first, which matches its own "{n} awaiting you" framing. The `PATCH` status flow and the `?status=` query param are untouched.

## Tests (mutation-checked)

- the default makes **two** scoped queries — `CONFIRMED` alone at `take: 200`, history `{ in: [BOOKED, DECLINED] }` at `take: 50`;
- the result returns actionable **ahead of** history (reversing the concat fails this);
- an explicit status stays a **single** query.

83/83 across the three booking suites, `tsc` 0 errors, lint clean.

## Not in scope

The issue also notes there is no total count or next-page control. That is a further enhancement; this change fixes the actual defect (actionable requests hidden) without an API or component rewrite.