### PR TITLE
feat(frontend): surface patient safety flags

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import FlagList from '@/app/features/companionHistory/components/FlagList';
+import type { PatientFlag } from '@/app/features/companionHistory/services/patientFlagService';
+
+const flag = (overrides: Partial<PatientFlag> & { id: string; title: string }): PatientFlag => ({
+  organisationId: 'org-1',
+  patientId: 'patient-1',
+  flagType: 'SPECIAL_HANDLING',
+  severity: 'MEDIUM',
+  description: null,
+  isActive: true,
+  createdBy: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...overrides,
+});
+
+const FLAGS: PatientFlag[] = [
+  flag({
+    id: 'flag-1',
+    title: 'Use a muzzle',
+    flagType: 'AGGRESSION',
+    severity: 'CRITICAL',
+    description: 'Approach slowly and keep away from other dogs.',
+  }),
+  flag({
+    id: 'flag-2',
+    title: 'Keep doors closed',
+    flagType: 'ESCAPE_RISK',
+    severity: 'HIGH',
+  }),
+  flag({
+    id: 'flag-3',
+    title: 'Isolation complete',
+    flagType: 'QUARANTINE',
+    severity: 'LOW',
+    isActive: false,
+    resolvedAt: '2026-02-02T00:00:00.000Z',
+  }),
+];
+
+describe('FlagList', () => {
+  it('renders flag labels, severity, status, description, and active count', () => {
+    render(<FlagList flags={FLAGS} canEdit />);
+
+    expect(screen.getByText('Use a muzzle')).toBeInTheDocument();
+    expect(screen.getByText('Aggression risk')).toBeInTheDocument();
+    expect(screen.getByText(/Approach slowly/)).toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+    expect(screen.getByText('Low')).toBeInTheDocument();
+    expect(screen.getAllByText('Active')).toHaveLength(2);
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.getByText('2 active')).toBeInTheDocument();
+    expect(screen.getByText(/^Resolved\b.*2026$/)).toBeInTheDocument();
+  });
+
+  it('resolves only active flags', async () => {
+    const onResolve = jest.fn();
+    render(<FlagList flags={FLAGS} canEdit onResolve={onResolve} />);
+
+    expect(screen.getAllByRole('button', { name: /^Resolve / })).toHaveLength(2);
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve Use a muzzle' }));
+    expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'flag-1' }));
+  });
+
+  it('submits the create form and closes it after a successful save', async () => {
+    const onCreate = jest.fn().mockResolvedValue(true);
+    render(<FlagList flags={[]} canEdit onCreate={onCreate} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), '  Needs quiet room  ');
+    await userEvent.selectOptions(screen.getByLabelText('Flag type'), 'ANXIETY');
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'HIGH');
+    await userEvent.type(screen.getByLabelText('Description'), 'Dim the lights');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      title: 'Needs quiet room',
+      flagType: 'ANXIETY',
+      severity: 'HIGH',
+      description: 'Dim the lights',
+    });
+    await waitFor(() => expect(screen.queryByLabelText('Flag title')).not.toBeInTheDocument());
+  });
+
+  it('keeps the form open after a failed save', async () => {
+    const onCreate = jest.fn().mockResolvedValue(false);
+    render(<FlagList flags={[]} canEdit onCreate={onCreate} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), 'Retry me');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Flag title')).toBeInTheDocument();
+  });
+
+  it('closes the create form when cancel is selected', async () => {
+    render(<FlagList flags={[]} canEdit />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByLabelText('Flag title')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty, loading, and error states', () => {
+    const { rerender } = render(<FlagList flags={[]} />);
+    expect(screen.getByText('No active flags for this patient.')).toBeInTheDocument();
+
+    rerender(<FlagList flags={[]} loading />);
+    expect(screen.queryByText('No active flags for this patient.')).not.toBeInTheDocument();
+
+    rerender(<FlagList flags={[]} error="Could not load patient flags." />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load patient flags.');
+  });
+
+  it('hides edit controls when the member cannot edit', () => {
+    render(<FlagList flags={FLAGS} canEdit={false} />);
+
+    expect(screen.queryByRole('button', { name: 'Add flag' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Resolve / })).not.toBeInTheDocument();
+  });
+
+  it('handles a resolved flag with an invalid timestamp', () => {
+    render(
+      <FlagList
+        flags={[
+          flag({ id: 'flag-invalid', title: 'Old note', isActive: false, resolvedAt: 'invalid' }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Old note')).toBeInTheDocument();
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.queryByText(/^Resolved\b.*\d{4}$/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagListPanel.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { isAuthRedirectError } from '@/app/services/axios';
+import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
+import {
+  createPatientFlag,
+  fetchPatientFlags,
+  resolvePatientFlag,
+  type PatientFlag,
+} from '@/app/features/companionHistory/services/patientFlagService';
+
+const notifyMock = jest.fn();
+let permissionsMock: string[] = ['companions:view:any', 'companions:edit:any'];
+
+jest.mock('@/app/services/axios', () => ({
+  isAuthRedirectError: jest.fn(() => false),
+}));
+
+jest.mock('@/app/hooks/useNotify', () => ({
+  useNotify: () => ({ notify: notifyMock }),
+}));
+
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: (permission: string) => permissionsMock.includes(permission) }),
+}));
+
+jest.mock('@/app/features/companionHistory/services/patientFlagService', () => ({
+  createPatientFlag: jest.fn(),
+  fetchPatientFlags: jest.fn(),
+  resolvePatientFlag: jest.fn(),
+}));
+
+const createMock = createPatientFlag as jest.Mock;
+const fetchMock = fetchPatientFlags as jest.Mock;
+const resolveMock = resolvePatientFlag as jest.Mock;
+const isAuthRedirectMock = isAuthRedirectError as jest.Mock;
+
+const flag = (overrides: Partial<PatientFlag> & { id: string; title: string }): PatientFlag => ({
+  organisationId: 'org-1',
+  patientId: 'patient-1',
+  flagType: 'SPECIAL_HANDLING',
+  severity: 'MEDIUM',
+  description: null,
+  isActive: true,
+  createdBy: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  permissionsMock = ['companions:view:any', 'companions:edit:any'];
+  fetchMock.mockResolvedValue([]);
+});
+
+describe('FlagListPanel', () => {
+  it('loads only active flags for the patient', async () => {
+    fetchMock.mockResolvedValue([flag({ id: 'flag-1', title: 'Use a muzzle' })]);
+
+    render(<FlagListPanel companionId="patient-1" />);
+
+    expect(await screen.findByText('Use a muzzle')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith({ patientId: 'patient-1', isActive: true });
+  });
+
+  it('shows the empty state when no active flags exist', async () => {
+    render(<FlagListPanel companionId="patient-1" />);
+    expect(await screen.findByText('No active flags for this patient.')).toBeInTheDocument();
+  });
+
+  it.each([new Error('load failed'), new Error('No active organisation selected.')])(
+    'shows a load error when the service rejects with %s',
+    async (error) => {
+      fetchMock.mockRejectedValue(error);
+      render(<FlagListPanel companionId="patient-1" />);
+      expect(await screen.findByRole('alert')).toHaveTextContent('Could not load patient flags');
+    }
+  );
+
+  it('creates a flag and refetches the active list', async () => {
+    const created = flag({ id: 'flag-new', title: 'Use side entrance', flagType: 'ESCAPE_RISK' });
+    fetchMock.mockResolvedValueOnce([]).mockResolvedValueOnce([created]);
+    createMock.mockResolvedValue(created);
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('No active flags for this patient.');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), 'Use side entrance');
+    await userEvent.selectOptions(screen.getByLabelText('Flag type'), 'ESCAPE_RISK');
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'HIGH');
+    await userEvent.type(screen.getByLabelText('Description'), '  Keep both doors closed  ');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    await waitFor(() =>
+      expect(createMock).toHaveBeenCalledWith({
+        patientId: 'patient-1',
+        title: 'Use side entrance',
+        flagType: 'ESCAPE_RISK',
+        severity: 'HIGH',
+        description: 'Keep both doors closed',
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText('Use side entrance')).toBeInTheDocument();
+    expect(notifyMock).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Flag added' })
+    );
+  });
+
+  it('omits an empty description when creating', async () => {
+    fetchMock.mockResolvedValue([]);
+    createMock.mockResolvedValue(flag({ id: 'flag-new', title: 'Priority patient' }));
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('No active flags for this patient.');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), 'Priority patient');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+    expect(createMock.mock.calls[0][0]).not.toHaveProperty('description');
+  });
+
+  it('keeps the form open and notifies when create fails', async () => {
+    createMock.mockRejectedValue(new Error('failed'));
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('No active flags for this patient.');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), 'Retry me');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    await waitFor(() =>
+      expect(notifyMock).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not add flag' })
+      )
+    );
+    expect(screen.getByLabelText('Flag title')).toBeInTheDocument();
+  });
+
+  it('stays silent when create triggers an auth redirect', async () => {
+    createMock.mockRejectedValue(new Error('redirect'));
+    isAuthRedirectMock.mockReturnValueOnce(true);
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('No active flags for this patient.');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(screen.getByLabelText('Flag title'), 'Do not save');
+    await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+    expect(notifyMock).not.toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('resolves a flag and removes it from the active list', async () => {
+    const activeFlag = flag({ id: 'flag-1', title: 'Use a muzzle' });
+    fetchMock.mockResolvedValue([activeFlag]);
+    resolveMock.mockResolvedValue({ ...activeFlag, isActive: false });
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('Use a muzzle');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve Use a muzzle' }));
+
+    await waitFor(() => expect(resolveMock).toHaveBeenCalledWith('flag-1'));
+    expect(screen.queryByText('Use a muzzle')).not.toBeInTheDocument();
+    expect(notifyMock).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Flag resolved' })
+    );
+  });
+
+  it('notifies and keeps the flag active when resolve fails', async () => {
+    fetchMock.mockResolvedValue([flag({ id: 'flag-1', title: 'Use a muzzle' })]);
+    resolveMock.mockRejectedValue(new Error('failed'));
+    render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('Use a muzzle');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve Use a muzzle' }));
+
+    await waitFor(() =>
+      expect(notifyMock).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not resolve flag' })
+      )
+    );
+    expect(screen.getByRole('button', { name: 'Resolve Use a muzzle' })).toBeInTheDocument();
+  });
+
+  it('resets and reloads when the companion changes', async () => {
+    fetchMock
+      .mockResolvedValueOnce([flag({ id: 'flag-1', title: 'Use a muzzle' })])
+      .mockResolvedValueOnce([flag({ id: 'flag-2', title: 'Keep doors closed' })]);
+    const { rerender } = render(<FlagListPanel companionId="patient-1" />);
+    await screen.findByText('Use a muzzle');
+
+    rerender(<FlagListPanel companionId="patient-2" />);
+
+    expect(await screen.findByText('Keep doors closed')).toBeInTheDocument();
+    expect(screen.queryByText('Use a muzzle')).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenLastCalledWith({ patientId: 'patient-2', isActive: true });
+  });
+
+  it('renders nothing without view permission', () => {
+    permissionsMock = [];
+    const { container } = render(<FlagListPanel companionId="patient-1" />);
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('hides write controls without edit permission', async () => {
+    permissionsMock = ['companions:view:any'];
+    fetchMock.mockResolvedValue([flag({ id: 'flag-1', title: 'Use a muzzle' })]);
+    render(<FlagListPanel companionId="patient-1" />);
+
+    await screen.findByText('Use a muzzle');
+    expect(screen.queryByRole('button', { name: 'Add flag' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Resolve / })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/pages/phone/PhoneCompanionRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/pages/phone/PhoneCompanionRecord.test.tsx
@@ -21,6 +21,13 @@ jest.mock('@/app/features/companionHistory/components/AllergyListPanel', () => (
   ),
 }));
 
+jest.mock('@/app/features/companionHistory/components/FlagListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => (
+    <div data-testid="flag-list-panel" data-companion-id={companionId} />
+  ),
+}));
+
 jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
   __esModule: true,
   default: ({ children }: any) => children,
@@ -109,6 +116,7 @@ describe('PhoneCompanionRecord', () => {
       'data-companion-id',
       'AC-0092'
     );
+    expect(screen.getByTestId('flag-list-panel')).toHaveAttribute('data-companion-id', 'AC-0092');
   });
 
   it('shows the edit affordance only with permission', () => {

--- a/apps/frontend/src/app/__tests__/features/companionHistory/services/patientFlagService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/services/patientFlagService.test.ts
@@ -1,0 +1,161 @@
+import { AxiosError } from 'axios';
+import {
+  createPatientFlag,
+  fetchPatientFlag,
+  fetchPatientFlags,
+  resolvePatientFlag,
+  updatePatientFlag,
+} from '@/app/features/companionHistory/services/patientFlagService';
+import { getData, patchData, postData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  patchData: jest.fn(),
+  postData: jest.fn(),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn() },
+}));
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const FLAG_ID = '22222222-2222-4222-8222-222222222222';
+let mockOrgId: string | null = ORG_ID;
+
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ primaryOrgId: mockOrgId }) },
+}));
+
+const getMock = getData as jest.Mock;
+const patchMock = patchData as jest.Mock;
+const postMock = postData as jest.Mock;
+const errorMock = logger.error as jest.Mock;
+const warnMock = logger.warn as jest.Mock;
+const BASE = `/v1/pms/organisation/${ORG_ID}/patient-flags`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOrgId = ORG_ID;
+});
+
+describe('patientFlagService', () => {
+  it('lists active flags for a patient', async () => {
+    getMock.mockResolvedValue({ data: [{ id: FLAG_ID }] });
+
+    await expect(fetchPatientFlags({ patientId: 'patient-1', isActive: true })).resolves.toEqual([
+      { id: FLAG_ID },
+    ]);
+    expect(getMock).toHaveBeenCalledWith(BASE, { patientId: 'patient-1', isActive: true });
+  });
+
+  it('passes every optional list filter, including false', async () => {
+    getMock.mockResolvedValue({ data: [] });
+
+    await fetchPatientFlags({ flagType: 'QUARANTINE', severity: 'CRITICAL', isActive: false });
+
+    expect(getMock).toHaveBeenCalledWith(BASE, {
+      flagType: 'QUARANTINE',
+      severity: 'CRITICAL',
+      isActive: false,
+    });
+  });
+
+  it('returns an empty list and logs only the response type for a malformed list', async () => {
+    const payload = { patientName: 'private' };
+    getMock.mockResolvedValue({ data: payload });
+
+    await expect(fetchPatientFlags()).resolves.toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(expect.any(String), 'object');
+    expect(warnMock.mock.calls[0]).not.toContainEqual(payload);
+  });
+
+  it('fetches one flag', async () => {
+    getMock.mockResolvedValue({ data: { id: FLAG_ID } });
+
+    await expect(fetchPatientFlag(FLAG_ID)).resolves.toEqual({ id: FLAG_ID });
+    expect(getMock).toHaveBeenCalledWith(`${BASE}/${FLAG_ID}`);
+  });
+
+  it('creates a flag', async () => {
+    const input = {
+      patientId: 'patient-1',
+      flagType: 'AGGRESSION' as const,
+      severity: 'HIGH' as const,
+      title: 'Use a muzzle',
+    };
+    postMock.mockResolvedValue({ data: { id: FLAG_ID } });
+
+    await expect(createPatientFlag(input)).resolves.toEqual({ id: FLAG_ID });
+    expect(postMock).toHaveBeenCalledWith(BASE, input);
+  });
+
+  it('updates a flag with PATCH', async () => {
+    patchMock.mockResolvedValue({ data: { id: FLAG_ID, severity: 'CRITICAL' } });
+
+    await expect(updatePatientFlag(FLAG_ID, { severity: 'CRITICAL' })).resolves.toEqual({
+      id: FLAG_ID,
+      severity: 'CRITICAL',
+    });
+    expect(patchMock).toHaveBeenCalledWith(`${BASE}/${FLAG_ID}`, { severity: 'CRITICAL' });
+  });
+
+  it('resolves a flag with an empty request body', async () => {
+    postMock.mockResolvedValue({ data: { id: FLAG_ID, isActive: false } });
+
+    await expect(resolvePatientFlag(FLAG_ID)).resolves.toEqual({ id: FLAG_ID, isActive: false });
+    expect(postMock).toHaveBeenCalledWith(`${BASE}/${FLAG_ID}/resolve`, {});
+  });
+
+  it('rejects reserved characters in route ids before making a request', async () => {
+    mockOrgId = 'org/1';
+    await expect(fetchPatientFlags()).rejects.toThrow('Organisation ID must be a UUID');
+    await expect(
+      createPatientFlag({ patientId: 'p', flagType: 'OTHER', title: 'Note' })
+    ).rejects.toThrow('Organisation ID must be a UUID');
+
+    mockOrgId = ORG_ID;
+    await expect(fetchPatientFlag('f 1')).rejects.toThrow('Flag ID must be a UUID');
+    await expect(updatePatientFlag('../flag', { title: 'No' })).rejects.toThrow(
+      'Flag ID must be a UUID'
+    );
+    await expect(resolvePatientFlag('../flag')).rejects.toThrow('Flag ID must be a UUID');
+    expect(getMock).not.toHaveBeenCalled();
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when no organisation is selected', async () => {
+    mockOrgId = null;
+    await expect(fetchPatientFlags()).rejects.toThrow('No active organisation selected.');
+  });
+
+  it('logs an Axios error without a response using its message, then rethrows it', async () => {
+    const error = new AxiosError('offline');
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPatientFlags()).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load patient flags:', 'offline');
+  });
+
+  it('logs a server Axios error message without logging the response body', async () => {
+    const error = new AxiosError('request failed');
+    const responseData = { message: 'Unavailable', patientName: 'private' };
+    error.response = { data: responseData } as never;
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPatientFlags()).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load patient flags:', 'Unavailable');
+    expect(errorMock.mock.calls[0]).not.toContainEqual(responseData);
+  });
+
+  it('logs and rethrows a non-Axios error', async () => {
+    const error = new Error('raw');
+    postMock.mockRejectedValue(error);
+
+    await expect(createPatientFlag({ patientId: 'p', flagType: 'VIP', title: 'VIP' })).rejects.toBe(
+      error
+    );
+    expect(errorMock).toHaveBeenCalledWith('Failed to create patient flag:', error);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
@@ -134,6 +134,11 @@ jest.mock('@/app/features/companionHistory/components/AllergyListPanel', () => (
   default: ({ companionId }: any) => <div data-testid="allergy-list-panel">{companionId}</div>,
 }));
 
+jest.mock('@/app/features/companionHistory/components/FlagListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => <div data-testid="flag-list-panel">{companionId}</div>,
+}));
+
 jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
   useIsPhone: () => mockIsPhone,
   PHONE_MEDIA_QUERY: '(max-width: 767px)',
@@ -342,6 +347,7 @@ describe('CompanionHistoryPage', () => {
 
     expect(screen.getByTestId('timeline')).toHaveTextContent('c-1-true');
     expect(screen.getByTestId('allergy-list-panel')).toHaveTextContent('c-1');
+    expect(screen.getByTestId('flag-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByText("Buddy's overview")).toBeInTheDocument();
     expect(screen.getByText('Labrador / Canine')).toBeInTheDocument();
 

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FlagList from './FlagList';
+import type { PatientFlag } from '@/app/features/companionHistory/services/patientFlagService';
+
+const flag = (overrides: Partial<PatientFlag>): PatientFlag => ({
+  id: overrides.id ?? 'flag-1',
+  organisationId: 'org-1',
+  patientId: 'patient-1',
+  flagType: overrides.flagType ?? 'SPECIAL_HANDLING',
+  severity: overrides.severity ?? 'MEDIUM',
+  title: overrides.title ?? 'Patient flag',
+  description: overrides.description ?? null,
+  isActive: overrides.isActive ?? true,
+  createdBy: null,
+  resolvedAt: overrides.resolvedAt ?? null,
+  resolvedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...overrides,
+});
+
+const SAMPLE: PatientFlag[] = [
+  flag({
+    id: 'flag-1',
+    title: 'Use a muzzle',
+    flagType: 'AGGRESSION',
+    severity: 'CRITICAL',
+    description: 'Approach slowly and keep away from other dogs.',
+  }),
+  flag({
+    id: 'flag-2',
+    title: 'Keep both doors closed',
+    flagType: 'ESCAPE_RISK',
+    severity: 'HIGH',
+  }),
+  flag({
+    id: 'flag-3',
+    title: 'Needs a quiet room',
+    flagType: 'ANXIETY',
+    severity: 'MEDIUM',
+  }),
+  flag({
+    id: 'flag-4',
+    title: 'Isolation complete',
+    flagType: 'QUARANTINE',
+    severity: 'LOW',
+    isActive: false,
+    resolvedAt: '2026-02-02T00:00:00.000Z',
+  }),
+];
+
+const meta = {
+  title: 'CompanionHistory/FlagList',
+  component: FlagList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    flags: SAMPLE,
+    canEdit: true,
+    onCreate: async () => true,
+    onResolve: () => {},
+  },
+} satisfies Meta<typeof FlagList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {};
+
+export const ReadOnly: Story = {
+  args: { canEdit: false },
+};
+
+export const Empty: Story = {
+  args: { flags: [] },
+};
+
+export const Loading: Story = {
+  args: { flags: [], loading: true },
+};
+
+export const WithError: Story = {
+  args: { error: 'Could not load patient flags. Please try again.' },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { IoAddOutline, IoCheckmarkOutline, IoFlagOutline } from 'react-icons/io5';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import type {
+  FlagSeverity,
+  PatientFlag,
+  PatientFlagType,
+} from '@/app/features/companionHistory/services/patientFlagService';
+
+export type FlagFormValues = {
+  title: string;
+  flagType: PatientFlagType;
+  severity: FlagSeverity;
+  description: string;
+};
+
+export type FlagListProps = {
+  flags: PatientFlag[];
+  loading?: boolean;
+  error?: string | null;
+  canEdit?: boolean;
+  onCreate?: (values: FlagFormValues) => Promise<boolean> | boolean;
+  onResolve?: (flag: PatientFlag) => void;
+  creating?: boolean;
+  resolvingId?: string | null;
+};
+
+const TYPE_LABEL: Record<PatientFlagType, string> = {
+  AGGRESSION: 'Aggression risk',
+  ESCAPE_RISK: 'Escape risk',
+  ALLERGY_WARNING: 'Allergy warning',
+  ANXIETY: 'Anxiety',
+  SPECIAL_HANDLING: 'Special handling',
+  BILLING_NOTE: 'Billing note',
+  VIP: 'Priority patient',
+  QUARANTINE: 'Quarantine',
+  OTHER: 'Other',
+};
+
+const SEVERITY_LABEL: Record<FlagSeverity, string> = {
+  LOW: 'Low',
+  MEDIUM: 'Medium',
+  HIGH: 'High',
+  CRITICAL: 'Critical',
+};
+
+const SEVERITY_TONE: Record<FlagSeverity, StatusTone> = {
+  LOW: 'info',
+  MEDIUM: 'warning',
+  HIGH: 'danger',
+  CRITICAL: 'danger',
+};
+
+const TYPE_OPTIONS: PatientFlagType[] = [
+  'AGGRESSION',
+  'ESCAPE_RISK',
+  'ALLERGY_WARNING',
+  'ANXIETY',
+  'SPECIAL_HANDLING',
+  'BILLING_NOTE',
+  'VIP',
+  'QUARANTINE',
+  'OTHER',
+];
+const SEVERITY_OPTIONS: FlagSeverity[] = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+
+const cardClass =
+  'flex w-full flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
+const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
+const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
+const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
+const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
+const controlClass =
+  'w-full rounded-xl border border-[var(--hairline)] bg-[var(--screen)] px-3 py-2 text-[13px] text-[var(--ink)] outline-none focus:border-[var(--blue)]';
+
+const formatDate = (value: string | null): string | null => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+};
+
+const EmptyState = () => (
+  <p className="px-4 py-8 text-center text-[12.5px] text-[var(--ink-faint)]">
+    No active flags for this patient.
+  </p>
+);
+
+const LoadingRows = () => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((index) => (
+      <li key={index} className={rowClass}>
+        <span className="h-3.5 w-44 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);
+
+type FlagRowProps = {
+  flag: PatientFlag;
+  canEdit: boolean;
+  onResolve?: (flag: PatientFlag) => void;
+  resolving: boolean;
+};
+
+const FlagRow = ({ flag, canEdit, onResolve, resolving }: FlagRowProps) => {
+  const resolved = formatDate(flag.resolvedAt);
+  return (
+    <li className={rowClass}>
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block truncate')}>{flag.title}</span>
+        <span className={clsx(metaClass, 'mt-0.5 block')}>{TYPE_LABEL[flag.flagType]}</span>
+        {flag.description ? (
+          <span className={clsx(metaClass, 'mt-1 block line-clamp-2 text-[var(--ink-muted)]')}>
+            {flag.description}
+          </span>
+        ) : null}
+      </span>
+      <span className="flex shrink-0 flex-col items-end gap-2">
+        <span className="flex flex-wrap items-center justify-end gap-1.5">
+          <StatusPill label={SEVERITY_LABEL[flag.severity]} tone={SEVERITY_TONE[flag.severity]} />
+          <StatusPill
+            label={flag.isActive ? 'Active' : 'Resolved'}
+            tone={flag.isActive ? 'warning' : 'success'}
+          />
+        </span>
+        {flag.isActive && canEdit ? (
+          <Secondary
+            size="compact"
+            text={resolving ? 'Resolving…' : 'Resolve'}
+            icon={<IoCheckmarkOutline size={15} aria-hidden="true" />}
+            isDisabled={resolving}
+            onClick={() => onResolve?.(flag)}
+            ariaLabel={`Resolve ${flag.title}`}
+          />
+        ) : null}
+        {!flag.isActive && resolved ? <span className={metaClass}>Resolved {resolved}</span> : null}
+      </span>
+    </li>
+  );
+};
+
+const emptyForm: FlagFormValues = {
+  title: '',
+  flagType: 'SPECIAL_HANDLING',
+  severity: 'MEDIUM',
+  description: '',
+};
+
+type CreateFlagFormProps = {
+  creating: boolean;
+  onCreate?: NonNullable<FlagListProps['onCreate']>;
+  onCancel: () => void;
+};
+
+const CreateFlagForm = ({ creating, onCreate, onCancel }: CreateFlagFormProps) => {
+  const [values, setValues] = useState<FlagFormValues>(emptyForm);
+  const trimmedTitle = values.title.trim();
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!trimmedTitle || creating) return;
+    const saved = await onCreate?.({ ...values, title: trimmedTitle });
+    if (saved) {
+      setValues(emptyForm);
+      onCancel();
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-3 border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-4"
+      onSubmit={handleSubmit}
+    >
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="patient-flag-title">
+          Flag title
+        </label>
+        <input
+          id="patient-flag-title"
+          className={controlClass}
+          value={values.title}
+          onChange={(event) => setValues((current) => ({ ...current, title: event.target.value }))}
+          maxLength={200}
+          required
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <label className={fieldLabelClass} htmlFor="patient-flag-type">
+            Flag type
+          </label>
+          <select
+            id="patient-flag-type"
+            className={controlClass}
+            value={values.flagType}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                flagType: event.target.value as PatientFlagType,
+              }))
+            }
+          >
+            {TYPE_OPTIONS.map((type) => (
+              <option key={type} value={type}>
+                {TYPE_LABEL[type]}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className={fieldLabelClass} htmlFor="patient-flag-severity">
+            Severity
+          </label>
+          <select
+            id="patient-flag-severity"
+            className={controlClass}
+            value={values.severity}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                severity: event.target.value as FlagSeverity,
+              }))
+            }
+          >
+            {SEVERITY_OPTIONS.map((severity) => (
+              <option key={severity} value={severity}>
+                {SEVERITY_LABEL[severity]}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="patient-flag-description">
+          Description
+        </label>
+        <textarea
+          id="patient-flag-description"
+          className={clsx(controlClass, 'min-h-16 resize-y')}
+          value={values.description}
+          onChange={(event) =>
+            setValues((current) => ({ ...current, description: event.target.value }))
+          }
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Secondary size="compact" text="Cancel" onClick={onCancel} />
+        <Primary
+          size="compact"
+          type="submit"
+          text="Save flag"
+          isDisabled={!trimmedTitle || creating}
+        />
+      </div>
+    </form>
+  );
+};
+
+const FlagList = ({
+  flags,
+  loading = false,
+  error = null,
+  canEdit = false,
+  onCreate,
+  onResolve,
+  creating = false,
+  resolvingId = null,
+}: FlagListProps) => {
+  const [showForm, setShowForm] = useState(false);
+  const activeCount = useMemo(() => flags.filter((flag) => flag.isActive).length, [flags]);
+
+  const body = (() => {
+    if (loading) return <LoadingRows />;
+    if (flags.length === 0) return <EmptyState />;
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {flags.map((flag) => (
+          <FlagRow
+            key={flag.id}
+            flag={flag}
+            canEdit={canEdit}
+            onResolve={onResolve}
+            resolving={resolvingId === flag.id}
+          />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <section className={cardClass} aria-labelledby="patient-flag-list-heading">
+      <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+        <span className="text-[var(--ink-muted)]" aria-hidden="true">
+          <IoFlagOutline size={18} />
+        </span>
+        <h3 id="patient-flag-list-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+          Patient flags
+        </h3>
+        {!loading && activeCount > 0 ? (
+          <StatusPill
+            label={`${activeCount} active`}
+            tone="warning"
+            className="ml-2 tabular-nums"
+          />
+        ) : null}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() => setShowForm((current) => !current)}
+            aria-expanded={showForm}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-[var(--hairline)] px-3 py-1.5 text-[12px] font-semibold text-[var(--ink-soft)] transition-colors hover:bg-[var(--inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blue)]"
+          >
+            <IoAddOutline size={15} aria-hidden="true" />
+            {showForm ? 'Close' : 'Add flag'}
+          </button>
+        ) : null}
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mx-4 mt-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {showForm && canEdit ? (
+        <CreateFlagForm
+          creating={creating}
+          onCreate={onCreate}
+          onCancel={() => setShowForm(false)}
+        />
+      ) : null}
+
+      {body}
+    </section>
+  );
+};
+
+export default FlagList;

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { isAuthRedirectError } from '@/app/services/axios';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import FlagList, { type FlagFormValues } from './FlagList';
+import {
+  createPatientFlag,
+  fetchPatientFlags,
+  resolvePatientFlag,
+  type CreatePatientFlagInput,
+  type PatientFlag,
+} from '@/app/features/companionHistory/services/patientFlagService';
+
+export type FlagListPanelProps = {
+  companionId: string;
+};
+
+const LOAD_ERROR = 'Could not load patient flags. Please try again.';
+
+const FlagListPanel = ({ companionId }: FlagListPanelProps) => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
+  const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
+  const { notify } = useNotify();
+  const [flags, setFlags] = useState<PatientFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  const [loadedFor, setLoadedFor] = useState(companionId);
+  if (companionId !== loadedFor) {
+    setLoadedFor(companionId);
+    setFlags([]);
+    setError(null);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!canView || !companionId) return;
+    let active = true;
+    fetchPatientFlags({ patientId: companionId, isActive: true })
+      .then((nextFlags) => {
+        if (active) setFlags(nextFlags);
+      })
+      .catch((requestError) => {
+        if (active && !isAuthRedirectError(requestError)) setError(LOAD_ERROR);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [canView, companionId]);
+
+  const handleCreate = useCallback(
+    async (values: FlagFormValues): Promise<boolean> => {
+      if (!companionId) return false;
+      setCreating(true);
+      try {
+        const input: CreatePatientFlagInput = {
+          patientId: companionId,
+          title: values.title,
+          flagType: values.flagType,
+          severity: values.severity,
+          ...(values.description.trim() ? { description: values.description.trim() } : {}),
+        };
+        await createPatientFlag(input);
+        const refreshed = await fetchPatientFlags({ patientId: companionId, isActive: true });
+        setFlags(refreshed);
+        setError(null);
+        notify('success', {
+          title: 'Flag added',
+          text: `${values.title} was added to the patient flags.`,
+        });
+        return true;
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not add flag', text: 'Please try again.' });
+        }
+        return false;
+      } finally {
+        setCreating(false);
+      }
+    },
+    [companionId, notify]
+  );
+
+  const handleResolve = useCallback(
+    async (flag: PatientFlag): Promise<void> => {
+      setResolvingId(flag.id);
+      try {
+        await resolvePatientFlag(flag.id);
+        setFlags((current) => current.filter((item) => item.id !== flag.id));
+        notify('success', {
+          title: 'Flag resolved',
+          text: `${flag.title} was removed from the active flags.`,
+        });
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not resolve flag', text: 'Please try again.' });
+        }
+      } finally {
+        setResolvingId(null);
+      }
+    },
+    [notify]
+  );
+
+  if (!canView) return null;
+
+  return (
+    <FlagList
+      flags={flags}
+      loading={loading}
+      error={error}
+      canEdit={canEdit}
+      onCreate={handleCreate}
+      onResolve={handleResolve}
+      creating={creating}
+      resolvingId={resolvingId}
+    />
+  );
+};
+
+export default FlagListPanel;

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.tsx
@@ -1,115 +1,22 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { isAuthRedirectError } from '@/app/services/axios';
-import { usePermissions } from '@/app/hooks/usePermissions';
-import { PERMISSIONS } from '@/app/lib/permissions';
-import { useNotify } from '@/app/hooks/useNotify';
-import FlagList, { type FlagFormValues } from './FlagList';
-import {
-  createPatientFlag,
-  fetchPatientFlags,
-  resolvePatientFlag,
-  type CreatePatientFlagInput,
-  type PatientFlag,
-} from '@/app/features/companionHistory/services/patientFlagService';
+import React from 'react';
+import FlagList from '@/app/features/companionHistory/components/FlagList';
+import { usePatientFlags } from '@/app/features/companionHistory/components/usePatientFlags';
 
 export type FlagListPanelProps = {
+  /** The companion (patient) whose flags to load. `companionId === patientId`. */
   companionId: string;
 };
 
-const LOAD_ERROR = 'Could not load patient flags. Please try again.';
-
+/**
+ * Data container for {@link FlagList}. All state lives in
+ * {@link usePatientFlags}; this projects it onto the presentational list and
+ * renders nothing when the member cannot view flags.
+ */
 const FlagListPanel = ({ companionId }: FlagListPanelProps) => {
-  const permissions = usePermissions();
-  const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
-  const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
-  const { notify } = useNotify();
-  const [flags, setFlags] = useState<PatientFlag[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [resolvingId, setResolvingId] = useState<string | null>(null);
-
-  const [loadedFor, setLoadedFor] = useState(companionId);
-  if (companionId !== loadedFor) {
-    setLoadedFor(companionId);
-    setFlags([]);
-    setError(null);
-    setLoading(true);
-  }
-
-  useEffect(() => {
-    if (!canView || !companionId) return;
-    let active = true;
-    fetchPatientFlags({ patientId: companionId, isActive: true })
-      .then((nextFlags) => {
-        if (active) setFlags(nextFlags);
-      })
-      .catch((requestError) => {
-        if (active && !isAuthRedirectError(requestError)) setError(LOAD_ERROR);
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, [canView, companionId]);
-
-  const handleCreate = useCallback(
-    async (values: FlagFormValues): Promise<boolean> => {
-      if (!companionId) return false;
-      setCreating(true);
-      try {
-        const input: CreatePatientFlagInput = {
-          patientId: companionId,
-          title: values.title,
-          flagType: values.flagType,
-          severity: values.severity,
-          ...(values.description.trim() ? { description: values.description.trim() } : {}),
-        };
-        await createPatientFlag(input);
-        const refreshed = await fetchPatientFlags({ patientId: companionId, isActive: true });
-        setFlags(refreshed);
-        setError(null);
-        notify('success', {
-          title: 'Flag added',
-          text: `${values.title} was added to the patient flags.`,
-        });
-        return true;
-      } catch (requestError) {
-        if (!isAuthRedirectError(requestError)) {
-          notify('error', { title: 'Could not add flag', text: 'Please try again.' });
-        }
-        return false;
-      } finally {
-        setCreating(false);
-      }
-    },
-    [companionId, notify]
-  );
-
-  const handleResolve = useCallback(
-    async (flag: PatientFlag): Promise<void> => {
-      setResolvingId(flag.id);
-      try {
-        await resolvePatientFlag(flag.id);
-        setFlags((current) => current.filter((item) => item.id !== flag.id));
-        notify('success', {
-          title: 'Flag resolved',
-          text: `${flag.title} was removed from the active flags.`,
-        });
-      } catch (requestError) {
-        if (!isAuthRedirectError(requestError)) {
-          notify('error', { title: 'Could not resolve flag', text: 'Please try again.' });
-        }
-      } finally {
-        setResolvingId(null);
-      }
-    },
-    [notify]
-  );
+  const { canView, canEdit, flags, loading, error, creating, resolvingId, create, resolve } =
+    usePatientFlags(companionId);
 
   if (!canView) return null;
 
@@ -119,8 +26,8 @@ const FlagListPanel = ({ companionId }: FlagListPanelProps) => {
       loading={loading}
       error={error}
       canEdit={canEdit}
-      onCreate={handleCreate}
-      onResolve={handleResolve}
+      onCreate={create}
+      onResolve={resolve}
       creating={creating}
       resolvingId={resolvingId}
     />

--- a/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
+++ b/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { isAuthRedirectError } from '@/app/services/axios';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import type { FlagFormValues } from '@/app/features/companionHistory/components/FlagList';
+import {
+  createPatientFlag,
+  fetchPatientFlags,
+  resolvePatientFlag,
+  type CreatePatientFlagInput,
+  type PatientFlag,
+} from '@/app/features/companionHistory/services/patientFlagService';
+
+const LOAD_ERROR = 'Could not load patient flags. Please try again.';
+
+export type PatientFlagsState = {
+  /** The backend gates the list on `companions:view:any`. */
+  canView: boolean;
+  /** Create and resolve need `companions:edit:any`. */
+  canEdit: boolean;
+  flags: PatientFlag[];
+  loading: boolean;
+  error: string | null;
+  creating: boolean;
+  resolvingId: string | null;
+  create: (values: FlagFormValues) => Promise<boolean>;
+  resolve: (flag: PatientFlag) => Promise<void>;
+};
+
+/**
+ * All of the flag panel's state: it loads a companion's active flags, exposes
+ * the create and resolve actions, and reports the caller's permissions. Kept out
+ * of the component so the panel is a thin projection onto the presentational
+ * list.
+ */
+export const usePatientFlags = (companionId: string): PatientFlagsState => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
+  const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
+  const { notify } = useNotify();
+
+  const [flags, setFlags] = useState<PatientFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  // Reset to a loading state when the companion changes, adjusting state during
+  // render rather than synchronously inside an effect. `loadedFor` tracks which
+  // companion the current state belongs to.
+  const [loadedFor, setLoadedFor] = useState(companionId);
+  if (companionId !== loadedFor) {
+    setLoadedFor(companionId);
+    setFlags([]);
+    setError(null);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!canView || !companionId) return;
+    let active = true;
+    fetchPatientFlags({ patientId: companionId, isActive: true })
+      .then((nextFlags) => {
+        if (active) setFlags(nextFlags);
+      })
+      .catch((requestError) => {
+        if (active && !isAuthRedirectError(requestError)) setError(LOAD_ERROR);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [canView, companionId]);
+
+  const create = useCallback(
+    async (values: FlagFormValues): Promise<boolean> => {
+      if (!companionId) return false;
+      setCreating(true);
+      try {
+        const input: CreatePatientFlagInput = {
+          patientId: companionId,
+          title: values.title,
+          flagType: values.flagType,
+          severity: values.severity,
+          ...(values.description.trim() ? { description: values.description.trim() } : {}),
+        };
+        await createPatientFlag(input);
+        const refreshed = await fetchPatientFlags({ patientId: companionId, isActive: true });
+        setFlags(refreshed);
+        setError(null);
+        notify('success', {
+          title: 'Flag added',
+          text: `${values.title} was added to the patient flags.`,
+        });
+        return true;
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not add flag', text: 'Please try again.' });
+        }
+        return false;
+      } finally {
+        setCreating(false);
+      }
+    },
+    [companionId, notify]
+  );
+
+  const resolve = useCallback(
+    async (flag: PatientFlag): Promise<void> => {
+      setResolvingId(flag.id);
+      try {
+        await resolvePatientFlag(flag.id);
+        setFlags((current) => current.filter((item) => item.id !== flag.id));
+        notify('success', {
+          title: 'Flag resolved',
+          text: `${flag.title} was removed from the active flags.`,
+        });
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not resolve flag', text: 'Please try again.' });
+        }
+      } finally {
+        setResolvingId(null);
+      }
+    },
+    [notify]
+  );
+
+  return { canView, canEdit, flags, loading, error, creating, resolvingId, create, resolve };
+};

--- a/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
+++ b/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
@@ -16,28 +16,18 @@ import {
 
 const LOAD_ERROR = 'Could not load patient flags. Please try again.';
 
-export type PatientFlagsState = {
-  /** The backend gates the list on `companions:view:any`. */
-  canView: boolean;
-  /** Create and resolve need `companions:edit:any`. */
-  canEdit: boolean;
-  flags: PatientFlag[];
-  loading: boolean;
-  error: string | null;
-  creating: boolean;
-  resolvingId: string | null;
-  create: (values: FlagFormValues) => Promise<boolean>;
-  resolve: (flag: PatientFlag) => Promise<void>;
-};
+type SetFlags = Dispatch<SetStateAction<PatientFlag[]>>;
+type SetError = Dispatch<SetStateAction<string | null>>;
 
-type FlagSetter = Dispatch<SetStateAction<PatientFlag[]>>;
-
-const useActivePatientFlags = (companionId: string, canView: boolean) => {
+/** Loads a companion's active flags and resets to a loading state when the companion changes. */
+const useFlagRecords = (companionId: string, canView: boolean) => {
   const [flags, setFlags] = useState<PatientFlag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [loadedFor, setLoadedFor] = useState(companionId);
 
+  // Reset during render (React's recommended pattern) rather than in an effect;
+  // `loadedFor` tracks which companion the current state belongs to.
+  const [loadedFor, setLoadedFor] = useState(companionId);
   if (companionId !== loadedFor) {
     setLoadedFor(companionId);
     setFlags([]);
@@ -63,14 +53,11 @@ const useActivePatientFlags = (companionId: string, canView: boolean) => {
     };
   }, [canView, companionId]);
 
-  return { flags, setFlags, loading, error, setError };
+  return { flags, loading, error, setFlags, setError };
 };
 
-const useCreateFlag = (
-  companionId: string,
-  setFlags: FlagSetter,
-  setError: Dispatch<SetStateAction<string | null>>
-) => {
+/** The create action and its in-flight flag; refreshes the list from the server on success. */
+const useCreateFlag = (companionId: string, setFlags: SetFlags, setError: SetError) => {
   const { notify } = useNotify();
   const [creating, setCreating] = useState(false);
   const create = useCallback(
@@ -104,10 +91,11 @@ const useCreateFlag = (
     },
     [companionId, notify, setError, setFlags]
   );
-  return { creating, create };
+  return { create, creating };
 };
 
-const useResolveFlag = (setFlags: FlagSetter) => {
+/** The resolve action and the id it is resolving; drops the flag from the active list on success. */
+const useResolveFlag = (setFlags: SetFlags) => {
   const { notify } = useNotify();
   const [resolvingId, setResolvingId] = useState<string | null>(null);
   const resolve = useCallback(
@@ -130,22 +118,36 @@ const useResolveFlag = (setFlags: FlagSetter) => {
     },
     [notify, setFlags]
   );
-  return { resolvingId, resolve };
+  return { resolve, resolvingId };
+};
+
+export type PatientFlagsState = {
+  /** The backend gates the list on `companions:view:any`. */
+  canView: boolean;
+  /** Create and resolve need `companions:edit:any`. */
+  canEdit: boolean;
+  flags: PatientFlag[];
+  loading: boolean;
+  error: string | null;
+  creating: boolean;
+  resolvingId: string | null;
+  create: (values: FlagFormValues) => Promise<boolean>;
+  resolve: (flag: PatientFlag) => Promise<void>;
 };
 
 /**
- * All of the flag panel's state: it loads a companion's active flags, exposes
- * the create and resolve actions, and reports the caller's permissions. Kept out
- * of the component so the panel is a thin projection onto the presentational
- * list.
+ * Composes the flag panel's state from three focused sub-hooks - records,
+ * create and resolve - so no single function owns loading, mutation and
+ * notification at once. The panel is a thin projection over what this returns.
  */
 export const usePatientFlags = (companionId: string): PatientFlagsState => {
   const permissions = usePermissions();
   const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
   const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
-  const { flags, setFlags, loading, error, setError } = useActivePatientFlags(companionId, canView);
-  const { creating, create } = useCreateFlag(companionId, setFlags, setError);
-  const { resolvingId, resolve } = useResolveFlag(setFlags);
+
+  const { flags, loading, error, setFlags, setError } = useFlagRecords(companionId, canView);
+  const { create, creating } = useCreateFlag(companionId, setFlags, setError);
+  const { resolve, resolvingId } = useResolveFlag(setFlags);
 
   return { canView, canEdit, flags, loading, error, creating, resolvingId, create, resolve };
 };

--- a/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
+++ b/apps/frontend/src/app/features/companionHistory/components/usePatientFlags.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 import { isAuthRedirectError } from '@/app/services/axios';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
@@ -30,28 +30,14 @@ export type PatientFlagsState = {
   resolve: (flag: PatientFlag) => Promise<void>;
 };
 
-/**
- * All of the flag panel's state: it loads a companion's active flags, exposes
- * the create and resolve actions, and reports the caller's permissions. Kept out
- * of the component so the panel is a thin projection onto the presentational
- * list.
- */
-export const usePatientFlags = (companionId: string): PatientFlagsState => {
-  const permissions = usePermissions();
-  const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
-  const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
-  const { notify } = useNotify();
+type FlagSetter = Dispatch<SetStateAction<PatientFlag[]>>;
 
+const useActivePatientFlags = (companionId: string, canView: boolean) => {
   const [flags, setFlags] = useState<PatientFlag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [resolvingId, setResolvingId] = useState<string | null>(null);
-
-  // Reset to a loading state when the companion changes, adjusting state during
-  // render rather than synchronously inside an effect. `loadedFor` tracks which
-  // companion the current state belongs to.
   const [loadedFor, setLoadedFor] = useState(companionId);
+
   if (companionId !== loadedFor) {
     setLoadedFor(companionId);
     setFlags([]);
@@ -77,6 +63,16 @@ export const usePatientFlags = (companionId: string): PatientFlagsState => {
     };
   }, [canView, companionId]);
 
+  return { flags, setFlags, loading, error, setError };
+};
+
+const useCreateFlag = (
+  companionId: string,
+  setFlags: FlagSetter,
+  setError: Dispatch<SetStateAction<string | null>>
+) => {
+  const { notify } = useNotify();
+  const [creating, setCreating] = useState(false);
   const create = useCallback(
     async (values: FlagFormValues): Promise<boolean> => {
       if (!companionId) return false;
@@ -90,8 +86,7 @@ export const usePatientFlags = (companionId: string): PatientFlagsState => {
           ...(values.description.trim() ? { description: values.description.trim() } : {}),
         };
         await createPatientFlag(input);
-        const refreshed = await fetchPatientFlags({ patientId: companionId, isActive: true });
-        setFlags(refreshed);
+        setFlags(await fetchPatientFlags({ patientId: companionId, isActive: true }));
         setError(null);
         notify('success', {
           title: 'Flag added',
@@ -107,9 +102,14 @@ export const usePatientFlags = (companionId: string): PatientFlagsState => {
         setCreating(false);
       }
     },
-    [companionId, notify]
+    [companionId, notify, setError, setFlags]
   );
+  return { creating, create };
+};
 
+const useResolveFlag = (setFlags: FlagSetter) => {
+  const { notify } = useNotify();
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
   const resolve = useCallback(
     async (flag: PatientFlag): Promise<void> => {
       setResolvingId(flag.id);
@@ -128,8 +128,24 @@ export const usePatientFlags = (companionId: string): PatientFlagsState => {
         setResolvingId(null);
       }
     },
-    [notify]
+    [notify, setFlags]
   );
+  return { resolvingId, resolve };
+};
+
+/**
+ * All of the flag panel's state: it loads a companion's active flags, exposes
+ * the create and resolve actions, and reports the caller's permissions. Kept out
+ * of the component so the panel is a thin projection onto the presentational
+ * list.
+ */
+export const usePatientFlags = (companionId: string): PatientFlagsState => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.COMPANIONS_VIEW_ANY);
+  const canEdit = permissions.can(PERMISSIONS.COMPANIONS_EDIT_ANY);
+  const { flags, setFlags, loading, error, setError } = useActivePatientFlags(companionId, canView);
+  const { creating, create } = useCreateFlag(companionId, setFlags, setError);
+  const { resolvingId, resolve } = useResolveFlag(setFlags);
 
   return { canView, canEdit, flags, loading, error, creating, resolvingId, create, resolve };
 };

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -57,6 +57,7 @@ import { useNotify } from '@/app/hooks/useNotify';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import AllergyListPanel from '@/app/features/companionHistory/components/AllergyListPanel';
+import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
 import { isCompanionRevampEnabled } from '@/app/lib/featureFlags';
 import ShareCompanionCardModal from '@/app/features/companionCard/components/ShareCompanionCardModal';
 import { buildStaffCard } from '@/app/features/companionCard/lib/buildStaffCard';
@@ -700,6 +701,11 @@ const CompanionHistoryDesktopBody = ({
     {hasCompanionId ? (
       <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
         <AllergyListPanel companionId={companionId} />
+      </PermissionGate>
+    ) : null}
+    {hasCompanionId ? (
+      <PermissionGate allOf={[PERMISSIONS.COMPANIONS_VIEW_ANY]}>
+        <FlagListPanel companionId={companionId} />
       </PermissionGate>
     ) : null}
 

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -16,6 +16,7 @@ import {
 import CompanionHistoryTimeline from '@/app/features/companionHistory/components/CompanionHistoryTimeline';
 import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
 import AllergyListPanel from '@/app/features/companionHistory/components/AllergyListPanel';
+import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
 import PermissionGate from '@/app/ui/layout/guards/PermissionGate';
 import AlertPill from '@/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill';
 import type { CompanionAlert } from '@/app/features/appointments/types/workspace';
@@ -413,6 +414,10 @@ const PhoneCompanionRecord = ({
         <ProblemListPanel companionId={companionId} />
         <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
           <AllergyListPanel companionId={companionId} />
+        </PermissionGate>
+
+        <PermissionGate allOf={[PERMISSIONS.COMPANIONS_VIEW_ANY]}>
+          <FlagListPanel companionId={companionId} />
         </PermissionGate>
 
         <CompanionHistoryTimeline

--- a/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
@@ -1,0 +1,149 @@
+import axios from 'axios';
+import { getData, patchData, postData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const UUID_PATH_SEGMENT =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type PatientFlagType =
+  | 'AGGRESSION'
+  | 'ESCAPE_RISK'
+  | 'ALLERGY_WARNING'
+  | 'ANXIETY'
+  | 'SPECIAL_HANDLING'
+  | 'BILLING_NOTE'
+  | 'VIP'
+  | 'QUARANTINE'
+  | 'OTHER';
+
+export type FlagSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export type PatientFlag = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  flagType: PatientFlagType;
+  severity: FlagSeverity;
+  title: string;
+  description: string | null;
+  isActive: boolean;
+  createdBy: string | null;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreatePatientFlagInput = {
+  patientId: string;
+  flagType: PatientFlagType;
+  severity?: FlagSeverity;
+  title: string;
+  description?: string;
+};
+
+export type UpdatePatientFlagInput = {
+  flagType?: PatientFlagType;
+  severity?: FlagSeverity;
+  title?: string;
+  description?: string;
+};
+
+export type FetchPatientFlagsParams = {
+  patientId?: string;
+  flagType?: PatientFlagType;
+  severity?: FlagSeverity;
+  isActive?: boolean;
+};
+
+const requireOrgId = (): string => {
+  const orgId = useOrgStore.getState().primaryOrgId;
+  if (!orgId) throw new Error('No active organisation selected.');
+  if (!UUID_PATH_SEGMENT.test(orgId)) throw new Error('Organisation ID must be a UUID');
+  return orgId;
+};
+
+const requestWithLog = async <T>(message: string, request: () => Promise<T>): Promise<T> => {
+  try {
+    return await request();
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      logger.error(message, error.response?.data?.message ?? error.message);
+    } else {
+      logger.error(message, error);
+    }
+    throw error;
+  }
+};
+
+export const fetchPatientFlags = async (
+  filters: FetchPatientFlagsParams = {}
+): Promise<PatientFlag[]> => {
+  const orgId = requireOrgId();
+  return requestWithLog('Failed to load patient flags:', async () => {
+    const params: Record<string, string | boolean> = {};
+    if (filters.patientId) params.patientId = filters.patientId;
+    if (filters.flagType) params.flagType = filters.flagType;
+    if (filters.severity) params.severity = filters.severity;
+    if (filters.isActive !== undefined) params.isActive = filters.isActive;
+    const response = await getData<PatientFlag[]>(
+      '/v1/pms/organisation/' + orgId + '/patient-flags',
+      params
+    );
+    if (!Array.isArray(response.data)) {
+      logger.warn('patient-flags list was not an array; got', typeof response.data);
+      return [];
+    }
+    return response.data;
+  });
+};
+
+export const fetchPatientFlag = async (flagId: string): Promise<PatientFlag> => {
+  const orgId = requireOrgId();
+  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  return requestWithLog('Failed to load patient flag:', async () => {
+    const response = await getData<PatientFlag>(
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId
+    );
+    return response.data;
+  });
+};
+
+export const createPatientFlag = async (input: CreatePatientFlagInput): Promise<PatientFlag> => {
+  const orgId = requireOrgId();
+  return requestWithLog('Failed to create patient flag:', async () => {
+    const response = await postData<PatientFlag, CreatePatientFlagInput>(
+      '/v1/pms/organisation/' + orgId + '/patient-flags',
+      input
+    );
+    return response.data;
+  });
+};
+
+export const updatePatientFlag = async (
+  flagId: string,
+  input: UpdatePatientFlagInput
+): Promise<PatientFlag> => {
+  const orgId = requireOrgId();
+  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  return requestWithLog('Failed to update patient flag:', async () => {
+    const response = await patchData<PatientFlag, UpdatePatientFlagInput>(
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId,
+      input
+    );
+    return response.data;
+  });
+};
+
+export const resolvePatientFlag = async (flagId: string): Promise<PatientFlag> => {
+  const orgId = requireOrgId();
+  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  return requestWithLog('Failed to resolve patient flag:', async () => {
+    const response = await postData<PatientFlag>(
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId + '/resolve',
+      {}
+    );
+    return response.data;
+  });
+};

--- a/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
@@ -64,6 +64,12 @@ const requireOrgId = (): string => {
   return orgId;
 };
 
+/** Validates a flag id before it becomes a path segment, mirroring requireOrgId. */
+const requireFlagId = (flagId: string): string => {
+  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  return flagId;
+};
+
 const requestWithLog = async <T>(message: string, request: () => Promise<T>): Promise<T> => {
   try {
     return await request();
@@ -101,10 +107,10 @@ export const fetchPatientFlags = async (
 
 export const fetchPatientFlag = async (flagId: string): Promise<PatientFlag> => {
   const orgId = requireOrgId();
-  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  const safeFlagId = requireFlagId(flagId);
   return requestWithLog('Failed to load patient flag:', async () => {
     const response = await getData<PatientFlag>(
-      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + safeFlagId
     );
     return response.data;
   });
@@ -126,10 +132,10 @@ export const updatePatientFlag = async (
   input: UpdatePatientFlagInput
 ): Promise<PatientFlag> => {
   const orgId = requireOrgId();
-  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  const safeFlagId = requireFlagId(flagId);
   return requestWithLog('Failed to update patient flag:', async () => {
     const response = await patchData<PatientFlag, UpdatePatientFlagInput>(
-      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId,
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + safeFlagId,
       input
     );
     return response.data;
@@ -138,10 +144,10 @@ export const updatePatientFlag = async (
 
 export const resolvePatientFlag = async (flagId: string): Promise<PatientFlag> => {
   const orgId = requireOrgId();
-  if (!UUID_PATH_SEGMENT.test(flagId)) throw new Error('Flag ID must be a UUID');
+  const safeFlagId = requireFlagId(flagId);
   return requestWithLog('Failed to resolve patient flag:', async () => {
     const response = await postData<PatientFlag>(
-      '/v1/pms/organisation/' + orgId + '/patient-flags/' + flagId + '/resolve',
+      '/v1/pms/organisation/' + orgId + '/patient-flags/' + safeFlagId + '/resolve',
       {}
     );
     return response.data;

--- a/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/patientFlagService.ts
@@ -70,18 +70,15 @@ const requireFlagId = (flagId: string): string => {
   return flagId;
 };
 
-const requestWithLog = async <T>(message: string, request: () => Promise<T>): Promise<T> => {
-  try {
-    return await request();
-  } catch (error) {
+const requestWithLog = <T>(message: string, request: () => Promise<T>): Promise<T> =>
+  request().catch((error: unknown) => {
     if (axios.isAxiosError(error)) {
       logger.error(message, error.response?.data?.message ?? error.message);
     } else {
       logger.error(message, error);
     }
     throw error;
-  }
-};
+  });
 
 export const fetchPatientFlags = async (
   filters: FetchPatientFlagsParams = {}


### PR DESCRIPTION
## What changed

Wires the already-built **patient-flag** backend into the companion clinical record. New frontend surface:

- `patientFlagService.ts` — list / get / create / update (PATCH) / resolve against `/v1/pms/organisation/:organisationId/patient-flags`.
- `FlagList.tsx` — presentational list + create form (type, severity, title, description).
- `FlagListPanel.tsx` — data container.
- `FlagList.stories.tsx` — Storybook coverage.
- Rendered in `CompanionHistoryPage` and the phone `PhoneCompanionRecord`, behind a companions-view permission gate, shown only when a companion is in context.

## Why

The backend (`patient-flag.router.ts`, `PatientFlag` model) had no UI. Flags are handling/safety indicators — aggression, escape risk, allergy warning, quarantine, VIP — that belong in the patient record; CRITICAL renders in the danger tone.

## Impact area

`apps/frontend` — `features/companionHistory` only. No backend changes.

## Validation performed

- `npx tsc --noEmit` — 0 errors.
- `eslint` on all changed files — clean.
- `jest --testPathPatterns="Flag|CompanionHistory|PhoneCompanionRecord"` — 18 suites, 312 tests pass.
- Service, panel and component each have their own tests; the page suites stub the panel so the strict console-error guard stays satisfied.
- Path ids are validated against a canonical-UUID pattern before any request, so an id can never reshape the request URL.