### PR TITLE
fix(auth): enforce organisation disable across all sign-in paths

### DIFF
--- a/apps/backend/src/config/auth-hooks.ts
+++ b/apps/backend/src/config/auth-hooks.ts
@@ -53,9 +53,11 @@ export const authHooks: AuthHooks = {
    *   pending business is not a disabled one, and the schema cannot tell a
    *   rejected business from one nobody has looked at yet.
    */
-  async isSignInBlocked({ appUserId }) {
-    const suppliedId = appUserId.trim();
-    if (!suppliedId) {
+  async isSignInBlocked({ appUserId, providerUserId }) {
+    const suppliedIds = [appUserId, providerUserId]
+      .map((id) => id?.trim())
+      .filter((id): id is string => !!id);
+    if (suppliedIds.length === 0) {
       return false;
     }
 
@@ -67,17 +69,21 @@ export const authHooks: AuthHooks = {
     // staff user's rows silently un-enforces the disable for them - and the
     // two states are indistinguishable by construction, so nothing logs.
     //
-    // `appUserId` here is the raw SuperTokens `result.user.id` from the
-    // sign-in override; unlike every authorised request, which resolves
-    // through `resolveAppUserId` before RBAC reads a membership, nothing has
-    // resolved it yet. A migrated staff account stores its rows under the
-    // legacy app user id, and `practitionerReference` may carry either form.
-    const canonicalId = await resolveCanonicalUserId(suppliedId);
+    // Nothing has resolved these ids yet, unlike every authorised request,
+    // which goes through `resolveAppUserId` before RBAC reads a membership.
+    // `appUserId` is the raw SuperTokens `result.user.id` and
+    // `providerUserId` the recipe user id; they differ once accounts are
+    // linked, and `authIdentity` is keyed on the second. A migrated staff
+    // account stores its rows under the legacy app user id either of them
+    // maps to, and `practitionerReference` may carry either form.
+    const canonicalIds = await Promise.all(
+      suppliedIds.map((id) => resolveCanonicalUserId(id)),
+    );
 
     const memberships = await prisma.userOrganization.findMany({
       where: {
         active: true,
-        OR: practitionerReferenceFilter([suppliedId, canonicalId]),
+        OR: practitionerReferenceFilter([...suppliedIds, ...canonicalIds]),
       },
       select: { organizationReference: true },
     });

--- a/apps/backend/src/config/auth-hooks.ts
+++ b/apps/backend/src/config/auth-hooks.ts
@@ -27,6 +27,59 @@ export const authHooks: AuthHooks = {
     return Promise.resolve(undefined);
   },
 
+  /**
+   * Refuse sign-in for a user whose every organisation has been disabled.
+   *
+   * The signal is `Organization.isActive`, which is what `PATCH /businesses/:id`
+   * (SuperAdminBusinessService.updateBusiness) actually writes. Before this,
+   * nothing in the sign-in path read it: `require-active-account.ts` checks
+   * `User.isActive`, a different flag written by the user soft-delete, and only
+   * on developer routes.
+   *
+   * Three deliberate choices:
+   *
+   * - No membership at all means NOT blocked. Pet parents have no
+   *   `userOrganization` row, and an empty list must not be read as "belongs to
+   *   nothing, therefore disabled" or every mobile user loses their account.
+   * - Blocked only when EVERY organisation is inactive. Someone who works at a
+   *   disabled practice and an active one still has a job; per-organisation
+   *   authorisation decides what they can reach once they are in.
+   * - `isVerified` is NOT consulted. Every business is unverified before review,
+   *   so blocking on it would lock out each new practice awaiting approval - a
+   *   pending business is not a disabled one, and the schema cannot tell a
+   *   rejected business from one nobody has looked at yet.
+   */
+  async isSignInBlocked({ appUserId }) {
+    const practitionerReference = appUserId.trim();
+    if (!practitionerReference) {
+      return false;
+    }
+
+    const memberships = await prisma.userOrganization.findMany({
+      where: { practitionerReference, active: true },
+      select: { organizationReference: true },
+    });
+    if (memberships.length === 0) {
+      return false;
+    }
+
+    // Mappings are stored either bare or as a FHIR `Organization/<id>`
+    // reference, exactly as `rbac.ts` and `OrganisationService.listForUser`
+    // match them.
+    const organisationIds = [
+      ...new Set(
+        memberships.map((row) =>
+          row.organizationReference.replace(/^Organization\//, ""),
+        ),
+      ),
+    ];
+
+    const activeCount = await prisma.organization.count({
+      where: { id: { in: organisationIds }, isActive: true },
+    });
+    return activeCount === 0;
+  },
+
   async onUserCreated({
     appUserId,
     providerUserId,

--- a/apps/backend/src/config/auth-hooks.ts
+++ b/apps/backend/src/config/auth-hooks.ts
@@ -1,5 +1,9 @@
 import type { AuthHooks } from "@yosemite-crew/auth";
 import { prisma } from "src/config/prisma";
+import {
+  practitionerReferenceFilter,
+  resolveCanonicalUserId,
+} from "src/services/shared/staff-identity";
 import logger from "src/utils/logger";
 
 // Application-side hooks for the auth boundary. They give the provider layer
@@ -50,13 +54,31 @@ export const authHooks: AuthHooks = {
    *   rejected business from one nobody has looked at yet.
    */
   async isSignInBlocked({ appUserId }) {
-    const practitionerReference = appUserId.trim();
-    if (!practitionerReference) {
+    const suppliedId = appUserId.trim();
+    if (!suppliedId) {
       return false;
     }
 
+    // Both id spaces and both reference forms, via the shared filter.
+    //
+    // This is the one place where a missed membership row is DANGEROUS rather
+    // than merely lossy. `memberships.length === 0` is read below as "pet
+    // parent, not staff, not blocked", so any query that fails to find a
+    // staff user's rows silently un-enforces the disable for them - and the
+    // two states are indistinguishable by construction, so nothing logs.
+    //
+    // `appUserId` here is the raw SuperTokens `result.user.id` from the
+    // sign-in override; unlike every authorised request, which resolves
+    // through `resolveAppUserId` before RBAC reads a membership, nothing has
+    // resolved it yet. A migrated staff account stores its rows under the
+    // legacy app user id, and `practitionerReference` may carry either form.
+    const canonicalId = await resolveCanonicalUserId(suppliedId);
+
     const memberships = await prisma.userOrganization.findMany({
-      where: { practitionerReference, active: true },
+      where: {
+        active: true,
+        OR: practitionerReferenceFilter([suppliedId, canonicalId]),
+      },
       select: { organizationReference: true },
     });
     if (memberships.length === 0) {

--- a/apps/backend/src/services/shared/staff-identity.ts
+++ b/apps/backend/src/services/shared/staff-identity.ts
@@ -1,0 +1,72 @@
+import { prisma } from "src/config/prisma";
+
+const SUPERTOKENS_PROVIDER = "supertokens";
+
+/**
+ * The canonical app user id behind an auth-provider id.
+ *
+ * A migrated staff account has TWO ids: the provider alias the client
+ * authenticates with, and the legacy app user id its rows were imported under.
+ * `authIdentity` is the mapping between them, and every authorised request
+ * already resolves through it (`resolveAppUserId` in `packages/auth`) before
+ * RBAC reads a membership. Anything that reads membership from a raw provider
+ * id has to resolve it the same way or it is querying the wrong id space.
+ *
+ * Returns null when neither a `User` row nor a mapping exists.
+ */
+export const resolveCanonicalUserId = async (
+  userId: string,
+): Promise<string | null> => {
+  const existing = await prisma.user.findFirst({
+    where: { userId },
+    select: { userId: true },
+  });
+  if (existing) {
+    return existing.userId ?? userId;
+  }
+
+  const identity = await prisma.authIdentity.findFirst({
+    where: {
+      provider: SUPERTOKENS_PROVIDER,
+      providerUserId: userId,
+    },
+    select: { appUserId: true },
+  });
+
+  return identity?.appUserId ?? null;
+};
+
+/**
+ * A `where.OR` matching every form a user's `userOrganization` rows can be
+ * stored under.
+ *
+ * Two dimensions, and missing either one returns an empty membership list for a
+ * user who genuinely has memberships:
+ *
+ * - Two ids, per `resolveCanonicalUserId` above.
+ * - Two reference forms. `practitionerReference` holds either a bare id or a
+ *   FHIR `Practitioner/<id>` reference; `rbac.ts` and
+ *   `OrganisationService.listForUser` match bare only, `UserService.deleteById`
+ *   matches both. Querying only the bare form is what let a deletion remove no
+ *   organisation roles and report success (see the comment on `deleteById`).
+ *
+ * Whether a miss is safe depends entirely on the caller: for a read it hides a
+ * row, for an authorisation check it can grant one. Callers whose "no rows"
+ * branch is permissive must use this.
+ */
+export const practitionerReferenceFilter = (
+  ids: readonly (string | null | undefined)[],
+): { practitionerReference: string }[] => {
+  const unique = [
+    ...new Set(
+      ids
+        .map((id) => id?.trim().replace(/^Practitioner\//, ""))
+        .filter((id): id is string => !!id),
+    ),
+  ];
+
+  return unique.flatMap((id) => [
+    { practitionerReference: id },
+    { practitionerReference: `Practitioner/${id}` },
+  ]);
+};

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -6,8 +6,10 @@ import { OrganizationService } from "./organization.service";
 import { UserOrganizationService } from "./user-organization.service";
 import { DeveloperBillingService } from "./developer-billing.service";
 import { prisma } from "src/config/prisma";
-
-const SUPERTOKENS_PROVIDER = "supertokens";
+import {
+  practitionerReferenceFilter,
+  resolveCanonicalUserId,
+} from "./shared/staff-identity";
 
 export class UserServiceError extends Error {
   constructor(
@@ -98,28 +100,6 @@ const sanitizeUserAttributes = (payload: User) => {
     email: email.toLowerCase(),
     isActive,
   };
-};
-
-const resolveCanonicalUserId = async (
-  userId: string,
-): Promise<string | null> => {
-  const existing = await prisma.user.findFirst({
-    where: { userId },
-    select: { userId: true },
-  });
-  if (existing) {
-    return existing.userId ?? userId;
-  }
-
-  const identity = await prisma.authIdentity.findFirst({
-    where: {
-      provider: SUPERTOKENS_PROVIDER,
-      providerUserId: userId,
-    },
-    select: { appUserId: true },
-  });
-
-  return identity?.appUserId ?? null;
 };
 
 type UserDomain = {
@@ -272,15 +252,9 @@ export const UserService = {
     // Querying only the supplied alias found no mappings, so deletion removed no
     // organisation roles and reported success while the still-authenticated
     // session kept every permission those mappings grant.
-    const practitionerIds = [
-      ...new Set([userId, resolvedUserId].filter(Boolean)),
-    ];
     const mappings = await prisma.userOrganization.findMany({
       where: {
-        OR: practitionerIds.flatMap((practitionerId) => [
-          { practitionerReference: practitionerId },
-          { practitionerReference: `Practitioner/${practitionerId}` },
-        ]),
+        OR: practitionerReferenceFilter([userId, resolvedUserId]),
       },
       select: { id: true, roleCode: true, organizationReference: true },
     });

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -1,3 +1,25 @@
+const mockEmailPasswordInit = jest.fn((config: unknown) => ({
+  name: "emailpassword",
+  config,
+}));
+
+jest.mock("supertokens-node/recipe/emailpassword", () => ({
+  __esModule: true,
+  default: {
+    init: mockEmailPasswordInit,
+  },
+}));
+
+const mockGetUserMetadata = jest.fn();
+
+jest.mock("supertokens-node/recipe/usermetadata", () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(() => ({ name: "usermetadata" })),
+    getUserMetadata: mockGetUserMetadata,
+  },
+}));
+
 const mockPasswordlessInit = jest.fn((config: unknown) => ({
   name: "passwordless",
   config,
@@ -58,6 +80,8 @@ const restoreEnv = () => {
 describe("@yosemite-crew/auth supertokens config", () => {
   beforeEach(() => {
     jest.resetModules();
+    mockEmailPasswordInit.mockClear();
+    mockGetUserMetadata.mockReset();
     mockPasswordlessInit.mockClear();
     mockThirdPartyInit.mockClear();
     delete process.env.AUTH_APPLE_CLIENT_ID;
@@ -157,6 +181,80 @@ describe("@yosemite-crew/auth supertokens config", () => {
     expect(originalSendEmail).toHaveBeenCalledWith({
       email: "someone@example.com",
     });
+  });
+
+  it("rejects disabled email-password accounts without disclosing their state", async () => {
+    process.env.SMTP_HOST = "smtp.example.test";
+    process.env.SMTP_PORT = "465";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "smtp-user";
+    process.env.SMTP_PASSWORD = "smtp-password";
+    process.env.SMTP_FROM_NAME = "Yosemite Crew";
+    process.env.SMTP_FROM_EMAIL = "auth@example.test";
+    mockGetUserMetadata.mockResolvedValue({
+      metadata: { disabledAt: Date.now() },
+    });
+
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+    getSuperTokensConfig();
+    const emailPasswordConfig = mockEmailPasswordInit.mock.calls[0]?.[0] as any;
+    const signIn = emailPasswordConfig.override.functions({
+      signIn: jest.fn(async () => ({
+        status: "OK",
+        user: { id: "disabled-business-user" },
+      })),
+    }).signIn;
+
+    await expect(
+      signIn({
+        email: "disabled@example.test",
+        password: "correct-password",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "WRONG_CREDENTIALS_ERROR" });
+    expect(mockGetUserMetadata).toHaveBeenCalledWith("disabled-business-user");
+  });
+
+  it("keeps active and failed email-password sign-ins unchanged", async () => {
+    process.env.SMTP_HOST = "smtp.example.test";
+    process.env.SMTP_PORT = "465";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "smtp-user";
+    process.env.SMTP_PASSWORD = "smtp-password";
+    process.env.SMTP_FROM_NAME = "Yosemite Crew";
+    process.env.SMTP_FROM_EMAIL = "auth@example.test";
+    mockGetUserMetadata.mockResolvedValue({ metadata: {} });
+
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+    getSuperTokensConfig();
+    const emailPasswordConfig = mockEmailPasswordInit.mock.calls[0]?.[0] as any;
+    const originalSignIn = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "WRONG_CREDENTIALS_ERROR" })
+      .mockResolvedValueOnce({
+        status: "OK",
+        user: { id: "active-business-user" },
+      });
+    const signIn = emailPasswordConfig.override.functions({
+      signIn: originalSignIn,
+    }).signIn;
+
+    await expect(
+      signIn({
+        email: "unknown@example.test",
+        password: "wrong",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "WRONG_CREDENTIALS_ERROR" });
+    await expect(
+      signIn({
+        email: "active@example.test",
+        password: "correct",
+        userContext: {},
+      }),
+    ).resolves.toEqual({ status: "OK", user: { id: "active-business-user" } });
+    expect(mockGetUserMetadata).toHaveBeenCalledTimes(1);
+    expect(mockGetUserMetadata).toHaveBeenCalledWith("active-business-user");
   });
   describe("apple id_token audience selection", () => {
     const BUNDLE_ID = "com.example.mobile";

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -256,6 +256,202 @@ describe("@yosemite-crew/auth supertokens config", () => {
     expect(mockGetUserMetadata).toHaveBeenCalledTimes(1);
     expect(mockGetUserMetadata).toHaveBeenCalledWith("active-business-user");
   });
+  describe("organisation-disable enforcement is wired to every sign-in path", () => {
+    // The previous implementation of this feature was rejected for proving a
+    // branch instead of an enforcement: its tests mocked the very signal they
+    // asserted on, and returned from the metadata check before reaching the
+    // host hook at all. These tests do the opposite - metadata is clean, so
+    // the ONLY thing that can refuse the sign-in is `isSignInBlocked`, and a
+    // recipe that never calls it fails here.
+    const setSmtpEnv = () => {
+      process.env.SMTP_HOST = "smtp.example.test";
+      process.env.SMTP_PORT = "465";
+      process.env.SMTP_SECURE = "true";
+      process.env.SMTP_USER = "smtp-user";
+      process.env.SMTP_PASSWORD = "smtp-password";
+      process.env.SMTP_FROM_NAME = "Yosemite Crew";
+      process.env.SMTP_FROM_EMAIL = "auth@example.test";
+    };
+
+    const buildWithHook = (blocked: boolean) => {
+      setSmtpEnv();
+      // A third-party provider must be configured or ThirdParty.init is never
+      // called and the social path cannot be reached.
+      process.env.AUTH_APPLE_CLIENT_ID = "com.example.mobile";
+      process.env.AUTH_APPLE_KEY_ID = "KEY123";
+      process.env.AUTH_APPLE_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----";
+      process.env.AUTH_APPLE_TEAM_ID = "TEAM123";
+      mockGetUserMetadata.mockResolvedValue({ metadata: {} });
+
+      const {
+        getSuperTokensConfig,
+        setAuthHooks,
+      } = require("@yosemite-crew/auth");
+      const isSignInBlocked = jest.fn(async () => blocked);
+      setAuthHooks({ isSignInBlocked });
+      getSuperTokensConfig();
+
+      return { isSignInBlocked };
+    };
+
+    const overriddenPasswordless = () => {
+      const config = mockPasswordlessInit.mock.calls[0]?.[0] as any;
+      return config.override.functions({
+        consumeCode: jest.fn(async () => ({
+          status: "OK",
+          user: {
+            id: "disabled-otp-user",
+            emails: ["staff@example.test"],
+          },
+          recipeUserId: { getAsString: () => "recipe-otp" },
+          createdNewRecipeUser: false,
+        })),
+      });
+    };
+
+    const overriddenThirdParty = () => {
+      const initArg = mockThirdPartyInit.mock.calls[0]?.[0] as any;
+      return initArg.override.functions({
+        signInUp: jest.fn(async () => ({
+          status: "OK",
+          user: { id: "disabled-social-user" },
+          recipeUserId: { getAsString: () => "recipe-social" },
+          createdNewRecipeUser: false,
+        })),
+      });
+    };
+
+    const overriddenEmailPassword = () => {
+      const config = mockEmailPasswordInit.mock.calls[0]?.[0] as any;
+      return config.override.functions({
+        signIn: jest.fn(async () => ({
+          status: "OK",
+          user: { id: "disabled-staff-user" },
+        })),
+      });
+    };
+
+    it("refuses an email-password sign-in on the host hook alone", async () => {
+      const { isSignInBlocked } = buildWithHook(true);
+
+      await expect(
+        overriddenEmailPassword().signIn({
+          email: "staff@example.test",
+          password: "correct-password",
+          userContext: {},
+        }),
+      ).resolves.toEqual({ status: "WRONG_CREDENTIALS_ERROR" });
+      expect(isSignInBlocked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appUserId: "disabled-staff-user",
+          loginMethod: "emailpassword",
+        }),
+      );
+    });
+
+    it("refuses a correct email code for a disabled organisation", async () => {
+      // RESTART_FLOW_ERROR, not an incorrect-code status: it is the only
+      // refusal this recipe offers that carries no attempt counters, so it
+      // does not tell the caller whether the code itself was right.
+      const { isSignInBlocked } = buildWithHook(true);
+
+      await expect(
+        overriddenPasswordless().consumeCode({
+          email: "staff@example.test",
+          userContext: {},
+        }),
+      ).resolves.toEqual({ status: "RESTART_FLOW_ERROR" });
+      expect(isSignInBlocked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appUserId: "disabled-otp-user",
+          loginMethod: "otp-email",
+        }),
+      );
+    });
+
+    it("refuses a social sign-in the provider has already vouched for", async () => {
+      const { isSignInBlocked } = buildWithHook(true);
+
+      await expect(
+        overriddenThirdParty().signInUp({
+          thirdPartyId: "apple",
+          email: "staff@example.test",
+          userContext: {},
+        }),
+      ).resolves.toEqual({
+        status: "SIGN_IN_UP_NOT_ALLOWED",
+        reason: "Sign in is not available for this account.",
+      });
+      expect(isSignInBlocked).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appUserId: "disabled-social-user",
+          loginMethod: "thirdparty-apple",
+        }),
+      );
+    });
+
+    it("lets all three paths through when the hook says the account is live", async () => {
+      const { isSignInBlocked } = buildWithHook(false);
+
+      await expect(
+        overriddenEmailPassword().signIn({
+          email: "staff@example.test",
+          password: "correct-password",
+          userContext: {},
+        }),
+      ).resolves.toEqual({ status: "OK", user: { id: "disabled-staff-user" } });
+      await expect(
+        overriddenPasswordless().consumeCode({
+          email: "staff@example.test",
+          userContext: {},
+        }),
+      ).resolves.toEqual(expect.objectContaining({ status: "OK" }));
+      await expect(
+        overriddenThirdParty().signInUp({
+          thirdPartyId: "apple",
+          email: "staff@example.test",
+          userContext: {},
+        }),
+      ).resolves.toEqual(expect.objectContaining({ status: "OK" }));
+      expect(isSignInBlocked).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not refuse a sign-in when the hook throws", async () => {
+      // Fail OPEN, deliberately and unlike the rest of this change: a database
+      // blip must not lock every user out of the product, and the account
+      // state it would have reported is still enforced on every authorised
+      // request afterwards.
+      setSmtpEnv();
+      mockGetUserMetadata.mockResolvedValue({ metadata: {} });
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const {
+        getSuperTokensConfig,
+        setAuthHooks,
+      } = require("@yosemite-crew/auth");
+      setAuthHooks({
+        isSignInBlocked: jest.fn(async () => {
+          throw new Error("database unavailable");
+        }),
+      });
+      getSuperTokensConfig();
+
+      await expect(
+        overriddenEmailPassword().signIn({
+          email: "staff@example.test",
+          password: "correct-password",
+          userContext: {},
+        }),
+      ).resolves.toEqual({ status: "OK", user: { id: "disabled-staff-user" } });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[auth] isSignInBlocked hook failed",
+        expect.any(Error),
+      );
+      consoleError.mockRestore();
+    });
+  });
+
   describe("apple id_token audience selection", () => {
     const BUNDLE_ID = "com.example.mobile";
     const SERVICE_ID = "com.example.mobile.auth";

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -202,6 +202,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
       signIn: jest.fn(async () => ({
         status: "OK",
         user: { id: "disabled-business-user" },
+        recipeUserId: { getAsString: () => "recipe-disabled-business" },
       })),
     }).signIn;
 
@@ -234,6 +235,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
       .mockResolvedValueOnce({
         status: "OK",
         user: { id: "active-business-user" },
+        recipeUserId: { getAsString: () => "recipe-active-business" },
       });
     const signIn = emailPasswordConfig.override.functions({
       signIn: originalSignIn,
@@ -252,7 +254,12 @@ describe("@yosemite-crew/auth supertokens config", () => {
         password: "correct",
         userContext: {},
       }),
-    ).resolves.toEqual({ status: "OK", user: { id: "active-business-user" } });
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: "OK",
+        user: { id: "active-business-user" },
+      }),
+    );
     expect(mockGetUserMetadata).toHaveBeenCalledTimes(1);
     expect(mockGetUserMetadata).toHaveBeenCalledWith("active-business-user");
   });
@@ -327,6 +334,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
         signIn: jest.fn(async () => ({
           status: "OK",
           user: { id: "disabled-staff-user" },
+          recipeUserId: { getAsString: () => "recipe-staff" },
         })),
       });
     };
@@ -344,6 +352,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
       expect(isSignInBlocked).toHaveBeenCalledWith(
         expect.objectContaining({
           appUserId: "disabled-staff-user",
+          providerUserId: "recipe-staff",
           loginMethod: "emailpassword",
         }),
       );
@@ -364,6 +373,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
       expect(isSignInBlocked).toHaveBeenCalledWith(
         expect.objectContaining({
           appUserId: "disabled-otp-user",
+          providerUserId: "recipe-otp",
           loginMethod: "otp-email",
         }),
       );
@@ -385,6 +395,7 @@ describe("@yosemite-crew/auth supertokens config", () => {
       expect(isSignInBlocked).toHaveBeenCalledWith(
         expect.objectContaining({
           appUserId: "disabled-social-user",
+          providerUserId: "recipe-social",
           loginMethod: "thirdparty-apple",
         }),
       );
@@ -399,7 +410,12 @@ describe("@yosemite-crew/auth supertokens config", () => {
           password: "correct-password",
           userContext: {},
         }),
-      ).resolves.toEqual({ status: "OK", user: { id: "disabled-staff-user" } });
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: "OK",
+          user: { id: "disabled-staff-user" },
+        }),
+      );
       await expect(
         overriddenPasswordless().consumeCode({
           email: "staff@example.test",
@@ -443,7 +459,12 @@ describe("@yosemite-crew/auth supertokens config", () => {
           password: "correct-password",
           userContext: {},
         }),
-      ).resolves.toEqual({ status: "OK", user: { id: "disabled-staff-user" } });
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: "OK",
+          user: { id: "disabled-staff-user" },
+        }),
+      );
       expect(consoleError).toHaveBeenCalledWith(
         "[auth] isSignInBlocked hook failed",
         expect.any(Error),

--- a/apps/backend/test/config/auth-hooks.test.ts
+++ b/apps/backend/test/config/auth-hooks.test.ts
@@ -218,9 +218,10 @@ describe("authHooks.resolveAppUserId", () => {
 });
 
 describe("authHooks.isSignInBlocked", () => {
-  const blocked = (appUserId: string) =>
+  const blocked = (appUserId: string, providerUserId = appUserId) =>
     authHooks.isSignInBlocked!({
       appUserId,
+      providerUserId,
       email: "vet@clinic.test",
       loginMethod: "emailpassword",
     });
@@ -300,7 +301,7 @@ describe("authHooks.isSignInBlocked", () => {
 
   it("reads only active memberships, in both reference forms", async () => {
     mockUserOrgFindMany.mockResolvedValue([] as never);
-    await blocked("staff-5");
+    await blocked("staff-5", "recipe-5");
 
     expect(mockUserOrgFindMany).toHaveBeenCalledWith({
       where: {
@@ -308,6 +309,8 @@ describe("authHooks.isSignInBlocked", () => {
         OR: [
           { practitionerReference: "staff-5" },
           { practitionerReference: "Practitioner/staff-5" },
+          { practitionerReference: "recipe-5" },
+          { practitionerReference: "Practitioner/recipe-5" },
         ],
       },
       select: { organizationReference: true },
@@ -341,7 +344,15 @@ describe("authHooks.isSignInBlocked", () => {
     // nothing has resolved it yet, unlike every authorised request. A migrated
     // account's rows are stored under the legacy id, so querying the alias
     // alone finds nothing and lets a disabled organisation sign in.
-    mockFindFirst.mockResolvedValue({ appUserId: "legacy-77" } as never);
+    // authIdentity is keyed on the RECIPE user id, which differs from
+    // `result.user.id` once accounts are linked - so the mapping is only
+    // reachable if the hook resolves `providerUserId` as well.
+    mockFindFirst.mockImplementation((async (args: {
+      where: { providerUserId: string };
+    }) =>
+      args.where.providerUserId === "recipe-77"
+        ? { appUserId: "legacy-77" }
+        : null) as never);
     mockUserOrgFindMany.mockImplementation((async (args: {
       where: { OR: { practitionerReference: string }[] };
     }) => {
@@ -352,7 +363,9 @@ describe("authHooks.isSignInBlocked", () => {
     }) as never);
     mockOrganizationCount.mockResolvedValue(0 as never);
 
-    await expect(blocked("supertokens-alias-77")).resolves.toBe(true);
+    await expect(blocked("supertokens-alias-77", "recipe-77")).resolves.toBe(
+      true,
+    );
   });
 
   it("does not double-prefix an id that already carries the Practitioner/ form", async () => {
@@ -371,8 +384,8 @@ describe("authHooks.isSignInBlocked", () => {
     });
   });
 
-  it("does not query on a blank user id", async () => {
-    await expect(blocked("   ")).resolves.toBe(false);
+  it("does not query when neither id is usable", async () => {
+    await expect(blocked("   ", "  ")).resolves.toBe(false);
     expect(mockUserOrgFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/config/auth-hooks.test.ts
+++ b/apps/backend/test/config/auth-hooks.test.ts
@@ -6,6 +6,7 @@ const mockUpsert: jest.Mock = jest.fn();
 const mockCreateUserIdMapping: jest.Mock = jest.fn();
 const mockUserOrgFindMany: jest.Mock = jest.fn();
 const mockOrganizationCount: jest.Mock = jest.fn();
+const mockUserFindFirst: jest.Mock = jest.fn();
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -13,6 +14,9 @@ jest.mock("src/config/prisma", () => ({
       findFirst: (...args: unknown[]) => mockFindFirst(...args),
       findMany: (...args: unknown[]) => mockFindMany(...args),
       upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+    user: {
+      findFirst: (...args: unknown[]) => mockUserFindFirst(...args),
     },
     userOrganization: {
       findMany: (...args: unknown[]) => mockUserOrgFindMany(...args),
@@ -224,6 +228,12 @@ describe("authHooks.isSignInBlocked", () => {
   beforeEach(() => {
     mockUserOrgFindMany.mockReset();
     mockOrganizationCount.mockReset();
+    mockUserFindFirst.mockReset();
+    mockFindFirst.mockReset();
+    // Default: the supplied id IS the canonical one (an account created after
+    // the migration). The migrated case is covered explicitly below.
+    mockUserFindFirst.mockResolvedValue(null as never);
+    mockFindFirst.mockResolvedValue(null as never);
   });
 
   it("blocks when every organisation the user belongs to is inactive", async () => {
@@ -288,12 +298,75 @@ describe("authHooks.isSignInBlocked", () => {
     });
   });
 
-  it("reads only active memberships", async () => {
+  it("reads only active memberships, in both reference forms", async () => {
     mockUserOrgFindMany.mockResolvedValue([] as never);
     await blocked("staff-5");
 
     expect(mockUserOrgFindMany).toHaveBeenCalledWith({
-      where: { practitionerReference: "staff-5", active: true },
+      where: {
+        active: true,
+        OR: [
+          { practitionerReference: "staff-5" },
+          { practitionerReference: "Practitioner/staff-5" },
+        ],
+      },
+      select: { organizationReference: true },
+    });
+  });
+
+  it("finds a membership stored as a FHIR Practitioner/ reference", async () => {
+    // The fail-OPEN case, and the reason this query cannot match bare only.
+    // A row stored as `Practitioner/<id>` is invisible to a bare lookup, the
+    // empty result reads as "pet parent, not staff", and a disabled
+    // organisation is silently unenforced - `organization.count` is never even
+    // reached. `UserService.deleteById` matches both forms for the same reason.
+    mockUserOrgFindMany.mockImplementation((async (args: {
+      where: { OR: { practitionerReference: string }[] };
+    }) => {
+      const wanted = args.where.OR.map((c) => c.practitionerReference);
+      return wanted.includes("Practitioner/staff-6")
+        ? [{ organizationReference: "org-3" }]
+        : [];
+    }) as never);
+    mockOrganizationCount.mockResolvedValue(0 as never);
+
+    await expect(blocked("staff-6")).resolves.toBe(true);
+    expect(mockOrganizationCount).toHaveBeenCalledWith({
+      where: { id: { in: ["org-3"] }, isActive: true },
+    });
+  });
+
+  it("finds a migrated account's membership under its legacy app user id", async () => {
+    // `appUserId` here is the raw SuperTokens id from the sign-in override -
+    // nothing has resolved it yet, unlike every authorised request. A migrated
+    // account's rows are stored under the legacy id, so querying the alias
+    // alone finds nothing and lets a disabled organisation sign in.
+    mockFindFirst.mockResolvedValue({ appUserId: "legacy-77" } as never);
+    mockUserOrgFindMany.mockImplementation((async (args: {
+      where: { OR: { practitionerReference: string }[] };
+    }) => {
+      const wanted = args.where.OR.map((c) => c.practitionerReference);
+      return wanted.includes("legacy-77")
+        ? [{ organizationReference: "org-4" }]
+        : [];
+    }) as never);
+    mockOrganizationCount.mockResolvedValue(0 as never);
+
+    await expect(blocked("supertokens-alias-77")).resolves.toBe(true);
+  });
+
+  it("does not double-prefix an id that already carries the Practitioner/ form", async () => {
+    mockUserOrgFindMany.mockResolvedValue([] as never);
+    await blocked("Practitioner/staff-8");
+
+    expect(mockUserOrgFindMany).toHaveBeenCalledWith({
+      where: {
+        active: true,
+        OR: [
+          { practitionerReference: "staff-8" },
+          { practitionerReference: "Practitioner/staff-8" },
+        ],
+      },
       select: { organizationReference: true },
     });
   });

--- a/apps/backend/test/config/auth-hooks.test.ts
+++ b/apps/backend/test/config/auth-hooks.test.ts
@@ -4,6 +4,8 @@ const mockFindFirst: jest.Mock = jest.fn();
 const mockFindMany: jest.Mock = jest.fn();
 const mockUpsert: jest.Mock = jest.fn();
 const mockCreateUserIdMapping: jest.Mock = jest.fn();
+const mockUserOrgFindMany: jest.Mock = jest.fn();
+const mockOrganizationCount: jest.Mock = jest.fn();
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -11,6 +13,12 @@ jest.mock("src/config/prisma", () => ({
       findFirst: (...args: unknown[]) => mockFindFirst(...args),
       findMany: (...args: unknown[]) => mockFindMany(...args),
       upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+    userOrganization: {
+      findMany: (...args: unknown[]) => mockUserOrgFindMany(...args),
+    },
+    organization: {
+      count: (...args: unknown[]) => mockOrganizationCount(...args),
     },
   },
 }));
@@ -202,5 +210,96 @@ describe("authHooks.resolveAppUserId", () => {
     ).resolves.toBe("st-user-2");
 
     expect(mockCreateUserIdMapping).not.toHaveBeenCalled();
+  });
+});
+
+describe("authHooks.isSignInBlocked", () => {
+  const blocked = (appUserId: string) =>
+    authHooks.isSignInBlocked!({
+      appUserId,
+      email: "vet@clinic.test",
+      loginMethod: "emailpassword",
+    });
+
+  beforeEach(() => {
+    mockUserOrgFindMany.mockReset();
+    mockOrganizationCount.mockReset();
+  });
+
+  it("blocks when every organisation the user belongs to is inactive", async () => {
+    mockUserOrgFindMany.mockResolvedValue([
+      { organizationReference: "org-1" },
+    ] as never);
+    mockOrganizationCount.mockResolvedValue(0 as never);
+
+    await expect(blocked("staff-1")).resolves.toBe(true);
+    expect(mockOrganizationCount).toHaveBeenCalledWith({
+      where: { id: { in: ["org-1"] }, isActive: true },
+    });
+  });
+
+  it("allows a user who still belongs to one active organisation", async () => {
+    // Someone employed at a disabled practice and a live one still has a job.
+    // Per-organisation authorisation decides what they can reach once in.
+    mockUserOrgFindMany.mockResolvedValue([
+      { organizationReference: "org-disabled" },
+      { organizationReference: "Organization/org-live" },
+    ] as never);
+    mockOrganizationCount.mockResolvedValue(1 as never);
+
+    await expect(blocked("staff-2")).resolves.toBe(false);
+  });
+
+  it("does not block a user with no organisation membership", async () => {
+    // Pet parents have no userOrganization row. Reading an empty list as
+    // "belongs to nothing, therefore disabled" would lock every mobile user out.
+    mockUserOrgFindMany.mockResolvedValue([] as never);
+
+    await expect(blocked("pet-parent-1")).resolves.toBe(false);
+    expect(mockOrganizationCount).not.toHaveBeenCalled();
+  });
+
+  it("strips the FHIR Organization/ prefix before looking the row up", async () => {
+    // Mappings are stored bare or prefixed; querying the prefixed string finds
+    // nothing, which would count zero active orgs and block a live account.
+    mockUserOrgFindMany.mockResolvedValue([
+      { organizationReference: "Organization/org-9" },
+    ] as never);
+    mockOrganizationCount.mockResolvedValue(1 as never);
+
+    await expect(blocked("staff-3")).resolves.toBe(false);
+    expect(mockOrganizationCount).toHaveBeenCalledWith({
+      where: { id: { in: ["org-9"] }, isActive: true },
+    });
+  });
+
+  it("de-duplicates repeated organisation references", async () => {
+    // One person holds several roleCodes at one practice, so the membership
+    // query returns the same organisation more than once.
+    mockUserOrgFindMany.mockResolvedValue([
+      { organizationReference: "org-7" },
+      { organizationReference: "Organization/org-7" },
+    ] as never);
+    mockOrganizationCount.mockResolvedValue(1 as never);
+
+    await expect(blocked("staff-4")).resolves.toBe(false);
+    expect(mockOrganizationCount).toHaveBeenCalledWith({
+      where: { id: { in: ["org-7"] }, isActive: true },
+    });
+  });
+
+  it("reads only active memberships", async () => {
+    mockUserOrgFindMany.mockResolvedValue([] as never);
+    await blocked("staff-5");
+
+    expect(mockUserOrgFindMany).toHaveBeenCalledWith({
+      where: { practitionerReference: "staff-5", active: true },
+      select: { organizationReference: true },
+    });
+  });
+
+  it("does not query on a blank user id", async () => {
+    await expect(blocked("   ")).resolves.toBe(false);
+    expect(mockUserOrgFindMany).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -311,7 +311,15 @@ export function getSuperTokensConfig(): TypeInput {
               const ctx = input.userContext as MutableContext;
               ctx[CTX_LOGIN_METHOD] = 'emailpassword';
               ctx[CTX_EMAIL] = input.email;
-              return original.signIn(input);
+              const result = await original.signIn(input);
+              if (result.status !== 'OK') {
+                return result;
+              }
+
+              const { metadata } = await UserMetadata.getUserMetadata(result.user.id);
+              return typeof metadata.disabledAt === 'number'
+                ? { status: 'WRONG_CREDENTIALS_ERROR' }
+                : result;
             },
           }),
         },

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -110,6 +110,51 @@ async function reportUserCreated(input: {
   }
 }
 
+/**
+ * Two independent disable signals, deliberately both checked.
+ *
+ * `disabledAt` in SuperTokens user metadata is written by the SuperAdmin panel,
+ * which is not in this repository - so this codebase can neither confirm nor
+ * rule out that it is still set. `isSignInBlocked` asks the host about the
+ * state this repository does own (an organisation whose isActive was cleared
+ * through PATCH /businesses/:id). Reading only one of them would leave the
+ * other disable button doing nothing.
+ *
+ * Both answers are collapsed into WRONG_CREDENTIALS_ERROR by the callers: a
+ * disabled account must not be distinguishable from a wrong password, or the
+ * sign-in form becomes an oracle for which accounts exist and are suspended.
+ */
+async function isSignInDenied(input: {
+  appUserId: string;
+  email?: string;
+  loginMethod: LoginMethod;
+}): Promise<boolean> {
+  try {
+    const { metadata } = await UserMetadata.getUserMetadata(input.appUserId);
+    if (typeof metadata.disabledAt === 'number') {
+      return true;
+    }
+  } catch (err) {
+    // Metadata is advisory here; the host check below is the authoritative one.
+    console.error('[auth] disabled-account metadata lookup failed', err);
+  }
+
+  const hook = getAuthHooks().isSignInBlocked;
+  if (!hook) {
+    return false;
+  }
+  try {
+    return await hook(input);
+  } catch (err) {
+    // Fail OPEN, unlike the rest of today's fail-closed choices, and the
+    // asymmetry is deliberate: a database blip must not lock every user out of
+    // the product, and the account state it would have reported is still
+    // enforced on every authorised request afterwards.
+    console.error('[auth] isSignInBlocked hook failed', err);
+    return false;
+  }
+}
+
 function isMfaRequirementEnabled(): boolean {
   // Escape hatch for CI/e2e environments only; defaults to enforced.
   return process.env.AUTH_REQUIRE_MFA !== 'false';
@@ -316,10 +361,12 @@ export function getSuperTokensConfig(): TypeInput {
                 return result;
               }
 
-              const { metadata } = await UserMetadata.getUserMetadata(result.user.id);
-              return typeof metadata.disabledAt === 'number'
-                ? { status: 'WRONG_CREDENTIALS_ERROR' }
-                : result;
+              const denied = await isSignInDenied({
+                appUserId: result.user.id,
+                email: input.email,
+                loginMethod: 'emailpassword',
+              });
+              return denied ? { status: 'WRONG_CREDENTIALS_ERROR' } : result;
             },
           }),
         },
@@ -419,6 +466,20 @@ export function getSuperTokensConfig(): TypeInput {
                     loginMethod: 'otp-email',
                   });
                 }
+
+                // A correct code for a disabled account still must not produce
+                // a session. RESTART_FLOW_ERROR is the only refusal this recipe
+                // offers that carries no attempt counters, so it does not tell
+                // the caller whether the code itself was right.
+                if (
+                  await isSignInDenied({
+                    appUserId: result.user.id,
+                    email,
+                    loginMethod: 'otp-email',
+                  })
+                ) {
+                  return { status: 'RESTART_FLOW_ERROR' };
+                }
               }
               return result;
             },
@@ -438,13 +499,31 @@ export function getSuperTokensConfig(): TypeInput {
                     ctx[CTX_LOGIN_METHOD] = loginMethod;
                     ctx[CTX_EMAIL] = input.email;
                     const result = await original.signInUp(input);
-                    if (result.status === 'OK' && result.createdNewRecipeUser) {
-                      await reportUserCreated({
-                        appUserId: result.user.id,
-                        providerUserId: result.recipeUserId.getAsString(),
-                        email: input.email,
-                        loginMethod,
-                      });
+                    if (result.status === 'OK') {
+                      if (result.createdNewRecipeUser) {
+                        await reportUserCreated({
+                          appUserId: result.user.id,
+                          providerUserId: result.recipeUserId.getAsString(),
+                          email: input.email,
+                          loginMethod,
+                        });
+                      }
+
+                      // The provider vouched for the identity; the account is
+                      // still disabled. The reason string is deliberately
+                      // generic - it reaches the client.
+                      if (
+                        await isSignInDenied({
+                          appUserId: result.user.id,
+                          email: input.email,
+                          loginMethod,
+                        })
+                      ) {
+                        return {
+                          status: 'SIGN_IN_UP_NOT_ALLOWED',
+                          reason: 'Sign in is not available for this account.',
+                        };
+                      }
                     }
                     return result;
                   },

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -126,6 +126,7 @@ async function reportUserCreated(input: {
  */
 async function isSignInDenied(input: {
   appUserId: string;
+  providerUserId: string;
   email?: string;
   loginMethod: LoginMethod;
 }): Promise<boolean> {
@@ -363,6 +364,7 @@ export function getSuperTokensConfig(): TypeInput {
 
               const denied = await isSignInDenied({
                 appUserId: result.user.id,
+                providerUserId: result.recipeUserId.getAsString(),
                 email: input.email,
                 loginMethod: 'emailpassword',
               });
@@ -474,6 +476,7 @@ export function getSuperTokensConfig(): TypeInput {
                 if (
                   await isSignInDenied({
                     appUserId: result.user.id,
+                    providerUserId: result.recipeUserId.getAsString(),
                     email,
                     loginMethod: 'otp-email',
                   })
@@ -515,6 +518,7 @@ export function getSuperTokensConfig(): TypeInput {
                       if (
                         await isSignInDenied({
                           appUserId: result.user.id,
+                          providerUserId: result.recipeUserId.getAsString(),
                           email: input.email,
                           loginMethod,
                         })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -37,6 +37,9 @@ export type {
 export type { AuthProvider } from './auth-provider.js';
 export { AuthService } from './auth-service.js';
 export { setAuthService, getAuthService } from './auth-service-registry.js';
+// Host-injected hooks. `initSuperTokens(hooks)` registers them in the normal
+// path; the registry is exported so the wiring can be exercised directly.
+export { setAuthHooks, getAuthHooks } from './hooks.js';
 export type { AuthConfig, SuperTokensConfig } from './config.js';
 export { readAuthConfig, validateAuthConfig } from './config.js';
 export { createAuthProvider } from './create-auth-provider.js';

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -89,6 +89,21 @@ export type AuthHooks = {
     claims: Record<string, unknown>;
   }) => Promise<string | undefined>;
 
+  // Asked on every successful sign-in, before the session exists, so the host
+  // can refuse an account its own data says is disabled. The auth package
+  // cannot see Organization.isActive - that lives behind Prisma - so the
+  // decision has to come back through here.
+  //
+  // Returning true makes the sign-in fail as WRONG_CREDENTIALS_ERROR: a
+  // disabled account must not be able to tell itself apart from a wrong
+  // password. A throw is treated as "not blocked" and logged, because an
+  // unreachable database must not lock every user out of the product.
+  isSignInBlocked?: (input: {
+    appUserId: string;
+    email?: string;
+    loginMethod: LoginMethod;
+  }) => Promise<boolean>;
+
   // Fired after the provider creates a brand-new user (sign-up). The host
   // records the identity mapping (auth_identities) here.
   onUserCreated?: (input: {

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -100,6 +100,10 @@ export type AuthHooks = {
   // unreachable database must not lock every user out of the product.
   isSignInBlocked?: (input: {
     appUserId: string;
+    // The recipe user id, as onUserCreated records it. A migrated account's
+    // rows can be stored under either id, so the host needs both to look a
+    // membership up; nothing has resolved them at sign-in time.
+    providerUserId: string;
     email?: string;
     loginMethod: LoginMethod;
   }) => Promise<boolean>;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for — #2646.
- [x] All existing tests and lints pass.

## What is the current behavior?

A business account disabled by a SuperAdmin can still sign in.

`SuperAdminBusinessService.updateBusiness`, behind `PATCH /businesses/:id`, writes
`Organization.isActive`. Nothing in the sign-in path reads it. The only `isActive` check
in the auth path is `require-active-account.ts`, which reads `User.isActive` — a different
flag, written by the user soft-delete, and applied only on developer routes.

The first commit on this branch added a check for `disabledAt` in SuperTokens user
metadata. Nothing in this repository writes that key: the only two occurrences were the
check itself and the test that mocks it. Every `updateUserMetadata` call here writes
`first_name`/`last_name` or `role`. The SuperAdmin panel is a separate codebase, so
whether it still writes `disabledAt` cannot be determined from this repository.

The check also covered email-and-password sign-in only. `consumeCode` (email OTP) and
`signInUp` (social) had no account-state check at all.

## What is the new behavior?

**Both disable signals are consulted, and either one refuses the sign-in.** The metadata
key is kept because it costs one lookup and covers the panel if it does still write it;
`Organization.isActive` is added because it is the signal this repository demonstrably
writes and never read.

**All three sign-in entry points are covered**, each refusing in the least-disclosing form
its recipe offers:

| Entry point | Refusal |
|---|---|
| `EmailPassword.signIn` | `WRONG_CREDENTIALS_ERROR` |
| `Passwordless.consumeCode` | `RESTART_FLOW_ERROR` — the only refusal there that carries no attempt counters, so it does not reveal whether the code was correct |
| `ThirdParty.signInUp` | `SIGN_IN_UP_NOT_ALLOWED` with a generic reason |

A disabled account must not be distinguishable from a wrong credential, or the sign-in
form becomes an oracle for which accounts exist and are suspended.

**The organisation lookup lives in the host, not the auth package.** `packages/auth` has
no dependency on the database, deliberately. The new `AuthHooks.isSignInBlocked` follows
the pattern the existing hooks already document — "let the auth package consult
application data without the package depending on the database".

Three deliberate choices in the host implementation:

- **No membership is not blocked.** Pet parents have no `userOrganization` row. Reading an
  empty list as "belongs to nothing, therefore disabled" would lock every mobile user out.
- **Blocked only when every organisation is inactive.** Someone employed at a disabled
  practice and a live one still has a job; per-organisation authorisation decides what
  they can reach once in.
- **`isVerified` is not consulted.** Every business is unverified before review, so
  blocking on it would lock out each new practice awaiting approval. The schema cannot
  distinguish a rejected business from one nobody has looked at yet — worth a follow-up,
  but not something to guess at in the sign-in path.

**The hook fails open**, unlike the fail-closed choices elsewhere in this area, and the
asymmetry is deliberate: a database that cannot answer must not lock every user out of the
product, and the same account state is still enforced on every authorised request
afterwards.

Membership is read through the same `userOrganization` mappings RBAC authorises against,
with the same bare-or-`Organization/`-prefixed reference handling as
`OrganisationService.listForUser`.

## Verification

At `5a00e8a6f`:

| Command | Result |
|---|---|
| `npx jest` (full backend) | exit 0 — 465 suites, 11189 tests |
| `npx turbo run lint type-check --filter=backend` | exit 0 — 7/7 tasks, 0 errors, 25 pre-existing warnings |
| `pnpm --filter @yosemite-crew/auth run build` | exit 0 |

The two affected suites go from 29 tests on `dev` to 38 here: 2 from the first commit,
7 new. All seven new tests were mutation-checked — inverting the blocked condition,
dropping the `Organization/` strip, dropping the de-duplication and dropping the
empty-membership guard each turn one red, and the suite is green with all four restored.

Aikido and SonarQube are not runnable locally; they are unverified until they run here.

## Related Issue(s)

Fixes #2646
