### PR TITLE
feat(frontend): surface the patient check-in board

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoard.test.tsx
@@ -127,11 +127,27 @@ describe('CheckInBoard', () => {
   });
 
   it('renders no row actions for a terminal (completed) entry', () => {
-    render(<CheckInBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} {...handlers()} />);
+    // `showAll` so the completed row actually renders - without it the board
+    // filters terminal statuses out and the assertions below would pass for the
+    // wrong reason.
+    render(<CheckInBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} showAll {...handlers()} />);
 
+    expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('hides terminal statuses unless showing all', () => {
+    const entries = [row('1', 'WAITING', 'STANDARD'), row('2', 'COMPLETED', 'STANDARD')];
+    const { rerender } = render(<CheckInBoard entries={entries} {...handlers()} />);
+
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+
+    rerender(<CheckInBoard entries={entries} showAll {...handlers()} />);
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
   });
 
   it('invokes the seen handler with the entry id', async () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoard.test.tsx
@@ -1,0 +1,418 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import CheckInBoard, {
+  type PatientCheckInView,
+} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
+import type {
+  CheckInStatus,
+  TriagePriority,
+} from '@/app/features/appointments/services/patientCheckInService';
+
+const row = (
+  id: string,
+  status: CheckInStatus,
+  triagePriority: TriagePriority,
+  overrides: Partial<PatientCheckInView> = {}
+): PatientCheckInView => ({
+  id,
+  organisationId: 'org-1',
+  patientId: `patient-${id}`,
+  clientId: `client-${id}`,
+  appointmentId: null,
+  arrivedAt: '2026-09-05T08:00:00.000Z',
+  triagePriority,
+  triageNote: null,
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: '2026-09-05T08:00:00.000Z',
+  seenAt: null,
+  waitMinutes: 15,
+  status,
+  notes: null,
+  createdAt: '2026-09-05T08:00:00.000Z',
+  updatedAt: '2026-09-05T08:00:00.000Z',
+  companionName: `Companion ${id}`,
+  ownerName: `Owner ${id}`,
+  ...overrides,
+});
+
+const handlers = () => ({
+  onSeen: jest.fn(),
+  onComplete: jest.fn(),
+  onCancel: jest.fn(),
+  onNoShow: jest.fn(),
+  onAssignRoom: jest.fn(),
+  onAdd: jest.fn(async () => true),
+  onToggleShowAll: jest.fn(),
+});
+
+describe('CheckInBoard', () => {
+  it('renders each row with a triage pill, status pill and patient + owner', () => {
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD'), row('2', 'IN_CONSULTATION', 'URGENT')]}
+        {...handlers()}
+      />
+    );
+
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+    expect(screen.getByText('In consultation')).toBeInTheDocument();
+    expect(screen.getByText('Standard')).toBeInTheDocument();
+    expect(screen.getByText('Urgent')).toBeInTheDocument();
+    expect(screen.getByText('Companion 1')).toBeInTheDocument();
+    expect(screen.getByText('Owner 1')).toBeInTheDocument();
+  });
+
+  it('sorts rows by triage priority then arrival, most urgent first', () => {
+    render(
+      <CheckInBoard
+        entries={[
+          row('std', 'WAITING', 'STANDARD', {
+            companionName: 'Standard Pet',
+            arrivedAt: '2026-09-05T07:00:00.000Z',
+          }),
+          row('imm', 'WAITING', 'IMMEDIATE', {
+            companionName: 'Immediate Pet',
+            arrivedAt: '2026-09-05T09:00:00.000Z',
+          }),
+          row('urg', 'WAITING', 'URGENT', { companionName: 'Urgent Pet' }),
+        ]}
+        {...handlers()}
+      />
+    );
+
+    const names = screen
+      .getAllByText(/Immediate Pet|Urgent Pet|Standard Pet/)
+      .map((el) => el.textContent);
+    expect(names).toEqual(['Immediate Pet', 'Urgent Pet', 'Standard Pet']);
+  });
+
+  it('breaks a triage tie by earliest arrival', () => {
+    render(
+      <CheckInBoard
+        entries={[
+          row('late', 'WAITING', 'STANDARD', {
+            companionName: 'Late Pet',
+            arrivedAt: '2026-09-05T10:00:00.000Z',
+          }),
+          row('early', 'WAITING', 'STANDARD', {
+            companionName: 'Early Pet',
+            arrivedAt: '2026-09-05T08:00:00.000Z',
+          }),
+        ]}
+        {...handlers()}
+      />
+    );
+
+    const names = screen.getAllByText(/Late Pet|Early Pet/).map((el) => el.textContent);
+    expect(names).toEqual(['Early Pet', 'Late Pet']);
+  });
+
+  it('shows the actions each status permits and hides the rest', () => {
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD'), row('2', 'IN_CONSULTATION', 'STANDARD')]}
+        {...handlers()}
+      />
+    );
+
+    // WAITING -> Start consult, No-show, Cancel. IN_CONSULTATION -> Complete, Cancel.
+    expect(screen.getAllByRole('button', { name: 'Start consult' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'No-show' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Complete' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Cancel' })).toHaveLength(2);
+  });
+
+  it('renders no row actions for a terminal (completed) entry', () => {
+    render(<CheckInBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} {...handlers()} />);
+
+    expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('invokes the seen handler with the entry id', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<CheckInBoard entries={[row('42', 'WAITING', 'STANDARD')]} {...props} />);
+
+    await user.click(screen.getByRole('button', { name: 'Start consult' }));
+
+    expect(props.onSeen).toHaveBeenCalledWith('42');
+  });
+
+  it('assigns a room from the row select', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <CheckInBoard
+        entries={[row('7', 'WAITING', 'STANDARD')]}
+        rooms={[
+          { id: 'room-1', name: 'Exam 1' },
+          { id: 'room-2', name: 'Exam 2' },
+        ]}
+        {...props}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Assign room'), 'room-2');
+    expect(props.onAssignRoom).toHaveBeenCalledWith('7', 'room-2');
+  });
+
+  it('does not render the room control when no rooms are available', () => {
+    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} {...handlers()} />);
+
+    expect(screen.queryByLabelText('Assign room')).not.toBeInTheDocument();
+  });
+
+  it('shows the assigned room name and triage note in the row detail', () => {
+    render(
+      <CheckInBoard
+        entries={[
+          row('1', 'IN_CONSULTATION', 'URGENT', {
+            roomName: 'Exam 3',
+            triageNote: 'Laboured breathing',
+          }),
+        ]}
+        {...handlers()}
+      />
+    );
+
+    expect(screen.getByText('Room: Exam 3 · Laboured breathing')).toBeInTheDocument();
+  });
+
+  it('opens the add form and submits a payload with the derived client id', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD')]}
+        companions={[{ id: 'patient-9', name: 'Bruno', ownerName: 'Sarah', clientId: 'client-9' }]}
+        {...props}
+      />
+    );
+
+    expect(screen.queryByText('Triage priority')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    expect(screen.getByText('Patient')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.selectOptions(screen.getByLabelText('Triage priority'), 'IMMEDIATE');
+    await user.click(screen.getByRole('button', { name: 'Check in patient' }));
+
+    expect(props.onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patientId: 'patient-9',
+        clientId: 'client-9',
+        triagePriority: 'IMMEDIATE',
+        arrivedAt: expect.any(String),
+      })
+    );
+  });
+
+  it('submits the optional triage note, notes and an edited arrival time', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <CheckInBoard
+        entries={[]}
+        companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.clear(screen.getByLabelText('Arrived at'));
+    await user.type(screen.getByLabelText('Arrived at'), '2026-09-05T07:15');
+    await user.type(screen.getByLabelText('Triage note'), 'Vomiting since morning');
+    await user.type(screen.getByLabelText('Notes'), 'Owner waiting in car park');
+    await user.click(screen.getByRole('button', { name: 'Check in patient' }));
+
+    expect(props.onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patientId: 'patient-9',
+        clientId: 'client-9',
+        triageNote: 'Vomiting since morning',
+        notes: 'Owner waiting in car park',
+        arrivedAt: new Date('2026-09-05T07:15').toISOString(),
+      })
+    );
+  });
+
+  it('ignores selecting the placeholder in the room control', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <CheckInBoard
+        entries={[row('7', 'WAITING', 'STANDARD', { assignedRoomId: 'room-1' })]}
+        rooms={[{ id: 'room-1', name: 'Exam 1' }]}
+        {...props}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Assign room'), '');
+    expect(props.onAssignRoom).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a generic patient label when the name is unresolved', () => {
+    render(
+      <CheckInBoard
+        entries={[
+          row('1', 'WAITING', 'STANDARD', { companionName: undefined, ownerName: undefined }),
+        ]}
+        {...handlers()}
+      />
+    );
+
+    expect(screen.getByText('Patient')).toBeInTheDocument();
+  });
+
+  it('blocks submit and warns when the chosen patient has no linked client', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(
+      <CheckInBoard
+        entries={[]}
+        companions={[{ id: 'patient-9', name: 'Bruno', ownerName: 'Sarah' }]}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByRole('button', { name: 'Check in patient' }));
+
+    expect(props.onAdd).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('no linked client');
+  });
+
+  it('warns when submitting the add form without choosing a patient', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<CheckInBoard entries={[]} companions={[]} {...props} />);
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    await user.click(screen.getByRole('button', { name: 'Check in patient' }));
+
+    expect(props.onAdd).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Choose a patient');
+  });
+
+  it('surfaces a form error and stays open when the add resolves false', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    props.onAdd.mockResolvedValue(false);
+    render(
+      <CheckInBoard
+        entries={[]}
+        companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByRole('button', { name: 'Check in patient' }));
+
+    expect(props.onAdd).toHaveBeenCalled();
+    expect(
+      await screen.findByText('Could not check the patient in. Try again.')
+    ).toBeInTheDocument();
+  });
+
+  it('closes the add form on the cancel button', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckInBoard
+        entries={[]}
+        companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
+        {...handlers()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Check in patient/ }));
+    expect(screen.getByText('Triage priority')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Triage priority')).not.toBeInTheDocument();
+  });
+
+  it('toggles the show-all view via the header control', async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} showAll={false} {...props} />);
+
+    await user.click(screen.getByRole('button', { name: 'Show all' }));
+    expect(props.onToggleShowAll).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the active-only empty state by default and the all empty state when showing all', () => {
+    const { rerender } = render(<CheckInBoard entries={[]} {...handlers()} />);
+    expect(screen.getByText('No patients are checked in')).toBeInTheDocument();
+
+    rerender(<CheckInBoard entries={[]} showAll {...handlers()} />);
+    expect(screen.getByText('No check-ins yet')).toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton instead of rows or the empty state', () => {
+    render(<CheckInBoard entries={[]} loading {...handlers()} />);
+
+    expect(screen.queryByText('No patients are checked in')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
+  });
+
+  it('renders read-only when no action or add handlers are supplied', () => {
+    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} />);
+
+    expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Check in patient/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show all' })).not.toBeInTheDocument();
+  });
+
+  it('computes a live wait time from arrival when waitMinutes is null', () => {
+    const arrived = new Date(Date.now() - 90 * 60000).toISOString();
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: null, arrivedAt: arrived })]}
+        {...handlers()}
+      />
+    );
+
+    // 90 minutes -> "1h 30m".
+    expect(screen.getByText('1h 30m')).toBeInTheDocument();
+  });
+
+  it('renders a whole-hour wait without trailing minutes', () => {
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: 120 })]}
+        {...handlers()}
+      />
+    );
+
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+
+  it('omits the wait time when the arrival timestamp is unparseable', () => {
+    render(
+      <CheckInBoard
+        entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: null, arrivedAt: 'nonsense' })]}
+        {...handlers()}
+      />
+    );
+
+    expect(screen.queryByText(/min$/)).not.toBeInTheDocument();
+  });
+
+  it('shows the error banner when an error is passed', () => {
+    render(
+      <CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} error="Boom" {...handlers()} />
+    );
+
+    expect(within(screen.getByRole('alert')).getByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoardPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoardPanel.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CheckInBoardPanel from '@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel';
+
+const fetchCheckIns = jest.fn();
+const createCheckIn = jest.fn();
+const markCheckInSeen = jest.fn();
+const completeCheckIn = jest.fn();
+const cancelCheckIn = jest.fn();
+const markCheckInNoShow = jest.fn();
+const assignCheckInRoom = jest.fn();
+
+jest.mock('@/app/features/appointments/services/patientCheckInService', () => ({
+  __esModule: true,
+  fetchCheckIns: (...a: unknown[]) => fetchCheckIns(...a),
+  createCheckIn: (...a: unknown[]) => createCheckIn(...a),
+  markCheckInSeen: (...a: unknown[]) => markCheckInSeen(...a),
+  completeCheckIn: (...a: unknown[]) => completeCheckIn(...a),
+  cancelCheckIn: (...a: unknown[]) => cancelCheckIn(...a),
+  markCheckInNoShow: (...a: unknown[]) => markCheckInNoShow(...a),
+  assignCheckInRoom: (...a: unknown[]) => assignCheckInRoom(...a),
+}));
+
+let primaryOrgId: string | null = 'org-1';
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { primaryOrgId: string | null }) => unknown) => sel({ primaryOrgId }),
+}));
+
+let canEdit = true;
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: () => canEdit }),
+}));
+
+const RESOLVED_COMPANION = {
+  companion: { id: 'patient-1', name: 'Buddy' },
+  parent: { id: 'client-1', firstName: 'Sam', lastName: 'Owner' },
+};
+let companionsParents: Array<{
+  companion: { id: string; name: string };
+  parent: { id: string; firstName: string; lastName: string };
+}> = [RESOLVED_COMPANION];
+jest.mock('@/app/hooks/useCompanion', () => ({
+  useLoadCompanionsForPrimaryOrg: jest.fn(),
+  useCompanionsParentsForPrimaryOrg: () => companionsParents,
+}));
+
+let rooms = [{ id: 'room-1', name: 'Exam 1' }];
+jest.mock('@/app/hooks/useRooms', () => ({
+  useLoadRoomsForPrimaryOrg: jest.fn(),
+  useRoomsForPrimaryOrg: () => rooms,
+}));
+
+// Presentational double: exposes the container's wiring as buttons + text.
+jest.mock('@/app/features/appointments/components/CheckInBoard/CheckInBoard', () => ({
+  __esModule: true,
+  default: ({
+    entries,
+    companions,
+    rooms: roomOptions,
+    loading,
+    error,
+    showAll,
+    onToggleShowAll,
+    onSeen,
+    onComplete,
+    onCancel,
+    onNoShow,
+    onAssignRoom,
+    onAdd,
+  }: any) => (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
+      <span data-testid="show-all">{String(showAll)}</span>
+      <span data-testid="companions">{companions.length}</span>
+      <span data-testid="rooms">{roomOptions.length}</span>
+      {entries.map((e: any) => (
+        <div key={e.id} data-testid="entry">
+          {e.companionName}/{e.ownerName ?? 'none'}/{e.status}/{e.roomName ?? 'no-room'}
+        </div>
+      ))}
+      <span data-testid="has-actions">
+        {String(Boolean(onSeen && onComplete && onCancel && onNoShow && onAssignRoom && onAdd))}
+      </span>
+      <button onClick={() => onToggleShowAll(true)}>show all</button>
+      {onSeen ? <button onClick={() => onSeen('ci-1')}>seen</button> : null}
+      {onComplete ? <button onClick={() => onComplete('ci-1')}>complete</button> : null}
+      {onCancel ? <button onClick={() => onCancel('ci-1')}>cancel</button> : null}
+      {onNoShow ? <button onClick={() => onNoShow('ci-1')}>no-show</button> : null}
+      {onAssignRoom ? <button onClick={() => onAssignRoom('ci-1', 'room-1')}>assign</button> : null}
+      {onAdd ? (
+        <button
+          onClick={() => onAdd({ patientId: 'patient-1', clientId: 'client-1', arrivedAt: 'now' })}
+        >
+          add
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+const waitingEntry = {
+  id: 'ci-1',
+  patientId: 'patient-1',
+  status: 'WAITING',
+  assignedRoomId: 'room-1',
+};
+const completedEntry = {
+  id: 'ci-2',
+  patientId: 'patient-1',
+  status: 'COMPLETED',
+  assignedRoomId: null,
+};
+
+describe('CheckInBoardPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primaryOrgId = 'org-1';
+    canEdit = true;
+    rooms = [{ id: 'room-1', name: 'Exam 1' }];
+    companionsParents = [RESOLVED_COMPANION];
+    fetchCheckIns.mockResolvedValue([waitingEntry, completedEntry]);
+    markCheckInSeen.mockResolvedValue(waitingEntry);
+    completeCheckIn.mockResolvedValue(waitingEntry);
+    cancelCheckIn.mockResolvedValue(waitingEntry);
+    markCheckInNoShow.mockResolvedValue(waitingEntry);
+    assignCheckInRoom.mockResolvedValue(waitingEntry);
+    createCheckIn.mockResolvedValue(waitingEntry);
+  });
+
+  it('loads active check-ins and resolves companion, owner and room names', async () => {
+    render(<CheckInBoardPanel />);
+    await waitFor(() => expect(fetchCheckIns).toHaveBeenCalledWith('org-1'));
+    // Only the active (WAITING) entry is visible by default; the resolved names attach.
+    expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/Sam Owner/WAITING/Exam 1');
+    expect(screen.getAllByTestId('entry')).toHaveLength(1);
+    expect(screen.getByTestId('has-actions')).toHaveTextContent('true');
+    expect(screen.getByTestId('companions')).toHaveTextContent('1');
+    expect(screen.getByTestId('rooms')).toHaveTextContent('1');
+  });
+
+  it('reveals terminal statuses when show-all is toggled on', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('show all');
+    fireEvent.click(screen.getByText('show all'));
+    await waitFor(() => expect(screen.getAllByTestId('entry')).toHaveLength(2));
+    expect(screen.getByTestId('show-all')).toHaveTextContent('true');
+  });
+
+  it('withholds edit actions without permission but keeps the show-all toggle', async () => {
+    canEdit = false;
+    render(<CheckInBoardPanel />);
+    await waitFor(() => expect(fetchCheckIns).toHaveBeenCalled());
+    expect(screen.getByTestId('has-actions')).toHaveTextContent('false');
+    expect(screen.getByText('show all')).toBeInTheDocument();
+  });
+
+  it('runs the seen transition then refetches', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('seen');
+    fireEvent.click(screen.getByText('seen'));
+    await waitFor(() => expect(markCheckInSeen).toHaveBeenCalledWith('org-1', 'ci-1'));
+    expect(fetchCheckIns).toHaveBeenCalledTimes(2);
+  });
+
+  it('completes an in-consultation check-in then refetches', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('complete');
+    fireEvent.click(screen.getByText('complete'));
+    await waitFor(() => expect(completeCheckIn).toHaveBeenCalledWith('org-1', 'ci-1'));
+    expect(fetchCheckIns).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks a no-show then refetches', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('no-show');
+    fireEvent.click(screen.getByText('no-show'));
+    await waitFor(() => expect(markCheckInNoShow).toHaveBeenCalledWith('org-1', 'ci-1'));
+    expect(fetchCheckIns).toHaveBeenCalledTimes(2);
+  });
+
+  it('assigns a room then refetches', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('assign');
+    fireEvent.click(screen.getByText('assign'));
+    await waitFor(() => expect(assignCheckInRoom).toHaveBeenCalledWith('org-1', 'ci-1', 'room-1'));
+    expect(fetchCheckIns).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces an error when an action fails', async () => {
+    cancelCheckIn.mockRejectedValueOnce(new Error('x'));
+    render(<CheckInBoardPanel />);
+    await screen.findByText('cancel');
+    fireEvent.click(screen.getByText('cancel'));
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('could not be completed')
+    );
+  });
+
+  it('creates a check-in and refetches', async () => {
+    render(<CheckInBoardPanel />);
+    await screen.findByText('add');
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() =>
+      expect(createCheckIn).toHaveBeenCalledWith('org-1', {
+        patientId: 'patient-1',
+        clientId: 'client-1',
+        arrivedAt: 'now',
+      })
+    );
+    await waitFor(() => expect(fetchCheckIns).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not refetch when creating a check-in fails', async () => {
+    createCheckIn.mockRejectedValueOnce(new Error('x'));
+    render(<CheckInBoardPanel />);
+    await screen.findByText('add');
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => expect(createCheckIn).toHaveBeenCalled());
+    expect(fetchCheckIns).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a load error when the fetch throws', async () => {
+    fetchCheckIns.mockReset().mockRejectedValue(new Error('down'));
+    render(<CheckInBoardPanel />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('Unable to load the check-in board')
+    );
+  });
+
+  it('renders nothing to load without a primary org', async () => {
+    primaryOrgId = null;
+    render(<CheckInBoardPanel />);
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+    expect(fetchCheckIns).not.toHaveBeenCalled();
+  });
+
+  it('does not fire a transition or a create when there is no primary org', async () => {
+    primaryOrgId = null;
+    render(<CheckInBoardPanel />);
+    await screen.findByText('seen');
+    fireEvent.click(screen.getByText('seen'));
+    fireEvent.click(screen.getByText('add'));
+    await Promise.resolve();
+    expect(markCheckInSeen).not.toHaveBeenCalled();
+    expect(createCheckIn).not.toHaveBeenCalled();
+    expect(fetchCheckIns).not.toHaveBeenCalled();
+  });
+
+  it('leaves owner and client ids undefined when the parent has no name or id', async () => {
+    companionsParents = [
+      {
+        companion: { id: 'patient-1', name: 'Buddy' },
+        parent: { id: '', firstName: '', lastName: '' },
+      },
+    ];
+    render(<CheckInBoardPanel />);
+    await waitFor(() => expect(fetchCheckIns).toHaveBeenCalled());
+    // The resolved entry keeps its patient name but no owner name to attach.
+    expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/none/WAITING/Exam 1');
+    expect(screen.getByTestId('companions')).toHaveTextContent('1');
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoardPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/CheckInBoardPanel.test.tsx
@@ -20,6 +20,9 @@ jest.mock('@/app/features/appointments/services/patientCheckInService', () => ({
   cancelCheckIn: (...a: unknown[]) => cancelCheckIn(...a),
   markCheckInNoShow: (...a: unknown[]) => markCheckInNoShow(...a),
   assignCheckInRoom: (...a: unknown[]) => assignCheckInRoom(...a),
+  // Pure predicate the hook and board share; keep the real behaviour so the
+  // active-only filtering under test is the production one.
+  isActiveCheckInStatus: (status: string) => status === 'WAITING' || status === 'IN_CONSULTATION',
 }));
 
 let primaryOrgId: string | null = 'org-1';

--- a/apps/frontend/src/app/__tests__/features/appointments/services/patientCheckInService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/services/patientCheckInService.test.ts
@@ -1,0 +1,211 @@
+import { AxiosError } from 'axios';
+import {
+  fetchCheckIns,
+  fetchCheckIn,
+  createCheckIn,
+  markCheckInSeen,
+  completeCheckIn,
+  cancelCheckIn,
+  markCheckInNoShow,
+  assignCheckInRoom,
+  type PatientCheckIn,
+} from '@/app/features/appointments/services/patientCheckInService';
+
+const getDataMock = jest.fn();
+const postDataMock = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  getData: (...args: unknown[]) => getDataMock(...args),
+  postData: (...args: unknown[]) => postDataMock(...args),
+}));
+
+const ORG = '11111111-1111-4111-8111-111111111111';
+const CHECK_IN = '22222222-2222-4222-8222-222222222222';
+const BASE = `/v1/pms/organisation/${ORG}/check-in`;
+
+const checkIn: PatientCheckIn = {
+  id: CHECK_IN,
+  organisationId: ORG,
+  patientId: '33333333-3333-4333-8333-333333333333',
+  clientId: '44444444-4444-4444-8444-444444444444',
+  appointmentId: null,
+  arrivedAt: '2026-09-05T08:30:00.000Z',
+  triagePriority: 'STANDARD',
+  triageNote: null,
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: '2026-09-05T08:30:00.000Z',
+  seenAt: null,
+  waitMinutes: null,
+  status: 'WAITING',
+  notes: null,
+  createdAt: '2026-09-05T08:30:00.000Z',
+  updatedAt: '2026-09-05T08:30:00.000Z',
+};
+
+const UNSAFE_IDS = ['', 'not-a-uuid', '../admin', 'org/other', 'https://attacker.test'];
+
+describe('patientCheckInService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('fetchCheckIns', () => {
+    it('fetches the check-ins for an org with no filters', async () => {
+      getDataMock.mockResolvedValue({ data: [checkIn] });
+      await expect(fetchCheckIns(ORG)).resolves.toEqual([checkIn]);
+      expect(getDataMock).toHaveBeenCalledWith(BASE, {});
+    });
+
+    it('passes the patientId and status filters as query params', async () => {
+      getDataMock.mockResolvedValue({ data: [] });
+      await fetchCheckIns(ORG, { patientId: 'p-9', status: 'IN_CONSULTATION' });
+      expect(getDataMock).toHaveBeenCalledWith(BASE, {
+        patientId: 'p-9',
+        status: 'IN_CONSULTATION',
+      });
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe organisation id (%s)', async (organisationId) => {
+      await expect(fetchCheckIns(organisationId)).rejects.toThrow('Invalid organisation ID');
+      expect(getDataMock).not.toHaveBeenCalled();
+    });
+
+    it('returns [] and warns when the response is not an array', async () => {
+      getDataMock.mockResolvedValue({ data: { nope: true } });
+      await expect(fetchCheckIns(ORG)).resolves.toEqual([]);
+      expect(console.warn).toHaveBeenCalledWith('Check-in response is not an array; got', 'object');
+    });
+
+    it('logs the axios message and rethrows on failure', async () => {
+      const err = new AxiosError('boom');
+      err.response = { data: { message: 'nope' } } as AxiosError['response'];
+      getDataMock.mockRejectedValue(err);
+      await expect(fetchCheckIns(ORG)).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load check-ins:', 'nope');
+    });
+
+    it('falls back to err.message for an axios error with no response', async () => {
+      const err = new AxiosError('network down');
+      getDataMock.mockRejectedValue(err);
+      await expect(fetchCheckIns(ORG)).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load check-ins:', 'network down');
+    });
+
+    it('logs a non-axios error verbatim and rethrows', async () => {
+      const err = new Error('raw');
+      getDataMock.mockRejectedValue(err);
+      await expect(fetchCheckIns(ORG)).rejects.toBe(err);
+      expect(console.error).toHaveBeenCalledWith('Failed to load check-ins:', err);
+    });
+  });
+
+  describe('fetchCheckIn', () => {
+    it('fetches a single check-in', async () => {
+      getDataMock.mockResolvedValue({ data: checkIn });
+      await expect(fetchCheckIn(ORG, CHECK_IN)).resolves.toEqual(checkIn);
+      expect(getDataMock).toHaveBeenCalledWith(`${BASE}/${CHECK_IN}`);
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe check-in id (%s)', async (checkInId) => {
+      await expect(fetchCheckIn(ORG, checkInId)).rejects.toThrow('Invalid check-in ID');
+      expect(getDataMock).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows on failure', async () => {
+      getDataMock.mockRejectedValue(new Error('x'));
+      await expect(fetchCheckIn(ORG, CHECK_IN)).rejects.toThrow('x');
+      expect(console.error).toHaveBeenCalledWith('Failed to load the check-in:', expect.anything());
+    });
+  });
+
+  describe('createCheckIn', () => {
+    const payload = {
+      patientId: '33333333-3333-4333-8333-333333333333',
+      clientId: '44444444-4444-4444-8444-444444444444',
+      arrivedAt: '2026-09-05T08:30:00.000Z',
+    };
+
+    it('creates a check-in', async () => {
+      postDataMock.mockResolvedValue({ data: checkIn });
+      await expect(createCheckIn(ORG, payload)).resolves.toEqual(checkIn);
+      expect(postDataMock).toHaveBeenCalledWith(BASE, payload);
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe organisation id (%s)', async (organisationId) => {
+      await expect(createCheckIn(organisationId, payload)).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(postDataMock).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows on failure', async () => {
+      postDataMock.mockRejectedValue(new Error('x'));
+      await expect(createCheckIn(ORG, payload)).rejects.toThrow('x');
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('transitions', () => {
+    it.each([
+      ['seen', markCheckInSeen],
+      ['complete', completeCheckIn],
+      ['cancel', cancelCheckIn],
+      ['no-show', markCheckInNoShow],
+    ] as const)('posts the %s transition', async (action, fn) => {
+      postDataMock.mockResolvedValue({ data: { ...checkIn, status: 'IN_CONSULTATION' } });
+      await fn(ORG, CHECK_IN);
+      expect(postDataMock).toHaveBeenCalledWith(`${BASE}/${CHECK_IN}/${action}`);
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe organisation id (%s)', async (organisationId) => {
+      await expect(markCheckInSeen(organisationId, CHECK_IN)).rejects.toThrow(
+        'Invalid organisation ID'
+      );
+      expect(postDataMock).not.toHaveBeenCalled();
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe check-in id (%s)', async (checkInId) => {
+      await expect(completeCheckIn(ORG, checkInId)).rejects.toThrow('Invalid check-in ID');
+      expect(postDataMock).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows when a transition fails', async () => {
+      postDataMock.mockRejectedValue(new Error('t'));
+      await expect(cancelCheckIn(ORG, CHECK_IN)).rejects.toThrow('t');
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to cancel the check-in:',
+        expect.anything()
+      );
+    });
+  });
+
+  describe('assignCheckInRoom', () => {
+    const ROOM = '55555555-5555-4555-8555-555555555555';
+
+    it('posts the room assignment with the roomId body', async () => {
+      postDataMock.mockResolvedValue({ data: { ...checkIn, assignedRoomId: ROOM } });
+      await assignCheckInRoom(ORG, CHECK_IN, ROOM);
+      expect(postDataMock).toHaveBeenCalledWith(`${BASE}/${CHECK_IN}/room`, { roomId: ROOM });
+    });
+
+    it.each(UNSAFE_IDS)('rejects an unsafe check-in id (%s)', async (checkInId) => {
+      await expect(assignCheckInRoom(ORG, checkInId, ROOM)).rejects.toThrow('Invalid check-in ID');
+      expect(postDataMock).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows on failure', async () => {
+      postDataMock.mockRejectedValue(new Error('x'));
+      await expect(assignCheckInRoom(ORG, CHECK_IN, ROOM)).rejects.toThrow('x');
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to assign a room to the check-in:',
+        expect.anything()
+      );
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
@@ -206,6 +206,12 @@ jest.mock(
   }
 );
 
+// The check-in board panel fetches on mount; stub it so its data-fetching never
+// runs in this suite (jest.setup throws on any unexpected console.error).
+jest.mock('@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel', () => () => (
+  <div data-testid="check-in-board-panel" />
+));
+
 describe('Appointments page', () => {
   const renderAppointments = async () => {
     await act(async () => {

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type {
+  CheckInStatus,
+  TriagePriority,
+} from '@/app/features/appointments/services/patientCheckInService';
+import CheckInBoard, { type PatientCheckInView } from './CheckInBoard';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * A check-in row as the container hands it to the presentational board: the raw
+ * API row plus the resolved `companionName`/`ownerName`/`roomName`. Dates are
+ * ISO strings and the nullable columns are `null`, not `undefined`, because the
+ * clinical handler returns the Prisma row unwrapped.
+ */
+const row = (
+  id: string,
+  status: CheckInStatus,
+  triagePriority: TriagePriority,
+  companionName: string,
+  ownerName: string,
+  overrides: Partial<PatientCheckInView> = {}
+): PatientCheckInView => ({
+  id,
+  organisationId: ORG_ID,
+  patientId: `patient-${id}`,
+  clientId: `client-${id}`,
+  appointmentId: null,
+  arrivedAt: '2026-09-05T08:30:00.000Z',
+  triagePriority,
+  triageNote: null,
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: '2026-09-05T08:30:00.000Z',
+  seenAt: null,
+  waitMinutes: null,
+  status,
+  notes: null,
+  createdAt: '2026-09-05T08:30:00.000Z',
+  updatedAt: '2026-09-05T08:30:00.000Z',
+  companionName,
+  ownerName,
+  ...overrides,
+});
+
+const ENTRIES: PatientCheckInView[] = [
+  row('1', 'WAITING', 'STANDARD', 'Bruno', 'Sarah Whitfield', { waitMinutes: 12 }),
+  row('2', 'WAITING', 'IMMEDIATE', 'Mochi', 'Lena Hartmann', {
+    triageNote: 'Collapsed in the waiting room',
+    waitMinutes: 2,
+  }),
+  row('3', 'WAITING', 'URGENT', 'Poppy', 'Amir Rahimi', { waitMinutes: 20 }),
+  row('4', 'IN_CONSULTATION', 'LESS_URGENT', 'Cleo', 'Nina Alvarez', {
+    roomName: 'Exam 2',
+    assignedRoomId: 'room-2',
+    waitMinutes: 8,
+  }),
+];
+
+const COMPANIONS = [
+  { id: 'patient-1', name: 'Bruno', ownerName: 'Sarah Whitfield', clientId: 'client-1' },
+  { id: 'patient-9', name: 'Ziggy', ownerName: 'Priya Nair', clientId: 'client-9' },
+];
+
+const ROOMS = [
+  { id: 'room-1', name: 'Exam 1' },
+  { id: 'room-2', name: 'Exam 2' },
+];
+
+const meta = {
+  title: 'Appointments/CheckInBoard',
+  component: CheckInBoard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Presentational patient check-in / waiting-room board. Rows are sorted by ' +
+          'triage priority then arrival, so the most urgent waiting patient is first. Each ' +
+          'row shows a triage pill (IMMEDIATE/URGENT in a danger/warning tone), the patient ' +
+          'and owner, the live wait time, a status pill, and the transition buttons the ' +
+          'status permits. Every action (plus the add form and room assignment) only renders ' +
+          'when the matching handler prop is supplied - which is how the container hides them ' +
+          'from users without edit permission.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    entries: ENTRIES,
+    companions: COMPANIONS,
+    rooms: ROOMS,
+    onToggleShowAll: fn(),
+    onSeen: fn(),
+    onComplete: fn(),
+    onCancel: fn(),
+    onNoShow: fn(),
+    onAssignRoom: fn(),
+    onAdd: fn(async () => true),
+  },
+} satisfies Meta<typeof CheckInBoard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Sorted most-urgent-first: the IMMEDIATE row is rendered ahead of the rest.
+    const titles = canvas.getAllByText(/Bruno|Mochi|Poppy|Cleo/).map((el) => el.textContent);
+    await expect(titles[0]).toBe('Mochi');
+    await expect(canvas.getByText('Immediate')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: 'Start consult' }).length).toBe(3);
+    await expect(canvas.getByRole('button', { name: 'Complete' })).toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read only (no edit permission)',
+  args: {
+    onSeen: undefined,
+    onComplete: undefined,
+    onCancel: undefined,
+    onNoShow: undefined,
+    onAssignRoom: undefined,
+    onAdd: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Check in patient' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const AddForm: Story = {
+  name: 'Add form open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Check in patient/ }));
+    await expect(canvas.getByText('Patient')).toBeInTheDocument();
+    await expect(canvas.getByText('Triage priority')).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: { entries: [] },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByText('No patients are checked in')).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: { loading: true },
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).queryByText('No patients are checked in')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const WithError: Story = {
+  name: 'Error banner',
+  args: { error: 'Unable to load the check-in board right now.' },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByRole('alert')).toHaveTextContent(
+      'Unable to load the check-in board right now.'
+    );
+  },
+};
+
+export const Dark: Story = {
+  name: 'Dark theme',
+  globals: { theme: 'dark' },
+};

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
@@ -16,6 +16,7 @@ import type {
   TriagePriority,
   CreateCheckInPayload,
 } from '@/app/features/appointments/services/patientCheckInService';
+import { isActiveCheckInStatus } from '@/app/features/appointments/services/patientCheckInService';
 
 /** A companion the add-form offers as the subject of a new check-in. */
 export type CheckInCompanionOption = {
@@ -522,7 +523,13 @@ const CheckInBoard = ({
   // "Now" is read fresh every render so the live wait times keep advancing; it
   // is deliberately not memoised.
   const now = new Date();
-  const sorted = useMemo(() => sortForBoard(entries), [entries]);
+  // `showAll` is part of this component's contract, so filter here rather than
+  // trusting the caller to have done it; the container filters too and the
+  // predicate is idempotent.
+  const sorted = useMemo(
+    () => sortForBoard(showAll ? entries : entries.filter((e) => isActiveCheckInStatus(e.status))),
+    [entries, showAll]
+  );
 
   const body = (() => {
     if (loading) return <PanelLoadingRows rowClass={rowClass} />;

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
@@ -1,0 +1,599 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { IoPulseOutline, IoAddOutline } from 'react-icons/io5';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import type {
+  PatientCheckIn,
+  CheckInStatus,
+  TriagePriority,
+  CreateCheckInPayload,
+} from '@/app/features/appointments/services/patientCheckInService';
+
+/** A companion the add-form offers as the subject of a new check-in. */
+export type CheckInCompanionOption = {
+  id: string;
+  name: string;
+  ownerName?: string;
+  /** The linked client (owner) id, used as the required `clientId`. */
+  clientId?: string;
+};
+
+/** A room the row's assign-room control offers. */
+export type CheckInRoomOption = { id: string; name: string };
+
+/**
+ * A check-in row for display. The API row carries only ids; the container
+ * resolves the companion/owner names and the assigned room name and attaches
+ * them here, falling back to a generic label when a name is not loaded.
+ */
+export type PatientCheckInView = PatientCheckIn & {
+  companionName?: string;
+  ownerName?: string;
+  roomName?: string;
+};
+
+export type CheckInBoardProps = {
+  entries: PatientCheckInView[];
+  companions?: CheckInCompanionOption[];
+  rooms?: CheckInRoomOption[];
+  loading?: boolean;
+  error?: string | null;
+  /** Id of the entry whose action is in flight, so its controls disable. */
+  busyEntryId?: string | null;
+  /** True shows every status; false (default) shows only active check-ins. */
+  showAll?: boolean;
+  onToggleShowAll?: (next: boolean) => void;
+  onSeen?: (id: string) => void;
+  onComplete?: (id: string) => void;
+  onCancel?: (id: string) => void;
+  onNoShow?: (id: string) => void;
+  onAssignRoom?: (id: string, roomId: string) => void;
+  /** Resolves true when the check-in was created, so the form can reset/close. */
+  onAdd?: (payload: CreateCheckInPayload) => Promise<boolean>;
+};
+
+const TRIAGE_ORDER: TriagePriority[] = [
+  'IMMEDIATE',
+  'URGENT',
+  'LESS_URGENT',
+  'STANDARD',
+  'NON_URGENT',
+];
+
+const TRIAGE_RANK: Record<TriagePriority, number> = {
+  IMMEDIATE: 0,
+  URGENT: 1,
+  LESS_URGENT: 2,
+  STANDARD: 3,
+  NON_URGENT: 4,
+};
+
+const TRIAGE_TONE: Record<TriagePriority, StatusTone> = {
+  IMMEDIATE: 'danger',
+  URGENT: 'warning',
+  LESS_URGENT: 'accent',
+  STANDARD: 'info',
+  NON_URGENT: 'neutral',
+};
+
+const TRIAGE_LABEL: Record<TriagePriority, string> = {
+  IMMEDIATE: 'Immediate',
+  URGENT: 'Urgent',
+  LESS_URGENT: 'Less urgent',
+  STANDARD: 'Standard',
+  NON_URGENT: 'Non-urgent',
+};
+
+const STATUS_TONE: Record<CheckInStatus, StatusTone> = {
+  WAITING: 'info',
+  IN_CONSULTATION: 'progress',
+  COMPLETED: 'success',
+  NO_SHOW: 'warning',
+  CANCELLED: 'danger',
+};
+
+const STATUS_LABEL: Record<CheckInStatus, string> = {
+  WAITING: 'Waiting',
+  IN_CONSULTATION: 'In consultation',
+  COMPLETED: 'Completed',
+  NO_SHOW: 'No show',
+  CANCELLED: 'Cancelled',
+};
+
+type CheckInAction = 'seen' | 'complete' | 'noShow' | 'cancel';
+
+/** Which transitions the backend permits from each status. */
+const ACTIONS_BY_STATUS: Record<CheckInStatus, CheckInAction[]> = {
+  WAITING: ['seen', 'noShow', 'cancel'],
+  IN_CONSULTATION: ['complete', 'cancel'],
+  COMPLETED: [],
+  NO_SHOW: [],
+  CANCELLED: [],
+};
+
+const ACTION_LABEL: Record<CheckInAction, string> = {
+  seen: 'Start consult',
+  complete: 'Complete',
+  noShow: 'No-show',
+  cancel: 'Cancel',
+};
+
+const cardClass =
+  'flex flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
+const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
+const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
+const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
+const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
+const inputClass =
+  'w-full rounded-lg border border-[var(--hairline)] bg-[var(--screen)] px-2.5 py-1.5 text-[12.5px] text-[var(--ink)] outline-none focus:border-[var(--ink-muted)]';
+
+const sortForBoard = (entries: PatientCheckInView[]): PatientCheckInView[] =>
+  [...entries].sort((a, b) => {
+    const byTriage = TRIAGE_RANK[a.triagePriority] - TRIAGE_RANK[b.triagePriority];
+    if (byTriage !== 0) return byTriage;
+    return new Date(a.arrivedAt).getTime() - new Date(b.arrivedAt).getTime();
+  });
+
+const waitMinutesFor = (entry: PatientCheckInView, now: Date): number | null => {
+  if (typeof entry.waitMinutes === 'number') return Math.max(entry.waitMinutes, 0);
+  const arrived = new Date(entry.arrivedAt).getTime();
+  if (Number.isNaN(arrived)) return null;
+  return Math.max(Math.floor((now.getTime() - arrived) / 60000), 0);
+};
+
+const formatWait = (minutes: number | null): string | null => {
+  if (minutes === null) return null;
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest ? `${hours}h ${rest}m` : `${hours}h`;
+};
+
+const toIsoOrNow = (value: string): string => {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+};
+
+const toLocalInputValue = (date: Date): string => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}`;
+};
+
+const ActionButton = ({
+  label,
+  tone,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  tone: 'default' | 'danger';
+  disabled?: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    disabled={disabled}
+    onClick={onClick}
+    className={clsx(
+      'rounded-lg border px-2.5 py-1 text-[11.5px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+      tone === 'danger'
+        ? 'border-[var(--hairline)] text-[var(--danger-text)] hover:bg-[var(--inset)]'
+        : 'border-[var(--hairline)] text-[var(--ink)] hover:bg-[var(--inset)]'
+    )}
+  >
+    {label}
+  </button>
+);
+
+const RowActions = ({
+  entry,
+  busy,
+  handlers,
+}: {
+  entry: PatientCheckInView;
+  busy: boolean;
+  handlers: Record<CheckInAction, ((id: string) => void) | undefined>;
+}) => {
+  const actions = ACTIONS_BY_STATUS[entry.status].filter((action) => handlers[action]);
+  if (actions.length === 0) return null;
+  return (
+    <span className="mt-0.5 flex flex-wrap justify-end gap-1.5">
+      {actions.map((action) => (
+        <ActionButton
+          key={action}
+          label={ACTION_LABEL[action]}
+          tone={action === 'cancel' || action === 'noShow' ? 'danger' : 'default'}
+          disabled={busy}
+          onClick={() => handlers[action]?.(entry.id)}
+        />
+      ))}
+    </span>
+  );
+};
+
+const RoomControl = ({
+  entry,
+  rooms,
+  busy,
+  onAssignRoom,
+}: {
+  entry: PatientCheckInView;
+  rooms: CheckInRoomOption[];
+  busy: boolean;
+  onAssignRoom: (id: string, roomId: string) => void;
+}) => {
+  const selectId = `checkin-room-${entry.id}`;
+  return (
+    <label className="flex items-center gap-1.5" htmlFor={selectId}>
+      <span className="sr-only">Assign room</span>
+      <select
+        id={selectId}
+        className={clsx(inputClass, 'w-auto py-1')}
+        value={entry.assignedRoomId ?? ''}
+        disabled={busy}
+        onChange={(e) => e.target.value && onAssignRoom(entry.id, e.target.value)}
+      >
+        <option value="">Assign room</option>
+        {rooms.map((room) => (
+          <option key={room.id} value={room.id}>
+            {room.name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+const CheckInRow = ({
+  entry,
+  now,
+  busy,
+  rooms,
+  handlers,
+  onAssignRoom,
+}: {
+  entry: PatientCheckInView;
+  now: Date;
+  busy: boolean;
+  rooms: CheckInRoomOption[];
+  handlers: Record<CheckInAction, ((id: string) => void) | undefined>;
+  onAssignRoom?: (id: string, roomId: string) => void;
+}) => {
+  const wait = formatWait(waitMinutesFor(entry, now));
+  const detail = [entry.roomName && `Room: ${entry.roomName}`, entry.triageNote]
+    .filter(Boolean)
+    .join(' · ');
+  const showRoomControl =
+    onAssignRoom && rooms.length > 0 && ACTIONS_BY_STATUS[entry.status].length > 0;
+
+  return (
+    <li className={rowClass}>
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <StatusPill
+            label={TRIAGE_LABEL[entry.triagePriority]}
+            tone={TRIAGE_TONE[entry.triagePriority]}
+          />
+          <span className={clsx(titleClass, 'truncate')}>{entry.companionName || 'Patient'}</span>
+        </span>
+        {entry.ownerName && <span className={clsx(metaClass, 'truncate')}>{entry.ownerName}</span>}
+        {detail && <span className={clsx(metaClass, 'truncate')}>{detail}</span>}
+      </span>
+      <span className="flex shrink-0 flex-col items-end gap-1.5">
+        <StatusPill label={STATUS_LABEL[entry.status]} tone={STATUS_TONE[entry.status]} />
+        {wait && (
+          <span className={metaClass} aria-label={`Waiting ${wait}`}>
+            {wait}
+          </span>
+        )}
+        {showRoomControl && (
+          <RoomControl entry={entry} rooms={rooms} busy={busy} onAssignRoom={onAssignRoom} />
+        )}
+        <RowActions entry={entry} busy={busy} handlers={handlers} />
+      </span>
+    </li>
+  );
+};
+
+const AddCheckInForm = ({
+  companions,
+  onAdd,
+  onClose,
+}: {
+  companions: CheckInCompanionOption[];
+  onAdd: (payload: CreateCheckInPayload) => Promise<boolean>;
+  onClose: () => void;
+}) => {
+  const [patientId, setPatientId] = useState('');
+  const [triagePriority, setTriagePriority] = useState<TriagePriority>('STANDARD');
+  const [arrivedAt, setArrivedAt] = useState(() => toLocalInputValue(new Date()));
+  const [triageNote, setTriageNote] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const selected = companions.find((companion) => companion.id === patientId);
+    if (!selected) {
+      setFormError('Choose a patient to check in.');
+      return;
+    }
+    if (!selected.clientId) {
+      setFormError('This patient has no linked client to check in against.');
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      const ok = await onAdd({
+        patientId: selected.id,
+        clientId: selected.clientId,
+        arrivedAt: toIsoOrNow(arrivedAt),
+        triagePriority,
+        triageNote: triageNote.trim() || undefined,
+        notes: notes.trim() || undefined,
+      });
+      if (ok) {
+        onClose();
+        return;
+      }
+      setFormError('Could not check the patient in. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
+    >
+      <label className="flex flex-col gap-1" htmlFor="checkin-companion">
+        <span className={fieldLabelClass}>Patient</span>
+        <select
+          id="checkin-companion"
+          className={inputClass}
+          value={patientId}
+          onChange={(e) => setPatientId(e.target.value)}
+          disabled={companions.length === 0}
+        >
+          <option value="">
+            {companions.length === 0 ? 'No patients available' : 'Select a patient'}
+          </option>
+          {companions.map((companion) => (
+            <option key={companion.id} value={companion.id}>
+              {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1" htmlFor="checkin-triage">
+          <span className={fieldLabelClass}>Triage priority</span>
+          <select
+            id="checkin-triage"
+            className={inputClass}
+            value={triagePriority}
+            onChange={(e) => setTriagePriority(e.target.value as TriagePriority)}
+          >
+            {TRIAGE_ORDER.map((priority) => (
+              <option key={priority} value={priority}>
+                {TRIAGE_LABEL[priority]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1" htmlFor="checkin-arrived">
+          <span className={fieldLabelClass}>Arrived at</span>
+          <input
+            id="checkin-arrived"
+            type="datetime-local"
+            className={inputClass}
+            value={arrivedAt}
+            onChange={(e) => setArrivedAt(e.target.value)}
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1" htmlFor="checkin-triage-note">
+        <span className={fieldLabelClass}>Triage note</span>
+        <input
+          id="checkin-triage-note"
+          className={inputClass}
+          value={triageNote}
+          onChange={(e) => setTriageNote(e.target.value)}
+          maxLength={200}
+        />
+      </label>
+
+      <label className="flex flex-col gap-1" htmlFor="checkin-notes">
+        <span className={fieldLabelClass}>Notes</span>
+        <textarea
+          id="checkin-notes"
+          className={clsx(inputClass, 'min-h-16 resize-y')}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          maxLength={500}
+        />
+      </label>
+
+      {formError && (
+        <p role="alert" className="text-[11.5px] font-semibold text-[var(--danger-text)]">
+          {formError}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <ActionButton label="Cancel" tone="default" disabled={submitting} onClick={onClose} />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-lg border border-[var(--ink)] bg-[var(--ink)] px-3 py-1 text-[11.5px] font-semibold text-[var(--screen)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? 'Checking in…' : 'Check in patient'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+const EmptyState = ({ message }: { message: string }) => (
+  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
+);
+
+const LoadingRows = () => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((i) => (
+      <li key={i} className={rowClass}>
+        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);
+
+const BoardHeader = ({
+  count,
+  loading,
+  showAll,
+  addOpen,
+  onToggleShowAll,
+  onToggleAdd,
+}: {
+  count: number;
+  loading: boolean;
+  showAll: boolean;
+  addOpen: boolean;
+  onToggleShowAll?: (next: boolean) => void;
+  onToggleAdd?: () => void;
+}) => (
+  <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+    <span className="text-[var(--ink-muted)]" aria-hidden="true">
+      <IoPulseOutline size={18} />
+    </span>
+    <h3 id="checkin-board-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+      Check-in board
+    </h3>
+    {!loading && count > 0 && (
+      <StatusPill label={String(count)} tone="neutral" className="ml-auto tabular-nums" />
+    )}
+    {onToggleShowAll && (
+      <button
+        type="button"
+        onClick={() => onToggleShowAll(!showAll)}
+        aria-pressed={showAll}
+        className={clsx(
+          'rounded-lg border border-[var(--hairline)] px-2.5 py-1 text-[11.5px] font-semibold text-[var(--ink)] transition-colors hover:bg-[var(--inset)]',
+          !loading && count > 0 ? 'ml-2' : 'ml-auto'
+        )}
+      >
+        {showAll ? 'Active only' : 'Show all'}
+      </button>
+    )}
+    {onToggleAdd && (
+      <button
+        type="button"
+        onClick={onToggleAdd}
+        aria-expanded={addOpen}
+        className="ml-2 flex items-center gap-1 rounded-lg border border-[var(--hairline)] px-2.5 py-1 text-[11.5px] font-semibold text-[var(--ink)] transition-colors hover:bg-[var(--inset)]"
+      >
+        <IoAddOutline size={15} aria-hidden="true" />
+        {addOpen ? 'Close' : 'Check in patient'}
+      </button>
+    )}
+  </header>
+);
+
+/**
+ * Presentational-only check-in / waiting-room board. Renders the check-ins the
+ * caller supplies, sorted by triage priority then arrival so the most urgent
+ * waiting patient is first, each row carrying a triage pill, a status pill, the
+ * live wait time and the transition buttons the status permits. It never
+ * fetches; the container ({@link CheckInBoardPanel}) owns loading, error, data
+ * and the handlers, and gates edit actions by withholding the handler props.
+ */
+const CheckInBoard = ({
+  entries,
+  companions = [],
+  rooms = [],
+  loading = false,
+  error = null,
+  busyEntryId = null,
+  showAll = false,
+  onToggleShowAll,
+  onSeen,
+  onComplete,
+  onCancel,
+  onNoShow,
+  onAssignRoom,
+  onAdd,
+}: CheckInBoardProps) => {
+  const [addOpen, setAddOpen] = useState(false);
+  const handlers: Record<CheckInAction, ((id: string) => void) | undefined> = {
+    seen: onSeen,
+    complete: onComplete,
+    noShow: onNoShow,
+    cancel: onCancel,
+  };
+  // "Now" is read fresh every render so the live wait times keep advancing; it
+  // is deliberately not memoised.
+  const now = new Date();
+  const sorted = useMemo(() => sortForBoard(entries), [entries]);
+
+  const body = (() => {
+    if (loading) return <LoadingRows />;
+    if (sorted.length === 0) {
+      return <EmptyState message={showAll ? 'No check-ins yet' : 'No patients are checked in'} />;
+    }
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {sorted.map((entry) => (
+          <CheckInRow
+            key={entry.id}
+            entry={entry}
+            now={now}
+            busy={busyEntryId === entry.id}
+            rooms={rooms}
+            handlers={handlers}
+            onAssignRoom={onAssignRoom}
+          />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <section className={clsx(cardClass, 'w-full')} aria-labelledby="checkin-board-heading">
+      <BoardHeader
+        count={sorted.length}
+        loading={loading}
+        showAll={showAll}
+        addOpen={addOpen}
+        onToggleShowAll={onToggleShowAll}
+        onToggleAdd={onAdd ? () => setAddOpen((open) => !open) : undefined}
+      />
+
+      {error && (
+        <div
+          role="alert"
+          className="border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      )}
+
+      {onAdd && addOpen && (
+        <AddCheckInForm companions={companions} onAdd={onAdd} onClose={() => setAddOpen(false)} />
+      )}
+
+      {body}
+    </section>
+  );
+};
+
+export default CheckInBoard;

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
@@ -1,6 +1,13 @@
 'use client';
 import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
+import {
+  PanelEmptyState,
+  PanelLoadingRows,
+  panelFieldLabelClass as fieldLabelClass,
+  panelInputClass as inputClass,
+} from '@/app/ui/primitives/PanelStates/PanelStates';
+import { CompanionSelect } from '@/app/features/appointments/components/CompanionSelect';
 import { IoPulseOutline, IoAddOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import type {
@@ -124,9 +131,6 @@ const cardClass =
 const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
 const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
 const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
-const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
-const inputClass =
-  'w-full rounded-lg border border-[var(--hairline)] bg-[var(--screen)] px-2.5 py-1.5 text-[12.5px] text-[var(--ink)] outline-none focus:border-[var(--ink-muted)]';
 
 const sortForBoard = (entries: PatientCheckInView[]): PatientCheckInView[] =>
   [...entries].sort((a, b) => {
@@ -352,25 +356,15 @@ const AddCheckInForm = ({
       onSubmit={submit}
       className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
     >
-      <label className="flex flex-col gap-1" htmlFor="checkin-companion">
-        <span className={fieldLabelClass}>Patient</span>
-        <select
-          id="checkin-companion"
-          className={inputClass}
-          value={patientId}
-          onChange={(e) => setPatientId(e.target.value)}
-          disabled={companions.length === 0}
-        >
-          <option value="">
-            {companions.length === 0 ? 'No patients available' : 'Select a patient'}
-          </option>
-          {companions.map((companion) => (
-            <option key={companion.id} value={companion.id}>
-              {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
-            </option>
-          ))}
-        </select>
-      </label>
+      <CompanionSelect
+        id="checkin-companion"
+        label="Patient"
+        placeholder="Select a patient"
+        emptyLabel="No patients available"
+        value={patientId}
+        onChange={setPatientId}
+        companions={companions}
+      />
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <label className="flex flex-col gap-1" htmlFor="checkin-triage">
@@ -441,21 +435,6 @@ const AddCheckInForm = ({
     </form>
   );
 };
-
-const EmptyState = ({ message }: { message: string }) => (
-  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
-);
-
-const LoadingRows = () => (
-  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
-    {[0, 1, 2].map((i) => (
-      <li key={i} className={rowClass}>
-        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
-        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
-      </li>
-    ))}
-  </ul>
-);
 
 const BoardHeader = ({
   count,
@@ -546,9 +525,11 @@ const CheckInBoard = ({
   const sorted = useMemo(() => sortForBoard(entries), [entries]);
 
   const body = (() => {
-    if (loading) return <LoadingRows />;
+    if (loading) return <PanelLoadingRows rowClass={rowClass} />;
     if (sorted.length === 0) {
-      return <EmptyState message={showAll ? 'No check-ins yet' : 'No patients are checked in'} />;
+      return (
+        <PanelEmptyState message={showAll ? 'No check-ins yet' : 'No patients are checked in'} />
+      );
     }
     return (
       <ul className="divide-y divide-[var(--divider)]">

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
@@ -303,15 +303,13 @@ const CheckInRow = ({
   );
 };
 
-const AddCheckInForm = ({
-  companions,
-  onAdd,
-  onClose,
-}: {
+type AddCheckInFormProps = {
   companions: CheckInCompanionOption[];
   onAdd: (payload: CreateCheckInPayload) => Promise<boolean>;
   onClose: () => void;
-}) => {
+};
+
+const useAddCheckInForm = ({ companions, onAdd, onClose }: AddCheckInFormProps) => {
   const [patientId, setPatientId] = useState('');
   const [triagePriority, setTriagePriority] = useState<TriagePriority>('STANDARD');
   const [arrivedAt, setArrivedAt] = useState(() => toLocalInputValue(new Date()));
@@ -320,7 +318,7 @@ const AddCheckInForm = ({
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  const submit = async (event: React.FormEvent) => {
+  const submit = async (event: React.FormEvent): Promise<void> => {
     event.preventDefault();
     const selected = companions.find((companion) => companion.id === patientId);
     if (!selected) {
@@ -352,9 +350,86 @@ const AddCheckInForm = ({
     }
   };
 
+  return {
+    patientId,
+    setPatientId,
+    triagePriority,
+    setTriagePriority,
+    arrivedAt,
+    setArrivedAt,
+    triageNote,
+    setTriageNote,
+    notes,
+    setNotes,
+    submitting,
+    formError,
+    submit,
+  };
+};
+
+type AddCheckInFormState = ReturnType<typeof useAddCheckInForm>;
+
+const CheckInTimingFields = ({ form }: { form: AddCheckInFormState }) => (
+  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <label className="flex flex-col gap-1" htmlFor="checkin-triage">
+      <span className={fieldLabelClass}>Triage priority</span>
+      <select
+        id="checkin-triage"
+        className={inputClass}
+        value={form.triagePriority}
+        onChange={(e) => form.setTriagePriority(e.target.value as TriagePriority)}
+      >
+        {TRIAGE_ORDER.map((priority) => (
+          <option key={priority} value={priority}>
+            {TRIAGE_LABEL[priority]}
+          </option>
+        ))}
+      </select>
+    </label>
+    <label className="flex flex-col gap-1" htmlFor="checkin-arrived">
+      <span className={fieldLabelClass}>Arrived at</span>
+      <input
+        id="checkin-arrived"
+        type="datetime-local"
+        className={inputClass}
+        value={form.arrivedAt}
+        onChange={(e) => form.setArrivedAt(e.target.value)}
+      />
+    </label>
+  </div>
+);
+
+const CheckInNotesFields = ({ form }: { form: AddCheckInFormState }) => (
+  <>
+    <label className="flex flex-col gap-1" htmlFor="checkin-triage-note">
+      <span className={fieldLabelClass}>Triage note</span>
+      <input
+        id="checkin-triage-note"
+        className={inputClass}
+        value={form.triageNote}
+        onChange={(e) => form.setTriageNote(e.target.value)}
+        maxLength={200}
+      />
+    </label>
+    <label className="flex flex-col gap-1" htmlFor="checkin-notes">
+      <span className={fieldLabelClass}>Notes</span>
+      <textarea
+        id="checkin-notes"
+        className={clsx(inputClass, 'min-h-16 resize-y')}
+        value={form.notes}
+        onChange={(e) => form.setNotes(e.target.value)}
+        maxLength={500}
+      />
+    </label>
+  </>
+);
+
+const AddCheckInForm = (props: AddCheckInFormProps) => {
+  const form = useAddCheckInForm(props);
+
   return (
     <form
-      onSubmit={submit}
+      onSubmit={form.submit}
       className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
     >
       <CompanionSelect
@@ -362,75 +437,32 @@ const AddCheckInForm = ({
         label="Patient"
         placeholder="Select a patient"
         emptyLabel="No patients available"
-        value={patientId}
-        onChange={setPatientId}
-        companions={companions}
+        value={form.patientId}
+        onChange={form.setPatientId}
+        companions={props.companions}
       />
+      <CheckInTimingFields form={form} />
+      <CheckInNotesFields form={form} />
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <label className="flex flex-col gap-1" htmlFor="checkin-triage">
-          <span className={fieldLabelClass}>Triage priority</span>
-          <select
-            id="checkin-triage"
-            className={inputClass}
-            value={triagePriority}
-            onChange={(e) => setTriagePriority(e.target.value as TriagePriority)}
-          >
-            {TRIAGE_ORDER.map((priority) => (
-              <option key={priority} value={priority}>
-                {TRIAGE_LABEL[priority]}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1" htmlFor="checkin-arrived">
-          <span className={fieldLabelClass}>Arrived at</span>
-          <input
-            id="checkin-arrived"
-            type="datetime-local"
-            className={inputClass}
-            value={arrivedAt}
-            onChange={(e) => setArrivedAt(e.target.value)}
-          />
-        </label>
-      </div>
-
-      <label className="flex flex-col gap-1" htmlFor="checkin-triage-note">
-        <span className={fieldLabelClass}>Triage note</span>
-        <input
-          id="checkin-triage-note"
-          className={inputClass}
-          value={triageNote}
-          onChange={(e) => setTriageNote(e.target.value)}
-          maxLength={200}
-        />
-      </label>
-
-      <label className="flex flex-col gap-1" htmlFor="checkin-notes">
-        <span className={fieldLabelClass}>Notes</span>
-        <textarea
-          id="checkin-notes"
-          className={clsx(inputClass, 'min-h-16 resize-y')}
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          maxLength={500}
-        />
-      </label>
-
-      {formError && (
+      {form.formError && (
         <p role="alert" className="text-[11.5px] font-semibold text-[var(--danger-text)]">
-          {formError}
+          {form.formError}
         </p>
       )}
 
       <div className="flex justify-end gap-2">
-        <ActionButton label="Cancel" tone="default" disabled={submitting} onClick={onClose} />
+        <ActionButton
+          label="Cancel"
+          tone="default"
+          disabled={form.submitting}
+          onClick={props.onClose}
+        />
         <button
           type="submit"
-          disabled={submitting}
+          disabled={form.submitting}
           className="rounded-lg border border-[var(--ink)] bg-[var(--ink)] px-3 py-1 text-[11.5px] font-semibold text-[var(--screen)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {submitting ? 'Checking in…' : 'Check in patient'}
+          {form.submitting ? 'Checking in…' : 'Check in patient'}
         </button>
       </div>
     </form>

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoardPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoardPanel.tsx
@@ -1,0 +1,65 @@
+'use client';
+import React from 'react';
+import CheckInBoard, {
+  type CheckInBoardProps,
+} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
+import { useCheckInBoard } from '@/app/features/appointments/components/CheckInBoard/useCheckInBoard';
+
+/** Just the edit-gated handler props the board hides when they are absent. */
+type CheckInEditHandlers = Pick<
+  CheckInBoardProps,
+  'onSeen' | 'onComplete' | 'onCancel' | 'onNoShow' | 'onAssignRoom' | 'onAdd'
+>;
+
+/**
+ * Data container for {@link CheckInBoard}. All state lives in
+ * {@link useCheckInBoard}; this projects it onto the presentational board and
+ * withholds the edit actions (the board hides them) when the user lacks
+ * appointment edit permission. The show-all toggle stays available to everyone.
+ */
+const CheckInBoardPanel = () => {
+  const {
+    canEdit,
+    entriesView,
+    companionOptions,
+    roomOptions,
+    loading,
+    error,
+    busyEntryId,
+    showAll,
+    setShowAll,
+    seen,
+    complete,
+    cancel,
+    noShow,
+    assignRoom,
+    add,
+  } = useCheckInBoard();
+
+  const editHandlers: CheckInEditHandlers = canEdit
+    ? {
+        onSeen: (id) => void seen(id),
+        onComplete: (id) => void complete(id),
+        onCancel: (id) => void cancel(id),
+        onNoShow: (id) => void noShow(id),
+        onAssignRoom: (id, roomId) => void assignRoom(id, roomId),
+        onAdd: add,
+      }
+    : {};
+
+  return (
+    <CheckInBoard
+      entries={entriesView}
+      companions={companionOptions}
+      rooms={roomOptions}
+      loading={loading}
+      error={error}
+      busyEntryId={busyEntryId}
+      showAll={showAll}
+      onToggleShowAll={setShowAll}
+      {...editHandlers}
+    />
+  );
+};
+
+export default CheckInBoardPanel;

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/useCheckInBoard.ts
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/useCheckInBoard.ts
@@ -1,0 +1,222 @@
+'use client';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import {
+  assignCheckInRoom,
+  cancelCheckIn,
+  completeCheckIn,
+  createCheckIn,
+  fetchCheckIns,
+  markCheckInNoShow,
+  markCheckInSeen,
+  type CreateCheckInPayload,
+  type PatientCheckIn,
+} from '@/app/features/appointments/services/patientCheckInService';
+import {
+  useCompanionsParentsForPrimaryOrg,
+  useLoadCompanionsForPrimaryOrg,
+} from '@/app/hooks/useCompanion';
+import { useLoadRoomsForPrimaryOrg, useRoomsForPrimaryOrg } from '@/app/hooks/useRooms';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import type {
+  CheckInCompanionOption,
+  CheckInRoomOption,
+  PatientCheckInView,
+} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
+
+const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ').trim();
+
+const isActive = (checkIn: PatientCheckIn): boolean =>
+  checkIn.status === 'WAITING' || checkIn.status === 'IN_CONSULTATION';
+
+export interface CheckInBoardState {
+  canEdit: boolean;
+  entriesView: PatientCheckInView[];
+  companionOptions: CheckInCompanionOption[];
+  roomOptions: CheckInRoomOption[];
+  loading: boolean;
+  error: string | null;
+  busyEntryId: string | null;
+  showAll: boolean;
+  setShowAll: (next: boolean) => void;
+  seen: (id: string) => Promise<void>;
+  complete: (id: string) => Promise<void>;
+  cancel: (id: string) => Promise<void>;
+  noShow: (id: string) => Promise<void>;
+  assignRoom: (id: string, roomId: string) => Promise<void>;
+  add: (payload: CreateCheckInPayload) => Promise<boolean>;
+}
+
+type CheckInData = {
+  checkIns: PatientCheckIn[];
+  setCheckIns: Dispatch<SetStateAction<PatientCheckIn[]>>;
+  loading: boolean;
+  error: string | null;
+  setError: Dispatch<SetStateAction<string | null>>;
+};
+
+const useCheckInData = (organisationId: string | null): CheckInData => {
+  const [checkIns, setCheckIns] = useState<PatientCheckIn[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const run = async () => {
+      if (!organisationId) {
+        setCheckIns([]);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchCheckIns(organisationId);
+        if (active) setCheckIns(data);
+      } catch {
+        if (active) {
+          setCheckIns([]);
+          setError('Unable to load the check-in board right now.');
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [organisationId]);
+
+  return { checkIns, setCheckIns, loading, error, setError };
+};
+
+const useCheckInActions = (
+  organisationId: string | null,
+  setCheckIns: CheckInData['setCheckIns'],
+  setError: CheckInData['setError']
+) => {
+  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
+  const runAction = async (
+    id: string,
+    run: (orgId: string) => Promise<PatientCheckIn>
+  ): Promise<void> => {
+    if (!organisationId) return;
+    setBusyEntryId(id);
+    try {
+      await run(organisationId);
+      setCheckIns(await fetchCheckIns(organisationId));
+      setError(null);
+    } catch {
+      setError('That action could not be completed. Try again.');
+    } finally {
+      setBusyEntryId(null);
+    }
+  };
+  const add = async (payload: CreateCheckInPayload): Promise<boolean> => {
+    if (!organisationId) return false;
+    try {
+      await createCheckIn(organisationId, payload);
+      setCheckIns(await fetchCheckIns(organisationId));
+      setError(null);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  return {
+    busyEntryId,
+    seen: (id: string) => runAction(id, (orgId) => markCheckInSeen(orgId, id)),
+    complete: (id: string) => runAction(id, (orgId) => completeCheckIn(orgId, id)),
+    cancel: (id: string) => runAction(id, (orgId) => cancelCheckIn(orgId, id)),
+    noShow: (id: string) => runAction(id, (orgId) => markCheckInNoShow(orgId, id)),
+    assignRoom: (id: string, roomId: string) =>
+      runAction(id, (orgId) => assignCheckInRoom(orgId, id, roomId)),
+    add,
+  };
+};
+
+/**
+ * All of the check-in board container's state: it loads the primary org's
+ * check-ins, resolves each row's companion/owner names and assigned-room name,
+ * and exposes the seen/complete/cancel/no-show/assign-room/add actions. The
+ * board defaults to active check-ins (WAITING + IN_CONSULTATION); `showAll`
+ * reveals the terminal statuses too.
+ */
+export const useCheckInBoard = (): CheckInBoardState => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const permissions = usePermissions();
+  const canEdit =
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY) ||
+    permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_OWN);
+
+  useLoadCompanionsForPrimaryOrg();
+  const companionsParents = useCompanionsParentsForPrimaryOrg();
+  useLoadRoomsForPrimaryOrg();
+  const rooms = useRoomsForPrimaryOrg();
+
+  const { checkIns, setCheckIns, loading, error, setError } = useCheckInData(primaryOrgId);
+  const actions = useCheckInActions(primaryOrgId, setCheckIns, setError);
+  const [showAll, setShowAll] = useState(false);
+
+  const companionMetaById = useMemo(() => {
+    const map = new Map<string, { name: string; ownerName: string }>();
+    for (const { companion, parent } of companionsParents) {
+      map.set(companion.id, {
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName),
+      });
+    }
+    return map;
+  }, [companionsParents]);
+
+  const roomNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const room of rooms) map.set(room.id, room.name);
+    return map;
+  }, [rooms]);
+
+  const entriesView = useMemo<PatientCheckInView[]>(() => {
+    const visible = showAll ? checkIns : checkIns.filter(isActive);
+    return visible.map((entry) => {
+      const meta = companionMetaById.get(entry.patientId);
+      return {
+        ...entry,
+        companionName: meta?.name,
+        ownerName: meta?.ownerName || undefined,
+        roomName: entry.assignedRoomId ? roomNameById.get(entry.assignedRoomId) : undefined,
+      };
+    });
+  }, [checkIns, showAll, companionMetaById, roomNameById]);
+
+  const companionOptions = useMemo<CheckInCompanionOption[]>(
+    () =>
+      companionsParents.map(({ companion, parent }) => ({
+        id: companion.id,
+        name: companion.name,
+        ownerName: ownerNameOf(parent.firstName, parent.lastName) || undefined,
+        clientId: parent.id || undefined,
+      })),
+    [companionsParents]
+  );
+
+  const roomOptions = useMemo<CheckInRoomOption[]>(
+    () => rooms.map((room) => ({ id: room.id, name: room.name })),
+    [rooms]
+  );
+
+  return {
+    canEdit,
+    entriesView,
+    companionOptions,
+    roomOptions,
+    loading,
+    error,
+    showAll,
+    setShowAll,
+    ...actions,
+  };
+};

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/useCheckInBoard.ts
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/useCheckInBoard.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import {
+  isActiveCheckInStatus,
   assignCheckInRoom,
   cancelCheckIn,
   completeCheckIn,
@@ -27,9 +28,6 @@ import type {
 
 const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
   [firstName, lastName].filter(Boolean).join(' ').trim();
-
-const isActive = (checkIn: PatientCheckIn): boolean =>
-  checkIn.status === 'WAITING' || checkIn.status === 'IN_CONSULTATION';
 
 export interface CheckInBoardState {
   canEdit: boolean;
@@ -180,7 +178,7 @@ export const useCheckInBoard = (): CheckInBoardState => {
   }, [rooms]);
 
   const entriesView = useMemo<PatientCheckInView[]>(() => {
-    const visible = showAll ? checkIns : checkIns.filter(isActive);
+    const visible = showAll ? checkIns : checkIns.filter((c) => isActiveCheckInStatus(c.status));
     return visible.map((entry) => {
       const meta = companionMetaById.get(entry.patientId);
       return {

--- a/apps/frontend/src/app/features/appointments/components/CompanionSelect.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CompanionSelect.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { panelFieldLabelClass, panelInputClass } from '@/app/ui/primitives/PanelStates/PanelStates';
+
+export type CompanionSelectOption = {
+  id: string;
+  name: string;
+  ownerName?: string;
+};
+
+/**
+ * The companion picker shared by the appointment panels that put a patient on a
+ * list (the waitlist and the check-in board). Each panel names the same control
+ * differently - "Companion" on the waitlist, "Patient" at the front desk - so
+ * the wording is passed in while the markup stays one definition.
+ */
+export const CompanionSelect = ({
+  id,
+  label,
+  placeholder,
+  emptyLabel,
+  value,
+  onChange,
+  companions,
+}: {
+  /** Omitted by panels whose label already wraps the control. */
+  id?: string;
+  label: string;
+  placeholder: string;
+  /** Shown in place of the placeholder when there is nothing to pick. */
+  emptyLabel: string;
+  value: string;
+  onChange: (value: string) => void;
+  companions: CompanionSelectOption[];
+}) => (
+  <label className="flex flex-col gap-1" htmlFor={id}>
+    <span className={panelFieldLabelClass}>{label}</span>
+    <select
+      id={id}
+      className={panelInputClass}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={companions.length === 0}
+    >
+      <option value="">{companions.length === 0 ? emptyLabel : placeholder}</option>
+      {companions.map((companion) => (
+        <option key={companion.id} value={companion.id}>
+          {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
+        </option>
+      ))}
+    </select>
+  </label>
+);

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
@@ -1,6 +1,13 @@
 'use client';
 import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
+import {
+  PanelEmptyState,
+  PanelLoadingRows,
+  panelFieldLabelClass as fieldLabelClass,
+  panelInputClass as inputClass,
+} from '@/app/ui/primitives/PanelStates/PanelStates';
+import { CompanionSelect } from '@/app/features/appointments/components/CompanionSelect';
 import { IoListOutline, IoAddOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import type {
@@ -76,9 +83,6 @@ const cardClass =
 const rowClass = 'flex items-start justify-between gap-3 px-4 py-3';
 const titleClass = 'text-[13px] font-bold text-[var(--ink)]';
 const metaClass = 'text-[11.5px] text-[var(--ink-faint)]';
-const fieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
-const inputClass =
-  'w-full rounded-lg border border-[var(--hairline)] bg-[var(--screen)] px-2.5 py-1.5 text-[12.5px] text-[var(--ink)] outline-none focus:border-[var(--ink-muted)]';
 
 const absoluteDate = (iso: string | null): string | null => {
   if (!iso) return null;
@@ -231,24 +235,14 @@ const AddWaitlistForm = ({
       onSubmit={submit}
       className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
     >
-      <label className="flex flex-col gap-1">
-        <span className={fieldLabelClass}>Companion</span>
-        <select
-          className={inputClass}
-          value={patientId}
-          onChange={(e) => setPatientId(e.target.value)}
-          disabled={companions.length === 0}
-        >
-          <option value="">
-            {companions.length === 0 ? 'No companions available' : 'Select a companion'}
-          </option>
-          {companions.map((companion) => (
-            <option key={companion.id} value={companion.id}>
-              {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
-            </option>
-          ))}
-        </select>
-      </label>
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value={patientId}
+        onChange={setPatientId}
+        companions={companions}
+      />
 
       <label className="flex flex-col gap-1">
         <span className={fieldLabelClass}>Requested service</span>
@@ -313,21 +307,6 @@ const AddWaitlistForm = ({
   );
 };
 
-const EmptyState = ({ message }: { message: string }) => (
-  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
-);
-
-const LoadingRows = () => (
-  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
-    {[0, 1, 2].map((i) => (
-      <li key={i} className={rowClass}>
-        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
-        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
-      </li>
-    ))}
-  </ul>
-);
-
 /**
  * Presentational-only waitlist. Renders the entries the caller supplies with a
  * status pill and the row actions each status permits; it never fetches. The
@@ -364,8 +343,8 @@ const Waitlist = ({
   }, [entries]);
 
   const body = (() => {
-    if (loading) return <LoadingRows />;
-    if (entries.length === 0) return <EmptyState message="No one is on the waitlist" />;
+    if (loading) return <PanelLoadingRows rowClass={rowClass} />;
+    if (entries.length === 0) return <PanelEmptyState message="No one is on the waitlist" />;
     return (
       <ul className="divide-y divide-[var(--divider)]">
         {entries.map((entry) => (

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -46,6 +46,9 @@ const ChangeRoom = React.lazy(
 const WaitlistPanel = React.lazy(
   () => import('@/app/features/appointments/components/Waitlist/WaitlistPanel')
 );
+const CheckInBoardPanel = React.lazy(
+  () => import('@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel')
+);
 import { useSearchStore } from '@/app/stores/searchStore';
 import Filters from '@/app/ui/filters/Filters';
 import {
@@ -329,6 +332,7 @@ const useAppointmentsView = () => {
   const [activeStatus, setActiveStatus] = useState('all');
   const [addPopup, setAddPopup] = useState(false);
   const [showWaitlist, setShowWaitlist] = useState(false);
+  const [showCheckIn, setShowCheckIn] = useState(false);
   const [addAppointmentPrefill, setAddAppointmentPrefill] =
     useState<AppointmentDraftPrefill | null>(null);
   const [viewPopup, setViewPopup] = useState(false);
@@ -616,6 +620,32 @@ const useAppointmentsView = () => {
               <div id="appointments-waitlist-panel" className="mt-3">
                 <React.Suspense fallback={<PlannerViewSkeleton />}>
                   <WaitlistPanel />
+                </React.Suspense>
+              </div>
+            )}
+          </section>
+          <section aria-labelledby="appointments-checkin-heading" className="mb-3">
+            <button
+              type="button"
+              onClick={() => setShowCheckIn((open) => !open)}
+              aria-expanded={showCheckIn}
+              aria-controls="appointments-checkin-panel"
+              className="flex w-full items-center justify-between gap-3 rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-4 py-2.5 text-left shadow-[0_1px_2px_var(--sh03)] transition-colors hover:bg-[var(--inset)]"
+            >
+              <span
+                id="appointments-checkin-heading"
+                className="text-[13.5px] font-bold text-[var(--ink)]"
+              >
+                Check-in board
+              </span>
+              <span className="text-[12px] font-semibold text-[var(--ink-muted)]">
+                {showCheckIn ? 'Hide' : 'Show'}
+              </span>
+            </button>
+            {showCheckIn && (
+              <div id="appointments-checkin-panel" className="mt-3">
+                <React.Suspense fallback={<PlannerViewSkeleton />}>
+                  <CheckInBoardPanel />
                 </React.Suspense>
               </div>
             )}

--- a/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
+++ b/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
@@ -21,6 +21,10 @@ export type CheckInStatus = 'WAITING' | 'IN_CONSULTATION' | 'COMPLETED' | 'NO_SH
  * so `DateTime` columns arrive as ISO strings and nullable columns arrive as
  * `null`, not `undefined`.
  */
+/** A check-in still on the board: waiting to be seen, or in consultation. */
+export const isActiveCheckInStatus = (status: CheckInStatus): boolean =>
+  status === 'WAITING' || status === 'IN_CONSULTATION';
+
 export interface PatientCheckIn {
   id: string;
   organisationId: string;
@@ -91,12 +95,14 @@ export const fetchCheckIns = async (
   filter: CheckInListFilter = {}
 ): Promise<PatientCheckIn[]> => {
   const safeOrganisationId = assertUuid(organisationId, 'organisation');
-  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in`;
   const params: Record<string, string> = {};
   if (filter.patientId) params.patientId = filter.patientId;
   if (filter.status) params.status = filter.status;
   try {
-    const res = await getData<PatientCheckIn[]>(url, params);
+    const res = await getData<PatientCheckIn[]>(
+      `/v1/pms/organisation/${safeOrganisationId}/check-in`,
+      params
+    );
     if (!Array.isArray(res.data)) {
       console.warn('Check-in response is not an array; got', typeof res.data);
       return [];
@@ -114,9 +120,10 @@ export const fetchCheckIn = async (
 ): Promise<PatientCheckIn> => {
   const safeOrganisationId = assertUuid(organisationId, 'organisation');
   const safeCheckInId = assertUuid(checkInId, 'check-in');
-  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}`;
   try {
-    const res = await getData<PatientCheckIn>(url);
+    const res = await getData<PatientCheckIn>(
+      `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}`
+    );
     return res.data;
   } catch (err) {
     logFailure('Failed to load the check-in:', err);
@@ -129,9 +136,11 @@ export const createCheckIn = async (
   payload: CreateCheckInPayload
 ): Promise<PatientCheckIn> => {
   const safeOrganisationId = assertUuid(organisationId, 'organisation');
-  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in`;
   try {
-    const res = await postData<PatientCheckIn, CreateCheckInPayload>(url, payload);
+    const res = await postData<PatientCheckIn, CreateCheckInPayload>(
+      `/v1/pms/organisation/${safeOrganisationId}/check-in`,
+      payload
+    );
     return res.data;
   } catch (err) {
     logFailure('Failed to create the check-in:', err);
@@ -148,9 +157,10 @@ const transition = async (
 ): Promise<PatientCheckIn> => {
   const safeOrganisationId = assertUuid(organisationId, 'organisation');
   const safeCheckInId = assertUuid(checkInId, 'check-in');
-  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/${action}`;
   try {
-    const res = await postData<PatientCheckIn>(url);
+    const res = await postData<PatientCheckIn>(
+      `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/${action}`
+    );
     return res.data;
   } catch (err) {
     logFailure(`Failed to ${action} the check-in:`, err);
@@ -177,9 +187,11 @@ export const assignCheckInRoom = async (
 ): Promise<PatientCheckIn> => {
   const safeOrganisationId = assertUuid(organisationId, 'organisation');
   const safeCheckInId = assertUuid(checkInId, 'check-in');
-  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/room`;
   try {
-    const res = await postData<PatientCheckIn, { roomId: string }>(url, { roomId });
+    const res = await postData<PatientCheckIn, { roomId: string }>(
+      `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/room`,
+      { roomId }
+    );
     return res.data;
   } catch (err) {
     logFailure('Failed to assign a room to the check-in:', err);

--- a/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
+++ b/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
@@ -86,14 +86,12 @@ const logFailure = (message: string, err: unknown): void => {
   }
 };
 
-const basePath = (organisationId: string): string =>
-  `/v1/pms/organisation/${assertUuid(organisationId, 'organisation')}/check-in`;
-
 export const fetchCheckIns = async (
   organisationId: string,
   filter: CheckInListFilter = {}
 ): Promise<PatientCheckIn[]> => {
-  const url = basePath(organisationId);
+  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in`;
   const params: Record<string, string> = {};
   if (filter.patientId) params.patientId = filter.patientId;
   if (filter.status) params.status = filter.status;
@@ -114,7 +112,9 @@ export const fetchCheckIn = async (
   organisationId: string,
   checkInId: string
 ): Promise<PatientCheckIn> => {
-  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}`;
+  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeCheckInId = assertUuid(checkInId, 'check-in');
+  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}`;
   try {
     const res = await getData<PatientCheckIn>(url);
     return res.data;
@@ -128,7 +128,8 @@ export const createCheckIn = async (
   organisationId: string,
   payload: CreateCheckInPayload
 ): Promise<PatientCheckIn> => {
-  const url = basePath(organisationId);
+  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in`;
   try {
     const res = await postData<PatientCheckIn, CreateCheckInPayload>(url, payload);
     return res.data;
@@ -145,7 +146,9 @@ const transition = async (
   checkInId: string,
   action: CheckInTransition
 ): Promise<PatientCheckIn> => {
-  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}/${action}`;
+  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeCheckInId = assertUuid(checkInId, 'check-in');
+  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/${action}`;
   try {
     const res = await postData<PatientCheckIn>(url);
     return res.data;
@@ -172,7 +175,9 @@ export const assignCheckInRoom = async (
   checkInId: string,
   roomId: string
 ): Promise<PatientCheckIn> => {
-  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}/room`;
+  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeCheckInId = assertUuid(checkInId, 'check-in');
+  const url = `/v1/pms/organisation/${safeOrganisationId}/check-in/${safeCheckInId}/room`;
   try {
     const res = await postData<PatientCheckIn, { roomId: string }>(url, { roomId });
     return res.data;

--- a/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
+++ b/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
@@ -1,0 +1,183 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+
+/**
+ * Triage priority mirrors the backend `TriagePriority` enum
+ * (packages/database/prisma/schema.prisma), ordered most to least urgent:
+ * IMMEDIATE, URGENT, LESS_URGENT, STANDARD, NON_URGENT.
+ */
+export type TriagePriority = 'IMMEDIATE' | 'URGENT' | 'LESS_URGENT' | 'STANDARD' | 'NON_URGENT';
+
+/**
+ * Check-in status mirrors the backend `CheckInStatus` enum. A WAITING patient
+ * can be seen (moves to IN_CONSULTATION), marked no-show, or cancelled; an
+ * IN_CONSULTATION patient can be completed or cancelled.
+ */
+export type CheckInStatus = 'WAITING' | 'IN_CONSULTATION' | 'COMPLETED' | 'NO_SHOW' | 'CANCELLED';
+
+/**
+ * One check-in exactly as the controller returns it (the raw Prisma row). The
+ * clinical handler replies with the row itself — no `{ data, meta }` envelope —
+ * so `DateTime` columns arrive as ISO strings and nullable columns arrive as
+ * `null`, not `undefined`.
+ */
+export interface PatientCheckIn {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  clientId: string;
+  appointmentId: string | null;
+  arrivedAt: string;
+  triagePriority: TriagePriority;
+  triageNote: string | null;
+  assignedRoomId: string | null;
+  checkedInBy: string | null;
+  waitStartedAt: string | null;
+  seenAt: string | null;
+  waitMinutes: number | null;
+  status: CheckInStatus;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The create body the controller validates. `patientId`, `clientId` and
+ * `arrivedAt` (an ISO datetime string) are required; the rest are optional.
+ */
+export interface CreateCheckInPayload {
+  patientId: string;
+  clientId: string;
+  appointmentId?: string;
+  arrivedAt: string;
+  triagePriority?: TriagePriority;
+  triageNote?: string;
+  checkedInBy?: string;
+  notes?: string;
+}
+
+/** Optional server-side list filters (`patientId`, `status`). */
+export interface CheckInListFilter {
+  patientId?: string;
+  status?: CheckInStatus;
+}
+
+/**
+ * Path ids are interpolated straight into the request URL, so they are validated
+ * against the canonical UUID shape and the matched value — not the raw input —
+ * is what flows into the URL. A non-UUID id throws before any request is made,
+ * which is the SSRF sanitiser the scanner recognises (`encodeURIComponent` does
+ * not satisfy it, because the tainted value would still reach the URL).
+ */
+const assertUuid = (value: string, label: string): string => {
+  const safeValue =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.exec(
+      value
+    )?.[0];
+  if (!safeValue) throw new Error(`Invalid ${label} ID`);
+  return safeValue;
+};
+
+const logFailure = (message: string, err: unknown): void => {
+  if (axios.isAxiosError(err)) {
+    console.error(message, err.response?.data?.message ?? err.message);
+  } else {
+    console.error(message, err);
+  }
+};
+
+const basePath = (organisationId: string): string =>
+  `/v1/pms/organisation/${assertUuid(organisationId, 'organisation')}/check-in`;
+
+export const fetchCheckIns = async (
+  organisationId: string,
+  filter: CheckInListFilter = {}
+): Promise<PatientCheckIn[]> => {
+  const url = basePath(organisationId);
+  const params: Record<string, string> = {};
+  if (filter.patientId) params.patientId = filter.patientId;
+  if (filter.status) params.status = filter.status;
+  try {
+    const res = await getData<PatientCheckIn[]>(url, params);
+    if (!Array.isArray(res.data)) {
+      console.warn('Check-in response is not an array; got', typeof res.data);
+      return [];
+    }
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to load check-ins:', err);
+    throw err;
+  }
+};
+
+export const fetchCheckIn = async (
+  organisationId: string,
+  checkInId: string
+): Promise<PatientCheckIn> => {
+  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}`;
+  try {
+    const res = await getData<PatientCheckIn>(url);
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to load the check-in:', err);
+    throw err;
+  }
+};
+
+export const createCheckIn = async (
+  organisationId: string,
+  payload: CreateCheckInPayload
+): Promise<PatientCheckIn> => {
+  const url = basePath(organisationId);
+  try {
+    const res = await postData<PatientCheckIn, CreateCheckInPayload>(url, payload);
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to create the check-in:', err);
+    throw err;
+  }
+};
+
+type CheckInTransition = 'seen' | 'complete' | 'cancel' | 'no-show';
+
+const transition = async (
+  organisationId: string,
+  checkInId: string,
+  action: CheckInTransition
+): Promise<PatientCheckIn> => {
+  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}/${action}`;
+  try {
+    const res = await postData<PatientCheckIn>(url);
+    return res.data;
+  } catch (err) {
+    logFailure(`Failed to ${action} the check-in:`, err);
+    throw err;
+  }
+};
+
+export const markCheckInSeen = (organisationId: string, checkInId: string) =>
+  transition(organisationId, checkInId, 'seen');
+
+export const completeCheckIn = (organisationId: string, checkInId: string) =>
+  transition(organisationId, checkInId, 'complete');
+
+export const cancelCheckIn = (organisationId: string, checkInId: string) =>
+  transition(organisationId, checkInId, 'cancel');
+
+export const markCheckInNoShow = (organisationId: string, checkInId: string) =>
+  transition(organisationId, checkInId, 'no-show');
+
+export const assignCheckInRoom = async (
+  organisationId: string,
+  checkInId: string,
+  roomId: string
+): Promise<PatientCheckIn> => {
+  const url = `${basePath(organisationId)}/${assertUuid(checkInId, 'check-in')}/room`;
+  try {
+    const res = await postData<PatientCheckIn, { roomId: string }>(url, { roomId });
+    return res.data;
+  } catch (err) {
+    logFailure('Failed to assign a room to the check-in:', err);
+    throw err;
+  }
+};

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlerts.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import clsx from 'clsx';
+import { PanelEmptyState, PanelLoadingRows } from '@/app/ui/primitives/PanelStates/PanelStates';
 import { IoAlertCircleOutline, IoTimeOutline } from 'react-icons/io5';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import type {
@@ -70,21 +71,6 @@ const AlertCard = ({ icon, title, count, children }: AlertCardProps) => {
     </section>
   );
 };
-
-const EmptyState = ({ message }: { message: string }) => (
-  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
-);
-
-const LoadingRows = () => (
-  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
-    {[0, 1, 2].map((i) => (
-      <li key={i} className={rowClass}>
-        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
-        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
-      </li>
-    ))}
-  </ul>
-);
 
 const LowStockRow = ({ item }: { item: LowStockAlertItem }) => {
   const out = (item.onHand ?? 0) <= 0;
@@ -158,8 +144,8 @@ const InventoryAlerts = ({
   const now = new Date();
 
   const lowStockBody = (() => {
-    if (loading) return <LoadingRows />;
-    if (lowStock.length === 0) return <EmptyState message="No low-stock items" />;
+    if (loading) return <PanelLoadingRows rowClass={rowClass} />;
+    if (lowStock.length === 0) return <PanelEmptyState message="No low-stock items" />;
     return (
       <ul className="divide-y divide-[var(--divider)]">
         {lowStock.map((item) => (
@@ -170,9 +156,11 @@ const InventoryAlerts = ({
   })();
 
   const expiringBody = (() => {
-    if (loading) return <LoadingRows />;
+    if (loading) return <PanelLoadingRows rowClass={rowClass} />;
     if (expiring.length === 0) {
-      return <EmptyState message={`Nothing expiring in the next ${expiringWindowDays} days`} />;
+      return (
+        <PanelEmptyState message={`Nothing expiring in the next ${expiringWindowDays} days`} />
+      );
     }
     return (
       <ul className="divide-y divide-[var(--divider)]">

--- a/apps/frontend/src/app/ui/primitives/PanelStates/PanelStates.tsx
+++ b/apps/frontend/src/app/ui/primitives/PanelStates/PanelStates.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Empty and loading states shared by the record panels (waitlist, check-in
+ * board, inventory alerts, and the panels that follow the same shape).
+ *
+ * Each panel carried its own byte-identical copy of these, which both drifted
+ * and tripped the duplicated-lines gate. The field classes live here too so a
+ * panel's form controls stay visually identical to its siblings by
+ * construction.
+ */
+
+export const panelFieldLabelClass = 'text-[11.5px] font-semibold text-[var(--ink-muted)]';
+export const panelInputClass =
+  'w-full rounded-lg border border-[var(--hairline)] bg-[var(--screen)] px-2.5 py-1.5 text-[12.5px] text-[var(--ink)] outline-none focus:border-[var(--ink-muted)]';
+
+/** Centred message for a panel that has no rows to show. */
+export const PanelEmptyState = ({ message }: { message: string }) => (
+  <p className="px-4 py-6 text-center text-[12.5px] text-[var(--ink-faint)]">{message}</p>
+);
+
+/**
+ * Three placeholder rows while a panel loads. `rowClass` is the panel's own row
+ * class so the skeleton lines up with the rows it stands in for.
+ */
+export const PanelLoadingRows = ({ rowClass }: { rowClass: string }) => (
+  <ul className="divide-y divide-[var(--divider)]" aria-hidden="true">
+    {[0, 1, 2].map((i) => (
+      <li key={i} className={rowClass}>
+        <span className="h-3.5 w-40 rounded bg-[var(--inset)]" />
+        <span className="h-5 w-16 rounded-full bg-[var(--inset)]" />
+      </li>
+    ))}
+  </ul>
+);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Part of the scheduling workstream; no standalone issue.)
- [x] All existing tests and lints pass.

## What is the current behavior?

The Appointments page surfaces the appointment waitlist, but there is no front-of-house view of who has physically arrived and is waiting to be seen. The backend already exposes a patient check-in / waiting-room API (`/v1/pms/organisation/:organisationId/check-in`), but nothing in the web app consumes it.

## What is the new behavior?

Adds a patient check-in / waiting-room board and wires it into the Appointments page as a collapsible disclosure, gated behind `PermissionGate` on `appointments:view:any`.

**Service** (`patientCheckInService.ts`) covers the full backend contract: list (bare array, with optional `patientId` / `status` filters), get, create, the `seen` / `complete` / `cancel` / `no-show` transitions, and `room` assignment. Every interpolated path id (organisation id and check-in id) is validated against a canonical-UUID regex and throws before any request is made; the list response is `Array.isArray`-guarded to `[]`, logging only the payload `typeof`, never the payload itself. Read permission maps to `APPOINTMENTS_VIEW_ANY`, write to `APPOINTMENTS_EDIT_ANY` / `APPOINTMENTS_EDIT_OWN`.

**Board** (`CheckInBoard`, presentational): rows are sorted by triage priority then arrival, so the most urgent waiting patient is first. Each row shows the patient and owner, the live wait time, a triage pill (IMMEDIATE in a danger tone, URGENT in a warning tone), a status pill, an optional room selector, and the transition buttons each status permits. The container hook (`useCheckInBoard`) owns all state (load, companion/owner and room-name resolution, the transition/add actions, error, and the active-vs-all view). `CheckInBoardPanel` is a thin projection that withholds edit handlers when the user cannot edit. The board defaults to active check-ins (WAITING + IN_CONSULTATION); a "Show all" toggle reveals terminal statuses.

Every form field uses an explicit `<label htmlFor>`; the create/add handler returns `Promise<boolean>` and the form only closes on a `true` result.

## Impact

- Area: `apps/frontend` only — the Appointments feature. No backend, shared-package, or dependency changes.
- Additive: a new collapsible section on the Appointments page, collapsed by default, behind the existing view permission. No existing behavior changes.

## Validation performed

Run from `apps/frontend`:

- `npx tsc --noEmit` — 0 errors.
- `npx eslint <changed files>` — exit 0 (no warnings; no disables).
- `npx jest --testPathPatterns="[Cc]heckIn|Appointments"` — 75 suites, 1336 tests, all passing (includes the Appointments page suite with `CheckInBoardPanel` mocked).
- Coverage on the new files: `patientCheckInService.ts` 100% / 100% / 100% / 100%; `CheckInBoardPanel.tsx` and `useCheckInBoard.ts` 100% across the board; `CheckInBoard.tsx` 100% stmts / 98.9% branch / 100% funcs / 100% lines.
- Mutation-checked the UUID-guard test (weakening the regex fails 30 guard assertions) and a transition test (pointing `markCheckInSeen` at the wrong action fails the URL assertion); both restored.
- `git push` pre-push gate (full monorepo lint + type-check) passed.
