### PR TITLE
feat(frontend): surface the patient consent list

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ConsentList from '@/app/features/companionHistory/components/ConsentList';
+import type { PatientConsent } from '@/app/features/companionHistory/services/patientConsentService';
+
+const consent = (
+  over: Partial<PatientConsent> & { id: string; consentType: PatientConsent['consentType'] }
+): PatientConsent => ({
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  status: 'ACTIVE',
+  procedureDesc: null,
+  consentedByName: 'Lena Hartmann',
+  consentedAt: '2026-01-10T09:00:00.000Z',
+  expiresAt: null,
+  witnessedBy: null,
+  revokedAt: null,
+  revokedReason: null,
+  documentId: null,
+  notes: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const CONSENTS: PatientConsent[] = [
+  consent({
+    id: 'c-1',
+    consentType: 'SURGICAL',
+    status: 'ACTIVE',
+    procedureDesc: 'Dental extraction',
+    witnessedBy: 'Dr. Okafor',
+    notes: 'Owner briefed on anaesthetic risk.',
+  }),
+  consent({ id: 'c-2', consentType: 'DNR', status: 'ACTIVE', consentedByName: null }),
+  consent({
+    id: 'c-3',
+    consentType: 'DATA_SHARING',
+    status: 'EXPIRED',
+    expiresAt: '2026-01-02T00:00:00.000Z',
+  }),
+  consent({
+    id: 'c-4',
+    consentType: 'ANESTHESIA',
+    status: 'REVOKED',
+    revokedAt: '2025-11-20T00:00:00.000Z',
+    revokedReason: 'Procedure postponed.',
+  }),
+];
+
+describe('ConsentList', () => {
+  it('renders active, expired and revoked consents with status pills and metadata', () => {
+    render(<ConsentList consents={CONSENTS} canEdit />);
+
+    // Consent-type titles.
+    expect(screen.getByText('Surgical')).toBeInTheDocument();
+    expect(screen.getByText('Do not resuscitate')).toBeInTheDocument();
+    expect(screen.getByText('Data sharing')).toBeInTheDocument();
+    expect(screen.getByText('Anaesthesia')).toBeInTheDocument();
+
+    // Status pills: two active, one expired, one revoked.
+    expect(screen.getAllByText('Active')).toHaveLength(2);
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+
+    // Metadata: procedure, consenting party, witness, notes and revoked reason.
+    expect(screen.getByText('Dental extraction')).toBeInTheDocument();
+    expect(screen.getAllByText(/Consented by Lena Hartmann/).length).toBeGreaterThan(0);
+    // The DNR consent has no named consenter, so the meta line drops the "by".
+    expect(screen.getByText(/^Consented ·/)).toBeInTheDocument();
+    expect(screen.getByText(/Witnessed by Dr. Okafor/)).toBeInTheDocument();
+    expect(screen.getByText('Owner briefed on anaesthetic risk.')).toBeInTheDocument();
+    expect(screen.getByText(/Reason: Procedure postponed\./)).toBeInTheDocument();
+
+    // Active count summary.
+    expect(screen.getByText('2 active')).toBeInTheDocument();
+  });
+
+  it('opens a revoke form only for active consents and submits the reason', async () => {
+    const onRevoke = jest.fn().mockResolvedValue(true);
+    render(<ConsentList consents={CONSENTS} canEdit onRevoke={onRevoke} />);
+
+    // Only the two ACTIVE consents get a revoke control.
+    expect(screen.getAllByRole('button', { name: /^Revoke / })).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.type(screen.getByLabelText('Reason for revoking'), 'Owner withdrew');
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    expect(onRevoke).toHaveBeenCalledWith(expect.objectContaining({ id: 'c-1' }), 'Owner withdrew');
+    // The form closes on a successful revoke.
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Reason for revoking')).not.toBeInTheDocument()
+    );
+  });
+
+  it('revokes without a reason, sending undefined', async () => {
+    const onRevoke = jest.fn().mockResolvedValue(true);
+    render(<ConsentList consents={[CONSENTS[1]]} canEdit onRevoke={onRevoke} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Revoke Do not resuscitate consent' })
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    expect(onRevoke).toHaveBeenCalledWith(expect.objectContaining({ id: 'c-2' }), undefined);
+  });
+
+  it('keeps the revoke form open when the revoke fails', async () => {
+    const onRevoke = jest.fn().mockResolvedValue(false);
+    render(<ConsentList consents={[CONSENTS[0]]} canEdit onRevoke={onRevoke} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    expect(onRevoke).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Reason for revoking')).toBeInTheDocument();
+  });
+
+  it('opens the grant form and submits collected values, then closes on success', async () => {
+    const onGrant = jest.fn().mockResolvedValue(true);
+    render(<ConsentList consents={CONSENTS} canEdit onGrant={onGrant} />);
+
+    // Form is hidden until the affordance is used.
+    expect(screen.queryByLabelText('Consent type')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+
+    await userEvent.selectOptions(screen.getByLabelText('Consent type'), 'DIAGNOSTIC');
+    await userEvent.type(screen.getByLabelText('Procedure'), 'Abdominal ultrasound');
+    await userEvent.type(screen.getByLabelText('Consented by'), 'Sam Owner');
+    fireEvent.change(screen.getByLabelText('Expiry date'), { target: { value: '2026-06-01' } });
+    await userEvent.type(screen.getByLabelText('Witnessed by'), 'Nurse Patel');
+    await userEvent.type(screen.getByLabelText('Notes'), 'Sedation discussed');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    expect(onGrant).toHaveBeenCalledWith({
+      consentType: 'DIAGNOSTIC',
+      procedureDesc: 'Abdominal ultrasound',
+      consentedByName: 'Sam Owner',
+      expiresAt: '2026-06-01',
+      witnessedBy: 'Nurse Patel',
+      notes: 'Sedation discussed',
+    });
+
+    // A resolved grant clears and closes the form.
+    await waitFor(() => expect(screen.queryByLabelText('Consent type')).not.toBeInTheDocument());
+  });
+
+  it('ignores a grant submit while a grant is already in flight', async () => {
+    const onGrant = jest.fn().mockResolvedValue(true);
+    render(<ConsentList consents={[]} canEdit creating onGrant={onGrant} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    const form = screen.getByLabelText('Consent type').closest('form');
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(onGrant).not.toHaveBeenCalled();
+  });
+
+  it('ignores a revoke submit while a revoke is already in flight', async () => {
+    const onRevoke = jest.fn().mockResolvedValue(true);
+    const { rerender } = render(
+      <ConsentList consents={[CONSENTS[0]]} canEdit onRevoke={onRevoke} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    // The parent marks this consent as revoking mid-flight.
+    rerender(<ConsentList consents={[CONSENTS[0]]} canEdit revokingId="c-1" onRevoke={onRevoke} />);
+    const form = screen.getByLabelText('Reason for revoking').closest('form');
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(onRevoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps the grant form open when the grant fails', async () => {
+    const onGrant = jest.fn().mockResolvedValue(false);
+    render(<ConsentList consents={[]} canEdit onGrant={onGrant} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    expect(onGrant).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Consent type')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no consents', () => {
+    render(<ConsentList consents={[]} canEdit />);
+    expect(screen.getByText(/No consents recorded/)).toBeInTheDocument();
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
+  it('renders a loading skeleton instead of the empty copy', () => {
+    render(<ConsentList consents={[]} loading canEdit />);
+    expect(screen.queryByText(/No consents recorded/)).not.toBeInTheDocument();
+  });
+
+  it('surfaces an error banner', () => {
+    render(
+      <ConsentList consents={[]} error="Could not load the consent list. Please try again." />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load the consent list');
+    expect(screen.queryByText(/No consents recorded/)).not.toBeInTheDocument();
+  });
+
+  it('disables every revoke trigger while a revoke is in flight', () => {
+    render(<ConsentList consents={CONSENTS} canEdit revokingId="c-1" />);
+    expect(screen.getByRole('button', { name: 'Revoke Surgical consent' })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Revoke Do not resuscitate consent' })
+    ).toBeDisabled();
+  });
+
+  it('hides the grant and revoke controls when the member cannot edit', () => {
+    render(<ConsentList consents={CONSENTS} canEdit={false} />);
+    expect(screen.queryByRole('button', { name: 'Record consent' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Revoke / })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
@@ -1,0 +1,308 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { isAuthRedirectError } from '@/app/services/axios';
+import ConsentListPanel from '@/app/features/companionHistory/components/ConsentListPanel';
+import {
+  fetchPatientConsents,
+  grantPatientConsent,
+  revokePatientConsent,
+  type PatientConsent,
+} from '@/app/features/companionHistory/services/patientConsentService';
+
+const notifyMock = jest.fn();
+let permissionsMock: string[] = ['appointments:view:any', 'appointments:edit:any'];
+
+jest.mock('@/app/services/axios', () => ({
+  isAuthRedirectError: jest.fn(() => false),
+}));
+
+jest.mock('@/app/hooks/useNotify', () => ({
+  useNotify: () => ({ notify: notifyMock }),
+}));
+
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: (permission: string) => permissionsMock.includes(permission) }),
+}));
+
+jest.mock('@/app/features/companionHistory/services/patientConsentService', () => ({
+  fetchPatientConsents: jest.fn(),
+  grantPatientConsent: jest.fn(),
+  revokePatientConsent: jest.fn(),
+}));
+
+const fetchMock = fetchPatientConsents as jest.Mock;
+const grantMock = grantPatientConsent as jest.Mock;
+const revokeMock = revokePatientConsent as jest.Mock;
+const isAuthRedirectMock = isAuthRedirectError as jest.Mock;
+
+const consent = (
+  over: Partial<PatientConsent> & { id: string; consentType: PatientConsent['consentType'] }
+): PatientConsent => ({
+  organisationId: 'org-1',
+  patientId: 'comp-1',
+  status: 'ACTIVE',
+  procedureDesc: null,
+  consentedByName: 'Lena Hartmann',
+  consentedAt: '2026-01-10T09:00:00.000Z',
+  expiresAt: null,
+  witnessedBy: null,
+  revokedAt: null,
+  revokedReason: null,
+  documentId: null,
+  notes: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  permissionsMock = ['appointments:view:any', 'appointments:edit:any'];
+  fetchMock.mockResolvedValue([]);
+});
+
+describe('ConsentListPanel', () => {
+  it('loads, sorts active consents first and renders them', async () => {
+    // A mix of statuses (active before revoked) plus two active consents with
+    // different grant dates exercises both branches of the sort comparator.
+    fetchMock.mockResolvedValue([
+      consent({
+        id: 'c-old',
+        consentType: 'ANESTHESIA',
+        status: 'REVOKED',
+        procedureDesc: 'Old anaesthesia consent',
+        revokedAt: '2025-11-20T00:00:00.000Z',
+      }),
+      consent({
+        id: 'c-1',
+        consentType: 'SURGICAL',
+        procedureDesc: 'Dental extraction',
+        consentedAt: '2026-01-08T09:00:00.000Z',
+      }),
+      consent({
+        id: 'c-2',
+        consentType: 'DIAGNOSTIC',
+        procedureDesc: 'Blood panel',
+        consentedAt: '2026-01-10T09:00:00.000Z',
+      }),
+    ]);
+
+    render(<ConsentListPanel companionId="comp-1" />);
+
+    expect(await screen.findByText('Dental extraction')).toBeInTheDocument();
+    expect(screen.getByText('Blood panel')).toBeInTheDocument();
+    expect(screen.getByText('Old anaesthesia consent')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith({ patientId: 'comp-1' });
+  });
+
+  it('shows the empty state when there are no consents', async () => {
+    render(<ConsentListPanel companionId="comp-1" />);
+    expect(await screen.findByText(/No consents recorded/)).toBeInTheDocument();
+  });
+
+  it.each([new Error('load failed'), new Error('No active organisation selected.')])(
+    'shows a load error when the service rejects with %s',
+    async (error) => {
+      fetchMock.mockRejectedValue(error);
+      render(<ConsentListPanel companionId="comp-1" />);
+      expect(await screen.findByRole('alert')).toHaveTextContent('Could not load the consent list');
+    }
+  );
+
+  it('grants a consent, converting the expiry to an ISO datetime, then refetches', async () => {
+    const created = consent({
+      id: 'c-new',
+      consentType: 'DIAGNOSTIC',
+      procedureDesc: 'Abdominal ultrasound',
+    });
+    fetchMock.mockResolvedValueOnce([]).mockResolvedValueOnce([created]);
+    grantMock.mockResolvedValue(created);
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText(/No consents recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.selectOptions(screen.getByLabelText('Consent type'), 'DIAGNOSTIC');
+    await userEvent.type(screen.getByLabelText('Procedure'), 'Abdominal ultrasound');
+    await userEvent.type(screen.getByLabelText('Consented by'), '  Sam Owner  ');
+    fireEvent.change(screen.getByLabelText('Expiry date'), { target: { value: '2026-06-01' } });
+    await userEvent.type(screen.getByLabelText('Witnessed by'), 'Nurse Patel');
+    await userEvent.type(screen.getByLabelText('Notes'), 'Sedation discussed');
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    await waitFor(() =>
+      expect(grantMock).toHaveBeenCalledWith({
+        patientId: 'comp-1',
+        consentType: 'DIAGNOSTIC',
+        procedureDesc: 'Abdominal ultrasound',
+        consentedByName: 'Sam Owner',
+        witnessedBy: 'Nurse Patel',
+        notes: 'Sedation discussed',
+        expiresAt: '2026-06-01T00:00:00.000Z',
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText('Abdominal ultrasound')).toBeInTheDocument();
+    expect(notifyMock).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Consent recorded' })
+    );
+  });
+
+  it('omits empty optional fields when granting', async () => {
+    grantMock.mockResolvedValue(consent({ id: 'c-new', consentType: 'SURGICAL' }));
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText(/No consents recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    await waitFor(() => expect(grantMock).toHaveBeenCalled());
+    expect(grantMock.mock.calls[0][0]).toEqual({ patientId: 'comp-1', consentType: 'SURGICAL' });
+  });
+
+  it('keeps the form open and notifies when the grant fails', async () => {
+    grantMock.mockRejectedValue(new Error('nope'));
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText(/No consents recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    await waitFor(() =>
+      expect(notifyMock).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not record consent' })
+      )
+    );
+    expect(screen.getByLabelText('Consent type')).toBeInTheDocument();
+  });
+
+  it('stays silent on an auth-redirect grant error', async () => {
+    grantMock.mockRejectedValue(new Error('redirecting'));
+    isAuthRedirectMock.mockReturnValueOnce(true);
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText(/No consents recorded/);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    await waitFor(() => expect(grantMock).toHaveBeenCalled());
+    expect(notifyMock).not.toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('does not grant when the companion id is missing', async () => {
+    render(<ConsentListPanel companionId="" />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save consent' }));
+
+    expect(grantMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('revokes an active consent and marks it revoked', async () => {
+    const active = consent({ id: 'c-1', consentType: 'SURGICAL', procedureDesc: 'Dental work' });
+    fetchMock.mockResolvedValue([
+      active,
+      consent({ id: 'c-2', consentType: 'DIAGNOSTIC', procedureDesc: 'Blood panel' }),
+    ]);
+    revokeMock.mockResolvedValue({
+      ...active,
+      status: 'REVOKED',
+      revokedAt: '2026-02-02T00:00:00.000Z',
+      revokedReason: 'Owner withdrew',
+    });
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText('Dental work');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.type(screen.getByLabelText('Reason for revoking'), 'Owner withdrew');
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    await waitFor(() => expect(revokeMock).toHaveBeenCalledWith('c-1', 'Owner withdrew'));
+    expect(await screen.findByText('Revoked')).toBeInTheDocument();
+    // The sibling consent is left in place, not dropped by the map.
+    expect(screen.getByText('Blood panel')).toBeInTheDocument();
+    expect(notifyMock).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ title: 'Consent revoked' })
+    );
+  });
+
+  it('stays silent on an auth-redirect revoke error', async () => {
+    fetchMock.mockResolvedValue([
+      consent({ id: 'c-1', consentType: 'SURGICAL', procedureDesc: 'Dental work' }),
+    ]);
+    revokeMock.mockRejectedValue(new Error('redirecting'));
+    isAuthRedirectMock.mockReturnValueOnce(true);
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText('Dental work');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    await waitFor(() => expect(revokeMock).toHaveBeenCalled());
+    expect(notifyMock).not.toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('notifies and keeps the consent active when revoke fails', async () => {
+    fetchMock.mockResolvedValue([
+      consent({ id: 'c-1', consentType: 'SURGICAL', procedureDesc: 'Dental work' }),
+    ]);
+    revokeMock.mockRejectedValue(new Error('nope'));
+    render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText('Dental work');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Revoke consent' }));
+
+    await waitFor(() =>
+      expect(notifyMock).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Could not revoke consent' })
+      )
+    );
+    // The consent stays active: its status pill still reads "Active" and the
+    // revoke form remains open for a retry.
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Revoke consent' })).toBeInTheDocument();
+  });
+
+  it('resets and refetches when the companion changes', async () => {
+    fetchMock.mockResolvedValueOnce([
+      consent({ id: 'c-1', consentType: 'SURGICAL', procedureDesc: 'Dental work' }),
+    ]);
+    const { rerender } = render(<ConsentListPanel companionId="comp-1" />);
+    await screen.findByText('Dental work');
+
+    fetchMock.mockResolvedValueOnce([
+      consent({ id: 'c-2', consentType: 'DNR', procedureDesc: 'End-of-life directive' }),
+    ]);
+    rerender(<ConsentListPanel companionId="comp-2" />);
+
+    expect(await screen.findByText('End-of-life directive')).toBeInTheDocument();
+    expect(screen.queryByText('Dental work')).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenLastCalledWith({ patientId: 'comp-2' });
+  });
+
+  it('renders nothing when the member cannot view consents', () => {
+    permissionsMock = [];
+    const { container } = render(<ConsentListPanel companionId="comp-1" />);
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('hides the edit controls when the member can view but not edit', async () => {
+    permissionsMock = ['appointments:view:any'];
+    fetchMock.mockResolvedValue([
+      consent({ id: 'c-1', consentType: 'SURGICAL', procedureDesc: 'Dental work' }),
+    ]);
+    render(<ConsentListPanel companionId="comp-1" />);
+
+    await screen.findByText('Dental work');
+    expect(screen.queryByRole('button', { name: 'Record consent' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Revoke / })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/pages/phone/PhoneCompanionRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/pages/phone/PhoneCompanionRecord.test.tsx
@@ -21,6 +21,13 @@ jest.mock('@/app/features/companionHistory/components/AllergyListPanel', () => (
   ),
 }));
 
+jest.mock('@/app/features/companionHistory/components/ConsentListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => (
+    <div data-testid="consent-list-panel" data-companion-id={companionId} />
+  ),
+}));
+
 jest.mock('@/app/features/companionHistory/components/FlagListPanel', () => ({
   __esModule: true,
   default: ({ companionId }: any) => (
@@ -113,6 +120,10 @@ describe('PhoneCompanionRecord', () => {
     // Timeline is rendered in the phone variant with the upload signal wired.
     expect(screen.getByTestId('timeline')).toHaveTextContent('AC-0092-phone-true-0');
     expect(screen.getByTestId('allergy-list-panel')).toHaveAttribute(
+      'data-companion-id',
+      'AC-0092'
+    );
+    expect(screen.getByTestId('consent-list-panel')).toHaveAttribute(
       'data-companion-id',
       'AC-0092'
     );

--- a/apps/frontend/src/app/__tests__/features/companionHistory/services/patientConsentService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/services/patientConsentService.test.ts
@@ -1,0 +1,179 @@
+import { AxiosError } from 'axios';
+import {
+  fetchPatientConsent,
+  fetchPatientConsents,
+  grantPatientConsent,
+  revokePatientConsent,
+} from '@/app/features/companionHistory/services/patientConsentService';
+import { getData, postData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn() },
+}));
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const CONSENT_ID = '22222222-2222-4222-8222-222222222222';
+const LEGACY_ORG_ID = '507f1f77bcf86cd799439011';
+
+let mockOrgId: string | null = ORG_ID;
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ primaryOrgId: mockOrgId }) },
+}));
+
+const getMock = getData as jest.Mock;
+const postMock = postData as jest.Mock;
+const errorMock = logger.error as jest.Mock;
+const warnMock = logger.warn as jest.Mock;
+
+const BASE = `/v1/pms/organisation/${ORG_ID}/patient-consents`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOrgId = ORG_ID;
+});
+
+describe('patientConsentService', () => {
+  it('fetches consents scoped to the org and patient', async () => {
+    getMock.mockResolvedValue({ data: [{ id: 'c-1' }] });
+    const result = await fetchPatientConsents({ patientId: 'pat-1' });
+    expect(getMock).toHaveBeenCalledWith(BASE, { patientId: 'pat-1' });
+    expect(result).toEqual([{ id: 'c-1' }]);
+  });
+
+  it('passes the status and type filters when supplied', async () => {
+    getMock.mockResolvedValue({ data: [] });
+    await fetchPatientConsents({ patientId: 'pat-1', status: 'ACTIVE', consentType: 'SURGICAL' });
+    expect(getMock).toHaveBeenCalledWith(BASE, {
+      patientId: 'pat-1',
+      status: 'ACTIVE',
+      consentType: 'SURGICAL',
+    });
+  });
+
+  it('throws when the patient id is missing', async () => {
+    await expect(fetchPatientConsents({ patientId: '' })).rejects.toThrow('Patient ID missing');
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list and logs only the response type for a malformed list', async () => {
+    const payload = { message: 'unexpected object' };
+    getMock.mockResolvedValue({ data: payload });
+    await expect(fetchPatientConsents({ patientId: 'pat-1' })).resolves.toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(expect.any(String), 'object');
+    // The payload itself must never be logged (PII).
+    expect(warnMock.mock.calls[0]).not.toContainEqual(payload);
+  });
+
+  it('accepts a legacy ObjectId organisation id', async () => {
+    mockOrgId = LEGACY_ORG_ID;
+    getMock.mockResolvedValue({ data: [] });
+    await fetchPatientConsents({ patientId: 'pat-1' });
+    expect(getMock).toHaveBeenCalledWith(`/v1/pms/organisation/${LEGACY_ORG_ID}/patient-consents`, {
+      patientId: 'pat-1',
+    });
+  });
+
+  it('fetches a single consent by id', async () => {
+    getMock.mockResolvedValue({ data: { id: 'c-1' } });
+    const result = await fetchPatientConsent(CONSENT_ID);
+    expect(getMock).toHaveBeenCalledWith(`${BASE}/${CONSENT_ID}`);
+    expect(result).toEqual({ id: 'c-1' });
+  });
+
+  it('grants a consent', async () => {
+    postMock.mockResolvedValue({ data: { id: 'c-new' } });
+    const input = {
+      patientId: 'pat-1',
+      consentType: 'SURGICAL' as const,
+      procedureDesc: 'Dental extraction',
+    };
+    const result = await grantPatientConsent(input);
+    expect(postMock).toHaveBeenCalledWith(BASE, input);
+    expect(result).toEqual({ id: 'c-new' });
+  });
+
+  it('revokes a consent, defaulting the body to an empty object', async () => {
+    postMock.mockResolvedValue({ data: { id: 'c-1', status: 'REVOKED' } });
+    await revokePatientConsent(CONSENT_ID);
+    expect(postMock).toHaveBeenCalledWith(`${BASE}/${CONSENT_ID}/revoke`, {});
+  });
+
+  it('revokes a consent with an explicit reason', async () => {
+    postMock.mockResolvedValue({ data: { id: 'c-1', status: 'REVOKED' } });
+    await revokePatientConsent(CONSENT_ID, 'Procedure cancelled');
+    expect(postMock).toHaveBeenCalledWith(`${BASE}/${CONSENT_ID}/revoke`, {
+      revokedReason: 'Procedure cancelled',
+    });
+  });
+
+  it('rejects reserved characters in route ids before making a request', async () => {
+    mockOrgId = 'org/1';
+    await expect(fetchPatientConsents({ patientId: 'pat-1' })).rejects.toThrow(
+      'Organisation ID contains unsupported characters'
+    );
+    await expect(grantPatientConsent({ patientId: 'pat-1', consentType: 'OTHER' })).rejects.toThrow(
+      'Organisation ID contains unsupported characters'
+    );
+
+    mockOrgId = ORG_ID;
+    await expect(fetchPatientConsent('../consent')).rejects.toThrow(
+      'Consent ID contains unsupported characters'
+    );
+    await expect(revokePatientConsent('../consent')).rejects.toThrow(
+      'Consent ID contains unsupported characters'
+    );
+    expect(getMock).not.toHaveBeenCalled();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when no organisation is selected', async () => {
+    mockOrgId = null;
+    await expect(fetchPatientConsents({ patientId: 'pat-1' })).rejects.toThrow(
+      'No active organisation selected.'
+    );
+  });
+
+  it('logs an Axios error without a response using its message, then rethrows it', async () => {
+    const error = new AxiosError('offline');
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPatientConsents({ patientId: 'pat-1' })).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load patient consents:', 'offline');
+  });
+
+  it('logs a server Axios error message without logging the response body', async () => {
+    const error = new AxiosError('request failed');
+    const responseData = { message: 'Unavailable', patientName: 'private' };
+    error.response = { data: responseData } as never;
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPatientConsent(CONSENT_ID)).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load patient consent:', 'Unavailable');
+    expect(errorMock.mock.calls[0]).not.toContainEqual(responseData);
+  });
+
+  it('falls back to the Axios message when the response carries no message', async () => {
+    const error = new AxiosError('grant failed');
+    error.response = { data: {} } as never;
+    postMock.mockRejectedValue(error);
+
+    await expect(
+      grantPatientConsent({ patientId: 'pat-1', consentType: 'TREATMENT' })
+    ).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to grant patient consent:', 'grant failed');
+  });
+
+  it('logs and rethrows a non-Axios error', async () => {
+    const error = new Error('raw');
+    postMock.mockRejectedValue(error);
+
+    await expect(revokePatientConsent(CONSENT_ID, 'because')).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to revoke patient consent:', error);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
@@ -134,6 +134,14 @@ jest.mock('@/app/features/companionHistory/components/AllergyListPanel', () => (
   default: ({ companionId }: any) => <div data-testid="allergy-list-panel">{companionId}</div>,
 }));
 
+// Stub the async consent-list panel: like the timeline above, it fetches on
+// mount, which would fire a state update outside act() and trip the strict
+// console.error guard in jest.setup. This suite does not exercise it.
+jest.mock('@/app/features/companionHistory/components/ConsentListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => <div data-testid="consent-list-panel">{companionId}</div>,
+}));
+
 jest.mock('@/app/features/companionHistory/components/FlagListPanel', () => ({
   __esModule: true,
   default: ({ companionId }: any) => <div data-testid="flag-list-panel">{companionId}</div>,
@@ -347,6 +355,7 @@ describe('CompanionHistoryPage', () => {
 
     expect(screen.getByTestId('timeline')).toHaveTextContent('c-1-true');
     expect(screen.getByTestId('allergy-list-panel')).toHaveTextContent('c-1');
+    expect(screen.getByTestId('consent-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByTestId('flag-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByText("Buddy's overview")).toBeInTheDocument();
     expect(screen.getByText('Labrador / Canine')).toBeInTheDocument();

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ConsentList from './ConsentList';
+import type { PatientConsent } from '@/app/features/companionHistory/services/patientConsentService';
+
+const consent = (over: Partial<PatientConsent>): PatientConsent => ({
+  id: over.id ?? 'c-1',
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  consentType: over.consentType ?? 'SURGICAL',
+  status: over.status ?? 'ACTIVE',
+  procedureDesc: over.procedureDesc ?? null,
+  consentedByName: over.consentedByName ?? null,
+  consentedAt: over.consentedAt ?? '2026-01-10T09:00:00.000Z',
+  expiresAt: over.expiresAt ?? null,
+  witnessedBy: over.witnessedBy ?? null,
+  revokedAt: over.revokedAt ?? null,
+  revokedReason: over.revokedReason ?? null,
+  documentId: null,
+  notes: over.notes ?? null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const SAMPLE: PatientConsent[] = [
+  consent({
+    id: 'c-1',
+    consentType: 'SURGICAL',
+    status: 'ACTIVE',
+    procedureDesc: 'Cranial cruciate ligament repair (left stifle)',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2026-01-08T09:00:00.000Z',
+    witnessedBy: 'Dr. Okafor',
+    notes: 'Owner briefed on anaesthetic risk and post-op physiotherapy.',
+  }),
+  consent({
+    id: 'c-2',
+    consentType: 'DNR',
+    status: 'ACTIVE',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2026-01-08T09:05:00.000Z',
+    notes: 'Do not resuscitate on cardiac or respiratory arrest.',
+  }),
+  consent({
+    id: 'c-3',
+    consentType: 'DATA_SHARING',
+    status: 'EXPIRED',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2025-01-02T09:00:00.000Z',
+    expiresAt: '2026-01-02T00:00:00.000Z',
+  }),
+  consent({
+    id: 'c-4',
+    consentType: 'ANESTHESIA',
+    status: 'REVOKED',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2025-11-02T09:00:00.000Z',
+    revokedAt: '2025-11-20T09:00:00.000Z',
+    revokedReason: 'Procedure postponed at the owner’s request.',
+  }),
+];
+
+const meta = {
+  title: 'CompanionHistory/ConsentList',
+  component: ConsentList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    canEdit: true,
+    consents: SAMPLE,
+    onGrant: async () => true,
+    onRevoke: async () => true,
+  },
+} satisfies Meta<typeof ConsentList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {};
+
+export const ReadOnly: Story = {
+  args: { canEdit: false },
+};
+
+export const Empty: Story = {
+  args: { consents: [] },
+};
+
+export const Loading: Story = {
+  args: { consents: [], loading: true },
+};
+
+export const WithError: Story = {
+  args: { error: 'Could not load the consent list. Please try again.' },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -1,0 +1,428 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { IoCloseCircleOutline, IoDocumentTextOutline } from 'react-icons/io5';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import {
+  ClinicalListEmpty,
+  ClinicalListError,
+  ClinicalListHeader,
+  ClinicalListLoadingRows,
+  cardClass,
+  controlClass,
+  fieldLabelClass,
+  formatDate,
+  metaClass,
+  rowClass,
+  titleClass,
+} from '@/app/features/companionHistory/components/ClinicalListChrome';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import type {
+  ConsentStatus,
+  ConsentType,
+  PatientConsent,
+} from '@/app/features/companionHistory/services/patientConsentService';
+
+/** The values the grant form emits. `expiresAt` is a raw `YYYY-MM-DD` (or ''). */
+export type ConsentFormValues = {
+  consentType: ConsentType;
+  procedureDesc: string;
+  consentedByName: string;
+  expiresAt: string;
+  witnessedBy: string;
+  notes: string;
+};
+
+export type ConsentListProps = {
+  consents: PatientConsent[];
+  loading?: boolean;
+  error?: string | null;
+  /** Gates the grant/revoke controls. Mirrors the backend `appointments:edit` gate. */
+  canEdit?: boolean;
+  /** Fired when the grant form is submitted. Returns true once the record is saved. */
+  onGrant?: (values: ConsentFormValues) => Promise<boolean> | boolean;
+  /** Fired when an active consent is revoked. Returns true once the revoke lands. */
+  onRevoke?: (consent: PatientConsent, revokedReason?: string) => Promise<boolean> | boolean;
+  /** Disables the grant form's submit while a grant is in flight. */
+  creating?: boolean;
+  /** Id of the consent currently being revoked, so its row shows a pending state. */
+  revokingId?: string | null;
+};
+
+const STATUS_LABEL: Record<ConsentStatus, string> = {
+  ACTIVE: 'Active',
+  REVOKED: 'Revoked',
+  EXPIRED: 'Expired',
+};
+
+const TYPE_LABEL: Record<ConsentType, string> = {
+  SURGICAL: 'Surgical',
+  ANESTHESIA: 'Anaesthesia',
+  DIAGNOSTIC: 'Diagnostic',
+  TREATMENT: 'Treatment',
+  DATA_SHARING: 'Data sharing',
+  DNR: 'Do not resuscitate',
+  OTHER: 'Other',
+};
+
+const TYPE_OPTIONS: ConsentType[] = [
+  'SURGICAL',
+  'ANESTHESIA',
+  'DIAGNOSTIC',
+  'TREATMENT',
+  'DATA_SHARING',
+  'DNR',
+  'OTHER',
+];
+
+/**
+ * The status pill tone. An active DNR directive reads in the danger tone and an
+ * expired consent in the warning tone; a revoked consent is neutral and any
+ * other active consent is a positive success.
+ */
+const statusTone = (consent: PatientConsent): StatusTone => {
+  if (consent.status === 'REVOKED') return 'neutral';
+  if (consent.status === 'EXPIRED') return 'warning';
+  return consent.consentType === 'DNR' ? 'danger' : 'success';
+};
+
+const RevokeConsentForm = ({
+  consent,
+  revoking,
+  onRevoke,
+  onCancel,
+}: {
+  consent: PatientConsent;
+  revoking: boolean;
+  onRevoke?: NonNullable<ConsentListProps['onRevoke']>;
+  onCancel: () => void;
+}) => {
+  const [reason, setReason] = useState('');
+  const reasonId = `consent-revoke-reason-${consent.id}`;
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (revoking) return;
+    const ok = await onRevoke?.(consent, reason.trim() || undefined);
+    if (ok) {
+      setReason('');
+      onCancel();
+    }
+  };
+
+  return (
+    <form className="mt-2 flex w-full flex-col gap-2" onSubmit={handleSubmit}>
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor={reasonId}>
+          Reason for revoking
+        </label>
+        <textarea
+          id={reasonId}
+          className={clsx(controlClass, 'min-h-14 resize-y')}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          maxLength={2000}
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Secondary size="compact" text="Cancel" onClick={onCancel} isDisabled={revoking} />
+        <Primary
+          size="compact"
+          type="submit"
+          text={revoking ? 'Revoking…' : 'Revoke consent'}
+          isDisabled={revoking}
+        />
+      </div>
+    </form>
+  );
+};
+
+const ConsentRow = ({
+  consent,
+  canEdit,
+  onRevoke,
+  revoking,
+  revokeDisabled,
+}: {
+  consent: PatientConsent;
+  canEdit: boolean;
+  onRevoke?: ConsentListProps['onRevoke'];
+  revoking: boolean;
+  revokeDisabled: boolean;
+}) => {
+  const [showRevoke, setShowRevoke] = useState(false);
+  const label = TYPE_LABEL[consent.consentType];
+  const consented = formatDate(consent.consentedAt);
+  const expires = formatDate(consent.expiresAt);
+  const revoked = formatDate(consent.revokedAt);
+  const isActive = consent.status === 'ACTIVE';
+  const consentedMeta = [
+    consent.consentedByName ? `Consented by ${consent.consentedByName}` : 'Consented',
+    consented,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <li className="flex flex-col">
+      <div className={rowClass}>
+        <span className="min-w-0">
+          <span className={clsx(titleClass, 'block truncate')}>{label}</span>
+          {consent.procedureDesc ? (
+            <span className={clsx(metaClass, 'mt-0.5 block')}>{consent.procedureDesc}</span>
+          ) : null}
+          <span className={clsx(metaClass, 'mt-1 block text-[var(--ink-muted)]')}>
+            {consentedMeta}
+          </span>
+          {expires ? (
+            <span className={clsx(metaClass, 'mt-1 block')}>
+              {'Expires '}
+              {expires}
+            </span>
+          ) : null}
+          {consent.witnessedBy ? (
+            <span className={clsx(metaClass, 'mt-1 block')}>
+              {'Witnessed by '}
+              {consent.witnessedBy}
+            </span>
+          ) : null}
+          {consent.notes ? (
+            <span className={clsx(metaClass, 'mt-1 block line-clamp-2 text-[var(--ink-muted)]')}>
+              {consent.notes}
+            </span>
+          ) : null}
+        </span>
+        <span className="flex shrink-0 flex-col items-end gap-2">
+          <StatusPill label={STATUS_LABEL[consent.status]} tone={statusTone(consent)} />
+          {isActive && canEdit && !showRevoke ? (
+            <Secondary
+              size="compact"
+              text="Revoke"
+              icon={<IoCloseCircleOutline size={15} aria-hidden="true" />}
+              isDisabled={revokeDisabled}
+              onClick={() => setShowRevoke(true)}
+              ariaLabel={`Revoke ${label} consent`}
+            />
+          ) : null}
+          {consent.status === 'REVOKED' && revoked ? (
+            <span className={metaClass}>
+              {'Revoked '}
+              {revoked}
+            </span>
+          ) : null}
+        </span>
+      </div>
+      {consent.status === 'REVOKED' && consent.revokedReason ? (
+        <span className={clsx(metaClass, 'block px-4 pb-3 text-[var(--ink-muted)]')}>
+          {'Reason: '}
+          {consent.revokedReason}
+        </span>
+      ) : null}
+      {showRevoke && canEdit ? (
+        <div className="px-4 pb-3">
+          <RevokeConsentForm
+            consent={consent}
+            revoking={revoking}
+            onRevoke={onRevoke}
+            onCancel={() => setShowRevoke(false)}
+          />
+        </div>
+      ) : null}
+    </li>
+  );
+};
+
+const emptyForm: ConsentFormValues = {
+  consentType: 'SURGICAL',
+  procedureDesc: '',
+  consentedByName: '',
+  expiresAt: '',
+  witnessedBy: '',
+  notes: '',
+};
+
+const GrantConsentForm = ({
+  creating,
+  onGrant,
+  onCancel,
+}: {
+  creating: boolean;
+  onGrant?: NonNullable<ConsentListProps['onGrant']>;
+  onCancel: () => void;
+}) => {
+  const [values, setValues] = useState<ConsentFormValues>(emptyForm);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (creating) return;
+    const ok = await onGrant?.(values);
+    if (ok) {
+      setValues(emptyForm);
+      onCancel();
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-3 border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-4"
+      onSubmit={handleSubmit}
+    >
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="consent-type">
+          Consent type
+        </label>
+        <select
+          id="consent-type"
+          className={controlClass}
+          value={values.consentType}
+          onChange={(e) => setValues((v) => ({ ...v, consentType: e.target.value as ConsentType }))}
+        >
+          {TYPE_OPTIONS.map((t) => (
+            <option key={t} value={t}>
+              {TYPE_LABEL[t]}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="consent-procedure">
+          Procedure
+        </label>
+        <input
+          id="consent-procedure"
+          className={controlClass}
+          value={values.procedureDesc}
+          onChange={(e) => setValues((v) => ({ ...v, procedureDesc: e.target.value }))}
+          maxLength={2000}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="consent-consented-by">
+          Consented by
+        </label>
+        <input
+          id="consent-consented-by"
+          className={controlClass}
+          value={values.consentedByName}
+          onChange={(e) => setValues((v) => ({ ...v, consentedByName: e.target.value }))}
+          maxLength={200}
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <label className={fieldLabelClass} htmlFor="consent-expires">
+            Expiry date
+          </label>
+          <input
+            id="consent-expires"
+            type="date"
+            className={controlClass}
+            value={values.expiresAt}
+            onChange={(e) => setValues((v) => ({ ...v, expiresAt: e.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className={fieldLabelClass} htmlFor="consent-witness">
+            Witnessed by
+          </label>
+          <input
+            id="consent-witness"
+            className={controlClass}
+            value={values.witnessedBy}
+            onChange={(e) => setValues((v) => ({ ...v, witnessedBy: e.target.value }))}
+            maxLength={200}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className={fieldLabelClass} htmlFor="consent-notes">
+          Notes
+        </label>
+        <textarea
+          id="consent-notes"
+          className={clsx(controlClass, 'min-h-16 resize-y')}
+          value={values.notes}
+          onChange={(e) => setValues((v) => ({ ...v, notes: e.target.value }))}
+          maxLength={2000}
+        />
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Secondary size="compact" text="Cancel" onClick={onCancel} />
+        <Primary size="compact" type="submit" text="Save consent" isDisabled={creating} />
+      </div>
+    </form>
+  );
+};
+
+/**
+ * Presentational clinical consent-list panel. Renders the consents the caller
+ * supplies and surfaces grant/revoke intents through callbacks; it never
+ * fetches. The container (`ConsentListPanel`) owns loading, error and data.
+ */
+const ConsentList = ({
+  consents,
+  loading = false,
+  error = null,
+  canEdit = false,
+  onGrant,
+  onRevoke,
+  creating = false,
+  revokingId = null,
+}: ConsentListProps) => {
+  const [showForm, setShowForm] = useState(false);
+  const activeCount = useMemo(
+    () => consents.filter((c) => c.status === 'ACTIVE').length,
+    [consents]
+  );
+
+  const body = (() => {
+    if (loading) return <ClinicalListLoadingRows />;
+    if (error) return null;
+    if (consents.length === 0)
+      return <ClinicalListEmpty message="No consents recorded for this patient yet." />;
+    return (
+      <ul className="divide-y divide-[var(--divider)]">
+        {consents.map((consent) => (
+          <ConsentRow
+            key={consent.id}
+            consent={consent}
+            canEdit={canEdit}
+            onRevoke={onRevoke}
+            revoking={revokingId === consent.id}
+            revokeDisabled={revokingId !== null}
+          />
+        ))}
+      </ul>
+    );
+  })();
+
+  return (
+    <section className={cardClass} aria-labelledby="consent-list-heading">
+      <ClinicalListHeader
+        icon={<IoDocumentTextOutline size={18} />}
+        headingId="consent-list-heading"
+        title="Consents"
+        activeCount={activeCount}
+        loading={loading}
+        canEdit={canEdit}
+        showForm={showForm}
+        onToggle={() => setShowForm((s) => !s)}
+        addLabel="Record consent"
+      />
+
+      <ClinicalListError error={error} />
+
+      {showForm && canEdit ? (
+        <GrantConsentForm
+          creating={creating}
+          onGrant={onGrant}
+          onCancel={() => setShowForm(false)}
+        />
+      ) : null}
+
+      {body}
+    </section>
+  );
+};
+
+export default ConsentList;

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -354,6 +354,42 @@ const GrantConsentForm = ({
   );
 };
 
+/** The list body: loading skeleton, error's null slot, empty state, or the rows. */
+const ConsentListBody = ({
+  loading,
+  error,
+  consents,
+  canEdit,
+  onRevoke,
+  revokingId,
+}: {
+  loading: boolean;
+  error: string | null;
+  consents: PatientConsent[];
+  canEdit: boolean;
+  onRevoke?: ConsentListProps['onRevoke'];
+  revokingId: string | null;
+}) => {
+  if (loading) return <ClinicalListLoadingRows />;
+  if (error) return null;
+  if (consents.length === 0)
+    return <ClinicalListEmpty message="No consents recorded for this patient yet." />;
+  return (
+    <ul className="divide-y divide-[var(--divider)]">
+      {consents.map((consent) => (
+        <ConsentRow
+          key={consent.id}
+          consent={consent}
+          canEdit={canEdit}
+          onRevoke={onRevoke}
+          revoking={revokingId === consent.id}
+          revokeDisabled={revokingId !== null}
+        />
+      ))}
+    </ul>
+  );
+};
+
 /**
  * Presentational clinical consent-list panel. Renders the consents the caller
  * supplies and surfaces grant/revoke intents through callbacks; it never
@@ -374,27 +410,6 @@ const ConsentList = ({
     () => consents.filter((c) => c.status === 'ACTIVE').length,
     [consents]
   );
-
-  const body = (() => {
-    if (loading) return <ClinicalListLoadingRows />;
-    if (error) return null;
-    if (consents.length === 0)
-      return <ClinicalListEmpty message="No consents recorded for this patient yet." />;
-    return (
-      <ul className="divide-y divide-[var(--divider)]">
-        {consents.map((consent) => (
-          <ConsentRow
-            key={consent.id}
-            consent={consent}
-            canEdit={canEdit}
-            onRevoke={onRevoke}
-            revoking={revokingId === consent.id}
-            revokeDisabled={revokingId !== null}
-          />
-        ))}
-      </ul>
-    );
-  })();
 
   return (
     <section className={cardClass} aria-labelledby="consent-list-heading">
@@ -420,7 +435,14 @@ const ConsentList = ({
         />
       ) : null}
 
-      {body}
+      <ConsentListBody
+        loading={loading}
+        error={error}
+        consents={consents}
+        canEdit={canEdit}
+        onRevoke={onRevoke}
+        revokingId={revokingId}
+      />
     </section>
   );
 };

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React from 'react';
+import ConsentList from '@/app/features/companionHistory/components/ConsentList';
+import { useConsentList } from '@/app/features/companionHistory/components/useConsentList';
+
+export type ConsentListPanelProps = {
+  /** The companion (patient) whose consents to load. `companionId === patientId`. */
+  companionId: string;
+};
+
+/**
+ * Data container for {@link ConsentList}. All state lives in
+ * {@link useConsentList}; this projects it onto the presentational list and
+ * renders nothing when the member cannot view consents.
+ */
+const ConsentListPanel = ({ companionId }: ConsentListPanelProps) => {
+  const { canView, canEdit, consents, loading, error, creating, revokingId, grant, revoke } =
+    useConsentList(companionId);
+
+  if (!canView) return null;
+
+  return (
+    <ConsentList
+      consents={consents}
+      loading={loading}
+      error={error}
+      canEdit={canEdit}
+      onGrant={grant}
+      onRevoke={revoke}
+      creating={creating}
+      revokingId={revokingId}
+    />
+  );
+};
+
+export default ConsentListPanel;

--- a/apps/frontend/src/app/features/companionHistory/components/useConsentList.ts
+++ b/apps/frontend/src/app/features/companionHistory/components/useConsentList.ts
@@ -1,0 +1,176 @@
+'use client';
+
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { isAuthRedirectError } from '@/app/services/axios';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { useNotify } from '@/app/hooks/useNotify';
+import type { ConsentFormValues } from '@/app/features/companionHistory/components/ConsentList';
+import {
+  fetchPatientConsents,
+  grantPatientConsent,
+  revokePatientConsent,
+  type ConsentStatus,
+  type CreatePatientConsentInput,
+  type PatientConsent,
+} from '@/app/features/companionHistory/services/patientConsentService';
+
+const LOAD_ERROR = 'Could not load the consent list. Please try again.';
+const toIsoDate = (value: string): string => new Date(`${value}T00:00:00.000Z`).toISOString();
+
+// Active consents lead the list; expired ones follow, then revoked. Within a
+// status the most recently granted consent reads first.
+const STATUS_ORDER: Record<ConsentStatus, number> = { ACTIVE: 0, EXPIRED: 1, REVOKED: 2 };
+const sortConsents = (items: PatientConsent[]): PatientConsent[] =>
+  [...items].sort(
+    (a, b) =>
+      STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
+      Date.parse(b.consentedAt) - Date.parse(a.consentedAt)
+  );
+
+type SetConsents = Dispatch<SetStateAction<PatientConsent[]>>;
+type SetError = Dispatch<SetStateAction<string | null>>;
+
+/** Loads a companion's consents and resets to a loading state when the companion changes. */
+const useConsentRecords = (companionId: string, canView: boolean) => {
+  const [consents, setConsents] = useState<PatientConsent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset during render (React's recommended pattern) rather than in an effect;
+  // `loadedFor` tracks which companion the current state belongs to.
+  const [loadedFor, setLoadedFor] = useState(companionId);
+  if (companionId !== loadedFor) {
+    setLoadedFor(companionId);
+    setConsents([]);
+    setError(null);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!canView || !companionId) return;
+    let active = true;
+    fetchPatientConsents({ patientId: companionId })
+      .then((next) => {
+        if (active) setConsents(sortConsents(next));
+      })
+      .catch((requestError) => {
+        if (active && !isAuthRedirectError(requestError)) setError(LOAD_ERROR);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [canView, companionId]);
+
+  return { consents, loading, error, setConsents, setError };
+};
+
+/** The grant action and its in-flight flag; refreshes the list from the server on success. */
+const useGrantConsent = (companionId: string, setConsents: SetConsents, setError: SetError) => {
+  const { notify } = useNotify();
+  const [creating, setCreating] = useState(false);
+  const grant = useCallback(
+    async (values: ConsentFormValues): Promise<boolean> => {
+      if (!companionId) return false;
+      setCreating(true);
+      try {
+        const input: CreatePatientConsentInput = {
+          patientId: companionId,
+          consentType: values.consentType,
+          ...(values.procedureDesc.trim() ? { procedureDesc: values.procedureDesc.trim() } : {}),
+          ...(values.consentedByName.trim()
+            ? { consentedByName: values.consentedByName.trim() }
+            : {}),
+          ...(values.witnessedBy.trim() ? { witnessedBy: values.witnessedBy.trim() } : {}),
+          ...(values.notes.trim() ? { notes: values.notes.trim() } : {}),
+          ...(values.expiresAt ? { expiresAt: toIsoDate(values.expiresAt) } : {}),
+        };
+        await grantPatientConsent(input);
+        setConsents(sortConsents(await fetchPatientConsents({ patientId: companionId })));
+        setError(null);
+        notify('success', {
+          title: 'Consent recorded',
+          text: 'The consent was added to the patient record.',
+        });
+        return true;
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not record consent', text: 'Please try again.' });
+        }
+        return false;
+      } finally {
+        setCreating(false);
+      }
+    },
+    [companionId, notify, setConsents, setError]
+  );
+  return { grant, creating };
+};
+
+/** The revoke action and the id it is revoking; updates the consent in place on success. */
+const useRevokeConsent = (setConsents: SetConsents) => {
+  const { notify } = useNotify();
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const revoke = useCallback(
+    async (consent: PatientConsent, revokedReason?: string): Promise<boolean> => {
+      setRevokingId(consent.id);
+      try {
+        const updated = await revokePatientConsent(consent.id, revokedReason);
+        setConsents((current) =>
+          sortConsents(current.map((item) => (item.id === updated.id ? updated : item)))
+        );
+        notify('success', {
+          title: 'Consent revoked',
+          text: 'The consent was marked revoked.',
+        });
+        return true;
+      } catch (requestError) {
+        if (!isAuthRedirectError(requestError)) {
+          notify('error', { title: 'Could not revoke consent', text: 'Please try again.' });
+        }
+        return false;
+      } finally {
+        setRevokingId(null);
+      }
+    },
+    [notify, setConsents]
+  );
+  return { revoke, revokingId };
+};
+
+export type ConsentListState = {
+  /** The backend gates the list on `appointments:view:any`. */
+  canView: boolean;
+  /** Grant and revoke need `appointments:edit:any`. */
+  canEdit: boolean;
+  consents: PatientConsent[];
+  loading: boolean;
+  error: string | null;
+  creating: boolean;
+  revokingId: string | null;
+  grant: (values: ConsentFormValues) => Promise<boolean>;
+  revoke: (consent: PatientConsent, revokedReason?: string) => Promise<boolean>;
+};
+
+/**
+ * Composes the consent panel's state from three focused sub-hooks - records,
+ * grant and revoke - so no single function owns loading, mutation and
+ * notification at once. The panel is a thin projection over what this returns.
+ */
+export const useConsentList = (companionId: string): ConsentListState => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.APPOINTMENTS_VIEW_ANY);
+  const canEdit = permissions.can(PERMISSIONS.APPOINTMENTS_EDIT_ANY);
+
+  const { consents, loading, error, setConsents, setError } = useConsentRecords(
+    companionId,
+    canView
+  );
+  const { grant, creating } = useGrantConsent(companionId, setConsents, setError);
+  const { revoke, revokingId } = useRevokeConsent(setConsents);
+
+  return { canView, canEdit, consents, loading, error, creating, revokingId, grant, revoke };
+};

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -57,6 +57,7 @@ import { useNotify } from '@/app/hooks/useNotify';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import AllergyListPanel from '@/app/features/companionHistory/components/AllergyListPanel';
+import ConsentListPanel from '@/app/features/companionHistory/components/ConsentListPanel';
 import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
 import { isCompanionRevampEnabled } from '@/app/lib/featureFlags';
 import ShareCompanionCardModal from '@/app/features/companionCard/components/ShareCompanionCardModal';
@@ -701,6 +702,11 @@ const CompanionHistoryDesktopBody = ({
     {hasCompanionId ? (
       <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
         <AllergyListPanel companionId={companionId} />
+      </PermissionGate>
+    ) : null}
+    {hasCompanionId ? (
+      <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
+        <ConsentListPanel companionId={companionId} />
       </PermissionGate>
     ) : null}
     {hasCompanionId ? (

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -16,6 +16,7 @@ import {
 import CompanionHistoryTimeline from '@/app/features/companionHistory/components/CompanionHistoryTimeline';
 import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
 import AllergyListPanel from '@/app/features/companionHistory/components/AllergyListPanel';
+import ConsentListPanel from '@/app/features/companionHistory/components/ConsentListPanel';
 import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
 import PermissionGate from '@/app/ui/layout/guards/PermissionGate';
 import AlertPill from '@/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill';
@@ -414,6 +415,10 @@ const PhoneCompanionRecord = ({
         <ProblemListPanel companionId={companionId} />
         <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
           <AllergyListPanel companionId={companionId} />
+        </PermissionGate>
+
+        <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
+          <ConsentListPanel companionId={companionId} />
         </PermissionGate>
 
         <PermissionGate allOf={[PERMISSIONS.COMPANIONS_VIEW_ANY]}>

--- a/apps/frontend/src/app/features/companionHistory/services/patientConsentService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/patientConsentService.ts
@@ -1,0 +1,164 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+// A route id only ever holds a bounded id charset (UUIDs and legacy ObjectIds).
+// Validating against it before the value becomes a path segment keeps a caller
+// from steering the request at another path (SSRF). `exec(...)?.[0]` returns the
+// matched value so the URL is built from the validated local, not the raw input.
+const PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+// Mirrors the backend PatientConsent enums (packages/database/prisma/schema.prisma).
+export type ConsentType =
+  'SURGICAL' | 'ANESTHESIA' | 'DIAGNOSTIC' | 'TREATMENT' | 'DATA_SHARING' | 'DNR' | 'OTHER';
+export type ConsentStatus = 'ACTIVE' | 'REVOKED' | 'EXPIRED';
+
+/**
+ * A patient consent as returned by the backend. Dates arrive as ISO strings over
+ * the wire (Prisma `DateTime` serialised to JSON), so they are typed as `string`,
+ * not `Date`. Nullable columns arrive as `null`.
+ */
+export type PatientConsent = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  consentType: ConsentType;
+  status: ConsentStatus;
+  procedureDesc: string | null;
+  consentedByName: string | null;
+  consentedAt: string;
+  expiresAt: string | null;
+  witnessedBy: string | null;
+  revokedAt: string | null;
+  revokedReason: string | null;
+  documentId: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * The grant payload. `consentedBy` is intentionally absent — the backend derives
+ * the acting user from the session rather than trusting the client.
+ */
+export type CreatePatientConsentInput = {
+  patientId: string;
+  consentType: ConsentType;
+  procedureDesc?: string;
+  consentedByName?: string;
+  /** ISO 8601 datetime string; the backend validates with `z.iso.datetime()`. */
+  consentedAt?: string;
+  expiresAt?: string;
+  witnessedBy?: string;
+  documentId?: string;
+  notes?: string;
+};
+
+export type FetchPatientConsentsParams = {
+  patientId: string;
+  status?: ConsentStatus;
+  consentType?: ConsentType;
+};
+
+/** Validates a value before it becomes a path segment; returns the matched local. */
+const safePathSegment = (value: string, label: string): string => {
+  const match = PATH_SEGMENT.exec(value)?.[0];
+  if (!match) throw new Error(`${label} contains unsupported characters`);
+  return match;
+};
+
+const requireOrgId = (): string => {
+  const orgId = useOrgStore.getState().primaryOrgId;
+  if (!orgId) throw new Error('No active organisation selected.');
+  return safePathSegment(orgId, 'Organisation ID');
+};
+
+/**
+ * Runs a request and logs a failure without leaking the response body. An Axios
+ * error is logged by its server message (or its own message when the request
+ * never reached the server); anything else is logged as-is. The error always
+ * rethrows so callers keep their existing handling.
+ */
+const requestWithLog = <T>(message: string, request: () => Promise<T>): Promise<T> =>
+  request().catch((error: unknown) => {
+    if (axios.isAxiosError(error)) {
+      logger.error(message, error.response?.data?.message ?? error.message);
+    } else {
+      logger.error(message, error);
+    }
+    throw error;
+  });
+
+/**
+ * GET the consent list for a patient. The controller returns a raw array; guard
+ * against a malformed body by returning an empty list rather than surfacing a
+ * broken shape. The warning logs only the received `typeof`, never the payload.
+ */
+export const fetchPatientConsents = async ({
+  patientId,
+  status,
+  consentType,
+}: FetchPatientConsentsParams): Promise<PatientConsent[]> => {
+  if (!patientId) throw new Error('Patient ID missing');
+  const safeOrganisationId = requireOrgId();
+  return requestWithLog('Failed to load patient consents:', async () => {
+    const params: Record<string, string> = { patientId };
+    if (status) params.status = status;
+    if (consentType) params.consentType = consentType;
+    const res = await getData<PatientConsent[]>(
+      `/v1/pms/organisation/${safeOrganisationId}/patient-consents`,
+      params
+    );
+    if (!Array.isArray(res.data)) {
+      logger.warn('patient-consents list was not an array; got', typeof res.data);
+      return [];
+    }
+    return res.data;
+  });
+};
+
+/** GET a single consent by id. The controller returns the record. */
+export const fetchPatientConsent = async (consentId: string): Promise<PatientConsent> => {
+  const safeOrganisationId = requireOrgId();
+  const safeConsentId = safePathSegment(consentId, 'Consent ID');
+  return requestWithLog('Failed to load patient consent:', async () => {
+    const res = await getData<PatientConsent>(
+      `/v1/pms/organisation/${safeOrganisationId}/patient-consents/${safeConsentId}`
+    );
+    return res.data;
+  });
+};
+
+/** POST a new consent grant. The controller returns the created record (201). */
+export const grantPatientConsent = async (
+  input: CreatePatientConsentInput
+): Promise<PatientConsent> => {
+  const safeOrganisationId = requireOrgId();
+  return requestWithLog('Failed to grant patient consent:', async () => {
+    const res = await postData<PatientConsent, CreatePatientConsentInput>(
+      `/v1/pms/organisation/${safeOrganisationId}/patient-consents`,
+      input
+    );
+    return res.data;
+  });
+};
+
+/**
+ * POST to the revoke endpoint. `revokedReason` is optional; the body defaults to
+ * an empty object when it is absent. The controller returns the revoked record.
+ */
+export const revokePatientConsent = async (
+  consentId: string,
+  revokedReason?: string
+): Promise<PatientConsent> => {
+  const safeOrganisationId = requireOrgId();
+  const safeConsentId = safePathSegment(consentId, 'Consent ID');
+  return requestWithLog('Failed to revoke patient consent:', async () => {
+    const res = await postData<PatientConsent, { revokedReason?: string }>(
+      `/v1/pms/organisation/${safeOrganisationId}/patient-consents/${safeConsentId}/revoke`,
+      revokedReason ? { revokedReason } : {}
+    );
+    return res.data;
+  });
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for. (This extends the shipped clinical companion-record series — the merged patient allergy (#2691) and patient safety flags (#2692) panels — and follows the same, reviewed pattern.)
- [x] All existing tests and lints pass.

## What is the current behavior?

The companion (patient) record surfaces the problem list, the allergy list and the safety-flag list, but there is no way to see or manage a patient's **consents** in the PIMS. The consent data exists in the backend (`/pms/organisation/:organisationId/patient-consents`) but has no frontend surface, so staff cannot check whether a surgical/anaesthesia/DNR consent is on record before a procedure.

## What is the new behavior?

Adds a **Patient Consent list** to the companion record, built to mirror the merged allergy/flag panels exactly.

**What changed**

- `services/patientConsentService.ts` — `list` / `get` / `grant` / `revoke` against `/v1/pms/organisation/:organisationId/patient-consents`. Route ids are validated against a bounded id charset before they become a path segment (SSRF guard), the list is guarded against a non-array body (returns `[]`, logs only the `typeof`, never the payload), and request failures are logged by message without leaking the response body.
- `components/ConsentList.tsx` (+ `ConsentList.stories.tsx`) — presentational list. Imports the shared `ClinicalListChrome` (never re-inlines it) so it stays visually identical to the sibling lists by construction. Active consents lead the list; an active DNR directive reads in the danger tone and an expired consent in the warning tone via the shared `StatusPill`. Grant and per-row revoke are inline forms with a `<label htmlFor>` for every field.
- `components/useConsentList.ts` — split into three focused sub-hooks (`useConsentRecords` load, `useGrantConsent` grant-then-refetch, `useRevokeConsent` revoke) composed by `useConsentList`, so no single hook owns loading, mutation and notification at once. `grant`/`revoke` return `Promise<boolean>`; the forms close from that boolean in the submit path.
- `components/ConsentListPanel.tsx` — thin data container that renders nothing when the member cannot view consents.
- Wired `ConsentListPanel` into `CompanionHistoryPage.tsx` (desktop) and `PhoneCompanionRecord.tsx` (phone), each in its own `appointments:view:any` `PermissionGate` block beside the allergy/flag panels.

**Why**

Consent is a clinical and medico-legal record staff need at the point of care. Surfacing it in the same place as the other clinical lists keeps the record complete and consistent.

**Impact area**

`apps/frontend` only — the companion (patient) record page (desktop + phone). No backend, schema or shared-package changes. Read is gated on `appointments:view:any`; grant/revoke on `appointments:edit:any`, matching the backend.

## Related Issue(s)

Extends the shipped clinical companion-record panels (patient allergies #2691, patient safety flags #2692); no separate tracking issue.

## Validation performed

Run from `apps/frontend` on this branch:

- `npx tsc --noEmit` — clean (exit 0, 0 errors).
- `npx eslint <changed files>` — clean (exit 0).
- `npx jest --testPathPatterns="[Cc]onsent|CompanionHistory|PhoneCompanionRecord"` — **86 passed** across 5 suites.
- `pnpm --filter frontend run build` — compiled successfully (exit 0).
- Pre-push hook: full monorepo lint + type-check — 18/18 tasks successful.

Coverage on the new files (jest):

| File | % Stmts | % Branch | % Funcs | % Lines |
| --- | --- | --- | --- | --- |
| patientConsentService.ts | 100 | 100 | 100 | 100 |
| ConsentList.tsx | 100 | 100 | 100 | 100 |
| ConsentListPanel.tsx | 100 | 100 | 100 | 100 |
| useConsentList.ts | 100 | 95.34 | 100 | 100 |

Mutation-checked the path-segment guard test and the revoke behavioural test (broke the logic, watched the test fail, restored).
