### PR TITLE
feat(frontend): surface the patient problem list

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ProblemList from '@/app/features/companionHistory/components/ProblemList';
+import type { PatientProblem } from '@/app/features/companionHistory/services/patientProblemService';
+
+const problem = (over: Partial<PatientProblem> & { id: string; name: string }): PatientProblem => ({
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  codeSystem: null,
+  code: null,
+  status: 'ACTIVE',
+  severity: null,
+  onsetDate: null,
+  resolvedDate: null,
+  notes: null,
+  recordedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const PROBLEMS: PatientProblem[] = [
+  problem({
+    id: 'p-1',
+    name: 'Chronic kidney disease',
+    status: 'ACTIVE',
+    severity: 'SEVERE',
+    onsetDate: '2025-11-02T00:00:00.000Z',
+    notes: 'IRIS stage 3.',
+  }),
+  problem({
+    id: 'p-2',
+    name: 'Mild dental tartar',
+    status: 'ACTIVE',
+    severity: 'MILD',
+  }),
+  problem({
+    id: 'p-3',
+    name: 'Post-operative wound',
+    status: 'RESOLVED',
+    severity: 'MODERATE',
+    resolvedDate: '2025-08-20T00:00:00.000Z',
+  }),
+];
+
+describe('ProblemList', () => {
+  it('renders active and resolved problems with status and severity pills', () => {
+    render(<ProblemList problems={PROBLEMS} canEdit />);
+
+    expect(screen.getByText('Chronic kidney disease')).toBeInTheDocument();
+    expect(screen.getByText('Post-operative wound')).toBeInTheDocument();
+
+    // Status pills: two active, one resolved.
+    expect(screen.getAllByText('Active')).toHaveLength(2);
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+
+    // Severity pills mapped to plain-language labels.
+    expect(screen.getByText('Severe')).toBeInTheDocument();
+    expect(screen.getByText('Mild')).toBeInTheDocument();
+    expect(screen.getByText('Moderate')).toBeInTheDocument();
+
+    // Active count summary.
+    expect(screen.getByText('2 active')).toBeInTheDocument();
+
+    // Onset + resolved metadata rendered (locale-agnostic: the formatted date
+    // ends with the year, and the "not recorded" row would not).
+    expect(screen.getByText(/^Onset\b.*2025$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Resolved\b.*2025$/)).toBeInTheDocument();
+  });
+
+  it('shows a resolve action only for active problems and fires onResolve', async () => {
+    const onResolve = jest.fn();
+    render(<ProblemList problems={PROBLEMS} canEdit onResolve={onResolve} />);
+
+    const resolveButtons = screen.getAllByRole('button', { name: /^Resolve / });
+    // Only the two ACTIVE problems get a resolve control, not the RESOLVED one.
+    expect(resolveButtons).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve Chronic kidney disease' }));
+    expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'p-1' }));
+  });
+
+  it('opens the add form and submits collected values, then closes on success', async () => {
+    const onCreate = jest.fn().mockResolvedValue(true);
+    render(<ProblemList problems={PROBLEMS} canEdit onCreate={onCreate} />);
+
+    // Form is hidden until the affordance is used.
+    expect(screen.queryByLabelText('Problem title')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Add problem/ }));
+
+    const nameInput = screen.getByLabelText('Problem title');
+    expect(nameInput).toBeInTheDocument();
+
+    await userEvent.type(nameInput, 'New skin lesion');
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'MODERATE');
+    fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      name: 'New skin lesion',
+      notes: '',
+      severity: 'MODERATE',
+      onsetDate: '2026-02-01',
+    });
+
+    // A resolved create clears and closes the form.
+    await waitFor(() => expect(screen.queryByLabelText('Problem title')).not.toBeInTheDocument());
+  });
+
+  it('keeps the form open when the create fails', async () => {
+    const onCreate = jest.fn().mockResolvedValue(false);
+    render(<ProblemList problems={[]} canEdit onCreate={onCreate} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Add problem/ }));
+    await userEvent.type(screen.getByLabelText('Problem title'), 'Retry me');
+    await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Problem title')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no problems', () => {
+    render(<ProblemList problems={[]} canEdit />);
+    expect(screen.getByText(/No problems recorded/)).toBeInTheDocument();
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
+  it('renders a loading skeleton instead of the empty copy', () => {
+    render(<ProblemList problems={[]} loading canEdit />);
+    expect(screen.queryByText(/No problems recorded/)).not.toBeInTheDocument();
+  });
+
+  it('surfaces an error banner', () => {
+    render(
+      <ProblemList problems={[]} error="Could not load the problem list. Please try again." />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load the problem list');
+  });
+
+  it('hides the add and resolve controls when the member cannot edit', () => {
+    render(<ProblemList problems={PROBLEMS} canEdit={false} />);
+    expect(screen.queryByRole('button', { name: /Add problem/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Resolve / })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemListPanel.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
+import {
+  createPatientProblem,
+  fetchPatientProblems,
+  resolvePatientProblem,
+  type PatientProblem,
+} from '@/app/features/companionHistory/services/patientProblemService';
+
+const mockNotify = jest.fn();
+let mockPermissions: string[] = ['appointments:view:any', 'appointments:edit:any'];
+
+jest.mock('@/app/services/axios', () => ({
+  isAuthRedirectError: jest.fn(() => false),
+}));
+
+jest.mock('@/app/hooks/useNotify', () => ({
+  useNotify: () => ({ notify: mockNotify }),
+}));
+
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: (perm: string) => mockPermissions.includes(perm) }),
+}));
+
+jest.mock('@/app/features/companionHistory/services/patientProblemService', () => ({
+  fetchPatientProblems: jest.fn(),
+  createPatientProblem: jest.fn(),
+  resolvePatientProblem: jest.fn(),
+}));
+
+const fetchMock = fetchPatientProblems as jest.Mock;
+const createMock = createPatientProblem as jest.Mock;
+const resolveMock = resolvePatientProblem as jest.Mock;
+
+const problem = (over: Partial<PatientProblem> & { id: string; name: string }): PatientProblem => ({
+  organisationId: 'org-1',
+  patientId: 'comp-1',
+  encounterId: null,
+  codeSystem: null,
+  code: null,
+  status: 'ACTIVE',
+  severity: null,
+  onsetDate: null,
+  resolvedDate: null,
+  notes: null,
+  recordedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPermissions = ['appointments:view:any', 'appointments:edit:any'];
+  fetchMock.mockResolvedValue([]);
+});
+
+describe('ProblemListPanel', () => {
+  it('loads and renders the patient problems', async () => {
+    fetchMock.mockResolvedValue([
+      problem({ id: 'p-1', name: 'Chronic kidney disease', severity: 'SEVERE' }),
+    ]);
+
+    render(<ProblemListPanel companionId="comp-1" />);
+
+    expect(await screen.findByText('Chronic kidney disease')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith({ patientId: 'comp-1' });
+  });
+
+  it('shows the empty state when there are no problems', async () => {
+    render(<ProblemListPanel companionId="comp-1" />);
+    expect(await screen.findByText(/No problems recorded/)).toBeInTheDocument();
+  });
+
+  it('shows an error banner when the load fails', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
+    render(<ProblemListPanel companionId="comp-1" />);
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load the problem list');
+  });
+
+  it('creates a problem, converting the onset date to an ISO datetime', async () => {
+    createMock.mockResolvedValue(
+      problem({ id: 'p-new', name: 'New skin lesion', severity: 'MODERATE' })
+    );
+    render(<ProblemListPanel companionId="comp-1" />);
+    await screen.findByText(/No problems recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: /Add problem/ }));
+    await userEvent.type(screen.getByLabelText('Problem title'), 'New skin lesion');
+    await userEvent.type(screen.getByLabelText('Description'), 'left flank');
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'MODERATE');
+    fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });
+    await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));
+
+    await waitFor(() =>
+      expect(createMock).toHaveBeenCalledWith({
+        patientId: 'comp-1',
+        name: 'New skin lesion',
+        notes: 'left flank',
+        severity: 'MODERATE',
+        onsetDate: '2026-02-01T00:00:00.000Z',
+      })
+    );
+    expect(await screen.findByText('New skin lesion')).toBeInTheDocument();
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Problem added' })
+    );
+  });
+
+  it('notifies on a failed create', async () => {
+    createMock.mockRejectedValue(new Error('nope'));
+    render(<ProblemListPanel companionId="comp-1" />);
+    await screen.findByText(/No problems recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: /Add problem/ }));
+    await userEvent.type(screen.getByLabelText('Problem title'), 'Retry me');
+    await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));
+
+    await waitFor(() =>
+      expect(mockNotify).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not add problem' })
+      )
+    );
+    // Form stays open after a failed save.
+    expect(screen.getByLabelText('Problem title')).toBeInTheDocument();
+  });
+
+  it('resolves an active problem and updates its status', async () => {
+    fetchMock.mockResolvedValue([problem({ id: 'p-1', name: 'Otitis externa', status: 'ACTIVE' })]);
+    resolveMock.mockResolvedValue(
+      problem({
+        id: 'p-1',
+        name: 'Otitis externa',
+        status: 'RESOLVED',
+        resolvedDate: '2026-02-02T00:00:00.000Z',
+      })
+    );
+    render(<ProblemListPanel companionId="comp-1" />);
+    await screen.findByText('Otitis externa');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve Otitis externa' }));
+
+    await waitFor(() => expect(resolveMock).toHaveBeenCalledWith('p-1'));
+    expect(await screen.findByText('Resolved')).toBeInTheDocument();
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Problem resolved' })
+    );
+  });
+
+  it('renders nothing when the member cannot view problems', () => {
+    mockPermissions = [];
+    const { container } = render(<ProblemListPanel companionId="comp-1" />);
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('hides the edit controls when the member can view but not edit', async () => {
+    mockPermissions = ['appointments:view:any'];
+    fetchMock.mockResolvedValue([problem({ id: 'p-1', name: 'Chronic kidney disease' })]);
+    render(<ProblemListPanel companionId="comp-1" />);
+
+    await screen.findByText('Chronic kidney disease');
+    expect(screen.queryByRole('button', { name: /Add problem/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Resolve / })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/services/patientProblemService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/services/patientProblemService.test.ts
@@ -1,0 +1,85 @@
+import {
+  createPatientProblem,
+  fetchPatientProblems,
+  resolvePatientProblem,
+  updatePatientProblem,
+} from '@/app/features/companionHistory/services/patientProblemService';
+import { getData, postData, putData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+  putData: jest.fn(),
+}));
+
+let mockOrgId: string | null = 'org-1';
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ primaryOrgId: mockOrgId }) },
+}));
+
+const getMock = getData as jest.Mock;
+const postMock = postData as jest.Mock;
+const putMock = putData as jest.Mock;
+
+const BASE = '/v1/pms/organisation/org-1/patient-problems';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOrgId = 'org-1';
+});
+
+describe('patientProblemService', () => {
+  it('fetches problems scoped to the org and patient', async () => {
+    getMock.mockResolvedValue({ data: [{ id: 'p-1' }] });
+    const result = await fetchPatientProblems({ patientId: 'pat-1' });
+    expect(getMock).toHaveBeenCalledWith(BASE, { patientId: 'pat-1' });
+    expect(result).toEqual([{ id: 'p-1' }]);
+  });
+
+  it('passes the status filter when supplied', async () => {
+    getMock.mockResolvedValue({ data: [] });
+    await fetchPatientProblems({ patientId: 'pat-1', status: 'ACTIVE' });
+    expect(getMock).toHaveBeenCalledWith(BASE, { patientId: 'pat-1', status: 'ACTIVE' });
+  });
+
+  it('throws when the patient id is missing', async () => {
+    await expect(fetchPatientProblems({ patientId: '' })).rejects.toThrow('Patient ID missing');
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('creates a problem', async () => {
+    postMock.mockResolvedValue({ data: { id: 'p-new' } });
+    const input = { patientId: 'pat-1', name: 'Otitis', severity: 'MILD' as const };
+    const result = await createPatientProblem(input);
+    expect(postMock).toHaveBeenCalledWith(BASE, input);
+    expect(result).toEqual({ id: 'p-new' });
+  });
+
+  it('updates a problem by id', async () => {
+    putMock.mockResolvedValue({ data: { id: 'p-1', status: 'INACTIVE' } });
+    const result = await updatePatientProblem('p-1', { status: 'INACTIVE' });
+    expect(putMock).toHaveBeenCalledWith(`${BASE}/p-1`, { status: 'INACTIVE' });
+    expect(result).toEqual({ id: 'p-1', status: 'INACTIVE' });
+  });
+
+  it('resolves a problem, defaulting the body to an empty object', async () => {
+    postMock.mockResolvedValue({ data: { id: 'p-1', status: 'RESOLVED' } });
+    await resolvePatientProblem('p-1');
+    expect(postMock).toHaveBeenCalledWith(`${BASE}/p-1/resolve`, {});
+  });
+
+  it('resolves a problem with an explicit resolved date', async () => {
+    postMock.mockResolvedValue({ data: { id: 'p-1', status: 'RESOLVED' } });
+    await resolvePatientProblem('p-1', '2026-02-02T00:00:00.000Z');
+    expect(postMock).toHaveBeenCalledWith(`${BASE}/p-1/resolve`, {
+      resolvedDate: '2026-02-02T00:00:00.000Z',
+    });
+  });
+
+  it('throws when no organisation is selected', async () => {
+    mockOrgId = null;
+    await expect(fetchPatientProblems({ patientId: 'pat-1' })).rejects.toThrow(
+      'No active organisation selected.'
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
@@ -118,6 +118,14 @@ jest.mock('@/app/features/companionHistory/components/CompanionHistoryTimeline',
   ),
 }));
 
+// Stub the async problem-list panel: like the timeline above, it fetches on
+// mount, which would fire a state update outside act() and trip the strict
+// console.error guard in jest.setup. This suite does not exercise it.
+jest.mock('@/app/features/companionHistory/components/ProblemListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => <div data-testid="problem-list-panel">{companionId}</div>,
+}));
+
 jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
   useIsPhone: () => mockIsPhone,
   PHONE_MEDIA_QUERY: '(max-width: 767px)',

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProblemList from './ProblemList';
+import type { PatientProblem } from '@/app/features/companionHistory/services/patientProblemService';
+
+const problem = (over: Partial<PatientProblem>): PatientProblem => ({
+  id: over.id ?? 'p-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  name: over.name ?? 'Problem',
+  codeSystem: null,
+  code: null,
+  status: over.status ?? 'ACTIVE',
+  severity: over.severity ?? null,
+  onsetDate: over.onsetDate ?? null,
+  resolvedDate: over.resolvedDate ?? null,
+  notes: over.notes ?? null,
+  recordedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const SAMPLE: PatientProblem[] = [
+  problem({
+    id: 'p-1',
+    name: 'Chronic kidney disease',
+    status: 'ACTIVE',
+    severity: 'SEVERE',
+    onsetDate: '2025-11-02T00:00:00.000Z',
+    code: 'N18.9',
+    notes: 'IRIS stage 3. Monitoring phosphate and blood pressure.',
+  }),
+  problem({
+    id: 'p-2',
+    name: 'Otitis externa (left ear)',
+    status: 'ACTIVE',
+    severity: 'MODERATE',
+    onsetDate: '2026-01-04T00:00:00.000Z',
+  }),
+  problem({
+    id: 'p-3',
+    name: 'Mild dental tartar',
+    status: 'ACTIVE',
+    severity: 'MILD',
+    onsetDate: '2025-09-18T00:00:00.000Z',
+  }),
+  problem({
+    id: 'p-4',
+    name: 'Post-operative wound',
+    status: 'RESOLVED',
+    severity: 'MODERATE',
+    onsetDate: '2025-08-01T00:00:00.000Z',
+    resolvedDate: '2025-08-20T00:00:00.000Z',
+  }),
+];
+
+const meta = {
+  title: 'CompanionHistory/ProblemList',
+  component: ProblemList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    canEdit: true,
+    problems: SAMPLE,
+    onCreate: async () => true,
+    onResolve: () => {},
+  },
+} satisfies Meta<typeof ProblemList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {};
+
+export const ReadOnly: Story = {
+  args: { canEdit: false },
+};
+
+export const Empty: Story = {
+  args: { problems: [] },
+};
+
+export const Loading: Story = {
+  args: { problems: [], loading: true },
+};
+
+export const WithError: Story = {
+  args: { error: 'Could not load the problem list. Please try again.' },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -157,7 +157,7 @@ const CreateProblemForm = ({
   onCancel,
 }: {
   creating: boolean;
-  onCreate?: ProblemListProps['onCreate'];
+  onCreate?: NonNullable<ProblemListProps['onCreate']>;
   onCancel: () => void;
 }) => {
   const [values, setValues] = useState<ProblemFormValues>(emptyForm);

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -1,0 +1,333 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { IoAddOutline, IoCheckmarkOutline, IoMedkitOutline } from 'react-icons/io5';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import type {
+  PatientProblem,
+  ProblemSeverity,
+  ProblemStatus,
+} from '@/app/features/companionHistory/services/patientProblemService';
+
+/** The values the create form emits. `onsetDate` is a raw `YYYY-MM-DD` (or ''). */
+export type ProblemFormValues = {
+  name: string;
+  notes: string;
+  severity: ProblemSeverity | '';
+  onsetDate: string;
+};
+
+export type ProblemListProps = {
+  problems: PatientProblem[];
+  loading?: boolean;
+  error?: string | null;
+  /** Gates the add/resolve controls. Mirrors the backend `appointments:edit` gate. */
+  canEdit?: boolean;
+  /** Fired when the create form is submitted. Returns true once the record is saved. */
+  onCreate?: (values: ProblemFormValues) => Promise<boolean> | boolean;
+  /** Fired when an active problem's resolve action is clicked. */
+  onResolve?: (problem: PatientProblem) => void;
+  /** Disables the create form's submit while a create is in flight. */
+  creating?: boolean;
+  /** Id of the problem currently being resolved, so its row shows a pending state. */
+  resolvingId?: string | null;
+};
+
+const STATUS_LABEL: Record<ProblemStatus, string> = {
+  ACTIVE: 'Active',
+  INACTIVE: 'Inactive',
+  RESOLVED: 'Resolved',
+};
+
+const STATUS_TONE: Record<ProblemStatus, StatusTone> = {
+  ACTIVE: 'warning',
+  INACTIVE: 'neutral',
+  RESOLVED: 'success',
+};
+
+const SEVERITY_LABEL: Record<ProblemSeverity, string> = {
+  MILD: 'Mild',
+  MODERATE: 'Moderate',
+  SEVERE: 'Severe',
+};
+
+const SEVERITY_TONE: Record<ProblemSeverity, StatusTone> = {
+  MILD: 'info',
+  MODERATE: 'warning',
+  SEVERE: 'danger',
+};
+
+const SEVERITY_OPTIONS: ProblemSeverity[] = ['MILD', 'MODERATE', 'SEVERE'];
+
+const cardClass =
+  'flex w-full flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
+const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
+const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
+const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
+const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
+const controlClass =
+  'w-full rounded-xl border border-[var(--hairline)] bg-[var(--screen)] px-3 py-2 text-[13px] text-[var(--ink)] outline-none focus:border-[var(--blue)]';
+
+const formatDate = (value: string | null): string | null => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+};
+
+const EmptyState = () => (
+  <p className="px-4 py-8 text-center text-[12.5px] text-[var(--ink-faint)]">
+    No problems recorded for this patient yet.
+  </p>
+);
+
+const LoadingRows = () => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((i) => (
+      <li key={i} className={rowClass}>
+        <span className="h-3.5 w-44 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);
+
+const ProblemRow = ({
+  problem,
+  canEdit,
+  onResolve,
+  resolving,
+}: {
+  problem: PatientProblem;
+  canEdit: boolean;
+  onResolve?: (problem: PatientProblem) => void;
+  resolving: boolean;
+}) => {
+  const onset = formatDate(problem.onsetDate);
+  const resolved = formatDate(problem.resolvedDate);
+  const isActive = problem.status === 'ACTIVE';
+  return (
+    <li className={rowClass}>
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block truncate')}>{problem.name}</span>
+        <span className={clsx(metaClass, 'mt-0.5 block')}>
+          {onset ? `Onset ${onset}` : 'Onset not recorded'}
+          {problem.code ? ` · ${problem.code}` : ''}
+        </span>
+        {problem.notes ? (
+          <span className={clsx(metaClass, 'mt-1 block line-clamp-2 text-[var(--ink-muted)]')}>
+            {problem.notes}
+          </span>
+        ) : null}
+      </span>
+      <span className="flex shrink-0 flex-col items-end gap-2">
+        <span className="flex flex-wrap items-center justify-end gap-1.5">
+          {problem.severity ? (
+            <StatusPill
+              label={SEVERITY_LABEL[problem.severity]}
+              tone={SEVERITY_TONE[problem.severity]}
+            />
+          ) : null}
+          <StatusPill label={STATUS_LABEL[problem.status]} tone={STATUS_TONE[problem.status]} />
+        </span>
+        {isActive && canEdit ? (
+          <Secondary
+            size="compact"
+            text={resolving ? 'Resolving…' : 'Resolve'}
+            icon={<IoCheckmarkOutline size={15} aria-hidden="true" />}
+            isDisabled={resolving}
+            onClick={() => onResolve?.(problem)}
+            ariaLabel={`Resolve ${problem.name}`}
+          />
+        ) : null}
+        {problem.status === 'RESOLVED' && resolved ? (
+          <span className={metaClass}>Resolved {resolved}</span>
+        ) : null}
+      </span>
+    </li>
+  );
+};
+
+const emptyForm: ProblemFormValues = { name: '', notes: '', severity: '', onsetDate: '' };
+
+const CreateProblemForm = ({
+  creating,
+  onCreate,
+  onCancel,
+}: {
+  creating: boolean;
+  onCreate?: ProblemListProps['onCreate'];
+  onCancel: () => void;
+}) => {
+  const [values, setValues] = useState<ProblemFormValues>(emptyForm);
+  const trimmedName = values.name.trim();
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!trimmedName || creating) return;
+    const ok = await onCreate?.({ ...values, name: trimmedName });
+    if (ok) {
+      setValues(emptyForm);
+      onCancel();
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-3 border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-4"
+      onSubmit={handleSubmit}
+    >
+      <label className="flex flex-col gap-1">
+        <span className={fieldLabelClass}>Problem title</span>
+        <input
+          className={controlClass}
+          value={values.name}
+          onChange={(e) => setValues((v) => ({ ...v, name: e.target.value }))}
+          placeholder="e.g. Chronic kidney disease"
+          maxLength={300}
+          required
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className={fieldLabelClass}>Description</span>
+        <textarea
+          className={clsx(controlClass, 'min-h-16 resize-y')}
+          value={values.notes}
+          onChange={(e) => setValues((v) => ({ ...v, notes: e.target.value }))}
+          placeholder="Clinical notes (optional)"
+          maxLength={2000}
+        />
+      </label>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className={fieldLabelClass}>Severity</span>
+          <select
+            className={controlClass}
+            value={values.severity}
+            onChange={(e) =>
+              setValues((v) => ({ ...v, severity: e.target.value as ProblemSeverity | '' }))
+            }
+          >
+            <option value="">No severity</option>
+            {SEVERITY_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {SEVERITY_LABEL[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className={fieldLabelClass}>Onset date</span>
+          <input
+            type="date"
+            className={controlClass}
+            value={values.onsetDate}
+            onChange={(e) => setValues((v) => ({ ...v, onsetDate: e.target.value }))}
+          />
+        </label>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Secondary size="compact" text="Cancel" onClick={onCancel} />
+        <Primary
+          size="compact"
+          type="submit"
+          text="Save problem"
+          isDisabled={!trimmedName || creating}
+        />
+      </div>
+    </form>
+  );
+};
+
+/**
+ * Presentational clinical problem-list panel. Renders the problems the caller
+ * supplies and surfaces create/resolve intents through callbacks; it never
+ * fetches. The container (`ProblemListPanel`) owns loading, error and data.
+ */
+const ProblemList = ({
+  problems,
+  loading = false,
+  error = null,
+  canEdit = false,
+  onCreate,
+  onResolve,
+  creating = false,
+  resolvingId = null,
+}: ProblemListProps) => {
+  const [showForm, setShowForm] = useState(false);
+  const activeCount = useMemo(
+    () => problems.filter((p) => p.status === 'ACTIVE').length,
+    [problems]
+  );
+
+  const body = (() => {
+    if (loading) return <LoadingRows />;
+    if (problems.length === 0) return <EmptyState />;
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {problems.map((problem) => (
+          <ProblemRow
+            key={problem.id}
+            problem={problem}
+            canEdit={canEdit}
+            onResolve={onResolve}
+            resolving={resolvingId === problem.id}
+          />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <section className={cardClass} aria-labelledby="problem-list-heading">
+      <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+        <span className="text-[var(--ink-muted)]" aria-hidden="true">
+          <IoMedkitOutline size={18} />
+        </span>
+        <h3 id="problem-list-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+          Problem list
+        </h3>
+        {!loading && activeCount > 0 ? (
+          <StatusPill
+            label={`${activeCount} active`}
+            tone="warning"
+            className="ml-2 tabular-nums"
+          />
+        ) : null}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() => setShowForm((s) => !s)}
+            aria-expanded={showForm}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--hairline)] px-3 py-1.5 text-[12px] font-semibold text-[var(--ink-soft)] transition-colors hover:bg-[var(--inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blue)]"
+          >
+            <IoAddOutline size={15} aria-hidden="true" />
+            {showForm ? 'Close' : 'Add problem'}
+          </button>
+        ) : null}
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mx-4 mt-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {showForm && canEdit ? (
+        <CreateProblemForm
+          creating={creating}
+          onCreate={onCreate}
+          onCancel={() => setShowForm(false)}
+        />
+      ) : null}
+
+      {body}
+    </section>
+  );
+};
+
+export default ProblemList;

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.tsx
@@ -1,0 +1,148 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import { isAuthRedirectError } from '@/app/services/axios';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import ProblemList, {
+  type ProblemFormValues,
+} from '@/app/features/companionHistory/components/ProblemList';
+import {
+  createPatientProblem,
+  fetchPatientProblems,
+  resolvePatientProblem,
+  type CreatePatientProblemInput,
+  type PatientProblem,
+} from '@/app/features/companionHistory/services/patientProblemService';
+
+export type ProblemListPanelProps = {
+  /** The companion (patient) whose problems to load. */
+  companionId: string;
+};
+
+// `<input type="date">` yields `YYYY-MM-DD`; the backend validates onsetDate with
+// `z.iso.datetime()`, so widen it to a UTC-midnight ISO datetime.
+const toIsoDate = (yyyyMmDd: string): string => new Date(`${yyyyMmDd}T00:00:00.000Z`).toISOString();
+
+const LOAD_ERROR = 'Could not load the problem list. Please try again.';
+
+/**
+ * Loads the problem list for a companion and wires create/resolve to the
+ * service. Renders nothing when the member cannot view problems (the backend
+ * gates the list on `appointments:view`), and gates the create/resolve controls
+ * on `appointments:edit`, matching the router's permissions.
+ */
+const ProblemListPanel = ({ companionId }: ProblemListPanelProps) => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.APPOINTMENTS_VIEW_ANY);
+  const canEdit = permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY);
+  const { notify } = useNotify();
+
+  const [problems, setProblems] = useState<PatientProblem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  // Reset to a loading state when the companion changes, adjusting state during
+  // render (React's recommended pattern) rather than synchronously inside an
+  // effect. `loadedFor` tracks which companion the current state belongs to.
+  const [loadedFor, setLoadedFor] = useState(companionId);
+  if (companionId !== loadedFor) {
+    setLoadedFor(companionId);
+    setProblems([]);
+    setError(null);
+    setLoading(true);
+  }
+
+  // Fetch happens off the render path; every setState here is inside an async
+  // callback, so it never triggers a synchronous cascade.
+  useEffect(() => {
+    if (!canView || !companionId) return;
+    let active = true;
+    fetchPatientProblems({ patientId: companionId })
+      .then((list) => {
+        if (active) setProblems(list);
+      })
+      .catch((err) => {
+        if (active && !isAuthRedirectError(err)) setError(LOAD_ERROR);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [canView, companionId]);
+
+  const handleCreate = useCallback(
+    async (values: ProblemFormValues): Promise<boolean> => {
+      if (!companionId) return false;
+      setCreating(true);
+      try {
+        const payload: CreatePatientProblemInput = {
+          patientId: companionId,
+          name: values.name,
+          ...(values.notes.trim() ? { notes: values.notes.trim() } : {}),
+          ...(values.severity ? { severity: values.severity } : {}),
+          ...(values.onsetDate ? { onsetDate: toIsoDate(values.onsetDate) } : {}),
+        };
+        const created = await createPatientProblem(payload);
+        // A new problem is ACTIVE, so prepending keeps the backend's
+        // active-first ordering without a refetch flash.
+        setProblems((prev) => [created, ...prev]);
+        notify('success', {
+          title: 'Problem added',
+          text: `${created.name} was added to the problem list.`,
+        });
+        return true;
+      } catch (err) {
+        if (!isAuthRedirectError(err)) {
+          notify('error', { title: 'Could not add problem', text: 'Please try again.' });
+        }
+        return false;
+      } finally {
+        setCreating(false);
+      }
+    },
+    [companionId, notify]
+  );
+
+  const handleResolve = useCallback(
+    async (problem: PatientProblem): Promise<void> => {
+      setResolvingId(problem.id);
+      try {
+        const updated = await resolvePatientProblem(problem.id);
+        setProblems((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+        notify('success', {
+          title: 'Problem resolved',
+          text: `${updated.name} was marked resolved.`,
+        });
+      } catch (err) {
+        if (!isAuthRedirectError(err)) {
+          notify('error', { title: 'Could not resolve problem', text: 'Please try again.' });
+        }
+      } finally {
+        setResolvingId(null);
+      }
+    },
+    [notify]
+  );
+
+  if (!canView) return null;
+
+  return (
+    <ProblemList
+      problems={problems}
+      loading={loading}
+      error={error}
+      canEdit={canEdit}
+      onCreate={handleCreate}
+      onResolve={handleResolve}
+      creating={creating}
+      resolvingId={resolvingId}
+    />
+  );
+};
+
+export default ProblemListPanel;

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -18,6 +18,7 @@ import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { useIsPhone } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import PhoneCompanionRecord from '@/app/features/companionHistory/pages/phone/PhoneCompanionRecord';
+import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
 import {
   useCompanionsParentsForPrimaryOrg,
   useLoadCompanionsForPrimaryOrg,
@@ -667,6 +668,8 @@ const CompanionHistoryDesktopBody = ({
         </div>
       )}
     </div>
+
+    {hasCompanionId ? <ProblemListPanel companionId={companionId} /> : null}
 
     {hasCompanionId ? (
       <CompanionHistoryTimeline companionId={companionId} showDocumentUpload />

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -13,6 +13,7 @@ import {
   IoPencilOutline,
 } from 'react-icons/io5';
 import CompanionHistoryTimeline from '@/app/features/companionHistory/components/CompanionHistoryTimeline';
+import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
 import AlertPill from '@/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill';
 import type { CompanionAlert } from '@/app/features/appointments/types/workspace';
 import type {
@@ -401,6 +402,8 @@ const PhoneCompanionRecord = ({
             {detailRows.length > 0 ? <PhoneRecordDetails rows={detailRows} /> : null}
           </>
         ) : null}
+
+        <ProblemListPanel companionId={companionId} />
 
         <CompanionHistoryTimeline
           companionId={companionId}

--- a/apps/frontend/src/app/features/companionHistory/services/patientProblemService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/patientProblemService.ts
@@ -1,0 +1,114 @@
+import { getData, postData, putData } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+// Mirrors the backend PatientProblem enums (packages/database/prisma/schema.prisma).
+export type ProblemStatus = 'ACTIVE' | 'INACTIVE' | 'RESOLVED';
+export type ProblemSeverity = 'MILD' | 'MODERATE' | 'SEVERE';
+
+/**
+ * A patient problem as returned by the backend. Dates arrive as ISO strings
+ * over the wire (Prisma `DateTime` serialised to JSON), so they are typed as
+ * `string`, not `Date`. Shape matches the controller's `problemSelect`.
+ */
+export type PatientProblem = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  encounterId: string | null;
+  name: string;
+  codeSystem: string | null;
+  code: string | null;
+  status: ProblemStatus;
+  severity: ProblemSeverity | null;
+  onsetDate: string | null;
+  resolvedDate: string | null;
+  notes: string | null;
+  recordedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreatePatientProblemInput = {
+  patientId: string;
+  encounterId?: string;
+  name: string;
+  codeSystem?: string;
+  code?: string;
+  severity?: ProblemSeverity;
+  /** ISO 8601 datetime string; the backend validates with `z.iso.datetime()`. */
+  onsetDate?: string;
+  notes?: string;
+};
+
+export type UpdatePatientProblemInput = {
+  name?: string;
+  codeSystem?: string;
+  code?: string;
+  status?: ProblemStatus;
+  severity?: ProblemSeverity;
+  onsetDate?: string;
+  resolvedDate?: string;
+  notes?: string;
+};
+
+const requireOrgId = (): string => {
+  const orgId = useOrgStore.getState().primaryOrgId;
+  if (!orgId) throw new Error('No active organisation selected.');
+  return orgId;
+};
+
+// Router mounts patient-problem.router at `/v1`, so the org-scoped collection is
+// `/v1/pms/organisation/:organisationId/patient-problems`.
+const collectionBase = (): string => `/v1/pms/organisation/${requireOrgId()}/patient-problems`;
+
+export type FetchPatientProblemsParams = {
+  patientId: string;
+  status?: ProblemStatus;
+};
+
+/** GET the problem list for a patient. The controller returns a raw array. */
+export const fetchPatientProblems = async ({
+  patientId,
+  status,
+}: FetchPatientProblemsParams): Promise<PatientProblem[]> => {
+  if (!patientId) throw new Error('Patient ID missing');
+  const params: Record<string, string> = { patientId };
+  if (status) params.status = status;
+  const res = await getData<PatientProblem[]>(collectionBase(), params);
+  return res.data;
+};
+
+/** POST a new problem. The controller returns the created record (201). */
+export const createPatientProblem = async (
+  input: CreatePatientProblemInput
+): Promise<PatientProblem> => {
+  const res = await postData<PatientProblem, CreatePatientProblemInput>(collectionBase(), input);
+  return res.data;
+};
+
+/** PUT a partial update. The controller returns the updated record. */
+export const updatePatientProblem = async (
+  problemId: string,
+  input: UpdatePatientProblemInput
+): Promise<PatientProblem> => {
+  const res = await putData<PatientProblem, UpdatePatientProblemInput>(
+    `${collectionBase()}/${problemId}`,
+    input
+  );
+  return res.data;
+};
+
+/**
+ * POST to the resolve endpoint. `resolvedDate` is optional; the backend defaults
+ * it to now. The controller returns the resolved record.
+ */
+export const resolvePatientProblem = async (
+  problemId: string,
+  resolvedDate?: string
+): Promise<PatientProblem> => {
+  const res = await postData<PatientProblem, { resolvedDate?: string }>(
+    `${collectionBase()}/${problemId}/resolve`,
+    resolvedDate ? { resolvedDate } : {}
+  );
+  return res.data;
+};


### PR DESCRIPTION
Wires the `PatientProblem` backend that had no client surface — the first of the clinical-record panels from the "wire what exists" wave. This is one of the "a clinician can reach none of them" gaps.

## What was unreachable
Full CRUD + resolve, RBAC-gated at `/v1/pms/organisation/:id/patient-problems` — the clinical problem list, with no screen.

## What this adds
A problem-list panel on the companion record (desktop **and** phone), above the history timeline: each problem shows a **status** and **severity** pill, onset/resolved dates and notes, a **resolve** action for active problems, and a create form. Reads/writes the existing endpoints under the same `appointments` view/edit permissions. Built on the shared `StatusPill` and tokens; zero hardcoded colours, theme-aware, responsive.

## Reality over assumptions
- List + mutations return **raw records** (no envelope).
- `ProblemStatus` = `ACTIVE|INACTIVE|RESOLVED`; `ProblemSeverity` = `MILD|MODERATE|SEVERE`.
- `onsetDate`/`resolvedDate` validate as **full ISO datetimes** — a `<input type=date>` value is widened to `…T00:00:00.000Z` before sending, or the API 400s.
- `companionId` **is** the backend `patientId`.

## Tests
Mutation-checked (forcing `isActive = true` reds the "resolve only on active" test): active + resolved rendering with pills, resolve gating, the create form, empty/loading/error. New source files at **99% statements / 93% branches**. `tsc` 0, lint clean, all green.