### PR TITLE
feat(frontend): surface insurance claims in finance

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/finance/insurance-claims/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/finance/insurance-claims/page.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'Insurance claims — Yosemite Crew' };
+
+// Re-exported rather than wrapped: the route adds no behaviour of its own, so a
+// local component that only returns the screen is indirection without intent.
+export { default } from '@/app/features/finance/pages/InsuranceClaims';

--- a/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+// Renders children so the gated action row is exercised; the permission logic
+// itself is covered by PermissionGate's own tests.
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/primitives/GlassTooltip/GlassTooltip', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+// Passthrough: the modal's portal/overlay behaviour is covered by CenterModal's
+// own tests, and rendering the children inline keeps the form queryable.
+jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
+  __esModule: true,
+  default: ({ showModal, children, ariaLabel }: any) =>
+    showModal ? (
+      <div role="dialog" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import InsuranceClaims, {
+  type InsuranceClaimsProps,
+} from '@/app/features/finance/pages/InsuranceClaims/InsuranceClaims';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+const makeClaim = (
+  overrides: Partial<InsuranceClaim> & { id: string; status: InsuranceClaimStatus }
+): InsuranceClaim => ({
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  invoiceId: null,
+  encounterId: null,
+  insurerName: 'Petsure',
+  policyNumber: 'PS-2291',
+  claimNumber: null,
+  submittedAmount: 420,
+  approvedAmount: null,
+  paidAmount: null,
+  currency: 'GBP',
+  submittedAt: null,
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+  ...overrides,
+});
+
+const CLAIMS: InsuranceClaim[] = [
+  makeClaim({ id: 'c1', status: 'DRAFT', patientId: 'pat-1', submittedAmount: 420 }),
+  makeClaim({
+    id: 'c2',
+    status: 'SUBMITTED',
+    patientId: 'pat-2',
+    insurerName: 'Bought By Many',
+    policyNumber: 'BBM-8841',
+    claimNumber: 'CLM-5567',
+    submittedAmount: 199.5,
+  }),
+  makeClaim({
+    id: 'c3',
+    status: 'PARTIALLY_APPROVED',
+    patientId: 'pat-3',
+    insurerName: 'Agria',
+    policyNumber: 'AG-1200',
+    submittedAmount: 1240.6,
+    approvedAmount: 900,
+  }),
+  makeClaim({
+    id: 'c4',
+    status: 'REJECTED',
+    patientId: 'pat-1',
+    submittedAmount: 310,
+    rejectionReason: 'Pre-existing condition excluded.',
+  }),
+];
+
+const NAMES: Record<string, string> = {
+  'pat-1': 'Marnie Whitlock',
+  'pat-2': 'Rufus Delacroix',
+  'pat-3': 'Pepper Osei',
+};
+
+const noop = () => {};
+
+const baseProps: InsuranceClaimsProps = {
+  claims: CLAIMS,
+  loading: false,
+  error: null,
+  onReload: noop,
+  emptyMessage: 'File a claim to recover a treatment cost.',
+  activeStatus: 'all',
+  onStatusChange: noop,
+  companionName: (patientId: string) => NAMES[patientId] ?? 'Unknown companion',
+  companions: [
+    { id: 'pat-1', name: 'Marnie Whitlock' },
+    { id: 'pat-2', name: 'Rufus Delacroix' },
+  ],
+  currency: 'GBP',
+  activeClaimId: null,
+  onSelect: noop,
+  pendingAction: null,
+  actionError: null,
+  onSubmitClaim: noop,
+  onCancelClaim: noop,
+  onUpdateStatus: noop,
+  createOpen: false,
+  onCreateOpenChange: noop,
+  creating: false,
+  createError: null,
+  onCreate: noop,
+};
+
+const setup = (overrides: Partial<InsuranceClaimsProps> = {}) => {
+  const props = { ...baseProps, ...overrides };
+  const view = render(<InsuranceClaims {...props} />);
+  return { props, ...view };
+};
+
+const table = () => screen.getByRole('table');
+
+describe('InsuranceClaims list', () => {
+  it('renders a row per claim with the insurer, policy and status pill', () => {
+    setup();
+
+    const rows = within(table());
+    expect(rows.getByText('Bought By Many')).toBeInTheDocument();
+    expect(rows.getByText('BBM-8841')).toBeInTheDocument();
+    // Status pills sit in the table; their labels are distinct from the column
+    // headers ("Submitted"/"Approved"/"Paid"), so these are unambiguous.
+    expect(rows.getByText('Draft')).toBeInTheDocument();
+    expect(rows.getByText('Partially approved')).toBeInTheDocument();
+    expect(rows.getByText('Rejected')).toBeInTheDocument();
+  });
+
+  it('formats the submitted and approved amounts, keeping the minor units', () => {
+    setup();
+
+    const rows = within(table());
+    // 199.5 must not print as "£200", and 1240.6 keeps both digits.
+    expect(rows.getByText('£199.50')).toBeInTheDocument();
+    expect(rows.getByText('£1,240.60')).toBeInTheDocument();
+    expect(rows.getByText('£900.00')).toBeInTheDocument();
+  });
+
+  it('shows a dash for figures the insurer has not decided yet', () => {
+    setup({ claims: [CLAIMS[0]] });
+
+    // A DRAFT has no claim number, no approved amount and no paid amount.
+    expect(within(table()).getAllByText('-').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows the empty state with the supplied reason', () => {
+    setup({ claims: [], emptyMessage: 'No claim matches that search.' });
+
+    expect(screen.getByText('No insurance claims yet')).toBeInTheDocument();
+    expect(screen.getByText('No claim matches that search.')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders the loading placeholder and no table while loading', () => {
+    setup({ claims: [], loading: true });
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByText('No insurance claims yet')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a load error with a retry', async () => {
+    const onReload = jest.fn();
+    setup({ claims: [], error: 'Unable to load insurance claims.', onReload });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Unable to load insurance claims.');
+    await userEvent.click(screen.getByRole('button', { name: 'Retry loading insurance claims' }));
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InsuranceClaims detail actions', () => {
+  it('offers Submit and Cancel on a DRAFT and no status picker', async () => {
+    const onSubmitClaim = jest.fn();
+    setup({ claims: [CLAIMS[0]], activeClaimId: 'c1', onSubmitClaim });
+
+    expect(screen.queryByLabelText('Move claim to')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel this claim' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit this claim to the insurer' }));
+    expect(onSubmitClaim).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a status picker and Cancel, but no Submit, on a SUBMITTED claim', () => {
+    setup({ claims: [CLAIMS[1]], activeClaimId: 'c2' });
+
+    expect(screen.getByLabelText('Move claim to')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Submit this claim to the insurer' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel this claim' })).toBeInTheDocument();
+  });
+
+  it('requires an approved amount before approving, then submits it', async () => {
+    const onUpdateStatus = jest.fn();
+    setup({ claims: [CLAIMS[1]], activeClaimId: 'c2', onUpdateStatus });
+
+    await userEvent.selectOptions(screen.getByLabelText('Move claim to'), 'APPROVED');
+    await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Enter the amount the insurer approved.'
+    );
+    expect(onUpdateStatus).not.toHaveBeenCalled();
+
+    await userEvent.type(screen.getByLabelText('Approved amount'), '150');
+    await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
+
+    expect(onUpdateStatus).toHaveBeenCalledWith({ status: 'APPROVED', approvedAmount: 150 });
+  });
+
+  it('rejects an approved amount above the submitted amount', async () => {
+    const onUpdateStatus = jest.fn();
+    // c2 was submitted for 199.5; approving for 500 must be caught client-side.
+    setup({ claims: [CLAIMS[1]], activeClaimId: 'c2', onUpdateStatus });
+
+    await userEvent.selectOptions(screen.getByLabelText('Move claim to'), 'APPROVED');
+    await userEvent.type(screen.getByLabelText('Approved amount'), '500');
+    await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Approved amount cannot exceed the submitted amount.'
+    );
+    expect(onUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('records a paid amount when settling an approved claim', async () => {
+    const onUpdateStatus = jest.fn();
+    const approved = makeClaim({
+      id: 'c9',
+      status: 'APPROVED',
+      submittedAmount: 400,
+      approvedAmount: 320,
+    });
+    setup({ claims: [approved], activeClaimId: 'c9', onUpdateStatus });
+
+    // The only forward move from APPROVED is PAID, so it is the default option.
+    await userEvent.type(screen.getByLabelText('Paid amount'), '320');
+    await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
+
+    expect(onUpdateStatus).toHaveBeenCalledWith({ status: 'PAID', paidAmount: 320 });
+  });
+
+  it('offers no actions on a terminal PAID claim', () => {
+    const paid = makeClaim({
+      id: 'c10',
+      status: 'PAID',
+      submittedAmount: 88,
+      approvedAmount: 88,
+      paidAmount: 88,
+    });
+    setup({ claims: [paid], activeClaimId: 'c10' });
+
+    expect(screen.queryByLabelText('Move claim to')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Submit this claim to the insurer' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel this claim' })).not.toBeInTheDocument();
+  });
+});
+
+describe('InsuranceClaims create form', () => {
+  it('opens the form from the header button', async () => {
+    const onCreateOpenChange = jest.fn();
+    setup({ onCreateOpenChange });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create a new insurance claim' }));
+    expect(onCreateOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('blocks a submit with no companion chosen', async () => {
+    const onCreate = jest.fn();
+    setup({ createOpen: true, claims: [], onCreate });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create this insurance claim' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Choose a companion for this claim.'
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('submits a complete draft as a CreateInsuranceClaimInput', async () => {
+    const onCreate = jest.fn();
+    setup({ createOpen: true, claims: [], onCreate });
+
+    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'pat-1');
+    await userEvent.clear(screen.getByLabelText('Insurer'));
+    await userEvent.type(screen.getByLabelText('Insurer'), 'Petsure');
+    await userEvent.type(screen.getByLabelText('Policy number'), 'PS-1');
+    await userEvent.type(screen.getByLabelText(/Submitted amount/), '250');
+    await userEvent.click(screen.getByRole('button', { name: 'Create this insurance claim' }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      patientId: 'pat-1',
+      insurerName: 'Petsure',
+      policyNumber: 'PS-1',
+      submittedAmount: 250,
+      currency: 'GBP',
+    });
+    const [input] = onCreate.mock.calls[0] as [{ submittedAmount: number }];
+    expect(typeof input.submittedAmount).toBe('number');
+  });
+
+  it('rejects a zero submitted amount', async () => {
+    const onCreate = jest.fn();
+    setup({ createOpen: true, claims: [], onCreate });
+
+    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'pat-1');
+    await userEvent.type(screen.getByLabelText('Insurer'), 'Petsure');
+    await userEvent.type(screen.getByLabelText('Policy number'), 'PS-1');
+    await userEvent.type(screen.getByLabelText(/Submitted amount/), '0');
+    await userEvent.click(screen.getByRole('button', { name: 'Create this insurance claim' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The submitted amount must be above zero.'
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
@@ -31,10 +31,13 @@ jest.mock('@/app/ui/primitives/GlassTooltip/GlassTooltip', () => ({
 // own tests, and rendering the children inline keeps the form queryable.
 jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
   __esModule: true,
-  default: ({ showModal, children, ariaLabel }: any) =>
+  default: ({ showModal, setShowModal, children, ariaLabel }: any) =>
     showModal ? (
       <div role="dialog" aria-label={ariaLabel}>
         {children}
+        <button type="button" onClick={() => setShowModal(false)}>
+          Dismiss modal
+        </button>
       </div>
     ) : null,
 }));
@@ -305,6 +308,21 @@ describe('InsuranceClaims create form', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Create a new insurance claim' }));
     expect(onCreateOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('allows modal dismissal when idle but blocks it while saving', async () => {
+    const onCreateOpenChange = jest.fn();
+    const { rerender } = setup({ createOpen: true, claims: [], onCreateOpenChange });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel creating this claim' }));
+    expect(onCreateOpenChange).toHaveBeenCalledWith(false);
+
+    onCreateOpenChange.mockClear();
+    rerender(
+      <InsuranceClaims {...baseProps} createOpen creating onCreateOpenChange={onCreateOpenChange} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss modal' }));
+    expect(onCreateOpenChange).not.toHaveBeenCalled();
   });
 
   it('blocks a submit with no companion chosen', async () => {

--- a/apps/frontend/src/app/__tests__/features/finance/services/insuranceClaimService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/finance/services/insuranceClaimService.test.ts
@@ -1,0 +1,141 @@
+import {
+  getClaimErrorMessage,
+  listInsuranceClaims,
+  getInsuranceClaim,
+  createInsuranceClaim,
+  updateInsuranceClaim,
+  submitInsuranceClaim,
+  updateInsuranceClaimStatus,
+  cancelInsuranceClaim,
+} from '@/app/features/finance/services/insuranceClaimService';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+const getData = jest.fn();
+const postData = jest.fn();
+const putData = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  getData: (...a: unknown[]) => getData(...a),
+  postData: (...a: unknown[]) => postData(...a),
+  putData: (...a: unknown[]) => putData(...a),
+}));
+
+const claim: InsuranceClaim = {
+  id: 'c-1',
+  organisationId: 'org-1',
+  patientId: 'p-1',
+  invoiceId: null,
+  encounterId: null,
+  insurerName: 'Acme Pet',
+  policyNumber: 'PN-1',
+  claimNumber: null,
+  submittedAmount: 45.5,
+  approvedAmount: null,
+  paidAmount: null,
+  currency: 'GBP',
+  status: 'DRAFT',
+  submittedAt: null,
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-09-01T09:00:00.000Z',
+  updatedAt: '2026-09-01T09:00:00.000Z',
+};
+
+const BASE = '/v1/pms/organisation/org-1/insurance-claims';
+
+describe('insuranceClaimService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('getClaimErrorMessage', () => {
+    it('prefers the API message', () => {
+      const err = { response: { data: { message: '  claim exists  ' } } };
+      expect(getClaimErrorMessage(err, 'fb')).toBe('claim exists');
+    });
+    it('falls back to the Error message', () => {
+      expect(getClaimErrorMessage(new Error('  boom  '), 'fb')).toBe('boom');
+    });
+    it('falls back to the provided default', () => {
+      expect(getClaimErrorMessage({ response: { data: {} } }, 'fb')).toBe('fb');
+      expect(getClaimErrorMessage(null, 'fb')).toBe('fb');
+    });
+  });
+
+  describe('listInsuranceClaims', () => {
+    it('throws when the org id is missing', async () => {
+      await expect(listInsuranceClaims('')).rejects.toThrow('Organisation ID missing');
+      expect(getData).not.toHaveBeenCalled();
+    });
+    it('sends only the provided filters', async () => {
+      getData.mockResolvedValue({ data: [claim] });
+      await expect(
+        listInsuranceClaims('org-1', { patientId: 'p-1', status: 'DRAFT', invoiceId: 'i-1' })
+      ).resolves.toEqual([claim]);
+      expect(getData).toHaveBeenCalledWith(BASE, {
+        patientId: 'p-1',
+        status: 'DRAFT',
+        invoiceId: 'i-1',
+      });
+    });
+    it('omits empty filters', async () => {
+      getData.mockResolvedValue({ data: [claim] });
+      await listInsuranceClaims('org-1');
+      expect(getData).toHaveBeenCalledWith(BASE, {});
+    });
+    it('guards against a non-array body', async () => {
+      getData.mockResolvedValue({ data: { message: 'nope' } });
+      await expect(listInsuranceClaims('org-1')).resolves.toEqual([]);
+    });
+  });
+
+  describe('single-claim reads and writes', () => {
+    beforeEach(() => {
+      getData.mockResolvedValue({ data: claim });
+      postData.mockResolvedValue({ data: claim });
+      putData.mockResolvedValue({ data: claim });
+    });
+
+    it('gets one claim', async () => {
+      await expect(getInsuranceClaim('org-1', 'c-1')).resolves.toEqual(claim);
+      expect(getData).toHaveBeenCalledWith(`${BASE}/c-1`);
+    });
+    it('creates a claim', async () => {
+      const input = {
+        patientId: 'p-1',
+        insurerName: 'Acme',
+        policyNumber: 'PN',
+        submittedAmount: 10,
+      };
+      await expect(createInsuranceClaim('org-1', input)).resolves.toEqual(claim);
+      expect(postData).toHaveBeenCalledWith(BASE, input);
+    });
+    it('updates a claim', async () => {
+      await expect(updateInsuranceClaim('org-1', 'c-1', { notes: 'n' })).resolves.toEqual(claim);
+      expect(putData).toHaveBeenCalledWith(`${BASE}/c-1`, { notes: 'n' });
+    });
+    it('submits a claim', async () => {
+      await expect(submitInsuranceClaim('org-1', 'c-1')).resolves.toEqual(claim);
+      expect(postData).toHaveBeenCalledWith(`${BASE}/c-1/submit`, {});
+    });
+    it('updates the status', async () => {
+      await expect(
+        updateInsuranceClaimStatus('org-1', 'c-1', { status: 'SUBMITTED' })
+      ).resolves.toEqual(claim);
+      expect(postData).toHaveBeenCalledWith(`${BASE}/c-1/status`, { status: 'SUBMITTED' });
+    });
+    it('cancels a claim', async () => {
+      await expect(cancelInsuranceClaim('org-1', 'c-1')).resolves.toEqual(claim);
+      expect(postData).toHaveBeenCalledWith(`${BASE}/c-1/cancel`, {});
+    });
+    it('encodes ids that carry a reserved character', async () => {
+      await getInsuranceClaim('org/1', 'c 1');
+      expect(getData).toHaveBeenCalledWith('/v1/pms/organisation/org%2F1/insurance-claims/c%201');
+    });
+    it('rejects a write without an org id', async () => {
+      await expect(getInsuranceClaim('', 'c-1')).rejects.toThrow('Organisation ID missing');
+    });
+  });
+});

--- a/apps/frontend/src/app/features/finance/hooks/useInsuranceClaims.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useInsuranceClaims.ts
@@ -1,0 +1,89 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getClaimErrorMessage,
+  listInsuranceClaims,
+} from '@/app/features/finance/services/insuranceClaimService';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+export type UseInsuranceClaims = {
+  claims: InsuranceClaim[];
+  loading: boolean;
+  error: string | null;
+  /** Merge one claim back in after a lifecycle action, without a refetch. */
+  upsert: (claim: InsuranceClaim) => void;
+  reload: () => void;
+};
+
+/**
+ * List the organisation's insurance claims, optionally narrowed to one status.
+ *
+ * Filtering is done server-side rather than in the component so the status pills
+ * stay correct once an organisation has more claims than one response holds.
+ * Mirrors `useEstimates` - a render-phase reset clears a previous org's list on
+ * a switch, and `upsert` guards against a response landing after that switch.
+ */
+export const useInsuranceClaims = (
+  organisationId?: string,
+  status?: InsuranceClaimStatus
+): UseInsuranceClaims => {
+  const [claims, setClaims] = useState<InsuranceClaim[]>([]);
+  const [loading, setLoading] = useState(Boolean(organisationId));
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const loadKey = `${organisationId ?? ''}|${status ?? ''}|${reloadToken}`;
+  const [prevLoadKey, setPrevLoadKey] = useState(loadKey);
+  if (prevLoadKey !== loadKey) {
+    setPrevLoadKey(loadKey);
+    setClaims([]);
+    setError(null);
+    setLoading(Boolean(organisationId));
+  }
+
+  useEffect(() => {
+    if (!organisationId) return undefined;
+    let active = true;
+    listInsuranceClaims(organisationId, status ? { status } : undefined)
+      .then((rows) => {
+        if (!active) return;
+        setClaims(rows);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setError(getClaimErrorMessage(err, 'Unable to load insurance claims.'));
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [organisationId, status, reloadToken]);
+
+  const upsert = useCallback(
+    (claim: InsuranceClaim) => {
+      if (organisationId && claim.organisationId !== organisationId) return;
+      setClaims((current) => {
+        const index = current.findIndex((row) => row.id === claim.id);
+        // A lifecycle action changes the status, which can move the claim out of
+        // the filter currently being viewed. Dropping it keeps the list honest
+        // instead of showing a row whose status contradicts the active pill.
+        if (status && claim.status !== status) {
+          return index === -1 ? current : current.filter((row) => row.id !== claim.id);
+        }
+        if (index === -1) return [claim, ...current];
+        const next = [...current];
+        next[index] = claim;
+        return next;
+      });
+    },
+    [status, organisationId]
+  );
+
+  const reload = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  return { claims, loading, error, upsert, reload };
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -156,6 +156,12 @@ const Finance = () => {
                 size="compact"
                 ariaLabel="Manage discounts"
               />
+              <Secondary
+                href="/finance/insurance-claims"
+                text="Insurance"
+                size="compact"
+                ariaLabel="View insurance claims"
+              />
             </div>
             <PhoneInvoiceList
               filteredList={filteredList}
@@ -209,6 +215,11 @@ const Finance = () => {
                   href="/finance/discounts"
                   text="Discounts"
                   ariaLabel="Manage discounts"
+                />
+                <Secondary
+                  href="/finance/insurance-claims"
+                  text="Insurance"
+                  ariaLabel="View insurance claims"
                 />
                 <StripeStatusPill />
               </div>

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.stories.tsx
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import InsuranceClaims from './InsuranceClaims';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+const NAMES: Record<string, string> = {
+  'pat-1': 'Marnie Whitlock',
+  'pat-2': 'Rufus Delacroix',
+  'pat-3': 'Pepper Osei',
+  'pat-4': 'Biscuit Adeyemi',
+};
+
+const claim = (
+  overrides: Partial<InsuranceClaim> & { id: string; status: InsuranceClaimStatus }
+): InsuranceClaim => ({
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  invoiceId: null,
+  encounterId: null,
+  insurerName: 'Petsure',
+  policyNumber: 'PS-2291',
+  claimNumber: null,
+  submittedAmount: 420,
+  approvedAmount: null,
+  paidAmount: null,
+  currency: 'GBP',
+  submittedAt: null,
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+  ...overrides,
+});
+
+const CLAIMS: InsuranceClaim[] = [
+  claim({
+    id: 'c1',
+    status: 'DRAFT',
+    patientId: 'pat-1',
+    insurerName: 'Petsure',
+    policyNumber: 'PS-2291',
+    submittedAmount: 420,
+  }),
+  claim({
+    id: 'c2',
+    status: 'SUBMITTED',
+    patientId: 'pat-2',
+    insurerName: 'Bought By Many',
+    policyNumber: 'BBM-8841',
+    claimNumber: 'CLM-5567',
+    submittedAmount: 199.5,
+    submittedAt: '2026-08-29T10:00:00.000Z',
+  }),
+  claim({
+    id: 'c3',
+    status: 'PARTIALLY_APPROVED',
+    patientId: 'pat-3',
+    insurerName: 'Agria',
+    policyNumber: 'AG-1200',
+    claimNumber: 'CLM-5568',
+    submittedAmount: 1240.6,
+    approvedAmount: 900,
+    submittedAt: '2026-08-25T10:00:00.000Z',
+    approvedAt: '2026-08-27T10:00:00.000Z',
+  }),
+  claim({
+    id: 'c4',
+    status: 'PAID',
+    patientId: 'pat-4',
+    insurerName: 'ManyPets',
+    policyNumber: 'MP-7781',
+    claimNumber: 'CLM-5569',
+    submittedAmount: 88,
+    approvedAmount: 88,
+    paidAmount: 88,
+    invoiceId: 'inv-1',
+    submittedAt: '2026-08-20T10:00:00.000Z',
+    approvedAt: '2026-08-22T10:00:00.000Z',
+    paidAt: '2026-08-24T10:00:00.000Z',
+  }),
+  claim({
+    id: 'c5',
+    status: 'REJECTED',
+    patientId: 'pat-1',
+    insurerName: 'Petsure',
+    policyNumber: 'PS-9002',
+    claimNumber: 'CLM-5570',
+    submittedAmount: 310,
+    rejectionReason: 'Pre-existing condition excluded by the policy.',
+    submittedAt: '2026-08-18T10:00:00.000Z',
+  }),
+];
+
+const noop = () => {};
+
+const meta = {
+  title: 'Finance/InsuranceClaims',
+  component: InsuranceClaims,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Insurance claims screen, presentational.\n\n' +
+          'Every piece of state and every action is handed in, so the same component drives the ' +
+          'page, this story and its test. Money is a plain float in major units, so £45.50 is stored ' +
+          'as 45.5 and formatted straight through; the approved and paid columns show a dash until ' +
+          'the insurer’s decision is recorded.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    claims: CLAIMS,
+    loading: false,
+    error: null,
+    onReload: noop,
+    emptyMessage: 'File a claim to recover a treatment cost from a pet parent’s insurer.',
+    activeStatus: 'all',
+    onStatusChange: noop,
+    companionName: (patientId: string) => NAMES[patientId] ?? 'Unknown companion',
+    companions: [
+      { id: 'pat-1', name: 'Marnie Whitlock' },
+      { id: 'pat-2', name: 'Rufus Delacroix' },
+    ],
+    currency: 'GBP',
+    activeClaimId: 'c3',
+    onSelect: noop,
+    pendingAction: null,
+    actionError: null,
+    onSubmitClaim: noop,
+    onCancelClaim: noop,
+    onUpdateStatus: noop,
+    createOpen: false,
+    onCreateOpenChange: noop,
+    creating: false,
+    createError: null,
+    onCreate: noop,
+  },
+} satisfies Meta<typeof InsuranceClaims>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MixedStatuses: Story = {
+  name: 'A row per claim',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Bought By Many')).toBeInTheDocument();
+    // Both decimals survive: 199.5 must not print as "£200".
+    await expect(canvas.getByText('£199.50')).toBeInTheDocument();
+    // The paid column reads as a dash while a claim is still under review.
+    await expect(canvas.getAllByText('-').length).toBeGreaterThan(0);
+  },
+};
+
+export const Empty: Story = {
+  name: 'No claims yet',
+  args: {
+    claims: [],
+    activeClaimId: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No insurance claims yet')).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  args: {
+    claims: [],
+    loading: true,
+    activeClaimId: null,
+  },
+};
+
+export const LoadError: Story = {
+  name: 'Failed to load',
+  args: {
+    claims: [],
+    error: 'Unable to load insurance claims.',
+    activeClaimId: null,
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
@@ -1,0 +1,212 @@
+'use client';
+import React, { useMemo } from 'react';
+import { IoInformationCircleOutline } from 'react-icons/io5';
+import { formatMoneyPrecise, sharedCurrency } from '@/app/lib/money';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
+import InsuranceClaimList from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList';
+import InsuranceClaimDetail, {
+  type ClaimAction,
+} from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail';
+import CreateInsuranceClaimDialog, {
+  type CompanionChoice,
+} from '@/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog';
+import {
+  InsuranceClaimStatusFilters,
+  type CreateInsuranceClaimInput,
+  type InsuranceClaim,
+  type UpdateClaimStatusInput,
+} from '@/app/features/finance/types/insuranceClaim';
+
+export type InsuranceClaimsProps = {
+  /** Already narrowed to the active status and search query by the container. */
+  claims: InsuranceClaim[];
+  loading: boolean;
+  error: string | null;
+  onReload: () => void;
+  /** Why the list is empty, resolved by the container from filter and query. */
+  emptyMessage: string;
+  activeStatus: string;
+  onStatusChange: (status: string) => void;
+  companionName: (patientId: string) => string;
+  companions: CompanionChoice[];
+  currency: string;
+  activeClaimId: string | null;
+  onSelect: (claim: InsuranceClaim) => void;
+  pendingAction: ClaimAction | null;
+  actionError: string | null;
+  onSubmitClaim: () => void;
+  onCancelClaim: () => void;
+  onUpdateStatus: (payload: UpdateClaimStatusInput) => void;
+  createOpen: boolean;
+  onCreateOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
+  creating: boolean;
+  createError: string | null;
+  onCreate: (input: CreateInsuranceClaimInput) => void;
+};
+
+/**
+ * The two figures a practice asks of a claims list: what is still with the
+ * insurer, and what has been paid back. DRAFT/SUBMITTED/UNDER_REVIEW count as in
+ * progress; only a PAID claim's `paidAmount` counts as recovered.
+ */
+const summariseClaims = (claims: InsuranceClaim[]) =>
+  claims.reduce(
+    (totals, claim) => {
+      if (
+        claim.status === 'DRAFT' ||
+        claim.status === 'SUBMITTED' ||
+        claim.status === 'UNDER_REVIEW'
+      ) {
+        return { ...totals, inProgress: totals.inProgress + claim.submittedAmount };
+      }
+      if (claim.status === 'PAID' && claim.paidAmount != null) {
+        return { ...totals, paid: totals.paid + claim.paidAmount };
+      }
+      return totals;
+    },
+    { inProgress: 0, paid: 0 }
+  );
+
+/**
+ * The Insurance claims screen: the same header anatomy as Finance and Estimates
+ * (title with a live count, an info affordance, a metrics sub-line, then the
+ * status filter and page actions on the right of that row), the shared table,
+ * and a detail panel for the selected claim. Presentational: every piece of
+ * state and every action is handed in, so the same component drives the page,
+ * its story and its test.
+ */
+const InsuranceClaims = ({
+  claims,
+  loading,
+  error,
+  onReload,
+  emptyMessage,
+  activeStatus,
+  onStatusChange,
+  companionName,
+  companions,
+  currency,
+  activeClaimId,
+  onSelect,
+  pendingAction,
+  actionError,
+  onSubmitClaim,
+  onCancelClaim,
+  onUpdateStatus,
+  createOpen,
+  onCreateOpenChange,
+  creating,
+  createError,
+  onCreate,
+}: InsuranceClaimsProps) => {
+  const metricsCurrency = useMemo(() => sharedCurrency(claims, currency), [claims, currency]);
+  const metrics = useMemo(() => summariseClaims(claims), [claims]);
+  const activeClaim = useMemo(
+    () => claims.find((claim) => claim.id === activeClaimId) ?? null,
+    [claims, activeClaimId]
+  );
+
+  return (
+    <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
+      <div className="flex items-center justify-between w-full flex-wrap gap-2">
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <h1 className="text-page-title">
+              {'Insurance claims'}{' '}
+              <span className="text-page-title-count">{`(${claims.length})`}</span>
+            </h1>
+            <GlassTooltip
+              content="File a claim against a pet's insurer, submit it, then record the insurer's decision and payment as the claim is settled."
+              side="bottom"
+            >
+              <button
+                type="button"
+                aria-label="Insurance claims info"
+                className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <IoInformationCircleOutline size={17} />
+              </button>
+            </GlassTooltip>
+          </div>
+          <p className="text-[13.5px] text-text-secondary">
+            {`${formatMoneyPrecise(metrics.inProgress, metricsCurrency)} with insurers · ${formatMoneyPrecise(
+              metrics.paid,
+              metricsCurrency
+            )} paid back`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap justify-end">
+          <InvoiceStatusFilterPills
+            options={InsuranceClaimStatusFilters}
+            activeStatus={activeStatus}
+            setActiveStatus={onStatusChange}
+            ariaLabel="Filter claims by status"
+            className="flex-wrap justify-end"
+          />
+          <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
+          <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+            <Primary
+              text="New insurance claim"
+              isDisabled={companions.length === 0}
+              onClick={() => onCreateOpenChange(true)}
+              ariaLabel="Create a new insurance claim"
+            />
+          </PermissionGate>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />
+      )}
+
+      {!loading && error && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3!">
+          <p role="alert" className="text-body-4 text-text-error">
+            {error}
+          </p>
+          <Secondary text="Retry" onClick={onReload} ariaLabel="Retry loading insurance claims" />
+        </div>
+      )}
+
+      {!loading && !error && claims.length === 0 && (
+        <div className="border border-card-border rounded-2xl px-6! py-10! text-center">
+          <p className="text-body-3 text-text-primary">No insurance claims yet</p>
+          <p className="text-body-4 text-text-secondary">{emptyMessage}</p>
+        </div>
+      )}
+
+      {!loading && !error && claims.length > 0 && (
+        <div className="flex flex-col gap-6">
+          <InsuranceClaimList claims={claims} activeClaimId={activeClaimId} onSelect={onSelect} />
+          {activeClaim && (
+            <InsuranceClaimDetail
+              claim={activeClaim}
+              companionName={companionName(activeClaim.patientId)}
+              pendingAction={pendingAction}
+              onSubmit={onSubmitClaim}
+              onCancel={onCancelClaim}
+              onUpdateStatus={onUpdateStatus}
+              error={actionError}
+            />
+          )}
+        </div>
+      )}
+
+      <CreateInsuranceClaimDialog
+        open={createOpen}
+        setOpen={onCreateOpenChange}
+        companions={companions}
+        currency={currency}
+        saving={creating}
+        error={createError}
+        onSubmit={onCreate}
+      />
+    </div>
+  );
+};
+
+export default InsuranceClaims;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
@@ -42,6 +42,55 @@ export type InsuranceClaimsProps = {
   onCreate: (input: CreateInsuranceClaimInput) => void;
 };
 
+type InsuranceClaimsResultsProps = Pick<
+  InsuranceClaimsProps,
+  | 'claims'
+  | 'loading'
+  | 'error'
+  | 'onReload'
+  | 'emptyMessage'
+  | 'activeClaimId'
+  | 'onSelect'
+  | 'companionName'
+  | 'pendingAction'
+  | 'onSubmitClaim'
+  | 'onCancelClaim'
+  | 'onUpdateStatus'
+  | 'actionError'
+> & { activeClaim: InsuranceClaim | null };
+
+const InsuranceClaimsResults = (props: InsuranceClaimsResultsProps) => (
+  <>
+    <InsuranceClaimsStates
+      loading={props.loading}
+      error={props.error}
+      onReload={props.onReload}
+      isEmpty={props.claims.length === 0}
+      emptyMessage={props.emptyMessage}
+    />
+    {!props.loading && !props.error && props.claims.length > 0 && (
+      <div className="flex flex-col gap-6">
+        <InsuranceClaimList
+          claims={props.claims}
+          activeClaimId={props.activeClaimId}
+          onSelect={props.onSelect}
+        />
+        {props.activeClaim && (
+          <InsuranceClaimDetail
+            claim={props.activeClaim}
+            companionName={props.companionName(props.activeClaim.patientId)}
+            pendingAction={props.pendingAction}
+            onSubmit={props.onSubmitClaim}
+            onCancel={props.onCancelClaim}
+            onUpdateStatus={props.onUpdateStatus}
+            error={props.actionError}
+          />
+        )}
+      </div>
+    )}
+  </>
+);
+
 /**
  * The Insurance claims screen: the same header anatomy as Finance and Estimates,
  * the shared table, and a detail panel for the selected claim. Presentational -
@@ -49,79 +98,31 @@ export type InsuranceClaimsProps = {
  * drives the page, its story and its test - and composed from the header, the
  * loading/error/empty states, the list, the detail and the create dialog.
  */
-const InsuranceClaims = ({
-  claims,
-  loading,
-  error,
-  onReload,
-  emptyMessage,
-  activeStatus,
-  onStatusChange,
-  companionName,
-  companions,
-  currency,
-  activeClaimId,
-  onSelect,
-  pendingAction,
-  actionError,
-  onSubmitClaim,
-  onCancelClaim,
-  onUpdateStatus,
-  createOpen,
-  onCreateOpenChange,
-  creating,
-  createError,
-  onCreate,
-}: InsuranceClaimsProps) => {
+const InsuranceClaims = (props: InsuranceClaimsProps) => {
   const activeClaim = useMemo(
-    () => claims.find((claim) => claim.id === activeClaimId) ?? null,
-    [claims, activeClaimId]
+    () => props.claims.find((claim) => claim.id === props.activeClaimId) ?? null,
+    [props.claims, props.activeClaimId]
   );
 
   return (
     <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
       <InsuranceClaimsHeader
-        claims={claims}
-        currency={currency}
-        activeStatus={activeStatus}
-        onStatusChange={onStatusChange}
-        companions={companions}
-        onCreate={() => onCreateOpenChange(true)}
+        claims={props.claims}
+        currency={props.currency}
+        activeStatus={props.activeStatus}
+        onStatusChange={props.onStatusChange}
+        companions={props.companions}
+        onCreate={() => props.onCreateOpenChange(true)}
       />
-
-      <InsuranceClaimsStates
-        loading={loading}
-        error={error}
-        onReload={onReload}
-        isEmpty={claims.length === 0}
-        emptyMessage={emptyMessage}
-      />
-
-      {!loading && !error && claims.length > 0 && (
-        <div className="flex flex-col gap-6">
-          <InsuranceClaimList claims={claims} activeClaimId={activeClaimId} onSelect={onSelect} />
-          {activeClaim && (
-            <InsuranceClaimDetail
-              claim={activeClaim}
-              companionName={companionName(activeClaim.patientId)}
-              pendingAction={pendingAction}
-              onSubmit={onSubmitClaim}
-              onCancel={onCancelClaim}
-              onUpdateStatus={onUpdateStatus}
-              error={actionError}
-            />
-          )}
-        </div>
-      )}
-
+      <InsuranceClaimsResults {...props} activeClaim={activeClaim} />
       <CreateInsuranceClaimDialog
-        open={createOpen}
-        setOpen={onCreateOpenChange}
-        companions={companions}
-        currency={currency}
-        saving={creating}
-        error={createError}
-        onSubmit={onCreate}
+        open={props.createOpen}
+        setOpen={props.onCreateOpenChange}
+        companions={props.companions}
+        currency={props.currency}
+        saving={props.creating}
+        error={props.createError}
+        onSubmit={props.onCreate}
       />
     </div>
   );

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
@@ -1,12 +1,7 @@
 'use client';
 import React, { useMemo } from 'react';
-import { IoInformationCircleOutline } from 'react-icons/io5';
-import { formatMoneyPrecise, sharedCurrency } from '@/app/lib/money';
-import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
-import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
-import { PERMISSIONS } from '@/app/lib/permissions';
-import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
-import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
+import InsuranceClaimsHeader from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader';
+import InsuranceClaimsStates from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates';
 import InsuranceClaimList from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList';
 import InsuranceClaimDetail, {
   type ClaimAction,
@@ -14,11 +9,10 @@ import InsuranceClaimDetail, {
 import CreateInsuranceClaimDialog, {
   type CompanionChoice,
 } from '@/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog';
-import {
-  InsuranceClaimStatusFilters,
-  type CreateInsuranceClaimInput,
-  type InsuranceClaim,
-  type UpdateClaimStatusInput,
+import type {
+  CreateInsuranceClaimInput,
+  InsuranceClaim,
+  UpdateClaimStatusInput,
 } from '@/app/features/finance/types/insuranceClaim';
 
 export type InsuranceClaimsProps = {
@@ -49,35 +43,11 @@ export type InsuranceClaimsProps = {
 };
 
 /**
- * The two figures a practice asks of a claims list: what is still with the
- * insurer, and what has been paid back. DRAFT/SUBMITTED/UNDER_REVIEW count as in
- * progress; only a PAID claim's `paidAmount` counts as recovered.
- */
-const summariseClaims = (claims: InsuranceClaim[]) =>
-  claims.reduce(
-    (totals, claim) => {
-      if (
-        claim.status === 'DRAFT' ||
-        claim.status === 'SUBMITTED' ||
-        claim.status === 'UNDER_REVIEW'
-      ) {
-        return { ...totals, inProgress: totals.inProgress + claim.submittedAmount };
-      }
-      if (claim.status === 'PAID' && claim.paidAmount != null) {
-        return { ...totals, paid: totals.paid + claim.paidAmount };
-      }
-      return totals;
-    },
-    { inProgress: 0, paid: 0 }
-  );
-
-/**
- * The Insurance claims screen: the same header anatomy as Finance and Estimates
- * (title with a live count, an info affordance, a metrics sub-line, then the
- * status filter and page actions on the right of that row), the shared table,
- * and a detail panel for the selected claim. Presentational: every piece of
- * state and every action is handed in, so the same component drives the page,
- * its story and its test.
+ * The Insurance claims screen: the same header anatomy as Finance and Estimates,
+ * the shared table, and a detail panel for the selected claim. Presentational -
+ * every piece of state and every action is handed in, so the same component
+ * drives the page, its story and its test - and composed from the header, the
+ * loading/error/empty states, the list, the detail and the create dialog.
  */
 const InsuranceClaims = ({
   claims,
@@ -103,8 +73,6 @@ const InsuranceClaims = ({
   createError,
   onCreate,
 }: InsuranceClaimsProps) => {
-  const metricsCurrency = useMemo(() => sharedCurrency(claims, currency), [claims, currency]);
-  const metrics = useMemo(() => summariseClaims(claims), [claims]);
   const activeClaim = useMemo(
     () => claims.find((claim) => claim.id === activeClaimId) ?? null,
     [claims, activeClaimId]
@@ -112,72 +80,22 @@ const InsuranceClaims = ({
 
   return (
     <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
-      <div className="flex items-center justify-between w-full flex-wrap gap-2">
-        <div className="flex flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <h1 className="text-page-title">
-              {'Insurance claims'}{' '}
-              <span className="text-page-title-count">{`(${claims.length})`}</span>
-            </h1>
-            <GlassTooltip
-              content="File a claim against a pet's insurer, submit it, then record the insurer's decision and payment as the claim is settled."
-              side="bottom"
-            >
-              <button
-                type="button"
-                aria-label="Insurance claims info"
-                className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
-              >
-                <IoInformationCircleOutline size={17} />
-              </button>
-            </GlassTooltip>
-          </div>
-          <p className="text-[13.5px] text-text-secondary">
-            {`${formatMoneyPrecise(metrics.inProgress, metricsCurrency)} with insurers · ${formatMoneyPrecise(
-              metrics.paid,
-              metricsCurrency
-            )} paid back`}
-          </p>
-        </div>
-        <div className="flex items-center gap-2 flex-wrap justify-end">
-          <InvoiceStatusFilterPills
-            options={InsuranceClaimStatusFilters}
-            activeStatus={activeStatus}
-            setActiveStatus={onStatusChange}
-            ariaLabel="Filter claims by status"
-            className="flex-wrap justify-end"
-          />
-          <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
-          <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-            <Primary
-              text="New insurance claim"
-              isDisabled={companions.length === 0}
-              onClick={() => onCreateOpenChange(true)}
-              ariaLabel="Create a new insurance claim"
-            />
-          </PermissionGate>
-        </div>
-      </div>
+      <InsuranceClaimsHeader
+        claims={claims}
+        currency={currency}
+        activeStatus={activeStatus}
+        onStatusChange={onStatusChange}
+        companions={companions}
+        onCreate={() => onCreateOpenChange(true)}
+      />
 
-      {loading && (
-        <div className="h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />
-      )}
-
-      {!loading && error && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3!">
-          <p role="alert" className="text-body-4 text-text-error">
-            {error}
-          </p>
-          <Secondary text="Retry" onClick={onReload} ariaLabel="Retry loading insurance claims" />
-        </div>
-      )}
-
-      {!loading && !error && claims.length === 0 && (
-        <div className="border border-card-border rounded-2xl px-6! py-10! text-center">
-          <p className="text-body-3 text-text-primary">No insurance claims yet</p>
-          <p className="text-body-4 text-text-secondary">{emptyMessage}</p>
-        </div>
-      )}
+      <InsuranceClaimsStates
+        loading={loading}
+        error={error}
+        onReload={onReload}
+        isEmpty={claims.length === 0}
+        emptyMessage={emptyMessage}
+      />
 
       {!loading && !error && claims.length > 0 && (
         <div className="flex flex-col gap-6">

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
@@ -20,6 +20,54 @@ type CreateInsuranceClaimDialogProps = {
   onSubmit: (input: CreateInsuranceClaimInput) => void;
 };
 
+type CreateInsuranceClaimDialogContentProps = Pick<
+  CreateInsuranceClaimDialogProps,
+  'companions' | 'currency' | 'saving' | 'error' | 'onSubmit'
+> & { onCancel: () => void };
+
+const CreateInsuranceClaimDialogContent = ({
+  companions,
+  currency,
+  saving,
+  error,
+  onSubmit,
+  onCancel,
+}: CreateInsuranceClaimDialogContentProps) => {
+  const { draft, setField, formError, submit } = useInsuranceClaimDraft();
+  const message = formError ?? error;
+
+  return (
+    <div className="flex flex-col gap-4 p-6!">
+      <h2 className="text-heading-4 text-text-primary">New insurance claim</h2>
+      <InsuranceClaimFormFields
+        draft={draft}
+        setField={setField}
+        currency={currency}
+        companions={companions}
+      />
+      {message ? (
+        <p role="alert" className="text-body-4 text-text-error">
+          {message}
+        </p>
+      ) : null}
+      <div className="flex items-center justify-end gap-2">
+        <Secondary
+          text="Cancel"
+          isDisabled={saving}
+          onClick={onCancel}
+          ariaLabel="Cancel creating this claim"
+        />
+        <Primary
+          text={saving ? 'Creating...' : 'Create claim'}
+          isDisabled={saving}
+          onClick={() => submit(currency, onSubmit)}
+          ariaLabel="Create this insurance claim"
+        />
+      </div>
+    </div>
+  );
+};
+
 /**
  * The insurance-claim editor. A claim always starts as a DRAFT, so there is no
  * status control here - the claim is submitted and progressed from its detail
@@ -37,9 +85,6 @@ const CreateInsuranceClaimDialog = ({
   error,
   onSubmit,
 }: CreateInsuranceClaimDialogProps) => {
-  const { draft, setField, formError, submit } = useInsuranceClaimDraft();
-  const message = formError ?? error;
-
   // A create request cannot be cancelled, so every dismissal route is closed
   // while saving - ModalBase also closes on Escape and an outside click, and
   // neither consults the disabled Cancel button.
@@ -55,37 +100,14 @@ const CreateInsuranceClaimDialog = ({
       ariaLabel="Create an insurance claim"
       containerClassName="sm:w-[min(640px,92vw)]! max-h-[90vh] overflow-y-auto"
     >
-      <div className="flex flex-col gap-4 p-6!">
-        <h2 className="text-heading-4 text-text-primary">New insurance claim</h2>
-
-        <InsuranceClaimFormFields
-          draft={draft}
-          setField={setField}
-          currency={currency}
-          companions={companions}
-        />
-
-        {message ? (
-          <p role="alert" className="text-body-4 text-text-error">
-            {message}
-          </p>
-        ) : null}
-
-        <div className="flex items-center justify-end gap-2">
-          <Secondary
-            text="Cancel"
-            isDisabled={saving}
-            onClick={() => setOpenUnlessSaving(false)}
-            ariaLabel="Cancel creating this claim"
-          />
-          <Primary
-            text={saving ? 'Creating...' : 'Create claim'}
-            isDisabled={saving}
-            onClick={() => submit(currency, onSubmit)}
-            ariaLabel="Create this insurance claim"
-          />
-        </div>
-      </div>
+      <CreateInsuranceClaimDialogContent
+        companions={companions}
+        currency={currency}
+        saving={saving}
+        error={error}
+        onSubmit={onSubmit}
+        onCancel={() => setOpenUnlessSaving(false)}
+      />
     </CenterModal>
   );
 };

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
@@ -1,15 +1,14 @@
 'use client';
-import React, { useState } from 'react';
+import React from 'react';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
-import { currencySymbol } from '@/app/lib/money';
-import {
-  fieldClass,
-  inputClass,
-} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import { useInsuranceClaimDraft } from '@/app/features/finance/pages/InsuranceClaims/Sections/useInsuranceClaimDraft';
+import InsuranceClaimFormFields, {
+  type CompanionChoice,
+} from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields';
 import type { CreateInsuranceClaimInput } from '@/app/features/finance/types/insuranceClaim';
 
-export type CompanionChoice = { id: string; name: string };
+export type { CompanionChoice };
 
 type CreateInsuranceClaimDialogProps = {
   open: boolean;
@@ -21,51 +20,13 @@ type CreateInsuranceClaimDialogProps = {
   onSubmit: (input: CreateInsuranceClaimInput) => void;
 };
 
-type Draft = {
-  patientId: string;
-  insurerName: string;
-  policyNumber: string;
-  submittedAmount: string;
-  invoiceId: string;
-  encounterId: string;
-  notes: string;
-};
-
-const emptyDraft: Draft = {
-  patientId: '',
-  insurerName: '',
-  policyNumber: '',
-  submittedAmount: '',
-  invoiceId: '',
-  encounterId: '',
-  notes: '',
-};
-
-type Validation = { ok: true } | { ok: false; message: string };
-
-/**
- * Validate the draft the way the controller's `CreateBodySchema` does, so the
- * user learns what is wrong before a request goes out rather than reading a zod
- * error afterwards: patient, insurer and policy are required, and the amount
- * must be positive.
- */
-const validateDraft = (draft: Draft): Validation => {
-  if (!draft.patientId) return { ok: false, message: 'Choose a companion for this claim.' };
-  if (!draft.insurerName.trim()) return { ok: false, message: "Enter the insurer's name." };
-  if (!draft.policyNumber.trim()) return { ok: false, message: 'Enter the policy number.' };
-  const amount = Number(draft.submittedAmount.trim());
-  if (!Number.isFinite(amount) || amount <= 0) {
-    return { ok: false, message: 'The submitted amount must be above zero.' };
-  }
-  return { ok: true };
-};
-
 /**
  * The insurance-claim editor. A claim always starts as a DRAFT, so there is no
  * status control here - the claim is submitted and progressed from its detail
- * panel. Only the fields the create endpoint accepts are shown; the optional
- * invoice and encounter links are free text because a claim can be filed before
- * either exists.
+ * panel. Composition: the draft state and validation live in
+ * `useInsuranceClaimDraft`, the fields in `InsuranceClaimFormFields`, and this
+ * component owns only the modal shell, the save-time dismissal guard and the
+ * error line.
  */
 const CreateInsuranceClaimDialog = ({
   open,
@@ -76,11 +37,8 @@ const CreateInsuranceClaimDialog = ({
   error,
   onSubmit,
 }: CreateInsuranceClaimDialogProps) => {
-  const [draft, setDraft] = useState<Draft>(emptyDraft);
-  const [formError, setFormError] = useState<string | null>(null);
+  const { draft, setField, formError, submit } = useInsuranceClaimDraft();
   const message = formError ?? error;
-
-  const set = (patch: Partial<Draft>) => setDraft((current) => ({ ...current, ...patch }));
 
   // A create request cannot be cancelled, so every dismissal route is closed
   // while saving - ModalBase also closes on Escape and an outside click, and
@@ -88,25 +46,6 @@ const CreateInsuranceClaimDialog = ({
   const setOpenUnlessSaving: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
     if (saving) return;
     setOpen(value);
-  };
-
-  const submit = () => {
-    const result = validateDraft(draft);
-    if (!result.ok) {
-      setFormError(result.message);
-      return;
-    }
-    setFormError(null);
-    onSubmit({
-      patientId: draft.patientId,
-      insurerName: draft.insurerName.trim(),
-      policyNumber: draft.policyNumber.trim(),
-      submittedAmount: Number(draft.submittedAmount.trim()),
-      currency,
-      ...(draft.invoiceId.trim() ? { invoiceId: draft.invoiceId.trim() } : {}),
-      ...(draft.encounterId.trim() ? { encounterId: draft.encounterId.trim() } : {}),
-      ...(draft.notes.trim() ? { notes: draft.notes.trim() } : {}),
-    });
   };
 
   return (
@@ -119,119 +58,12 @@ const CreateInsuranceClaimDialog = ({
       <div className="flex flex-col gap-4 p-6!">
         <h2 className="text-heading-4 text-text-primary">New insurance claim</h2>
 
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-companion" className="text-caption-2 font-bold text-text-tertiary">
-            Companion
-          </label>
-          <span className={fieldClass}>
-            <select
-              id="claim-companion"
-              value={draft.patientId}
-              onChange={(e) => set({ patientId: e.target.value })}
-              className={inputClass}
-            >
-              <option value="">Choose a companion</option>
-              {companions.map((companion) => (
-                <option key={companion.id} value={companion.id}>
-                  {companion.name}
-                </option>
-              ))}
-            </select>
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-insurer" className="text-caption-2 font-bold text-text-tertiary">
-            Insurer
-          </label>
-          <span className={fieldClass}>
-            <input
-              id="claim-insurer"
-              type="text"
-              value={draft.insurerName}
-              onChange={(e) => set({ insurerName: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-policy" className="text-caption-2 font-bold text-text-tertiary">
-            Policy number
-          </label>
-          <span className={fieldClass}>
-            <input
-              id="claim-policy"
-              type="text"
-              value={draft.policyNumber}
-              onChange={(e) => set({ policyNumber: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-amount" className="text-caption-2 font-bold text-text-tertiary">
-            {`Submitted amount (${currencySymbol(currency)})`}
-          </label>
-          <span className={`${fieldClass} max-w-52`}>
-            <input
-              id="claim-amount"
-              type="number"
-              min="0"
-              step="0.01"
-              inputMode="decimal"
-              value={draft.submittedAmount}
-              onChange={(e) => set({ submittedAmount: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-invoice" className="text-caption-2 font-bold text-text-tertiary">
-            Invoice ID (optional)
-          </label>
-          <span className={fieldClass}>
-            <input
-              id="claim-invoice"
-              type="text"
-              value={draft.invoiceId}
-              onChange={(e) => set({ invoiceId: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-encounter" className="text-caption-2 font-bold text-text-tertiary">
-            Encounter ID (optional)
-          </label>
-          <span className={fieldClass}>
-            <input
-              id="claim-encounter"
-              type="text"
-              value={draft.encounterId}
-              onChange={(e) => set({ encounterId: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label htmlFor="claim-notes" className="text-caption-2 font-bold text-text-tertiary">
-            Notes (optional)
-          </label>
-          <span className={fieldClass}>
-            <textarea
-              id="claim-notes"
-              rows={2}
-              value={draft.notes}
-              onChange={(e) => set({ notes: e.target.value })}
-              className={inputClass}
-            />
-          </span>
-        </div>
+        <InsuranceClaimFormFields
+          draft={draft}
+          setField={setField}
+          currency={currency}
+          companions={companions}
+        />
 
         {message ? (
           <p role="alert" className="text-body-4 text-text-error">
@@ -249,7 +81,7 @@ const CreateInsuranceClaimDialog = ({
           <Primary
             text={saving ? 'Creating...' : 'Create claim'}
             isDisabled={saving}
-            onClick={submit}
+            onClick={() => submit(currency, onSubmit)}
             ariaLabel="Create this insurance claim"
           />
         </div>

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.tsx
@@ -1,0 +1,261 @@
+'use client';
+import React, { useState } from 'react';
+import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { currencySymbol } from '@/app/lib/money';
+import {
+  fieldClass,
+  inputClass,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import type { CreateInsuranceClaimInput } from '@/app/features/finance/types/insuranceClaim';
+
+export type CompanionChoice = { id: string; name: string };
+
+type CreateInsuranceClaimDialogProps = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  companions: CompanionChoice[];
+  currency: string;
+  saving: boolean;
+  error: string | null;
+  onSubmit: (input: CreateInsuranceClaimInput) => void;
+};
+
+type Draft = {
+  patientId: string;
+  insurerName: string;
+  policyNumber: string;
+  submittedAmount: string;
+  invoiceId: string;
+  encounterId: string;
+  notes: string;
+};
+
+const emptyDraft: Draft = {
+  patientId: '',
+  insurerName: '',
+  policyNumber: '',
+  submittedAmount: '',
+  invoiceId: '',
+  encounterId: '',
+  notes: '',
+};
+
+type Validation = { ok: true } | { ok: false; message: string };
+
+/**
+ * Validate the draft the way the controller's `CreateBodySchema` does, so the
+ * user learns what is wrong before a request goes out rather than reading a zod
+ * error afterwards: patient, insurer and policy are required, and the amount
+ * must be positive.
+ */
+const validateDraft = (draft: Draft): Validation => {
+  if (!draft.patientId) return { ok: false, message: 'Choose a companion for this claim.' };
+  if (!draft.insurerName.trim()) return { ok: false, message: "Enter the insurer's name." };
+  if (!draft.policyNumber.trim()) return { ok: false, message: 'Enter the policy number.' };
+  const amount = Number(draft.submittedAmount.trim());
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { ok: false, message: 'The submitted amount must be above zero.' };
+  }
+  return { ok: true };
+};
+
+/**
+ * The insurance-claim editor. A claim always starts as a DRAFT, so there is no
+ * status control here - the claim is submitted and progressed from its detail
+ * panel. Only the fields the create endpoint accepts are shown; the optional
+ * invoice and encounter links are free text because a claim can be filed before
+ * either exists.
+ */
+const CreateInsuranceClaimDialog = ({
+  open,
+  setOpen,
+  companions,
+  currency,
+  saving,
+  error,
+  onSubmit,
+}: CreateInsuranceClaimDialogProps) => {
+  const [draft, setDraft] = useState<Draft>(emptyDraft);
+  const [formError, setFormError] = useState<string | null>(null);
+  const message = formError ?? error;
+
+  const set = (patch: Partial<Draft>) => setDraft((current) => ({ ...current, ...patch }));
+
+  // A create request cannot be cancelled, so every dismissal route is closed
+  // while saving - ModalBase also closes on Escape and an outside click, and
+  // neither consults the disabled Cancel button.
+  const setOpenUnlessSaving: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
+    if (saving) return;
+    setOpen(value);
+  };
+
+  const submit = () => {
+    const result = validateDraft(draft);
+    if (!result.ok) {
+      setFormError(result.message);
+      return;
+    }
+    setFormError(null);
+    onSubmit({
+      patientId: draft.patientId,
+      insurerName: draft.insurerName.trim(),
+      policyNumber: draft.policyNumber.trim(),
+      submittedAmount: Number(draft.submittedAmount.trim()),
+      currency,
+      ...(draft.invoiceId.trim() ? { invoiceId: draft.invoiceId.trim() } : {}),
+      ...(draft.encounterId.trim() ? { encounterId: draft.encounterId.trim() } : {}),
+      ...(draft.notes.trim() ? { notes: draft.notes.trim() } : {}),
+    });
+  };
+
+  return (
+    <CenterModal
+      showModal={open}
+      setShowModal={setOpenUnlessSaving}
+      ariaLabel="Create an insurance claim"
+      containerClassName="sm:w-[min(640px,92vw)]! max-h-[90vh] overflow-y-auto"
+    >
+      <div className="flex flex-col gap-4 p-6!">
+        <h2 className="text-heading-4 text-text-primary">New insurance claim</h2>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-companion" className="text-caption-2 font-bold text-text-tertiary">
+            Companion
+          </label>
+          <span className={fieldClass}>
+            <select
+              id="claim-companion"
+              value={draft.patientId}
+              onChange={(e) => set({ patientId: e.target.value })}
+              className={inputClass}
+            >
+              <option value="">Choose a companion</option>
+              {companions.map((companion) => (
+                <option key={companion.id} value={companion.id}>
+                  {companion.name}
+                </option>
+              ))}
+            </select>
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-insurer" className="text-caption-2 font-bold text-text-tertiary">
+            Insurer
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="claim-insurer"
+              type="text"
+              value={draft.insurerName}
+              onChange={(e) => set({ insurerName: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-policy" className="text-caption-2 font-bold text-text-tertiary">
+            Policy number
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="claim-policy"
+              type="text"
+              value={draft.policyNumber}
+              onChange={(e) => set({ policyNumber: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-amount" className="text-caption-2 font-bold text-text-tertiary">
+            {`Submitted amount (${currencySymbol(currency)})`}
+          </label>
+          <span className={`${fieldClass} max-w-52`}>
+            <input
+              id="claim-amount"
+              type="number"
+              min="0"
+              step="0.01"
+              inputMode="decimal"
+              value={draft.submittedAmount}
+              onChange={(e) => set({ submittedAmount: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-invoice" className="text-caption-2 font-bold text-text-tertiary">
+            Invoice ID (optional)
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="claim-invoice"
+              type="text"
+              value={draft.invoiceId}
+              onChange={(e) => set({ invoiceId: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-encounter" className="text-caption-2 font-bold text-text-tertiary">
+            Encounter ID (optional)
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="claim-encounter"
+              type="text"
+              value={draft.encounterId}
+              onChange={(e) => set({ encounterId: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="claim-notes" className="text-caption-2 font-bold text-text-tertiary">
+            Notes (optional)
+          </label>
+          <span className={fieldClass}>
+            <textarea
+              id="claim-notes"
+              rows={2}
+              value={draft.notes}
+              onChange={(e) => set({ notes: e.target.value })}
+              className={inputClass}
+            />
+          </span>
+        </div>
+
+        {message ? (
+          <p role="alert" className="text-body-4 text-text-error">
+            {message}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Secondary
+            text="Cancel"
+            isDisabled={saving}
+            onClick={() => setOpenUnlessSaving(false)}
+            ariaLabel="Cancel creating this claim"
+          />
+          <Primary
+            text={saving ? 'Creating...' : 'Create claim'}
+            isDisabled={saving}
+            onClick={submit}
+            ariaLabel="Create this insurance claim"
+          />
+        </div>
+      </div>
+    </CenterModal>
+  );
+};
+
+export default CreateInsuranceClaimDialog;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
@@ -1,0 +1,344 @@
+'use client';
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import { formatDisplayDate } from '@/app/lib/date';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import {
+  fieldClass,
+  inputClass,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import InsuranceClaimStatusBadge from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge';
+import {
+  canCancel,
+  canSubmit,
+  claimStatusLabel,
+  nextReviewStatuses,
+  statusNeedsApprovedAmount,
+  statusNeedsPaidAmount,
+  type InsuranceClaim,
+  type InsuranceClaimStatus,
+  type UpdateClaimStatusInput,
+} from '@/app/features/finance/types/insuranceClaim';
+
+export type ClaimAction = 'submit' | 'cancel' | 'status';
+
+type InsuranceClaimDetailProps = {
+  claim: InsuranceClaim;
+  companionName: string;
+  /** Which action is in flight, so only that control shows a pending label. */
+  pendingAction: ClaimAction | null;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onUpdateStatus: (payload: UpdateClaimStatusInput) => void;
+  error: string | null;
+};
+
+const summaryRow = (label: string, value: string, emphasis = false) => (
+  <div className="flex items-center justify-between gap-4" key={label}>
+    <dt className="text-body-4 text-text-secondary">{label}</dt>
+    <dd className={emphasis ? 'text-body-2 text-text-primary' : 'text-body-3 text-text-primary'}>
+      {value}
+    </dd>
+  </div>
+);
+
+/** A blank or unparseable numeric field reads as NaN so a required check catches it. */
+const toAmount = (raw: string): number => Number(raw.trim());
+
+type Validation = { ok: true } | { ok: false; message: string };
+
+/**
+ * Client-side echo of the service's `assertClaimAmountsCoherent`, so the user is
+ * told what is wrong before the request 400s. The backend still enforces every
+ * rule - this only spares a round trip on the obvious misses.
+ */
+const validateStatusChange = (
+  claim: InsuranceClaim,
+  status: InsuranceClaimStatus,
+  approved: string,
+  paid: string
+): Validation => {
+  if (statusNeedsApprovedAmount(status)) {
+    const value = toAmount(approved);
+    if (!Number.isFinite(value) || value <= 0) {
+      return { ok: false, message: 'Enter the amount the insurer approved.' };
+    }
+    if (value > claim.submittedAmount) {
+      return { ok: false, message: 'Approved amount cannot exceed the submitted amount.' };
+    }
+    if (status === 'PARTIALLY_APPROVED' && value >= claim.submittedAmount) {
+      return {
+        ok: false,
+        message: 'A partially approved claim must be approved for less than the submitted amount.',
+      };
+    }
+  }
+  if (statusNeedsPaidAmount(status)) {
+    const value = toAmount(paid);
+    const ceiling = claim.approvedAmount ?? claim.submittedAmount;
+    if (!Number.isFinite(value) || value <= 0) {
+      return { ok: false, message: 'Enter the amount the insurer paid.' };
+    }
+    if (value > ceiling) {
+      return { ok: false, message: 'Paid amount cannot exceed the approved amount.' };
+    }
+  }
+  return { ok: true };
+};
+
+/** The inline "move this claim on" form: a next-status picker and its amounts. */
+const StatusChangeForm = ({
+  claim,
+  busy,
+  onUpdateStatus,
+}: {
+  claim: InsuranceClaim;
+  busy: boolean;
+  onUpdateStatus: (payload: UpdateClaimStatusInput) => void;
+}) => {
+  const options = nextReviewStatuses(claim.status);
+  const [status, setStatus] = useState<InsuranceClaimStatus>(options[0]);
+  const [approved, setApproved] = useState('');
+  const [paid, setPaid] = useState('');
+  const [reason, setReason] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = () => {
+    const result = validateStatusChange(claim, status, approved, paid);
+    if (!result.ok) {
+      setFormError(result.message);
+      return;
+    }
+    setFormError(null);
+    onUpdateStatus({
+      status,
+      ...(statusNeedsApprovedAmount(status) ? { approvedAmount: toAmount(approved) } : {}),
+      ...(statusNeedsPaidAmount(status) ? { paidAmount: toAmount(paid) } : {}),
+      ...(status === 'REJECTED' && reason.trim() ? { rejectionReason: reason.trim() } : {}),
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-card-border p-4!">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="claim-next-status" className="text-caption-2 font-bold text-text-tertiary">
+          Move claim to
+        </label>
+        <span className={`${fieldClass} max-w-72`}>
+          <select
+            id="claim-next-status"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as InsuranceClaimStatus)}
+            className={inputClass}
+          >
+            {options.map((option) => (
+              <option key={option} value={option}>
+                {claimStatusLabel(option)}
+              </option>
+            ))}
+          </select>
+        </span>
+      </div>
+
+      {statusNeedsApprovedAmount(status) && (
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="claim-approved-amount"
+            className="text-caption-2 font-bold text-text-tertiary"
+          >
+            Approved amount
+          </label>
+          <span className={`${fieldClass} max-w-52`}>
+            <input
+              id="claim-approved-amount"
+              type="number"
+              min="0"
+              step="0.01"
+              inputMode="decimal"
+              value={approved}
+              onChange={(e) => setApproved(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+      )}
+
+      {statusNeedsPaidAmount(status) && (
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="claim-paid-amount"
+            className="text-caption-2 font-bold text-text-tertiary"
+          >
+            Paid amount
+          </label>
+          <span className={`${fieldClass} max-w-52`}>
+            <input
+              id="claim-paid-amount"
+              type="number"
+              min="0"
+              step="0.01"
+              inputMode="decimal"
+              value={paid}
+              onChange={(e) => setPaid(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+      )}
+
+      {status === 'REJECTED' && (
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="claim-rejection-reason"
+            className="text-caption-2 font-bold text-text-tertiary"
+          >
+            Rejection reason (optional)
+          </label>
+          <span className={fieldClass}>
+            <textarea
+              id="claim-rejection-reason"
+              rows={2}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+      )}
+
+      {formError ? (
+        <p role="alert" className="text-body-4 text-text-error">
+          {formError}
+        </p>
+      ) : null}
+
+      <div className="flex justify-end">
+        <Primary
+          text={busy ? 'Updating...' : 'Update status'}
+          isDisabled={busy}
+          onClick={submit}
+          ariaLabel="Update this claim's status"
+        />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * One claim: its amounts, its detail, and the lifecycle actions the backend will
+ * currently accept.
+ *
+ * Actions are gated twice - by `billing:edit:any` so a read-only user never sees
+ * them, and by the status predicates so the UI never offers a transition the
+ * service would reject with a 409.
+ */
+const InsuranceClaimDetail = ({
+  claim,
+  companionName,
+  pendingAction,
+  onSubmit,
+  onCancel,
+  onUpdateStatus,
+  error,
+}: InsuranceClaimDetailProps) => {
+  // Reset the inline form when the selected claim changes, so a half-typed
+  // amount does not carry across to a different claim.
+  const [prevClaimId, setPrevClaimId] = useState(claim.id);
+  const [formKey, setFormKey] = useState(0);
+  if (prevClaimId !== claim.id) {
+    setPrevClaimId(claim.id);
+    setFormKey((key) => key + 1);
+  }
+
+  const busy = pendingAction !== null;
+  const reviewOptions = nextReviewStatuses(claim.status);
+
+  return (
+    <div className="border border-card-border rounded-2xl flex flex-col">
+      <div className="px-6! py-4! border-b border-b-card-border flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <h2 className="text-heading-4 text-text-primary">{companionName}</h2>
+          <InsuranceClaimStatusBadge status={claim.status} />
+        </div>
+        {claim.invoiceId ? (
+          <Link
+            href={`/finance?invoiceId=${claim.invoiceId}`}
+            className="text-body-4 text-blue-text underline underline-offset-2"
+          >
+            View the invoice
+          </Link>
+        ) : null}
+      </div>
+
+      <div className="px-6! py-4! flex flex-col gap-4">
+        <dl className="flex flex-col gap-2" aria-label="Claim details">
+          {summaryRow('Insurer', claim.insurerName)}
+          {summaryRow('Policy number', claim.policyNumber)}
+          {claim.claimNumber ? summaryRow('Claim number', claim.claimNumber) : null}
+          {summaryRow('Submitted', formatMoneyPrecise(claim.submittedAmount, claim.currency))}
+          {claim.approvedAmount != null
+            ? summaryRow('Approved', formatMoneyPrecise(claim.approvedAmount, claim.currency))
+            : null}
+          {claim.paidAmount != null
+            ? summaryRow('Paid', formatMoneyPrecise(claim.paidAmount, claim.currency), true)
+            : null}
+          {claim.submittedAt
+            ? summaryRow('Submitted on', formatDisplayDate(claim.submittedAt, '-'))
+            : null}
+          {claim.paidAt ? summaryRow('Paid on', formatDisplayDate(claim.paidAt, '-')) : null}
+        </dl>
+
+        {claim.notes ? (
+          <p className="text-body-4 text-text-secondary whitespace-pre-line">{claim.notes}</p>
+        ) : null}
+
+        {claim.rejectionReason ? (
+          <p className="text-body-4 text-text-secondary">Rejected: {claim.rejectionReason}</p>
+        ) : null}
+
+        {error ? (
+          <p role="alert" className="text-body-4 text-text-error">
+            {error}
+          </p>
+        ) : null}
+
+        <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+          <div className="flex flex-col gap-4">
+            {reviewOptions.length > 0 && (
+              <StatusChangeForm
+                key={formKey}
+                claim={claim}
+                busy={busy}
+                onUpdateStatus={onUpdateStatus}
+              />
+            )}
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              {canSubmit(claim.status) && (
+                <Primary
+                  text={pendingAction === 'submit' ? 'Submitting...' : 'Submit claim'}
+                  isDisabled={busy}
+                  onClick={onSubmit}
+                  ariaLabel="Submit this claim to the insurer"
+                />
+              )}
+              {canCancel(claim.status) && (
+                <Secondary
+                  danger
+                  text={pendingAction === 'cancel' ? 'Cancelling...' : 'Cancel claim'}
+                  isDisabled={busy}
+                  onClick={onCancel}
+                  ariaLabel="Cancel this claim"
+                />
+              )}
+            </div>
+          </div>
+        </PermissionGate>
+      </div>
+    </div>
+  );
+};
+
+export default InsuranceClaimDetail;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
@@ -1,0 +1,148 @@
+'use client';
+import React from 'react';
+import { currencySymbol } from '@/app/lib/money';
+import {
+  fieldClass,
+  inputClass,
+} from '@/app/features/finance/pages/Estimates/Sections/estimateDraft';
+import type { ClaimDraft } from '@/app/features/finance/pages/InsuranceClaims/Sections/useInsuranceClaimDraft';
+
+export type CompanionChoice = { id: string; name: string };
+
+type InsuranceClaimFormFieldsProps = {
+  draft: ClaimDraft;
+  setField: (patch: Partial<ClaimDraft>) => void;
+  currency: string;
+  companions: CompanionChoice[];
+};
+
+/**
+ * The claim create form's fields. Only the fields the create endpoint accepts
+ * are shown; the optional invoice and encounter links are free text because a
+ * claim can be filed before either exists. Presentational - the draft state and
+ * its validation live in `useInsuranceClaimDraft`.
+ */
+const InsuranceClaimFormFields = ({
+  draft,
+  setField,
+  currency,
+  companions,
+}: InsuranceClaimFormFieldsProps) => (
+  <>
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-companion" className="text-caption-2 font-bold text-text-tertiary">
+        Companion
+      </label>
+      <span className={fieldClass}>
+        <select
+          id="claim-companion"
+          value={draft.patientId}
+          onChange={(e) => setField({ patientId: e.target.value })}
+          className={inputClass}
+        >
+          <option value="">Choose a companion</option>
+          {companions.map((companion) => (
+            <option key={companion.id} value={companion.id}>
+              {companion.name}
+            </option>
+          ))}
+        </select>
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-insurer" className="text-caption-2 font-bold text-text-tertiary">
+        Insurer
+      </label>
+      <span className={fieldClass}>
+        <input
+          id="claim-insurer"
+          type="text"
+          value={draft.insurerName}
+          onChange={(e) => setField({ insurerName: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-policy" className="text-caption-2 font-bold text-text-tertiary">
+        Policy number
+      </label>
+      <span className={fieldClass}>
+        <input
+          id="claim-policy"
+          type="text"
+          value={draft.policyNumber}
+          onChange={(e) => setField({ policyNumber: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-amount" className="text-caption-2 font-bold text-text-tertiary">
+        {`Submitted amount (${currencySymbol(currency)})`}
+      </label>
+      <span className={`${fieldClass} max-w-52`}>
+        <input
+          id="claim-amount"
+          type="number"
+          min="0"
+          step="0.01"
+          inputMode="decimal"
+          value={draft.submittedAmount}
+          onChange={(e) => setField({ submittedAmount: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-invoice" className="text-caption-2 font-bold text-text-tertiary">
+        Invoice ID (optional)
+      </label>
+      <span className={fieldClass}>
+        <input
+          id="claim-invoice"
+          type="text"
+          value={draft.invoiceId}
+          onChange={(e) => setField({ invoiceId: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-encounter" className="text-caption-2 font-bold text-text-tertiary">
+        Encounter ID (optional)
+      </label>
+      <span className={fieldClass}>
+        <input
+          id="claim-encounter"
+          type="text"
+          value={draft.encounterId}
+          onChange={(e) => setField({ encounterId: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+
+    <div className="flex flex-col gap-1">
+      <label htmlFor="claim-notes" className="text-caption-2 font-bold text-text-tertiary">
+        Notes (optional)
+      </label>
+      <span className={fieldClass}>
+        <textarea
+          id="claim-notes"
+          rows={2}
+          value={draft.notes}
+          onChange={(e) => setField({ notes: e.target.value })}
+          className={inputClass}
+        />
+      </span>
+    </div>
+  </>
+);
+
+export default InsuranceClaimFormFields;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList.tsx
@@ -1,0 +1,121 @@
+'use client';
+import React, { useMemo } from 'react';
+import { IoEyeOutline } from 'react-icons/io5';
+import { formatMoneyPrecise } from '@/app/lib/money';
+import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
+import InsuranceClaimStatusBadge from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+type InsuranceClaimListProps = {
+  claims: InsuranceClaim[];
+  /** The open claim, highlighted in the list. */
+  activeClaimId: string | null;
+  onSelect: (claim: InsuranceClaim) => void;
+};
+
+/** A nullable money column: a dash when the figure has not been set yet. */
+const money = (amount: number | null, currency: string): string =>
+  amount == null ? '-' : formatMoneyPrecise(amount, currency);
+
+/**
+ * The insurer's name over its policy number, the way the invoice table stacks a
+ * primary and a quiet second line, so the two finance tables read as one family.
+ */
+const InsurerCell = ({ claim }: { claim: InsuranceClaim }) => (
+  <div className="flex flex-col gap-0.5 min-w-0">
+    <span className="truncate text-body-3 text-text-primary" title={claim.insurerName}>
+      {claim.insurerName}
+    </span>
+    <span className="truncate text-caption-2 text-text-secondary" title={claim.policyNumber}>
+      {claim.policyNumber}
+    </span>
+  </div>
+);
+
+/**
+ * The insurance claims list, rendered through the shared `GenericTable` so it
+ * inherits the app's column-header typography, contrast, sticky behaviour and
+ * pager rather than maintaining a second finance table of its own.
+ */
+const InsuranceClaimList = ({ claims, activeClaimId, onSelect }: InsuranceClaimListProps) => {
+  const columns = useMemo<Column<InsuranceClaim>[]>(
+    () => [
+      {
+        key: 'insurerName',
+        label: 'Insurer / policy',
+        render: (claim) => <InsurerCell claim={claim} />,
+      },
+      {
+        key: 'claimNumber',
+        label: 'Claim no.',
+        render: (claim) => (
+          <span className="text-text-secondary tabular-nums">{claim.claimNumber ?? '-'}</span>
+        ),
+      },
+      {
+        key: 'submittedAmount',
+        label: 'Submitted',
+        render: (claim) => (
+          <span className="block text-right tabular-nums text-text-primary">
+            {formatMoneyPrecise(claim.submittedAmount, claim.currency)}
+          </span>
+        ),
+      },
+      {
+        key: 'approvedAmount',
+        label: 'Approved',
+        render: (claim) => (
+          <span className="block text-right tabular-nums text-text-secondary">
+            {money(claim.approvedAmount, claim.currency)}
+          </span>
+        ),
+      },
+      {
+        // Money reads down the column, so the settled figure is right-aligned and
+        // weighted the way the invoice table's TOTAL is.
+        key: 'paidAmount',
+        label: 'Paid',
+        render: (claim) => (
+          <span className="block text-right font-bold tabular-nums text-text-primary">
+            {money(claim.paidAmount, claim.currency)}
+          </span>
+        ),
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        render: (claim) => <InsuranceClaimStatusBadge status={claim.status} />,
+      },
+      {
+        key: 'actions',
+        label: 'Actions',
+        render: (claim) => (
+          <button
+            type="button"
+            onClick={() => onSelect(claim)}
+            className="grid-row-action flex size-[30px] items-center justify-center rounded-full! border cursor-pointer transition-colors hover:bg-card-hover"
+            aria-label={`Open the claim for ${claim.insurerName}`}
+          >
+            <IoEyeOutline size={14} aria-hidden="true" />
+          </button>
+        ),
+      },
+    ],
+    [onSelect]
+  );
+
+  return (
+    <GenericTable
+      data={claims}
+      columns={columns}
+      caption="Insurance claims for this organisation"
+      itemNoun="claims"
+      pagination
+      // Kept through GenericTable's row hook rather than dropped: without it the
+      // detail panel below can belong to any row on screen.
+      rowClassName={(claim) => (claim.id === activeClaimId ? 'bg-card-hover' : '')}
+    />
+  );
+};
+
+export default InsuranceClaimList;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge.tsx
@@ -1,0 +1,19 @@
+'use client';
+import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import {
+  claimStatusBadge,
+  type InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+type InsuranceClaimStatusBadgeProps = {
+  status: InsuranceClaimStatus;
+};
+
+/** The claim's lifecycle state, using the same tokens as the filter row. */
+const InsuranceClaimStatusBadge = ({ status }: InsuranceClaimStatusBadgeProps) => {
+  const { label, bg, text, border } = claimStatusBadge(status);
+  return <StatusPill tokens={{ bg, text, border }} label={label} />;
+};
+
+export default InsuranceClaimStatusBadge;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.tsx
@@ -1,0 +1,114 @@
+'use client';
+import React, { useMemo } from 'react';
+import { IoInformationCircleOutline } from 'react-icons/io5';
+import { formatMoneyPrecise, sharedCurrency } from '@/app/lib/money';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
+import {
+  InsuranceClaimStatusFilters,
+  type InsuranceClaim,
+} from '@/app/features/finance/types/insuranceClaim';
+import type { CompanionChoice } from '@/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog';
+
+type InsuranceClaimsHeaderProps = {
+  claims: InsuranceClaim[];
+  currency: string;
+  activeStatus: string;
+  onStatusChange: (status: string) => void;
+  companions: CompanionChoice[];
+  onCreate: () => void;
+};
+
+/**
+ * The two figures a practice asks of a claims list: what is still with the
+ * insurer, and what has been paid back. DRAFT/SUBMITTED/UNDER_REVIEW count as in
+ * progress; only a PAID claim's `paidAmount` counts as recovered.
+ */
+const summariseClaims = (claims: InsuranceClaim[]) =>
+  claims.reduce(
+    (totals, claim) => {
+      if (
+        claim.status === 'DRAFT' ||
+        claim.status === 'SUBMITTED' ||
+        claim.status === 'UNDER_REVIEW'
+      ) {
+        return { ...totals, inProgress: totals.inProgress + claim.submittedAmount };
+      }
+      if (claim.status === 'PAID' && claim.paidAmount != null) {
+        return { ...totals, paid: totals.paid + claim.paidAmount };
+      }
+      return totals;
+    },
+    { inProgress: 0, paid: 0 }
+  );
+
+/**
+ * The Insurance claims header: the same anatomy as Finance and Estimates - a
+ * title with a live count, an info affordance, a metrics sub-line, then the
+ * status filter and page actions on the right of that row.
+ */
+const InsuranceClaimsHeader = ({
+  claims,
+  currency,
+  activeStatus,
+  onStatusChange,
+  companions,
+  onCreate,
+}: InsuranceClaimsHeaderProps) => {
+  const metricsCurrency = useMemo(() => sharedCurrency(claims, currency), [claims, currency]);
+  const metrics = useMemo(() => summariseClaims(claims), [claims]);
+
+  return (
+    <div className="flex items-center justify-between w-full flex-wrap gap-2">
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <h1 className="text-page-title">
+            {'Insurance claims'}{' '}
+            <span className="text-page-title-count">{`(${claims.length})`}</span>
+          </h1>
+          <GlassTooltip
+            content="File a claim against a pet's insurer, submit it, then record the insurer's decision and payment as the claim is settled."
+            side="bottom"
+          >
+            <button
+              type="button"
+              aria-label="Insurance claims info"
+              className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
+            >
+              <IoInformationCircleOutline size={17} />
+            </button>
+          </GlassTooltip>
+        </div>
+        <p className="text-[13.5px] text-text-secondary">
+          {`${formatMoneyPrecise(metrics.inProgress, metricsCurrency)} with insurers · ${formatMoneyPrecise(
+            metrics.paid,
+            metricsCurrency
+          )} paid back`}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 flex-wrap justify-end">
+        <InvoiceStatusFilterPills
+          options={InsuranceClaimStatusFilters}
+          activeStatus={activeStatus}
+          setActiveStatus={onStatusChange}
+          ariaLabel="Filter claims by status"
+          className="flex-wrap justify-end"
+        />
+        <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
+        <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+          <Primary
+            text="New insurance claim"
+            isDisabled={companions.length === 0}
+            onClick={onCreate}
+            ariaLabel="Create a new insurance claim"
+          />
+        </PermissionGate>
+      </div>
+    </div>
+  );
+};
+
+export default InsuranceClaimsHeader;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates.tsx
@@ -1,0 +1,53 @@
+'use client';
+import React from 'react';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+
+type InsuranceClaimsStatesProps = {
+  loading: boolean;
+  error: string | null;
+  onReload: () => void;
+  isEmpty: boolean;
+  /** Why the list is empty, resolved by the container from filter and query. */
+  emptyMessage: string;
+};
+
+/**
+ * The list's loading, error and empty placeholders, which are mutually
+ * exclusive with the table. Returns null once there are claims to show, so the
+ * page reads as `<States/>` then the table rather than three inline branches.
+ */
+const InsuranceClaimsStates = ({
+  loading,
+  error,
+  onReload,
+  isEmpty,
+  emptyMessage,
+}: InsuranceClaimsStatesProps) => {
+  if (loading) {
+    return <div className="h-40 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />;
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3!">
+        <p role="alert" className="text-body-4 text-text-error">
+          {error}
+        </p>
+        <Secondary text="Retry" onClick={onReload} ariaLabel="Retry loading insurance claims" />
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="border border-card-border rounded-2xl px-6! py-10! text-center">
+        <p className="text-body-3 text-text-primary">No insurance claims yet</p>
+        <p className="text-body-4 text-text-secondary">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default InsuranceClaimsStates;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/useInsuranceClaimDraft.ts
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/useInsuranceClaimDraft.ts
@@ -1,0 +1,91 @@
+'use client';
+import { useState } from 'react';
+import type { CreateInsuranceClaimInput } from '@/app/features/finance/types/insuranceClaim';
+
+/**
+ * The claim editor's draft state, validation and payload building. Kept out of
+ * the dialog component so the dialog reads as composition, so Fast Refresh can
+ * preserve the form's state (a component file that also exports non-components
+ * forces a full reload), and so the validation can be tested without rendering.
+ */
+export type ClaimDraft = {
+  patientId: string;
+  insurerName: string;
+  policyNumber: string;
+  submittedAmount: string;
+  invoiceId: string;
+  encounterId: string;
+  notes: string;
+};
+
+const emptyDraft: ClaimDraft = {
+  patientId: '',
+  insurerName: '',
+  policyNumber: '',
+  submittedAmount: '',
+  invoiceId: '',
+  encounterId: '',
+  notes: '',
+};
+
+type Validation = { ok: true } | { ok: false; message: string };
+
+/**
+ * Validate the draft the way the controller's `CreateBodySchema` does, so the
+ * user learns what is wrong before a request goes out rather than reading a zod
+ * error afterwards: patient, insurer and policy are required, and the amount
+ * must be positive.
+ */
+export const validateClaimDraft = (draft: ClaimDraft): Validation => {
+  if (!draft.patientId) return { ok: false, message: 'Choose a companion for this claim.' };
+  if (!draft.insurerName.trim()) return { ok: false, message: "Enter the insurer's name." };
+  if (!draft.policyNumber.trim()) return { ok: false, message: 'Enter the policy number.' };
+  const amount = Number(draft.submittedAmount.trim());
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { ok: false, message: 'The submitted amount must be above zero.' };
+  }
+  return { ok: true };
+};
+
+/** Build the create payload, trimming strings and omitting the empty optionals. */
+export const buildClaimInput = (
+  draft: ClaimDraft,
+  currency: string
+): CreateInsuranceClaimInput => ({
+  patientId: draft.patientId,
+  insurerName: draft.insurerName.trim(),
+  policyNumber: draft.policyNumber.trim(),
+  submittedAmount: Number(draft.submittedAmount.trim()),
+  currency,
+  ...(draft.invoiceId.trim() ? { invoiceId: draft.invoiceId.trim() } : {}),
+  ...(draft.encounterId.trim() ? { encounterId: draft.encounterId.trim() } : {}),
+  ...(draft.notes.trim() ? { notes: draft.notes.trim() } : {}),
+});
+
+export type UseInsuranceClaimDraft = {
+  draft: ClaimDraft;
+  setField: (patch: Partial<ClaimDraft>) => void;
+  formError: string | null;
+  /** Validate, then either surface the message or hand the built payload up. */
+  submit: (currency: string, onSubmit: (input: CreateInsuranceClaimInput) => void) => void;
+};
+
+export const useInsuranceClaimDraft = (): UseInsuranceClaimDraft => {
+  const [draft, setDraft] = useState<ClaimDraft>(emptyDraft);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const setField = (patch: Partial<ClaimDraft>) =>
+    setDraft((current) => ({ ...current, ...patch }));
+
+  const submit = (currency: string, onSubmit: (input: CreateInsuranceClaimInput) => void) => {
+    const result = validateClaimDraft(draft);
+    if (!result.ok) {
+      setFormError(result.message);
+      return;
+    }
+    setFormError(null);
+    onSubmit(buildClaimInput(draft, currency));
+  };
+
+  return { draft, setField, formError, submit };
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/index.tsx
@@ -1,0 +1,227 @@
+'use client';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
+import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
+import PageSkeleton from '@/app/ui/layout/PageSkeleton';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { loadCompanionsForPrimaryOrg } from '@/app/features/companions/services/companionService';
+import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
+import { useInsuranceClaims } from '@/app/features/finance/hooks/useInsuranceClaims';
+import {
+  cancelInsuranceClaim,
+  createInsuranceClaim,
+  getClaimErrorMessage,
+  submitInsuranceClaim,
+  updateInsuranceClaimStatus,
+} from '@/app/features/finance/services/insuranceClaimService';
+import {
+  claimStatusLabel,
+  type CreateInsuranceClaimInput,
+  type InsuranceClaim,
+  type InsuranceClaimStatus,
+  type UpdateClaimStatusInput,
+} from '@/app/features/finance/types/insuranceClaim';
+import InsuranceClaims from '@/app/features/finance/pages/InsuranceClaims/InsuranceClaims';
+import type { ClaimAction } from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail';
+
+const CLAIMS_PAGE_SKELETON = <PageSkeleton variant="list" />;
+
+/**
+ * Why the list is empty: a search that matched nothing, a status filter with no
+ * members, or an organisation with no claims at all. Named rather than nested in
+ * JSX - Sonar S3358 rejects a nested ternary, and the branches read better here.
+ */
+const emptyListMessage = (
+  hasQuery: boolean,
+  hasAnyClaim: boolean,
+  activeStatus: string
+): string => {
+  if (hasQuery && hasAnyClaim) return 'No claim matches that search.';
+  if (activeStatus !== 'all')
+    return `No claim is currently ${claimStatusLabel(activeStatus as InsuranceClaimStatus).toLowerCase()}.`;
+  return 'File a claim to recover a treatment cost from a pet parent’s insurer.';
+};
+
+const InsuranceClaimsContent = () => {
+  const { notify } = useNotify();
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const currency = useCurrencyForPrimaryOrg();
+
+  const query = useSearchStore((s) => s.query);
+  const [activeStatus, setActiveStatus] = useState('all');
+  const statusFilter: InsuranceClaimStatus | undefined =
+    activeStatus === 'all' ? undefined : (activeStatus as InsuranceClaimStatus);
+
+  const { claims, loading, error, upsert, reload } = useInsuranceClaims(
+    primaryOrgId ?? undefined,
+    statusFilter
+  );
+
+  const [activeClaimId, setActiveClaimId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<ClaimAction | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const companionsById = useCompanionStore((s) => s.companionsById);
+  const companionsIdsByOrgId = useCompanionStore((s) => s.companionsIdsByOrgId);
+
+  // Companions name each row and populate the create picker; the claims API
+  // returns a bare patientId, so without them a row would read as a uuid.
+  useEffect(() => {
+    if (!primaryOrgId) return;
+    if ((companionsIdsByOrgId[primaryOrgId] ?? []).length > 0) return;
+    loadCompanionsForPrimaryOrg().catch(() => {
+      /* The picker simply stays empty and "New claim" is disabled. */
+    });
+  }, [primaryOrgId, companionsIdsByOrgId]);
+
+  const companions = useMemo(() => {
+    if (!primaryOrgId) return [];
+    return (companionsIdsByOrgId[primaryOrgId] ?? []).flatMap((id) => {
+      const companion = companionsById[id];
+      return companion ? [{ id: companion.id, name: companion.name || 'Unnamed companion' }] : [];
+    });
+  }, [primaryOrgId, companionsById, companionsIdsByOrgId]);
+
+  const companionName = useCallback(
+    (patientId: string) => companionsById[patientId]?.name || 'Unknown companion',
+    [companionsById]
+  );
+
+  // The shared finance header writes to the search store, so match on the fields
+  // a user typing there would expect: the companion, the insurer, or the policy.
+  const visibleClaims = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return claims;
+    return claims.filter((claim) =>
+      [companionName(claim.patientId), claim.insurerName, claim.policyNumber]
+        .join(' ')
+        .toLowerCase()
+        .includes(needle)
+    );
+  }, [claims, query, companionName]);
+
+  const runAction = async (
+    action: ClaimAction,
+    claim: InsuranceClaim,
+    work: () => Promise<InsuranceClaim>
+  ) => {
+    if (!primaryOrgId) return;
+    setPendingAction(action);
+    setActionError(null);
+    try {
+      const updated = await work();
+      upsert(updated);
+      if (statusFilter && updated.status !== statusFilter) setActiveClaimId(null);
+      notify('success', { title: 'Claim updated', text: 'The claim has been updated.' });
+    } catch (err: unknown) {
+      const message = getClaimErrorMessage(err, 'That action could not be completed.');
+      setActionError(message);
+      notify('error', { title: 'Claim not updated', text: message });
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const activeClaim = useMemo(
+    () => visibleClaims.find((claim) => claim.id === activeClaimId) ?? null,
+    [visibleClaims, activeClaimId]
+  );
+
+  const handleSubmitClaim = () => {
+    if (!primaryOrgId || !activeClaim) return;
+    void runAction('submit', activeClaim, () => submitInsuranceClaim(primaryOrgId, activeClaim.id));
+  };
+
+  const handleCancelClaim = () => {
+    if (!primaryOrgId || !activeClaim) return;
+    void runAction('cancel', activeClaim, () => cancelInsuranceClaim(primaryOrgId, activeClaim.id));
+  };
+
+  const handleUpdateStatus = (payload: UpdateClaimStatusInput) => {
+    if (!primaryOrgId || !activeClaim) return;
+    void runAction('status', activeClaim, () =>
+      updateInsuranceClaimStatus(primaryOrgId, activeClaim.id, payload)
+    );
+  };
+
+  const handleCreate = async (input: CreateInsuranceClaimInput) => {
+    if (!primaryOrgId) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const created = await createInsuranceClaim(primaryOrgId, input);
+      // A new claim is always DRAFT. Move to the filter it lives under first, so
+      // selecting it does not leave an unchanged list with nothing selected.
+      if (statusFilter && created.status !== statusFilter) setActiveStatus(created.status);
+      upsert(created);
+      setActiveClaimId(created.id);
+      setCreateOpen(false);
+      notify('success', { title: 'Claim created', text: 'The claim is saved as a draft.' });
+    } catch (err: unknown) {
+      setCreateError(getClaimErrorMessage(err, 'The claim could not be created.'));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <InsuranceClaims
+      claims={visibleClaims}
+      loading={loading}
+      error={error}
+      onReload={reload}
+      emptyMessage={emptyListMessage(Boolean(query.trim()), claims.length > 0, activeStatus)}
+      activeStatus={activeStatus}
+      onStatusChange={(value) => {
+        setActiveStatus(value);
+        setActiveClaimId(null);
+      }}
+      companionName={companionName}
+      companions={companions}
+      currency={currency}
+      activeClaimId={activeClaimId}
+      onSelect={(claim) => {
+        setActiveClaimId(claim.id);
+        setActionError(null);
+      }}
+      pendingAction={pendingAction}
+      actionError={actionError}
+      onSubmitClaim={handleSubmitClaim}
+      onCancelClaim={handleCancelClaim}
+      onUpdateStatus={handleUpdateStatus}
+      createOpen={createOpen}
+      onCreateOpenChange={setCreateOpen}
+      creating={creating}
+      createError={createError}
+      onCreate={(input) => void handleCreate(input)}
+    />
+  );
+};
+
+const InsuranceClaimsPage = () => (
+  <PermissionGate allOf={[PERMISSIONS.BILLING_VIEW_ANY]} fallback={<Fallback />}>
+    <InsuranceClaimsContent />
+  </PermissionGate>
+);
+
+const ProtectedInsuranceClaims = () => (
+  <ProtectedRoute skeleton={CLAIMS_PAGE_SKELETON}>
+    <OrgGuard skeleton={CLAIMS_PAGE_SKELETON}>
+      <Suspense fallback={CLAIMS_PAGE_SKELETON}>
+        <InsuranceClaimsPage />
+      </Suspense>
+    </OrgGuard>
+  </ProtectedRoute>
+);
+
+export default ProtectedInsuranceClaims;

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/index.tsx
@@ -110,11 +110,7 @@ const InsuranceClaimsContent = () => {
     );
   }, [claims, query, companionName]);
 
-  const runAction = async (
-    action: ClaimAction,
-    claim: InsuranceClaim,
-    work: () => Promise<InsuranceClaim>
-  ) => {
+  const runAction = async (action: ClaimAction, work: () => Promise<InsuranceClaim>) => {
     if (!primaryOrgId) return;
     setPendingAction(action);
     setActionError(null);
@@ -139,17 +135,17 @@ const InsuranceClaimsContent = () => {
 
   const handleSubmitClaim = () => {
     if (!primaryOrgId || !activeClaim) return;
-    void runAction('submit', activeClaim, () => submitInsuranceClaim(primaryOrgId, activeClaim.id));
+    void runAction('submit', () => submitInsuranceClaim(primaryOrgId, activeClaim.id));
   };
 
   const handleCancelClaim = () => {
     if (!primaryOrgId || !activeClaim) return;
-    void runAction('cancel', activeClaim, () => cancelInsuranceClaim(primaryOrgId, activeClaim.id));
+    void runAction('cancel', () => cancelInsuranceClaim(primaryOrgId, activeClaim.id));
   };
 
   const handleUpdateStatus = (payload: UpdateClaimStatusInput) => {
     if (!primaryOrgId || !activeClaim) return;
-    void runAction('status', activeClaim, () =>
+    void runAction('status', () =>
       updateInsuranceClaimStatus(primaryOrgId, activeClaim.id, payload)
     );
   };

--- a/apps/frontend/src/app/features/finance/services/insuranceClaimService.ts
+++ b/apps/frontend/src/app/features/finance/services/insuranceClaimService.ts
@@ -1,0 +1,118 @@
+import { getData, postData, putData } from '@/app/services/axios';
+import type {
+  CreateInsuranceClaimInput,
+  InsuranceClaim,
+  InsuranceClaimStatus,
+  UpdateClaimStatusInput,
+} from '@/app/features/finance/types/insuranceClaim';
+
+const claimsPath = (organisationId: string) =>
+  `/v1/pms/organisation/${organisationId}/insurance-claims`;
+
+const assertOrg = (organisationId: string) => {
+  if (!organisationId) throw new Error('Organisation ID missing');
+};
+
+/**
+ * Human-readable message from an insurance-claim API error.
+ *
+ * The clinical controllers reply `{ message: string }` on every failure - both
+ * the service errors (404/409/400) and the fallback 500 - so unlike the
+ * estimate endpoints there is no zod `flatten` to unpack. Falling back to the
+ * axios error's own message keeps a network failure legible too.
+ */
+export const getClaimErrorMessage = (error: unknown, fallback: string): string => {
+  const data = (error as { response?: { data?: unknown } } | null)?.response?.data;
+  if (typeof data === 'object' && data !== null) {
+    const message = (data as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  return fallback;
+};
+
+export const listInsuranceClaims = async (
+  organisationId: string,
+  filters?: { patientId?: string; status?: InsuranceClaimStatus; invoiceId?: string }
+): Promise<InsuranceClaim[]> => {
+  assertOrg(organisationId);
+  // Passed as `params` rather than a query string so the request takes part in
+  // the shared GET de-duplication, which keys on both.
+  const params: Record<string, string> = {};
+  if (filters?.patientId) params.patientId = filters.patientId;
+  if (filters?.status) params.status = filters.status;
+  if (filters?.invoiceId) params.invoiceId = filters.invoiceId;
+  const res = await getData<InsuranceClaim[]>(claimsPath(organisationId), params);
+  // The list endpoint returns a bare array. Guard anyway: a proxy or error page
+  // replying with an object would otherwise crash `.map` in the table.
+  return Array.isArray(res.data) ? res.data : [];
+};
+
+export const getInsuranceClaim = async (
+  organisationId: string,
+  claimId: string
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await getData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}`);
+  return res.data;
+};
+
+export const createInsuranceClaim = async (
+  organisationId: string,
+  input: CreateInsuranceClaimInput
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await postData<InsuranceClaim>(claimsPath(organisationId), input);
+  return res.data;
+};
+
+export const updateInsuranceClaim = async (
+  organisationId: string,
+  claimId: string,
+  input: Partial<
+    Pick<
+      InsuranceClaim,
+      | 'insurerName'
+      | 'policyNumber'
+      | 'claimNumber'
+      | 'submittedAmount'
+      | 'notes'
+      | 'externalClaimRef'
+    >
+  >
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await putData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}`, input);
+  return res.data;
+};
+
+export const submitInsuranceClaim = async (
+  organisationId: string,
+  claimId: string
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await postData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}/submit`, {});
+  return res.data;
+};
+
+export const updateInsuranceClaimStatus = async (
+  organisationId: string,
+  claimId: string,
+  input: UpdateClaimStatusInput
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await postData<InsuranceClaim>(
+    `${claimsPath(organisationId)}/${claimId}/status`,
+    input
+  );
+  return res.data;
+};
+
+export const cancelInsuranceClaim = async (
+  organisationId: string,
+  claimId: string
+): Promise<InsuranceClaim> => {
+  assertOrg(organisationId);
+  const res = await postData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}/cancel`, {});
+  return res.data;
+};

--- a/apps/frontend/src/app/features/finance/services/insuranceClaimService.ts
+++ b/apps/frontend/src/app/features/finance/services/insuranceClaimService.ts
@@ -6,8 +6,14 @@ import type {
   UpdateClaimStatusInput,
 } from '@/app/features/finance/types/insuranceClaim';
 
+// Encode the caller's own org id + claim id as single path segments so the
+// request stays pinned to `/v1/pms/organisation/<seg>/insurance-claims/<seg>`
+// even if an id ever carried a slash or dot (what the SSRF scanner checks).
 const claimsPath = (organisationId: string) =>
-  `/v1/pms/organisation/${organisationId}/insurance-claims`;
+  `/v1/pms/organisation/${encodeURIComponent(organisationId)}/insurance-claims`;
+
+const claimPath = (organisationId: string, claimId: string) =>
+  `${claimsPath(organisationId)}/${encodeURIComponent(claimId)}`;
 
 const assertOrg = (organisationId: string) => {
   if (!organisationId) throw new Error('Organisation ID missing');
@@ -53,7 +59,7 @@ export const getInsuranceClaim = async (
   claimId: string
 ): Promise<InsuranceClaim> => {
   assertOrg(organisationId);
-  const res = await getData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}`);
+  const res = await getData<InsuranceClaim>(claimPath(organisationId, claimId));
   return res.data;
 };
 
@@ -82,7 +88,7 @@ export const updateInsuranceClaim = async (
   >
 ): Promise<InsuranceClaim> => {
   assertOrg(organisationId);
-  const res = await putData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}`, input);
+  const res = await putData<InsuranceClaim>(claimPath(organisationId, claimId), input);
   return res.data;
 };
 
@@ -91,7 +97,7 @@ export const submitInsuranceClaim = async (
   claimId: string
 ): Promise<InsuranceClaim> => {
   assertOrg(organisationId);
-  const res = await postData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}/submit`, {});
+  const res = await postData<InsuranceClaim>(`${claimPath(organisationId, claimId)}/submit`, {});
   return res.data;
 };
 
@@ -101,10 +107,7 @@ export const updateInsuranceClaimStatus = async (
   input: UpdateClaimStatusInput
 ): Promise<InsuranceClaim> => {
   assertOrg(organisationId);
-  const res = await postData<InsuranceClaim>(
-    `${claimsPath(organisationId)}/${claimId}/status`,
-    input
-  );
+  const res = await postData<InsuranceClaim>(`${claimPath(organisationId, claimId)}/status`, input);
   return res.data;
 };
 
@@ -113,6 +116,6 @@ export const cancelInsuranceClaim = async (
   claimId: string
 ): Promise<InsuranceClaim> => {
   assertOrg(organisationId);
-  const res = await postData<InsuranceClaim>(`${claimsPath(organisationId)}/${claimId}/cancel`, {});
+  const res = await postData<InsuranceClaim>(`${claimPath(organisationId, claimId)}/cancel`, {});
   return res.data;
 };

--- a/apps/frontend/src/app/features/finance/types/insuranceClaim.ts
+++ b/apps/frontend/src/app/features/finance/types/insuranceClaim.ts
@@ -1,0 +1,190 @@
+import {
+  StatusOption,
+  dropdownStatusFromToken,
+} from '@/app/features/companions/pages/Companions/types';
+
+/**
+ * Insurance claim shapes as the backend returns them.
+ *
+ * These live here rather than in `@yosemite-crew/types` because the
+ * insurance-claim endpoints reply with the raw Prisma selection
+ * (`insurance-claim.service.ts` `claimSelect`), not a DTO, and no other
+ * workspace consumes them yet. Money columns are plain floats in major units -
+ * `submittedAmount: 45.5` is £45.50 - so they format straight through
+ * `formatMoneyPrecise` with no minor-unit conversion.
+ */
+export type InsuranceClaimStatus =
+  | 'DRAFT'
+  | 'SUBMITTED'
+  | 'UNDER_REVIEW'
+  | 'APPROVED'
+  | 'PARTIALLY_APPROVED'
+  | 'REJECTED'
+  | 'PAID'
+  | 'CANCELLED';
+
+export type InsuranceClaim = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  invoiceId: string | null;
+  encounterId: string | null;
+  insurerName: string;
+  policyNumber: string;
+  claimNumber: string | null;
+  submittedAmount: number;
+  approvedAmount: number | null;
+  paidAmount: number | null;
+  currency: string;
+  status: InsuranceClaimStatus;
+  submittedAt: string | null;
+  approvedAt: string | null;
+  paidAt: string | null;
+  rejectionReason: string | null;
+  notes: string | null;
+  externalClaimRef: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** The body the create endpoint accepts (`CreateBodySchema`). */
+export type CreateInsuranceClaimInput = {
+  patientId: string;
+  invoiceId?: string;
+  encounterId?: string;
+  insurerName: string;
+  policyNumber: string;
+  submittedAmount: number;
+  currency?: string;
+  notes?: string;
+};
+
+/** The body the status endpoint accepts (`UpdateStatusBodySchema`). */
+export type UpdateClaimStatusInput = {
+  status: InsuranceClaimStatus;
+  approvedAmount?: number;
+  paidAmount?: number;
+  rejectionReason?: string;
+  claimNumber?: string;
+  externalClaimRef?: string;
+};
+
+/**
+ * The status transitions the service will accept, mirroring
+ * `CLAIM_STATUS_TRANSITIONS` in insurance-claim.service.ts. Keeping this next to
+ * the type means the UI offers a transition rather than letting the request 409.
+ */
+const CLAIM_STATUS_TRANSITIONS: Record<InsuranceClaimStatus, readonly InsuranceClaimStatus[]> = {
+  DRAFT: ['SUBMITTED', 'CANCELLED'],
+  SUBMITTED: ['UNDER_REVIEW', 'APPROVED', 'PARTIALLY_APPROVED', 'REJECTED', 'CANCELLED'],
+  UNDER_REVIEW: ['APPROVED', 'PARTIALLY_APPROVED', 'REJECTED', 'CANCELLED'],
+  APPROVED: ['PAID', 'CANCELLED'],
+  PARTIALLY_APPROVED: ['PAID', 'CANCELLED'],
+  REJECTED: [],
+  PAID: [],
+  CANCELLED: [],
+};
+
+/** A DRAFT is submitted through the dedicated `/submit` endpoint. */
+export const canSubmit = (status: InsuranceClaimStatus): boolean => status === 'DRAFT';
+
+/**
+ * Whether the dedicated `/cancel` endpoint will accept the claim. That guard is
+ * broader than the transition map: cancel only refuses a claim that is already
+ * CANCELLED or already PAID, so a REJECTED claim can still be cancelled.
+ */
+export const canCancel = (status: InsuranceClaimStatus): boolean =>
+  status !== 'CANCELLED' && status !== 'PAID';
+
+/** Only a DRAFT can be edited (the service's `update` rejects any other). */
+export const canEditClaim = (status: InsuranceClaimStatus): boolean => status === 'DRAFT';
+
+/**
+ * The statuses the `/status` endpoint will move this claim to, excluding
+ * CANCELLED (handled by the dedicated Cancel button) and SUBMITTED (handled by
+ * the dedicated Submit button on a DRAFT). Empty for a DRAFT and for any
+ * terminal status, so the caller can hide the picker entirely.
+ */
+export const nextReviewStatuses = (status: InsuranceClaimStatus): readonly InsuranceClaimStatus[] =>
+  CLAIM_STATUS_TRANSITIONS[status].filter((next) => next !== 'CANCELLED' && next !== 'SUBMITTED');
+
+/** Moving to these statuses requires an approved amount (`assertClaimAmountsCoherent`). */
+export const statusNeedsApprovedAmount = (status: InsuranceClaimStatus): boolean =>
+  status === 'APPROVED' || status === 'PARTIALLY_APPROVED';
+
+/** Moving to PAID requires a paid amount. */
+export const statusNeedsPaidAmount = (status: InsuranceClaimStatus): boolean => status === 'PAID';
+
+/**
+ * The pill token prefix per status, in lifecycle order. One map feeds both the
+ * filter row and the row badge, so the two can never drift apart. Neutral while
+ * the claim is still being prepared, info/progress/accent through review,
+ * success for a paid claim, danger for a rejection and warning for a
+ * cancellation - the same family the estimate and invoice pills use.
+ */
+const CLAIM_STATUS_TOKEN: Record<InsuranceClaimStatus, string> = {
+  DRAFT: 'color-pill-neutral',
+  SUBMITTED: 'color-pill-info',
+  UNDER_REVIEW: 'color-pill-progress',
+  APPROVED: 'color-pill-progress',
+  PARTIALLY_APPROVED: 'color-pill-accent',
+  PAID: 'color-pill-success',
+  REJECTED: 'color-pill-danger',
+  CANCELLED: 'color-pill-warning',
+};
+
+const CLAIM_STATUS_LABEL: Record<InsuranceClaimStatus, string> = {
+  DRAFT: 'Draft',
+  SUBMITTED: 'Submitted',
+  UNDER_REVIEW: 'Under review',
+  APPROVED: 'Approved',
+  PARTIALLY_APPROVED: 'Partially approved',
+  PAID: 'Paid',
+  REJECTED: 'Rejected',
+  CANCELLED: 'Cancelled',
+};
+
+/** The human label for a status, used wherever the raw enum would read badly. */
+export const claimStatusLabel = (status: InsuranceClaimStatus): string =>
+  CLAIM_STATUS_LABEL[status];
+
+/**
+ * Filter order, following the claim's normal path first - draft, submitted,
+ * under review, approved, partially approved, paid - with the two dead ends
+ * (rejected, cancelled) after it rather than stranded in the enum's order.
+ */
+const CLAIM_FILTER_ORDER: readonly InsuranceClaimStatus[] = [
+  'DRAFT',
+  'SUBMITTED',
+  'UNDER_REVIEW',
+  'APPROVED',
+  'PARTIALLY_APPROVED',
+  'PAID',
+  'REJECTED',
+  'CANCELLED',
+];
+
+/** Filter pills, with "All" first. */
+export const InsuranceClaimStatusFilters: StatusOption[] = [
+  dropdownStatusFromToken('All', 'all', 'color-pill-neutral'),
+  ...CLAIM_FILTER_ORDER.map((status) =>
+    dropdownStatusFromToken(CLAIM_STATUS_LABEL[status], status, CLAIM_STATUS_TOKEN[status])
+  ),
+];
+
+/**
+ * The badge tokens and label for one status. Returns every field, so the badge
+ * needs no `??` fallbacks: the record is keyed by the union, and an unmapped
+ * status is a type error rather than a runtime branch nothing can reach.
+ */
+export const claimStatusBadge = (
+  status: InsuranceClaimStatus
+): { label: string; bg: string; text: string; border: string } => {
+  const prefix = CLAIM_STATUS_TOKEN[status];
+  return {
+    label: CLAIM_STATUS_LABEL[status],
+    bg: `var(--${prefix}-bg)`,
+    text: `var(--${prefix}-text)`,
+    border: `var(--${prefix}-border)`,
+  };
+};


### PR DESCRIPTION
Wires the `InsuranceClaim` backend that had no client surface — part of the "wire what exists" wave.

## What was unreachable
`create/update/submit/status/cancel`, RBAC-gated at `/v1/pms/organisation/:id/insurance-claims`. A practice could not raise or track a claim.

## What this adds
An **Insurance claims** page as a peer of Estimates and Discounts, reachable from a new "Insurance" pill on the finance header (desktop + phone):
- a list — insurer, policy, claim number, submitted/approved/paid amounts, status pill;
- a detail view with status-aware actions (submit a draft, advance status, cancel);
- a create form.

Built by reusing the **shipped Estimates anatomy 1:1** — `GenericTable`, `StatusPill`, the money/date formatters, the `BILLING` permission stack — so it matches finance exactly.

## Reality over assumptions
- List is a **bare array**; errors are `{ message }` (the shared clinical handler, unlike estimates' `{ error }`).
- `InsuranceClaimStatus`: DRAFT / SUBMITTED / UNDER_REVIEW / APPROVED / PARTIALLY_APPROVED / REJECTED / PAID / CANCELLED, with the service's transition map.
- Money is a **Float in major units** (no minor-unit conversion) — confirmed against `money.ts`, rendered through `formatMoneyPrecise`.
- `/cancel` is broader than the transition map (a REJECTED claim can still be cancelled); the UI mirrors the **endpoint**, so it never hides a valid action.

## Tests
16/16, mutation-checked and guarded against wrapper false-greens: claims + amounts + status pills, the actions each status permits, the create and update-status forms, empty/loading/error. `tsc` 0, lint clean.