### PR TITLE
fix(repo): persist mobile notification archive and scope writes to the owner

### DIFF
--- a/apps/backend/src/controllers/app/notification.controller.ts
+++ b/apps/backend/src/controllers/app/notification.controller.ts
@@ -3,25 +3,45 @@ import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import { NotificationService } from "src/services/notification.service";
 import { resolveVerifiedUserId } from "src/utils/request";
 
+/**
+ * The id notification rows are keyed by, for the caller of this request.
+ *
+ * Notifications are written against the mobile user's `parentId`, which is what
+ * listNotifications already reads, so every per-notification route has to
+ * resolve the same id before it can scope a write to its owner. Writes the 401
+ * or 404 itself and returns undefined, so callers bail on a falsy result.
+ */
+const resolveNotificationOwnerId = async (
+  req: Request,
+  res: Response,
+): Promise<string | undefined> => {
+  const authUserId = resolveVerifiedUserId(req);
+  if (!authUserId) {
+    res.status(401).json({ message: "Not authenticated: userId is missing." });
+    return undefined;
+  }
+
+  const authUser = await AuthUserMobileService.getByProviderUserId(authUserId);
+  const ownerId = authUser?.parentId?.toString();
+  if (!ownerId) {
+    res.status(404).json({ message: "User not found." });
+    return undefined;
+  }
+
+  return ownerId;
+};
+
 export const NotificationController = {
   // List notifications for current user
   listNotifications: async (req: Request, res: Response) => {
     try {
-      const authUserId = resolveVerifiedUserId(req);
-      if (!authUserId) {
-        return res
-          .status(401)
-          .json({ message: "Not authenticated: userId is missing." });
-      }
-      const authUser =
-        await AuthUserMobileService.getByProviderUserId(authUserId);
-      if (!authUser) {
-        return res.status(404).json({ message: "User not found." });
+      const ownerId = await resolveNotificationOwnerId(req, res);
+      if (!ownerId) {
+        return res;
       }
 
-      const notifications = await NotificationService.listNotificationsForUser(
-        authUser.parentId?.toString() || "",
-      );
+      const notifications =
+        await NotificationService.listNotificationsForUser(ownerId);
       return res.status(200).json({ notifications });
     } catch (err) {
       console.error("Error listing notifications", err);
@@ -37,13 +57,55 @@ export const NotificationController = {
         return res.status(400).json({ message: "notificationId is required." });
       }
 
-      await NotificationService.markNotificationAsSeen(notificationId);
+      const ownerId = await resolveNotificationOwnerId(req, res);
+      if (!ownerId) {
+        return res;
+      }
+
+      const updated = await NotificationService.markNotificationAsSeen(
+        notificationId,
+        ownerId,
+      );
+      if (updated === 0) {
+        return res.status(404).json({ message: "Notification not found." });
+      }
+
       return res.status(200).json({ message: "Notification marked as seen." });
     } catch (err) {
       console.error("Error marking notification as seen", err);
       return res
         .status(500)
         .json({ message: "Failed to mark notification as seen." });
+    }
+  },
+
+  // Archive notification
+  archive: async (req: Request, res: Response) => {
+    try {
+      const { notificationId } = req.params;
+      if (!notificationId) {
+        return res.status(400).json({ message: "notificationId is required." });
+      }
+
+      const ownerId = await resolveNotificationOwnerId(req, res);
+      if (!ownerId) {
+        return res;
+      }
+
+      const outcome = await NotificationService.archiveNotificationForUser(
+        notificationId,
+        ownerId,
+      );
+      if (outcome === "not-found") {
+        return res.status(404).json({ message: "Notification not found." });
+      }
+
+      return res.status(200).json({ message: "Notification archived." });
+    } catch (err) {
+      console.error("Error archiving notification", err);
+      return res
+        .status(500)
+        .json({ message: "Failed to archive notification." });
     }
   },
 };

--- a/apps/backend/src/controllers/app/notification.controller.ts
+++ b/apps/backend/src/controllers/app/notification.controller.ts
@@ -37,7 +37,7 @@ export const NotificationController = {
     try {
       const ownerId = await resolveNotificationOwnerId(req, res);
       if (!ownerId) {
-        return res;
+        return;
       }
 
       const notifications =
@@ -59,7 +59,7 @@ export const NotificationController = {
 
       const ownerId = await resolveNotificationOwnerId(req, res);
       if (!ownerId) {
-        return res;
+        return;
       }
 
       const updated = await NotificationService.markNotificationAsSeen(
@@ -89,7 +89,7 @@ export const NotificationController = {
 
       const ownerId = await resolveNotificationOwnerId(req, res);
       if (!ownerId) {
-        return res;
+        return;
       }
 
       const outcome = await NotificationService.archiveNotificationForUser(

--- a/apps/backend/src/routers/notification.router.ts
+++ b/apps/backend/src/routers/notification.router.ts
@@ -18,4 +18,11 @@ notificationRouter.post(
   NotificationController.markAsSeen,
 );
 
+// Archive notification (removes it from the owner's list without deleting it)
+notificationRouter.post(
+  "/mobile/:notificationId/archive",
+  requireMobileAuth,
+  NotificationController.archive,
+);
+
 export default notificationRouter;

--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -221,7 +221,7 @@ export const NotificationService = {
     }
 
     const sendOptions: SendOptions = notificationId
-      ? { ...options, data: { ...(options?.data ?? {}), notificationId } }
+      ? { ...options, data: { ...options?.data, notificationId } }
       : (options ?? {});
 
     // Use for..of to handle async cleanly

--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -32,7 +32,7 @@ const createNotificationRecord = async (input: {
   body: string;
   type: string;
 }) => {
-  await prisma.notification.create({
+  const record = await prisma.notification.create({
     data: {
       userId: input.userId,
       title: input.title,
@@ -41,7 +41,10 @@ const createNotificationRecord = async (input: {
       enabled: true,
       isSeen: false,
     },
+    select: { id: true },
   });
+
+  return record.id;
 };
 
 export type Platform = "ANDROID" | "IOS" | "WEB";
@@ -194,6 +197,33 @@ export const NotificationService = {
 
     const results: SendResult[] = [];
 
+    // One row per notification, written before the fan-out rather than inside
+    // it. Inside the loop it produced one row per device, so a user with a
+    // phone and a tablet saw every notification twice in the list. Awaited
+    // because the row's id goes out in the push data: the app keys mark-read
+    // and archive by it, and an id minted on the device matches no row.
+    let notificationId: string | undefined;
+    try {
+      notificationId = await createNotificationRecord({
+        userId,
+        title: payload.title,
+        body: payload.body,
+        type: payload.type ?? "GENERAL",
+      });
+    } catch (err) {
+      // A failed write must not swallow the push - the user still gets the
+      // alert, it just arrives without a row to act on.
+      logger.error(
+        `Failed to log notification for user ${userId}: ${
+          err instanceof Error ? err.message : "Unknown error"
+        }`,
+      );
+    }
+
+    const sendOptions: SendOptions = notificationId
+      ? { ...options, data: { ...(options?.data ?? {}), notificationId } }
+      : (options ?? {});
+
     // Use for..of to handle async cleanly
     for (const record of tokens) {
       if (!record) continue;
@@ -201,22 +231,9 @@ export const NotificationService = {
       const result = await this.sendToDevice(
         record.deviceToken,
         payload,
-        options,
+        sendOptions,
       );
       results.push(result);
-
-      void createNotificationRecord({
-        userId,
-        title: payload.title,
-        body: payload.body,
-        type: payload.type ?? "GENERAL",
-      }).catch((err) => {
-        logger.error(
-          `Failed to log notification for user ${userId}: ${
-            err instanceof Error ? err.message : "Unknown error"
-          }`,
-        );
-      });
     }
 
     return results;
@@ -260,14 +277,75 @@ export const NotificationService = {
     });
   },
 
-  async markNotificationAsSeen(notificationId: string) {
+  /**
+   * Mark one notification seen, scoped to its owner.
+   *
+   * The userId in the `where` is load-bearing, not belt-and-braces: the
+   * notification id arrives from the client, so without it any authenticated
+   * caller could mark another user's notification seen by guessing an id.
+   * Returns the number of rows changed so the caller can tell "not yours or
+   * not there" from "done" - an id that matches nothing updates nothing, which
+   * a bare updateMany reports as success.
+   */
+  async markNotificationAsSeen(notificationId: string, userId: string) {
     if (!isNonEmptyString(notificationId)) {
       throw new Error("notificationId is required to mark as seen");
     }
+    if (!isNonEmptyString(userId)) {
+      throw new Error("userId is required to mark as seen");
+    }
 
-    await prisma.notification.updateMany({
-      where: { id: notificationId },
+    const { count } = await prisma.notification.updateMany({
+      where: { id: notificationId, userId },
       data: { isSeen: true },
     });
+
+    return count;
+  },
+
+  /**
+   * Archive one notification, scoped to its owner. Owner scoping is required
+   * for the same reason as markNotificationAsSeen.
+   *
+   * Archiving stamps `archivedAt` rather than deleting the row, so the record
+   * survives for audit and the client can still list it under its archived
+   * filter. `archivedAt: null` in the `where` keeps the first archive time: a
+   * second swipe on the same row must not rewrite when the owner archived it.
+   *
+   * The three outcomes are returned separately because the caller has to map
+   * them to different statuses, and "already archived" is a success from the
+   * owner's point of view - the notification is where they put it. Collapsing
+   * it into the miss case would 404 a swipe that already worked.
+   */
+  async archiveNotificationForUser(
+    notificationId: string,
+    userId: string,
+  ): Promise<"archived" | "already-archived" | "not-found"> {
+    if (!isNonEmptyString(notificationId)) {
+      throw new Error("notificationId is required to archive");
+    }
+    if (!isNonEmptyString(userId)) {
+      throw new Error("userId is required to archive");
+    }
+
+    const { count } = await prisma.notification.updateMany({
+      where: { id: notificationId, userId, archivedAt: null },
+      data: { archivedAt: new Date() },
+    });
+
+    if (count > 0) {
+      return "archived";
+    }
+
+    // Nothing updated: either the row is already archived, or it does not
+    // exist / belongs to someone else. Only this second query can tell them
+    // apart, and it stays scoped to the owner so it cannot confirm the
+    // existence of another user's notification.
+    const existing = await prisma.notification.findFirst({
+      where: { id: notificationId, userId },
+      select: { id: true },
+    });
+
+    return existing ? "already-archived" : "not-found";
   },
 };

--- a/apps/backend/test/controllers/notification.controller.test.ts
+++ b/apps/backend/test/controllers/notification.controller.test.ts
@@ -1,0 +1,242 @@
+import { NotificationController } from "../../src/controllers/app/notification.controller";
+import { AuthUserMobileService } from "../../src/services/authUserMobile.service";
+import { NotificationService } from "../../src/services/notification.service";
+
+jest.mock("../../src/services/authUserMobile.service", () => ({
+  AuthUserMobileService: {
+    getByProviderUserId: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/services/notification.service", () => ({
+  NotificationService: {
+    listNotificationsForUser: jest.fn(),
+    markNotificationAsSeen: jest.fn(),
+    archiveNotificationForUser: jest.fn(),
+  },
+}));
+
+const mockedAuthUserMobileService = AuthUserMobileService as unknown as {
+  getByProviderUserId: jest.Mock;
+};
+
+const mockedNotificationService = NotificationService as unknown as {
+  listNotificationsForUser: jest.Mock;
+  markNotificationAsSeen: jest.Mock;
+  archiveNotificationForUser: jest.Mock;
+};
+
+const createResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+});
+
+// The mobile middleware puts the provider user id on the request; parentId is
+// the id notification rows are actually keyed by.
+const authedRequest = (overrides: Record<string, unknown> = {}) => ({
+  userId: "provider-user-1",
+  params: { notificationId: "notif-1" },
+  ...overrides,
+});
+
+describe("NotificationController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAuthUserMobileService.getByProviderUserId.mockResolvedValue({
+      parentId: "owner-1",
+    });
+  });
+
+  describe("owner resolution", () => {
+    it.each([
+      ["listNotifications", () => NotificationController.listNotifications],
+      ["markAsSeen", () => NotificationController.markAsSeen],
+      ["archive", () => NotificationController.archive],
+    ])("401s %s when the request is not authenticated", async (_name, get) => {
+      const res = createResponse();
+
+      await get()(authedRequest({ userId: undefined }) as any, res as any);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Not authenticated: userId is missing.",
+      });
+    });
+
+    it.each([
+      ["listNotifications", () => NotificationController.listNotifications],
+      ["markAsSeen", () => NotificationController.markAsSeen],
+      ["archive", () => NotificationController.archive],
+    ])("404s %s when the mobile user has no parent", async (_name, get) => {
+      mockedAuthUserMobileService.getByProviderUserId.mockResolvedValueOnce(
+        null,
+      );
+      const res = createResponse();
+
+      await get()(authedRequest() as any, res as any);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "User not found." });
+    });
+  });
+
+  describe("listNotifications", () => {
+    it("lists the resolved owner's notifications", async () => {
+      mockedNotificationService.listNotificationsForUser.mockResolvedValueOnce([
+        { id: "notif-1" },
+      ]);
+      const res = createResponse();
+
+      await NotificationController.listNotifications(
+        authedRequest() as any,
+        res as any,
+      );
+
+      expect(
+        mockedNotificationService.listNotificationsForUser,
+      ).toHaveBeenCalledWith("owner-1");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        notifications: [{ id: "notif-1" }],
+      });
+    });
+
+    it("500s when the service throws", async () => {
+      mockedNotificationService.listNotificationsForUser.mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const res = createResponse();
+
+      await NotificationController.listNotifications(
+        authedRequest() as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("markAsSeen", () => {
+    it("400s without a notificationId", async () => {
+      const res = createResponse();
+
+      await NotificationController.markAsSeen(
+        authedRequest({ params: {} }) as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(
+        mockedNotificationService.markNotificationAsSeen,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("passes the resolved owner, so the update cannot cross users", async () => {
+      mockedNotificationService.markNotificationAsSeen.mockResolvedValueOnce(1);
+      const res = createResponse();
+
+      await NotificationController.markAsSeen(
+        authedRequest() as any,
+        res as any,
+      );
+
+      expect(
+        mockedNotificationService.markNotificationAsSeen,
+      ).toHaveBeenCalledWith("notif-1", "owner-1");
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("404s an id that belongs to nobody, rather than reporting success", async () => {
+      mockedNotificationService.markNotificationAsSeen.mockResolvedValueOnce(0);
+      const res = createResponse();
+
+      await NotificationController.markAsSeen(
+        authedRequest({ params: { notificationId: "someone-elses" } }) as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Notification not found.",
+      });
+    });
+
+    it("500s when the service throws", async () => {
+      mockedNotificationService.markNotificationAsSeen.mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const res = createResponse();
+
+      await NotificationController.markAsSeen(
+        authedRequest() as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("archive", () => {
+    it("400s without a notificationId", async () => {
+      const res = createResponse();
+
+      await NotificationController.archive(
+        authedRequest({ params: {} }) as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(
+        mockedNotificationService.archiveNotificationForUser,
+      ).not.toHaveBeenCalled();
+    });
+
+    it.each(["archived", "already-archived"])(
+      "200s a %s notification",
+      async (outcome) => {
+        mockedNotificationService.archiveNotificationForUser.mockResolvedValueOnce(
+          outcome,
+        );
+        const res = createResponse();
+
+        await NotificationController.archive(
+          authedRequest() as any,
+          res as any,
+        );
+
+        expect(
+          mockedNotificationService.archiveNotificationForUser,
+        ).toHaveBeenCalledWith("notif-1", "owner-1");
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+          message: "Notification archived.",
+        });
+      },
+    );
+
+    it("404s an id that is not the caller's", async () => {
+      mockedNotificationService.archiveNotificationForUser.mockResolvedValueOnce(
+        "not-found",
+      );
+      const res = createResponse();
+
+      await NotificationController.archive(
+        authedRequest({ params: { notificationId: "someone-elses" } }) as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("500s when the service throws", async () => {
+      mockedNotificationService.archiveNotificationForUser.mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const res = createResponse();
+
+      await NotificationController.archive(authedRequest() as any, res as any);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/apps/backend/test/services/notification.service.test.ts
+++ b/apps/backend/test/services/notification.service.test.ts
@@ -35,6 +35,7 @@ jest.mock("src/config/prisma", () => ({
   prisma: {
     notification: {
       create: jest.fn(),
+      findFirst: jest.fn(),
       findMany: jest.fn(),
       updateMany: jest.fn(),
     },
@@ -50,6 +51,12 @@ describe("NotificationService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (prisma.notification.create as jest.Mock).mockResolvedValue({
+      id: "notif-row-1",
+    });
+    (prisma.notification.updateMany as jest.Mock).mockResolvedValue({
+      count: 1,
+    });
   });
 
   describe("sendToDevice", () => {
@@ -204,17 +211,17 @@ describe("NotificationService", () => {
       expect(res).toEqual([]);
     });
 
-    it("stores notifications via prisma for each token", async () => {
+    it("stores one notification row per notification, not per device", async () => {
       (DeviceTokenService.getTokensForUser as jest.Mock).mockResolvedValueOnce([
         { deviceToken: "token-1" },
+        { deviceToken: "token-2" },
       ]);
       mockSend.mockResolvedValue("msg-id");
 
       const res = await NotificationService.sendToUser("user1", payload);
-      await new Promise(process.nextTick); // flush dangling create promise
 
-      expect(res).toHaveLength(1);
-      expect(res[0].token).toBe("token-1");
+      expect(res).toHaveLength(2);
+      expect(prisma.notification.create).toHaveBeenCalledTimes(1);
       expect(prisma.notification.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -225,7 +232,43 @@ describe("NotificationService", () => {
       );
     });
 
-    it("loops through tokens, skips invalid records, and logs DB errors asynchronously", async () => {
+    it("sends the stored row id to every device so the app can act on it", async () => {
+      (DeviceTokenService.getTokensForUser as jest.Mock).mockResolvedValueOnce([
+        { deviceToken: "token-1" },
+        { deviceToken: "token-2" },
+      ]);
+      mockSend.mockResolvedValue("msg-id");
+
+      await NotificationService.sendToUser("user1", payload, {
+        data: { deepLink: "/appointments/1" },
+      });
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      for (const call of mockSend.mock.calls) {
+        expect(call[0].data).toEqual({
+          deepLink: "/appointments/1",
+          notificationId: "notif-row-1",
+        });
+      }
+    });
+
+    it("still delivers the push when the row cannot be written", async () => {
+      (DeviceTokenService.getTokensForUser as jest.Mock).mockResolvedValueOnce([
+        { deviceToken: "token-1" },
+      ]);
+      mockSend.mockResolvedValue("msg-id");
+      (prisma.notification.create as jest.Mock).mockRejectedValueOnce(
+        new Error("DB Insert Failed"),
+      );
+
+      const res = await NotificationService.sendToUser("user1", payload);
+
+      expect(res).toHaveLength(1);
+      expect(res[0].success).toBe(true);
+      expect(mockSend.mock.calls[0][0].data).toEqual({});
+    });
+
+    it("loops through tokens, skips invalid records, and logs DB errors", async () => {
       // Notice: we mock `deviceToken` here because the source code accesses `record.deviceToken`
       const mockTokens = [
         null, // Should hit `if (!record) continue;`
@@ -242,9 +285,6 @@ describe("NotificationService", () => {
       );
 
       const res = await NotificationService.sendToUser("user1", payload);
-
-      // We must wait a tick for the dangling .catch() on create to execute
-      await new Promise(process.nextTick);
 
       expect(res).toHaveLength(1);
       expect(res[0].token).toBe("token-1");
@@ -264,7 +304,6 @@ describe("NotificationService", () => {
       );
 
       await NotificationService.sendToUser("user1", payload);
-      await new Promise(process.nextTick); // flush dangling promises
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Unknown error"),
@@ -333,15 +372,101 @@ describe("NotificationService", () => {
   describe("markNotificationAsSeen", () => {
     it("throws if notificationId is missing", async () => {
       await expect(
-        NotificationService.markNotificationAsSeen(""),
+        NotificationService.markNotificationAsSeen("", "user1"),
       ).rejects.toThrow("notificationId is required");
     });
 
-    it("updates notification via prisma", async () => {
-      await NotificationService.markNotificationAsSeen("notif-1");
+    it("throws if userId is missing", async () => {
+      await expect(
+        NotificationService.markNotificationAsSeen("notif-1", ""),
+      ).rejects.toThrow("userId is required");
+    });
+
+    it("scopes the update to the owner, so another user's id matches nothing", async () => {
+      const count = await NotificationService.markNotificationAsSeen(
+        "notif-1",
+        "user1",
+      );
+
       expect(prisma.notification.updateMany).toHaveBeenCalledWith({
-        where: { id: "notif-1" },
+        where: { id: "notif-1", userId: "user1" },
         data: { isSeen: true },
+      });
+      expect(count).toBe(1);
+    });
+
+    it("reports zero when the notification is not this user's", async () => {
+      (prisma.notification.updateMany as jest.Mock).mockResolvedValueOnce({
+        count: 0,
+      });
+
+      const count = await NotificationService.markNotificationAsSeen(
+        "someone-elses",
+        "user1",
+      );
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("archiveNotificationForUser", () => {
+    it("throws if notificationId is missing", async () => {
+      await expect(
+        NotificationService.archiveNotificationForUser("", "user1"),
+      ).rejects.toThrow("notificationId is required");
+    });
+
+    it("throws if userId is missing", async () => {
+      await expect(
+        NotificationService.archiveNotificationForUser("notif-1", ""),
+      ).rejects.toThrow("userId is required");
+    });
+
+    it("stamps archivedAt for the owner's un-archived notification", async () => {
+      const res = await NotificationService.archiveNotificationForUser(
+        "notif-1",
+        "user1",
+      );
+
+      expect(res).toBe("archived");
+      expect(prisma.notification.updateMany).toHaveBeenCalledWith({
+        where: { id: "notif-1", userId: "user1", archivedAt: null },
+        data: { archivedAt: expect.any(Date) },
+      });
+      expect(prisma.notification.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("treats a second archive as success and keeps the original timestamp", async () => {
+      (prisma.notification.updateMany as jest.Mock).mockResolvedValueOnce({
+        count: 0,
+      });
+      (prisma.notification.findFirst as jest.Mock).mockResolvedValueOnce({
+        id: "notif-1",
+      });
+
+      const res = await NotificationService.archiveNotificationForUser(
+        "notif-1",
+        "user1",
+      );
+
+      expect(res).toBe("already-archived");
+    });
+
+    it("reports not-found for an id that is not this user's", async () => {
+      (prisma.notification.updateMany as jest.Mock).mockResolvedValueOnce({
+        count: 0,
+      });
+      (prisma.notification.findFirst as jest.Mock).mockResolvedValueOnce(null);
+
+      const res = await NotificationService.archiveNotificationForUser(
+        "someone-elses",
+        "user1",
+      );
+
+      expect(res).toBe("not-found");
+      expect(prisma.notification.findFirst).toHaveBeenCalledWith({
+        where: { id: "someone-elses", userId: "user1" },
+        select: { id: true },
       });
     });
   });

--- a/apps/mobileAppYC/__tests__/features/notifications/notificationSlice.test.ts
+++ b/apps/mobileAppYC/__tests__/features/notifications/notificationSlice.test.ts
@@ -9,12 +9,8 @@ import notificationReducer, {
 } from '@/features/notifications/notificationSlice';
 import {
   fetchNotificationsForCompanion,
-  createNotification,
   markNotificationAsRead,
-  markAllNotificationsAsRead,
-  deleteNotification,
   archiveNotification,
-  clearAllNotifications,
 } from '@/features/notifications/thunks';
 
 describe('notificationSlice', () => {
@@ -147,38 +143,6 @@ describe('notificationSlice', () => {
     });
   });
 
-  describe('createNotification', () => {
-    it('pending', () => {
-      const state = notificationReducer(initialState, {
-        type: createNotification.pending.type,
-      });
-      expect(state.loading).toBe(true);
-    });
-
-    it('fulfilled (unread)', () => {
-      const payload = {id: '1', status: 'unread'};
-      const action = {type: createNotification.fulfilled.type, payload};
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items[0]).toEqual(payload);
-      expect(state.unreadCount).toBe(1);
-    });
-
-    it('fulfilled (read)', () => {
-      const payload = {id: '1', status: 'read'};
-      const action = {type: createNotification.fulfilled.type, payload};
-      const state = notificationReducer(initialState, action as any);
-      expect(state.unreadCount).toBe(0);
-    });
-
-    it('rejected', () => {
-      const state = notificationReducer(initialState, {
-        type: createNotification.rejected.type,
-      });
-      expect(state.loading).toBe(false);
-      expect(state.error).toBe('Failed to create notification');
-    });
-  });
-
   describe('markNotificationAsRead', () => {
     it('fulfilled - updates unread to read', () => {
       initialState.items = [{id: '1', status: 'unread'}];
@@ -217,70 +181,6 @@ describe('notificationSlice', () => {
         type: markNotificationAsRead.rejected.type,
       });
       expect(state.error).toBe('Failed to mark notification as read');
-    });
-  });
-
-  describe('markAllNotificationsAsRead', () => {
-    it('fulfilled - marks all unread as read', () => {
-      initialState.items = [
-        {id: '1', status: 'unread'},
-        {id: '2', status: 'read'},
-      ];
-      initialState.unreadCount = 1;
-      const action = {type: markAllNotificationsAsRead.fulfilled.type};
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items[0].status).toBe('read');
-      expect(state.unreadCount).toBe(0);
-    });
-
-    it('rejected', () => {
-      const state = notificationReducer(initialState, {
-        type: markAllNotificationsAsRead.rejected.type,
-      });
-      expect(state.error).toBe('Failed to mark notifications as read');
-    });
-  });
-
-  describe('deleteNotification', () => {
-    it('fulfilled - deletes unread (decrements count)', () => {
-      initialState.items = [{id: '1', status: 'unread'}];
-      initialState.unreadCount = 1;
-      const action = {
-        type: deleteNotification.fulfilled.type,
-        payload: {notificationId: '1'},
-      };
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items).toHaveLength(0);
-      expect(state.unreadCount).toBe(0);
-    });
-
-    it('fulfilled - deletes read (count stays)', () => {
-      initialState.items = [{id: '1', status: 'read'}];
-      initialState.unreadCount = 5;
-      const action = {
-        type: deleteNotification.fulfilled.type,
-        payload: {notificationId: '1'},
-      };
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items).toHaveLength(0);
-      expect(state.unreadCount).toBe(5);
-    });
-
-    it('fulfilled - item missing', () => {
-      initialState.items = [{id: '1', status: 'read'}];
-      const action = {
-        type: deleteNotification.fulfilled.type,
-        payload: {notificationId: '999'},
-      };
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items).toHaveLength(1);
-    });
-
-    it('rejected', () => {
-      const state = notificationReducer(initialState, {
-        type: deleteNotification.rejected.type,
-      });
-      expect(state.error).toBe('Failed to delete notification');
     });
   });
 
@@ -323,28 +223,6 @@ describe('notificationSlice', () => {
         type: archiveNotification.rejected.type,
       });
       expect(state.error).toBe('Failed to archive notification');
-    });
-  });
-
-  describe('clearAllNotifications', () => {
-    it('fulfilled - keeps only archived, resets count', () => {
-      initialState.items = [
-        {id: '1', status: 'unread'},
-        {id: '2', status: 'archived'},
-      ];
-      initialState.unreadCount = 1;
-      const action = {type: clearAllNotifications.fulfilled.type};
-      const state = notificationReducer(initialState, action as any);
-      expect(state.items).toHaveLength(1);
-      expect(state.items[0].status).toBe('archived');
-      expect(state.unreadCount).toBe(0);
-    });
-
-    it('rejected', () => {
-      const state = notificationReducer(initialState, {
-        type: clearAllNotifications.rejected.type,
-      });
-      expect(state.error).toBe('Failed to clear notifications');
     });
   });
 });

--- a/apps/mobileAppYC/__tests__/features/notifications/services/notificationService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/notifications/services/notificationService.test.ts
@@ -1,4 +1,5 @@
 import {
+  archiveMobileNotification,
   fetchMobileNotifications,
   markMobileNotificationSeen,
 } from '../../../../src/features/notifications/services/notificationService';
@@ -13,7 +14,7 @@ jest.mock('@/shared/services/apiClient', () => ({
     get: jest.fn(),
     post: jest.fn(),
   },
-  withAuthHeaders: jest.fn().mockImplementation((token) => ({
+  withAuthHeaders: jest.fn().mockImplementation(token => ({
     Authorization: `Bearer ${token}`,
   })),
 }));
@@ -64,7 +65,9 @@ describe('notificationService', () => {
 
       expect(apiClient.get).toHaveBeenCalledWith(
         '/v1/notification/mobile',
-        expect.objectContaining({headers: {Authorization: `Bearer ${mockToken}`}}),
+        expect.objectContaining({
+          headers: {Authorization: `Bearer ${mockToken}`},
+        }),
       );
 
       // Verify Sorting (Newest first) - "Appointment" is 02 Jan, "Billing" is 01 Jan
@@ -214,27 +217,42 @@ describe('notificationService', () => {
     });
 
     it('normalizes specific related types correctly', async () => {
-         const types = ['appointment', 'document', 'task', 'message', 'payment', 'unknown'];
+      const types = [
+        'appointment',
+        'document',
+        'task',
+        'message',
+        'payment',
+        'unknown',
+      ];
 
-         (apiClient.get as jest.Mock).mockResolvedValue({
-            data: types.map(t => ({id: t, relatedType: t, createdAt: new Date().toISOString()}))
-         });
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: types.map(t => ({
+          id: t,
+          relatedType: t,
+          createdAt: new Date().toISOString(),
+        })),
+      });
 
-         const result = await fetchMobileNotifications();
+      const result = await fetchMobileNotifications();
 
-         expect(result.find(n => n.id === 'appointment')?.relatedType).toBe('appointment');
-         expect(result.find(n => n.id === 'document')?.relatedType).toBe('document');
-         expect(result.find(n => n.id === 'task')?.relatedType).toBe('task');
-         expect(result.find(n => n.id === 'message')?.relatedType).toBe('message');
-         expect(result.find(n => n.id === 'payment')?.relatedType).toBe('payment');
-         expect(result.find(n => n.id === 'unknown')?.relatedType).toBeUndefined();
+      expect(result.find(n => n.id === 'appointment')?.relatedType).toBe(
+        'appointment',
+      );
+      expect(result.find(n => n.id === 'document')?.relatedType).toBe(
+        'document',
+      );
+      expect(result.find(n => n.id === 'task')?.relatedType).toBe('task');
+      expect(result.find(n => n.id === 'message')?.relatedType).toBe('message');
+      expect(result.find(n => n.id === 'payment')?.relatedType).toBe('payment');
+      expect(result.find(n => n.id === 'unknown')?.relatedType).toBeUndefined();
     });
 
     // --- Branch Coverage: Payload Structures ---
 
     it('extracts list from "notifications" property', async () => {
       (apiClient.get as jest.Mock).mockResolvedValue({
-        data: { notifications: [{ id: '1' }] },
+        data: {notifications: [{id: '1'}]},
       });
       const result = await fetchMobileNotifications();
       expect(result).toHaveLength(1);
@@ -242,22 +260,22 @@ describe('notificationService', () => {
 
     it('extracts list from "items" property', async () => {
       (apiClient.get as jest.Mock).mockResolvedValue({
-        data: { items: [{ id: '1' }] },
+        data: {items: [{id: '1'}]},
       });
       const result = await fetchMobileNotifications();
       expect(result).toHaveLength(1);
     });
 
     it('extracts list from nested "data" property', async () => {
-        (apiClient.get as jest.Mock).mockResolvedValue({
-          data: { data: [{ id: '1' }] },
-        });
-        const result = await fetchMobileNotifications();
-        expect(result).toHaveLength(1);
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: {data: [{id: '1'}]},
       });
+      const result = await fetchMobileNotifications();
+      expect(result).toHaveLength(1);
+    });
 
     it('returns empty array for invalid payload', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue({ data: null });
+      (apiClient.get as jest.Mock).mockResolvedValue({data: null});
       const result = await fetchMobileNotifications();
       expect(result).toEqual([]);
     });
@@ -266,23 +284,26 @@ describe('notificationService', () => {
 
     it('handles missing auth token gracefully', async () => {
       (getFreshStoredTokens as jest.Mock).mockResolvedValue(null);
-      (apiClient.get as jest.Mock).mockResolvedValue({ data: [] });
+      (apiClient.get as jest.Mock).mockResolvedValue({data: []});
 
       await fetchMobileNotifications();
 
       // Should call without headers object (or undefined headers)
-      expect(apiClient.get).toHaveBeenCalledWith('/v1/notification/mobile', undefined);
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/v1/notification/mobile',
+        undefined,
+      );
     });
 
     // --- Date Parsing Edge Case ---
     it('handles invalid dates gracefully by falling back to current date', async () => {
-        (apiClient.get as jest.Mock).mockResolvedValue({
-            data: [{ id: '1', createdAt: 'invalid-date-string' }],
-          });
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: [{id: '1', createdAt: 'invalid-date-string'}],
+      });
 
-        const result = await fetchMobileNotifications();
-        // Should parse to a valid ISO string (current time fallback)
-        expect(Date.parse(result[0].timestamp)).not.toBeNaN();
+      const result = await fetchMobileNotifications();
+      // Should parse to a valid ISO string (current time fallback)
+      expect(Date.parse(result[0].timestamp)).not.toBeNaN();
     });
   });
 
@@ -297,7 +318,9 @@ describe('notificationService', () => {
       expect(apiClient.post).toHaveBeenCalledWith(
         '/v1/notification/mobile/123/seen',
         undefined,
-        expect.objectContaining({headers: {Authorization: `Bearer ${mockToken}`}}),
+        expect.objectContaining({
+          headers: {Authorization: `Bearer ${mockToken}`},
+        }),
       );
     });
 
@@ -316,6 +339,86 @@ describe('notificationService', () => {
         undefined,
         undefined, // No headers passed
       );
+    });
+  });
+
+  // ===========================================================================
+  // 3. archiveMobileNotification
+  // ===========================================================================
+
+  describe('archiveMobileNotification', () => {
+    it('calls API to archive the notification', async () => {
+      await archiveMobileNotification('123');
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/v1/notification/mobile/123/archive',
+        undefined,
+        expect.objectContaining({
+          headers: {Authorization: `Bearer ${mockToken}`},
+        }),
+      );
+    });
+
+    it('returns early if notificationId is missing', async () => {
+      await archiveMobileNotification('');
+      expect(apiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('handles missing auth token gracefully', async () => {
+      (getFreshStoredTokens as jest.Mock).mockResolvedValue(null);
+
+      await archiveMobileNotification('123');
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/v1/notification/mobile/123/archive',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('propagates a rejected archive so the thunk can report it', async () => {
+      (apiClient.post as jest.Mock).mockRejectedValueOnce(
+        new Error('Notification not found.'),
+      );
+
+      await expect(archiveMobileNotification('123')).rejects.toThrow(
+        'Notification not found.',
+      );
+    });
+  });
+
+  // ===========================================================================
+  // 4. archivedAt round-trip - the bug this endpoint exists to fix
+  // ===========================================================================
+
+  describe('archived notifications survive a reload', () => {
+    it('reads an archived row as archived even though it is also seen', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: {
+          notifications: [
+            {
+              id: 'archived-1',
+              title: 'Archived',
+              isSeen: true,
+              archivedAt: '2026-09-05T10:00:00Z',
+              createdAt: '2026-09-05T09:00:00Z',
+            },
+            {
+              id: 'live-1',
+              title: 'Live',
+              isSeen: true,
+              archivedAt: null,
+              createdAt: '2026-09-05T09:30:00Z',
+            },
+          ],
+        },
+      });
+
+      const result = await fetchMobileNotifications();
+
+      expect(result.find(n => n.id === 'archived-1')?.status).toBe('archived');
+      // isSeen alone must still read as 'read', not 'archived'.
+      expect(result.find(n => n.id === 'live-1')?.status).toBe('read');
     });
   });
 });

--- a/apps/mobileAppYC/__tests__/features/notifications/thunks.test.ts
+++ b/apps/mobileAppYC/__tests__/features/notifications/thunks.test.ts
@@ -1,205 +1,153 @@
-import { configureStore } from '@reduxjs/toolkit';
+import {configureStore} from '@reduxjs/toolkit';
 import notificationReducer from '@/features/notifications/notificationSlice';
 import {
   fetchNotificationsForCompanion,
-  createNotification,
   markNotificationAsRead,
-  markAllNotificationsAsRead,
-  deleteNotification,
   archiveNotification,
-  clearAllNotifications
 } from '@/features/notifications/thunks';
 import {
+  archiveMobileNotification,
   fetchMobileNotifications,
   markMobileNotificationSeen,
 } from '@/features/notifications/services/notificationService';
 
 jest.mock('@/features/notifications/services/notificationService');
 
-const mockedFetchMobileNotifications = fetchMobileNotifications as jest.MockedFunction<
-  typeof fetchMobileNotifications
->;
-const mockedMarkMobileNotificationSeen = markMobileNotificationSeen as jest.MockedFunction<
-  typeof markMobileNotificationSeen
->;
+const mockedFetchMobileNotifications =
+  fetchMobileNotifications as jest.MockedFunction<
+    typeof fetchMobileNotifications
+  >;
+const mockedMarkMobileNotificationSeen =
+  markMobileNotificationSeen as jest.MockedFunction<
+    typeof markMobileNotificationSeen
+  >;
+const mockedArchiveMobileNotification =
+  archiveMobileNotification as jest.MockedFunction<
+    typeof archiveMobileNotification
+  >;
 
 describe('Notification Thunks', () => {
   let store: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
     mockedFetchMobileNotifications.mockResolvedValue([]);
     mockedMarkMobileNotificationSeen.mockResolvedValue();
+    mockedArchiveMobileNotification.mockResolvedValue();
     store = configureStore({
-      reducer: { notifications: notificationReducer },
+      reducer: {notifications: notificationReducer},
     });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-    jest.restoreAllMocks();
-  });
-
-  // Helper to run successful thunks
   const runSuccess = async (action: any) => {
-    const promise = store.dispatch(action);
-    jest.runAllTimers();
-    const res = await promise;
+    const res = await store.dispatch(action);
     expect(res.type).toMatch(/\/fulfilled$/);
     return res;
   };
 
-  // Helper to run failed thunks
   const runFailure = async (action: any, expectedMessage: string) => {
-    const promise = store.dispatch(action);
-    // We don't need runAllTimers here because our mock throws synchronously
-    const res = await promise;
+    const res = await store.dispatch(action);
     expect(res.type).toMatch(/\/rejected$/);
     expect(res.payload).toBe(expectedMessage);
   };
 
-  describe('1. Success Paths (Happy Path)', () => {
+  describe('1. Success paths - each thunk calls its endpoint', () => {
     it('fetchNotificationsForCompanion resolves successfully', async () => {
-      const res = await runSuccess(fetchNotificationsForCompanion({ companionId: 'c1' }));
+      const res = await runSuccess(
+        fetchNotificationsForCompanion({companionId: 'c1'}),
+      );
+      expect(mockedFetchMobileNotifications).toHaveBeenCalledTimes(1);
       expect(res.payload.companionId).toBe('c1');
       expect(res.payload.notifications).toEqual([]);
     });
 
-    it('createNotification resolves successfully', async () => {
-      const payload = { title: 'Test', category: 'messages', companionId: 'c1' };
-      const res = await runSuccess(createNotification(payload as any));
-      expect(res.payload.title).toBe('Test');
-      expect(res.payload.id).toBeDefined();
+    it('fetchNotificationsForCompanion falls back to the default companion', async () => {
+      const res = await runSuccess(fetchNotificationsForCompanion({}));
+      expect(res.payload.companionId).toBe('default-companion');
     });
 
-    it('markNotificationAsRead resolves successfully', async () => {
-      const res = await runSuccess(markNotificationAsRead({ notificationId: '1' }));
+    it('markNotificationAsRead posts to the seen endpoint', async () => {
+      const res = await runSuccess(
+        markNotificationAsRead({notificationId: '1'}),
+      );
+      expect(mockedMarkMobileNotificationSeen).toHaveBeenCalledWith('1');
       expect(res.payload.notificationId).toBe('1');
     });
 
-    it('markAllNotificationsAsRead resolves successfully', async () => {
-      const res = await runSuccess(markAllNotificationsAsRead({ companionId: 'c1' }));
-      expect(res.payload.companionId).toBe('c1');
-    });
-
-    it('deleteNotification resolves successfully', async () => {
-      const res = await runSuccess(deleteNotification({ notificationId: '1' }));
+    it('archiveNotification posts to the archive endpoint', async () => {
+      const res = await runSuccess(archiveNotification({notificationId: '1'}));
+      expect(mockedArchiveMobileNotification).toHaveBeenCalledWith('1');
       expect(res.payload.notificationId).toBe('1');
-    });
-
-    it('archiveNotification resolves successfully', async () => {
-      const res = await runSuccess(archiveNotification({ notificationId: '1' }));
-      expect(res.payload.notificationId).toBe('1');
-    });
-
-    it('clearAllNotifications resolves successfully', async () => {
-      await runSuccess(clearAllNotifications());
     });
   });
 
-  // --------------------------------------------------------------------------
-  // BRANCH COVERAGE: error instanceof Error ? TRUE : ...
-  // --------------------------------------------------------------------------
-  describe('2. Error Path: Standard Error Object', () => {
+  describe('2. Error path - Error object', () => {
     beforeEach(() => {
-      // Mock setTimeout to throw a real Error object
-      jest.spyOn(globalThis, 'setTimeout').mockImplementation(() => {
-        throw new Error('Network Error');
-      });
-      mockedFetchMobileNotifications.mockRejectedValue(new Error('Network Error'));
-      mockedMarkMobileNotificationSeen.mockRejectedValue(new Error('Network Error'));
+      mockedFetchMobileNotifications.mockRejectedValue(
+        new Error('Network Error'),
+      );
+      mockedMarkMobileNotificationSeen.mockRejectedValue(
+        new Error('Network Error'),
+      );
+      mockedArchiveMobileNotification.mockRejectedValue(
+        new Error('Network Error'),
+      );
     });
 
-    it('fetchNotificationsForCompanion catches Error object', async () => {
-      await runFailure(fetchNotificationsForCompanion({ companionId: 'c1' }), 'Network Error');
+    it('fetchNotificationsForCompanion surfaces the message', async () => {
+      await runFailure(
+        fetchNotificationsForCompanion({companionId: 'c1'}),
+        'Network Error',
+      );
     });
 
-    it('createNotification catches Error object', async () => {
-      await runFailure(createNotification({} as any), 'Network Error');
+    it('markNotificationAsRead surfaces the message', async () => {
+      await runFailure(
+        markNotificationAsRead({notificationId: '1'}),
+        'Network Error',
+      );
     });
 
-    it('markNotificationAsRead catches Error object', async () => {
-      await runFailure(markNotificationAsRead({ notificationId: '1' }), 'Network Error');
-    });
-
-    it('markAllNotificationsAsRead catches Error object', async () => {
-      await runFailure(markAllNotificationsAsRead({ companionId: 'c1' }), 'Network Error');
-    });
-
-    it('deleteNotification catches Error object', async () => {
-      await runFailure(deleteNotification({ notificationId: '1' }), 'Network Error');
-    });
-
-    it('archiveNotification catches Error object', async () => {
-      await runFailure(archiveNotification({ notificationId: '1' }), 'Network Error');
-    });
-
-    it('clearAllNotifications catches Error object', async () => {
-      await runFailure(clearAllNotifications(), 'Network Error');
+    it('archiveNotification surfaces the message, so a failed archive is not shown as done', async () => {
+      await runFailure(
+        archiveNotification({notificationId: '1'}),
+        'Network Error',
+      );
+      expect(store.getState().notifications.error).toBe('Network Error');
     });
   });
 
-  // --------------------------------------------------------------------------
-  // BRANCH COVERAGE: error instanceof Error ? ... : FALSE (Default String)
-  // --------------------------------------------------------------------------
-  describe('3. Error Path: Non-Error Object (Fallback Messages)', () => {
+  describe('3. Error path - non-Error value falls back to a fixed message', () => {
     beforeEach(() => {
-      // Mock setTimeout to throw a string (not an Error instance)
-      // This forces the 'else' branch in the catch block
-      jest.spyOn(globalThis, 'setTimeout').mockImplementation(() => {
-        throw 'Something weird happened';
-      });
-      mockedFetchMobileNotifications.mockRejectedValue('Something weird happened' as any);
-      mockedMarkMobileNotificationSeen.mockRejectedValue('Something weird happened' as any);
+      mockedFetchMobileNotifications.mockRejectedValue(
+        'Something weird happened' as any,
+      );
+      mockedMarkMobileNotificationSeen.mockRejectedValue(
+        'Something weird happened' as any,
+      );
+      mockedArchiveMobileNotification.mockRejectedValue(
+        'Something weird happened' as any,
+      );
     });
 
     it('fetchNotificationsForCompanion uses fallback message', async () => {
       await runFailure(
-        fetchNotificationsForCompanion({ companionId: 'c1' }),
-        'Failed to fetch notifications'
-      );
-    });
-
-    it('createNotification uses fallback message', async () => {
-      await runFailure(
-        createNotification({} as any),
-        'Failed to create notification'
+        fetchNotificationsForCompanion({companionId: 'c1'}),
+        'Failed to fetch notifications',
       );
     });
 
     it('markNotificationAsRead uses fallback message', async () => {
       await runFailure(
-        markNotificationAsRead({ notificationId: '1' }),
-        'Failed to mark notification as read'
-      );
-    });
-
-    it('markAllNotificationsAsRead uses fallback message', async () => {
-      await runFailure(
-        markAllNotificationsAsRead({ companionId: 'c1' }),
-        'Failed to mark notifications as read'
-      );
-    });
-
-    it('deleteNotification uses fallback message', async () => {
-      await runFailure(
-        deleteNotification({ notificationId: '1' }),
-        'Failed to delete notification'
+        markNotificationAsRead({notificationId: '1'}),
+        'Failed to mark notification as read',
       );
     });
 
     it('archiveNotification uses fallback message', async () => {
       await runFailure(
-        archiveNotification({ notificationId: '1' }),
-        'Failed to archive notification'
-      );
-    });
-
-    it('clearAllNotifications uses fallback message', async () => {
-      await runFailure(
-        clearAllNotifications(),
-        'Failed to clear notifications'
+        archiveNotification({notificationId: '1'}),
+        'Failed to archive notification',
       );
     });
   });

--- a/apps/mobileAppYC/__tests__/services/firebaseNotifications.test.ts
+++ b/apps/mobileAppYC/__tests__/services/firebaseNotifications.test.ts
@@ -9,7 +9,6 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 // 2. Mock Redux Actions
 jest.mock('@/features/notifications', () => ({
-  createNotification: jest.fn(payload => ({type: 'MOCK_CREATE', payload})),
   addNotificationToList: jest.fn(payload => ({type: 'MOCK_ADD_LIST', payload})),
 }));
 
@@ -370,7 +369,7 @@ describe('firebaseNotifications Service', () => {
       data: {category: 'tasks', priority: 'high'},
     };
 
-    it('dispatches CREATE_NOTIFICATION and displays via Notifee', async () => {
+    it('seats the notification in the list and displays via Notifee', async () => {
       const {initializeNotifications} = loadService();
 
       await initializeNotifications({
@@ -397,7 +396,7 @@ describe('firebaseNotifications Service', () => {
       );
     });
 
-    it('falls back to addNotificationToList on dispatch error', async () => {
+    it('keys the seated item by the id the backend sent, so it can be archived', async () => {
       const {initializeNotifications} = loadService();
       await initializeNotifications({
         dispatch: mockDispatch,
@@ -406,12 +405,31 @@ describe('firebaseNotifications Service', () => {
 
       const registeredCallback = mockMessaging.onMessage.mock.calls[0][1];
 
-      // Make dispatch fail
-      mockDispatch.mockRejectedValueOnce(new Error('Fail'));
+      await registeredCallback({
+        ...mockRemoteMessage,
+        data: {...mockRemoteMessage.data, notificationId: 'row-42'},
+      });
+
+      const [[payload]] = require('@/features/notifications')
+        .addNotificationToList.mock.calls;
+      expect(payload.id).toBe('row-42');
+      expect(payload.status).toBe('unread');
+    });
+
+    it('falls back to a local id when the push carries none', async () => {
+      const {initializeNotifications} = loadService();
+      await initializeNotifications({
+        dispatch: mockDispatch,
+        onNavigate: mockNavigate,
+      });
+
+      const registeredCallback = mockMessaging.onMessage.mock.calls[0][1];
 
       await registeredCallback(mockRemoteMessage);
 
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      const [[payload]] = require('@/features/notifications')
+        .addNotificationToList.mock.calls;
+      expect(payload.id).toMatch(/^notif_\d+$/);
     });
 
     it('handles background messages via exported handler', async () => {
@@ -440,8 +458,8 @@ describe('firebaseNotifications Service', () => {
         },
       });
 
-      const [[payload]] = require('@/features/notifications').createNotification
-        .mock.calls;
+      const [[payload]] = require('@/features/notifications')
+        .addNotificationToList.mock.calls;
       expect(payload.relatedType).toBe('appointment');
       expect(payload.metadata.navigationId).toBe('nav-1');
       expect(payload.metadata.trackingId).toBe('track-1');
@@ -461,8 +479,8 @@ describe('firebaseNotifications Service', () => {
         data: {relatedType: 'not-a-real-type'},
       });
 
-      const [[payload]] = require('@/features/notifications').createNotification
-        .mock.calls;
+      const [[payload]] = require('@/features/notifications')
+        .addNotificationToList.mock.calls;
       expect(payload.relatedType).toBeUndefined();
     });
 

--- a/apps/mobileAppYC/src/features/notifications/index.ts
+++ b/apps/mobileAppYC/src/features/notifications/index.ts
@@ -15,12 +15,8 @@ export {
 // Export thunks
 export {
   fetchNotificationsForCompanion,
-  createNotification,
   markNotificationAsRead,
-  markAllNotificationsAsRead,
-  deleteNotification,
   archiveNotification,
-  clearAllNotifications,
 } from './thunks';
 
 // Export selectors

--- a/apps/mobileAppYC/src/features/notifications/notificationSlice.ts
+++ b/apps/mobileAppYC/src/features/notifications/notificationSlice.ts
@@ -6,12 +6,8 @@ import type {
 } from './types';
 import {
   fetchNotificationsForCompanion,
-  createNotification,
   markNotificationAsRead,
-  markAllNotificationsAsRead,
-  deleteNotification,
   archiveNotification,
-  clearAllNotifications,
 } from './thunks';
 
 import {
@@ -103,24 +99,6 @@ export const notificationSlice = createSlice({
         );
       })
 
-      // Create notification
-      .addCase(createNotification.pending, state => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(createNotification.fulfilled, (state, action) => {
-        state.loading = false;
-        state.items.unshift(action.payload);
-        if (action.payload.status === 'unread') {
-          state.unreadCount += 1;
-        }
-        state.error = null;
-      })
-      .addCase(createNotification.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.payload ?? 'Failed to create notification';
-      })
-
       // Mark as read
       .addCase(markNotificationAsRead.pending, state => {
         state.error = null;
@@ -136,42 +114,6 @@ export const notificationSlice = createSlice({
       })
       .addCase(markNotificationAsRead.rejected, (state, action) => {
         state.error = action.payload ?? 'Failed to mark notification as read';
-      })
-
-      // Mark all as read
-      .addCase(markAllNotificationsAsRead.pending, state => {
-        state.error = null;
-      })
-      .addCase(markAllNotificationsAsRead.fulfilled, state => {
-        for (const notification of state.items) {
-          if (notification.status === 'unread') {
-            notification.status = 'read';
-          }
-        }
-        state.unreadCount = 0;
-      })
-      .addCase(markAllNotificationsAsRead.rejected, (state, action) => {
-        state.error = action.payload ?? 'Failed to mark notifications as read';
-      })
-
-      // Delete notification
-      .addCase(deleteNotification.pending, state => {
-        state.error = null;
-      })
-      .addCase(deleteNotification.fulfilled, (state, action) => {
-        const index = state.items.findIndex(
-          n => n.id === action.payload.notificationId,
-        );
-        if (index !== -1) {
-          const notification = state.items[index];
-          if (notification.status === 'unread') {
-            state.unreadCount = Math.max(0, state.unreadCount - 1);
-          }
-          state.items.splice(index, 1);
-        }
-      })
-      .addCase(deleteNotification.rejected, (state, action) => {
-        state.error = action.payload ?? 'Failed to delete notification';
       })
 
       // Archive notification
@@ -191,18 +133,6 @@ export const notificationSlice = createSlice({
       })
       .addCase(archiveNotification.rejected, (state, action) => {
         state.error = action.payload ?? 'Failed to archive notification';
-      })
-
-      // Clear all notifications
-      .addCase(clearAllNotifications.pending, state => {
-        state.error = null;
-      })
-      .addCase(clearAllNotifications.fulfilled, state => {
-        state.items = state.items.filter(n => n.status === 'archived');
-        state.unreadCount = 0;
-      })
-      .addCase(clearAllNotifications.rejected, (state, action) => {
-        state.error = action.payload ?? 'Failed to clear notifications';
       });
   },
 });

--- a/apps/mobileAppYC/src/features/notifications/services/notificationService.ts
+++ b/apps/mobileAppYC/src/features/notifications/services/notificationService.ts
@@ -34,6 +34,7 @@ type MobileNotificationRecord = {
   relatedType?: string;
   link?: string;
   deepLink?: string;
+  archivedAt?: string | null;
   createdAt?: string;
   updatedAt?: string;
   timestamp?: string;
@@ -57,20 +58,36 @@ const ALLOWED_CATEGORIES: NotificationCategory[] = [
   'payment',
 ];
 
-const ALLOWED_PRIORITIES: NotificationPriority[] = ['low', 'medium', 'high', 'urgent'];
+const ALLOWED_PRIORITIES: NotificationPriority[] = [
+  'low',
+  'medium',
+  'high',
+  'urgent',
+];
 
-const normalizeCategorySynonym = (raw?: string): NotificationCategory | null => {
+const normalizeCategorySynonym = (
+  raw?: string,
+): NotificationCategory | null => {
   if (!raw) {
     return null;
   }
 
   const value = raw.toLowerCase();
 
-  if (value === 'appointment' || value === 'appointments' || value === 'appts') {
+  if (
+    value === 'appointment' ||
+    value === 'appointments' ||
+    value === 'appts'
+  ) {
     return 'appointments';
   }
 
-  if (value === 'payment' || value === 'payments' || value === 'invoice' || value === 'billing') {
+  if (
+    value === 'payment' ||
+    value === 'payments' ||
+    value === 'invoice' ||
+    value === 'billing'
+  ) {
     return 'payment';
   }
 
@@ -115,9 +132,7 @@ const normalizePriority = (raw?: string): NotificationPriority => {
   return match ?? 'medium';
 };
 
-const normalizeRelatedType = (
-  raw?: string,
-): Notification['relatedType'] => {
+const normalizeRelatedType = (raw?: string): Notification['relatedType'] => {
   if (!raw) {
     return undefined;
   }
@@ -140,7 +155,16 @@ const normalizeRelatedType = (
   return undefined;
 };
 
-const deriveStatus = (record: MobileNotificationRecord): Notification['status'] => {
+const deriveStatus = (
+  record: MobileNotificationRecord,
+): Notification['status'] => {
+  // Checked before the status string: archived is what the API records as a
+  // timestamp, and an archived notification is also seen, so reading isSeen
+  // first would bring an archived row back into the visible list on reload.
+  if (record.archivedAt) {
+    return 'archived';
+  }
+
   const normalized = (record.status ?? record.state ?? '').toLowerCase();
   if (normalized === 'read' || normalized === 'seen') {
     return 'read';
@@ -226,7 +250,9 @@ const normalizeNotification = (
   };
 };
 
-const extractNotificationList = (payload: unknown): MobileNotificationRecord[] => {
+const extractNotificationList = (
+  payload: unknown,
+): MobileNotificationRecord[] => {
   if (!payload) {
     return [];
   }
@@ -273,6 +299,21 @@ export const markMobileNotificationSeen = async (
   const headers = await buildAuthHeaders();
   await apiClient.post(
     `${NOTIFICATIONS_ENDPOINT}/${notificationId}/seen`,
+    undefined,
+    headers ? {headers} : undefined,
+  );
+};
+
+export const archiveMobileNotification = async (
+  notificationId: string,
+): Promise<void> => {
+  if (!notificationId) {
+    return;
+  }
+
+  const headers = await buildAuthHeaders();
+  await apiClient.post(
+    `${NOTIFICATIONS_ENDPOINT}/${notificationId}/archive`,
     undefined,
     headers ? {headers} : undefined,
   );

--- a/apps/mobileAppYC/src/features/notifications/thunks.ts
+++ b/apps/mobileAppYC/src/features/notifications/thunks.ts
@@ -1,12 +1,10 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
-import type {Notification, CreateNotificationPayload} from './types';
+import type {Notification} from './types';
 import {
+  archiveMobileNotification,
   fetchMobileNotifications,
   markMobileNotificationSeen,
 } from '@/features/notifications/services/notificationService';
-
-// Simulate network delay
-const mockDelay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * Fetch notifications for a companion
@@ -27,49 +25,9 @@ export const fetchNotificationsForCompanion = createAsyncThunk<
       };
     } catch (error) {
       return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to fetch notifications',
-      );
-    }
-  },
-);
-
-/**
- * Create a new notification
- */
-export const createNotification = createAsyncThunk<
-  Notification,
-  CreateNotificationPayload,
-  {rejectValue: string}
->(
-  'notifications/create',
-  async (payload, {rejectWithValue}) => {
-    try {
-      await mockDelay(300);
-      // NOTE: Replace with actual API call when backend is ready
-      // const response = await notificationService.create(payload);
-      // return response;
-
-      const notification: Notification = {
-        id: `notif_${Date.now()}`,
-        companionId: payload.companionId,
-        title: payload.title,
-        description: payload.description,
-        category: payload.category,
-        icon: payload.icon,
-        avatarUrl: payload.avatarUrl,
-        timestamp: new Date().toISOString(),
-        status: 'unread',
-        priority: payload.priority || 'medium',
-        deepLink: payload.deepLink,
-        relatedId: payload.relatedId,
-        relatedType: payload.relatedType,
-        metadata: payload.metadata,
-      };
-
-      return notification;
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to create notification',
+        error instanceof Error
+          ? error.message
+          : 'Failed to fetch notifications',
       );
     }
   },
@@ -82,65 +40,18 @@ export const markNotificationAsRead = createAsyncThunk<
   {notificationId: string},
   {notificationId: string},
   {rejectValue: string}
->(
-  'notifications/markAsRead',
-  async ({notificationId}, {rejectWithValue}) => {
-    try {
-      await markMobileNotificationSeen(notificationId);
-      return {notificationId};
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to mark notification as read',
-      );
-    }
-  },
-);
-
-/**
- * Mark all notifications as read for a companion
- */
-export const markAllNotificationsAsRead = createAsyncThunk<
-  {companionId: string},
-  {companionId: string},
-  {rejectValue: string}
->(
-  'notifications/markAllAsRead',
-  async ({companionId}, {rejectWithValue}) => {
-    try {
-      await mockDelay(300);
-      // NOTE: Replace with actual API call when backend is ready
-      // await notificationService.markAllAsRead(companionId);
-      return {companionId};
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to mark notifications as read',
-      );
-    }
-  },
-);
-
-/**
- * Delete a notification
- */
-export const deleteNotification = createAsyncThunk<
-  {notificationId: string},
-  {notificationId: string},
-  {rejectValue: string}
->(
-  'notifications/delete',
-  async ({notificationId}, {rejectWithValue}) => {
-    try {
-      await mockDelay(200);
-      // NOTE: Replace with actual API call when backend is ready
-      // await notificationService.delete(notificationId);
-      return {notificationId};
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to delete notification',
-      );
-    }
-  },
-);
+>('notifications/markAsRead', async ({notificationId}, {rejectWithValue}) => {
+  try {
+    await markMobileNotificationSeen(notificationId);
+    return {notificationId};
+  } catch (error) {
+    return rejectWithValue(
+      error instanceof Error
+        ? error.message
+        : 'Failed to mark notification as read',
+    );
+  }
+});
 
 /**
  * Archive a notification
@@ -149,40 +60,13 @@ export const archiveNotification = createAsyncThunk<
   {notificationId: string},
   {notificationId: string},
   {rejectValue: string}
->(
-  'notifications/archive',
-  async ({notificationId}, {rejectWithValue}) => {
-    try {
-      await mockDelay(200);
-      // NOTE: Replace with actual API call when backend is ready
-      // await notificationService.archive(notificationId);
-      return {notificationId};
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to archive notification',
-      );
-    }
-  },
-);
-
-/**
- * Clear all notifications
- */
-export const clearAllNotifications = createAsyncThunk<
-  void,
-  void,
-  {rejectValue: string}
->(
-  'notifications/clearAll',
-  async (_, {rejectWithValue}) => {
-    try {
-      await mockDelay(400);
-      // NOTE: Replace with actual API call when backend is ready
-      // await notificationService.clearAll();
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to clear notifications',
-      );
-    }
-  },
-);
+>('notifications/archive', async ({notificationId}, {rejectWithValue}) => {
+  try {
+    await archiveMobileNotification(notificationId);
+    return {notificationId};
+  } catch (error) {
+    return rejectWithValue(
+      error instanceof Error ? error.message : 'Failed to archive notification',
+    );
+  }
+});

--- a/apps/mobileAppYC/src/shared/services/firebaseNotifications.ts
+++ b/apps/mobileAppYC/src/shared/services/firebaseNotifications.ts
@@ -21,10 +21,7 @@ import notifee, {
   type Event,
 } from '@notifee/react-native';
 import type {AppDispatch} from '@/app/store';
-import {
-  createNotification,
-  addNotificationToList,
-} from '@/features/notifications';
+import {addNotificationToList} from '@/features/notifications';
 import type {
   CreateNotificationPayload,
   NotificationCategory,
@@ -240,34 +237,33 @@ async function handleRemoteMessage(
   const data = normalizeDataRecord(remoteMessage.data);
 
   if (notificationPayload && cachedDispatch) {
-    try {
-      await (cachedDispatch(
-        createNotification(notificationPayload) as any,
-      ) as Promise<unknown>);
-    } catch (error) {
-      console.error(
-        '[firebaseNotifications] Failed to create notification',
-        error,
-      );
-      cachedDispatch(
-        addNotificationToList({
-          id: data.notificationId || `notif_${Date.now()}`,
-          companionId: notificationPayload.companionId,
-          title: notificationPayload.title,
-          description: notificationPayload.description,
-          category: notificationPayload.category,
-          icon: notificationPayload.icon,
-          avatarUrl: notificationPayload.avatarUrl,
-          timestamp: new Date().toISOString(),
-          status: 'unread',
-          priority: notificationPayload.priority ?? 'medium',
-          deepLink: notificationPayload.deepLink,
-          relatedId: notificationPayload.relatedId,
-          relatedType: notificationPayload.relatedType,
-          metadata: notificationPayload.metadata,
-        }),
-      );
-    }
+    // Seat the push in the list directly. This used to go through a
+    // `createNotification` thunk that awaited a mock delay and then built this
+    // same object, with this dispatch as its catch-block fallback - two copies
+    // of one mapping, and no API call in either, because the backend already
+    // wrote the row before it sent the push.
+    //
+    // `data.notificationId` is that row's id and comes from the same send. The
+    // local fallback keeps a malformed push visible, but nothing keyed by id
+    // will reach the server for it until the next fetch replaces the item.
+    cachedDispatch(
+      addNotificationToList({
+        id: data.notificationId || `notif_${Date.now()}`,
+        companionId: notificationPayload.companionId,
+        title: notificationPayload.title,
+        description: notificationPayload.description,
+        category: notificationPayload.category,
+        icon: notificationPayload.icon,
+        avatarUrl: notificationPayload.avatarUrl,
+        timestamp: new Date().toISOString(),
+        status: 'unread',
+        priority: notificationPayload.priority ?? 'medium',
+        deepLink: notificationPayload.deepLink,
+        relatedId: notificationPayload.relatedId,
+        relatedType: notificationPayload.relatedType,
+        metadata: notificationPayload.metadata,
+      }),
+    );
   }
 
   const hasNativeNotificationPayload = Boolean(remoteMessage.notification);

--- a/packages/database/prisma/migrations/20260905120000_notification_archived_at/migration.sql
+++ b/packages/database/prisma/migrations/20260905120000_notification_archived_at/migration.sql
@@ -1,0 +1,7 @@
+-- Record when a notification was archived by its owner.
+--
+-- Purely additive: a nullable column with no default and no constraint, so the
+-- running process serves fine against this schema before the new code cuts over
+-- (see #2603). Every existing row reads as not archived without a backfill.
+ALTER TABLE "Notification"
+  ADD COLUMN IF NOT EXISTS "archivedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3703,15 +3703,21 @@ model DeviceToken {
 }
 
 model Notification {
-  id        String           @id @default(uuid())
-  userId    String
-  title     String
-  body      String
-  type      NotificationType
-  enabled   Boolean          @default(true)
-  isSeen    Boolean          @default(false)
-  createdAt DateTime         @default(now())
-  updatedAt DateTime         @updatedAt
+  id         String           @id @default(uuid())
+  userId     String
+  title      String
+  body       String
+  type       NotificationType
+  enabled    Boolean          @default(true)
+  isSeen     Boolean          @default(false)
+  /// Set when the owner archives the notification from the mobile list. Nullable
+  /// rather than a boolean so the row records *when* it left the list, and so
+  /// every notification that predates archiving reads as not archived without a
+  /// backfill. Archiving never deletes: the row stays for audit, and the client
+  /// filters it out of the visible list.
+  archivedAt DateTime?
+  createdAt  DateTime         @default(now())
+  updatedAt  DateTime         @updatedAt
 
   @@index([userId])
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Swiping a notification past 25% of the screen width in the mobile app archives it: the row animates off-screen, it disappears from the list, and the unread badge drops by one. Nothing persists. On the next load the notification is back, unread.

`archiveNotification` in `features/notifications/thunks.ts` awaited a 200 ms mock delay and returned, above a commented-out call to a `notificationService` the issue said had never been written.

Three further defects surfaced while tracing that path:

1. `NotificationService.markNotificationAsSeen` ran `updateMany({where: {id: notificationId}})` on an id supplied by the client, with no owner in the `where` and no user id passed by the controller. Any authenticated mobile user could mark another user's notification seen by id.
2. `sendToUser` created a `Notification` row **inside** the per-device-token loop, so a user with a phone and a tablet got two rows for one notification, both shown in the list.
3. The row's id never reached the device, so the app minted `notif_${Date.now()}` for push-delivered notifications. Any per-notification write against one of those items targets an id the server does not have.

Note for reviewers: part of #2625 is already fixed on `dev` and the issue does not say so. `markNotificationAsRead` calls the seen endpoint, and `fetchNotificationsForCompanion` calls a real `notificationService.ts`. That is #2657 in the wild.

## What is the new behavior?

**Archive persists.**

- `Notification` gains a nullable `archivedAt`. The migration is `ADD COLUMN IF NOT EXISTS`, purely additive, so the pre-cutover window described in #2603 does not apply to it.
- New route `POST /v1/notification/mobile/:notificationId/archive` behind `requireMobileAuth`. It stamps `archivedAt` only when the row is currently un-archived, so a second swipe keeps the first archive time rather than rewriting it. Already-archived is a 200, not a 404 - the notification is where the owner put it.
- `archiveMobileNotification` in the mobile service, wired into the thunk. `deriveStatus` reads `archivedAt` before `isSeen`, because an archived row is also seen and checking `isSeen` first would bring it back into the visible list on reload.

**Writes are scoped to their owner.**

- `markNotificationAsSeen` and the new `archiveNotificationForUser` both put `userId` in the `where` and return what actually changed, so an id belonging to someone else matches nothing and is reported as a 404 rather than as success. The owner id is resolved once, in a shared helper, from the same `parentId` the list endpoint already reads.

**Notifications have one row and a stable identity.**

- `sendToUser` writes the row once, before the token fan-out, and puts its id into the push `data`. The app seats the push using that id, so mark-read and archive on a just-arrived notification reach the row behind it. A failed write still delivers the push.

**Dead mock thunks removed.**

- `markAllNotificationsAsRead`, `deleteNotification` and `clearAllNotifications` had no endpoint and no dispatch site anywhere in `apps/mobileAppYC/src`. Clear All was removed from the UI by design. This is the "remove the affordances" branch of the decision the issue asks for, taken because there are no affordances left to keep.
- `createNotification` was a mock delay followed by an object built from the push payload, with a `dispatch(addNotificationToList(...))` fallback in its own catch block that built the same object. Replaced by that dispatch, so there is one mapping instead of two and no thunk pretending to be an API call.

### Behaviour change a user can notice

`POST /v1/notification/mobile/:notificationId/seen` used to return 200 unconditionally. It now returns 404 when the scoped update matches no row (`count === 0`), which is what makes the cross-tenant fix observable rather than silent. The mobile `markNotificationAsRead` thunk `rejectWithValue`s on that response, so an id the server does not recognise for the caller changes from a silent no-op into a visible failure in the app.

This is the intended direction - reporting success for an update that changed nothing is the defect this PR is about - but it is the one change here that a user could notice, so it is called out rather than left to be rediscovered.

### Verification

Run on `a6be055`:

- `npx jest` in `apps/backend` - 466 suites, 11206 tests, all pass.
- `npx jest` in `apps/mobileAppYC` - 500 suites, 8547 tests, all pass.
- `pnpm --filter backend run type-check`, `pnpm --filter mobileAppYC run type-check` - both exit 0.
- `pnpm --filter backend run lint`, `pnpm --filter mobileAppYC run lint` - both exit 0. The 25 backend warnings are pre-existing and none are in the files touched here.
- Coverage on the touched files: `notification.controller.ts` 100% stmts/branch, `notification.service.ts` 98% stmts / 92.85% branch (the uncovered lines are the pre-existing Firebase credential bootstrap), mobile `thunks.ts` and `notificationSlice.ts` 100%, `notificationService.ts` 98.26%, `firebaseNotifications.ts` 99.49%.

Aikido was not run locally - no CLI or MCP on this machine - so it is unverified until it runs on this PR.

Not verified end to end against deployed dev: the archive path needs a signed-in mobile build and a live push, which I cannot exercise from here. The endpoint, the owner scoping and the client wiring are covered by the tests above.

## Related Issue(s)

Refs #2625

Follow-up, not in this PR: the duplicate-row and missing-push-id defects are fixed here, but nothing backfills the duplicate `Notification` rows already written in production by the old per-token loop.

