### PR TITLE
feat(frontend): add the controlled-substances register

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/controlled-substances/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/controlled-substances/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Controlled drugs — Yosemite Crew' };
+import React from 'react';
+import ProtectedControlledSubstances from '@/app/features/compliance/pages/ControlledSubstances';
+
+function page() {
+  return <ProtectedControlledSubstances />;
+}
+
+export default page;

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceLogs.test.ts
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceLogs.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useControlledSubstanceLogs } from '@/app/features/compliance/hooks/useControlledSubstanceLogs';
+import {
+  fetchControlledSubstanceLogs,
+  getControlledSubstanceErrorMessage,
+} from '@/app/features/compliance/services/controlledSubstanceService';
+import type { ControlledSubstanceLog } from '@/app/features/compliance/types/controlledSubstance';
+
+jest.mock('@/app/features/compliance/services/controlledSubstanceService', () => ({
+  fetchControlledSubstanceLogs: jest.fn(),
+  getControlledSubstanceErrorMessage: jest.fn(() => 'friendly error'),
+}));
+
+const mockFetch = fetchControlledSubstanceLogs as jest.Mock;
+
+const row = (id: string): ControlledSubstanceLog =>
+  ({ id, drug: 'Ketamine', deaSchedule: 'III' }) as ControlledSubstanceLog;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useControlledSubstanceLogs', () => {
+  it('loads the register for an organisation', async () => {
+    mockFetch.mockResolvedValue([row('a')]);
+    const { result } = renderHook(() =>
+      useControlledSubstanceLogs('org-1', { fromDate: 'f', toDate: 't' })
+    );
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.logs).toEqual([row('a')]);
+    expect(result.current.error).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith('org-1', { fromDate: 'f', toDate: 't' });
+  });
+
+  it('surfaces a friendly error when the load fails', async () => {
+    mockFetch.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useControlledSubstanceLogs('org-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('friendly error');
+    expect(getControlledSubstanceErrorMessage).toHaveBeenCalled();
+  });
+
+  it('does nothing without an organisation id', () => {
+    const { result } = renderHook(() => useControlledSubstanceLogs(undefined));
+    expect(result.current.loading).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('refetches when reload is called', async () => {
+    mockFetch.mockResolvedValue([row('a')]);
+    const { result } = renderHook(() => useControlledSubstanceLogs('org-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.reload();
+    });
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('ignores a resolved load after unmount', async () => {
+    let resolveFetch: (rows: ControlledSubstanceLog[]) => void = () => {};
+    mockFetch.mockReturnValue(
+      new Promise<ControlledSubstanceLog[]>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    const { unmount } = renderHook(() => useControlledSubstanceLogs('org-1'));
+    unmount();
+    await act(async () => {
+      resolveFetch([row('a')]);
+    });
+    // No throw: the `active` guard swallowed the late resolution.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a rejected load after unmount', async () => {
+    let rejectFetch: (err: unknown) => void = () => {};
+    mockFetch.mockReturnValue(
+      new Promise<ControlledSubstanceLog[]>((_resolve, reject) => {
+        rejectFetch = reject;
+      })
+    );
+    const { unmount } = renderHook(() => useControlledSubstanceLogs('org-1'));
+    unmount();
+    await act(async () => {
+      rejectFetch(new Error('late'));
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets and refetches when the date range changes', async () => {
+    mockFetch.mockResolvedValue([row('a')]);
+    const { result, rerender } = renderHook(
+      ({ range }) => useControlledSubstanceLogs('org-1', range),
+      { initialProps: { range: { fromDate: 'f1' } as { fromDate?: string } } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ range: { fromDate: 'f2' } });
+    // The render-phase reset flips loading back on for the new query.
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetch).toHaveBeenLastCalledWith('org-1', { fromDate: 'f2', toDate: undefined });
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
@@ -1,0 +1,343 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ControlledSubstanceRegister from '@/app/features/compliance/components/ControlledSubstanceRegister';
+import type { ControlledSubstanceLog } from '@/app/features/compliance/types/controlledSubstance';
+
+const makeEntry = (overrides: Partial<ControlledSubstanceLog>): ControlledSubstanceLog => ({
+  id: 'log-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  loggedAt: '2026-09-03T14:30:00.000Z',
+  drug: 'Ketamine',
+  deaSchedule: 'III',
+  lotNumber: 'LOT-1',
+  strength: 100,
+  unit: 'MG',
+  amountDrawn: 2,
+  amountAdministered: 1.5,
+  amountWasted: 0.5,
+  wastedWitness: 'Dr. Alvarez',
+  balanceBefore: 20,
+  balanceAfter: 18,
+  administeredBy: 'Dr. Reyes',
+  notes: 'Sedation.',
+  createdAt: '2026-09-03T14:31:00.000Z',
+  updatedAt: '2026-09-03T14:31:00.000Z',
+  ...overrides,
+});
+
+const withWitness = makeEntry({
+  id: 'log-1',
+  drug: 'Fentanyl citrate',
+  deaSchedule: 'II',
+  amountWasted: 0.5,
+  wastedWitness: 'Dr. Alvarez',
+});
+
+const missingWitness = makeEntry({
+  id: 'log-2',
+  drug: 'Ketamine',
+  deaSchedule: 'III',
+  amountWasted: 20,
+  wastedWitness: null,
+});
+
+// No strength, no balances, no waste: exercises the em-dash display branches.
+const sparse = makeEntry({
+  id: 'log-3',
+  drug: 'Phenobarbital',
+  deaSchedule: 'V',
+  unit: 'TABLET',
+  strength: null,
+  amountWasted: 0,
+  wastedWitness: null,
+  balanceBefore: null,
+  balanceAfter: null,
+  administeredBy: null,
+  notes: null,
+});
+
+const baseProps = {
+  entries: [] as ControlledSubstanceLog[],
+  loading: false,
+  error: null as string | null,
+  dateRange: {},
+  onDateRangeChange: jest.fn(),
+  canRecord: true,
+  creating: false,
+  createError: null as string | null,
+  onCreate: jest.fn(),
+};
+
+const renderRegister = (overrides: Partial<typeof baseProps> = {}) =>
+  render(<ControlledSubstanceRegister {...baseProps} {...overrides} />);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ControlledSubstanceRegister', () => {
+  it('renders entries with the DEA-schedule pill and exact amounts', () => {
+    renderRegister({ entries: [withWitness, missingWitness, sparse] });
+
+    expect(screen.getByText('Fentanyl citrate')).toBeInTheDocument();
+    // DEA schedule pill (mapped from the raw enum, never the bare "II").
+    expect(screen.getByText('Schedule II')).toBeInTheDocument();
+    expect(screen.getByText('Schedule III')).toBeInTheDocument();
+    expect(screen.getByText('Schedule V')).toBeInTheDocument();
+    // Exact amount preserved to the decimal.
+    expect(screen.getByText('0.5')).toBeInTheDocument();
+    // Sparse row: no strength/balance/administered-by renders as em dashes,
+    // and the balance-before -> balance-after arrow shows for a row that has them.
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('→').length).toBe(2);
+  });
+
+  it('emphasises waste and shows the witness, flagging a missing one', () => {
+    renderRegister({ entries: [withWitness, missingWitness] });
+
+    // Waste with a witness recorded shows the witness name.
+    expect(screen.getByText(/Witness:\s*Dr\. Alvarez/)).toBeInTheDocument();
+    // Waste with no witness is flagged as a compliance gap.
+    expect(screen.getByText('Witness missing')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no entries', () => {
+    renderRegister({ entries: [] });
+    expect(screen.getByText('No controlled substance entries yet.')).toBeInTheDocument();
+  });
+
+  it('renders the loading state', () => {
+    renderRegister({ entries: [], loading: true });
+    expect(screen.getByTestId('cs-register-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    renderRegister({ entries: [], error: 'Boom' });
+    expect(screen.getByRole('alert')).toHaveTextContent('Boom');
+  });
+
+  it('hides the add action when the viewer cannot record', () => {
+    renderRegister({ canRecord: false });
+    expect(
+      screen.queryByRole('button', { name: 'Add a controlled substance entry' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('filters the table by drug name', async () => {
+    const user = userEvent.setup();
+    renderRegister({ entries: [withWitness, missingWitness] });
+
+    await user.type(screen.getByLabelText('Drug'), 'fentanyl');
+
+    expect(screen.getByText('Fentanyl citrate')).toBeInTheDocument();
+    expect(screen.queryByText('Ketamine')).not.toBeInTheDocument();
+  });
+
+  it('opens the add form and submits a fully populated entry', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Midazolam');
+    await user.selectOptions(within(form).getByLabelText('DEA schedule'), 'IV');
+    await user.selectOptions(within(form).getByLabelText('Unit'), 'ML');
+    await user.type(within(form).getByLabelText('Strength (optional)'), '5');
+    await user.type(within(form).getByLabelText('Lot number (optional)'), 'LOT-9');
+    await user.type(within(form).getByLabelText('Amount drawn'), '5');
+    await user.type(within(form).getByLabelText('Amount administered'), '3');
+    await user.type(within(form).getByLabelText('Amount wasted'), '2');
+    await user.type(within(form).getByLabelText('Waste witness'), 'Dr. Alvarez');
+    await user.type(within(form).getByLabelText('Balance before (optional)'), '50');
+    await user.type(within(form).getByLabelText('Balance after (optional)'), '45');
+    await user.type(within(form).getByLabelText('Notes (optional)'), 'Post-op sedation.');
+
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        drug: 'Midazolam',
+        deaSchedule: 'IV',
+        unit: 'ML',
+        strength: 5,
+        lotNumber: 'LOT-9',
+        amountDrawn: 5,
+        amountAdministered: 3,
+        amountWasted: 2,
+        wastedWitness: 'Dr. Alvarez',
+        balanceBefore: 50,
+        balanceAfter: 45,
+        notes: 'Post-op sedation.',
+      })
+    );
+    expect(onCreate.mock.calls[0][0].loggedAt).toEqual(expect.any(String));
+  });
+
+  it('defaults optional fields and omits them when left blank', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Morphine');
+    await user.type(within(form).getByLabelText('Amount drawn'), '10');
+    await user.type(within(form).getByLabelText('Amount administered'), '10');
+
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    const payload = onCreate.mock.calls[0][0];
+    expect(payload).toMatchObject({ drug: 'Morphine', amountWasted: 0 });
+    expect(payload.strength).toBeUndefined();
+    expect(payload.lotNumber).toBeUndefined();
+    expect(payload.wastedWitness).toBeUndefined();
+    expect(payload.notes).toBeUndefined();
+  });
+
+  it('rejects a blank drug name and a non-positive amount drawn', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+    const save = screen.getByRole('button', { name: 'Save this controlled substance entry' });
+
+    await user.click(save);
+    expect(within(form).getByRole('alert')).toHaveTextContent('Enter the drug name.');
+    expect(onCreate).not.toHaveBeenCalled();
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Ketamine');
+    await user.click(save);
+    expect(within(form).getByRole('alert')).toHaveTextContent(
+      'Amount drawn must be greater than zero.'
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires an administered amount', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Ketamine');
+    await user.type(within(form).getByLabelText('Amount drawn'), '5');
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(within(form).getByRole('alert')).toHaveTextContent('Enter the amount administered.');
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a create error from the parent', async () => {
+    const user = userEvent.setup();
+    renderRegister({ createError: 'Server said no.' });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    expect(screen.getByRole('alert')).toHaveTextContent('Server said no.');
+  });
+
+  it('closes the form after a create settles successfully', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderRegister({ creating: false });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    expect(
+      screen.getByRole('form', { name: 'Add controlled substance entry' })
+    ).toBeInTheDocument();
+
+    // Parent flips creating on, then off with no error: the form should close.
+    rerender(<ControlledSubstanceRegister {...baseProps} creating={true} />);
+    rerender(<ControlledSubstanceRegister {...baseProps} creating={false} />);
+
+    expect(
+      screen.queryByRole('form', { name: 'Add controlled substance entry' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('blocks a waste entry that has no witness', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Ketamine');
+    await user.type(within(form).getByLabelText('Amount drawn'), '2');
+    await user.type(within(form).getByLabelText('Amount administered'), '1');
+    await user.type(within(form).getByLabelText('Amount wasted'), '1');
+
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(within(form).getByRole('alert')).toHaveTextContent(
+      'A witness is required whenever any amount is wasted.'
+    );
+  });
+
+  it('blocks an entry whose administered plus wasted exceeds the amount drawn', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Ketamine');
+    await user.type(within(form).getByLabelText('Amount drawn'), '1');
+    await user.type(within(form).getByLabelText('Amount administered'), '1');
+    await user.type(within(form).getByLabelText('Amount wasted'), '1');
+    await user.type(within(form).getByLabelText('Waste witness'), 'Dr. Alvarez');
+
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(within(form).getByRole('alert')).toHaveTextContent(
+      'Administered plus wasted cannot exceed the amount drawn.'
+    );
+  });
+
+  it('converts date filters into ISO bounds', () => {
+    const onDateRangeChange = jest.fn();
+    renderRegister({ onDateRangeChange });
+
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2026-09-01' } });
+    expect(onDateRangeChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fromDate: '2026-09-01T00:00:00.000Z' })
+    );
+
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: '2026-09-30' } });
+    expect(onDateRangeChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ toDate: '2026-09-30T23:59:59.999Z' })
+    );
+  });
+
+  it('shows an active date range and clears a bound', () => {
+    const onDateRangeChange = jest.fn();
+    renderRegister({
+      dateRange: { fromDate: '2026-09-01T00:00:00.000Z', toDate: '2026-09-30T23:59:59.999Z' },
+      onDateRangeChange,
+    });
+
+    // The ISO bounds display back as the date input's yyyy-mm-dd value.
+    expect(screen.getByLabelText<HTMLInputElement>('From').value).toBe('2026-09-01');
+    expect(screen.getByLabelText<HTMLInputElement>('To').value).toBe('2026-09-30');
+
+    // Clearing the input drops that bound to undefined.
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '' } });
+    expect(onDateRangeChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fromDate: undefined })
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ControlledSubstanceRegister from '@/app/features/compliance/components/ControlledSubstanceRegister';
@@ -247,22 +247,54 @@ describe('ControlledSubstanceRegister', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Server said no.');
   });
 
-  it('closes the form after a create settles successfully', async () => {
+  it('closes the form when the save resolves true', async () => {
     const user = userEvent.setup();
-    const { rerender } = renderRegister({ creating: false });
+    const onCreate = jest.fn().mockResolvedValue(true);
+    renderRegister({ onCreate });
 
     await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Midazolam');
+    await user.type(within(form).getByLabelText('Amount drawn'), '5');
+    await user.type(within(form).getByLabelText('Amount administered'), '5');
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('form', { name: 'Add controlled substance entry' })
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  it('shows a disabled saving state on the submit button while creating', async () => {
+    const user = userEvent.setup();
+    renderRegister({ creating: true });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const save = screen.getByRole('button', { name: 'Save this controlled substance entry' });
+    expect(save).toHaveTextContent('Saving');
+    expect(save).toBeDisabled();
+  });
+
+  it('keeps the form open when the save resolves false', async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn().mockResolvedValue(false);
+    renderRegister({ onCreate });
+
+    await user.click(screen.getByRole('button', { name: 'Add a controlled substance entry' }));
+    const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
+
+    await user.type(within(form).getByLabelText('Drug name'), 'Midazolam');
+    await user.type(within(form).getByLabelText('Amount drawn'), '5');
+    await user.type(within(form).getByLabelText('Amount administered'), '5');
+    await user.click(screen.getByRole('button', { name: 'Save this controlled substance entry' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
     expect(
       screen.getByRole('form', { name: 'Add controlled substance entry' })
     ).toBeInTheDocument();
-
-    // Parent flips creating on, then off with no error: the form should close.
-    rerender(<ControlledSubstanceRegister {...baseProps} creating={true} />);
-    rerender(<ControlledSubstanceRegister {...baseProps} creating={false} />);
-
-    expect(
-      screen.queryByRole('form', { name: 'Add controlled substance entry' })
-    ).not.toBeInTheDocument();
   });
 
   it('blocks a waste entry that has no witness', async () => {

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceService.test.ts
@@ -1,0 +1,160 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+import {
+  createControlledSubstanceLog,
+  fetchControlledSubstanceLogs,
+  getControlledSubstanceErrorMessage,
+} from '@/app/features/compliance/services/controlledSubstanceService';
+import {
+  formatAmount,
+  type ControlledSubstanceLog,
+  type CreateControlledSubstanceLogInput,
+} from '@/app/features/compliance/types/controlledSubstance';
+
+jest.mock('axios', () => ({ isAxiosError: jest.fn() }));
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+}));
+
+const mockGetData = getData as jest.Mock;
+const mockPostData = postData as jest.Mock;
+const mockIsAxiosError = axios.isAxiosError as unknown as jest.Mock;
+
+const ORG = 'org-1';
+
+const record: ControlledSubstanceLog = {
+  id: 'log-1',
+  organisationId: ORG,
+  patientId: null,
+  encounterId: null,
+  loggedAt: '2026-09-03T14:30:00.000Z',
+  drug: 'Ketamine',
+  deaSchedule: 'III',
+  lotNumber: null,
+  strength: null,
+  unit: 'MG',
+  amountDrawn: 2,
+  amountAdministered: 1.5,
+  amountWasted: 0.5,
+  wastedWitness: 'Dr. Alvarez',
+  balanceBefore: null,
+  balanceAfter: null,
+  administeredBy: 'Dr. Reyes',
+  notes: null,
+  createdAt: '2026-09-03T14:31:00.000Z',
+  updatedAt: '2026-09-03T14:31:00.000Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsAxiosError.mockReturnValue(false);
+});
+
+describe('fetchControlledSubstanceLogs', () => {
+  it('requests the org path and returns the array', async () => {
+    mockGetData.mockResolvedValue({ data: [record] });
+    const result = await fetchControlledSubstanceLogs(ORG);
+    expect(mockGetData).toHaveBeenCalledWith(
+      '/v1/pms/organisation/org-1/controlled-substance-logs',
+      {}
+    );
+    expect(result).toEqual([record]);
+  });
+
+  it('passes only the filters that are set', async () => {
+    mockGetData.mockResolvedValue({ data: [] });
+    await fetchControlledSubstanceLogs(ORG, {
+      drug: 'keta',
+      deaSchedule: 'II',
+      fromDate: '2026-09-01T00:00:00.000Z',
+      toDate: '2026-09-30T23:59:59.999Z',
+      patientId: 'pat-1',
+    });
+    expect(mockGetData).toHaveBeenCalledWith(
+      '/v1/pms/organisation/org-1/controlled-substance-logs',
+      {
+        drug: 'keta',
+        deaSchedule: 'II',
+        fromDate: '2026-09-01T00:00:00.000Z',
+        toDate: '2026-09-30T23:59:59.999Z',
+        patientId: 'pat-1',
+      }
+    );
+  });
+
+  it('guards a non-array response', async () => {
+    mockGetData.mockResolvedValue({ data: { message: 'nope' } });
+    expect(await fetchControlledSubstanceLogs(ORG)).toEqual([]);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(fetchControlledSubstanceLogs('')).rejects.toThrow('Organisation ID missing');
+    expect(mockGetData).not.toHaveBeenCalled();
+  });
+});
+
+describe('createControlledSubstanceLog', () => {
+  const payload: CreateControlledSubstanceLogInput = {
+    loggedAt: '2026-09-03T14:30:00.000Z',
+    drug: 'Ketamine',
+    deaSchedule: 'III',
+    unit: 'MG',
+    amountDrawn: 2,
+    amountAdministered: 1.5,
+    amountWasted: 0.5,
+    wastedWitness: 'Dr. Alvarez',
+  };
+
+  it('posts to the org path and returns the record', async () => {
+    mockPostData.mockResolvedValue({ data: record });
+    const result = await createControlledSubstanceLog(ORG, payload);
+    expect(mockPostData).toHaveBeenCalledWith(
+      '/v1/pms/organisation/org-1/controlled-substance-logs',
+      payload
+    );
+    expect(result).toBe(record);
+  });
+
+  it('throws when the organisation id is missing', async () => {
+    await expect(createControlledSubstanceLog('', payload)).rejects.toThrow(
+      'Organisation ID missing'
+    );
+    expect(mockPostData).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatAmount', () => {
+  it('renders an exact decimal without rounding it away', () => {
+    expect(formatAmount(0.05)).toBe('0.05');
+    expect(formatAmount(0)).toBe('0');
+    expect(formatAmount(-2)).toBe('-2');
+  });
+
+  it('renders an em dash for missing or non-numeric values', () => {
+    expect(formatAmount(null)).toBe('—');
+    expect(formatAmount(undefined)).toBe('—');
+    expect(formatAmount(Number.NaN)).toBe('—');
+  });
+});
+
+describe('getControlledSubstanceErrorMessage', () => {
+  it('reads the message from an axios error body', () => {
+    mockIsAxiosError.mockReturnValue(true);
+    const err = { response: { data: { message: 'Amount wasted cannot be negative.' } } };
+    expect(getControlledSubstanceErrorMessage(err, 'fallback')).toBe(
+      'Amount wasted cannot be negative.'
+    );
+  });
+
+  it('falls back to the Error message for a non-axios error', () => {
+    expect(getControlledSubstanceErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+  });
+
+  it('uses the fallback when there is nothing usable', () => {
+    mockIsAxiosError.mockReturnValue(true);
+    expect(getControlledSubstanceErrorMessage({ response: { data: {} } }, 'fallback')).toBe(
+      'fallback'
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceService.test.ts
@@ -88,10 +88,15 @@ describe('fetchControlledSubstanceLogs', () => {
     expect(await fetchControlledSubstanceLogs(ORG)).toEqual([]);
   });
 
-  it('throws when the organisation id is missing', async () => {
-    await expect(fetchControlledSubstanceLogs('')).rejects.toThrow('Organisation ID missing');
-    expect(mockGetData).not.toHaveBeenCalled();
-  });
+  it.each(['', '../admin', 'org/other', 'https://attacker.test'])(
+    'rejects an unsafe organisation id (%s)',
+    async (organisationId) => {
+      await expect(fetchControlledSubstanceLogs(organisationId)).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(mockGetData).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe('createControlledSubstanceLog', () => {
@@ -116,12 +121,15 @@ describe('createControlledSubstanceLog', () => {
     expect(result).toBe(record);
   });
 
-  it('throws when the organisation id is missing', async () => {
-    await expect(createControlledSubstanceLog('', payload)).rejects.toThrow(
-      'Organisation ID missing'
-    );
-    expect(mockPostData).not.toHaveBeenCalled();
-  });
+  it.each(['', '../admin', 'org/other', 'https://attacker.test'])(
+    'rejects an unsafe organisation id (%s)',
+    async (organisationId) => {
+      await expect(createControlledSubstanceLog(organisationId, payload)).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(mockPostData).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe('formatAmount', () => {

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstancesPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstancesPage.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ProtectedControlledSubstances from '@/app/features/compliance/pages/ControlledSubstances';
+import { useControlledSubstanceLogs } from '@/app/features/compliance/hooks/useControlledSubstanceLogs';
+import {
+  createControlledSubstanceLog,
+  getControlledSubstanceErrorMessage,
+} from '@/app/features/compliance/services/controlledSubstanceService';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { useNotify } from '@/app/hooks/useNotify';
+
+jest.mock('@/app/ui/layout/guards/ProtectedRoute', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('@/app/ui/layout/guards/OrgGuard', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  __esModule: true,
+  PermissionGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('@/app/ui/layout/PageSkeleton', () => ({
+  __esModule: true,
+  default: () => <div>skeleton</div>,
+}));
+
+jest.mock('@/app/features/compliance/hooks/useControlledSubstanceLogs', () => ({
+  useControlledSubstanceLogs: jest.fn(),
+}));
+jest.mock('@/app/features/compliance/services/controlledSubstanceService', () => ({
+  createControlledSubstanceLog: jest.fn(),
+  getControlledSubstanceErrorMessage: jest.fn(() => 'friendly error'),
+}));
+jest.mock('@/app/stores/orgStore', () => ({ useOrgStore: jest.fn() }));
+jest.mock('@/app/hooks/usePermissions', () => ({ usePermissions: jest.fn() }));
+jest.mock('@/app/hooks/useNotify', () => ({ useNotify: jest.fn() }));
+
+// Stand-in for the presentational register: surfaces the wired props and
+// fires onCreate on demand so the container's handleCreate is exercised.
+const SAMPLE_INPUT = {
+  loggedAt: '2026-09-03T14:30:00.000Z',
+  drug: 'Ketamine',
+  deaSchedule: 'III' as const,
+  unit: 'MG' as const,
+  amountDrawn: 2,
+  amountAdministered: 2,
+};
+jest.mock('@/app/features/compliance/components/ControlledSubstanceRegister', () => ({
+  __esModule: true,
+  default: (props: {
+    canRecord: boolean;
+    creating: boolean;
+    createError: string | null;
+    onCreate: (input: typeof SAMPLE_INPUT) => void;
+    entries: Array<{ id: string }>;
+  }) => (
+    <div>
+      <span data-testid="entry-count">{props.entries.length}</span>
+      <span data-testid="can-record">{String(props.canRecord)}</span>
+      <span data-testid="create-error">{props.createError ?? ''}</span>
+      <button type="button" onClick={() => props.onCreate(SAMPLE_INPUT)}>
+        fire-create
+      </button>
+    </div>
+  ),
+}));
+
+const mockUseLogs = useControlledSubstanceLogs as jest.Mock;
+const mockCreate = createControlledSubstanceLog as jest.Mock;
+const mockNotify = jest.fn();
+const reload = jest.fn();
+const can = jest.fn(() => true);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useOrgStore as unknown as jest.Mock).mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({ primaryOrgId: 'org-1' })
+  );
+  (usePermissions as jest.Mock).mockReturnValue({ can });
+  (useNotify as jest.Mock).mockReturnValue({ notify: mockNotify });
+  mockUseLogs.mockReturnValue({
+    logs: [{ id: 'log-1' }],
+    loading: false,
+    error: null,
+    reload,
+  });
+});
+
+describe('ProtectedControlledSubstances', () => {
+  it('wires the register with the primary org logs and record permission', () => {
+    render(<ProtectedControlledSubstances />);
+    expect(screen.getByTestId('entry-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('can-record')).toHaveTextContent('true');
+    expect(mockUseLogs).toHaveBeenCalledWith('org-1', {});
+  });
+
+  it('logs an entry, notifies success and reloads', async () => {
+    mockCreate.mockResolvedValue({ id: 'log-2' });
+    const user = userEvent.setup();
+    render(<ProtectedControlledSubstances />);
+
+    await user.click(screen.getByRole('button', { name: 'fire-create' }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('org-1', SAMPLE_INPUT));
+    expect(mockNotify).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Entry logged' })
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a create error without reloading', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup();
+    render(<ProtectedControlledSubstances />);
+
+    await user.click(screen.getByRole('button', { name: 'fire-create' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('create-error')).toHaveTextContent('friendly error')
+    );
+    expect(getControlledSubstanceErrorMessage).toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not call the API when there is no primary org', async () => {
+    (useOrgStore as unknown as jest.Mock).mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({ primaryOrgId: null })
+    );
+    const user = userEvent.setup();
+    render(<ProtectedControlledSubstances />);
+
+    await user.click(screen.getByRole('button', { name: 'fire-create' }));
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/constants/routes.ts
+++ b/apps/frontend/src/app/constants/routes.ts
@@ -56,7 +56,7 @@ export const appRoutes: RouteItem[] = [
     name: 'Controlled drugs',
     href: '/controlled-substances',
     verify: true,
-    requiredAnyPermissions: [PERMISSIONS.APPOINTMENTS_VIEW_ANY],
+    requiredAnyPermissions: [PERMISSIONS.PRESCRIPTION_VIEW_ANY, PERMISSIONS.PRESCRIPTION_VIEW_OWN],
   },
   {
     name: 'Integrations',

--- a/apps/frontend/src/app/constants/routes.ts
+++ b/apps/frontend/src/app/constants/routes.ts
@@ -53,6 +53,12 @@ export const appRoutes: RouteItem[] = [
     requiredAnyPermissions: [PERMISSIONS.INVENTORY_VIEW_ANY],
   },
   {
+    name: 'Controlled drugs',
+    href: '/controlled-substances',
+    verify: true,
+    requiredAnyPermissions: [PERMISSIONS.APPOINTMENTS_VIEW_ANY],
+  },
+  {
     name: 'Integrations',
     href: '/integrations',
     verify: true,

--- a/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.stories.tsx
+++ b/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import ControlledSubstanceRegister from './ControlledSubstanceRegister';
+import type { ControlledSubstanceLog } from '@/app/features/compliance/types/controlledSubstance';
+
+const entry = (overrides: Partial<ControlledSubstanceLog>): ControlledSubstanceLog => ({
+  id: 'log-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  encounterId: null,
+  loggedAt: '2026-09-03T14:30:00.000Z',
+  drug: 'Ketamine',
+  deaSchedule: 'III',
+  lotNumber: 'LOT-4471',
+  strength: 100,
+  unit: 'MG',
+  amountDrawn: 2,
+  amountAdministered: 1.5,
+  amountWasted: 0.5,
+  wastedWitness: 'Dr. Alvarez',
+  balanceBefore: 20,
+  balanceAfter: 18,
+  administeredBy: 'Dr. Reyes',
+  notes: 'Sedation for laceration repair.',
+  createdAt: '2026-09-03T14:31:00.000Z',
+  updatedAt: '2026-09-03T14:31:00.000Z',
+  ...overrides,
+});
+
+const SAMPLE: ControlledSubstanceLog[] = [
+  entry({
+    id: 'log-1',
+    drug: 'Fentanyl citrate',
+    deaSchedule: 'II',
+    unit: 'ML',
+    strength: 0.05,
+    amountDrawn: 2,
+    amountAdministered: 1.5,
+    amountWasted: 0.5,
+    wastedWitness: 'Dr. Alvarez',
+    balanceBefore: 10,
+    balanceAfter: 8,
+  }),
+  entry({
+    id: 'log-2',
+    drug: 'Ketamine',
+    deaSchedule: 'III',
+    unit: 'MG',
+    amountDrawn: 100,
+    amountAdministered: 80,
+    amountWasted: 20,
+    // Compliance red flag: waste with no witness recorded.
+    wastedWitness: null,
+    balanceBefore: 500,
+    balanceAfter: 400,
+    administeredBy: 'Dr. Reyes',
+    notes: 'Induction.',
+  }),
+  entry({
+    id: 'log-3',
+    drug: 'Diazepam',
+    deaSchedule: 'IV',
+    unit: 'ML',
+    strength: 5,
+    amountDrawn: 1,
+    amountAdministered: 1,
+    amountWasted: 0,
+    wastedWitness: null,
+    balanceBefore: 12,
+    balanceAfter: 11,
+    notes: null,
+  }),
+  entry({
+    id: 'log-4',
+    drug: 'Phenobarbital',
+    deaSchedule: 'V',
+    unit: 'TABLET',
+    strength: null,
+    amountDrawn: 3,
+    amountAdministered: 3,
+    amountWasted: 0,
+    wastedWitness: null,
+    balanceBefore: null,
+    balanceAfter: null,
+    administeredBy: null,
+  }),
+];
+
+const meta: Meta<typeof ControlledSubstanceRegister> = {
+  title: 'Features/Compliance/ControlledSubstanceRegister',
+  component: ControlledSubstanceRegister,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    dateRange: {},
+    onDateRangeChange: fn(),
+    canRecord: true,
+    creating: false,
+    createError: null,
+    onCreate: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '80vh', padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ControlledSubstanceRegister>;
+
+export const Populated: Story = {
+  args: { entries: SAMPLE, loading: false, error: null },
+};
+
+export const ReadOnly: Story = {
+  args: { entries: SAMPLE, loading: false, error: null, canRecord: false },
+};
+
+export const Empty: Story = {
+  args: { entries: [], loading: false, error: null },
+};
+
+export const Loading: Story = {
+  args: { entries: [], loading: true, error: null },
+};
+
+export const ErrorState: Story = {
+  args: {
+    entries: [],
+    loading: false,
+    error: 'Unable to load the controlled substance register.',
+  },
+};

--- a/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
+++ b/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { IoAddOutline, IoSearchOutline, IoWarningOutline } from 'react-icons/io5';
 import clsx from 'clsx';
 
@@ -32,7 +32,8 @@ type ControlledSubstanceRegisterProps = {
   canRecord: boolean;
   creating: boolean;
   createError: string | null;
-  onCreate: (input: CreateControlledSubstanceLogInput) => void;
+  /** Resolves `true` when the entry was saved, so the form can close itself. */
+  onCreate: (input: CreateControlledSubstanceLogInput) => Promise<boolean>;
 };
 
 const fieldClass =
@@ -205,13 +206,12 @@ const ControlledSubstanceRegister = ({
   const [drugQuery, setDrugQuery] = useState('');
   const [addOpen, setAddOpen] = useState(false);
 
-  // Close the form once a create settles successfully (creating true -> false
-  // with no error). A failed create keeps it open so the error stays visible.
-  const wasCreating = useRef(false);
-  useEffect(() => {
-    if (wasCreating.current && !creating && !createError) setAddOpen(false);
-    wasCreating.current = creating;
-  }, [creating, createError]);
+  // Close the form only when the save actually succeeds. Driven by the create
+  // promise resolving inside the submit path, not a useEffect watching a prop,
+  // so a failed save keeps the form (and its values) on screen.
+  const handleFormSubmit = async (input: CreateControlledSubstanceLogInput) => {
+    if (await onCreate(input)) setAddOpen(false);
+  };
 
   const columns = useMemo(() => buildColumns(), []);
 
@@ -300,7 +300,7 @@ const ControlledSubstanceRegister = ({
         <AddEntryForm
           creating={creating}
           createError={createError}
-          onSubmit={onCreate}
+          onSubmit={handleFormSubmit}
           onCancel={() => setAddOpen(false)}
         />
       )}
@@ -480,7 +480,6 @@ const AddEntryForm = ({ creating, createError, onSubmit, onCancel }: AddEntryFor
             value={drug}
             onChange={(event) => setDrug(event.target.value)}
             className={inputClass}
-            placeholder="e.g. Ketamine"
           />
         </Field>
 
@@ -579,7 +578,6 @@ const AddEntryForm = ({ creating, createError, onSubmit, onCancel }: AddEntryFor
             value={wastedWitness}
             onChange={(event) => setWastedWitness(event.target.value)}
             className={inputClass}
-            placeholder="Required when any amount is wasted"
           />
         </Field>
 

--- a/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
+++ b/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
@@ -1,0 +1,667 @@
+'use client';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { IoAddOutline, IoSearchOutline, IoWarningOutline } from 'react-icons/io5';
+import clsx from 'clsx';
+
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
+import { formatDateTimeLocal } from '@/app/lib/date';
+import {
+  DEA_SCHEDULES,
+  DEA_SCHEDULE_LABEL,
+  DEA_SCHEDULE_TONE,
+  DRUG_UNITS,
+  DRUG_UNIT_LABEL,
+  formatAmount,
+  type ControlledSubstanceLog,
+  type CreateControlledSubstanceLogInput,
+  type DeaSchedule,
+  type DrugUnit,
+} from '@/app/features/compliance/types/controlledSubstance';
+
+export type ControlledSubstanceDateRange = { fromDate?: string; toDate?: string };
+
+type ControlledSubstanceRegisterProps = {
+  entries: ControlledSubstanceLog[];
+  loading: boolean;
+  error: string | null;
+  dateRange: ControlledSubstanceDateRange;
+  onDateRangeChange: (range: ControlledSubstanceDateRange) => void;
+  /** Whether the viewer may append entries (prescription:edit permission). */
+  canRecord: boolean;
+  creating: boolean;
+  createError: string | null;
+  onCreate: (input: CreateControlledSubstanceLogInput) => void;
+};
+
+const fieldClass =
+  'flex items-stretch overflow-hidden rounded-2xl border border-input-border-default focus-within:border-input-border-active';
+const inputClass =
+  'min-w-0 flex-1 bg-transparent px-3 py-2 text-body-4 text-text-primary outline-none';
+const labelClass = 'text-caption-2 font-bold text-text-tertiary';
+
+/** yyyy-mm-dd (from a date input) to the ISO datetime the API's date bounds want. */
+const toIsoBound = (date: string, endOfDay: boolean): string | undefined => {
+  if (!date) return undefined;
+  const time = endOfDay ? '23:59:59.999' : '00:00:00.000';
+  return `${date}T${time}Z`;
+};
+
+/** A date input value (yyyy-mm-dd) back out of an ISO bound, for controlled inputs. */
+const fromIsoBound = (iso?: string): string => (iso ? iso.slice(0, 10) : '');
+
+/** The witness line under a waste amount: the name, or a compliance-gap flag. */
+const WitnessLine = ({ entry }: { entry: ControlledSubstanceLog }) => {
+  if (entry.amountWasted <= 0) return null;
+  if (!entry.wastedWitness?.trim()) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-caption-2 font-semibold"
+        style={{ color: 'var(--danger-text)' }}
+      >
+        <IoWarningOutline size={12} aria-hidden="true" />
+        Witness missing
+      </span>
+    );
+  }
+  return (
+    <span className="text-caption-2 text-text-tertiary" title={entry.wastedWitness}>
+      Witness: {entry.wastedWitness}
+    </span>
+  );
+};
+
+/** The `wasted` cell: emphasised amount plus its witness, the compliance line. */
+const WastedCell = ({ entry }: { entry: ControlledSubstanceLog }) => {
+  const hasWaste = entry.amountWasted > 0;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span
+        className={clsx('tabular-nums', hasWaste ? 'font-bold' : 'text-text-secondary')}
+        style={hasWaste ? { color: 'var(--danger-text)' } : undefined}
+      >
+        {formatAmount(entry.amountWasted)}
+      </span>
+      <WitnessLine entry={entry} />
+    </div>
+  );
+};
+
+const BalanceCell = ({ entry }: { entry: ControlledSubstanceLog }) => {
+  if (entry.balanceBefore === null && entry.balanceAfter === null) {
+    return <span className="text-text-tertiary">—</span>;
+  }
+  return (
+    <span className="whitespace-nowrap tabular-nums text-text-secondary">
+      {formatAmount(entry.balanceBefore)}
+      <span className="px-1 text-text-tertiary" aria-hidden="true">
+        →
+      </span>
+      {formatAmount(entry.balanceAfter)}
+    </span>
+  );
+};
+
+const StrengthUnitCell = ({ entry }: { entry: ControlledSubstanceLog }) => (
+  <span className="whitespace-nowrap text-text-secondary">
+    {entry.strength !== null && (
+      <span className="tabular-nums text-text-primary">{formatAmount(entry.strength)} </span>
+    )}
+    {DRUG_UNIT_LABEL[entry.unit]}
+  </span>
+);
+
+const buildColumns = (): Column<ControlledSubstanceLog>[] => [
+  {
+    key: 'loggedAt',
+    label: 'Logged at',
+    render: (entry) => (
+      <span className="whitespace-nowrap text-text-secondary">
+        {formatDateTimeLocal(entry.loggedAt)}
+      </span>
+    ),
+  },
+  {
+    key: 'drug',
+    label: 'Drug',
+    render: (entry) => (
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate font-semibold text-text-primary" title={entry.drug}>
+          {entry.drug}
+        </span>
+        <StatusPill
+          label={DEA_SCHEDULE_LABEL[entry.deaSchedule]}
+          tone={DEA_SCHEDULE_TONE[entry.deaSchedule]}
+        />
+      </div>
+    ),
+  },
+  {
+    key: 'strength',
+    label: 'Strength / unit',
+    render: (entry) => <StrengthUnitCell entry={entry} />,
+  },
+  {
+    key: 'amountDrawn',
+    label: 'Drawn',
+    render: (entry) => (
+      <span className="tabular-nums text-text-primary">{formatAmount(entry.amountDrawn)}</span>
+    ),
+  },
+  {
+    key: 'amountAdministered',
+    label: 'Administered',
+    render: (entry) => (
+      <span className="tabular-nums text-text-primary">
+        {formatAmount(entry.amountAdministered)}
+      </span>
+    ),
+  },
+  {
+    key: 'amountWasted',
+    label: 'Wasted',
+    render: (entry) => <WastedCell entry={entry} />,
+  },
+  {
+    key: 'balanceAfter',
+    label: 'Balance',
+    render: (entry) => <BalanceCell entry={entry} />,
+  },
+  {
+    key: 'administeredBy',
+    label: 'By',
+    render: (entry) => (
+      <span className="truncate text-text-secondary" title={entry.administeredBy ?? undefined}>
+        {entry.administeredBy?.trim() ? entry.administeredBy : '—'}
+      </span>
+    ),
+  },
+  {
+    key: 'notes',
+    label: 'Notes',
+    render: (entry) =>
+      entry.notes?.trim() ? (
+        <span className="line-clamp-2 max-w-[16rem] text-text-secondary" title={entry.notes}>
+          {entry.notes}
+        </span>
+      ) : (
+        <span className="text-text-tertiary">—</span>
+      ),
+  },
+];
+
+const ControlledSubstanceRegister = ({
+  entries,
+  loading,
+  error,
+  dateRange,
+  onDateRangeChange,
+  canRecord,
+  creating,
+  createError,
+  onCreate,
+}: ControlledSubstanceRegisterProps) => {
+  const [drugQuery, setDrugQuery] = useState('');
+  const [addOpen, setAddOpen] = useState(false);
+
+  // Close the form once a create settles successfully (creating true -> false
+  // with no error). A failed create keeps it open so the error stays visible.
+  const wasCreating = useRef(false);
+  useEffect(() => {
+    if (wasCreating.current && !creating && !createError) setAddOpen(false);
+    wasCreating.current = creating;
+  }, [creating, createError]);
+
+  const columns = useMemo(() => buildColumns(), []);
+
+  const filteredEntries = useMemo(() => {
+    const query = drugQuery.trim().toLowerCase();
+    if (!query) return entries;
+    return entries.filter((entry) => entry.drug.toLowerCase().includes(query));
+  }, [entries, drugQuery]);
+
+  const setBound = (key: 'fromDate' | 'toDate', value: string) => {
+    onDateRangeChange({
+      ...dateRange,
+      [key]: toIsoBound(value, key === 'toDate'),
+    });
+  };
+
+  return (
+    <div className="relative flex h-full min-h-0 w-full flex-col gap-4 yc-page-content">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-heading-4 text-text-primary">Controlled substances register</h1>
+          <p className="max-w-2xl text-body-4 text-text-secondary">
+            A running DEA compliance log of every controlled-drug draw, administration and waste.
+          </p>
+        </div>
+        {canRecord && (
+          <Primary
+            text="Add entry"
+            icon={<IoAddOutline size={16} aria-hidden="true" />}
+            onClick={() => setAddOpen((open) => !open)}
+            ariaLabel="Add a controlled substance entry"
+          />
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex min-w-56 flex-1 flex-col gap-1">
+          <label htmlFor="cs-drug-filter" className={labelClass}>
+            Drug
+          </label>
+          <span className={fieldClass}>
+            <span className="flex items-center pl-3 text-text-tertiary" aria-hidden="true">
+              <IoSearchOutline size={16} />
+            </span>
+            <input
+              id="cs-drug-filter"
+              type="search"
+              value={drugQuery}
+              onChange={(event) => setDrugQuery(event.target.value)}
+              placeholder="Filter by drug"
+              className={inputClass}
+            />
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="cs-from-date" className={labelClass}>
+            From
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="cs-from-date"
+              type="date"
+              value={fromIsoBound(dateRange.fromDate)}
+              onChange={(event) => setBound('fromDate', event.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="cs-to-date" className={labelClass}>
+            To
+          </label>
+          <span className={fieldClass}>
+            <input
+              id="cs-to-date"
+              type="date"
+              value={fromIsoBound(dateRange.toDate)}
+              onChange={(event) => setBound('toDate', event.target.value)}
+              className={inputClass}
+            />
+          </span>
+        </div>
+      </div>
+
+      {addOpen && canRecord && (
+        <AddEntryForm
+          creating={creating}
+          createError={createError}
+          onSubmit={onCreate}
+          onCancel={() => setAddOpen(false)}
+        />
+      )}
+
+      <div className="min-h-0 flex-1">
+        <RegisterBody loading={loading} error={error} entries={filteredEntries} columns={columns} />
+      </div>
+    </div>
+  );
+};
+
+const RegisterBody = ({
+  loading,
+  error,
+  entries,
+  columns,
+}: {
+  loading: boolean;
+  error: string | null;
+  entries: ControlledSubstanceLog[];
+  columns: Column<ControlledSubstanceLog>[];
+}) => {
+  if (loading) {
+    return (
+      <div
+        className="h-full min-h-64 animate-pulse rounded-2xl bg-card-hover"
+        aria-hidden="true"
+        data-testid="cs-register-loading"
+      />
+    );
+  }
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="rounded-2xl border border-card-border p-6 text-body-4 text-text-error"
+      >
+        {error}
+      </div>
+    );
+  }
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-2xl border border-card-border p-8 text-center">
+        <p className="text-body-3 text-text-primary">No controlled substance entries yet.</p>
+        <p className="mt-1 text-body-4 text-text-secondary">
+          Log a draw, administration or waste to start the compliance register.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <GenericTable
+      data={entries}
+      columns={columns}
+      caption="Controlled substance register for this organisation"
+      itemNoun="entries"
+      pagination
+    />
+  );
+};
+
+type AddEntryFormProps = {
+  creating: boolean;
+  createError: string | null;
+  onSubmit: (input: CreateControlledSubstanceLogInput) => void;
+  onCancel: () => void;
+};
+
+const parseOptionalNumber = (raw: string): number | undefined => {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/** Now as the value a datetime-local input expects (local time, no seconds). */
+const nowLocalDateTime = (): string => {
+  const now = new Date();
+  const offset = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, 16);
+};
+
+const AddEntryForm = ({ creating, createError, onSubmit, onCancel }: AddEntryFormProps) => {
+  const [loggedAt, setLoggedAt] = useState(nowLocalDateTime);
+  const [drug, setDrug] = useState('');
+  const [deaSchedule, setDeaSchedule] = useState<DeaSchedule>('II');
+  const [unit, setUnit] = useState<DrugUnit>('ML');
+  const [strength, setStrength] = useState('');
+  const [lotNumber, setLotNumber] = useState('');
+  const [amountDrawn, setAmountDrawn] = useState('');
+  const [amountAdministered, setAmountAdministered] = useState('');
+  const [amountWasted, setAmountWasted] = useState('');
+  const [wastedWitness, setWastedWitness] = useState('');
+  const [balanceBefore, setBalanceBefore] = useState('');
+  const [balanceAfter, setBalanceAfter] = useState('');
+  const [notes, setNotes] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = () => {
+    const trimmedDrug = drug.trim();
+    if (!trimmedDrug) {
+      setFormError('Enter the drug name.');
+      return;
+    }
+    const drawn = parseOptionalNumber(amountDrawn);
+    if (drawn === undefined || drawn <= 0) {
+      setFormError('Amount drawn must be greater than zero.');
+      return;
+    }
+    const administered = parseOptionalNumber(amountAdministered);
+    if (administered === undefined) {
+      setFormError('Enter the amount administered.');
+      return;
+    }
+    // Negatives are rejected by the inputs' `min="0"` and again by the server,
+    // so a blank field is the only administered/wasted case left to catch here.
+    const wasted = parseOptionalNumber(amountWasted) ?? 0;
+    // Mirror the backend reconciliation so the user is told before the request.
+    if (administered + wasted > drawn) {
+      setFormError('Administered plus wasted cannot exceed the amount drawn.');
+      return;
+    }
+    // Compliance affordance: waste needs a witness. The backend leaves the
+    // witness optional, so the register enforces it at the form.
+    if (wasted > 0 && !wastedWitness.trim()) {
+      setFormError('A witness is required whenever any amount is wasted.');
+      return;
+    }
+
+    setFormError(null);
+    onSubmit({
+      loggedAt: new Date(loggedAt).toISOString(),
+      drug: trimmedDrug,
+      deaSchedule,
+      unit,
+      amountDrawn: drawn,
+      amountAdministered: administered,
+      amountWasted: wasted,
+      wastedWitness: wastedWitness.trim() || undefined,
+      strength: parseOptionalNumber(strength),
+      lotNumber: lotNumber.trim() || undefined,
+      balanceBefore: parseOptionalNumber(balanceBefore),
+      balanceAfter: parseOptionalNumber(balanceAfter),
+      notes: notes.trim() || undefined,
+    });
+  };
+
+  const message = formError ?? createError;
+
+  return (
+    <form
+      aria-label="Add controlled substance entry"
+      className="flex flex-col gap-4 rounded-2xl border border-card-border p-5!"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <h2 className="text-heading-6 text-text-primary">New register entry</h2>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Field id="cs-logged-at" label="Logged at">
+          <input
+            id="cs-logged-at"
+            type="datetime-local"
+            value={loggedAt}
+            onChange={(event) => setLoggedAt(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-drug" label="Drug name">
+          <input
+            id="cs-drug"
+            type="text"
+            value={drug}
+            onChange={(event) => setDrug(event.target.value)}
+            className={inputClass}
+            placeholder="e.g. Ketamine"
+          />
+        </Field>
+
+        <Field id="cs-schedule" label="DEA schedule">
+          <select
+            id="cs-schedule"
+            value={deaSchedule}
+            onChange={(event) => setDeaSchedule(event.target.value as DeaSchedule)}
+            className={inputClass}
+          >
+            {DEA_SCHEDULES.map((schedule) => (
+              <option key={schedule} value={schedule}>
+                {DEA_SCHEDULE_LABEL[schedule]}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field id="cs-unit" label="Unit">
+          <select
+            id="cs-unit"
+            value={unit}
+            onChange={(event) => setUnit(event.target.value as DrugUnit)}
+            className={inputClass}
+          >
+            {DRUG_UNITS.map((option) => (
+              <option key={option} value={option}>
+                {DRUG_UNIT_LABEL[option]}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field id="cs-strength" label="Strength (optional)">
+          <input
+            id="cs-strength"
+            type="number"
+            step="any"
+            min="0"
+            value={strength}
+            onChange={(event) => setStrength(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-lot" label="Lot number (optional)">
+          <input
+            id="cs-lot"
+            type="text"
+            value={lotNumber}
+            onChange={(event) => setLotNumber(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-drawn" label="Amount drawn">
+          <input
+            id="cs-drawn"
+            type="number"
+            step="any"
+            min="0"
+            value={amountDrawn}
+            onChange={(event) => setAmountDrawn(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-administered" label="Amount administered">
+          <input
+            id="cs-administered"
+            type="number"
+            step="any"
+            min="0"
+            value={amountAdministered}
+            onChange={(event) => setAmountAdministered(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-wasted" label="Amount wasted">
+          <input
+            id="cs-wasted"
+            type="number"
+            step="any"
+            min="0"
+            value={amountWasted}
+            onChange={(event) => setAmountWasted(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-witness" label="Waste witness">
+          <input
+            id="cs-witness"
+            type="text"
+            value={wastedWitness}
+            onChange={(event) => setWastedWitness(event.target.value)}
+            className={inputClass}
+            placeholder="Required when any amount is wasted"
+          />
+        </Field>
+
+        <Field id="cs-balance-before" label="Balance before (optional)">
+          <input
+            id="cs-balance-before"
+            type="number"
+            step="any"
+            min="0"
+            value={balanceBefore}
+            onChange={(event) => setBalanceBefore(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field id="cs-balance-after" label="Balance after (optional)">
+          <input
+            id="cs-balance-after"
+            type="number"
+            step="any"
+            min="0"
+            value={balanceAfter}
+            onChange={(event) => setBalanceAfter(event.target.value)}
+            className={inputClass}
+          />
+        </Field>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="cs-notes" className={labelClass}>
+          Notes (optional)
+        </label>
+        <span className={fieldClass}>
+          <textarea
+            id="cs-notes"
+            rows={2}
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            className={inputClass}
+          />
+        </span>
+      </div>
+
+      {message ? (
+        <p role="alert" className="text-body-4 text-text-error">
+          {message}
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-end gap-2">
+        <Secondary
+          text="Cancel"
+          isDisabled={creating}
+          onClick={onCancel}
+          ariaLabel="Cancel adding an entry"
+        />
+        <Primary
+          text={creating ? 'Saving…' : 'Save entry'}
+          type="submit"
+          isDisabled={creating}
+          ariaLabel="Save this controlled substance entry"
+        />
+      </div>
+    </form>
+  );
+};
+
+const Field = ({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1">
+    <label htmlFor={id} className={labelClass}>
+      {label}
+    </label>
+    <span className={fieldClass}>{children}</span>
+  </div>
+);
+
+export default ControlledSubstanceRegister;

--- a/apps/frontend/src/app/features/compliance/hooks/useControlledSubstanceLogs.ts
+++ b/apps/frontend/src/app/features/compliance/hooks/useControlledSubstanceLogs.ts
@@ -1,0 +1,77 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchControlledSubstanceLogs,
+  getControlledSubstanceErrorMessage,
+} from '@/app/features/compliance/services/controlledSubstanceService';
+import type { ControlledSubstanceLog } from '@/app/features/compliance/types/controlledSubstance';
+
+export type ControlledSubstanceDateRange = { fromDate?: string; toDate?: string };
+
+export type UseControlledSubstanceLogs = {
+  logs: ControlledSubstanceLog[];
+  loading: boolean;
+  error: string | null;
+  /** Refetch the register, e.g. after appending an entry. */
+  reload: () => void;
+};
+
+/**
+ * List the organisation's controlled-substance ledger, bounded to a date range.
+ *
+ * Date bounds are server-side so the register stays correct once an org has
+ * more entries than one response holds. The free-text drug filter is applied in
+ * the register component instead, over the returned rows, so a keystroke does
+ * not fire a request.
+ */
+export const useControlledSubstanceLogs = (
+  organisationId?: string,
+  dateRange: ControlledSubstanceDateRange = {}
+): UseControlledSubstanceLogs => {
+  const [logs, setLogs] = useState<ControlledSubstanceLog[]>([]);
+  const [loading, setLoading] = useState(Boolean(organisationId));
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const { fromDate, toDate } = dateRange;
+
+  // Render-phase reset (matching useEstimates): an org switch or a date-range
+  // change clears the previous org's rows immediately rather than showing them
+  // under the new query while the refetch is in flight.
+  const loadKey = `${organisationId ?? ''}|${fromDate ?? ''}|${toDate ?? ''}|${reloadToken}`;
+  const [prevLoadKey, setPrevLoadKey] = useState(loadKey);
+  if (prevLoadKey !== loadKey) {
+    setPrevLoadKey(loadKey);
+    setLogs([]);
+    setError(null);
+    setLoading(Boolean(organisationId));
+  }
+
+  useEffect(() => {
+    if (!organisationId) return undefined;
+    let active = true;
+    fetchControlledSubstanceLogs(organisationId, { fromDate, toDate })
+      .then((rows) => {
+        if (!active) return;
+        setLogs(rows);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setError(
+          getControlledSubstanceErrorMessage(
+            err,
+            'Unable to load the controlled substance register.'
+          )
+        );
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [organisationId, fromDate, toDate, reloadToken]);
+
+  const reload = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  return { logs, loading, error, reload };
+};

--- a/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
+++ b/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+import React, { Suspense, useState } from 'react';
+import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
+import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
+import PageSkeleton from '@/app/ui/layout/PageSkeleton';
+import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import ControlledSubstanceRegister, {
+  type ControlledSubstanceDateRange,
+} from '@/app/features/compliance/components/ControlledSubstanceRegister';
+import { useControlledSubstanceLogs } from '@/app/features/compliance/hooks/useControlledSubstanceLogs';
+import {
+  createControlledSubstanceLog,
+  getControlledSubstanceErrorMessage,
+} from '@/app/features/compliance/services/controlledSubstanceService';
+import type { CreateControlledSubstanceLogInput } from '@/app/features/compliance/types/controlledSubstance';
+
+const PAGE_SKELETON = <PageSkeleton variant="list" />;
+
+const ControlledSubstancesContent = () => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const { notify } = useNotify();
+  const { can } = usePermissions();
+  const canRecord = can({
+    anyOf: [PERMISSIONS.PRESCRIPTION_EDIT_ANY, PERMISSIONS.PRESCRIPTION_EDIT_OWN],
+  });
+
+  const [dateRange, setDateRange] = useState<ControlledSubstanceDateRange>({});
+  const { logs, loading, error, reload } = useControlledSubstanceLogs(
+    primaryOrgId ?? undefined,
+    dateRange
+  );
+
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const handleCreate = async (input: CreateControlledSubstanceLogInput) => {
+    if (!primaryOrgId) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      await createControlledSubstanceLog(primaryOrgId, input);
+      notify('success', {
+        title: 'Entry logged',
+        text: 'The controlled substance entry has been recorded.',
+      });
+      reload();
+    } catch (err) {
+      setCreateError(getControlledSubstanceErrorMessage(err, 'Unable to log the entry.'));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <ControlledSubstanceRegister
+      entries={logs}
+      loading={loading}
+      error={error}
+      dateRange={dateRange}
+      onDateRangeChange={setDateRange}
+      canRecord={canRecord}
+      creating={creating}
+      createError={createError}
+      onCreate={(input) => void handleCreate(input)}
+    />
+  );
+};
+
+const ControlledSubstances = () => (
+  <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]} deniedResource="Controlled drugs">
+    <ControlledSubstancesContent />
+  </PermissionGate>
+);
+
+const ProtectedControlledSubstances = () => (
+  <ProtectedRoute skeleton={PAGE_SKELETON}>
+    <OrgGuard skeleton={PAGE_SKELETON}>
+      <Suspense fallback={PAGE_SKELETON}>
+        <ControlledSubstances />
+      </Suspense>
+    </OrgGuard>
+  </ProtectedRoute>
+);
+
+export default ProtectedControlledSubstances;

--- a/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
+++ b/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
@@ -37,8 +37,8 @@ const ControlledSubstancesContent = () => {
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
-  const handleCreate = async (input: CreateControlledSubstanceLogInput) => {
-    if (!primaryOrgId) return;
+  const handleCreate = async (input: CreateControlledSubstanceLogInput): Promise<boolean> => {
+    if (!primaryOrgId) return false;
     setCreating(true);
     setCreateError(null);
     try {
@@ -48,10 +48,12 @@ const ControlledSubstancesContent = () => {
         text: 'The controlled substance entry has been recorded.',
       });
       reload();
+      setCreating(false);
+      return true;
     } catch (err) {
       setCreateError(getControlledSubstanceErrorMessage(err, 'Unable to log the entry.'));
-    } finally {
       setCreating(false);
+      return false;
     }
   };
 
@@ -65,13 +67,16 @@ const ControlledSubstancesContent = () => {
       canRecord={canRecord}
       creating={creating}
       createError={createError}
-      onCreate={(input) => void handleCreate(input)}
+      onCreate={handleCreate}
     />
   );
 };
 
 const ControlledSubstances = () => (
-  <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]} deniedResource="Controlled drugs">
+  <PermissionGate
+    anyOf={[PERMISSIONS.PRESCRIPTION_VIEW_ANY, PERMISSIONS.PRESCRIPTION_VIEW_OWN]}
+    deniedResource="Controlled drugs"
+  >
     <ControlledSubstancesContent />
   </PermissionGate>
 );

--- a/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
+++ b/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
@@ -12,7 +12,10 @@ import type {
  * `/v1/pms/organisation/:organisationId/...` family the estimates service uses.
  */
 const basePath = (organisationId: string) =>
-  `/v1/pms/organisation/${organisationId}/controlled-substance-logs`;
+  // Encode the caller's own org id as a single path segment: it keeps the
+  // request pinned to `/v1/pms/organisation/<segment>/...` even if the id ever
+  // carried a slash or dot, which is what the SSRF scanner wants to see.
+  `/v1/pms/organisation/${encodeURIComponent(organisationId)}/controlled-substance-logs`;
 
 const assertOrg = (organisationId: string) => {
   if (!organisationId) throw new Error('Organisation ID missing');

--- a/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
+++ b/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
@@ -6,21 +6,6 @@ import type {
   CreateControlledSubstanceLogInput,
 } from '@/app/features/compliance/types/controlledSubstance';
 
-/**
- * Base path for the controlled-substance-log router. It is mounted under `/v1`
- * (apps/backend/src/routers/index.ts), so the full path matches the clinical
- * `/v1/pms/organisation/:organisationId/...` family the estimates service uses.
- */
-const basePath = (organisationId: string) =>
-  // Encode the caller's own org id as a single path segment: it keeps the
-  // request pinned to `/v1/pms/organisation/<segment>/...` even if the id ever
-  // carried a slash or dot, which is what the SSRF scanner wants to see.
-  `/v1/pms/organisation/${encodeURIComponent(organisationId)}/controlled-substance-logs`;
-
-const assertOrg = (organisationId: string) => {
-  if (!organisationId) throw new Error('Organisation ID missing');
-};
-
 /** Human-readable message from a controlled-substance API error. */
 export const getControlledSubstanceErrorMessage = (error: unknown, fallback: string): string => {
   if (axios.isAxiosError(error)) {
@@ -35,14 +20,17 @@ export const fetchControlledSubstanceLogs = async (
   organisationId: string,
   filters: ControlledSubstanceLogFilters = {}
 ): Promise<ControlledSubstanceLog[]> => {
-  assertOrg(organisationId);
+  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
   const params: Record<string, string> = {};
   if (filters.drug) params.drug = filters.drug;
   if (filters.deaSchedule) params.deaSchedule = filters.deaSchedule;
   if (filters.fromDate) params.fromDate = filters.fromDate;
   if (filters.toDate) params.toDate = filters.toDate;
   if (filters.patientId) params.patientId = filters.patientId;
-  const res = await getData<ControlledSubstanceLog[]>(basePath(organisationId), params);
+  const res = await getData<ControlledSubstanceLog[]>(
+    `/v1/pms/organisation/${organisationId}/controlled-substance-logs`,
+    params
+  );
   // The list endpoint returns a bare array. Guard so a proxy/error page that
   // replies with an object cannot crash `.map` in the register table.
   return Array.isArray(res.data) ? res.data : [];
@@ -52,7 +40,10 @@ export const createControlledSubstanceLog = async (
   organisationId: string,
   payload: CreateControlledSubstanceLogInput
 ): Promise<ControlledSubstanceLog> => {
-  assertOrg(organisationId);
-  const res = await postData<ControlledSubstanceLog>(basePath(organisationId), payload);
+  if (!/^[A-Za-z0-9_-]+$/.test(organisationId)) throw new Error('Invalid organisation ID');
+  const res = await postData<ControlledSubstanceLog>(
+    `/v1/pms/organisation/${organisationId}/controlled-substance-logs`,
+    payload
+  );
   return res.data;
 };

--- a/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
+++ b/apps/frontend/src/app/features/compliance/services/controlledSubstanceService.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+import type {
+  ControlledSubstanceLog,
+  ControlledSubstanceLogFilters,
+  CreateControlledSubstanceLogInput,
+} from '@/app/features/compliance/types/controlledSubstance';
+
+/**
+ * Base path for the controlled-substance-log router. It is mounted under `/v1`
+ * (apps/backend/src/routers/index.ts), so the full path matches the clinical
+ * `/v1/pms/organisation/:organisationId/...` family the estimates service uses.
+ */
+const basePath = (organisationId: string) =>
+  `/v1/pms/organisation/${organisationId}/controlled-substance-logs`;
+
+const assertOrg = (organisationId: string) => {
+  if (!organisationId) throw new Error('Organisation ID missing');
+};
+
+/** Human-readable message from a controlled-substance API error. */
+export const getControlledSubstanceErrorMessage = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: unknown } | undefined;
+    if (typeof data?.message === 'string' && data.message.trim()) return data.message.trim();
+  }
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  return fallback;
+};
+
+export const fetchControlledSubstanceLogs = async (
+  organisationId: string,
+  filters: ControlledSubstanceLogFilters = {}
+): Promise<ControlledSubstanceLog[]> => {
+  assertOrg(organisationId);
+  const params: Record<string, string> = {};
+  if (filters.drug) params.drug = filters.drug;
+  if (filters.deaSchedule) params.deaSchedule = filters.deaSchedule;
+  if (filters.fromDate) params.fromDate = filters.fromDate;
+  if (filters.toDate) params.toDate = filters.toDate;
+  if (filters.patientId) params.patientId = filters.patientId;
+  const res = await getData<ControlledSubstanceLog[]>(basePath(organisationId), params);
+  // The list endpoint returns a bare array. Guard so a proxy/error page that
+  // replies with an object cannot crash `.map` in the register table.
+  return Array.isArray(res.data) ? res.data : [];
+};
+
+export const createControlledSubstanceLog = async (
+  organisationId: string,
+  payload: CreateControlledSubstanceLogInput
+): Promise<ControlledSubstanceLog> => {
+  assertOrg(organisationId);
+  const res = await postData<ControlledSubstanceLog>(basePath(organisationId), payload);
+  return res.data;
+};

--- a/apps/frontend/src/app/features/compliance/types/controlledSubstance.ts
+++ b/apps/frontend/src/app/features/compliance/types/controlledSubstance.ts
@@ -1,0 +1,119 @@
+import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+
+/**
+ * Types for the DEA controlled-substance register. Mirrors the backend
+ * `ControlledSubstanceLog` model and the `DeaSchedule` / `DrugUnit` enums
+ * (packages/database/prisma/schema.prisma). Dates arrive as ISO strings over
+ * JSON, so `loggedAt`, `createdAt` and `updatedAt` are typed as `string`.
+ */
+export type DeaSchedule = 'II' | 'III' | 'IV' | 'V';
+
+export type DrugUnit = 'ML' | 'MG' | 'MCG' | 'TABLET' | 'CAPSULE' | 'PATCH' | 'UNIT';
+
+export interface ControlledSubstanceLog {
+  id: string;
+  organisationId: string;
+  patientId: string | null;
+  encounterId: string | null;
+  loggedAt: string;
+  drug: string;
+  deaSchedule: DeaSchedule;
+  lotNumber: string | null;
+  strength: number | null;
+  unit: DrugUnit;
+  amountDrawn: number;
+  amountAdministered: number;
+  amountWasted: number;
+  wastedWitness: string | null;
+  balanceBefore: number | null;
+  balanceAfter: number | null;
+  administeredBy: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The create payload the register sends. `administeredBy` is intentionally
+ * absent: the backend stamps it from the authenticated user, never from the
+ * request body (controlled-substance-log.controller.ts).
+ */
+export interface CreateControlledSubstanceLogInput {
+  loggedAt: string;
+  drug: string;
+  deaSchedule: DeaSchedule;
+  unit: DrugUnit;
+  amountDrawn: number;
+  amountAdministered: number;
+  amountWasted?: number;
+  wastedWitness?: string;
+  strength?: number;
+  lotNumber?: string;
+  balanceBefore?: number;
+  balanceAfter?: number;
+  patientId?: string;
+  encounterId?: string;
+  notes?: string;
+}
+
+/**
+ * List filters the API supports. `drug` is a case-insensitive contains match,
+ * the schedule is exact, and `fromDate`/`toDate` bound `loggedAt` (all ISO
+ * datetimes).
+ */
+export interface ControlledSubstanceLogFilters {
+  drug?: string;
+  deaSchedule?: DeaSchedule;
+  fromDate?: string;
+  toDate?: string;
+  patientId?: string;
+}
+
+export const DEA_SCHEDULES: readonly DeaSchedule[] = ['II', 'III', 'IV', 'V'];
+
+export const DRUG_UNITS: readonly DrugUnit[] = [
+  'ML',
+  'MG',
+  'MCG',
+  'TABLET',
+  'CAPSULE',
+  'PATCH',
+  'UNIT',
+];
+
+export const DEA_SCHEDULE_LABEL: Record<DeaSchedule, string> = {
+  II: 'Schedule II',
+  III: 'Schedule III',
+  IV: 'Schedule IV',
+  V: 'Schedule V',
+};
+
+/**
+ * Hotter tone for the tighter schedule: C-II is the most restricted, C-V the
+ * least. The pill is read at a glance by a controller reconciling the ledger.
+ */
+export const DEA_SCHEDULE_TONE: Record<DeaSchedule, StatusTone> = {
+  II: 'danger',
+  III: 'warning',
+  IV: 'info',
+  V: 'neutral',
+};
+
+export const DRUG_UNIT_LABEL: Record<DrugUnit, string> = {
+  ML: 'mL',
+  MG: 'mg',
+  MCG: 'mcg',
+  TABLET: 'tablet',
+  CAPSULE: 'capsule',
+  PATCH: 'patch',
+  UNIT: 'unit',
+};
+
+/**
+ * Exact amount rendering. A controlled-drug ledger reconciles to the last
+ * decimal, so we render the number's own shortest round-trip string rather than
+ * a fixed-precision format that could silently drop 0.05 mL. `null` balances
+ * render as an em dash.
+ */
+export const formatAmount = (value: number | null | undefined): string =>
+  value === null || value === undefined || Number.isNaN(value) ? '—' : String(value);

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   IoChevronForwardOutline,
   IoCubeOutline,
   IoExtensionPuzzleOutline,
+  IoFlaskOutline,
   IoGitNetworkOutline,
   IoGlobeOutline,
   IoGridOutline,
@@ -50,6 +51,7 @@ const ROUTE_ICONS: Record<string, IconType> = {
   Finance: IoWalletOutline,
   Companions: IoPaw,
   Inventory: IoCubeOutline,
+  'Controlled drugs': IoFlaskOutline,
   Integrations: IoGitNetworkOutline,
   Network: IoGlobeOutline,
   Templates: IoBookOutline,
@@ -64,7 +66,7 @@ const APP_ROUTE_GROUPS = [
   { label: 'Overview', routeNames: ['Dashboard'] },
   { label: 'Schedule & Work', routeNames: ['Appointments', 'Tasks', 'Chat'] },
   { label: 'Clients & Records', routeNames: ['Companions', 'Templates'] },
-  { label: 'Business', routeNames: ['Finance', 'Inventory'] },
+  { label: 'Business', routeNames: ['Finance', 'Inventory', 'Controlled drugs'] },
   { label: 'Administration', routeNames: ['Organization', 'Integrations', 'Network'] },
 ] as const;
 

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -23,6 +23,7 @@ const STRICT_CSP_PATH_PREFIXES = [
   '/book-onboarding',
   '/chat',
   '/companions',
+  '/controlled-substances',
   '/create-org',
   '/dashboard',
   '/developers/api-keys',


### PR DESCRIPTION
Wires the `ControlledSubstanceLog` backend — a DEA/controlled-drug draw/administer/waste ledger — that had no client surface. Part of the "wire what exists" wave.

## What was unreachable
RBAC-gated CRUD at `/v1/pms/organisation/:id/controlled-substance-logs`; a practice had no register to read or add to.

## What this adds
A **Controlled drugs** page (one route + one Sidebar entry, Business group):
- a register table — logged-at, drug + DEA-schedule pill (tone hotter for a tighter schedule), strength/unit, drawn / administered / **wasted + witness**, running balance before→after, administered-by;
- drug and date-range filters;
- an add-entry form.

Amounts render at **exact decimal precision** with tabular figures — no digit rounded away, which matters for a controlled-drug ledger.

## Compliance-aware where the backend is lenient
Waste needs no witness server-side, so the register **flags "Witness missing"** (danger) on any wasted row without one, and the add form **requires** a witness when `amountWasted > 0`.

## Reality over assumptions
List is a bare array with `patientId`/`drug`/`deaSchedule`/date filters (drug filtered client-side, dates server-side); `DeaSchedule` II/III/IV/V, `DrugUnit` ML/MG/MCG/TABLET/CAPSULE/PATCH/UNIT; create reconciles `administered + wasted <= drawn`.

## Tests
Mutation-checked (inverting the witness condition reds the waste/witness test): entries, the schedule pill, the waste+witness emphasis and missing-witness flag, the add form, empty/loading/error. **39 tests, ~100% coverage**; `tsc` 0, lint clean.