### PR TITLE
fix(backend): stop confirming an IDEXX batch whose result status did not map

### DIFF
--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -178,6 +178,7 @@ type ResultOrderContext = {
   appointmentId: string | null;
   createdByUserId: string | null;
   patientId: string | null;
+  unmappedStatus: boolean;
 };
 
 const syncLabOrderFromResult = async (
@@ -188,6 +189,7 @@ const syncLabOrderFromResult = async (
     appointmentId: null,
     createdByUserId: null,
     patientId: null,
+    unmappedStatus: false,
   };
 
   const orderId = coerceString(result.orderId);
@@ -212,6 +214,15 @@ const syncLabOrderFromResult = async (
           externalStatus: coerceString(result.status),
           responsePayload: toJsonInput(result),
         },
+      });
+    } else {
+      context.unmappedStatus = true;
+      logger.warn("IDEXX result status did not map to a LabOrder status", {
+        resultId: coerceString(result.resultId),
+        orderId,
+        status: coerceString(result.status),
+        statusDetail: coerceString(result.statusDetail),
+        modality: coerceString(result.modality),
       });
     }
   }
@@ -294,6 +305,7 @@ const processIdexxResult = async (
   const resultId = coerceStringOrEmpty(result.resultId);
   await upsertLabResult(result, resultId, context.organisationId);
   await maybeCreateResultArtifacts(client, result, resultId, context);
+  return context.unmappedStatus;
 };
 
 const recordBatchSyncState = async (
@@ -345,8 +357,23 @@ export const IdexxResultsService = {
         break;
       }
 
+      let hasUnmappedResult = false;
       for (const result of results as IdexxResult[]) {
-        await processIdexxResult(client, result);
+        const unmapped = await processIdexxResult(client, result);
+        hasUnmappedResult = hasUnmappedResult || unmapped;
+      }
+
+      // Confirming tells IDEXX the batch was consumed and stops it being re-sent, so a batch
+      // we only half-applied must not be confirmed: the LabOrder status transition for the
+      // unmapped row was skipped and would be lost for good. Leave it for the next poll and
+      // stop here. Polling stays stuck on this batch until mapResultStatusToLabOrder learns
+      // the status, which is the intent - the warning above names the status to add.
+      if (hasUnmappedResult) {
+        logger.error(
+          "IDEXX batch left unconfirmed: a result status did not map to a LabOrder status",
+          { batchId },
+        );
+        break;
       }
 
       await client.confirmLatestBatch(batchId);

--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -360,7 +360,7 @@ export const IdexxResultsService = {
       let hasUnmappedResult = false;
       for (const result of results as IdexxResult[]) {
         const unmapped = await processIdexxResult(client, result);
-        hasUnmappedResult = hasUnmappedResult || unmapped;
+        hasUnmappedResult ||= unmapped;
       }
 
       // Confirming tells IDEXX the batch was consumed and stops it being re-sent, so a batch

--- a/apps/backend/test/services/idexx-results.service.test.ts
+++ b/apps/backend/test/services/idexx-results.service.test.ts
@@ -213,4 +213,97 @@ describe("IdexxResultsService", () => {
       }),
     );
   });
+
+  // Confirming the batch tells IDEXX it was consumed, so a batch whose LabOrder transition we
+  // skipped must stay unconfirmed - otherwise the transition is lost for good.
+  it("leaves a batch unconfirmed when a result status does not map", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          resultId: "result-1",
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(1, 1);
+
+    expect(mockedPrisma.labOrder.update).not.toHaveBeenCalled();
+    expect(mockConfirmLatestBatch).not.toHaveBeenCalled();
+    expect(mockedPrisma.labResultSyncState.upsert).not.toHaveBeenCalled();
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      "IDEXX result status did not map to a LabOrder status",
+      expect.objectContaining({
+        resultId: "result-1",
+        orderId: "order-1",
+        status: "REQUIRES_REVIEW",
+      }),
+    );
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      "IDEXX batch left unconfirmed: a result status did not map to a LabOrder status",
+      { batchId: "batch-1" },
+    );
+  });
+
+  // The result row itself still lands, so an unmapped status is not a lost result - but the
+  // document and task are gated on COMPLETE, and a COMPLETE status always maps, so an unmapped
+  // row never produces either.
+  it("still persists a result whose status does not map", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          resultId: "result-1",
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(1, 1);
+
+    expect(mockedPrisma.labResult.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ organisationId: "org-1" }),
+      }),
+    );
+    expect(mockedTaskService.createCustom).not.toHaveBeenCalled();
+    expect(mockedDocumentService.create).not.toHaveBeenCalled();
+  });
+
+  it("holds back a mixed batch, applying the rows that do map", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          resultId: "result-1",
+          orderId: "order-1",
+          status: "COMPLETE",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+        {
+          resultId: "result-2",
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          updatedDate: "2026-06-17T12:05:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(2, 1);
+
+    expect(mockedPrisma.labOrder.update).toHaveBeenCalledTimes(1);
+    expect(mockConfirmLatestBatch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for — item 4 of #2611.
- [x] All existing tests and lints pass.

## What is the current behavior?

`mapResultStatusToLabOrder` returns null for any IDEXX status outside its vocabulary. In
`syncLabOrderFromResult` that null had no `else` and no log, so the `LabOrder` status transition
was skipped silently. `pollLatest` then called `confirmLatestBatch(batchId)` and
`recordBatchSyncState` unconditionally, which tells IDEXX the batch was consumed — so the skipped
transition is never re-sent and is lost for good.

Two corrections to how #2611 describes this, both verified in code and by test:

- The result row is **not** dropped. `upsertLabResult` runs regardless of the mapping, so the
  `LabResult` lands and is queryable.
- But `maybeCreateResultArtifacts` returns early unless `result.status` is `COMPLETE`, and a
  `COMPLETE` status always maps. So an unmapped row produces no PDF document and no LAB_RESULTS
  task either — the result is in the database and nothing tells the clinic to look at it.

## What is the new behavior?

- An unmapped status is logged at warn with `resultId`, `orderId`, `status`, `statusDetail` and
  `modality` — the identifiers needed to extend the mapper.
- A batch containing an unmapped row is **not** confirmed. The poll loop logs an error naming the
  batch and stops, leaving the batch for the next poll to retry.

The trade-off is deliberate: a status IDEXX sends that we never map will stall polling until
`mapResultStatusToLabOrder` learns it. That is the fail-closed choice #2610 made for unknown
Stripe subscription statuses, and the warn line names the exact status to add. The alternative —
log and confirm anyway — keeps the queue flowing but keeps losing order transitions.

Three tests added to `test/services/idexx-results.service.test.ts`:

- `leaves a batch unconfirmed when a result status does not map` — asserts no `labOrder.update`,
  no `confirmLatestBatch`, no `labResultSyncState.upsert`, and both log lines.
- `still persists a result whose status does not map` — asserts `labResult.upsert` was called with
  the LabOrder's organisation, and that `TaskService.createCustom` and `DocumentService.create`
  were not.
- `holds back a mixed batch, applying the rows that do map` — one mapped row plus one unmapped:
  exactly one `labOrder.update`, and the batch still unconfirmed.

## Verification

Run at commit `504939a9a`, base `7e67c6f62`:

| Command | Result |
|---|---|
| `npx jest --testPathPatterns=idexx-results.service` | exit 0 — 6 passed |
| `npx jest` (full backend suite) | exit 0 — 465 suites, 11183 tests |
| `npx turbo run lint type-check --filter=backend` | exit 0 — 0 errors, 25 pre-existing warnings in untouched files |

Aikido and SonarQube are not runnable locally here; they are unverified until they run on this PR.

## Related Issue(s)

Addresses item 4 of #2611. Does not close it — the remaining four items each need a product
decision before any code is written, and are written up on the issue thread.
