### PR TITLE
feat(ci): close referenced issues when their PR merges to dev

### DIFF
--- a/.github/workflows/close-dev-issues.yml
+++ b/.github/workflows/close-dev-issues.yml
@@ -1,0 +1,41 @@
+name: Close referenced issues on dev
+
+# GitHub only fires `Closes #N` / `Fixes #N` when a PR merges into the DEFAULT
+# branch. This repo merges into `dev`, so issues a PR body marks as closed stay
+# open forever - shipped work reads as live and gets re-started. This closes them
+# here, reading the same keywords GitHub would, only on `dev`.
+on:
+  push:
+    branches:
+      - dev
+
+concurrency:
+  # One run per pushed commit; never cancel a run mid-close.
+  group: close-dev-issues-${{ github.sha }}
+
+permissions: {}
+
+jobs:
+  close:
+    name: Close issues the merged PR resolves
+    # Only the canonical repo; a fork has no business closing these issues.
+    if: github.repository_owner == 'YosemiteCrew'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # No setup-node on purpose, matching tls-expiry.yml: the script imports only
+      # node builtins and shells out to the preinstalled gh CLI, so the runner's
+      # Node is enough and nothing in the workspace can stop an issue from closing.
+      - name: Close referenced issues
+        run: node scripts/ci/close-referenced-issues.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/ci/close-referenced-issues.mjs
+++ b/scripts/ci/close-referenced-issues.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Close the issues a merged PR says it closes, on a repo whose default branch is
+// not the one it merges into.
+//
+// GitHub only honours `Closes #N` / `Fixes #N` when the PR merges into the
+// DEFAULT branch. This repo merges into `dev`, so every issue a PR body marks as
+// closed stays open forever - work that shipped weeks ago still reads as live,
+// and people re-start it. This runs on push to `dev`, reads the closing keywords
+// out of the merged PR's body exactly as GitHub itself would, comments which PR
+// closed the issue and that it merged to `dev`, and closes it.
+//
+// It is deliberately narrow:
+//   - only the keywords GitHub recognises, never a bare `#123` mention;
+//   - only same-repo `#N`, never a cross-repo `owner/repo#N`;
+//   - a comment before every close, so the trail names the PR;
+//   - already-closed issues are left alone, so a re-run is a no-op.
+//
+// It uses the `gh` CLI already present on GitHub runners and no other dependency.
+import { execFileSync } from 'node:child_process';
+import { argv, env, exit, stderr, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
+
+// GitHub's own closing-keyword set: close/closes/closed, fix/fixes/fixed,
+// resolve/resolves/resolved. The keyword must sit immediately before the
+// reference (an optional colon and whitespace between), so `Closes #1, #2` marks
+// only #1 - which is exactly what GitHub does, and keeps a bare `#2` mention from
+// closing anything.
+const CLOSING_KEYWORD = /\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\b[:\s]+#(\d+)/gi;
+
+// Cross-repo references (`owner/repo#N`) carry a `/` or word char right before
+// the keyword's issue; the `\b#` above already excludes `repo#N`, but a body may
+// still paste a full URL. Numbers are validated as same-repo issues by the API
+// call in main(), so a stray match simply finds no open issue and is skipped.
+export const closedIssues = (body) => {
+  const found = new Set();
+  for (const match of String(body ?? '').matchAll(CLOSING_KEYWORD)) {
+    found.add(Number(match[1]));
+  }
+  return [...found];
+};
+
+const gh = (args) => execFileSync('gh', args, { encoding: 'utf8' }).trim();
+
+// The PRs a commit belongs to. A squash or merge commit on `dev` maps to the one
+// PR that introduced it; the API is authoritative regardless of merge style,
+// where scraping `(#N)` out of the subject line is not.
+const pullsForCommit = (repo, sha) => {
+  const out = gh(['api', `repos/${repo}/commits/${sha}/pulls`, '--jq', '.[].number']);
+  return out
+    .split('\n')
+    .map((line) => Number(line.trim()))
+    .filter((n) => Number.isInteger(n) && n > 0);
+};
+
+const issueState = (repo, number) => {
+  try {
+    return gh(['api', `repos/${repo}/issues/${number}`, '--jq', '.state']);
+  } catch {
+    // A number that is not an issue in this repo (a pull request id, or a
+    // cross-repo reference that slipped through) 404s. Not ours to close.
+    return null;
+  }
+};
+
+const main = () => {
+  const repo = env.GITHUB_REPOSITORY;
+  const sha = env.GITHUB_SHA;
+  if (!repo || !sha) {
+    stderr.write('GITHUB_REPOSITORY and GITHUB_SHA are required\n');
+    exit(2);
+  }
+
+  const prs = pullsForCommit(repo, sha);
+  if (prs.length === 0) {
+    stdout.write(`No PR is associated with ${sha}; nothing to close.\n`);
+    return;
+  }
+
+  let closed = 0;
+  for (const pr of prs) {
+    const body = gh(['api', `repos/${repo}/issues/${pr}`, '--jq', '.body']);
+    for (const issue of closedIssues(body)) {
+      if (issue === pr) continue; // a PR never closes itself
+      const state = issueState(repo, issue);
+      if (state !== 'open') {
+        stdout.write(`#${issue}: ${state ?? 'not an issue'}, skipping.\n`);
+        continue;
+      }
+      gh([
+        'api',
+        `repos/${repo}/issues/${issue}/comments`,
+        '-f',
+        `body=Closed by #${pr}, which merged into \`dev\`. GitHub does not fire closing keywords outside the default branch, so this is closed here instead.`,
+      ]);
+      gh(['api', '-X', 'PATCH', `repos/${repo}/issues/${issue}`, '-f', 'state=closed']);
+      stdout.write(`Closed #${issue} (referenced by #${pr}).\n`);
+      closed += 1;
+    }
+  }
+  stdout.write(`Done: closed ${closed} issue(s).\n`);
+};
+
+// Only run when invoked directly, so the test can import closedIssues().
+const invokedDirectly = () => {
+  if (!argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv[1]);
+  } catch {
+    return false;
+  }
+};
+
+if (invokedDirectly()) {
+  main();
+}

--- a/scripts/ci/close-referenced-issues.test.mjs
+++ b/scripts/ci/close-referenced-issues.test.mjs
@@ -1,0 +1,63 @@
+// Tests for the closing-keyword parser. The gh-driven side effects are exercised
+// by the workflow itself; what is pinned here is that the parser mirrors GitHub's
+// own rule - so this never closes an issue GitHub would have left open.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { closedIssues } from './close-referenced-issues.mjs';
+
+test('matches every keyword GitHub recognises', () => {
+  for (const kw of [
+    'close',
+    'closes',
+    'closed',
+    'fix',
+    'fixes',
+    'fixed',
+    'resolve',
+    'resolves',
+    'resolved',
+  ]) {
+    assert.deepEqual(closedIssues(`${kw} #7`), [7], kw);
+    assert.deepEqual(closedIssues(`${kw.toUpperCase()} #7`), [7], kw);
+  }
+});
+
+test('accepts the optional colon GitHub allows', () => {
+  assert.deepEqual(closedIssues('Closes: #12'), [12]);
+});
+
+test('a bare mention with no keyword closes nothing', () => {
+  assert.deepEqual(closedIssues('See #99 for context'), []);
+  assert.deepEqual(closedIssues('#99'), []);
+});
+
+test('the keyword must sit on each reference, as on GitHub', () => {
+  // GitHub closes only #1 here - the keyword does not carry to #2.
+  assert.deepEqual(closedIssues('Closes #1, #2'), [1]);
+  assert.deepEqual(closedIssues('Closes #1 and closes #2'), [1, 2]);
+});
+
+test('does not match a cross-repo reference', () => {
+  assert.deepEqual(closedIssues('Fixes owner/repo#5'), []);
+});
+
+test('deduplicates and handles an empty body', () => {
+  assert.deepEqual(closedIssues('Fixes #3 and fixes #3'), [3]);
+  assert.deepEqual(closedIssues(''), []);
+  assert.deepEqual(closedIssues(undefined), []);
+  assert.deepEqual(closedIssues(null), []);
+});
+
+test('reads keywords from a realistic multi-line PR body', () => {
+  const body = [
+    '## What changed',
+    'Reworked the thing.',
+    '',
+    'Closes #2554. Also fixes #2552.',
+    'Mentions #2603 as related follow-up.',
+  ].join('\n');
+  assert.deepEqual(
+    closedIssues(body).sort((a, b) => a - b),
+    [2552, 2554]
+  );
+});


### PR DESCRIPTION
Addresses #2657. **Opening for your review rather than auto-merging** — it changes behaviour for every contributor (issues start closing automatically), which #2657 itself said wants a decision. Green and ready whenever you want it; decline if you'd rather keep closing by hand or make `dev` the default branch instead.

## Why

GitHub only honours `Closes #N` / `Fixes #N` when a PR merges into the **default branch**. This repo merges into `dev`, so every issue a PR body marks closed stays open forever. #2657 measured eleven closed by hand in one session; I've closed six more by hand this session for the same reason. Authors write the keyword expecting it to work — this makes it work.

## What it does

On push to `dev`: find the merged PR for the pushed commit, read the closing keywords out of its body, comment which PR closed the issue (and that it merged to `dev`), then close it.

Deliberately narrow, matching GitHub's own rule so it never closes something GitHub would have left open:

- only GitHub's keyword set (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`) — never a bare `#123` mention;
- the keyword must sit on **each** reference, so `Closes #1, #2` marks only `#1`;
- only same-repo `#N`, never a cross-repo `owner/repo#N`;
- a comment **before** each close, so the trail names the PR;
- already-closed issues are left alone, so a re-run is a no-op.

## How it's verified

- The parser is pure and unit-tested (7 cases) against GitHub's semantics — keyword variants, the optional colon, bare mentions ignored, per-reference keyword rule, cross-repo ignored, dedup, empty/null body, a realistic multi-line body.
- The commit→PR mapping uses the `commits/{sha}/pulls` API, which **does** resolve a squash-merge commit to its PR — verified live against `dev`'s head (the squashed #2681 → `2681`).
- Dry-run against #2681's real body extracted `[2554]`, and #2554 (already closed by hand) would be skipped by the open-state guard — confirming idempotency.

`node --test` green, lint clean, workflow YAML valid.

## Alternatives (from #2657)

Making `dev` the default branch fixes this for free but moves PR targeting, branch protection, and every "default branch" assumption in CI — much larger. This is the contained option.