### PR TITLE
feat(frontend): surface inventory low-stock and expiring alerts

### DIFF
--- a/apps/frontend/src/app/__tests__/features/inventory/InventoryAlerts.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/inventory/InventoryAlerts.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InventoryAlerts from '@/app/features/inventory/components/InventoryAlerts/InventoryAlerts';
+import type {
+  ExpiringAlertBatch,
+  LowStockAlertItem,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+
+/** Anchored to now so the relative-date pills are deterministic across time. */
+const inDays = (days: number): string => {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+};
+
+const lowStock: LowStockAlertItem[] = [
+  { id: 'i1', name: 'Meloxicam 15 mg/mL', onHand: 2, reorderLevel: 10, unitOfMeasure: 'mL' },
+  { id: 'i2', name: 'Rabies vaccine', onHand: 0, reorderLevel: 25, unitOfMeasure: 'dose' },
+];
+
+const expiring: ExpiringAlertBatch[] = [
+  {
+    id: 'b1',
+    itemId: 'i1',
+    batchNumber: 'B-2026-04',
+    expiryDate: inDays(3),
+    quantity: 18,
+    inventoryItem: { name: 'Meloxicam 15 mg/mL' },
+  },
+  { id: 'b2', itemId: 'i7', batchNumber: 'B-2026-07', expiryDate: inDays(21), quantity: 30 },
+];
+
+describe('InventoryAlerts', () => {
+  it('renders low-stock rows with the on-hand / reorder figure and out-of-stock emphasis', () => {
+    render(<InventoryAlerts lowStock={lowStock} expiring={[]} />);
+
+    const lowStockGroup = screen.getByRole('region', { name: 'Low stock' });
+    expect(within(lowStockGroup).getByText('Meloxicam 15 mg/mL')).toBeInTheDocument();
+    expect(within(lowStockGroup).getByText('Rabies vaccine')).toBeInTheDocument();
+
+    // The on-hand / reorder figure is split across nodes ("2 / 10 mL"), so match the row text.
+    expect(within(lowStockGroup).getByText(/2 \/ 10/)).toBeInTheDocument();
+
+    // onHand 0 => danger "Out of stock"; a positive-but-low item => "Low".
+    expect(within(lowStockGroup).getByText('Out of stock')).toBeInTheDocument();
+    expect(within(lowStockGroup).getByText('Low')).toBeInTheDocument();
+  });
+
+  it('renders expiring rows with quantity and a batch-number fallback when no item name', () => {
+    render(<InventoryAlerts lowStock={[]} expiring={expiring} />);
+
+    const expiringGroup = screen.getByRole('region', { name: 'Expiring soon' });
+    // Item name is used as the row title when the relation is present.
+    expect(within(expiringGroup).getByText('Meloxicam 15 mg/mL')).toBeInTheDocument();
+    // The second batch has no inventoryItem, so the batch number becomes the title.
+    expect(within(expiringGroup).getByText('B-2026-07')).toBeInTheDocument();
+    // Quantities render.
+    expect(within(expiringGroup).getByText('18')).toBeInTheDocument();
+    expect(within(expiringGroup).getByText('30')).toBeInTheDocument();
+  });
+
+  it('shows a clean empty state for each group when there are no alerts', () => {
+    render(<InventoryAlerts lowStock={[]} expiring={[]} expiringWindowDays={30} />);
+
+    expect(screen.getByText('No low-stock items')).toBeInTheDocument();
+    expect(screen.getByText('Nothing expiring in the next 30 days')).toBeInTheDocument();
+    // Empty means empty — no rows leaked in from the other group's fixtures.
+    expect(screen.queryByText('Out of stock')).not.toBeInTheDocument();
+  });
+
+  it('renders an error banner when the container reports a load failure', () => {
+    render(
+      <InventoryAlerts
+        lowStock={[]}
+        expiring={[]}
+        error="Unable to load inventory alerts right now."
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Unable to load inventory alerts right now.'
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/inventory/components/InventoryAlertsPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/inventory/components/InventoryAlertsPanel.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InventoryAlertsPanel from '@/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel';
+
+const fetchLowStockAlerts = jest.fn();
+const fetchExpiringAlerts = jest.fn();
+jest.mock('@/app/features/inventory/services/inventoryAlertsService', () => ({
+  __esModule: true,
+  fetchLowStockAlerts: (...a: unknown[]) => fetchLowStockAlerts(...a),
+  fetchExpiringAlerts: (...a: unknown[]) => fetchExpiringAlerts(...a),
+}));
+
+// Presentational double: surfaces the container's props for assertions.
+jest.mock('@/app/features/inventory/components/InventoryAlerts/InventoryAlerts', () => ({
+  __esModule: true,
+  default: ({ lowStock, expiring, loading, error, expiringWindowDays }: any) => (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      <span data-testid="window">{expiringWindowDays}</span>
+      <span data-testid="low">{lowStock.length}</span>
+      <span data-testid="exp">{expiring.length}</span>
+    </div>
+  ),
+}));
+
+describe('InventoryAlertsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLowStockAlerts.mockResolvedValue([{ id: 'i-1' }]);
+    fetchExpiringAlerts.mockResolvedValue([{ id: 'b-1' }, { id: 'b-2' }]);
+  });
+
+  it('loads both alert sets in parallel for the org', async () => {
+    render(<InventoryAlertsPanel organisationId="org-1" />);
+    await waitFor(() => expect(screen.getByTestId('low')).toHaveTextContent('1'));
+    expect(fetchLowStockAlerts).toHaveBeenCalledWith('org-1');
+    expect(fetchExpiringAlerts).toHaveBeenCalledWith('org-1', 30);
+    expect(screen.getByTestId('exp')).toHaveTextContent('2');
+    expect(screen.getByTestId('loading')).toHaveTextContent('false');
+  });
+
+  it('honours a custom expiring window', async () => {
+    render(<InventoryAlertsPanel organisationId="org-1" expiringWindowDays={7} />);
+    await waitFor(() => expect(fetchExpiringAlerts).toHaveBeenCalledWith('org-1', 7));
+    expect(screen.getByTestId('window')).toHaveTextContent('7');
+  });
+
+  it('does not fetch without an org id', async () => {
+    render(<InventoryAlertsPanel />);
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+    expect(fetchLowStockAlerts).not.toHaveBeenCalled();
+    expect(fetchExpiringAlerts).not.toHaveBeenCalled();
+    expect(screen.getByTestId('low')).toHaveTextContent('0');
+  });
+
+  it('surfaces an error when a fetch rejects', async () => {
+    fetchExpiringAlerts.mockRejectedValueOnce(new Error('down'));
+    render(<InventoryAlertsPanel organisationId="org-1" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('Unable to load inventory alerts')
+    );
+    expect(screen.getByTestId('low')).toHaveTextContent('0');
+    expect(screen.getByTestId('exp')).toHaveTextContent('0');
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/inventory/services/inventoryAlertsService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/inventory/services/inventoryAlertsService.test.ts
@@ -1,0 +1,108 @@
+import { AxiosError } from 'axios';
+import {
+  fetchLowStockAlerts,
+  fetchExpiringAlerts,
+  type LowStockAlertItem,
+  type ExpiringAlertBatch,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+
+const getData = jest.fn();
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  getData: (...a: unknown[]) => getData(...a),
+}));
+
+const lowItem: LowStockAlertItem = {
+  id: 'i-1',
+  name: 'Amoxicillin',
+  onHand: 2,
+  reorderLevel: 10,
+};
+const batch: ExpiringAlertBatch = {
+  id: 'b-1',
+  itemId: 'i-1',
+  batchNumber: 'LOT-9',
+  expiryDate: '2026-10-01T00:00:00.000Z',
+  quantity: 5,
+};
+
+const LOW = '/v1/inventory/organisation/org-1/alerts/low-stock';
+const EXP = '/v1/inventory/organisation/org-1/alerts/expiring';
+
+describe('inventoryAlertsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('fetchLowStockAlerts', () => {
+    it('returns the array of items', async () => {
+      getData.mockResolvedValue({ data: [lowItem] });
+      await expect(fetchLowStockAlerts('org-1')).resolves.toEqual([lowItem]);
+      expect(getData).toHaveBeenCalledWith(LOW);
+    });
+    it('guards a non-array body', async () => {
+      getData.mockResolvedValue({ data: { message: 'nope' } });
+      await expect(fetchLowStockAlerts('org-1')).resolves.toEqual([]);
+      expect(console.warn).toHaveBeenCalled();
+    });
+    it('logs the axios message and rethrows', async () => {
+      const err = new AxiosError('boom');
+      err.response = { data: { message: 'down' } } as AxiosError['response'];
+      getData.mockRejectedValue(err);
+      await expect(fetchLowStockAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load low-stock alerts:', 'down');
+    });
+    it('falls back to the axios message when there is no response body', async () => {
+      const err = new AxiosError('offline');
+      getData.mockRejectedValue(err);
+      await expect(fetchLowStockAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load low-stock alerts:', 'offline');
+    });
+    it('logs a non-axios error and rethrows', async () => {
+      const err = new Error('raw');
+      getData.mockRejectedValue(err);
+      await expect(fetchLowStockAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load low-stock alerts:', err);
+    });
+  });
+
+  describe('fetchExpiringAlerts', () => {
+    it('passes the default 30-day window', async () => {
+      getData.mockResolvedValue({ data: [batch] });
+      await expect(fetchExpiringAlerts('org-1')).resolves.toEqual([batch]);
+      expect(getData).toHaveBeenCalledWith(EXP, { days: 30 });
+    });
+    it('passes an explicit window', async () => {
+      getData.mockResolvedValue({ data: [batch] });
+      await fetchExpiringAlerts('org-1', 7);
+      expect(getData).toHaveBeenCalledWith(EXP, { days: 7 });
+    });
+    it('guards a non-array body', async () => {
+      getData.mockResolvedValue({ data: null });
+      await expect(fetchExpiringAlerts('org-1')).resolves.toEqual([]);
+      expect(console.warn).toHaveBeenCalled();
+    });
+    it('logs the axios message and rethrows', async () => {
+      const err = new AxiosError('boom');
+      err.response = { data: { message: 'gone' } } as AxiosError['response'];
+      getData.mockRejectedValue(err);
+      await expect(fetchExpiringAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load expiring alerts:', 'gone');
+    });
+    it('falls back to the axios message when there is no response body', async () => {
+      const err = new AxiosError('offline');
+      getData.mockRejectedValue(err);
+      await expect(fetchExpiringAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load expiring alerts:', 'offline');
+    });
+    it('logs a non-axios error and rethrows', async () => {
+      const err = new Error('raw');
+      getData.mockRejectedValue(err);
+      await expect(fetchExpiringAlerts('org-1')).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load expiring alerts:', err);
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
@@ -320,6 +320,14 @@ jest.mock('@/app/ui/tables/InventoryTurnoverTable', () => ({
 }));
 
 // Mock Modals (Updated to handle async errors in onClick to prevent Unhandled Promise Rejections)
+// Stub the alerts panel: it fetches low-stock/expiring on mount, which in this
+// page suite errors (no service mock) and logs console.error, tripping
+// jest.setup's strict guard. This suite does not exercise it.
+jest.mock('@/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid="inventory-alerts-panel" />,
+}));
+
 jest.mock('@/app/features/inventory/components/AddInventory', () => ({
   __esModule: true,
   default: ({ showModal, onSubmit }: any) =>

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.stories.tsx
@@ -1,0 +1,174 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import type {
+  ExpiringAlertBatch,
+  LowStockAlertItem,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+import InventoryAlerts from './InventoryAlerts';
+
+/** Expiry fixtures are anchored to render-time so the relative pills ("in 3 days",
+ *  "yesterday") stay correct forever rather than drifting into the past like a
+ *  hardcoded ISO date would. */
+const inDays = (days: number): string => {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+};
+
+const LOW_STOCK: LowStockAlertItem[] = [
+  {
+    id: 'item-1',
+    name: 'Meloxicam 15 mg/mL',
+    onHand: 2,
+    reorderLevel: 10,
+    unitOfMeasure: 'mL',
+    category: 'Medicine',
+    sku: 'SKU-4471',
+  },
+  {
+    id: 'item-2',
+    name: 'Rabies vaccine (Nobivac)',
+    onHand: 0,
+    reorderLevel: 25,
+    unitOfMeasure: 'dose',
+    category: 'Vaccine',
+    sku: 'SKU-2210',
+  },
+  {
+    id: 'item-3',
+    name: 'IV catheter 22G',
+    onHand: 6,
+    reorderLevel: 40,
+    unitOfMeasure: 'unit',
+    category: 'Consumable',
+    sku: 'SKU-0098',
+  },
+];
+
+const EXPIRING: ExpiringAlertBatch[] = [
+  {
+    id: 'batch-1',
+    itemId: 'item-1',
+    batchNumber: 'B-2026-04',
+    expiryDate: inDays(3),
+    quantity: 18,
+    inventoryItem: { name: 'Meloxicam 15 mg/mL' },
+  },
+  {
+    id: 'batch-2',
+    itemId: 'item-9',
+    batchNumber: 'B-2026-01',
+    expiryDate: inDays(-1),
+    quantity: 4,
+    inventoryItem: { name: 'Amoxicillin 250 mg' },
+  },
+  {
+    id: 'batch-3',
+    itemId: 'item-7',
+    batchNumber: 'B-2026-07',
+    expiryDate: inDays(21),
+    quantity: 30,
+    // No item relation on purpose — the panel falls back to the batch number.
+  },
+];
+
+const meta = {
+  title: 'Inventory/InventoryAlerts',
+  component: InventoryAlerts,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Two grouped alert lists for the inventory page — **Low stock** and **Expiring soon**. ' +
+          'Presentational only: it renders the arrays the container passes and never fetches. ' +
+          'A zero-on-hand item reads as danger ("Out of stock"); an already-expired batch reads ' +
+          'as danger with a relative + absolute date. Each group has its own empty state.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    lowStock: LOW_STOCK,
+    expiring: EXPIRING,
+    loading: false,
+    error: null,
+    expiringWindowDays: 30,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 900 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InventoryAlerts>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  name: 'Populated',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Both group headings render.
+    await expect(canvas.getByText('Low stock')).toBeInTheDocument();
+    await expect(canvas.getByText('Expiring soon')).toBeInTheDocument();
+    // Low-stock rows, including the zero-on-hand danger case.
+    await expect(canvas.getByText('Meloxicam 15 mg/mL')).toBeInTheDocument();
+    await expect(canvas.getByText('Out of stock')).toBeInTheDocument();
+    await expect(canvas.getAllByText('Low').length).toBeGreaterThan(0);
+    // The batch with no item relation falls back to its batch number as the title.
+    await expect(canvas.getByText('B-2026-07')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A few of each. The Rabies row is at zero on hand, so it carries the danger "Out of ' +
+          'stock" pill instead of "Low"; the expired batch carries a danger date pill.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'Empty',
+  args: { lowStock: [], expiring: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No low-stock items')).toBeInTheDocument();
+    await expect(canvas.getByText('Nothing expiring in the next 30 days')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The all-clear state: both groups show their own empty line. The expiring copy names ' +
+          'the window it checked so "nothing" is unambiguous.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  args: { loading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Skeleton rows replace content; the real data must not be on screen yet.
+    await expect(canvas.queryByText('Meloxicam 15 mg/mL')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Low stock')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the container fetches, each group shows three placeholder rows and the header ' +
+          'count is suppressed — the panel keeps its shape so the page does not jump on load.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
@@ -18,6 +18,13 @@ export type InventoryAlertsProps = {
 };
 
 const DAY_MS = 86_400_000;
+const RELATIVE_DAY_FORMATTER = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+const ABSOLUTE_DATE_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
 
 /** Midnight-anchored day delta, so "in 1 day" flips on the calendar boundary, not at a
  *  clock-time 24h from now — a batch expiring later today should read "today", not "tomorrow". */
@@ -27,11 +34,9 @@ const dayDelta = (target: Date, now: Date): number => {
   return Math.round((t - n) / DAY_MS);
 };
 
-const relativeDays = (delta: number): string =>
-  new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(delta, 'day');
+const relativeDays = (delta: number): string => RELATIVE_DAY_FORMATTER.format(delta, 'day');
 
-const absoluteDate = (date: Date): string =>
-  date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+const absoluteDate = (date: Date): string => ABSOLUTE_DATE_FORMATTER.format(date);
 
 const cardClass =
   'flex flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
@@ -1,0 +1,209 @@
+'use client';
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+import { IoAlertCircleOutline, IoTimeOutline } from 'react-icons/io5';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import type {
+  ExpiringAlertBatch,
+  LowStockAlertItem,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+
+export type InventoryAlertsProps = {
+  lowStock: LowStockAlertItem[];
+  expiring: ExpiringAlertBatch[];
+  loading?: boolean;
+  error?: string | null;
+  /** Window used for the "Nothing expiring in the next N days" empty copy. Default 30. */
+  expiringWindowDays?: number;
+};
+
+const DAY_MS = 86_400_000;
+
+/** Midnight-anchored day delta, so "in 1 day" flips on the calendar boundary, not at a
+ *  clock-time 24h from now — a batch expiring later today should read "today", not "tomorrow". */
+const dayDelta = (target: Date, now: Date): number => {
+  const t = Date.UTC(target.getFullYear(), target.getMonth(), target.getDate());
+  const n = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  return Math.round((t - n) / DAY_MS);
+};
+
+const relativeDays = (delta: number): string =>
+  new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(delta, 'day');
+
+const absoluteDate = (date: Date): string =>
+  date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+
+const cardClass =
+  'flex flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
+const rowClass = 'flex items-center justify-between gap-3 px-4 py-3';
+const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
+const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
+
+type AlertCardProps = {
+  icon: React.ReactNode;
+  title: string;
+  count: number;
+  children: React.ReactNode;
+};
+
+const AlertCard = ({ icon, title, count, children }: AlertCardProps) => {
+  const headingId = `inventory-alerts-${title.toLowerCase().replace(/\s+/g, '-')}`;
+  return (
+    <section className={cardClass} aria-labelledby={headingId}>
+      <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+        <span className="text-[var(--ink-muted)]" aria-hidden="true">
+          {icon}
+        </span>
+        <h3 id={headingId} className="text-[13.5px] font-bold text-[var(--ink)]">
+          {title}
+        </h3>
+        {count > 0 && (
+          <StatusPill label={String(count)} tone="neutral" className="ml-auto tabular-nums" />
+        )}
+      </header>
+      {children}
+    </section>
+  );
+};
+
+const EmptyState = ({ message }: { message: string }) => (
+  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
+);
+
+const LoadingRows = () => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((i) => (
+      <li key={i} className={rowClass}>
+        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);
+
+const LowStockRow = ({ item }: { item: LowStockAlertItem }) => {
+  const out = (item.onHand ?? 0) <= 0;
+  const unit = item.unitOfMeasure || item.stockUnitType || '';
+  return (
+    <li className={rowClass}>
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block truncate')}>{item.name}</span>
+        <span className={clsx(metaClass, 'block')}>
+          {item.category ? `${item.category} · ` : ''}
+          {item.sku ?? ''}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-2.5">
+        <span
+          className={clsx(
+            'text-[12.5px] font-bold tabular-nums',
+            out ? 'text-[var(--danger-text)]' : 'text-[var(--ink)]'
+          )}
+        >
+          {item.onHand ?? 0} / {item.reorderLevel ?? 0}
+          {unit ? <span className="font-semibold text-[var(--ink-faint)]"> {unit}</span> : null}
+        </span>
+        <StatusPill label={out ? 'Out of stock' : 'Low'} tone={out ? 'danger' : 'warning'} />
+      </span>
+    </li>
+  );
+};
+
+const ExpiringRow = ({ batch, now }: { batch: ExpiringAlertBatch; now: Date }) => {
+  const label = batch.inventoryItem?.name || batch.batchNumber || 'Batch';
+  const parsed = batch.expiryDate ? new Date(batch.expiryDate) : null;
+  const valid = parsed !== null && !Number.isNaN(parsed.getTime());
+  const delta = valid ? dayDelta(parsed, now) : null;
+  const expired = delta !== null && delta < 0;
+  return (
+    <li className={rowClass}>
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block truncate')}>{label}</span>
+        <span className={clsx(metaClass, 'block')}>
+          {batch.batchNumber ? `Batch ${batch.batchNumber} · ` : ''}
+          Qty <span className="tabular-nums">{batch.quantity ?? 0}</span>
+        </span>
+      </span>
+      <span className="flex shrink-0 flex-col items-end gap-1">
+        <StatusPill
+          label={valid ? relativeDays(delta as number) : 'No expiry date'}
+          tone={expired ? 'danger' : 'warning'}
+        />
+        {valid && <span className={metaClass}>{absoluteDate(parsed as Date)}</span>}
+      </span>
+    </li>
+  );
+};
+
+/**
+ * Presentational-only inventory alerts. Renders two grouped lists — low stock and
+ * expiring soon — from arrays the caller supplies; it never fetches. The container
+ * (`InventoryAlertsPanel`) owns loading, error and data.
+ */
+const InventoryAlerts = ({
+  lowStock,
+  expiring,
+  loading = false,
+  error = null,
+  expiringWindowDays = 30,
+}: InventoryAlertsProps) => {
+  // `now` is captured once per render so every row in a pass agrees on "today".
+  const now = useMemo(() => new Date(), []);
+
+  const lowStockBody = (() => {
+    if (loading) return <LoadingRows />;
+    if (lowStock.length === 0) return <EmptyState message="No low-stock items" />;
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {lowStock.map((item) => (
+          <LowStockRow key={item.id} item={item} />
+        ))}
+      </ul>
+    );
+  })();
+
+  const expiringBody = (() => {
+    if (loading) return <LoadingRows />;
+    if (expiring.length === 0) {
+      return <EmptyState message={`Nothing expiring in the next ${expiringWindowDays} days`} />;
+    }
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {expiring.map((batch) => (
+          <ExpiringRow key={batch.id} batch={batch} now={now} />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {error && (
+        <div
+          role="alert"
+          className="rounded-2xl border border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <AlertCard
+          icon={<IoAlertCircleOutline size={18} />}
+          title="Low stock"
+          count={loading ? 0 : lowStock.length}
+        >
+          {lowStockBody}
+        </AlertCard>
+        <AlertCard
+          icon={<IoTimeOutline size={18} />}
+          title="Expiring soon"
+          count={loading ? 0 : expiring.length}
+        >
+          {expiringBody}
+        </AlertCard>
+      </div>
+    </div>
+  );
+};
+
+export default InventoryAlerts;

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import { IoAlertCircleOutline, IoTimeOutline } from 'react-icons/io5';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
@@ -148,7 +148,9 @@ const InventoryAlerts = ({
   expiringWindowDays = 30,
 }: InventoryAlertsProps) => {
   // `now` is captured once per render so every row in a pass agrees on "today".
-  const now = useMemo(() => new Date(), []);
+  // Fresh each render so relative day labels never go stale; one value per
+  // pass, so every row in a render still agrees on "today".
+  const now = new Date();
 
   const lowStockBody = (() => {
     if (loading) return <LoadingRows />;

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import InventoryAlerts from '@/app/features/inventory/components/InventoryAlerts/InventoryAlerts';
+import {
+  fetchExpiringAlerts,
+  fetchLowStockAlerts,
+  type ExpiringAlertBatch,
+  type LowStockAlertItem,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+
+type InventoryAlertsPanelProps = {
+  organisationId?: string;
+  /** Expiry look-ahead window; also drives the empty-state copy. Default 30. */
+  expiringWindowDays?: number;
+};
+
+/**
+ * Data container for {@link InventoryAlerts}. Loads low-stock and expiring alerts for
+ * the org in parallel and hands the presentational component its arrays plus loading /
+ * error. Kept thin on purpose: fetching lives here, rendering lives in InventoryAlerts.
+ */
+const InventoryAlertsPanel = ({
+  organisationId,
+  expiringWindowDays = 30,
+}: InventoryAlertsPanelProps) => {
+  const [lowStock, setLowStock] = useState<LowStockAlertItem[]>([]);
+  const [expiring, setExpiring] = useState<ExpiringAlertBatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Guards a state update after the org switches or the panel unmounts mid-flight.
+    let active = true;
+
+    // The loader is declared inside the effect so the hooks lint can see that every
+    // setState it performs happens after an await, not synchronously during the body.
+    const run = async () => {
+      if (!organisationId) {
+        setLowStock([]);
+        setExpiring([]);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      try {
+        const [low, exp] = await Promise.all([
+          fetchLowStockAlerts(organisationId),
+          fetchExpiringAlerts(organisationId, expiringWindowDays),
+        ]);
+        if (!active) return;
+        setLowStock(low);
+        setExpiring(exp);
+      } catch {
+        if (!active) return;
+        setLowStock([]);
+        setExpiring([]);
+        setError('Unable to load inventory alerts right now.');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      active = false;
+    };
+  }, [organisationId, expiringWindowDays]);
+
+  return (
+    <InventoryAlerts
+      lowStock={lowStock}
+      expiring={expiring}
+      loading={loading}
+      error={error}
+      expiringWindowDays={expiringWindowDays}
+    />
+  );
+};
+
+export default InventoryAlertsPanel;

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -59,6 +59,7 @@ import { usePhonePrimaryAction } from '@/app/ui/layout/PhoneShell/usePhonePrimar
 import { useIsPhone } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import DispensaryDetailModal from '@/app/features/inventory/components/DispensaryDetailModal';
 import InventoryPhoneCatalog from '@/app/features/inventory/pages/Inventory/InventoryPhoneCatalog';
+import InventoryAlertsPanel from '@/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel';
 import type { InventoryTurnoverFilterState } from '@/app/ui/filters/InventoryTurnoverFilters';
 import { StatusOption, status } from '@/app/features/companions/pages/Companions/types';
 import { Primary } from '@/app/ui/primitives/Buttons';
@@ -1280,6 +1281,12 @@ const useInventoryContent = () => {
                 setDispensarySearch={setDispensarySearch}
               />
             </div>
+
+            {activeView === 'inventory' && (
+              <section aria-label="Inventory alerts" className="w-full shrink-0">
+                <InventoryAlertsPanel organisationId={primaryOrgId ?? undefined} />
+              </section>
+            )}
 
             {loadingList && activeView === 'inventory' && (
               <div className="text-grey-noti text-sm font-satoshi">Loading inventory…</div>

--- a/apps/frontend/src/app/features/inventory/services/inventoryAlertsService.ts
+++ b/apps/frontend/src/app/features/inventory/services/inventoryAlertsService.ts
@@ -1,0 +1,77 @@
+import axios from 'axios';
+import { getData } from '@/app/services/axios';
+
+/**
+ * The low-stock endpoint returns raw `InventoryItem` rows the backend has already
+ * filtered to `(onHand ?? 0) <= reorderLevel` (reorderLevel truthy). These are the
+ * fields the alerts UI reads — the full item carries ~40 more that the panel ignores.
+ */
+export type LowStockAlertItem = {
+  id: string;
+  name: string;
+  onHand: number;
+  reorderLevel: number | null;
+  unitOfMeasure?: string | null;
+  stockUnitType?: string | null;
+  category?: string | null;
+  sku?: string | null;
+};
+
+/**
+ * The expiring endpoint returns raw `InventoryBatch` rows ordered by `expiryDate` asc.
+ * `inventoryItem` is typed optional because the current handler does NOT `include` the
+ * item relation — the batch carries only `itemId`. Typing it means a later `include`
+ * flows through without a UI change; until then the panel falls back to the batch number.
+ */
+export type ExpiringAlertBatch = {
+  id: string;
+  itemId: string;
+  batchNumber?: string | null;
+  expiryDate: string | null;
+  quantity: number;
+  inventoryItem?: { name?: string | null } | null;
+};
+
+export const fetchLowStockAlerts = async (organisationId: string): Promise<LowStockAlertItem[]> => {
+  try {
+    const res = await getData<LowStockAlertItem[]>(
+      `/v1/inventory/organisation/${organisationId}/alerts/low-stock`
+    );
+    if (!Array.isArray(res.data)) {
+      console.warn('Low-stock alerts response is not an array', res.data);
+      return [];
+    }
+    return res.data;
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      console.error('Failed to load low-stock alerts:', err.response?.data?.message ?? err.message);
+    } else {
+      console.error('Failed to load low-stock alerts:', err);
+    }
+    throw err;
+  }
+};
+
+export const fetchExpiringAlerts = async (
+  organisationId: string,
+  days = 30
+): Promise<ExpiringAlertBatch[]> => {
+  try {
+    const res = await getData<ExpiringAlertBatch[]>(
+      `/v1/inventory/organisation/${organisationId}/alerts/expiring`,
+      { days }
+    );
+    if (!Array.isArray(res.data)) {
+      console.warn('Expiring alerts response is not an array', res.data);
+      return [];
+    }
+    return res.data;
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      console.error('Failed to load expiring alerts:', err.response?.data?.message ?? err.message);
+    } else {
+      console.error('Failed to load expiring alerts:', err);
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
Wires two already-built, mounted, permission-gated backend endpoints that had **no client surface** — part of the "wire what exists" wave from the re-verified capability roadmap.

## What was unreachable
- `GET /v1/inventory/organisation/:id/alerts/low-stock` — items at/below reorder level.
- `GET /v1/inventory/organisation/:id/alerts/expiring?days=N` — batches expiring soon.

A clinic had no way to see either.

## What this adds
- `inventoryAlertsService.ts` — `fetchLowStockAlerts` / `fetchExpiringAlerts` over the repo's axios helper, typed against the **real** backend shapes.
- `InventoryAlerts` (presentational) — low-stock + expiring-soon groups, per-group empty states, loading + error states, built on the same tokens and the shared `StatusPill` the rest of inventory uses. Theme-aware, responsive, accessible.
- `InventoryAlertsPanel` (container) — parallel fetch, org-switch/unmount guard.
- Wired onto the inventory page in a 7-line diff, inside the existing `INVENTORY_VIEW_ANY` `PermissionGate`, scoped to the primary org. Page not restructured.

## Reality over the spec
Items expose `unitOfMeasure`/`sku` (there is no `unit`/`code`), and the expiring endpoint returns raw batch rows with **no item relation** — so the expiring row title falls back to the batch number, and the item type is optional so a future `include` flows through with no code change.

## Tests
Mutation-checked (flipping `onHand <= 0` to `< 0` reds the out-of-stock test): low-stock rows + out-of-stock emphasis, expiring rows + batch fallback, both empty states, the error banner. Storybook story covers populated/empty/loading. `tsc` 0, lint clean, 4/4 pass.