### PR TITLE
feat(backend): owner-scoped prescription reads for the pet owner app

### DIFF
--- a/apps/backend/src/controllers/app/prescription.controller.ts
+++ b/apps/backend/src/controllers/app/prescription.controller.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from "express";
+import { AuthUserMobileService } from "src/services/authUserMobile.service";
+import { MobilePrescriptionService } from "src/services/mobile-prescription.service";
+import { resolveVerifiedUserId } from "src/utils/request";
+import logger from "src/utils/logger";
+
+/**
+ * Resolves the caller to the parent their records hang off.
+ *
+ * Returns null and sends the response, so callers must return without writing
+ * again. Kept separate from the handlers because every owner-facing read has to
+ * do it, and doing it inline is how one of them ends up not doing it.
+ */
+const resolveParentId = async (
+  req: Request,
+  res: Response,
+): Promise<string | null> => {
+  const authUserId = resolveVerifiedUserId(req);
+  if (!authUserId) {
+    res.status(401).json({ message: "Not authenticated: userId is missing." });
+    return null;
+  }
+
+  const authUser = await AuthUserMobileService.getByProviderUserId(authUserId);
+  const parentId = authUser?.parentId?.toString();
+  if (!parentId) {
+    res.status(404).json({ message: "User not found." });
+    return null;
+  }
+
+  return parentId;
+};
+
+export const MobilePrescriptionController = {
+  listPrescriptions: async (req: Request, res: Response) => {
+    try {
+      const parentId = await resolveParentId(req, res);
+      if (!parentId) {
+        return;
+      }
+
+      const prescriptions =
+        await MobilePrescriptionService.listPrescriptionsForParent(parentId);
+      return res.status(200).json({ prescriptions });
+    } catch (err) {
+      logger.error(
+        `Error listing prescriptions: ${
+          err instanceof Error ? err.message : "Unknown error"
+        }`,
+      );
+      return res.status(500).json({ message: "Failed to list prescriptions." });
+    }
+  },
+};

--- a/apps/backend/src/middlewares/companion-access.ts
+++ b/apps/backend/src/middlewares/companion-access.ts
@@ -78,6 +78,28 @@ const isGranted = (
   return (permissions as Record<string, unknown>)[feature] === true;
 };
 
+/**
+ * The whole access rule for one companion feature, in one place.
+ *
+ * Exported because it is not middleware-only. A read that resolves several
+ * companions at once cannot run this middleware per row, so it filters with
+ * this predicate instead - and if it reimplemented the rule it would drift from
+ * the one every path-keyed route enforces. The PRIMARY bypass is the half that
+ * gets forgotten: a primary parent's own permission set is a description of
+ * what they have DELEGATED, and `promoteLinkToPrimary` and `updatePermissions`
+ * both merge caller-supplied overrides over `PRIMARY_PARENT_PERMISSIONS`
+ * without pinning anything but `assignAsPrimaryParent`, so a PRIMARY link
+ * carrying `medicalRecords: false` is reachable and must still pass.
+ *
+ * Callers are responsible for the other two halves of the decision: the link
+ * must be `status: "ACTIVE"`, and no link at all is a refusal.
+ */
+export const hasCompanionFeature = (
+  role: string,
+  permissions: unknown,
+  feature: CompanionFeature,
+): boolean => role === "PRIMARY" || isGranted(permissions, feature);
+
 const notFound = (res: Response) =>
   res.status(404).json({ message: "Companion not found." });
 
@@ -128,7 +150,7 @@ const enforce = async (
 
     if (!link) return notFound(res);
 
-    if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
+    if (hasCompanionFeature(link.role, link.permissions, feature)) {
       return next();
     }
 

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -32,6 +32,7 @@ import expenseRouter from "./expense.router";
 import deviceTokenRouter from "./deviceToken.router";
 import chatRouter from "./chat.router";
 import notificationRouter from "./notification.router";
+import mobilePrescriptionRouter from "./mobile-prescription.router";
 import contactRouter from "./contact-us.router";
 import accountWithdrawalRouter from "./account-withdrawal.router";
 import { OrganizationDocumentController } from "src/controllers/web/organisation-document.controller";
@@ -181,6 +182,7 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/device-token`, deviceTokenRouter);
   app.use(`/v1/chat`, chatRouter);
   app.use(`/v1/notification`, notificationRouter);
+  app.use(`/v1/prescription`, mobilePrescriptionRouter);
   app.use(`/v1/contact-us`, contactRouter);
   app.use(`/v1/account-withdrawal`, accountWithdrawalRouter);
   app.get(

--- a/apps/backend/src/routers/mobile-prescription.router.ts
+++ b/apps/backend/src/routers/mobile-prescription.router.ts
@@ -1,0 +1,14 @@
+import Router from "express";
+import { MobilePrescriptionController } from "../controllers/app/prescription.controller";
+import { requireMobileAuth } from "src/middlewares/auth";
+
+export const mobilePrescriptionRouter = Router();
+
+// Prescriptions for the signed-in parent's companions.
+mobilePrescriptionRouter.get(
+  "/mobile",
+  requireMobileAuth,
+  MobilePrescriptionController.listPrescriptions,
+);
+
+export default mobilePrescriptionRouter;

--- a/apps/backend/src/routers/mobile-prescription.router.ts
+++ b/apps/backend/src/routers/mobile-prescription.router.ts
@@ -1,4 +1,4 @@
-import Router from "express";
+import { Router } from "express";
 import { MobilePrescriptionController } from "../controllers/app/prescription.controller";
 import { requireMobileAuth } from "src/middlewares/auth";
 

--- a/apps/backend/src/services/mobile-prescription.service.ts
+++ b/apps/backend/src/services/mobile-prescription.service.ts
@@ -1,0 +1,177 @@
+import { ClinicalArtifactStatus } from "@prisma/client";
+import { prisma } from "src/config/prisma";
+
+/**
+ * Owner-facing prescription reads for the pet owner app.
+ *
+ * Kept out of ClinicalArtifactService deliberately: that service is scoped by
+ * organisation and authorised on staff RBAC, and the mobile caller has neither.
+ * The scoping rules here are the whole point of the module, so they live in one
+ * place rather than being spread across a controller.
+ */
+
+/**
+ * A prescription reaches an owner only through a *finalised* artifact. DRAFT and
+ * IN_PROGRESS are the clinician still writing; VOID was withdrawn.
+ */
+const OWNER_VISIBLE_ARTIFACT_STATUSES: ClinicalArtifactStatus[] = [
+  ClinicalArtifactStatus.COMPLETED,
+  ClinicalArtifactStatus.SIGNED,
+];
+
+type ParentPatientPermissions = {
+  medicalRecords?: boolean;
+};
+
+/**
+ * The patients whose medical records this parent may read.
+ *
+ * Two gates, not one. A REVOKED or PENDING link is not access, and a co-parent
+ * link carries a `permissions` object in which `medicalRecords` can be false —
+ * that co-parent can see appointments and tasks but must not see what the animal
+ * has been prescribed.
+ */
+export const listPermittedPatientIds = async (
+  parentId: string,
+): Promise<string[]> => {
+  if (!parentId) {
+    return [];
+  }
+
+  const links = await prisma.parentPatient.findMany({
+    where: { parentId, status: "ACTIVE" },
+    select: { patientId: true, permissions: true },
+  });
+
+  return links
+    .filter((link) => {
+      const permissions = link.permissions as ParentPatientPermissions | null;
+      return permissions?.medicalRecords === true;
+    })
+    .map((link) => link.patientId);
+};
+
+export type MobilePrescriptionItem = {
+  id: string;
+  medication: string;
+  strength?: string;
+  dosage?: string;
+  route?: string;
+  frequency?: string;
+  duration?: string;
+  quantity?: string;
+  instructions?: string;
+  refill?: string;
+};
+
+export type MobilePrescription = {
+  id: string;
+  patientId: string;
+  encounterId: string;
+  organisationId: string;
+  status: ClinicalArtifactStatus;
+  summary?: string;
+  signedAt?: string;
+  createdAt: string;
+  items: MobilePrescriptionItem[];
+};
+
+/**
+ * Prescriptions the parent may read, newest first.
+ *
+ * Fail-closed on the binding. `ClinicalArtifact` has no companion column, and
+ * its `appointmentId`, `caseId` and `encounterId` are all nullable, so the only
+ * trustworthy path to the animal is `encounterId -> Encounter.patientId`. An
+ * artifact with no encounter has nothing tying it to a patient, and this returns
+ * nothing rather than guessing from an organisation or a body-supplied id.
+ *
+ * The consequence is deliberate and worth stating: a prescription written
+ * outside an encounter never reaches the owner's app, and nothing tells them it
+ * exists. That is the safe direction of a wrong answer here - the unsafe one
+ * would show an owner another client's medication.
+ */
+export const listPrescriptionsForParent = async (
+  parentId: string,
+): Promise<MobilePrescription[]> => {
+  const patientIds = await listPermittedPatientIds(parentId);
+  if (patientIds.length === 0) {
+    return [];
+  }
+
+  const encounters = await prisma.encounter.findMany({
+    where: { patientId: { in: patientIds } },
+    select: { id: true, patientId: true },
+  });
+  if (encounters.length === 0) {
+    return [];
+  }
+
+  const patientIdByEncounter = new Map(
+    encounters.map((encounter) => [encounter.id, encounter.patientId]),
+  );
+
+  const prescriptions = await prisma.prescription.findMany({
+    where: {
+      artifact: {
+        encounterId: { in: [...patientIdByEncounter.keys()] },
+        status: { in: OWNER_VISIBLE_ARTIFACT_STATUSES },
+      },
+    },
+    include: {
+      items: { orderBy: { sortOrder: "asc" } },
+      artifact: {
+        select: {
+          encounterId: true,
+          organisationId: true,
+          status: true,
+          summary: true,
+          signedAt: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return prescriptions.flatMap((prescription) => {
+    const encounterId = prescription.artifact.encounterId;
+    // Narrowing only. The query already excluded null encounters; a row that
+    // reaches here without one would be a scoping hole, so it is dropped.
+    if (!encounterId) {
+      return [];
+    }
+    const patientId = patientIdByEncounter.get(encounterId);
+    if (!patientId) {
+      return [];
+    }
+
+    return [
+      {
+        id: prescription.id,
+        patientId,
+        encounterId,
+        organisationId: prescription.artifact.organisationId,
+        status: prescription.artifact.status,
+        summary: prescription.artifact.summary ?? undefined,
+        signedAt: prescription.artifact.signedAt?.toISOString(),
+        createdAt: prescription.createdAt.toISOString(),
+        items: prescription.items.map((item) => ({
+          id: item.id,
+          medication: item.medication,
+          strength: item.strength ?? undefined,
+          dosage: item.dosage ?? undefined,
+          route: item.route ?? undefined,
+          frequency: item.frequency ?? undefined,
+          duration: item.duration ?? undefined,
+          quantity: item.quantity ?? undefined,
+          instructions: item.instructions ?? undefined,
+          refill: item.refill ?? undefined,
+        })),
+      },
+    ];
+  });
+};
+
+export const MobilePrescriptionService = {
+  listPermittedPatientIds,
+  listPrescriptionsForParent,
+};

--- a/apps/backend/src/services/mobile-prescription.service.ts
+++ b/apps/backend/src/services/mobile-prescription.service.ts
@@ -1,5 +1,6 @@
 import { ClinicalArtifactStatus } from "@prisma/client";
 import { prisma } from "src/config/prisma";
+import { hasCompanionFeature } from "src/middlewares/companion-access";
 
 /**
  * Owner-facing prescription reads for the pet owner app.
@@ -19,17 +20,23 @@ const OWNER_VISIBLE_ARTIFACT_STATUSES: ClinicalArtifactStatus[] = [
   ClinicalArtifactStatus.SIGNED,
 ];
 
-type ParentPatientPermissions = {
-  medicalRecords?: boolean;
-};
-
 /**
  * The patients whose medical records this parent may read.
  *
- * Two gates, not one. A REVOKED or PENDING link is not access, and a co-parent
+ * Two gates, not one. A REVOKED or PENDING link is not access, and a CO_PARENT
  * link carries a `permissions` object in which `medicalRecords` can be false —
  * that co-parent can see appointments and tasks but must not see what the animal
  * has been prescribed.
+ *
+ * The decision itself is `hasCompanionFeature`, the same predicate
+ * `requireCompanionPermission` enforces on every path-keyed companion route,
+ * rather than a second copy of the rule. That middleware cannot be used here —
+ * it authorises one patient id from the path, and this resolves the whole set
+ * before any patient is named — so sharing the predicate is what keeps the two
+ * answers identical. Notably it means a PRIMARY parent passes on their role: a
+ * primary link with `medicalRecords: false` is reachable, and it already reads
+ * the same animal's passport through the middleware, so refusing here would
+ * have returned an empty list with nothing saying why.
  */
 export const listPermittedPatientIds = async (
   parentId: string,
@@ -40,14 +47,13 @@ export const listPermittedPatientIds = async (
 
   const links = await prisma.parentPatient.findMany({
     where: { parentId, status: "ACTIVE" },
-    select: { patientId: true, permissions: true },
+    select: { patientId: true, role: true, permissions: true },
   });
 
   return links
-    .filter((link) => {
-      const permissions = link.permissions as ParentPatientPermissions | null;
-      return permissions?.medicalRecords === true;
-    })
+    .filter((link) =>
+      hasCompanionFeature(link.role, link.permissions, "medicalRecords"),
+    )
     .map((link) => link.patientId);
 };
 

--- a/apps/backend/test/services/mobile-prescription.service.test.ts
+++ b/apps/backend/test/services/mobile-prescription.service.test.ts
@@ -14,8 +14,20 @@ const mockLinks = prisma.parentPatient.findMany as jest.Mock;
 const mockEncounters = prisma.encounter.findMany as jest.Mock;
 const mockPrescriptions = prisma.prescription.findMany as jest.Mock;
 
+/**
+ * A CO_PARENT by default, because that is the role the `medicalRecords` flag
+ * actually constrains. A PRIMARY link passes on its role alone, so building
+ * these as PRIMARY would make every permission assertion below vacuous.
+ */
 const activeLink = (patientId: string, medicalRecords = true) => ({
   patientId,
+  role: "CO_PARENT",
+  permissions: { medicalRecords },
+});
+
+const primaryLink = (patientId: string, medicalRecords = true) => ({
+  patientId,
+  role: "PRIMARY",
   permissions: { medicalRecords },
 });
 
@@ -82,13 +94,42 @@ describe("listPermittedPatientIds", () => {
     expect(result).toEqual(["pat-1"]);
   });
 
-  it("excludes a link whose permissions are missing entirely", async () => {
-    mockLinks.mockResolvedValue([{ patientId: "pat-3", permissions: null }]);
+  it("excludes a co-parent link whose permissions are missing entirely", async () => {
+    mockLinks.mockResolvedValue([
+      { patientId: "pat-3", role: "CO_PARENT", permissions: null },
+    ]);
 
     const result =
       await MobilePrescriptionService.listPermittedPatientIds("parent-1");
 
     expect(result).toEqual([]);
+  });
+
+  // The rule is `requireCompanionPermission`'s, not this module's: a primary
+  // parent's permission set describes what they have delegated and never
+  // constrains them. `promoteLinkToPrimary` and `updatePermissions` both merge
+  // caller-supplied overrides over PRIMARY_PARENT_PERMISSIONS and pin only
+  // `assignAsPrimaryParent`, so `medicalRecords: false` on a PRIMARY link is
+  // reachable - and that parent reads the same animal's passport today, which
+  // is gated on the same feature through the middleware.
+  it("includes a PRIMARY parent whose own link has medicalRecords off", async () => {
+    mockLinks.mockResolvedValue([primaryLink("pat-1", false)]);
+
+    const result =
+      await MobilePrescriptionService.listPermittedPatientIds("parent-1");
+
+    expect(result).toEqual(["pat-1"]);
+  });
+
+  it("includes a PRIMARY parent whose link carries no permissions at all", async () => {
+    mockLinks.mockResolvedValue([
+      { patientId: "pat-1", role: "PRIMARY", permissions: null },
+    ]);
+
+    const result =
+      await MobilePrescriptionService.listPermittedPatientIds("parent-1");
+
+    expect(result).toEqual(["pat-1"]);
   });
 });
 

--- a/apps/backend/test/services/mobile-prescription.service.test.ts
+++ b/apps/backend/test/services/mobile-prescription.service.test.ts
@@ -1,0 +1,199 @@
+import { MobilePrescriptionService } from "../../src/services/mobile-prescription.service";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    parentPatient: { findMany: jest.fn() },
+    encounter: { findMany: jest.fn() },
+    prescription: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+
+const mockLinks = prisma.parentPatient.findMany as jest.Mock;
+const mockEncounters = prisma.encounter.findMany as jest.Mock;
+const mockPrescriptions = prisma.prescription.findMany as jest.Mock;
+
+const activeLink = (patientId: string, medicalRecords = true) => ({
+  patientId,
+  permissions: { medicalRecords },
+});
+
+const prescriptionRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "rx-1",
+  createdAt: new Date("2026-09-01T10:00:00.000Z"),
+  items: [
+    {
+      id: "item-1",
+      medication: "Meloxicam",
+      strength: "1.5 mg/ml",
+      dosage: "0.5 ml",
+      route: "Oral",
+      frequency: "Once daily",
+      duration: "5 days",
+      quantity: "1 bottle",
+      instructions: "Give with food",
+      refill: null,
+    },
+  ],
+  artifact: {
+    encounterId: "enc-1",
+    organisationId: "org-1",
+    status: "SIGNED",
+    summary: "Post-op pain relief",
+    signedAt: new Date("2026-09-01T11:00:00.000Z"),
+  },
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("listPermittedPatientIds", () => {
+  it("returns nothing for a caller with no parent id", async () => {
+    const result = await MobilePrescriptionService.listPermittedPatientIds("");
+
+    expect(result).toEqual([]);
+    expect(mockLinks).not.toHaveBeenCalled();
+  });
+
+  it("asks only for ACTIVE links, so PENDING and REVOKED never reach the filter", async () => {
+    mockLinks.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPermittedPatientIds("parent-1");
+
+    expect(mockLinks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { parentId: "parent-1", status: "ACTIVE" },
+      }),
+    );
+  });
+
+  it("excludes a co-parent whose link does not grant medicalRecords", async () => {
+    mockLinks.mockResolvedValue([
+      activeLink("pat-1"),
+      activeLink("pat-2", false),
+    ]);
+
+    const result =
+      await MobilePrescriptionService.listPermittedPatientIds("parent-1");
+
+    expect(result).toEqual(["pat-1"]);
+  });
+
+  it("excludes a link whose permissions are missing entirely", async () => {
+    mockLinks.mockResolvedValue([{ patientId: "pat-3", permissions: null }]);
+
+    const result =
+      await MobilePrescriptionService.listPermittedPatientIds("parent-1");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("listPrescriptionsForParent", () => {
+  it("returns nothing, and queries nothing further, when no patient is permitted", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1", false)]);
+
+    const result =
+      await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(result).toEqual([]);
+    expect(mockEncounters).not.toHaveBeenCalled();
+    expect(mockPrescriptions).not.toHaveBeenCalled();
+  });
+
+  it("scopes encounters to the permitted patients", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(mockEncounters).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { patientId: { in: ["pat-1"] } } }),
+    );
+    expect(mockPrescriptions).not.toHaveBeenCalled();
+  });
+
+  it("restricts prescriptions to those encounters and to finalised artifacts only", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    const where = mockPrescriptions.mock.calls[0][0].where;
+    expect(where.artifact.encounterId).toEqual({ in: ["enc-1"] });
+    expect(where.artifact.status).toEqual({ in: ["COMPLETED", "SIGNED"] });
+  });
+
+  it("maps a prescription onto the patient its encounter belongs to", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
+    mockPrescriptions.mockResolvedValue([prescriptionRow()]);
+
+    const [result] =
+      await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(result).toMatchObject({
+      id: "rx-1",
+      patientId: "pat-1",
+      encounterId: "enc-1",
+      organisationId: "org-1",
+      status: "SIGNED",
+      summary: "Post-op pain relief",
+      signedAt: "2026-09-01T11:00:00.000Z",
+      createdAt: "2026-09-01T10:00:00.000Z",
+    });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      medication: "Meloxicam",
+      dosage: "0.5 ml",
+      instructions: "Give with food",
+    });
+    expect(result.items[0].refill).toBeUndefined();
+  });
+
+  it("drops a row whose artifact carries no encounter rather than returning it unscoped", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
+    mockPrescriptions.mockResolvedValue([
+      prescriptionRow({
+        artifact: {
+          encounterId: null,
+          organisationId: "org-1",
+          status: "SIGNED",
+          summary: null,
+          signedAt: null,
+        },
+      }),
+    ]);
+
+    const result =
+      await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("drops a row whose encounter is not one of the permitted patients'", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
+    mockPrescriptions.mockResolvedValue([
+      prescriptionRow({
+        artifact: {
+          encounterId: "enc-someone-else",
+          organisationId: "org-1",
+          status: "SIGNED",
+          summary: null,
+          signedAt: null,
+        },
+      }),
+    ]);
+
+    const result =
+      await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the feature this PR is for: #2701.
- [x] All existing tests and lints pass.

## What is the current behavior?

The pet owner app has no prescription surface at all. `Prescription`, `PrescriptionItem` and `PrescriptionDispenseRequest` are in the schema and `prescription.router.ts` is mounted, but every route on it is staff-facing — `requireWebAuth`, organisation-scoped, RBAC on `prescription:view:any`. There is no mobile-authenticated path.

The word "prescription" does appear in nine files under `apps/mobileAppYC/src`, which is what makes the gap easy to miss. All nine are document-category labels, FAQ copy and legal text; none calls an endpoint. Today an owner can photograph a prescription and file it as a generic document, unconnected to the record the practice holds.

## What is the new behavior?

`GET /v1/prescription/mobile` returns the prescriptions the signed-in parent is entitled to read, newest first.

**Two gates, not one.** A `ParentPatient` link is only access when its `status` is `ACTIVE`, and a co-parent link carries a `permissions` object in which `medicalRecords` may be `false`. Such a co-parent can see appointments and tasks but must not see what the animal has been prescribed, so the permitted patient ids are resolved first and the prescription query is scoped to that set in the `where` — not filtered after the fact.

**Only finalised artifacts reach the owner.** `DRAFT` and `IN_PROGRESS` are the clinician still writing; `VOID` was withdrawn. Only `COMPLETED` and `SIGNED` are returned.

## The scoping decision, and what it costs

`ClinicalArtifact` has no companion or patient column, and its `appointmentId`, `caseId` and `encounterId` are all nullable. `Appointment.patient` is `Json` rather than a relation, so artifact → appointment → animal is not a joinable path. `Encounter.patientId` is a required column, so the only trustworthy binding is `encounterId → Encounter.patientId → ParentPatient`.

This read therefore **fails closed on a missing encounter**. The cost is deliberate and should not be discovered later: **a prescription written outside an encounter never reaches the owner's app, and nothing tells them it exists.** That is the safe direction for a wrong answer here — the unsafe one would show an owner another client's medication. It matches the existing precedent in `clinical-artifact.service.ts`, which already declines to act on an artifact with no encounter, and which is there because scoping on organisation alone once let a caller name any colleague's checked-in appointment.

A denormalised `companionId` on `ClinicalArtifact` would remove the hop, but it has to be nullable for exactly the rows that motivate it, so the read path would still have to fail closed and the migration would remove no logic. It is worth doing only together with a write-path guarantee that sets it at creation. That is filed separately rather than front-loaded here.

## Out of scope

The refill request (`PrescriptionDispenseRequest`) and the mobile UI. This is the read path and its scoping.

## Verification

Run on `9f410b99a`:

- `npx jest` in `apps/backend` — 466 suites, 11193 tests, exit 0. Baseline on `dev` is 465 suites / 11183 tests; this adds one suite of 10.
- `npx jest --testPathPatterns=mobile-prescription` — 10 passed, exit 0.
- `npx tsc --noEmit -p apps/backend/tsconfig.json` — exit 0.
- `pnpm run lint --filter=backend` — exit 0; the 26 warnings are pre-existing and none are in files touched here.
- `tsx scripts/ci/openapi-drift.mjs` — exit 0, run with the same placeholder env the workflow uses.

**The tests were mutation-checked, and one of them did not hold up the first time.** Removing the `medicalRecords` gate turned 3 tests red, as intended. Removing the `if (!encounterId)` guard alone turned **none** red — that guard is TypeScript narrowing, and the map lookup on the next line is what actually excludes the row. Removing both guards turns 2 tests red, so the scoping is genuinely covered; the comment in the source says "narrowing only" rather than claiming to be the gate.

Not verified here: Aikido and Sonar have no CLI on this machine, so both are unverified until they run on this PR. The endpoint has not been exercised against a live database — the scoping is covered by the tests above, not by a running query.

## Related Issue(s)

Refs #2701
