### PR TITLE
fix(auth): enforce disabled business accounts at sign-in

### DIFF
--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -1,3 +1,25 @@
+const mockEmailPasswordInit = jest.fn((config: unknown) => ({
+  name: "emailpassword",
+  config,
+}));
+
+jest.mock("supertokens-node/recipe/emailpassword", () => ({
+  __esModule: true,
+  default: {
+    init: mockEmailPasswordInit,
+  },
+}));
+
+const mockGetUserMetadata = jest.fn();
+
+jest.mock("supertokens-node/recipe/usermetadata", () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(() => ({ name: "usermetadata" })),
+    getUserMetadata: mockGetUserMetadata,
+  },
+}));
+
 const mockPasswordlessInit = jest.fn((config: unknown) => ({
   name: "passwordless",
   config,
@@ -58,6 +80,8 @@ const restoreEnv = () => {
 describe("@yosemite-crew/auth supertokens config", () => {
   beforeEach(() => {
     jest.resetModules();
+    mockEmailPasswordInit.mockClear();
+    mockGetUserMetadata.mockReset();
     mockPasswordlessInit.mockClear();
     mockThirdPartyInit.mockClear();
     delete process.env.AUTH_APPLE_CLIENT_ID;
@@ -157,6 +181,80 @@ describe("@yosemite-crew/auth supertokens config", () => {
     expect(originalSendEmail).toHaveBeenCalledWith({
       email: "someone@example.com",
     });
+  });
+
+  it("rejects disabled email-password accounts without disclosing their state", async () => {
+    process.env.SMTP_HOST = "smtp.example.test";
+    process.env.SMTP_PORT = "465";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "smtp-user";
+    process.env.SMTP_PASSWORD = "smtp-password";
+    process.env.SMTP_FROM_NAME = "Yosemite Crew";
+    process.env.SMTP_FROM_EMAIL = "auth@example.test";
+    mockGetUserMetadata.mockResolvedValue({
+      metadata: { disabledAt: Date.now() },
+    });
+
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+    getSuperTokensConfig();
+    const emailPasswordConfig = mockEmailPasswordInit.mock.calls[0]?.[0] as any;
+    const signIn = emailPasswordConfig.override.functions({
+      signIn: jest.fn(async () => ({
+        status: "OK",
+        user: { id: "disabled-business-user" },
+      })),
+    }).signIn;
+
+    await expect(
+      signIn({
+        email: "disabled@example.test",
+        password: "correct-password",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "WRONG_CREDENTIALS_ERROR" });
+    expect(mockGetUserMetadata).toHaveBeenCalledWith("disabled-business-user");
+  });
+
+  it("keeps active and failed email-password sign-ins unchanged", async () => {
+    process.env.SMTP_HOST = "smtp.example.test";
+    process.env.SMTP_PORT = "465";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "smtp-user";
+    process.env.SMTP_PASSWORD = "smtp-password";
+    process.env.SMTP_FROM_NAME = "Yosemite Crew";
+    process.env.SMTP_FROM_EMAIL = "auth@example.test";
+    mockGetUserMetadata.mockResolvedValue({ metadata: {} });
+
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+    getSuperTokensConfig();
+    const emailPasswordConfig = mockEmailPasswordInit.mock.calls[0]?.[0] as any;
+    const originalSignIn = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "WRONG_CREDENTIALS_ERROR" })
+      .mockResolvedValueOnce({
+        status: "OK",
+        user: { id: "active-business-user" },
+      });
+    const signIn = emailPasswordConfig.override.functions({
+      signIn: originalSignIn,
+    }).signIn;
+
+    await expect(
+      signIn({
+        email: "unknown@example.test",
+        password: "wrong",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "WRONG_CREDENTIALS_ERROR" });
+    await expect(
+      signIn({
+        email: "active@example.test",
+        password: "correct",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "OK", user: { id: "active-business-user" } });
+    expect(mockGetUserMetadata).toHaveBeenCalledTimes(1);
+    expect(mockGetUserMetadata).toHaveBeenCalledWith("active-business-user");
   });
   describe("apple id_token audience selection", () => {
     const BUNDLE_ID = "com.example.mobile";

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -311,7 +311,15 @@ export function getSuperTokensConfig(): TypeInput {
               const ctx = input.userContext as MutableContext;
               ctx[CTX_LOGIN_METHOD] = 'emailpassword';
               ctx[CTX_EMAIL] = input.email;
-              return original.signIn(input);
+              const result = await original.signIn(input);
+              if (result.status !== 'OK') {
+                return result;
+              }
+
+              const { metadata } = await UserMetadata.getUserMetadata(result.user.id);
+              return typeof metadata.disabledAt === 'number'
+                ? { status: 'WRONG_CREDENTIALS_ERROR' }
+                : result;
             },
           }),
         },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The SuperAdmin panel writes its approval decisions into SuperTokens `UserMetadata` (`approvedAt`, `rejectedAt`, `disabledAt`, `rejectionDisabled`), and nothing in this repository reads them. `packages/auth` and `apps/backend` only ever consult `metadata.role`, so a rejected or disabled business account has its live sessions revoked by the panel and can then simply sign in again. The panel's copy - "rejecting disables the account and signs it out everywhere" - is true only for the panel's own login, which does check `disabledAt` in its own backend config.

## What is the new behavior?

The `emailpassword` `signIn` override reads the user's metadata after a successful credential check and returns `WRONG_CREDENTIALS_ERROR` when `disabledAt` is a number.

Three properties worth being explicit about:

- **The refusal is generic.** A disabled account gets the same answer as a wrong password, so the response does not disclose that the address exists or that it was disabled.
- **It runs only after `status === 'OK'`.** A failed credential check returns before the metadata lookup, so a wrong password costs no extra round trip and cannot be used to probe account state.
- **Passwordless and social are untouched.** Pet parents never go through approval, and gating them was explicitly out of scope in the issue.

## Scope - this does not close the issue

#2646 has three parts and this addresses one of them. **Do not close it on merge.**

- Fixed: a *disabled* account can no longer sign in again after the panel revokes its sessions.
- Not fixed: a **Pending** business account can still sign in and use the product as if approved. The issue leaves `approvedAt` explicitly as a product decision - either approval gates access, in which case the same hook is the place for it, or the panel copy should say the queue is informational. That decision has not been made.
- **Worth a check by someone with panel access:** the issue states `disabledAt` "covers both manual disable and rejection", and this guard keys on `disabledAt` alone. If a rejection in the panel writes only `rejectedAt` or `rejectionDisabled` without also setting `disabledAt`, rejected accounts still sign in and this PR would not show it. Nothing in this repository can confirm which keys the panel writes.

For the same reason, `grep disabledAt` in this repo finds only unrelated Prisma columns on `integration.service.ts`. The writer is the external panel; the guard is not reading a key nobody sets.

## Verification

Run at `e0386953d`:

| Command | Exit | Result |
|---|---|---|
| `pnpm --filter backend exec jest --testPathPatterns=supertokens.config` | 0 | 1 suite, 21 tests passed |
| `npx jest` (full backend) | 0 | 465 suites, 11182 tests passed |
| `pnpm --filter @yosemite-crew/auth run type-check` | 0 | - |
| pre-push hook (monorepo lint + type-check) | 0 | - |

Both new tests were mutation-checked. Removing the disabled check fails 2 of 21; removing the `status !== 'OK'` early return fails 1 of 21. Restored, 21/21.

**One thing about that full-suite number, because the first run said otherwise.** The initial run reported 86 failed suites and 55 failed tests, exit 1, on `zod_1.z.uuid is not a function` - the worktree had zod 3.25.76 installed while the repo pins 4.5.4 through a pnpm override. The failures were an environment fault, not this change. After `CI=1 pnpm install --frozen-lockfile --config.confirmModulesPurge=false` and a Prisma client regeneration the suite is 465/465. The focused suite passed in both states, which is precisely why it was not enough on its own.

**Not verified, stated plainly.** Aikido has no CLI or MCP on this machine, so the first scan is the one on this PR. Nothing here was exercised against a live SuperTokens instance or the SuperAdmin panel; the sign-in override is proved by unit tests against a mocked recipe, not by a real disabled account being refused.

## Related Issue(s)

Related to #2646
