### PR TITLE
fix(ci): retry transient TLS-probe failures before flagging expiry

### DIFF
--- a/scripts/ci/check-tls-expiry.mjs
+++ b/scripts/ci/check-tls-expiry.mjs
@@ -91,7 +91,7 @@ const parseArgs = (args) => {
 // (CERT_HAS_EXPIRED, ERR_TLS_CERT_ALTNAME_INVALID, ...), which is a hard failure
 // either way. So there is never a reason to disable verification to read a
 // certificate we have already decided to fail on.
-const inspectHost = (host, now) =>
+const inspectHostOnce = (host, now) =>
   new Promise((resolve) => {
     const socket = tls.connect(
       { host, port: 443, servername: host, ALPNProtocols: ['http/1.1'] },
@@ -133,6 +133,40 @@ const inspectHost = (host, now) =>
     );
   });
 
+// A single transient connection failure - a slow forwarding host, a dropped SYN,
+// a momentary DNS hiccup - must not open an expiry issue on its own. The apex
+// yosemitecrew.com redirects to www off a third-party host that intermittently
+// times out from CI, while its certificate is valid for over a year. Retry those.
+//
+// Certificate-validation failures are NOT retried: they are deterministic and
+// carry a specific code (CERT_HAS_EXPIRED, ERR_TLS_CERT_ALTNAME_INVALID, ...),
+// so a second attempt would fail identically - retrying would only delay a real
+// alarm. A "no certificate presented" result is likewise deterministic.
+const TRANSIENT_ERROR =
+  /^(ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENETUNREACH|EHOSTUNREACH|ENETDOWN|EPIPE)$|timed out/;
+
+export const isTransient = (detail) => TRANSIENT_ERROR.test(String(detail ?? ''));
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Retry only transient errors, up to `attempts` looks. A cert error or a healthy
+// certificate returns on the first look. Injectable `probeOnce` keeps the retry
+// decision testable without touching the network.
+export const probeWithRetry = async (
+  probeOnce,
+  host,
+  now,
+  { attempts = 3, delayMs = 1000 } = {}
+) => {
+  let result;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    result = await probeOnce(host, now);
+    if (result.status !== 'error' || !isTransient(result.detail)) return result;
+    if (attempt < attempts) await sleep(delayMs);
+  }
+  return result;
+};
+
 // A host is a failure when it is untrusted, when it expires inside the fail
 // window, or when it could not be inspected at all - an unreachable or
 // verification-failing host is a problem, not a pass.
@@ -151,7 +185,7 @@ const main = async () => {
   const opts = parseArgs(argv.slice(2));
   const now = new Date();
   const results = evaluate(
-    await Promise.all(opts.hosts.map((host) => inspectHost(host, now))),
+    await Promise.all(opts.hosts.map((host) => probeWithRetry(inspectHostOnce, host, now))),
     opts
   );
 

--- a/scripts/ci/check-tls-expiry.test.mjs
+++ b/scripts/ci/check-tls-expiry.test.mjs
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { evaluate } from './check-tls-expiry.mjs';
+import { evaluate, isTransient, probeWithRetry } from './check-tls-expiry.mjs';
 
 const script = join(dirname(fileURLToPath(import.meta.url)), 'check-tls-expiry.mjs');
 const OPTS = { warnDays: 30, failDays: 14 };
@@ -139,4 +139,65 @@ test('--json emits parseable JSON on stdout with no annotations mixed in', () =>
   assert.equal(Array.isArray(parsed), true);
   assert.equal(parsed[0].host, 'no-such-host.invalid');
   assert.equal(parsed[0].verdict, 'error');
+});
+
+// --- retry of transient connection failures (issue #2350) ---
+// The apex host timed out once from CI and opened a TLS-expiry issue while its
+// certificate was valid for over a year. Transient errors are retried; a real
+// certificate verdict is returned on the first look.
+
+test('isTransient matches connection failures, not certificate failures', () => {
+  for (const d of ['ETIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'timed out after 15000ms']) {
+    assert.equal(isTransient(d), true, d);
+  }
+  for (const d of [
+    'CERT_HAS_EXPIRED',
+    'ERR_TLS_CERT_ALTNAME_INVALID',
+    'no certificate presented',
+  ]) {
+    assert.equal(isTransient(d), false, d);
+  }
+});
+
+test('probeWithRetry retries a transient error and then succeeds', async () => {
+  let calls = 0;
+  const probeOnce = async () => {
+    calls += 1;
+    if (calls < 3) return { host: 'apex.test', status: 'error', detail: 'ETIMEDOUT' };
+    return { host: 'apex.test', status: 'ok', daysLeft: 400 };
+  };
+  const result = await probeWithRetry(probeOnce, 'apex.test', new Date(), {
+    attempts: 3,
+    delayMs: 0,
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.status, 'ok');
+});
+
+test('probeWithRetry does NOT retry a certificate failure', async () => {
+  let calls = 0;
+  const probeOnce = async () => {
+    calls += 1;
+    return { host: 'expired.test', status: 'error', detail: 'CERT_HAS_EXPIRED' };
+  };
+  const result = await probeWithRetry(probeOnce, 'expired.test', new Date(), {
+    attempts: 3,
+    delayMs: 0,
+  });
+  assert.equal(calls, 1);
+  assert.equal(result.detail, 'CERT_HAS_EXPIRED');
+});
+
+test('probeWithRetry gives up after the attempt budget and reports the error', async () => {
+  let calls = 0;
+  const probeOnce = async () => {
+    calls += 1;
+    return { host: 'down.test', status: 'error', detail: 'ECONNREFUSED' };
+  };
+  const result = await probeWithRetry(probeOnce, 'down.test', new Date(), {
+    attempts: 3,
+    delayMs: 0,
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.status, 'error');
 });


### PR DESCRIPTION
Addresses #2350.

## What happened

The daily TLS expiry check opened *"TLS certificate expiring or untrusted"* for `yosemitecrew.com: ETIMEDOUT` while every subdomain passed. Probed live, the apex is fine:

```
subject: CN=yosemitecrew.com
issuer:  Sectigo Public Server Authentication CA DV R36
expire:  Feb 20 23:59:59 2027 GMT
SSL certificate verify ok.
```

The apex `301`-redirects to `www` off a third-party host (`81.169.145.145`) that is intermittently slow to reach from CI. A browser follows the redirect and never notices; the check does one raw `tls.connect` with **no retry**, so a single dropped handshake becomes a hard failure and an issue.

## The fix

Retry **transient** connection errors — `ETIMEDOUT`, `ECONNRESET`, `ECONNREFUSED`, `EAI_AGAIN`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETDOWN`, `EPIPE`, and the socket-timeout path — up to three looks.

Certificate verdicts are **not** retried: a valid cert, or a deterministic validation error (`CERT_HAS_EXPIRED`, `ERR_TLS_CERT_ALTNAME_INVALID`, "no certificate presented"), returns on the first look. So a genuine expiry still reds the build immediately — the retry only absorbs flakiness, never delays a real alarm.

## Tests (mutation-checked)

The retry wrapper takes an injectable probe, so the decision is unit-tested with no network:
- `isTransient` matches connection failures, not certificate failures;
- retries a transient error then succeeds;
- does **not** retry a certificate failure — dropping the `isTransient` guard reds this test;
- gives up after the attempt budget and reports the error.

16/16 pass. Classification and CLI behaviour are unchanged.

## Note

`ds.yosemitecrew.com` (Let's Encrypt) reported ~41 days left in the same run — within LE's normal auto-renewal window, but the genuine one to keep an eye on.