### PR TITLE
feat(frontend): surface the appointment waitlist

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/Waitlist.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Waitlist.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import Waitlist, {
+  type WaitlistEntryView,
+} from '@/app/features/appointments/components/Waitlist/Waitlist';
+import type { WaitlistStatus } from '@/app/features/appointments/services/waitlistService';
+
+const entry = (
+  id: string,
+  status: WaitlistStatus,
+  overrides: Partial<WaitlistEntryView> = {}
+): WaitlistEntryView => ({
+  id,
+  organisationId: 'org-1',
+  patientId: `patient-${id}`,
+  requestedBy: null,
+  preferredLeadId: null,
+  appointmentType: 'Dental',
+  earliestDate: null,
+  latestDate: null,
+  notes: null,
+  status,
+  offeredAt: null,
+  bookedAt: null,
+  expiresAt: null,
+  createdAt: '2026-09-01T08:00:00.000Z',
+  updatedAt: '2026-09-01T08:00:00.000Z',
+  companionName: `Companion ${id}`,
+  ownerName: `Owner ${id}`,
+  ...overrides,
+});
+
+const handlers = () => ({
+  onOffer: jest.fn(),
+  onBook: jest.fn(),
+  onCancel: jest.fn(),
+  onAdd: jest.fn(async () => true),
+});
+
+describe('Waitlist', () => {
+  it('renders each entry with a status pill and the companion + owner', () => {
+    render(
+      <Waitlist
+        entries={[entry('1', 'WAITING'), entry('2', 'OFFERED'), entry('3', 'BOOKED')]}
+        {...handlers()}
+      />
+    );
+
+    // StatusPill uppercases via CSS, so the DOM text keeps title case.
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+    expect(screen.getByText('Offered')).toBeInTheDocument();
+    expect(screen.getByText('Booked')).toBeInTheDocument();
+    expect(screen.getByText('Companion 1')).toBeInTheDocument();
+    expect(screen.getByText('Owner 1')).toBeInTheDocument();
+  });
+
+  it('shows the actions each status permits and hides the rest', () => {
+    render(<Waitlist entries={[entry('1', 'WAITING'), entry('2', 'OFFERED')]} {...handlers()} />);
+
+    // WAITING -> Offer, Book, Cancel. OFFERED -> Book, Cancel (no Offer).
+    expect(screen.getAllByRole('button', { name: 'Offer' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Book' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Cancel' })).toHaveLength(2);
+  });
+
+  it('renders no row actions for a terminal (booked) entry', () => {
+    render(<Waitlist entries={[entry('1', 'BOOKED')]} {...handlers()} />);
+
+    expect(screen.queryByRole('button', { name: 'Offer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Book' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('invokes the offer handler with the entry id', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<Waitlist entries={[entry('42', 'WAITING')]} {...props} />);
+
+    await user.click(screen.getByRole('button', { name: 'Offer' }));
+
+    expect(props.onOffer).toHaveBeenCalledWith('42');
+  });
+
+  it('opens the add form and submits a payload', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <Waitlist
+        entries={[entry('1', 'WAITING')]}
+        companions={[{ id: 'patient-1', name: 'Bruno', ownerName: 'Sarah' }]}
+        {...props}
+      />
+    );
+
+    // The form is closed until the affordance is clicked.
+    expect(screen.queryByText('Requested service')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Add to waitlist/ }));
+    expect(screen.getByText('Companion')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByRole('combobox'), 'patient-1');
+    await user.type(screen.getByPlaceholderText('e.g. Dental, Vaccination'), 'Dental');
+    // The submit button is the one inside the open form (type=submit).
+    await user.click(screen.getByRole('button', { name: 'Add to waitlist' }));
+
+    expect(props.onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ patientId: 'patient-1', appointmentType: 'Dental' })
+    );
+  });
+
+  it('shows the empty state when there are no entries', () => {
+    render(<Waitlist entries={[]} {...handlers()} />);
+
+    expect(screen.getByText('No one is on the waitlist')).toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton instead of rows or the empty state', () => {
+    render(<Waitlist entries={[]} loading {...handlers()} />);
+
+    expect(screen.queryByText('No one is on the waitlist')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Offer' })).not.toBeInTheDocument();
+  });
+
+  it('renders read-only when no action or add handlers are supplied', () => {
+    render(<Waitlist entries={[entry('1', 'WAITING')]} />);
+
+    expect(screen.queryByRole('button', { name: 'Offer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add to waitlist/ })).not.toBeInTheDocument();
+  });
+
+  it('numbers WAITING entries by their FIFO queue position', () => {
+    render(
+      <Waitlist
+        entries={[entry('1', 'WAITING'), entry('2', 'OFFERED'), entry('3', 'WAITING')]}
+        {...handlers()}
+      />
+    );
+
+    // Two WAITING entries -> positions 1 and 2; the OFFERED row is not numbered.
+    expect(screen.getByLabelText('Queue position 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Queue position 2')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Queue position 3')).not.toBeInTheDocument();
+  });
+
+  it('shows the error banner when an error is passed', () => {
+    render(<Waitlist entries={[entry('1', 'WAITING')]} error="Boom" {...handlers()} />);
+
+    expect(within(screen.getByRole('alert')).getByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WaitlistPanel from '@/app/features/appointments/components/Waitlist/WaitlistPanel';
+
+const fetchWaitlist = jest.fn();
+const addToWaitlist = jest.fn();
+const offerWaitlistEntry = jest.fn();
+const bookWaitlistEntry = jest.fn();
+const cancelWaitlistEntry = jest.fn();
+
+jest.mock('@/app/features/appointments/services/waitlistService', () => ({
+  __esModule: true,
+  fetchWaitlist: (...a: unknown[]) => fetchWaitlist(...a),
+  addToWaitlist: (...a: unknown[]) => addToWaitlist(...a),
+  offerWaitlistEntry: (...a: unknown[]) => offerWaitlistEntry(...a),
+  bookWaitlistEntry: (...a: unknown[]) => bookWaitlistEntry(...a),
+  cancelWaitlistEntry: (...a: unknown[]) => cancelWaitlistEntry(...a),
+}));
+
+let primaryOrgId: string | null = 'org-1';
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { primaryOrgId: string | null }) => unknown) => sel({ primaryOrgId }),
+}));
+
+let canEdit = true;
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: () => canEdit }),
+}));
+
+const companionsParents = [
+  { companion: { id: 'p-1', name: 'Buddy' }, parent: { firstName: 'Sam', lastName: 'Owner' } },
+];
+jest.mock('@/app/hooks/useCompanion', () => ({
+  useLoadCompanionsForPrimaryOrg: jest.fn(),
+  useCompanionsParentsForPrimaryOrg: () => companionsParents,
+}));
+
+// Presentational double: exposes the container's wiring as buttons + text.
+jest.mock('@/app/features/appointments/components/Waitlist/Waitlist', () => ({
+  __esModule: true,
+  default: ({ entries, loading, error, onOffer, onBook, onCancel, onAdd }: any) => (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      {entries.map((e: any) => (
+        <div key={e.id} data-testid="entry">
+          {e.companionName}/{e.ownerName ?? 'none'}/{e.status}
+        </div>
+      ))}
+      <span data-testid="has-actions">
+        {String(Boolean(onOffer && onBook && onCancel && onAdd))}
+      </span>
+      {onOffer ? <button onClick={() => onOffer('w-1')}>offer</button> : null}
+      {onCancel ? <button onClick={() => onCancel('w-1')}>cancel</button> : null}
+      {onAdd ? <button onClick={() => onAdd({ patientId: 'p-1' })}>add</button> : null}
+    </div>
+  ),
+}));
+
+const entry = { id: 'w-1', patientId: 'p-1', status: 'WAITING' };
+
+describe('WaitlistPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primaryOrgId = 'org-1';
+    canEdit = true;
+    fetchWaitlist.mockResolvedValue([entry]);
+    offerWaitlistEntry.mockResolvedValue(entry);
+    cancelWaitlistEntry.mockResolvedValue(entry);
+    addToWaitlist.mockResolvedValue(entry);
+  });
+
+  it('loads the waitlist and resolves companion + owner names', async () => {
+    render(<WaitlistPanel />);
+    await waitFor(() => expect(fetchWaitlist).toHaveBeenCalledWith('org-1'));
+    expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/Sam Owner/WAITING');
+    expect(screen.getByTestId('has-actions')).toHaveTextContent('true');
+  });
+
+  it('withholds edit actions without permission', async () => {
+    canEdit = false;
+    render(<WaitlistPanel />);
+    await waitFor(() => expect(fetchWaitlist).toHaveBeenCalled());
+    expect(screen.getByTestId('has-actions')).toHaveTextContent('false');
+  });
+
+  it('runs an action then refetches', async () => {
+    render(<WaitlistPanel />);
+    await screen.findByText('offer');
+    fireEvent.click(screen.getByText('offer'));
+    await waitFor(() => expect(offerWaitlistEntry).toHaveBeenCalledWith('org-1', 'w-1'));
+    expect(fetchWaitlist).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces an error when an action fails', async () => {
+    cancelWaitlistEntry.mockRejectedValueOnce(new Error('x'));
+    render(<WaitlistPanel />);
+    await screen.findByText('cancel');
+    fireEvent.click(screen.getByText('cancel'));
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('could not be completed')
+    );
+  });
+
+  it('adds an entry and refetches', async () => {
+    render(<WaitlistPanel />);
+    await screen.findByText('add');
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => expect(addToWaitlist).toHaveBeenCalledWith('org-1', { patientId: 'p-1' }));
+  });
+
+  it('shows a load error when the fetch throws', async () => {
+    fetchWaitlist.mockReset().mockRejectedValue(new Error('down'));
+    render(<WaitlistPanel />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('Unable to load the waitlist')
+    );
+  });
+
+  it('renders nothing to load without a primary org', async () => {
+    primaryOrgId = null;
+    render(<WaitlistPanel />);
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+    expect(fetchWaitlist).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
@@ -52,6 +52,7 @@ jest.mock('@/app/features/appointments/components/Waitlist/Waitlist', () => ({
         {String(Boolean(onOffer && onBook && onCancel && onAdd))}
       </span>
       {onOffer ? <button onClick={() => onOffer('w-1')}>offer</button> : null}
+      {onBook ? <button onClick={() => onBook('w-1')}>book</button> : null}
       {onCancel ? <button onClick={() => onCancel('w-1')}>cancel</button> : null}
       {onAdd ? <button onClick={() => onAdd({ patientId: 'p-1' })}>add</button> : null}
     </div>
@@ -93,6 +94,14 @@ describe('WaitlistPanel', () => {
     expect(fetchWaitlist).toHaveBeenCalledTimes(2);
   });
 
+  it('books an offered entry then refetches', async () => {
+    render(<WaitlistPanel />);
+    await screen.findByText('book');
+    fireEvent.click(screen.getByText('book'));
+    await waitFor(() => expect(bookWaitlistEntry).toHaveBeenCalledWith('org-1', 'w-1'));
+    expect(fetchWaitlist).toHaveBeenCalledTimes(2);
+  });
+
   it('surfaces an error when an action fails', async () => {
     cancelWaitlistEntry.mockRejectedValueOnce(new Error('x'));
     render(<WaitlistPanel />);
@@ -108,6 +117,15 @@ describe('WaitlistPanel', () => {
     await screen.findByText('add');
     fireEvent.click(screen.getByText('add'));
     await waitFor(() => expect(addToWaitlist).toHaveBeenCalledWith('org-1', { patientId: 'p-1' }));
+  });
+
+  it('does not refetch when adding an entry fails', async () => {
+    addToWaitlist.mockRejectedValueOnce(new Error('x'));
+    render(<WaitlistPanel />);
+    await screen.findByText('add');
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => expect(addToWaitlist).toHaveBeenCalled());
+    expect(fetchWaitlist).toHaveBeenCalledTimes(1);
   });
 
   it('shows a load error when the fetch throws', async () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
@@ -52,6 +52,34 @@ describe('waitlistService', () => {
     expect(getDataMock).toHaveBeenCalledWith(BASE);
   });
 
+  it.each(['', '../admin', 'org/other', 'https://attacker.test'])(
+    'rejects an unsafe organisation id from fetch (%s)',
+    async (organisationId) => {
+      await expect(fetchWaitlist(organisationId)).rejects.toThrow('Invalid organisation ID');
+      expect(getDataMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['', '../admin', 'org/other', 'https://attacker.test'])(
+    'rejects an unsafe organisation id from add (%s)',
+    async (organisationId) => {
+      await expect(addToWaitlist(organisationId, { patientId: 'p-1' })).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(postDataMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['', '../admin', 'org/other', 'https://attacker.test'])(
+    'rejects an unsafe organisation id from transitions (%s)',
+    async (organisationId) => {
+      await expect(offerWaitlistEntry(organisationId, 'w-1')).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(postDataMock).not.toHaveBeenCalled();
+    }
+  );
+
   it('returns [] and warns when the response is not an array', async () => {
     getDataMock.mockResolvedValue({ data: { nope: true } });
     await expect(fetchWaitlist('org-1')).resolves.toEqual([]);
@@ -94,6 +122,16 @@ describe('waitlistService', () => {
     await fn('org-1', 'w-1');
     expect(postDataMock).toHaveBeenCalledWith(`${BASE}/w-1/${action}`);
   });
+
+  it.each(['', '../admin', 'entry/other', 'https://attacker.test'])(
+    'rejects an unsafe waitlist entry id (%s)',
+    async (entryId) => {
+      await expect(offerWaitlistEntry('org-1', entryId)).rejects.toThrow(
+        'Invalid waitlist entry ID'
+      );
+      expect(postDataMock).not.toHaveBeenCalled();
+    }
+  );
 
   it('rethrows and logs when a transition fails', async () => {
     postDataMock.mockRejectedValue(new Error('t'));

--- a/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
@@ -1,0 +1,106 @@
+import { AxiosError } from 'axios';
+import {
+  fetchWaitlist,
+  addToWaitlist,
+  offerWaitlistEntry,
+  bookWaitlistEntry,
+  cancelWaitlistEntry,
+  type WaitlistEntry,
+} from '@/app/features/appointments/services/waitlistService';
+
+const getDataMock = jest.fn();
+const postDataMock = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  getData: (...args: unknown[]) => getDataMock(...args),
+  postData: (...args: unknown[]) => postDataMock(...args),
+}));
+
+const entry: WaitlistEntry = {
+  id: 'w-1',
+  organisationId: 'org-1',
+  patientId: 'p-1',
+  requestedBy: null,
+  preferredLeadId: null,
+  appointmentType: null,
+  earliestDate: null,
+  latestDate: null,
+  notes: null,
+  status: 'WAITING',
+  offeredAt: null,
+  bookedAt: null,
+  expiresAt: null,
+  createdAt: '2026-09-01T09:00:00.000Z',
+  updatedAt: '2026-09-01T09:00:00.000Z',
+};
+
+const BASE = '/v1/pms/organisation/org-1/waitlist';
+
+describe('waitlistService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('fetches the waitlist for an org', async () => {
+    getDataMock.mockResolvedValue({ data: [entry] });
+    await expect(fetchWaitlist('org-1')).resolves.toEqual([entry]);
+    expect(getDataMock).toHaveBeenCalledWith(BASE);
+  });
+
+  it('returns [] and warns when the response is not an array', async () => {
+    getDataMock.mockResolvedValue({ data: { nope: true } });
+    await expect(fetchWaitlist('org-1')).resolves.toEqual([]);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('logs the axios message and rethrows on a fetch failure', async () => {
+    const err = new AxiosError('boom');
+    err.response = { data: { message: 'nope' } } as AxiosError['response'];
+    getDataMock.mockRejectedValue(err);
+    await expect(fetchWaitlist('org-1')).rejects.toBe(err);
+    expect(console.error).toHaveBeenCalledWith('Failed to load waitlist:', 'nope');
+  });
+
+  it('logs a non-axios error verbatim and rethrows', async () => {
+    const err = new Error('raw');
+    getDataMock.mockRejectedValue(err);
+    await expect(fetchWaitlist('org-1')).rejects.toBe(err);
+    expect(console.error).toHaveBeenCalledWith('Failed to load waitlist:', err);
+  });
+
+  it('adds an entry', async () => {
+    postDataMock.mockResolvedValue({ data: entry });
+    await expect(addToWaitlist('org-1', { patientId: 'p-1' })).resolves.toEqual(entry);
+    expect(postDataMock).toHaveBeenCalledWith(BASE, { patientId: 'p-1' });
+  });
+
+  it('rethrows when add fails', async () => {
+    postDataMock.mockRejectedValue(new Error('x'));
+    await expect(addToWaitlist('org-1', { patientId: 'p-1' })).rejects.toThrow('x');
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['offer', offerWaitlistEntry],
+    ['book', bookWaitlistEntry],
+    ['cancel', cancelWaitlistEntry],
+  ] as const)('posts the %s transition', async (action, fn) => {
+    postDataMock.mockResolvedValue({ data: { ...entry, status: 'OFFERED' } });
+    await fn('org-1', 'w-1');
+    expect(postDataMock).toHaveBeenCalledWith(`${BASE}/w-1/${action}`);
+  });
+
+  it('rethrows and logs when a transition fails', async () => {
+    postDataMock.mockRejectedValue(new Error('t'));
+    await expect(cancelWaitlistEntry('org-1', 'w-1')).rejects.toThrow('t');
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to cancel waitlist entry:',
+      expect.anything()
+    );
+  });
+});

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type { WaitlistStatus } from '@/app/features/appointments/services/waitlistService';
+import Waitlist, { type WaitlistEntryView } from './Waitlist';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * A waitlist row as the container hands it to the presentational component: the
+ * raw API entry plus the resolved `companionName`/`ownerName`. The dates are ISO
+ * strings because the clinical handler returns the Prisma row unwrapped, and the
+ * nullable columns are `null`, not `undefined`.
+ */
+const entry = (
+  id: string,
+  status: WaitlistStatus,
+  companionName: string,
+  ownerName: string,
+  overrides: Partial<WaitlistEntryView> = {}
+): WaitlistEntryView => ({
+  id,
+  organisationId: ORG_ID,
+  patientId: `patient-${id}`,
+  requestedBy: 'user-1',
+  preferredLeadId: null,
+  appointmentType: 'Dental',
+  earliestDate: null,
+  latestDate: null,
+  notes: null,
+  status,
+  offeredAt: status === 'OFFERED' ? '2026-09-02T09:00:00.000Z' : null,
+  bookedAt: status === 'BOOKED' ? '2026-09-02T11:00:00.000Z' : null,
+  expiresAt: null,
+  createdAt: '2026-09-01T08:00:00.000Z',
+  updatedAt: '2026-09-02T09:00:00.000Z',
+  companionName,
+  ownerName,
+  ...overrides,
+});
+
+const ENTRIES: WaitlistEntryView[] = [
+  entry('1', 'WAITING', 'Bruno', 'Sarah Whitfield', {
+    appointmentType: 'Dental cleaning',
+    notes: 'Flexible mornings',
+  }),
+  entry('2', 'WAITING', 'Mochi', 'Lena Hartmann', { appointmentType: 'Vaccination' }),
+  entry('3', 'OFFERED', 'Poppy', 'Amir Rahimi', { appointmentType: 'Recheck' }),
+  entry('4', 'BOOKED', 'Cleo', 'Nina Alvarez', { appointmentType: 'Surgery consult' }),
+  entry('5', 'CANCELLED', 'Rex', 'Tom Becker', { appointmentType: 'Grooming' }),
+];
+
+const COMPANIONS = [
+  { id: 'patient-1', name: 'Bruno', ownerName: 'Sarah Whitfield' },
+  { id: 'patient-9', name: 'Ziggy', ownerName: 'Priya Nair' },
+];
+
+const meta = {
+  title: 'Appointments/Waitlist',
+  component: Waitlist,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Presentational waitlist panel. Each row shows the companion and owner, the ' +
+          'requested service and reason, its FIFO queue position while WAITING, and a ' +
+          '`StatusPill` for the status. The offer/book/cancel actions on a row follow what ' +
+          'the backend permits from that status, and every action (plus the add form) only ' +
+          'renders when the matching handler prop is supplied - which is how the container ' +
+          'hides them from users without edit permission.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    entries: ENTRIES,
+    companions: COMPANIONS,
+    onOffer: fn(),
+    onBook: fn(),
+    onCancel: fn(),
+    onAdd: fn(async () => true),
+  },
+} satisfies Meta<typeof Waitlist>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Uppercased by StatusPill, so query the DOM casing.
+    await expect(canvas.getAllByText('Waiting').length).toBe(2);
+    await expect(canvas.getByText('Offered')).toBeInTheDocument();
+    await expect(canvas.getByText('Booked')).toBeInTheDocument();
+    // A WAITING row offers all three actions; a BOOKED row is terminal.
+    await expect(canvas.getAllByRole('button', { name: 'Offer' }).length).toBe(2);
+    await expect(canvas.getAllByRole('button', { name: 'Book' }).length).toBe(3);
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read only (no edit permission)',
+  args: { onOffer: undefined, onBook: undefined, onCancel: undefined, onAdd: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: 'Offer' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Add to waitlist' })).not.toBeInTheDocument();
+  },
+};
+
+export const AddForm: Story = {
+  name: 'Add form open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Add to waitlist/ }));
+    await expect(canvas.getByText('Companion')).toBeInTheDocument();
+    await expect(canvas.getByText('Requested service')).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: { entries: [] },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByText('No one is on the waitlist')).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+  play: async ({ canvasElement }) => {
+    // The skeleton renders instead of the empty message and instead of rows.
+    await expect(
+      within(canvasElement).queryByText('No one is on the waitlist')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const WithError: Story = {
+  name: 'Error banner',
+  args: { error: 'Unable to load the waitlist right now.' },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByRole('alert')).toHaveTextContent(
+      'Unable to load the waitlist right now.'
+    );
+  },
+};
+
+export const Dark: Story = {
+  name: 'Dark theme',
+  globals: { theme: 'dark' },
+};

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
@@ -1,0 +1,436 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { IoListOutline, IoAddOutline } from 'react-icons/io5';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import type {
+  WaitlistEntry,
+  WaitlistStatus,
+  AddToWaitlistPayload,
+} from '@/app/features/appointments/services/waitlistService';
+
+/** A companion the add-form offers as the subject of a new waitlist entry. */
+export type WaitlistCompanionOption = { id: string; name: string; ownerName?: string };
+
+/**
+ * A waitlist row for display. The API entry carries only `patientId`; the
+ * container resolves the companion + owner names from the companions store and
+ * attaches them here, falling back to a generic label when the companion is not
+ * loaded (same optional-with-fallback shape the inventory alerts panel uses).
+ */
+export type WaitlistEntryView = WaitlistEntry & {
+  companionName?: string;
+  ownerName?: string;
+};
+
+export type WaitlistProps = {
+  entries: WaitlistEntryView[];
+  /** Companions offered in the add-form select. Empty disables adding. */
+  companions?: WaitlistCompanionOption[];
+  loading?: boolean;
+  error?: string | null;
+  /** Id of the entry whose action is in flight, so its buttons disable. */
+  busyEntryId?: string | null;
+  onOffer?: (id: string) => void;
+  onBook?: (id: string) => void;
+  onCancel?: (id: string) => void;
+  /** Resolves true when the entry was added, so the form can reset and close. */
+  onAdd?: (payload: AddToWaitlistPayload) => Promise<boolean>;
+};
+
+const STATUS_TONE: Record<WaitlistStatus, StatusTone> = {
+  WAITING: 'info',
+  OFFERED: 'warning',
+  BOOKED: 'success',
+  CANCELLED: 'danger',
+  EXPIRED: 'neutral',
+};
+
+const STATUS_LABEL: Record<WaitlistStatus, string> = {
+  WAITING: 'Waiting',
+  OFFERED: 'Offered',
+  BOOKED: 'Booked',
+  CANCELLED: 'Cancelled',
+  EXPIRED: 'Expired',
+};
+
+type WaitlistAction = 'offer' | 'book' | 'cancel';
+
+/** Which transitions the backend permits from each status (waitlist.service.ts). */
+const ACTIONS_BY_STATUS: Record<WaitlistStatus, WaitlistAction[]> = {
+  WAITING: ['offer', 'book', 'cancel'],
+  OFFERED: ['book', 'cancel'],
+  BOOKED: [],
+  CANCELLED: [],
+  EXPIRED: [],
+};
+
+const ACTION_LABEL: Record<WaitlistAction, string> = {
+  offer: 'Offer',
+  book: 'Book',
+  cancel: 'Cancel',
+};
+
+const cardClass =
+  'flex flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
+const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
+const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
+const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
+const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
+const inputClass =
+  'w-full rounded-lg border border-[var(--hairline)] bg-[var(--screen)] px-2.5 py-1.5 text-[12.5px] text-[var(--ink)] outline-none focus:border-[var(--ink-muted)]';
+
+const absoluteDate = (iso: string | null): string | null => {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+};
+
+const toIsoOrUndefined = (value: string): string | undefined => {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+const ActionButton = ({
+  label,
+  tone,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  tone: 'default' | 'danger';
+  disabled?: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    disabled={disabled}
+    onClick={onClick}
+    className={clsx(
+      'rounded-lg border px-2.5 py-1 text-[11.5px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+      tone === 'danger'
+        ? 'border-[var(--hairline)] text-[var(--danger-text)] hover:bg-[var(--inset)]'
+        : 'border-[var(--hairline)] text-[var(--ink)] hover:bg-[var(--inset)]'
+    )}
+  >
+    {label}
+  </button>
+);
+
+const WaitlistRow = ({
+  entry,
+  position,
+  busy,
+  onOffer,
+  onBook,
+  onCancel,
+}: {
+  entry: WaitlistEntryView;
+  position: number | null;
+  busy: boolean;
+  onOffer?: (id: string) => void;
+  onBook?: (id: string) => void;
+  onCancel?: (id: string) => void;
+}) => {
+  const handlers = { offer: onOffer, book: onBook, cancel: onCancel };
+  const serviceReason = [entry.appointmentType, entry.notes].filter(Boolean).join(' · ');
+  const added = absoluteDate(entry.createdAt);
+  const actions = ACTIONS_BY_STATUS[entry.status].filter((action) => handlers[action]);
+
+  return (
+    <li className={rowClass}>
+      <span className="flex min-w-0 items-start gap-2.5">
+        {position !== null && (
+          <span
+            className="mt-0.5 w-5 shrink-0 text-center text-[12px] font-bold tabular-nums text-[var(--ink-faint)]"
+            aria-label={`Queue position ${position}`}
+          >
+            {position}
+          </span>
+        )}
+        <span className="min-w-0">
+          <span className={clsx(titleClass, 'block truncate')}>
+            {entry.companionName || 'Companion'}
+          </span>
+          {entry.ownerName && (
+            <span className={clsx(metaClass, 'block truncate')}>{entry.ownerName}</span>
+          )}
+          {serviceReason && (
+            <span className={clsx(metaClass, 'mt-0.5 block truncate')}>{serviceReason}</span>
+          )}
+        </span>
+      </span>
+      <span className="flex shrink-0 flex-col items-end gap-1.5">
+        <StatusPill label={STATUS_LABEL[entry.status]} tone={STATUS_TONE[entry.status]} />
+        {added && <span className={metaClass}>Added {added}</span>}
+        {actions.length > 0 && (
+          <span className="mt-0.5 flex flex-wrap justify-end gap-1.5">
+            {actions.map((action) => (
+              <ActionButton
+                key={action}
+                label={ACTION_LABEL[action]}
+                tone={action === 'cancel' ? 'danger' : 'default'}
+                disabled={busy}
+                onClick={() => handlers[action]?.(entry.id)}
+              />
+            ))}
+          </span>
+        )}
+      </span>
+    </li>
+  );
+};
+
+const AddWaitlistForm = ({
+  companions,
+  onAdd,
+  onClose,
+}: {
+  companions: WaitlistCompanionOption[];
+  onAdd: (payload: AddToWaitlistPayload) => Promise<boolean>;
+  onClose: () => void;
+}) => {
+  const [patientId, setPatientId] = useState('');
+  const [appointmentType, setAppointmentType] = useState('');
+  const [notes, setNotes] = useState('');
+  const [earliestDate, setEarliestDate] = useState('');
+  const [latestDate, setLatestDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!patientId) {
+      setFormError('Choose a companion to add to the waitlist.');
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      const ok = await onAdd({
+        patientId,
+        appointmentType: appointmentType.trim() || undefined,
+        notes: notes.trim() || undefined,
+        earliestDate: toIsoOrUndefined(earliestDate),
+        latestDate: toIsoOrUndefined(latestDate),
+      });
+      if (ok) {
+        onClose();
+        return;
+      }
+      setFormError('Could not add to the waitlist. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
+    >
+      <label className="flex flex-col gap-1">
+        <span className={fieldLabelClass}>Companion</span>
+        <select
+          className={inputClass}
+          value={patientId}
+          onChange={(e) => setPatientId(e.target.value)}
+          disabled={companions.length === 0}
+        >
+          <option value="">
+            {companions.length === 0 ? 'No companions available' : 'Select a companion'}
+          </option>
+          {companions.map((companion) => (
+            <option key={companion.id} value={companion.id}>
+              {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className={fieldLabelClass}>Requested service</span>
+        <input
+          className={inputClass}
+          value={appointmentType}
+          onChange={(e) => setAppointmentType(e.target.value)}
+          maxLength={100}
+          placeholder="e.g. Dental, Vaccination"
+        />
+      </label>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className={fieldLabelClass}>Earliest date</span>
+          <input
+            type="date"
+            className={inputClass}
+            value={earliestDate}
+            onChange={(e) => setEarliestDate(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className={fieldLabelClass}>Latest date</span>
+          <input
+            type="date"
+            className={inputClass}
+            value={latestDate}
+            onChange={(e) => setLatestDate(e.target.value)}
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className={fieldLabelClass}>Reason / notes</span>
+        <textarea
+          className={clsx(inputClass, 'min-h-16 resize-y')}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          maxLength={500}
+          placeholder="Anything the scheduler should know"
+        />
+      </label>
+
+      {formError && (
+        <p role="alert" className="text-[11.5px] font-semibold text-[var(--danger-text)]">
+          {formError}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <ActionButton label="Cancel" tone="default" disabled={submitting} onClick={onClose} />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-lg border border-[var(--ink)] bg-[var(--ink)] px-3 py-1 text-[11.5px] font-semibold text-[var(--screen)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? 'Adding…' : 'Add to waitlist'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+const EmptyState = ({ message }: { message: string }) => (
+  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
+);
+
+const LoadingRows = () => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((i) => (
+      <li key={i} className={rowClass}>
+        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);
+
+/**
+ * Presentational-only waitlist. Renders the entries the caller supplies with a
+ * status pill and the row actions each status permits; it never fetches. The
+ * container ({@link WaitlistPanel}) owns loading, error, data and the action
+ * handlers. Actions and the add form only appear when the matching handler prop
+ * is provided, so the container gates them on edit permission by withholding
+ * the handlers.
+ */
+const Waitlist = ({
+  entries,
+  companions = [],
+  loading = false,
+  error = null,
+  busyEntryId = null,
+  onOffer,
+  onBook,
+  onCancel,
+  onAdd,
+}: WaitlistProps) => {
+  const [addOpen, setAddOpen] = useState(false);
+
+  // FIFO priority: the backend offers the oldest WAITING entry first, so number
+  // the WAITING entries in the order the list arrives (createdAt asc).
+  const positionById = useMemo(() => {
+    const map = new Map<string, number>();
+    let n = 0;
+    for (const entry of entries) {
+      if (entry.status === 'WAITING') {
+        n += 1;
+        map.set(entry.id, n);
+      }
+    }
+    return map;
+  }, [entries]);
+
+  const body = (() => {
+    if (loading) return <LoadingRows />;
+    if (entries.length === 0) return <EmptyState message="No one is on the waitlist" />;
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {entries.map((entry) => (
+          <WaitlistRow
+            key={entry.id}
+            entry={entry}
+            position={positionById.get(entry.id) ?? null}
+            busy={busyEntryId === entry.id}
+            onOffer={onOffer}
+            onBook={onBook}
+            onCancel={onCancel}
+          />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <section className={clsx(cardClass, 'w-full')} aria-labelledby="waitlist-heading">
+      <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+        <span className="text-[var(--ink-muted)]" aria-hidden="true">
+          <IoListOutline size={18} />
+        </span>
+        <h3 id="waitlist-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+          Waitlist
+        </h3>
+        {!loading && entries.length > 0 && (
+          <StatusPill
+            label={String(entries.length)}
+            tone="neutral"
+            className="ml-auto tabular-nums"
+          />
+        )}
+        {onAdd && (
+          <button
+            type="button"
+            onClick={() => setAddOpen((open) => !open)}
+            aria-expanded={addOpen}
+            className={clsx(
+              'flex items-center gap-1 rounded-lg border border-[var(--hairline)] px-2.5 py-1 text-[11.5px] font-semibold text-[var(--ink)] transition-colors hover:bg-[var(--inset)]',
+              !loading && entries.length > 0 ? 'ml-2' : 'ml-auto'
+            )}
+          >
+            <IoAddOutline size={15} aria-hidden="true" />
+            {addOpen ? 'Close' : 'Add to waitlist'}
+          </button>
+        )}
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      )}
+
+      {onAdd && addOpen && (
+        <AddWaitlistForm companions={companions} onAdd={onAdd} onClose={() => setAddOpen(false)} />
+      )}
+
+      {body}
+    </section>
+  );
+};
+
+export default Waitlist;

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
@@ -1,147 +1,26 @@
 'use client';
-import React, { useEffect, useMemo, useState } from 'react';
-import Waitlist, {
-  type WaitlistCompanionOption,
-  type WaitlistEntryView,
-} from '@/app/features/appointments/components/Waitlist/Waitlist';
-import {
-  addToWaitlist,
-  bookWaitlistEntry,
-  cancelWaitlistEntry,
-  fetchWaitlist,
-  offerWaitlistEntry,
-  type AddToWaitlistPayload,
-  type WaitlistEntry,
-} from '@/app/features/appointments/services/waitlistService';
-import {
-  useCompanionsParentsForPrimaryOrg,
-  useLoadCompanionsForPrimaryOrg,
-} from '@/app/hooks/useCompanion';
-import { useOrgStore } from '@/app/stores/orgStore';
-import { usePermissions } from '@/app/hooks/usePermissions';
-import { PERMISSIONS } from '@/app/lib/permissions';
-
-const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
-  [firstName, lastName].filter(Boolean).join(' ').trim();
+import React from 'react';
+import Waitlist from '@/app/features/appointments/components/Waitlist/Waitlist';
+import { useWaitlist } from '@/app/features/appointments/components/Waitlist/useWaitlist';
 
 /**
- * Data container for {@link Waitlist}. Loads the primary org's waitlist, resolves
- * each entry's companion + owner names from the companions store (the entry
- * itself carries only `patientId`), and wires the offer/book/cancel/add actions
- * back through the service. Edit actions are withheld — the panel hides them —
- * when the user lacks appointment edit permission.
+ * Data container for {@link Waitlist}. All state lives in {@link useWaitlist};
+ * this projects it onto the presentational panel and withholds the edit actions
+ * (the panel hides them) when the user lacks appointment edit permission.
  */
 const WaitlistPanel = () => {
-  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
-  const permissions = usePermissions();
-  const canEdit =
-    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY) ||
-    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_OWN);
-
-  useLoadCompanionsForPrimaryOrg();
-  const companionsParents = useCompanionsParentsForPrimaryOrg();
-
-  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-
-    const run = async () => {
-      if (!primaryOrgId) {
-        setEntries([]);
-        setError(null);
-        setLoading(false);
-        return;
-      }
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await fetchWaitlist(primaryOrgId);
-        if (!active) return;
-        setEntries(data);
-      } catch {
-        if (!active) return;
-        setEntries([]);
-        setError('Unable to load the waitlist right now.');
-      } finally {
-        if (active) setLoading(false);
-      }
-    };
-
-    void run();
-
-    return () => {
-      active = false;
-    };
-  }, [primaryOrgId]);
-
-  const companionMetaById = useMemo(() => {
-    const map = new Map<string, { name: string; ownerName: string }>();
-    for (const { companion, parent } of companionsParents) {
-      map.set(companion.id, {
-        name: companion.name,
-        ownerName: ownerNameOf(parent.firstName, parent.lastName),
-      });
-    }
-    return map;
-  }, [companionsParents]);
-
-  const entriesView = useMemo<WaitlistEntryView[]>(
-    () =>
-      entries.map((entry) => {
-        const meta = companionMetaById.get(entry.patientId);
-        return {
-          ...entry,
-          companionName: meta?.name,
-          ownerName: meta?.ownerName || undefined,
-        };
-      }),
-    [entries, companionMetaById]
-  );
-
-  const companionOptions = useMemo<WaitlistCompanionOption[]>(
-    () =>
-      companionsParents.map(({ companion, parent }) => ({
-        id: companion.id,
-        name: companion.name,
-        ownerName: ownerNameOf(parent.firstName, parent.lastName) || undefined,
-      })),
-    [companionsParents]
-  );
-
-  const runAction = async (
-    id: string,
-    action: (organisationId: string, entryId: string) => Promise<WaitlistEntry>
-  ) => {
-    if (!primaryOrgId) return;
-    setBusyEntryId(id);
-    try {
-      await action(primaryOrgId, id);
-      const data = await fetchWaitlist(primaryOrgId);
-      setEntries(data);
-      setError(null);
-    } catch {
-      setError('That action could not be completed. Try again.');
-    } finally {
-      setBusyEntryId(null);
-    }
-  };
-
-  const handleAdd = async (payload: AddToWaitlistPayload): Promise<boolean> => {
-    if (!primaryOrgId) return false;
-    try {
-      await addToWaitlist(primaryOrgId, payload);
-      const data = await fetchWaitlist(primaryOrgId);
-      setEntries(data);
-      setError(null);
-      return true;
-    } catch {
-      return false;
-    }
-  };
+  const {
+    canEdit,
+    entriesView,
+    companionOptions,
+    loading,
+    error,
+    busyEntryId,
+    offer,
+    book,
+    cancel,
+    add,
+  } = useWaitlist();
 
   return (
     <Waitlist
@@ -150,10 +29,10 @@ const WaitlistPanel = () => {
       loading={loading}
       error={error}
       busyEntryId={busyEntryId}
-      onOffer={canEdit ? (id) => void runAction(id, offerWaitlistEntry) : undefined}
-      onBook={canEdit ? (id) => void runAction(id, bookWaitlistEntry) : undefined}
-      onCancel={canEdit ? (id) => void runAction(id, cancelWaitlistEntry) : undefined}
-      onAdd={canEdit ? handleAdd : undefined}
+      onOffer={canEdit ? (id) => void offer(id) : undefined}
+      onBook={canEdit ? (id) => void book(id) : undefined}
+      onCancel={canEdit ? (id) => void cancel(id) : undefined}
+      onAdd={canEdit ? add : undefined}
     />
   );
 };

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
@@ -1,0 +1,161 @@
+'use client';
+import React, { useEffect, useMemo, useState } from 'react';
+import Waitlist, {
+  type WaitlistCompanionOption,
+  type WaitlistEntryView,
+} from '@/app/features/appointments/components/Waitlist/Waitlist';
+import {
+  addToWaitlist,
+  bookWaitlistEntry,
+  cancelWaitlistEntry,
+  fetchWaitlist,
+  offerWaitlistEntry,
+  type AddToWaitlistPayload,
+  type WaitlistEntry,
+} from '@/app/features/appointments/services/waitlistService';
+import {
+  useCompanionsParentsForPrimaryOrg,
+  useLoadCompanionsForPrimaryOrg,
+} from '@/app/hooks/useCompanion';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+
+const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ').trim();
+
+/**
+ * Data container for {@link Waitlist}. Loads the primary org's waitlist, resolves
+ * each entry's companion + owner names from the companions store (the entry
+ * itself carries only `patientId`), and wires the offer/book/cancel/add actions
+ * back through the service. Edit actions are withheld — the panel hides them —
+ * when the user lacks appointment edit permission.
+ */
+const WaitlistPanel = () => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const permissions = usePermissions();
+  const canEdit =
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY) ||
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_OWN);
+
+  useLoadCompanionsForPrimaryOrg();
+  const companionsParents = useCompanionsParentsForPrimaryOrg();
+
+  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const run = async () => {
+      if (!primaryOrgId) {
+        setEntries([]);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchWaitlist(primaryOrgId);
+        if (!active) return;
+        setEntries(data);
+      } catch {
+        if (!active) return;
+        setEntries([]);
+        setError('Unable to load the waitlist right now.');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      active = false;
+    };
+  }, [primaryOrgId]);
+
+  const companionMetaById = useMemo(() => {
+    const map = new Map<string, { name: string; ownerName: string }>();
+    for (const { companion, parent } of companionsParents) {
+      map.set(companion.id, {
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName),
+      });
+    }
+    return map;
+  }, [companionsParents]);
+
+  const entriesView = useMemo<WaitlistEntryView[]>(
+    () =>
+      entries.map((entry) => {
+        const meta = companionMetaById.get(entry.patientId);
+        return {
+          ...entry,
+          companionName: meta?.name,
+          ownerName: meta?.ownerName || undefined,
+        };
+      }),
+    [entries, companionMetaById]
+  );
+
+  const companionOptions = useMemo<WaitlistCompanionOption[]>(
+    () =>
+      companionsParents.map(({ companion, parent }) => ({
+        id: companion.id,
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName) || undefined,
+      })),
+    [companionsParents]
+  );
+
+  const runAction = async (
+    id: string,
+    action: (organisationId: string, entryId: string) => Promise<WaitlistEntry>
+  ) => {
+    if (!primaryOrgId) return;
+    setBusyEntryId(id);
+    try {
+      await action(primaryOrgId, id);
+      const data = await fetchWaitlist(primaryOrgId);
+      setEntries(data);
+      setError(null);
+    } catch {
+      setError('That action could not be completed. Try again.');
+    } finally {
+      setBusyEntryId(null);
+    }
+  };
+
+  const handleAdd = async (payload: AddToWaitlistPayload): Promise<boolean> => {
+    if (!primaryOrgId) return false;
+    try {
+      await addToWaitlist(primaryOrgId, payload);
+      const data = await fetchWaitlist(primaryOrgId);
+      setEntries(data);
+      setError(null);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return (
+    <Waitlist
+      entries={entriesView}
+      companions={companionOptions}
+      loading={loading}
+      error={error}
+      busyEntryId={busyEntryId}
+      onOffer={canEdit ? (id) => void runAction(id, offerWaitlistEntry) : undefined}
+      onBook={canEdit ? (id) => void runAction(id, bookWaitlistEntry) : undefined}
+      onCancel={canEdit ? (id) => void runAction(id, cancelWaitlistEntry) : undefined}
+      onAdd={canEdit ? handleAdd : undefined}
+    />
+  );
+};
+
+export default WaitlistPanel;

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
@@ -1,0 +1,161 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  addToWaitlist,
+  bookWaitlistEntry,
+  cancelWaitlistEntry,
+  fetchWaitlist,
+  offerWaitlistEntry,
+  type AddToWaitlistPayload,
+  type WaitlistEntry,
+} from '@/app/features/appointments/services/waitlistService';
+import {
+  useCompanionsParentsForPrimaryOrg,
+  useLoadCompanionsForPrimaryOrg,
+} from '@/app/hooks/useCompanion';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import type {
+  WaitlistCompanionOption,
+  WaitlistEntryView,
+} from '@/app/features/appointments/components/Waitlist/Waitlist';
+
+const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ').trim();
+
+export interface WaitlistState {
+  canEdit: boolean;
+  entriesView: WaitlistEntryView[];
+  companionOptions: WaitlistCompanionOption[];
+  loading: boolean;
+  error: string | null;
+  busyEntryId: string | null;
+  offer: (id: string) => Promise<void>;
+  book: (id: string) => Promise<void>;
+  cancel: (id: string) => Promise<void>;
+  add: (payload: AddToWaitlistPayload) => Promise<boolean>;
+}
+
+/**
+ * All of the waitlist container's state: it loads the primary org's waitlist,
+ * resolves each entry's companion + owner names from the companions store (the
+ * entry itself carries only `patientId`), and exposes the offer/book/cancel/add
+ * actions. Kept out of the component so the container is a thin projection.
+ */
+export const useWaitlist = (): WaitlistState => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const permissions = usePermissions();
+  const canEdit =
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY) ||
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_OWN);
+
+  useLoadCompanionsForPrimaryOrg();
+  const companionsParents = useCompanionsParentsForPrimaryOrg();
+
+  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      if (!primaryOrgId) {
+        setEntries([]);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchWaitlist(primaryOrgId);
+        if (active) setEntries(data);
+      } catch {
+        if (active) {
+          setEntries([]);
+          setError('Unable to load the waitlist right now.');
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [primaryOrgId]);
+
+  const companionMetaById = useMemo(() => {
+    const map = new Map<string, { name: string; ownerName: string }>();
+    for (const { companion, parent } of companionsParents) {
+      map.set(companion.id, {
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName),
+      });
+    }
+    return map;
+  }, [companionsParents]);
+
+  const entriesView = useMemo<WaitlistEntryView[]>(
+    () =>
+      entries.map((entry) => {
+        const meta = companionMetaById.get(entry.patientId);
+        return { ...entry, companionName: meta?.name, ownerName: meta?.ownerName || undefined };
+      }),
+    [entries, companionMetaById]
+  );
+
+  const companionOptions = useMemo<WaitlistCompanionOption[]>(
+    () =>
+      companionsParents.map(({ companion, parent }) => ({
+        id: companion.id,
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName) || undefined,
+      })),
+    [companionsParents]
+  );
+
+  const runAction = async (
+    id: string,
+    action: (organisationId: string, entryId: string) => Promise<WaitlistEntry>
+  ): Promise<void> => {
+    if (!primaryOrgId) return;
+    setBusyEntryId(id);
+    try {
+      await action(primaryOrgId, id);
+      setEntries(await fetchWaitlist(primaryOrgId));
+      setError(null);
+    } catch {
+      setError('That action could not be completed. Try again.');
+    } finally {
+      setBusyEntryId(null);
+    }
+  };
+
+  const add = async (payload: AddToWaitlistPayload): Promise<boolean> => {
+    if (!primaryOrgId) return false;
+    try {
+      await addToWaitlist(primaryOrgId, payload);
+      setEntries(await fetchWaitlist(primaryOrgId));
+      setError(null);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return {
+    canEdit,
+    entriesView,
+    companionOptions,
+    loading,
+    error,
+    busyEntryId,
+    offer: (id) => runAction(id, offerWaitlistEntry),
+    book: (id) => runAction(id, bookWaitlistEntry),
+    cancel: (id) => runAction(id, cancelWaitlistEntry),
+    add,
+  };
+};

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import {
   addToWaitlist,
   bookWaitlistEntry,
@@ -37,6 +37,93 @@ export interface WaitlistState {
   add: (payload: AddToWaitlistPayload) => Promise<boolean>;
 }
 
+type WaitlistData = {
+  entries: WaitlistEntry[];
+  setEntries: Dispatch<SetStateAction<WaitlistEntry[]>>;
+  loading: boolean;
+  error: string | null;
+  setError: Dispatch<SetStateAction<string | null>>;
+};
+
+const useWaitlistData = (organisationId: string | null): WaitlistData => {
+  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      if (!organisationId) {
+        setEntries([]);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchWaitlist(organisationId);
+        if (active) setEntries(data);
+      } catch {
+        if (active) {
+          setEntries([]);
+          setError('Unable to load the waitlist right now.');
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [organisationId]);
+
+  return { entries, setEntries, loading, error, setError };
+};
+
+const useWaitlistActions = (
+  organisationId: string | null,
+  setEntries: WaitlistData['setEntries'],
+  setError: WaitlistData['setError']
+) => {
+  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
+  const runAction = async (
+    id: string,
+    action: (orgId: string, entryId: string) => Promise<WaitlistEntry>
+  ): Promise<void> => {
+    if (!organisationId) return;
+    setBusyEntryId(id);
+    try {
+      await action(organisationId, id);
+      setEntries(await fetchWaitlist(organisationId));
+      setError(null);
+    } catch {
+      setError('That action could not be completed. Try again.');
+    } finally {
+      setBusyEntryId(null);
+    }
+  };
+  const add = async (payload: AddToWaitlistPayload): Promise<boolean> => {
+    if (!organisationId) return false;
+    try {
+      await addToWaitlist(organisationId, payload);
+      setEntries(await fetchWaitlist(organisationId));
+      setError(null);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  return {
+    busyEntryId,
+    offer: (id: string) => runAction(id, offerWaitlistEntry),
+    book: (id: string) => runAction(id, bookWaitlistEntry),
+    cancel: (id: string) => runAction(id, cancelWaitlistEntry),
+    add,
+  };
+};
+
 /**
  * All of the waitlist container's state: it loads the primary org's waitlist,
  * resolves each entry's companion + owner names from the companions store (the
@@ -52,40 +139,8 @@ export const useWaitlist = (): WaitlistState => {
 
   useLoadCompanionsForPrimaryOrg();
   const companionsParents = useCompanionsParentsForPrimaryOrg();
-
-  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    const run = async () => {
-      if (!primaryOrgId) {
-        setEntries([]);
-        setError(null);
-        setLoading(false);
-        return;
-      }
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await fetchWaitlist(primaryOrgId);
-        if (active) setEntries(data);
-      } catch {
-        if (active) {
-          setEntries([]);
-          setError('Unable to load the waitlist right now.');
-        }
-      } finally {
-        if (active) setLoading(false);
-      }
-    };
-    void run();
-    return () => {
-      active = false;
-    };
-  }, [primaryOrgId]);
+  const { entries, setEntries, loading, error, setError } = useWaitlistData(primaryOrgId);
+  const actions = useWaitlistActions(primaryOrgId, setEntries, setError);
 
   const companionMetaById = useMemo(() => {
     const map = new Map<string, { name: string; ownerName: string }>();
@@ -117,45 +172,12 @@ export const useWaitlist = (): WaitlistState => {
     [companionsParents]
   );
 
-  const runAction = async (
-    id: string,
-    action: (organisationId: string, entryId: string) => Promise<WaitlistEntry>
-  ): Promise<void> => {
-    if (!primaryOrgId) return;
-    setBusyEntryId(id);
-    try {
-      await action(primaryOrgId, id);
-      setEntries(await fetchWaitlist(primaryOrgId));
-      setError(null);
-    } catch {
-      setError('That action could not be completed. Try again.');
-    } finally {
-      setBusyEntryId(null);
-    }
-  };
-
-  const add = async (payload: AddToWaitlistPayload): Promise<boolean> => {
-    if (!primaryOrgId) return false;
-    try {
-      await addToWaitlist(primaryOrgId, payload);
-      setEntries(await fetchWaitlist(primaryOrgId));
-      setError(null);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
   return {
     canEdit,
     entriesView,
     companionOptions,
     loading,
     error,
-    busyEntryId,
-    offer: (id) => runAction(id, offerWaitlistEntry),
-    book: (id) => runAction(id, bookWaitlistEntry),
-    cancel: (id) => runAction(id, cancelWaitlistEntry),
-    add,
+    ...actions,
   };
 };

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -43,6 +43,9 @@ const ChangeStatus = React.lazy(
 const ChangeRoom = React.lazy(
   () => import('@/app/features/appointments/pages/Appointments/Sections/ChangeRoom')
 );
+const WaitlistPanel = React.lazy(
+  () => import('@/app/features/appointments/components/Waitlist/WaitlistPanel')
+);
 import { useSearchStore } from '@/app/stores/searchStore';
 import Filters from '@/app/ui/filters/Filters';
 import {
@@ -325,6 +328,7 @@ const useAppointmentsView = () => {
   const [activeFilter, setActiveFilter] = useState('all');
   const [activeStatus, setActiveStatus] = useState('all');
   const [addPopup, setAddPopup] = useState(false);
+  const [showWaitlist, setShowWaitlist] = useState(false);
   const [addAppointmentPrefill, setAddAppointmentPrefill] =
     useState<AppointmentDraftPrefill | null>(null);
   const [viewPopup, setViewPopup] = useState(false);
@@ -590,6 +594,32 @@ const useAppointmentsView = () => {
           deniedResource="Appointments"
           deniedDetail="the appointment schedule"
         >
+          <section aria-labelledby="appointments-waitlist-heading" className="mb-3">
+            <button
+              type="button"
+              onClick={() => setShowWaitlist((open) => !open)}
+              aria-expanded={showWaitlist}
+              aria-controls="appointments-waitlist-panel"
+              className="flex w-full items-center justify-between gap-3 rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-4 py-2.5 text-left shadow-[0_1px_2px_var(--sh03)] transition-colors hover:bg-[var(--inset)]"
+            >
+              <span
+                id="appointments-waitlist-heading"
+                className="text-[13.5px] font-bold text-[var(--ink)]"
+              >
+                Waitlist
+              </span>
+              <span className="text-[12px] font-semibold text-[var(--ink-muted)]">
+                {showWaitlist ? 'Hide' : 'Show'}
+              </span>
+            </button>
+            {showWaitlist && (
+              <div id="appointments-waitlist-panel" className="mt-3">
+                <React.Suspense fallback={<PlannerViewSkeleton />}>
+                  <WaitlistPanel />
+                </React.Suspense>
+              </div>
+            )}
+          </section>
           <div className={wrapperClassName}>
             {activeView === 'list' && (
               <Filters

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+
+/**
+ * Waitlist status mirrors the backend `WaitlistStatus` enum
+ * (packages/database/prisma/schema.prisma). WAITING entries can be offered a
+ * slot; OFFERED/WAITING can be booked; anything not already CANCELLED/EXPIRED
+ * can be cancelled.
+ */
+export type WaitlistStatus = 'WAITING' | 'OFFERED' | 'BOOKED' | 'CANCELLED' | 'EXPIRED';
+
+/**
+ * One waitlist entry exactly as the controller returns it (the Prisma
+ * `entrySelect` in waitlist.service.ts). The clinical handler replies with the
+ * raw row — no `{ data, meta }` envelope — so `DateTime` columns arrive as ISO
+ * strings and the nullable columns arrive as `null`, not `undefined`.
+ */
+export interface WaitlistEntry {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  requestedBy: string | null;
+  preferredLeadId: string | null;
+  appointmentType: string | null;
+  earliestDate: string | null;
+  latestDate: string | null;
+  notes: string | null;
+  status: WaitlistStatus;
+  offeredAt: string | null;
+  bookedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The add-entry body the controller validates (`AddBodySchema`). Only
+ * `patientId` is required; the date fields are ISO datetime strings.
+ */
+export interface AddToWaitlistPayload {
+  patientId: string;
+  preferredLeadId?: string;
+  appointmentType?: string;
+  earliestDate?: string;
+  latestDate?: string;
+  notes?: string;
+  expiresAt?: string;
+}
+
+const waitlistPath = (organisationId: string) => `/v1/pms/organisation/${organisationId}/waitlist`;
+
+const logFailure = (message: string, err: unknown): void => {
+  if (axios.isAxiosError(err)) {
+    console.error(message, err.response?.data?.message ?? err.message);
+  } else {
+    console.error(message, err);
+  }
+};
+
+export const fetchWaitlist = async (organisationId: string): Promise<WaitlistEntry[]> => {
+  try {
+    const res = await getData<WaitlistEntry[]>(waitlistPath(organisationId));
+    if (!Array.isArray(res.data)) {
+      console.warn('Waitlist response is not an array', res.data);
+      return [];
+    }
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to load waitlist:', err);
+    throw err;
+  }
+};
+
+export const addToWaitlist = async (
+  organisationId: string,
+  payload: AddToWaitlistPayload
+): Promise<WaitlistEntry> => {
+  try {
+    const res = await postData<WaitlistEntry, AddToWaitlistPayload>(
+      waitlistPath(organisationId),
+      payload
+    );
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to add waitlist entry:', err);
+    throw err;
+  }
+};
+
+const transition = async (
+  organisationId: string,
+  entryId: string,
+  action: 'offer' | 'book' | 'cancel'
+): Promise<WaitlistEntry> => {
+  try {
+    const res = await postData<WaitlistEntry>(
+      `${waitlistPath(organisationId)}/${entryId}/${action}`
+    );
+    return res.data;
+  } catch (err) {
+    logFailure(`Failed to ${action} waitlist entry:`, err);
+    throw err;
+  }
+};
+
+export const offerWaitlistEntry = (organisationId: string, entryId: string) =>
+  transition(organisationId, entryId, 'offer');
+
+export const bookWaitlistEntry = (organisationId: string, entryId: string) =>
+  transition(organisationId, entryId, 'book');
+
+export const cancelWaitlistEntry = (organisationId: string, entryId: string) =>
+  transition(organisationId, entryId, 'cancel');

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -47,12 +47,6 @@ export interface AddToWaitlistPayload {
   expiresAt?: string;
 }
 
-// Encode the caller's own org id + entry id as single path segments so the
-// request stays pinned to `/v1/pms/organisation/<seg>/waitlist/<seg>/...`
-// even if an id ever carried a slash or dot (what the SSRF scanner checks).
-const waitlistPath = (organisationId: string) =>
-  `/v1/pms/organisation/${encodeURIComponent(organisationId)}/waitlist`;
-
 const logFailure = (message: string, err: unknown): void => {
   if (axios.isAxiosError(err)) {
     console.error(message, err.response?.data?.message ?? err.message);
@@ -62,8 +56,9 @@ const logFailure = (message: string, err: unknown): void => {
 };
 
 export const fetchWaitlist = async (organisationId: string): Promise<WaitlistEntry[]> => {
+  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
   try {
-    const res = await getData<WaitlistEntry[]>(waitlistPath(organisationId));
+    const res = await getData<WaitlistEntry[]>(`/v1/pms/organisation/${organisationId}/waitlist`);
     if (!Array.isArray(res.data)) {
       console.warn('Waitlist response is not an array; got', typeof res.data);
       return [];
@@ -79,9 +74,10 @@ export const addToWaitlist = async (
   organisationId: string,
   payload: AddToWaitlistPayload
 ): Promise<WaitlistEntry> => {
+  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
   try {
     const res = await postData<WaitlistEntry, AddToWaitlistPayload>(
-      waitlistPath(organisationId),
+      `/v1/pms/organisation/${organisationId}/waitlist`,
       payload
     );
     return res.data;
@@ -96,9 +92,11 @@ const transition = async (
   entryId: string,
   action: 'offer' | 'book' | 'cancel'
 ): Promise<WaitlistEntry> => {
+  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
+  if (!/^[A-Za-z0-9_-]+$/.test(entryId)) throw new Error('Invalid waitlist entry ID');
   try {
     const res = await postData<WaitlistEntry>(
-      `${waitlistPath(organisationId)}/${encodeURIComponent(entryId)}/${action}`
+      `/v1/pms/organisation/${organisationId}/waitlist/${entryId}/${action}`
     );
     return res.data;
   } catch (err) {

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -48,7 +48,7 @@ export interface AddToWaitlistPayload {
 }
 
 const safePathSegment = (value: string, label: string): string => {
-  const safeValue = value.match(/^[A-Za-z0-9_-]+$/)?.[0];
+  const safeValue = /^[A-Za-z0-9_-]+$/.exec(value)?.[0];
   if (!safeValue) throw new Error(`Invalid ${label} ID`);
   return safeValue;
 };

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -61,7 +61,7 @@ export const fetchWaitlist = async (organisationId: string): Promise<WaitlistEnt
   try {
     const res = await getData<WaitlistEntry[]>(waitlistPath(organisationId));
     if (!Array.isArray(res.data)) {
-      console.warn('Waitlist response is not an array', res.data);
+      console.warn('Waitlist response is not an array; got', typeof res.data);
       return [];
     }
     return res.data;

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -47,6 +47,12 @@ export interface AddToWaitlistPayload {
   expiresAt?: string;
 }
 
+const safePathSegment = (value: string, label: string): string => {
+  const safeValue = value.match(/^[A-Za-z0-9_-]+$/)?.[0];
+  if (!safeValue) throw new Error(`Invalid ${label} ID`);
+  return safeValue;
+};
+
 const logFailure = (message: string, err: unknown): void => {
   if (axios.isAxiosError(err)) {
     console.error(message, err.response?.data?.message ?? err.message);
@@ -56,9 +62,11 @@ const logFailure = (message: string, err: unknown): void => {
 };
 
 export const fetchWaitlist = async (organisationId: string): Promise<WaitlistEntry[]> => {
-  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
+  const safeOrganisationId = safePathSegment(organisationId, 'organisation');
   try {
-    const res = await getData<WaitlistEntry[]>(`/v1/pms/organisation/${organisationId}/waitlist`);
+    const res = await getData<WaitlistEntry[]>(
+      `/v1/pms/organisation/${safeOrganisationId}/waitlist`
+    );
     if (!Array.isArray(res.data)) {
       console.warn('Waitlist response is not an array; got', typeof res.data);
       return [];
@@ -74,10 +82,10 @@ export const addToWaitlist = async (
   organisationId: string,
   payload: AddToWaitlistPayload
 ): Promise<WaitlistEntry> => {
-  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
+  const safeOrganisationId = safePathSegment(organisationId, 'organisation');
   try {
     const res = await postData<WaitlistEntry, AddToWaitlistPayload>(
-      `/v1/pms/organisation/${organisationId}/waitlist`,
+      `/v1/pms/organisation/${safeOrganisationId}/waitlist`,
       payload
     );
     return res.data;
@@ -92,11 +100,11 @@ const transition = async (
   entryId: string,
   action: 'offer' | 'book' | 'cancel'
 ): Promise<WaitlistEntry> => {
-  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
-  if (!/^[A-Za-z0-9_-]+$/.test(entryId)) throw new Error('Invalid waitlist entry ID');
+  const safeOrganisationId = safePathSegment(organisationId, 'organisation');
+  const safeEntryId = safePathSegment(entryId, 'waitlist entry');
   try {
     const res = await postData<WaitlistEntry>(
-      `/v1/pms/organisation/${organisationId}/waitlist/${entryId}/${action}`
+      `/v1/pms/organisation/${safeOrganisationId}/waitlist/${safeEntryId}/${action}`
     );
     return res.data;
   } catch (err) {

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -47,7 +47,11 @@ export interface AddToWaitlistPayload {
   expiresAt?: string;
 }
 
-const waitlistPath = (organisationId: string) => `/v1/pms/organisation/${organisationId}/waitlist`;
+// Encode the caller's own org id + entry id as single path segments so the
+// request stays pinned to `/v1/pms/organisation/<seg>/waitlist/<seg>/...`
+// even if an id ever carried a slash or dot (what the SSRF scanner checks).
+const waitlistPath = (organisationId: string) =>
+  `/v1/pms/organisation/${encodeURIComponent(organisationId)}/waitlist`;
 
 const logFailure = (message: string, err: unknown): void => {
   if (axios.isAxiosError(err)) {
@@ -94,7 +98,7 @@ const transition = async (
 ): Promise<WaitlistEntry> => {
   try {
     const res = await postData<WaitlistEntry>(
-      `${waitlistPath(organisationId)}/${entryId}/${action}`
+      `${waitlistPath(organisationId)}/${encodeURIComponent(entryId)}/${action}`
     );
     return res.data;
   } catch (err) {


### PR DESCRIPTION
Wires the waitlist backend that had no client surface — part of the "wire what exists" wave.

## What was unreachable
The full waitlist API (model, service with offer/book/cancel/expire, RBAC-gated router at `/v1/pms/organisation/:id/waitlist`) existed and was mounted, but a clinic had no way to see or manage its waitlist.

## What this adds
A collapsible **Waitlist** panel on the appointments page:
- each entry shows the companion + owner, requested service, queue position, a status pill, and status-aware **Offer / Book / Cancel** actions;
- an add-to-waitlist form;
- lazy-loaded inside the existing `APPOINTMENTS_VIEW_ANY` `PermissionGate`, code-split so it only fetches when expanded;
- edit actions withheld unless the user holds `appointments:edit`.

Built on the shared `StatusPill` and the same tokens as the rest of the app — theme-aware, responsive, accessible (`aria-expanded`/`aria-controls`).

## Reality over assumptions
The entry carries only a `patientId` (companion/owner names resolved from the companions store); there is **no** `priority` column, so "priority" is the true FIFO queue position the backend offers by (`createdAt asc`); and `book` accepts `WAITING` or `OFFERED`.

## Tests
Mutation-checked (adding `offer` to `OFFERED`'s action set reds the per-status test): status pills, correct actions per status, the add form, empty/loading/error. Story covers populated/read-only/empty/loading/error/dark. `tsc` 0, lint clean, 10/10; appointments page suites still 52/52.