### PR TITLE
fix(backend): replace deprecated Documenso document create

### DIFF
--- a/apps/backend/src/services/documenso.service.ts
+++ b/apps/backend/src/services/documenso.service.ts
@@ -84,21 +84,6 @@ const getDocumensoClient = (apiKeyOverride?: string) => {
   return client;
 };
 
-async function uploadPdfBuffer(pdf: Buffer, uploadUrl: string) {
-  const response = await fetch(uploadUrl, {
-    method: "PUT",
-    body: new Uint8Array(pdf),
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Length": pdf.length.toString(),
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Upload failed: ${response.status}`);
-  }
-}
-
 export type SignedDocument = {
   downloadUrl?: string;
   filename?: string;
@@ -129,7 +114,7 @@ export class DocumensoService {
       logger.info("Creating document with signature placement", {
         placement,
       });
-      const request = {
+      const payload = {
         title: title ?? "Form Submission",
         recipients: [
           {
@@ -149,19 +134,15 @@ export class DocumensoService {
           },
         ],
       };
-      // createV0 is deprecated, but its replacement documents.create() returns
-      // only { envelopeId, id } - no uploadUrl and no recipients. The callers
-      // below read document.recipients[0].token to build the signing URL, so
-      // migrating needs a second documents.get() round-trip and a rewrite of the
-      // upload path. That is a behavioural change on the e-signature flow, so it
-      // is tracked in #2643 and tested there against a live Documenso.
-      const created = await documenso.documents.createV0(request); // NOSONAR
+      const created = await documenso.documents.create({
+        payload,
+        file: {
+          fileName: "document.pdf",
+          content: new Uint8Array(pdf),
+        },
+      });
 
-      const { document, uploadUrl } = created;
-
-      await uploadPdfBuffer(pdf, uploadUrl);
-
-      return document;
+      return await documenso.documents.get({ documentId: created.id });
     } catch (error) {
       if (error instanceof errors.DocumensoError) {
         logger.error("API error:", error.message);

--- a/apps/backend/test/services/documenso.service.test.ts
+++ b/apps/backend/test/services/documenso.service.test.ts
@@ -320,6 +320,27 @@ describe("DocumensoService", () => {
         expect(logger.error).toHaveBeenCalledWith("Status code:", 400);
         expect(logger.error).toHaveBeenCalledWith("Body:", "Bad Request");
       });
+
+      it("handles a failed lookup after the document is created", async () => {
+        mockCreate.mockResolvedValueOnce({ id: 5, envelopeId: "env_5" });
+        mockGet.mockRejectedValueOnce(
+          new (DocumensoError as any)("Lookup failed", 503, "Unavailable"),
+        );
+
+        const result = await DocumensoService.createDocument({
+          pdf: Buffer.from("test"),
+          signerEmail: "test@test.com",
+        });
+
+        expect(result).toBeUndefined();
+        expect(mockGet).toHaveBeenCalledWith({ documentId: 5 });
+        expect(logger.error).toHaveBeenCalledWith(
+          "API error:",
+          "Lookup failed",
+        );
+        expect(logger.error).toHaveBeenCalledWith("Status code:", 503);
+        expect(logger.error).toHaveBeenCalledWith("Body:", "Unavailable");
+      });
     });
 
     describe("distributeDocument", () => {

--- a/apps/backend/test/services/documenso.service.test.ts
+++ b/apps/backend/test/services/documenso.service.test.ts
@@ -25,7 +25,7 @@ jest.mock("../../src/utils/logger", () => ({
   },
 }));
 
-const mockCreateV0 = jest.fn();
+const mockCreate = jest.fn();
 const mockDistribute = jest.fn();
 const mockGet = jest.fn();
 
@@ -33,7 +33,7 @@ jest.mock("@documenso/sdk-typescript", () => {
   return {
     Documenso: jest.fn().mockImplementation(() => ({
       documents: {
-        createV0: mockCreateV0,
+        create: mockCreate,
         distribute: mockDistribute,
         get: mockGet,
       },
@@ -54,9 +54,6 @@ jest.mock("@documenso/sdk-typescript/models/errors/index.js", () => {
   return { DocumensoError: MockDocumensoError, __esModule: true };
 });
 
-// Set up global fetch mock
-globalThis.fetch = jest.fn();
-
 // --- HELPER TO TEST LOAD-TIME ENV VARIABLES ---
 function getModule(envOverrides: Record<string, string>) {
   let mod: any;
@@ -74,7 +71,6 @@ function getModule(envOverrides: Record<string, string>) {
 describe("DocumensoService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true });
   });
 
   describe("Configuration & Environment Variable Errors", () => {
@@ -183,34 +179,36 @@ describe("DocumensoService", () => {
 
     describe("createDocument", () => {
       it("creates a document successfully and falls back to signerEmail for name", async () => {
-        mockCreateV0.mockResolvedValueOnce({
-          document: { id: "doc_1" },
-          uploadUrl: "http://upload",
+        mockCreate.mockResolvedValueOnce({ id: 1, envelopeId: "env_1" });
+        mockGet.mockResolvedValueOnce({
+          id: 1,
+          recipients: [{ id: 11, token: "synthetic-recipient-token" }],
         });
         const result = await DocumensoService.createDocument({
           pdf: Buffer.from("test"),
           signerEmail: "test@test.com",
         });
 
-        expect(result).toEqual({ id: "doc_1" });
-        expect(mockCreateV0).toHaveBeenCalledWith(
+        expect(result.recipients[0].token).toBe("synthetic-recipient-token");
+        expect(mockCreate).toHaveBeenCalledWith(
           expect.objectContaining({
-            recipients: expect.arrayContaining([
-              expect.objectContaining({ name: "test@test.com" }),
-            ]),
+            payload: expect.objectContaining({
+              recipients: expect.arrayContaining([
+                expect.objectContaining({ name: "test@test.com" }),
+              ]),
+            }),
+            file: {
+              fileName: "document.pdf",
+              content: expect.any(Uint8Array),
+            },
           }),
         );
-        expect(globalThis.fetch).toHaveBeenCalledWith(
-          "http://upload",
-          expect.any(Object),
-        );
+        expect(mockGet).toHaveBeenCalledWith({ documentId: 1 });
       });
 
       it("uses provided signerName and caches Documenso Client", async () => {
-        mockCreateV0.mockResolvedValue({
-          document: { id: "doc_2" },
-          uploadUrl: "http://upload",
-        });
+        mockCreate.mockResolvedValue({ id: 2, envelopeId: "env_2" });
+        mockGet.mockResolvedValue({ id: 2, recipients: [] });
 
         // 1st Call - Misses cache, sets cache
         await DocumensoService.createDocument({
@@ -228,21 +226,21 @@ describe("DocumensoService", () => {
           apiKey: "cache_key_1",
         });
 
-        expect(result).toEqual({ id: "doc_2" });
-        expect(mockCreateV0).toHaveBeenCalledWith(
+        expect(result).toEqual({ id: 2, recipients: [] });
+        expect(mockCreate).toHaveBeenCalledWith(
           expect.objectContaining({
-            recipients: expect.arrayContaining([
-              expect.objectContaining({ name: "John Doe" }),
-            ]),
+            payload: expect.objectContaining({
+              recipients: expect.arrayContaining([
+                expect.objectContaining({ name: "John Doe" }),
+              ]),
+            }),
           }),
         );
       });
 
       it("sends the signature field on-page so the signer can reach it", async () => {
-        mockCreateV0.mockResolvedValueOnce({
-          document: { id: "doc_sig" },
-          uploadUrl: "http://upload",
-        });
+        mockCreate.mockResolvedValueOnce({ id: 3, envelopeId: "env_3" });
+        mockGet.mockResolvedValueOnce({ id: 3, recipients: [] });
 
         await DocumensoService.createDocument({
           pdf: Buffer.from("test"),
@@ -256,18 +254,20 @@ describe("DocumensoService", () => {
           },
         });
 
-        const arg = mockCreateV0.mock.calls.at(-1)?.[0] as {
-          recipients: Array<{
-            fields: Array<{
-              type: string;
-              pageX: number;
-              pageY: number;
-              width: number;
-              height: number;
+        const arg = mockCreate.mock.calls.at(-1)?.[0] as {
+          payload: {
+            recipients: Array<{
+              fields: Array<{
+                type: string;
+                pageX: number;
+                pageY: number;
+                width: number;
+                height: number;
+              }>;
             }>;
-          }>;
+          };
         };
-        const field = arg.recipients[0].fields[0];
+        const field = arg.payload.recipients[0].fields[0];
         expect(field.type).toBe("SIGNATURE");
         // Documenso uses 0–100 page percentages. PDF points (>100) placed the
         // field off-page where the signer could not reach it — the historical
@@ -286,49 +286,29 @@ describe("DocumensoService", () => {
       });
 
       it("falls back to an on-page default placement when none is provided", async () => {
-        mockCreateV0.mockResolvedValueOnce({
-          document: { id: "doc_def" },
-          uploadUrl: "http://upload",
-        });
+        mockCreate.mockResolvedValueOnce({ id: 4, envelopeId: "env_4" });
+        mockGet.mockResolvedValueOnce({ id: 4, recipients: [] });
 
         await DocumensoService.createDocument({
           pdf: Buffer.from("test"),
           signerEmail: "test@test.com",
         });
 
-        const arg = mockCreateV0.mock.calls.at(-1)?.[0] as {
-          recipients: Array<{
-            fields: Array<{ pageX: number; pageY: number; height: number }>;
-          }>;
+        const arg = mockCreate.mock.calls.at(-1)?.[0] as {
+          payload: {
+            recipients: Array<{
+              fields: Array<{ pageX: number; pageY: number; height: number }>;
+            }>;
+          };
         };
-        const field = arg.recipients[0].fields[0];
+        const field = arg.payload.recipients[0].fields[0];
         expect(field.pageX).toBeLessThanOrEqual(100);
         expect(field.pageY).toBeLessThanOrEqual(100);
         expect(field.pageY + field.height).toBeLessThanOrEqual(100);
       });
 
-      it("throws when uploadPdfBuffer fetch fails (!response.ok)", async () => {
-        (globalThis.fetch as jest.Mock).mockResolvedValueOnce({
-          ok: false,
-          status: 502,
-        });
-        mockCreateV0.mockResolvedValueOnce({
-          document: {},
-          uploadUrl: "http://upload",
-        });
-
-        await DocumensoService.createDocument({
-          pdf: Buffer.from(""),
-          signerEmail: "a@a.com",
-        });
-        expect(logger.error).toHaveBeenCalledWith(
-          "An unexpected error occurred:",
-          expect.objectContaining({ message: "Upload failed: 502" }),
-        );
-      });
-
       it("handles DocumensoError", async () => {
-        mockCreateV0.mockRejectedValueOnce(
+        mockCreate.mockRejectedValueOnce(
           new (DocumensoError as any)("API Failed", 400, "Bad Request"),
         );
         await DocumensoService.createDocument({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

`DocumensoService.createDocument()` still calls the deprecated `documents.createV0()` API and uploads the PDF through a separate presigned `PUT`. The supported `documents.create()` API accepts the PDF directly, but returns only the document id and envelope id.

Issue #2637's signing-portal guidance is already present on `dev`, so this PR addresses the remaining deprecated-create work from #2643.

## What is the new behavior?

Document creation now sends the PDF and signing payload through `documents.create()`, then retrieves the created document through `documents.get()`. The returned object still includes the recipient token used by existing packet and record signing callers.

The focused service tests assert the multipart request, the recipient-bearing follow-up lookup, and the failure path when document creation succeeds but the lookup fails.

- `pnpm --filter backend exec jest --runInBand --no-watchman test/services/documenso.service.test.ts`: exit 0, 1 suite and 28 tests passed.
- Mutation check changed the lookup from `created.id` to `created.id + 1`: exit 1, 2 assertions failed; the implementation was restored before the final checks.
- `pnpm --filter backend run lint`: exit 0, 25 warnings in unchanged backend files.
- `pnpm --filter backend run type-check`: exit 0.
- `pnpm --filter backend run build`: exit 0, `Build succeeded`.
- Pre-push `pnpm run lint`: exit 0, 10 tasks succeeded.
- Pre-push `pnpm run type-check`: exit 0, 18 tasks succeeded.

The focused suite was run for this service change. A clean full backend Jest result is not claimed here.

## Related Issue(s)

Fixes #2643
