### PR TITLE
fix(ci): apply migrations after the build, and gate the ones the running code cannot survive

### DIFF
--- a/.github/workflows/_migration.yaml
+++ b/.github/workflows/_migration.yaml
@@ -117,6 +117,45 @@ jobs:
 
           echo "No existing migration was modified."
 
+      # Applying cleanly to an empty database is not the same as the code that
+      # is already deployed surviving the change.
+      #
+      # scripts/deploy/api-deploy.sh applies migrations and then boots and
+      # smoke-tests the new bundle before `pm2 restart` cuts over, so the OLD
+      # process serves traffic against the NEW schema for the length of that
+      # window - and if the smoke boot fails the script deliberately does not cut
+      # over, which leaves it there indefinitely. The rollback restores the code;
+      # nothing rolls back the schema.
+      #
+      # Additive migrations are unaffected, which is why this has not bitten yet.
+      # Raised by the Codex review on #2599, which renames three columns; that PR
+      # was safe because all three tables held zero rows, which is a fact about
+      # that PR and not about renames.
+      #
+      # This does not refuse the change - it refuses an UNDECLARED one. The
+      # declaration is the expand-contract reasoning written down next to the SQL
+      # it describes, where a reviewer sees it.
+      - name: Check destructive migrations say how the deployed code survives
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only migrations this branch ADDS. An edit to an existing one is
+          # already refused by the immutability check above, and re-classifying
+          # the whole history would fail every pull request on migrations that
+          # shipped long ago.
+          added=()
+          while IFS= read -r path; do
+            [ -n "$path" ] && added+=("$path")
+          done < <(git diff --no-renames --diff-filter=A --name-only "$BASE_SHA...HEAD" \
+                     -- packages/database/prisma/migrations \
+                   | grep -E '/migration\.sql$' || true)
+
+          node scripts/ci/classify-migration.mjs "${added[@]+"${added[@]}"}"
+
       # `migrate diff --from-migrations` replays the whole history into a
       # throwaway database, so it needs one that is not the target.
       - name: Create shadow database

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -12,8 +12,10 @@ name: Deploy API
 # the laptop, not the judgement.
 on:
   # The deploy itself stays manual (see below). The unit tests for its git-sync
-  # step do not: they are the only thing standing between a refspec edit and a
-  # deploy that stops on a ref-lock error, which is how this script first failed.
+  # and migration steps do not: they are the only thing standing between a
+  # refspec edit and a deploy that stops on a ref-lock error, which is how this
+  # script first failed, and between a diff-range edit and a schema-hazard notice
+  # that names the wrong migrations.
   pull_request:
     paths:
       - 'scripts/deploy/**'
@@ -44,8 +46,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  git-sync-tests:
-    name: git-sync unit tests
+  deploy-script-tests:
+    name: deploy script unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,6 +55,11 @@ jobs:
           persist-credentials: false
       - name: Run deploy git-sync tests
         run: ./scripts/deploy/tests/git-sync.test.sh
+      # Both suites build their own git history, so neither needs the checkout
+      # to be complete - but migrate.test.sh does need a real one, which is why
+      # it is here rather than mocked.
+      - name: Run deploy migration tests
+        run: ./scripts/deploy/tests/migrate.test.sh
 
   deploy:
     # Only ever on an explicit dispatch. The pull_request trigger above exists for
@@ -62,7 +69,7 @@ jobs:
     # The tests gate the deploy rather than running beside it. Without this the two
     # jobs start together on a dispatch, and a broken ref-sync change could reach a
     # live host while its own suite was still going red in parallel.
-    needs: git-sync-tests
+    needs: deploy-script-tests
     name: Deploy API (${{ inputs.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -35,7 +35,11 @@
  * Exits non-zero if any file has a hazard with no declaration.
  */
 import { readFileSync } from 'node:fs';
-import { basename, dirname } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveWithin } from './safe-path.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
 
 /**
  * The marker that declares a hazard survivable, and the floor its explanation
@@ -89,8 +93,16 @@ export const stripSqlComments = (sql) => {
       let depth = 1;
       i += 2;
       while (i < sql.length && depth > 0) {
-        if (sql.slice(i, i + 2) === '/*') { depth += 1; i += 2; continue; }
-        if (sql.slice(i, i + 2) === '*/') { depth -= 1; i += 2; continue; }
+        if (sql.slice(i, i + 2) === '/*') {
+          depth += 1;
+          i += 2;
+          continue;
+        }
+        if (sql.slice(i, i + 2) === '*/') {
+          depth -= 1;
+          i += 2;
+          continue;
+        }
         // Newlines inside the comment are kept so line numbers do not shift.
         if (sql[i] === '\n') out += '\n';
         i += 1;
@@ -107,7 +119,11 @@ export const stripSqlComments = (sql) => {
       // the first and reopening at the second covers exactly the same text, so
       // no `--` can surface outside a literal between them.
       while (i < sql.length) {
-        if (sql[i] === quote) { out += quote; i += 1; break; }
+        if (sql[i] === quote) {
+          out += quote;
+          i += 1;
+          break;
+        }
         out += sql[i];
         i += 1;
       }
@@ -147,7 +163,11 @@ export const splitStatements = (sql) => {
       i += 1;
       // Doubled quotes re-pair on their own; see stripSqlComments.
       while (i < sql.length) {
-        if (sql[i] === quote) { current += quote; i += 1; break; }
+        if (sql[i] === quote) {
+          current += quote;
+          i += 1;
+          break;
+        }
         current += sql[i];
         i += 1;
       }
@@ -202,7 +222,10 @@ const RULES = [
   { kind: 'drops a column', test: (u) => u.includes('DROP COLUMN') },
   { kind: 'renames a column', test: (u) => u.includes('RENAME COLUMN') },
   { kind: 'renames a table', test: (u) => u.includes('ALTER TABLE') && u.includes('RENAME TO') },
-  { kind: 'renames an enum type', test: (u) => u.includes('ALTER TYPE') && u.includes('RENAME TO') },
+  {
+    kind: 'renames an enum type',
+    test: (u) => u.includes('ALTER TYPE') && u.includes('RENAME TO'),
+  },
   { kind: 'drops an enum type', test: (u) => u.includes('DROP TYPE') },
   { kind: 'drops a view', test: (u) => u.includes('DROP VIEW') },
   { kind: 'drops a schema', test: (u) => u.includes('DROP SCHEMA') },
@@ -241,6 +264,21 @@ export const classifyMigrationSql = (sql) => {
 };
 
 /**
+ * A line comment whose first content IS the marker. Anchored on purpose.
+ *
+ * A plain substring search over the raw file was a gate bypass: the marker text
+ * inside a string literal - `INSERT ... VALUES ('deployed-code-survives: ...')`
+ * - would have been read as a declaration and cleared the hazardous statement
+ * next to it. Raised by the Aikido review on this change.
+ *
+ * Requiring the comment to START with the marker also rules out a comment that
+ * merely mentions it in passing. The cost is that a declaration written inside
+ * a block comment is not recognised; the failure message names the `--` form,
+ * and refusing an unrecognised declaration fails safe.
+ */
+const DECLARATION_LINE = new RegExp(`^\\s*--\\s*${DECLARATION_MARKER}`);
+
+/**
  * The explanation attached to the marker, or null.
  *
  * Read from the RAW file, before comments are stripped - the declaration is
@@ -249,10 +287,12 @@ export const classifyMigrationSql = (sql) => {
  */
 export const readDeclaration = (sql) => {
   const lines = sql.split('\n');
-  const start = lines.findIndex((line) => line.includes(DECLARATION_MARKER));
+  const start = lines.findIndex((line) => DECLARATION_LINE.test(line));
   if (start === -1) return null;
 
-  const first = lines[start].slice(lines[start].indexOf(DECLARATION_MARKER) + DECLARATION_MARKER.length);
+  const first = lines[start].slice(
+    lines[start].indexOf(DECLARATION_MARKER) + DECLARATION_MARKER.length
+  );
   const parts = [first.trim()];
 
   for (let i = start + 1; i < lines.length; i += 1) {
@@ -294,7 +334,21 @@ const main = (paths) => {
   let failed = 0;
 
   for (const path of paths) {
-    const review = reviewMigration({ name: migrationName(path), sql: readFileSync(path, 'utf8') });
+    // The CI step feeds this repo-relative paths straight out of
+    // `git diff --name-only`, but it is a command-line script and the argument
+    // is not otherwise constrained. resolveWithin is the same containment the
+    // other scripts here apply to paths they did not author.
+    const resolved = resolveWithin(repoRoot, path);
+    if (resolved === null) {
+      console.log(`::error::${path} resolves outside the repository.`);
+      failed += 1;
+      continue;
+    }
+
+    const review = reviewMigration({
+      name: migrationName(relative(repoRoot, resolved)),
+      sql: readFileSync(resolved, 'utf8'),
+    });
 
     if (review.hazards.length === 0) {
       console.log(`ok  ${review.name}: additive only.`);
@@ -311,13 +365,17 @@ const main = (paths) => {
     }
 
     failed += 1;
-    console.log(`::error file=${path}::${review.name} changes the schema in a way the deployed code may not survive.`);
+    console.log(
+      `::error file=${path}::${review.name} changes the schema in a way the deployed code may not survive.`
+    );
     console.log(listed);
 
     if (review.verdict === 'declaration-too-short') {
       console.log(`    The ${DECLARATION_MARKER} note is ${review.declaration.length} characters:`);
       console.log(`      "${review.declaration}"`);
-      console.log(`    It needs at least ${MIN_DECLARATION_LENGTH} - enough to say something a reviewer can disagree with.`);
+      console.log(
+        `    It needs at least ${MIN_DECLARATION_LENGTH} - enough to say something a reviewer can disagree with.`
+      );
       continue;
     }
 
@@ -332,7 +390,9 @@ const main = (paths) => {
   }
 
   if (failed > 0) {
-    console.log(`\n${failed} migration(s) change the schema under the running code with no explanation.`);
+    // Deliberately not "N migrations change the schema": a path that resolves
+    // outside the repository counts here too, and was never read.
+    console.log(`\n${failed} of ${paths.length} new migration(s) did not pass.`);
     return 1;
   }
 

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+/**
+ * Fails a pull request that adds a migration whose SQL breaks the code that is
+ * already deployed, unless the migration says in writing why it does not.
+ *
+ * The hazard is a property of how this repository deploys, not of any one
+ * migration. `scripts/deploy/api-deploy.sh` applies migrations and then boots
+ * and smoke-tests the new bundle before `pm2 restart` cuts over, so the OLD
+ * process serves traffic against the NEW schema for the length of that window -
+ * and if the smoke boot fails the script deliberately does not cut over, which
+ * leaves the old process on the new schema indefinitely. The rollback restores
+ * the code. Nothing rolls back the schema.
+ *
+ * Additive migrations are unaffected, which is why this has not bitten yet.
+ * A migration that removes or renames something a running query still names
+ * turns every request touching that table into a 500 for the length of the
+ * window, and a failed deploy makes that permanent until someone intervenes.
+ *
+ * Raised by the Codex review on #2599, which renames three columns. That PR was
+ * safe on its own terms - all three tables held zero rows - but the hazard is
+ * general and applies to the first rename on a populated table.
+ *
+ * The declaration this asks for is the expand-contract step made explicit:
+ *
+ *     -- deployed-code-survives: the replacement column shipped in
+ *     --   20260901120000_add_new_name and the reader was updated in #2610, so
+ *     --   no deployed query names the old one.
+ *
+ * That is a claim a reviewer can check, sitting in the diff next to the SQL it
+ * describes. It is not a suppression switch: the hazard is still reported, and
+ * the text is what a reviewer reads before approving.
+ *
+ *   node scripts/ci/classify-migration.mjs <migration.sql...>
+ *
+ * Exits non-zero if any file has a hazard with no declaration.
+ */
+import { readFileSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
+
+/**
+ * The marker that declares a hazard survivable, and the floor its explanation
+ * has to clear. The floor exists because "-- deployed-code-survives: ok" would
+ * satisfy a bare presence check while saying nothing, and this gate is only
+ * worth having if the sentence it forces is one a reviewer can disagree with.
+ */
+export const DECLARATION_MARKER = 'deployed-code-survives:';
+export const MIN_DECLARATION_LENGTH = 30;
+
+/**
+ * Removes SQL comments, leaving string and identifier literals intact.
+ *
+ * Both halves matter and they pull in opposite directions:
+ *
+ *   Comments MUST go. Prisma writes a warning header on exactly the migrations
+ *   this gate cares about - "You are about to drop the column `companion` on
+ *   the `AdverseEventReport` table" - and a substring match over the raw file
+ *   would fire on that prose whether or not the statement below it survives.
+ *   20260615100345_parent_patient_migration is a real example in this repo.
+ *
+ *   Literals MUST STAY. Migrations here run DDL out of a string inside a DO
+ *   block (`EXECUTE 'UPDATE "AdverseEventReport" SET ...'`, same file), so
+ *   blanking literal bodies - the obvious way to stop a `--` inside a string
+ *   being read as a comment - would hide the very statements that are most
+ *   worth catching.
+ *
+ * So this tracks quoting only well enough to know when a `--` or a `/*` is
+ * really a comment: inside '...' or "..." it is not. Postgres block comments
+ * nest, so the depth is counted rather than scanning for the first close.
+ *
+ * Dollar-quoted bodies ($$ ... $$) are deliberately NOT treated as opaque. A DO
+ * block's body is ordinary SQL, comments inside it are real comments, and its
+ * statements are real statements.
+ */
+export const stripSqlComments = (sql) => {
+  let out = '';
+  let i = 0;
+
+  while (i < sql.length) {
+    const pair = sql.slice(i, i + 2);
+
+    if (pair === '--') {
+      while (i < sql.length && sql[i] !== '\n') i += 1;
+      // The newline itself is left for the next pass, so line structure - and
+      // therefore the reported line numbers - survive.
+      continue;
+    }
+
+    if (pair === '/*') {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql.slice(i, i + 2) === '/*') { depth += 1; i += 2; continue; }
+        if (sql.slice(i, i + 2) === '*/') { depth -= 1; i += 2; continue; }
+        // Newlines inside the comment are kept so line numbers do not shift.
+        if (sql[i] === '\n') out += '\n';
+        i += 1;
+      }
+      out += ' ';
+      continue;
+    }
+
+    if (sql[i] === "'" || sql[i] === '"') {
+      const quote = sql[i];
+      out += quote;
+      i += 1;
+      // A doubled quote ('' inside a literal) needs no special case: closing at
+      // the first and reopening at the second covers exactly the same text, so
+      // no `--` can surface outside a literal between them.
+      while (i < sql.length) {
+        if (sql[i] === quote) { out += quote; i += 1; break; }
+        out += sql[i];
+        i += 1;
+      }
+      continue;
+    }
+
+    out += sql[i];
+    i += 1;
+  }
+
+  return out;
+};
+
+/**
+ * Splits comment-free SQL into statements on `;`, ignoring one inside a literal.
+ *
+ * Statement scope only matters for the three rules below that need two keywords
+ * together - ALTER TABLE + RENAME TO, ALTER TYPE + RENAME TO, and the ADD COLUMN
+ * clauses. Every other rule is a single keyword and survives any split.
+ *
+ * A dollar-quoted body ($$ ... $$) is deliberately NOT held together. Splitting
+ * inside one gives TIGHTER statements, and tighter is the safe direction here: a
+ * DO block that renames an index in one branch and alters a table in another
+ * would, held whole, satisfy `ALTER TABLE` and `RENAME TO` at once and report a
+ * table rename that is not there. Real `ALTER TABLE ... RENAME TO` is a single
+ * statement either way, so nothing is lost.
+ */
+export const splitStatements = (sql) => {
+  const statements = [];
+  let current = '';
+  let i = 0;
+
+  while (i < sql.length) {
+    if (sql[i] === "'" || sql[i] === '"') {
+      const quote = sql[i];
+      current += quote;
+      i += 1;
+      // Doubled quotes re-pair on their own; see stripSqlComments.
+      while (i < sql.length) {
+        if (sql[i] === quote) { current += quote; i += 1; break; }
+        current += sql[i];
+        i += 1;
+      }
+      continue;
+    }
+
+    if (sql[i] === ';') {
+      statements.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+
+    current += sql[i];
+    i += 1;
+  }
+
+  statements.push(current);
+  return statements.filter((s) => s.trim() !== '');
+};
+
+const normalise = (statement) => statement.replace(/\s+/g, ' ').trim().toUpperCase();
+
+/**
+ * Every clause introduced by ADD COLUMN, so a required column with no default
+ * is still found when it shares a statement with a column that has one.
+ * `ALTER TABLE "X" ADD COLUMN "a" TEXT NOT NULL, ADD COLUMN "b" INT DEFAULT 0`
+ * is one statement, and asking whether DEFAULT appears anywhere in it would
+ * clear the first clause on the strength of the second.
+ */
+const addColumnClauses = (upper) => upper.split('ADD COLUMN').slice(1);
+
+/**
+ * What "the deployed code stops working" looks like in SQL.
+ *
+ * Deliberately NOT here, because neither breaks a running query:
+ *   DROP INDEX      - costs a plan, not a result. `ALTER INDEX ... RENAME TO`
+ *                     likewise: index names appear in no application query, and
+ *                     Prisma emits them routinely, so flagging them would make
+ *                     this gate noise. That is why the table rename below has
+ *                     to check for ALTER TABLE rather than matching RENAME TO
+ *                     on its own.
+ *   DROP CONSTRAINT - old code keeps reading and writing. Dropping a UNIQUE
+ *                     changes what a race can produce, which is a correctness
+ *                     question for review, not a break at cutover.
+ *
+ * ALTER TYPE ... RENAME TO is here: Prisma sends enum values with an explicit
+ * cast to the type name, so a deployed client keeps naming the old type.
+ */
+const RULES = [
+  { kind: 'drops a table', test: (u) => u.includes('DROP TABLE') },
+  { kind: 'drops a column', test: (u) => u.includes('DROP COLUMN') },
+  { kind: 'renames a column', test: (u) => u.includes('RENAME COLUMN') },
+  { kind: 'renames a table', test: (u) => u.includes('ALTER TABLE') && u.includes('RENAME TO') },
+  { kind: 'renames an enum type', test: (u) => u.includes('ALTER TYPE') && u.includes('RENAME TO') },
+  { kind: 'drops an enum type', test: (u) => u.includes('DROP TYPE') },
+  { kind: 'drops a view', test: (u) => u.includes('DROP VIEW') },
+  { kind: 'drops a schema', test: (u) => u.includes('DROP SCHEMA') },
+  { kind: 'truncates a table', test: (u) => u.includes('TRUNCATE') },
+  {
+    kind: 'makes an existing column NOT NULL',
+    test: (u) => u.includes('SET NOT NULL'),
+  },
+  {
+    kind: 'changes a column type',
+    test: (u) => u.includes('SET DATA TYPE') || (u.includes('ALTER COLUMN') && /\bTYPE\b/.test(u)),
+  },
+  {
+    kind: 'adds a required column with no default',
+    test: (u) => addColumnClauses(u).some((c) => c.includes('NOT NULL') && !c.includes('DEFAULT')),
+  },
+];
+
+/**
+ * The hazards in one migration's SQL, as {kind, statement} pairs.
+ * Exported so the classification that reds a build is testable on its own.
+ */
+export const classifyMigrationSql = (sql) => {
+  const hazards = [];
+
+  for (const statement of splitStatements(stripSqlComments(sql))) {
+    const upper = normalise(statement);
+    for (const rule of RULES) {
+      if (rule.test(upper)) {
+        hazards.push({ kind: rule.kind, statement: statement.replace(/\s+/g, ' ').trim() });
+      }
+    }
+  }
+
+  return hazards;
+};
+
+/**
+ * The explanation attached to the marker, or null.
+ *
+ * Read from the RAW file, before comments are stripped - the declaration is
+ * itself a comment. Continuation lines let the sentence be a sentence: the
+ * marker line plus every `--` line immediately following it are joined.
+ */
+export const readDeclaration = (sql) => {
+  const lines = sql.split('\n');
+  const start = lines.findIndex((line) => line.includes(DECLARATION_MARKER));
+  if (start === -1) return null;
+
+  const first = lines[start].slice(lines[start].indexOf(DECLARATION_MARKER) + DECLARATION_MARKER.length);
+  const parts = [first.trim()];
+
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line.startsWith('--')) break;
+    parts.push(line.replace(/^--\s?/, '').trim());
+  }
+
+  const text = parts.join(' ').replace(/\s+/g, ' ').trim();
+  return text === '' ? null : text;
+};
+
+/**
+ * @returns {{name: string, hazards: Array, declaration: string|null,
+ *            verdict: 'ok'|'undeclared'|'declaration-too-short'}}
+ */
+export const reviewMigration = ({ name, sql }) => {
+  const hazards = classifyMigrationSql(sql);
+  const declaration = readDeclaration(sql);
+
+  if (hazards.length === 0) return { name, hazards, declaration, verdict: 'ok' };
+  if (declaration === null) return { name, hazards, declaration, verdict: 'undeclared' };
+  if (declaration.length < MIN_DECLARATION_LENGTH) {
+    return { name, hazards, declaration, verdict: 'declaration-too-short' };
+  }
+  return { name, hazards, declaration, verdict: 'ok' };
+};
+
+/** `.../migrations/20260901120000_atcvet_code_system/migration.sql` -> the directory name. */
+export const migrationName = (path) =>
+  basename(path) === 'migration.sql' ? basename(dirname(path)) : path;
+
+const main = (paths) => {
+  if (paths.length === 0) {
+    console.log('No new migrations in this pull request.');
+    return 0;
+  }
+
+  let failed = 0;
+
+  for (const path of paths) {
+    const review = reviewMigration({ name: migrationName(path), sql: readFileSync(path, 'utf8') });
+
+    if (review.hazards.length === 0) {
+      console.log(`ok  ${review.name}: additive only.`);
+      continue;
+    }
+
+    const listed = review.hazards.map((h) => `      - ${h.kind}: ${h.statement}`).join('\n');
+
+    if (review.verdict === 'ok') {
+      console.log(`ok  ${review.name}: ${review.hazards.length} hazard(s), declared.`);
+      console.log(listed);
+      console.log(`      declared: ${review.declaration}`);
+      continue;
+    }
+
+    failed += 1;
+    console.log(`::error file=${path}::${review.name} changes the schema in a way the deployed code may not survive.`);
+    console.log(listed);
+
+    if (review.verdict === 'declaration-too-short') {
+      console.log(`    The ${DECLARATION_MARKER} note is ${review.declaration.length} characters:`);
+      console.log(`      "${review.declaration}"`);
+      console.log(`    It needs at least ${MIN_DECLARATION_LENGTH} - enough to say something a reviewer can disagree with.`);
+      continue;
+    }
+
+    console.log(`    api-deploy.sh applies migrations before it cuts over, so the CURRENTLY`);
+    console.log(`    DEPLOYED code runs against this schema for the length of the smoke window -`);
+    console.log(`    and for good, if the smoke boot fails and the deploy stops without cutting`);
+    console.log(`    over. The code rollback does not roll the schema back.`);
+    console.log(`    Either ship the expand step first (add the new thing, move the readers,`);
+    console.log(`    remove the old thing in a later release), or say why no deployed reader`);
+    console.log(`    names what this changes, in the migration itself:`);
+    console.log(`      -- ${DECLARATION_MARKER} <why the deployed code keeps working>`);
+  }
+
+  if (failed > 0) {
+    console.log(`\n${failed} migration(s) change the schema under the running code with no explanation.`);
+    return 1;
+  }
+
+  console.log(`\nEvery new migration is additive or explains how the deployed code survives it.`);
+  return 0;
+};
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -1,0 +1,287 @@
+// Tests for the destructive-migration gate.
+//
+// What is pinned here is the CLASSIFICATION, because that is what decides
+// whether a migration reds a build. Each case below is either a shape this
+// repository's migrations actually take, or a way an earlier draft of this
+// gate got the answer wrong.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  classifyMigrationSql,
+  stripSqlComments,
+  splitStatements,
+  readDeclaration,
+  reviewMigration,
+  migrationName,
+  MIN_DECLARATION_LENGTH,
+} from './classify-migration.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const kinds = (sql) => classifyMigrationSql(sql).map((h) => h.kind);
+
+test('an additive migration has no hazards', () => {
+  assert.deepEqual(
+    kinds('-- AlterTable\nALTER TABLE "Invoice" ADD COLUMN "note" TEXT;'),
+    [],
+  );
+});
+
+test('a dropped column is a hazard', () => {
+  assert.deepEqual(
+    kinds('ALTER TABLE "Invoice" DROP COLUMN "note";'),
+    ['drops a column'],
+  );
+});
+
+test('a renamed column is a hazard - the #2599 shape', () => {
+  // #2599 renamed three columns. It was safe because all three tables held zero
+  // rows, which is a fact about that PR, not about renames.
+  assert.deepEqual(
+    kinds('ALTER TABLE "Invoice" RENAME COLUMN "old" TO "new";'),
+    ['renames a column'],
+  );
+});
+
+// The false positive that would have made this gate useless. Prisma writes this
+// header on precisely the migrations worth catching, and
+// 20260615100345_parent_patient_migration in this repo carries a real one.
+test('Prisma\'s warning header is not mistaken for the statement', () => {
+  const sql = `/*
+  Warnings:
+
+  - You are about to drop the column \`companion\` on the \`AdverseEventReport\` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "AdverseEventReport" ADD COLUMN "patient" JSONB;
+`;
+  assert.deepEqual(kinds(sql), []);
+});
+
+test('the real 20260615100345 migration is classified from its statements, not its prose', () => {
+  const path = join(
+    repoRoot,
+    'packages/database/prisma/migrations/20260615100345_parent_patient_migration/migration.sql',
+  );
+  const sql = readFileSync(path, 'utf8');
+
+  // It genuinely does drop a column and set another NOT NULL further down, so
+  // the answer must be non-empty - but it must come from the DDL. Stripping the
+  // header alone leaves those statements standing.
+  const found = kinds(sql);
+  assert.ok(found.includes('drops a column'), `expected a real drop, got ${JSON.stringify(found)}`);
+
+  // And the prose alone must not be enough: with every statement removed, only
+  // the warning block remains and nothing should fire.
+  const proseOnly = sql.slice(0, sql.indexOf('*/') + 2);
+  assert.deepEqual(kinds(proseOnly), []);
+});
+
+// Migrations here run DDL out of a string inside a DO block, so blanking
+// literal bodies - the easy way to stop `--` in a string reading as a comment -
+// would hide the statements most worth catching.
+test('DDL executed from inside a DO block is still seen', () => {
+  const sql = `DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name = 'companion') THEN
+    EXECUTE 'ALTER TABLE "AdverseEventReport" DROP COLUMN "companion"';
+  END IF;
+END $$;`;
+  assert.deepEqual(kinds(sql), ['drops a column']);
+});
+
+test('a table rename inside a DO block is reported', () => {
+  const sql = `DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE "Old" RENAME TO "New"';
+END $$;`;
+  assert.deepEqual(kinds(sql), ['renames a table']);
+});
+
+test('a DO block is split at its semicolons, so unrelated clauses do not combine', () => {
+  // Held whole, this block satisfies ALTER TABLE and RENAME TO at once and
+  // reports a table rename that is not there. Only the index is renamed.
+  const sql = `DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE "Invoice" ADD COLUMN "note" TEXT';
+  EXECUTE 'ALTER INDEX "Invoice_id_idx" RENAME TO "Invoice_pkey_idx"';
+END $$;`;
+  assert.deepEqual(kinds(sql), []);
+});
+
+// ALTER INDEX ... RENAME TO appears 26 times in this repo's history. Index
+// names appear in no application query, so flagging them would drown the
+// signal - which is why the table rule checks for ALTER TABLE.
+test('renaming an index is not a hazard, renaming a table is', () => {
+  assert.deepEqual(kinds('ALTER INDEX "Invoice_id_idx" RENAME TO "Invoice_pkey_idx";'), []);
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" RENAME TO "Bill";'), ['renames a table']);
+});
+
+test('renaming an enum type is a hazard', () => {
+  // Prisma casts enum values to the type by name, so a deployed client keeps
+  // naming the old one.
+  assert.deepEqual(kinds('ALTER TYPE "CodeSystem" RENAME TO "CodeSystemV2";'), ['renames an enum type']);
+});
+
+test('renaming a constraint is not mistaken for renaming a table', () => {
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" RENAME CONSTRAINT "a" TO "b";'), []);
+});
+
+test('a required column with no default is caught beside one that has a default', () => {
+  // Asking whether DEFAULT appears anywhere in the statement clears the first
+  // clause on the strength of the second.
+  const sql = 'ALTER TABLE "Invoice" ADD COLUMN "a" TEXT NOT NULL, ADD COLUMN "b" INT NOT NULL DEFAULT 0;';
+  assert.deepEqual(kinds(sql), ['adds a required column with no default']);
+});
+
+test('a required column WITH a default is additive', () => {
+  assert.deepEqual(
+    kinds(`ALTER TABLE "Invoice" ADD COLUMN "b" INT NOT NULL DEFAULT 0;`),
+    [],
+  );
+});
+
+test('ADD COLUMN IF NOT EXISTS is not read as NOT NULL', () => {
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" ADD COLUMN IF NOT EXISTS "patient" JSONB;'), []);
+});
+
+test('tightening an existing column to NOT NULL is a hazard', () => {
+  assert.deepEqual(
+    kinds('ALTER TABLE "CodeEntry" ALTER COLUMN "code" SET NOT NULL;'),
+    ['makes an existing column NOT NULL'],
+  );
+});
+
+test('relaxing a column to NULL is not', () => {
+  assert.deepEqual(kinds('ALTER TABLE "CodeEntry" ALTER COLUMN "code" DROP NOT NULL;'), []);
+});
+
+test('a column type change is a hazard', () => {
+  assert.deepEqual(
+    kinds('ALTER TABLE "Invoice" ALTER COLUMN "subtotal" SET DATA TYPE DECIMAL(10,2);'),
+    ['changes a column type'],
+  );
+});
+
+test('dropped tables, types, views and schemas are hazards', () => {
+  assert.deepEqual(kinds('DROP TABLE "Legacy";'), ['drops a table']);
+  assert.deepEqual(kinds('DROP TYPE "OldEnum";'), ['drops an enum type']);
+  assert.deepEqual(kinds('DROP VIEW "InvoiceSummary";'), ['drops a view']);
+  assert.deepEqual(kinds('DROP SCHEMA "legacy" CASCADE;'), ['drops a schema']);
+  assert.deepEqual(kinds('TRUNCATE TABLE "CodeEntry";'), ['truncates a table']);
+});
+
+test('creating an index or a constraint is additive', () => {
+  // The deliberate non-hazards. If these ever start firing the gate becomes
+  // noise, and noise is how a gate gets turned off.
+  assert.deepEqual(kinds('CREATE UNIQUE INDEX "Invoice_key" ON "Invoice"("id");'), []);
+  assert.deepEqual(kinds('DROP INDEX "Invoice_key";'), []);
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" DROP CONSTRAINT "Invoice_fk";'), []);
+});
+
+test('a line comment describing a drop is not mistaken for one', () => {
+  // Migration files are commented in the same words as the SQL they describe,
+  // so a substring match over the raw file fires on the prose.
+  const sql = '-- AlterTable: this used to DROP COLUMN "note", see #2599\nSELECT 1;';
+  assert.deepEqual(kinds(sql), []);
+});
+
+test("a doubled quote inside a literal needs no special case", () => {
+  // Pinned because the scanner deliberately has no '' branch. Closing the
+  // literal at the first quote and reopening at the second spans exactly the
+  // same text, so the `--` here can never surface outside a literal and eat the
+  // statement that follows. If that ever stops being true this goes red.
+  const sql = `INSERT INTO "Note" ("body") VALUES ('it''s -- fine'); DROP TABLE "Legacy";`;
+  assert.deepEqual(kinds(sql), ['drops a table']);
+  assert.ok(stripSqlComments(sql).includes("it''s -- fine"));
+});
+
+test('stripSqlComments keeps a literal that contains a comment marker', () => {
+  // Blanking or truncating here would drop the DROP TABLE that follows.
+  const sql = `INSERT INTO "Note" ("body") VALUES ('a -- not a comment');\nDROP TABLE "Legacy";`;
+  const stripped = stripSqlComments(sql);
+  assert.ok(stripped.includes('a -- not a comment'), stripped);
+  assert.deepEqual(kinds(sql), ['drops a table']);
+});
+
+test('stripSqlComments handles nested block comments', () => {
+  // Postgres nests them. Scanning for the first */ ends the comment at the
+  // INNER close, and everything between it and the outer close - the DDL below
+  // - re-enters the text as live SQL and is reported as a hazard that is not
+  // there.
+  const sql = '/* outer /* inner */ ALTER TABLE "X" DROP COLUMN "y"; */ SELECT 1;';
+  assert.deepEqual(kinds(sql), []);
+});
+
+test('stripSqlComments preserves line count so reported SQL stays locatable', () => {
+  const sql = '-- one\n/* two\nthree */\nSELECT 1;';
+  assert.equal(stripSqlComments(sql).split('\n').length, sql.split('\n').length);
+});
+
+test('splitStatements ignores a semicolon inside a literal', () => {
+  assert.equal(splitStatements(`SELECT 'a;b'; SELECT 2;`).length, 2);
+});
+
+test('readDeclaration joins continuation lines', () => {
+  const sql = [
+    '-- deployed-code-survives: the replacement column shipped in',
+    '--   20260901120000_add_new_name and every reader moved in #2610,',
+    '--   so no deployed query names the old one.',
+    'ALTER TABLE "Invoice" DROP COLUMN "old";',
+  ].join('\n');
+
+  const declaration = readDeclaration(sql);
+  assert.match(declaration, /^the replacement column shipped in 20260901120000_add_new_name/);
+  assert.match(declaration, /no deployed query names the old one\.$/);
+});
+
+test('readDeclaration returns null when the marker is absent or empty', () => {
+  assert.equal(readDeclaration('ALTER TABLE "Invoice" DROP COLUMN "old";'), null);
+  assert.equal(readDeclaration('-- deployed-code-survives:\nSELECT 1;'), null);
+});
+
+test('a hazard with no declaration fails', () => {
+  const review = reviewMigration({ name: 'm', sql: 'ALTER TABLE "Invoice" DROP COLUMN "old";' });
+  assert.equal(review.verdict, 'undeclared');
+});
+
+test('a hazard with a real declaration passes', () => {
+  const sql = [
+    '-- deployed-code-survives: nothing reads this column; the last reader was',
+    '--   removed in #2610 and the table holds zero rows in production.',
+    'ALTER TABLE "Invoice" DROP COLUMN "old";',
+  ].join('\n');
+  assert.equal(reviewMigration({ name: 'm', sql }).verdict, 'ok');
+});
+
+test('a token declaration is refused', () => {
+  // The whole point: "-- deployed-code-survives: ok" satisfies a presence check
+  // while saying nothing a reviewer can disagree with.
+  const sql = '-- deployed-code-survives: ok\nALTER TABLE "Invoice" DROP COLUMN "old";';
+  const review = reviewMigration({ name: 'm', sql });
+  assert.equal(review.verdict, 'declaration-too-short');
+  assert.ok(review.declaration.length < MIN_DECLARATION_LENGTH);
+});
+
+test('an additive migration needs no declaration', () => {
+  const review = reviewMigration({ name: 'm', sql: 'ALTER TABLE "Invoice" ADD COLUMN "note" TEXT;' });
+  assert.equal(review.verdict, 'ok');
+  assert.equal(review.declaration, null);
+});
+
+test('migrationName reads the directory, which is what Prisma checksums', () => {
+  assert.equal(
+    migrationName('packages/database/prisma/migrations/20260901120000_atcvet_code_system/migration.sql'),
+    '20260901120000_atcvet_code_system',
+  );
+});
+
+test('every hazard reports the statement that caused it', () => {
+  const [hazard] = classifyMigrationSql('ALTER TABLE\n  "Invoice"\n  DROP COLUMN "old";');
+  // Whitespace-collapsed, so a statement split over lines is still one readable
+  // line in the CI log.
+  assert.equal(hazard.statement, 'ALTER TABLE "Invoice" DROP COLUMN "old"');
+});

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -23,32 +23,25 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
 const kinds = (sql) => classifyMigrationSql(sql).map((h) => h.kind);
 
 test('an additive migration has no hazards', () => {
-  assert.deepEqual(
-    kinds('-- AlterTable\nALTER TABLE "Invoice" ADD COLUMN "note" TEXT;'),
-    [],
-  );
+  assert.deepEqual(kinds('-- AlterTable\nALTER TABLE "Invoice" ADD COLUMN "note" TEXT;'), []);
 });
 
 test('a dropped column is a hazard', () => {
-  assert.deepEqual(
-    kinds('ALTER TABLE "Invoice" DROP COLUMN "note";'),
-    ['drops a column'],
-  );
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" DROP COLUMN "note";'), ['drops a column']);
 });
 
 test('a renamed column is a hazard - the #2599 shape', () => {
   // #2599 renamed three columns. It was safe because all three tables held zero
   // rows, which is a fact about that PR, not about renames.
-  assert.deepEqual(
-    kinds('ALTER TABLE "Invoice" RENAME COLUMN "old" TO "new";'),
-    ['renames a column'],
-  );
+  assert.deepEqual(kinds('ALTER TABLE "Invoice" RENAME COLUMN "old" TO "new";'), [
+    'renames a column',
+  ]);
 });
 
 // The false positive that would have made this gate useless. Prisma writes this
 // header on precisely the migrations worth catching, and
 // 20260615100345_parent_patient_migration in this repo carries a real one.
-test('Prisma\'s warning header is not mistaken for the statement', () => {
+test("Prisma's warning header is not mistaken for the statement", () => {
   const sql = `/*
   Warnings:
 
@@ -64,7 +57,7 @@ ALTER TABLE "AdverseEventReport" ADD COLUMN "patient" JSONB;
 test('the real 20260615100345 migration is classified from its statements, not its prose', () => {
   const path = join(
     repoRoot,
-    'packages/database/prisma/migrations/20260615100345_parent_patient_migration/migration.sql',
+    'packages/database/prisma/migrations/20260615100345_parent_patient_migration/migration.sql'
   );
   const sql = readFileSync(path, 'utf8');
 
@@ -123,7 +116,9 @@ test('renaming an index is not a hazard, renaming a table is', () => {
 test('renaming an enum type is a hazard', () => {
   // Prisma casts enum values to the type by name, so a deployed client keeps
   // naming the old one.
-  assert.deepEqual(kinds('ALTER TYPE "CodeSystem" RENAME TO "CodeSystemV2";'), ['renames an enum type']);
+  assert.deepEqual(kinds('ALTER TYPE "CodeSystem" RENAME TO "CodeSystemV2";'), [
+    'renames an enum type',
+  ]);
 });
 
 test('renaming a constraint is not mistaken for renaming a table', () => {
@@ -133,15 +128,13 @@ test('renaming a constraint is not mistaken for renaming a table', () => {
 test('a required column with no default is caught beside one that has a default', () => {
   // Asking whether DEFAULT appears anywhere in the statement clears the first
   // clause on the strength of the second.
-  const sql = 'ALTER TABLE "Invoice" ADD COLUMN "a" TEXT NOT NULL, ADD COLUMN "b" INT NOT NULL DEFAULT 0;';
+  const sql =
+    'ALTER TABLE "Invoice" ADD COLUMN "a" TEXT NOT NULL, ADD COLUMN "b" INT NOT NULL DEFAULT 0;';
   assert.deepEqual(kinds(sql), ['adds a required column with no default']);
 });
 
 test('a required column WITH a default is additive', () => {
-  assert.deepEqual(
-    kinds(`ALTER TABLE "Invoice" ADD COLUMN "b" INT NOT NULL DEFAULT 0;`),
-    [],
-  );
+  assert.deepEqual(kinds(`ALTER TABLE "Invoice" ADD COLUMN "b" INT NOT NULL DEFAULT 0;`), []);
 });
 
 test('ADD COLUMN IF NOT EXISTS is not read as NOT NULL', () => {
@@ -149,10 +142,9 @@ test('ADD COLUMN IF NOT EXISTS is not read as NOT NULL', () => {
 });
 
 test('tightening an existing column to NOT NULL is a hazard', () => {
-  assert.deepEqual(
-    kinds('ALTER TABLE "CodeEntry" ALTER COLUMN "code" SET NOT NULL;'),
-    ['makes an existing column NOT NULL'],
-  );
+  assert.deepEqual(kinds('ALTER TABLE "CodeEntry" ALTER COLUMN "code" SET NOT NULL;'), [
+    'makes an existing column NOT NULL',
+  ]);
 });
 
 test('relaxing a column to NULL is not', () => {
@@ -162,7 +154,7 @@ test('relaxing a column to NULL is not', () => {
 test('a column type change is a hazard', () => {
   assert.deepEqual(
     kinds('ALTER TABLE "Invoice" ALTER COLUMN "subtotal" SET DATA TYPE DECIMAL(10,2);'),
-    ['changes a column type'],
+    ['changes a column type']
   );
 });
 
@@ -189,7 +181,7 @@ test('a line comment describing a drop is not mistaken for one', () => {
   assert.deepEqual(kinds(sql), []);
 });
 
-test("a doubled quote inside a literal needs no special case", () => {
+test('a doubled quote inside a literal needs no special case', () => {
   // Pinned because the scanner deliberately has no '' branch. Closing the
   // literal at the first quote and reopening at the second spans exactly the
   // same text, so the `--` here can never surface outside a literal and eat the
@@ -238,6 +230,37 @@ test('readDeclaration joins continuation lines', () => {
   assert.match(declaration, /no deployed query names the old one\.$/);
 });
 
+// The gate bypass Aikido found on this change: a plain substring search over
+// the raw file let the marker text inside DATA clear the hazard beside it.
+test('the marker inside a string literal is not a declaration', () => {
+  const sql = [
+    `INSERT INTO "Note" ("body") VALUES ('deployed-code-survives: this is data, not a promise');`,
+    'ALTER TABLE "Invoice" DROP COLUMN "old";',
+  ].join('\n');
+
+  assert.equal(readDeclaration(sql), null);
+  assert.equal(reviewMigration({ name: 'm', sql }).verdict, 'undeclared');
+});
+
+test('a comment that only mentions the marker is not a declaration', () => {
+  const sql = [
+    '-- see the deployed-code-survives: convention in _migration.yaml',
+    'ALTER TABLE "Invoice" DROP COLUMN "old";',
+  ].join('\n');
+
+  assert.equal(readDeclaration(sql), null);
+});
+
+test('the marker is recognised however the comment is indented', () => {
+  const sql = [
+    '   --   deployed-code-survives: nothing has read this column since #2610,',
+    '--   and the table holds zero rows in production.',
+    'ALTER TABLE "Invoice" DROP COLUMN "old";',
+  ].join('\n');
+
+  assert.equal(reviewMigration({ name: 'm', sql }).verdict, 'ok');
+});
+
 test('readDeclaration returns null when the marker is absent or empty', () => {
   assert.equal(readDeclaration('ALTER TABLE "Invoice" DROP COLUMN "old";'), null);
   assert.equal(readDeclaration('-- deployed-code-survives:\nSELECT 1;'), null);
@@ -267,15 +290,20 @@ test('a token declaration is refused', () => {
 });
 
 test('an additive migration needs no declaration', () => {
-  const review = reviewMigration({ name: 'm', sql: 'ALTER TABLE "Invoice" ADD COLUMN "note" TEXT;' });
+  const review = reviewMigration({
+    name: 'm',
+    sql: 'ALTER TABLE "Invoice" ADD COLUMN "note" TEXT;',
+  });
   assert.equal(review.verdict, 'ok');
   assert.equal(review.declaration, null);
 });
 
 test('migrationName reads the directory, which is what Prisma checksums', () => {
   assert.equal(
-    migrationName('packages/database/prisma/migrations/20260901120000_atcvet_code_system/migration.sql'),
-    '20260901120000_atcvet_code_system',
+    migrationName(
+      'packages/database/prisma/migrations/20260901120000_atcvet_code_system/migration.sql'
+    ),
+    '20260901120000_atcvet_code_system'
   );
 });
 

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -99,6 +99,8 @@ deploy_git_sync "$REPO_DIR" "$GIT_REF" "${REQUIRE_PROMOTED_FROM:-}"
 # loud if the deploy stops after the schema has moved.
 INCOMING_MIGRATIONS="$(deploy_incoming_migrations "$ROLLBACK_SHA" HEAD)"
 MIGRATIONS_APPLIED=0
+CUTOVER_DONE=0
+SMOKE_PID=""
 
 if [ -n "$INCOMING_MIGRATIONS" ]; then
   echo "this deploy adds $(printf '%s\n' "$INCOMING_MIGRATIONS" | grep -c '') migration(s):"
@@ -107,14 +109,28 @@ else
   echo "this deploy adds no migrations - the schema does not move"
 fi
 
-# Said once, here, so every later exit can just point at it.
-stopped_without_cutover() {
-  if [ "$MIGRATIONS_APPLIED" = "1" ]; then
-    # Deliberate word splitting - one argument per migration. Prisma directory
-    # names are <timestamp>_<snake_case>, so there is nothing here to glob.
-    # shellcheck disable=SC2086
-    deploy_schema_hazard_notice "$ROLLBACK_SHA" $INCOMING_MIGRATIONS
+# Said on the way out, not from the branches that remembered to say it.
+#
+# This script runs under `set -e`, so a command that simply fails ends it where
+# it stands. Hanging the notice off the two branches that test a status meant
+# every other exit between the migration and the cutover was silent - including
+# the likeliest one of all, `prisma migrate deploy` halting part-way through and
+# leaving the earlier migrations applied. An EXIT trap cannot be walked past.
+#
+# It also owns the smoke process, so there is one handler rather than an
+# arm/disarm pair around the boot that a later edit could fall out of.
+on_exit() {
+  local status=$?
+
+  if [ -n "$SMOKE_PID" ]; then
+    kill "$SMOKE_PID" 2>/dev/null || true
   fi
+
+  # Deliberate word splitting - one argument per migration. Prisma directory
+  # names are <timestamp>_<snake_case>, so there is nothing here to glob.
+  # shellcheck disable=SC2086
+  deploy_stop_notice "$status" "$MIGRATIONS_APPLIED" "$CUTOVER_DONE" \
+    "$ROLLBACK_SHA" $INCOMING_MIGRATIONS
 }
 
 say "install"
@@ -166,15 +182,24 @@ say "migrations"
 if [ -n "$INCOMING_MIGRATIONS" ]; then
   echo "  applying, after which a rollback to $ROLLBACK_SHA no longer restores the box on its own"
 fi
+# Armed before the schema can move, and the flag is set before the command
+# rather than after it: `prisma migrate deploy` halting on migration three of
+# three has already applied two. Setting it after was the bug - the assignment
+# was unreachable in exactly the case it described. It over-reports only if
+# Prisma fails having applied nothing, and over-reporting a schema hazard is the
+# safe direction. A deploy that carries no migrations cannot move the schema at
+# all, so it stays silent.
+trap on_exit EXIT
+if [ -n "$INCOMING_MIGRATIONS" ]; then
+  MIGRATIONS_APPLIED=1
+fi
 pnpm --filter @yosemite-crew/database run prisma:deploy
-MIGRATIONS_APPLIED=1
 
 say "smoke boot on :$SMOKE_PORT"
 cd apps/backend
 rm -f /tmp/api-smoke.log
 PORT="$SMOKE_PORT" nohup node dist/index.js >/tmp/api-smoke.log 2>&1 &
 SMOKE_PID=$!
-trap 'kill "$SMOKE_PID" 2>/dev/null || true' EXIT
 sleep 25
 CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health" || echo 000)"
 echo "  /health -> $CODE"
@@ -184,11 +209,10 @@ echo "  real route : $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/pe
 echo "  bogus route: $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/definitely-not-a-route" | head -c 30)"
 grep -iE 'ERR_REQUIRE_ESM|Cannot find module|FATAL ERROR' /tmp/api-smoke.log | head -5 || true
 kill "$SMOKE_PID" 2>/dev/null || true
-trap - EXIT
+SMOKE_PID=""
 sleep 2
 if [ "$CODE" != "200" ]; then
   echo "smoke boot failed - NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
-  stopped_without_cutover
   exit 1
 fi
 
@@ -202,8 +226,10 @@ pm2 describe "$PM2_TARGET" | grep -iE 'status|node.js version' || true
 ss -ltn 2>/dev/null | grep -q ':8080' \
   && echo "  listening on 8080" \
   || { echo "  NOTHING LISTENING on 8080 - roll back to $ROLLBACK_SHA" >&2
-       stopped_without_cutover
        exit 1; }
+# Past here the running process IS the new code, so the schema being ahead of it
+# is no longer true and the notice must stop claiming it.
+CUTOVER_DONE=1
 
 say "done"
 echo "deployed $(git -C "$REPO_DIR" rev-parse --short HEAD)  (rollback: $ROLLBACK_SHA)"

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -29,6 +29,17 @@
 #   port BEFORE pm2   an immediate port check races the boot. Boot the new bundle
 #                     somewhere harmless first; only cut over if it answers.
 #
+#   migrate AFTER     Migrations used to run at step 4 of 8, before the build. The
+#   the build         cutover is step 7, so the OLD process served traffic against
+#                     the NEW schema for the whole build AND smoke window - and a
+#                     failed build left it there for good, because a failure exits
+#                     without cutting over and nothing rolls a migration back.
+#                     The build needs the generated Prisma CLIENT, not the
+#                     database, so only `prisma generate` has to precede it. The
+#                     smoke boot genuinely does need the new schema, so that much
+#                     of the window is irreducible - what is left is reported
+#                     explicitly on every path that stops without cutting over.
+#
 # Usage: api-deploy.sh <repo-dir> <pm2-target> <git-ref> [smoke-port]
 set -euo pipefail
 
@@ -43,13 +54,17 @@ NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
 # looking for a helper that is not on the box, and bash exits before preflight
 # with a bare "No such file or directory" - so say what is actually wrong.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ ! -r "$SCRIPT_DIR/lib/git-sync.sh" ]; then
-  echo "missing $SCRIPT_DIR/lib/git-sync.sh" >&2
-  echo "Copy the whole scripts/deploy directory to the host, not just this file." >&2
-  exit 1
-fi
+for helper in git-sync migrate; do
+  if [ ! -r "$SCRIPT_DIR/lib/$helper.sh" ]; then
+    echo "missing $SCRIPT_DIR/lib/$helper.sh" >&2
+    echo "Copy the whole scripts/deploy directory to the host, not just this file." >&2
+    exit 1
+  fi
+done
 # shellcheck source=lib/git-sync.sh
 . "$SCRIPT_DIR/lib/git-sync.sh"
+# shellcheck source=lib/migrate.sh
+. "$SCRIPT_DIR/lib/migrate.sh"
 export PATH="$NODE_BIN:$PATH"
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
 
@@ -78,12 +93,39 @@ say "checkout $GIT_REF"
 # meant to arrive first.
 deploy_git_sync "$REPO_DIR" "$GIT_REF" "${REQUIRE_PROMOTED_FROM:-}"
 
+# Before anything is installed, built or applied: name the migrations this
+# deploy would add on top of what the box is serving. That set is exactly what a
+# rollback to $ROLLBACK_SHA would leave applied, so it is what has to be said out
+# loud if the deploy stops after the schema has moved.
+INCOMING_MIGRATIONS="$(deploy_incoming_migrations "$ROLLBACK_SHA" HEAD)"
+MIGRATIONS_APPLIED=0
+
+if [ -n "$INCOMING_MIGRATIONS" ]; then
+  echo "this deploy adds $(printf '%s\n' "$INCOMING_MIGRATIONS" | grep -c '') migration(s):"
+  printf '%s\n' "$INCOMING_MIGRATIONS" | sed 's/^/  /'
+else
+  echo "this deploy adds no migrations - the schema does not move"
+fi
+
+# Said once, here, so every later exit can just point at it.
+stopped_without_cutover() {
+  if [ "$MIGRATIONS_APPLIED" = "1" ]; then
+    # Deliberate word splitting - one argument per migration. Prisma directory
+    # names are <timestamp>_<snake_case>, so there is nothing here to glob.
+    # shellcheck disable=SC2086
+    deploy_schema_hazard_notice "$ROLLBACK_SHA" $INCOMING_MIGRATIONS
+  fi
+}
+
 say "install"
 pnpm install --frozen-lockfile
 
-say "prisma client + migrations"
+# The client, not the database. `prisma generate` reads schema.prisma and writes
+# the typed client the build compiles against; it touches nothing live, so it is
+# safe to run before the build has been proved. `prisma migrate deploy` is the
+# irreversible half and waits until after it.
+say "prisma client"
 pnpm --filter @yosemite-crew/database run prisma:generate
-pnpm --filter @yosemite-crew/database run prisma:deploy
 
 say "build packages"
 BUILD_START="$(date '+%Y-%m-%d %H:%M:%S')"
@@ -113,6 +155,20 @@ for pkg in types fhirtypes fhir lib database auth; do
 done
 test -s apps/backend/dist/index.js || { echo "backend bundle missing" >&2; exit 1; }
 
+# The point of no return, and the last step before it that can still fail
+# harmlessly. Everything above this line is repeatable: a failed install, build
+# or freshness check leaves the box exactly as it was found, serving the old
+# bundle against the old schema. From here on it does not.
+#
+# The smoke boot below runs the new code, which needs the new schema, so this
+# cannot move any later.
+say "migrations"
+if [ -n "$INCOMING_MIGRATIONS" ]; then
+  echo "  applying, after which a rollback to $ROLLBACK_SHA no longer restores the box on its own"
+fi
+pnpm --filter @yosemite-crew/database run prisma:deploy
+MIGRATIONS_APPLIED=1
+
 say "smoke boot on :$SMOKE_PORT"
 cd apps/backend
 rm -f /tmp/api-smoke.log
@@ -132,6 +188,7 @@ trap - EXIT
 sleep 2
 if [ "$CODE" != "200" ]; then
   echo "smoke boot failed - NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  stopped_without_cutover
   exit 1
 fi
 
@@ -144,7 +201,9 @@ sleep 30
 pm2 describe "$PM2_TARGET" | grep -iE 'status|node.js version' || true
 ss -ltn 2>/dev/null | grep -q ':8080' \
   && echo "  listening on 8080" \
-  || { echo "  NOTHING LISTENING on 8080 - roll back to $ROLLBACK_SHA" >&2; exit 1; }
+  || { echo "  NOTHING LISTENING on 8080 - roll back to $ROLLBACK_SHA" >&2
+       stopped_without_cutover
+       exit 1; }
 
 say "done"
 echo "deployed $(git -C "$REPO_DIR" rev-parse --short HEAD)  (rollback: $ROLLBACK_SHA)"

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Which migrations a deploy is about to introduce, and what that costs if the
+# deploy does not finish.
+#
+# api-deploy.sh cannot cut over before it has proved the new bundle boots, and
+# it cannot prove that without the new schema, so there is a window in which the
+# OLD process serves traffic against the NEW schema. The window is not the
+# problem on its own - a failed deploy is, because the script deliberately does
+# not cut over, and the rollback it prints restores the CODE. Nothing rolls back
+# the schema, so the old process stays on an incompatible one indefinitely.
+#
+# Shrinking that window is api-deploy.sh's job (it applies migrations after the
+# build rather than before it, so a build failure - the common one on the 1.9 GB
+# dev box - never reaches the database at all). Saying what is still exposed
+# when a deploy stops is this file's job.
+#
+# Extracted so it can be tested against a real git history rather than only
+# being found on a live box, the same reason lib/git-sync.sh exists.
+
+# deploy_incoming_migrations <from-sha> [to-ref]
+#
+# Echoes, one per line, the migration directory names that <to-ref> adds on top
+# of <from-sha>. Must be run inside the repository.
+#
+# The filesystem is the right source here rather than the database. Migrations
+# are append-only - .github/workflows/_migration.yaml fails a pull request that
+# edits or deletes an applied one - so a diff between the commit the box is
+# serving and the commit being deployed names exactly the migrations that a
+# rollback to the former would leave stranded. Migrations older than <from-sha>
+# are already covered by the running code, whether or not this box has applied
+# them yet.
+#
+# Two-dot on purpose. A rollback deploys an older ref, where the newer
+# migrations are deletions rather than additions, and correctly reports none: a
+# rollback applies no new schema.
+deploy_incoming_migrations() {
+  local from="${1:?commit currently deployed required}"
+  local to="${2:-HEAD}"
+
+  git rev-parse --verify --quiet "$from^{commit}" >/dev/null || {
+    echo "deploy_incoming_migrations: cannot resolve '$from'" >&2
+    return 1
+  }
+
+  git diff --no-renames --diff-filter=A --name-only "$from..$to" \
+    -- packages/database/prisma/migrations \
+    | sed -n -E 's#^packages/database/prisma/migrations/([^/]+)/migration\.sql$#\1#p' \
+    | sort
+}
+
+# deploy_schema_hazard_notice <rollback-sha> <migration>...
+#
+# What to say when the deploy stops after the schema has moved. Written to
+# stderr beside the code rollback, because the code rollback on its own reads as
+# if the box has been restored, and it has not.
+deploy_schema_hazard_notice() {
+  local rollback_sha="${1:?rollback sha required}"
+  shift
+
+  {
+    echo
+    echo "!!! THE SCHEMA IS AHEAD OF THE RUNNING CODE."
+    echo
+    echo "This deploy applied ${#} migration(s) and then did NOT cut over, so the"
+    echo "process still serving traffic is the OLD one, now running against the NEW"
+    echo "schema. Checking out $rollback_sha restores the code and does NOT undo any"
+    echo "of this:"
+    printf '  %s\n' "$@"
+    echo
+    echo "If any of them removed or renamed something the running code still names,"
+    echo "every request touching it is failing NOW and will keep failing. Either fix"
+    echo "forward and re-deploy, or write and apply a migration that reverses them."
+    echo "Prisma has no down-migration; there is nothing to run that undoes this by"
+    echo "itself."
+  } >&2
+}

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -49,6 +49,39 @@ deploy_incoming_migrations() {
     | sort
 }
 
+# deploy_stop_notice <exit-status> <migrations-applied> <cutover-done> <rollback-sha> <migration>...
+#
+# Whether an exiting deploy owes the operator the hazard notice.
+#
+# Separated from the notice text because the two failed independently: the
+# wording was right while the notice was unreachable on the path most likely to
+# need it. api-deploy.sh runs under `set -e`, so a bare command failure ends the
+# script where it stands - it does not fall through to a call site further
+# down. `prisma migrate deploy` applies migrations one at a time and halts at
+# the first failure, leaving the earlier ones applied, which is precisely the
+# state the notice exists to announce and precisely the state that skipped it.
+#
+# So the caller installs this on an EXIT trap instead of calling it from the
+# branches it remembered to cover, and the decision lives here where it can be
+# tested without a live box.
+#
+# Silent on a clean exit, on a deploy whose schema never moved, and after a
+# verified cutover - past that point the running code is the new code, so the
+# schema being ahead of it is no longer true.
+deploy_stop_notice() {
+  local status="${1:?exit status required}"
+  local applied="${2:?migrations-applied flag required}"
+  local cutover="${3:?cutover-done flag required}"
+  local rollback_sha="${4:?rollback sha required}"
+  shift 4
+
+  if [ "$status" = "0" ]; then return 0; fi
+  if [ "$applied" != "1" ]; then return 0; fi
+  if [ "$cutover" = "1" ]; then return 0; fi
+
+  deploy_schema_hazard_notice "$rollback_sha" "$@"
+}
+
 # deploy_schema_hazard_notice <rollback-sha> <migration>...
 #
 # What to say when the deploy stops after the schema has moved. Written to

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -205,5 +205,121 @@ else
 fi
 
 echo
+echo "deploy_stop_notice"
+
+# The notice text was never the defect. The defect was that it could not be
+# reached on the path most likely to need it, so what is pinned here is when it
+# fires - each condition separately, and then the `set -e` behaviour that made
+# the original unreachable.
+
+fired() { # fired <status> <applied> <cutover>
+  if [ -n "$(deploy_stop_notice "$1" "$2" "$3" abc1234 20260102000000_second 2>&1 >/dev/null)" ]; then
+    echo yes
+  else
+    echo no
+  fi
+}
+
+check "fires when a failed deploy left migrations applied before cutover" \
+  "yes" "$(fired 1 1 0)"
+check "silent on a clean exit" "no" "$(fired 0 1 0)"
+check "silent when the schema never moved" "no" "$(fired 1 0 0)"
+check "silent once the cutover is verified" "no" "$(fired 1 1 1)"
+check "a non-1 failure status still fires" "yes" "$(fired 127 1 0)"
+
+STOP_NOTICE="$(deploy_stop_notice 1 1 0 abc1234 20260102000000_second 20260103000000_third 2>&1 >/dev/null)"
+case "$STOP_NOTICE" in
+  *20260102000000_second*20260103000000_third*) ok "passes every migration through to the notice" ;;
+  *) no "passes every migration through to the notice" "$STOP_NOTICE" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# The regression itself.
+#
+# api-deploy.sh runs under `set -euo pipefail`. `prisma migrate deploy` applies
+# migrations one at a time and halts at the first failure, having applied the
+# earlier ones - a bare non-zero exit, not a status this script tests. The
+# original hung the notice off two `if` branches further down, so `set -e` ended
+# the script before either was reached and the operator was told nothing.
+#
+# Driven through a real bash process rather than by calling the function,
+# because what is under test is that an EXIT trap survives `set -e` where a call
+# site below the failure does not.
+# ---------------------------------------------------------------------------
+cat > "$WORK/deploy-shape.sh" <<SHAPE
+#!/usr/bin/env bash
+set -euo pipefail
+. "$HERE/../lib/migrate.sh"
+
+MIGRATIONS_APPLIED=0
+CUTOVER_DONE=0
+INCOMING_MIGRATIONS="20260102000000_second"
+
+on_exit() {
+  local status=\$?
+  # shellcheck disable=SC2086
+  deploy_stop_notice "\$status" "\$MIGRATIONS_APPLIED" "\$CUTOVER_DONE" \\
+    abc1234 \$INCOMING_MIGRATIONS
+}
+
+trap on_exit EXIT
+MIGRATIONS_APPLIED=1
+# Stands in for prisma halting part-way: two applied, then a bare failure.
+echo "applied 20260101000000_first"
+echo "applied 20260102000000_second"
+false
+echo "UNREACHABLE"
+SHAPE
+chmod +x "$WORK/deploy-shape.sh"
+
+SHAPE_ERR="$("$WORK/deploy-shape.sh" 2>&1 >/dev/null || true)"
+SHAPE_OUT="$("$WORK/deploy-shape.sh" 2>/dev/null || true)"
+
+case "$SHAPE_ERR" in
+  *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*)
+    ok "a bare command failure under set -e still reaches the notice" ;;
+  *) no "a bare command failure under set -e still reaches the notice" \
+       "stderr was: $SHAPE_ERR" ;;
+esac
+
+case "$SHAPE_OUT" in
+  *UNREACHABLE*) no "the failing command still ends the deploy" "it kept going" ;;
+  *) ok "the failing command still ends the deploy" ;;
+esac
+
+if "$WORK/deploy-shape.sh" >/dev/null 2>&1; then
+  no "the deploy still exits non-zero" "it returned 0"
+else
+  ok "the deploy still exits non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# And the same invariant on the real file, since the behaviour above is only
+# the notice's if api-deploy.sh keeps this order: arm the trap, then raise the
+# flag, then move the schema. Setting the flag after the command was the bug -
+# the assignment was unreachable in exactly the case it described.
+# ---------------------------------------------------------------------------
+DEPLOY_SH="$HERE/../api-deploy.sh"
+line_of() { grep -n -m1 -F "$1" "$DEPLOY_SH" | cut -d: -f1; }
+
+TRAP_LINE="$(line_of 'trap on_exit EXIT')"
+FLAG_LINE="$(line_of 'MIGRATIONS_APPLIED=1')"
+DEPLOY_LINE="$(line_of 'run prisma:deploy')"
+
+if [ -n "$TRAP_LINE" ] && [ -n "$FLAG_LINE" ] && [ -n "$DEPLOY_LINE" ] \
+   && [ "$TRAP_LINE" -lt "$FLAG_LINE" ] && [ "$FLAG_LINE" -lt "$DEPLOY_LINE" ]; then
+  ok "api-deploy.sh arms the trap and raises the flag before applying migrations"
+else
+  no "api-deploy.sh arms the trap and raises the flag before applying migrations" \
+     "trap=$TRAP_LINE flag=$FLAG_LINE deploy=$DEPLOY_LINE"
+fi
+
+if grep -q 'trap - EXIT' "$DEPLOY_SH"; then
+  no "api-deploy.sh keeps one exit handler" "it disarms the EXIT trap somewhere"
+else
+  ok "api-deploy.sh keeps one exit handler rather than an arm/disarm pair"
+fi
+
+echo
 printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# Regression tests for the migration half of the deploy.
+#
+# What is pinned here is which migrations a deploy is about to introduce, since
+# that is the set a code rollback would leave applied - the sentence the
+# operator reads when a deploy stops without cutting over. Driven against a real
+# git history rather than a mocked one, for the same reason git-sync.test.sh is:
+# the answer is a property of `git diff` semantics, not of our wrapper.
+#
+# Usage: scripts/deploy/tests/migrate.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/migrate.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+ok() { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL + 1)); }
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "expected '$2', got '$3'"; fi
+}
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t "$@"; }
+
+REPO="$WORK/repo"
+
+add_migration() { # add_migration <name> [sql]
+  local name="$1" sql="${2:-SELECT 1;}"
+  mkdir -p "$REPO/packages/database/prisma/migrations/$name"
+  printf '%s\n' "$sql" > "$REPO/packages/database/prisma/migrations/$name/migration.sql"
+  git_quiet -C "$REPO" add -A
+  git_quiet -C "$REPO" commit --quiet -m "add $name"
+  git -C "$REPO" rev-parse HEAD
+}
+
+git_quiet init --quiet "$REPO"
+mkdir -p "$REPO/packages/database/prisma/migrations"
+echo readme > "$REPO/README.md"
+git_quiet -C "$REPO" add -A
+git_quiet -C "$REPO" commit --quiet -m "root"
+ROOT="$(git -C "$REPO" rev-parse HEAD)"
+
+M1="$(add_migration 20260101000000_first)"
+M2="$(add_migration 20260102000000_second)"
+M3="$(add_migration 20260103000000_third)"
+
+cd "$REPO"
+
+echo "deploy_incoming_migrations"
+
+# ---------------------------------------------------------------------------
+# The ordinary deploy: the box is on an older commit, and every migration added
+# since is one a code rollback would leave applied.
+# ---------------------------------------------------------------------------
+check "reports the migrations added since the deployed commit" \
+  "20260102000000_second
+20260103000000_third" \
+  "$(deploy_incoming_migrations "$M1" "$M3")"
+
+check "reports nothing when the box is already on the deployed commit" \
+  "" \
+  "$(deploy_incoming_migrations "$M3" "$M3")"
+
+check "reports every migration when the box predates them all" \
+  "20260101000000_first
+20260102000000_second
+20260103000000_third" \
+  "$(deploy_incoming_migrations "$ROOT" "$M3")"
+
+# ---------------------------------------------------------------------------
+# A rollback applies no new schema. Two-dot rather than three-dot is what makes
+# this true: deploying an older ref sees the newer migrations as deletions.
+# ---------------------------------------------------------------------------
+check "a rollback to an older ref introduces no migrations" \
+  "" \
+  "$(deploy_incoming_migrations "$M3" "$M1")"
+
+# ---------------------------------------------------------------------------
+# Only migration.sql counts. A README or a lock file inside the migrations tree
+# changes no schema, and reporting one would tell an operator their schema had
+# moved when it had not.
+# ---------------------------------------------------------------------------
+mkdir -p "$REPO/packages/database/prisma/migrations/20260104000000_notes"
+echo "provider = postgresql" > "$REPO/packages/database/prisma/migrations/migration_lock.toml"
+echo "notes" > "$REPO/packages/database/prisma/migrations/20260104000000_notes/README.md"
+git_quiet -C "$REPO" add -A
+git_quiet -C "$REPO" commit --quiet -m "non-sql files"
+NON_SQL="$(git -C "$REPO" rev-parse HEAD)"
+
+check "a directory with no migration.sql is not a migration" \
+  "" \
+  "$(deploy_incoming_migrations "$M3" "$NON_SQL")"
+
+# ---------------------------------------------------------------------------
+# Changes elsewhere in the repo, and edits to an EXISTING migration, are not
+# new migrations. The immutability gate in _migration.yaml already refuses the
+# latter on a pull request; this makes sure a deploy does not double-count one
+# that reached the box some other way.
+# ---------------------------------------------------------------------------
+echo "app change" > "$REPO/apps-file.txt"
+printf 'SELECT 2;\n' > "$REPO/packages/database/prisma/migrations/20260101000000_first/migration.sql"
+git_quiet -C "$REPO" add -A
+git_quiet -C "$REPO" commit --quiet -m "edit an applied migration and an app file"
+EDITED="$(git -C "$REPO" rev-parse HEAD)"
+
+check "an edited migration is not reported as a new one" \
+  "" \
+  "$(deploy_incoming_migrations "$NON_SQL" "$EDITED")"
+
+# ---------------------------------------------------------------------------
+# A rename is a delete plus an add, so the added half IS a migration the box has
+# not applied under that name - Prisma keys applied migrations by directory
+# name. --no-renames is what makes it visible.
+# ---------------------------------------------------------------------------
+git_quiet -C "$REPO" mv \
+  packages/database/prisma/migrations/20260103000000_third \
+  packages/database/prisma/migrations/20260105000000_third_renamed
+git_quiet -C "$REPO" commit --quiet -m "rename a migration"
+RENAMED="$(git -C "$REPO" rev-parse HEAD)"
+
+check "a renamed migration is reported under its new name" \
+  "20260105000000_third_renamed" \
+  "$(deploy_incoming_migrations "$EDITED" "$RENAMED")"
+
+# ---------------------------------------------------------------------------
+# Two-dot rather than three-dot, the case where they disagree.
+#
+# The box is on `dev`; production deploys `main`. A migration that reached dev
+# first and was then promoted to main is present in BOTH trees and is not new to
+# this box. Three-dot compares the merge base to the target, so it would report
+# that migration as incoming and put it in a schema-hazard notice describing a
+# schema move that already happened - the operator is then told to reverse a
+# migration their running code depends on.
+# ---------------------------------------------------------------------------
+git_quiet -C "$REPO" checkout --quiet -b promoted "$M2"
+git_quiet -C "$REPO" checkout --quiet -b box "$M2"
+BOX="$(add_migration 20260110000000_shared)"
+git_quiet -C "$REPO" checkout --quiet promoted
+# The two branches have to actually diverge. Cherry-picking onto the same parent
+# with the same tree, author and second reproduces the SAME sha, and the
+# scenario collapses into "deploying the commit already running".
+echo "promoted only" > "$REPO/promoted-only.txt"
+git_quiet -C "$REPO" add -A
+git_quiet -C "$REPO" commit --quiet -m "a commit that only main has"
+git_quiet -C "$REPO" cherry-pick "$BOX" >/dev/null
+TARGET="$(git -C "$REPO" rev-parse HEAD)"
+
+[ "$TARGET" != "$BOX" ] || { echo "setup error: the branches did not diverge" >&2; exit 1; }
+
+check "a migration already on the box is not reported when it arrives by another route" \
+  "" \
+  "$(deploy_incoming_migrations "$BOX" "$TARGET")"
+
+git_quiet -C "$REPO" checkout --quiet "$RENAMED"
+
+# ---------------------------------------------------------------------------
+# An unresolvable commit must fail rather than quietly report "no migrations",
+# and must say so. Reporting an empty set for a commit that could not be read
+# would tell the operator the schema had not moved.
+# ---------------------------------------------------------------------------
+BAD_ERR="$(deploy_incoming_migrations "0000000000000000000000000000000000000000" HEAD 2>&1 >/dev/null || true)"
+
+if deploy_incoming_migrations "0000000000000000000000000000000000000000" HEAD >/dev/null 2>&1; then
+  no "an unresolvable commit fails" "it returned 0"
+else
+  ok "an unresolvable commit fails rather than reporting an empty set"
+fi
+
+case "$BAD_ERR" in
+  *"cannot resolve"*) ok "an unresolvable commit says which one" ;;
+  *) no "an unresolvable commit says which one" "stderr was: $BAD_ERR" ;;
+esac
+
+echo
+echo "deploy_schema_hazard_notice"
+
+NOTICE="$(deploy_schema_hazard_notice abc1234 20260102000000_second 20260103000000_third 2>&1)"
+
+case "$NOTICE" in
+  *"20260102000000_second"*) ok "names every stranded migration" ;;
+  *) no "names every stranded migration" "$NOTICE" ;;
+esac
+
+case "$NOTICE" in
+  *"abc1234"*) ok "names the code rollback it does not undo" ;;
+  *) no "names the code rollback it does not undo" "$NOTICE" ;;
+esac
+
+check "counts the migrations it lists" "2" \
+  "$(printf '%s\n' "$NOTICE" | grep -oE 'applied [0-9]+ migration' | grep -oE '[0-9]+')"
+
+# The whole point of the notice is that it goes to stderr next to the failure,
+# not to stdout where a `$(...)` capture would swallow it.
+if [ -z "$(deploy_schema_hazard_notice abc1234 m1 2>/dev/null)" ]; then
+  ok "writes to stderr, not stdout"
+else
+  no "writes to stderr, not stdout" "something reached stdout"
+fi
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -300,7 +300,9 @@ fi
 # the assignment was unreachable in exactly the case it described.
 # ---------------------------------------------------------------------------
 DEPLOY_SH="$HERE/../api-deploy.sh"
-line_of() { grep -n -m1 -F "$1" "$DEPLOY_SH" | cut -d: -f1; }
+# `|| true` so a missing line reports as a failed check rather than aborting
+# the whole suite through `set -e` on the assignment below.
+line_of() { grep -n -m1 -F "$1" "$DEPLOY_SH" | cut -d: -f1 || true; }
 
 TRAP_LINE="$(line_of 'trap on_exit EXIT')"
 FLAG_LINE="$(line_of 'MIGRATIONS_APPLIED=1')"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`scripts/deploy/api-deploy.sh` applies Prisma migrations at step 4 of 8 and cuts over at step 7. The old PM2 process therefore serves traffic against the new schema for the whole build and smoke window, and a failed build or smoke exits without cutting over - leaving the migration applied and the old process running against it indefinitely.

Line 134 is explicit that a smoke failure does not cut over, which is the right call for the process and is exactly what makes this sharp: the rollback restores the code, and nothing rolls back the schema. Additive migrations are unaffected, which is why this has not bitten yet.

Raised by the Codex review on #2599, which renames three columns. That PR was safe on its own terms - all three tables held zero rows - but the hazard is general and applies to the first rename on a populated table.

## What is the new behavior?

**The build no longer runs inside the window.** The build needs the generated Prisma client, not the database, so only `prisma generate` has to precede it. `prisma migrate deploy` moves to after the freshness check and immediately before the smoke boot. A failed install, build or freshness check now leaves the box exactly as it was found. The smoke boot runs the new code and genuinely does need the new schema, so that much of the window is irreducible - reordering past it, as #2603 notes, does not work.

**What is left is said out loud.** `scripts/deploy/lib/migrate.sh` works out which migrations the deploy introduces on top of the commit the box is serving, from `git diff` rather than the database - migrations are append-only, enforced by the immutability check in `_migration.yaml`, so that set is exactly what a rollback would leave applied. The deploy prints it before applying anything, and every path that stops without cutting over prints which migrations the recorded rollback sha does **not** undo.

**And the part that does not depend on anybody remembering.** `scripts/ci/classify-migration.mjs` fails a pull request that adds a migration which drops or renames a column, table or enum type, tightens a column to `NOT NULL`, changes a column type, adds a required column with no default, or truncates - unless the migration says in writing why the deployed code survives it:

```sql
-- deployed-code-survives: the replacement column shipped in
--   20260901120000_add_new_name and every reader moved in #2610, so no
--   deployed query names the old one.
```

That is the expand-contract reasoning written next to the SQL it describes, where a reviewer sees it. It does not suppress the finding - the hazard is still printed - and a token declaration (`ok`) is refused. `DROP INDEX`, `ALTER INDEX ... RENAME TO` and `DROP CONSTRAINT` are deliberately not hazards; a gate that fires on the 26 index renames already in this history is noise, and noise is how a gate gets turned off.

The classifier strips SQL comments before matching, which is load-bearing rather than tidy: Prisma writes `You are about to drop the column ...` as a warning header on precisely the migrations worth catching, and `20260615100345_parent_patient_migration` in this repo carries a real one. It keeps string literals, because migrations here run DDL out of `EXECUTE '...'` inside `DO` blocks.

## Verification

Run at `fed532dbb`:

| Command | Exit | Result |
|---|---|---|
| `pnpm run test:scripts` | 0 | 288 tests, 288 pass, 0 fail (whole suite, not just the new file) |
| `scripts/deploy/tests/migrate.test.sh` | 0 | 14 passed, 0 failed |
| `scripts/deploy/tests/git-sync.test.sh` | 0 | 16 passed, 0 failed |
| `pnpm run lint` | 0 | 10/10 tasks, 2 pre-existing warnings in untouched frontend files |
| `pnpm run type-check` | 0 | 18/18 tasks |
| `bash -n scripts/deploy/api-deploy.sh` | 0 | - |

Every new test was mutation-checked: the logic was broken one rule at a time and the suite was confirmed to go red. Three cases did **not** fail under mutation on the first pass and the tests were rewritten until they did - a nested block comment, `--` line stripping, and two-dot vs three-dot diff range. Two branches turned out to be genuinely unreachable no-ops under mutation (dollar-quote handling in the statement splitter, and `''` escape handling in the scanner) and were removed rather than left untested.

The CI gate was also exercised end to end against a real branch, not only through its unit tests:

| Case | Exit |
|---|---|
| branch with no new migrations | 0, "No new migrations in this pull request." |
| new migration with `DROP COLUMN` and no declaration | 1, hazard reported from the DDL and not from Prisma's warning header |
| same, with `-- deployed-code-survives: ok` | 1, "It needs at least 30" |
| same, with a real two-line declaration | 0, hazard still printed alongside the declaration |
| purely additive migration | 0, "additive only" |

**Aikido found two issues on `fed532dbb` and both are fixed in `b40e0bc58`, not suppressed.**

- *HIGH, and a real gate bypass:* `readDeclaration` matched the marker anywhere in the raw file, so `deployed-code-survives:` inside a string literal - data, not a promise - cleared the hazardous statement next to it. The marker now only counts as the first content of a `--` line comment. Three tests cover it, and all three go red if the anchor is loosened.
- *MEDIUM:* the classifier read a path from `argv` unconstrained. It now uses `resolveWithin` from `scripts/ci/safe-path.mjs`, the same containment `merge-coverage`, `lcov-check` and `affected-matrix` apply to paths they did not author. An escaping path fails the run rather than being skipped.

Suite after the fix: `pnpm run test:scripts` exit 0, 291/291.

## What CI has and has not exercised here

The `deploy script unit tests` job ran both shell suites on ubuntu, not only on the machine this was written on - `16 passed, 0 failed` for git-sync and `14 passed, 0 failed` for the new migration suite (run 33965330247).

**The CI gate step itself does not run on this pull request, and that is expected.** `ci.yaml` calls `_migration.yaml` only when `@yosemite-crew/database` is in the affected matrix, which is the right condition - the gate classifies migrations, and a pull request that adds one necessarily touches that workspace (#2696 adding `20260905120000_notification_archived_at` did trigger the stage). This pull request changes no migrations, so the stage is correctly skipped and the step is unexercised in CI until the first migration-carrying pull request lands after it.

What stands behind it in the meantime is the unit suite (36 tests, every one mutation-checked) and the end-to-end run above against a real branch. Worth stating rather than leaving someone to assume a green tick covered it.

**Not verified, stated plainly.** Aikido has no CLI or MCP on the machine this was written on, so the first scan was the one on this PR rather than a local pre-check. Neither half has been exercised against a live API box; `api-deploy.sh` is only reachable by an explicit `workflow_dispatch`, so the reordering is proved by reading and by `bash -n`, not by a deploy. The `deploy-script-tests` job runs both shell suites on any PR touching `scripts/deploy/**`.

The `git-sync-tests` job is renamed to `deploy-script-tests` since it now runs both suites. `dev` has no branch protection, so no required check changes name under it.

## Related Issue(s)

Fixes #2603


