### PR TITLE
fix(backend): mount the notification router as a Router, not a sub-application

### DIFF
--- a/apps/backend/eslint.config.js
+++ b/apps/backend/eslint.config.js
@@ -119,4 +119,29 @@ export default [
       ],
     },
   },
+  {
+    /* #2711: `import Router from "express"` binds the default export - the app
+       factory - so `Router()` builds a full sub-application and mounting it
+       gives it its own settings. `defaultConfiguration` sets
+       `x-powered-by` as the child's own property, which shadows the
+       `app.disable("x-powered-by")` in app.ts, so the mounted routes answer
+       with the header the rest of the API suppresses.
+
+       Sonar raises this as `typescript:S5689`, but the quality gate measures
+       new code only, so an occurrence that reaches dev stops being enforced.
+       This is scoped to routers because no router needs the app factory;
+       app.ts legitimately default-imports express. */
+    files: ["src/routers/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "ImportDeclaration[source.value='express'] > ImportDefaultSpecifier",
+          message:
+            'Import { Router } from "express". The default export is the app factory, so calling it mounts a sub-application, not a router.',
+        },
+      ],
+    },
+  },
 ];

--- a/apps/backend/src/routers/notification.router.ts
+++ b/apps/backend/src/routers/notification.router.ts
@@ -1,4 +1,4 @@
-import Router from "express";
+import { Router } from "express";
 import { NotificationController } from "../controllers/app/notification.controller";
 import { requireMobileAuth } from "src/middlewares/auth";
 


### PR DESCRIPTION
Closes #2711.

`apps/backend/src/routers/notification.router.ts:1` was `import Router from "express"`. That binds express's **default** export — the app factory — so `Router()` built a full express **sub-application**, and `routers/index.ts:183` mounted it as one at `/v1/notification`.

Same defect Sonar caught as `typescript:S5689` on #2703, except this one was already on `dev`. It survived because the Sonar quality gate is measured on **new** code: once an occurrence lands, it sits in the backlog and blocks nothing.

## What it actually broke

`app.ts:69` calls `app.disable("x-powered-by")`, so the rest of the API answers with no `X-Powered-By`. Those three notification routes answered with `X-Powered-By: Express`.

The mechanism bounds the blast radius, so it is worth stating precisely. Express 4.21.2 `lib/application.js` prototype-chains a mounted sub-app's `settings` to the parent's in the `mount` handler, so parent settings are normally visible to the child. But `defaultConfiguration` sets `this.enable('x-powered-by')` as the child's **own** property, which shadows the parent's disabled value, and unlike `trust proxy` there is no corresponding delete on mount.

Verified against the installed express rather than reasoned about — parent with `x-powered-by` disabled and `trust proxy` set to 1, one mounted sub-app and one mounted Router, one request each carrying `X-Forwarded-For: 203.0.113.7`:

```
default-import call -> listen/settings: function object
named-import call   -> listen/settings: undefined undefined

/sub/x  ip= 203.0.113.7 | X-Powered-By: Express
/r/x    ip= 203.0.113.7 | X-Powered-By: null
```

So `trust proxy` **is** inherited correctly — both report the forwarded ip — and the leak is confined to `x-powered-by`. This is header hygiene on three mobile routes, not an authorisation or routing defect.

**Helmet does not cover it.** `app.ts:68` mounts `helmet()`, whose `hidePoweredBy` calls `res.removeHeader` when the request passes the parent — before it reaches the sub-app, which then sets the header again in its own `expressInit`. Re-ran the same repro with `helmet()` mounted on the parent: `/sub/x` still answers `X-Powered-By: Express`, `/r/x` still `null`.

## The guard, and why it is not a test

The one-line import fix is the defect. The second change is the enforcement, and it is a judgement call worth a reviewer's attention.

`sonarjs/x-powered-by` is turned off in `apps/backend/eslint.config.js` with the justification *"app.ts calls app.disable("x-powered-by") and mounts helmet"* — which is exactly the assumption a mounted sub-app breaks. And S5689 only gates new code. So nothing would have caught the next occurrence either.

The guard is `no-restricted-syntax` on `src/routers/**/*.ts` matching an `ImportDefaultSpecifier` from `express`. Two deliberate choices:

- **Scoped to routers**, because no router needs the app factory, while `app.ts` legitimately default-imports express.
- **`no-restricted-syntax`, not `no-restricted-imports`**, because flat config replaces a rule's options rather than merging them: adding `no-restricted-imports` in a routers-scoped block would have silently displaced the existing auth-boundary guard (#1672) on those same files. Verified rather than assumed — with the guard in place, adding `import Session from "supertokens-node/recipe/session"` to a router still reports `'supertokens-node/recipe/session' import is restricted ... no-restricted-imports`.

I added no runtime test. A bespoke "this export is a Router" assertion would restate a rule that the linter now enforces repo-wide and would not exist for the next router. The lint rule is the enforcement; the mutation below is the proof it enforces.

## Evidence at `bab45b552`

`git rev-parse HEAD` confirmed as `bab45b552` in the same shell as each run, before and after; tree clean.

| Command | Result |
|---|---|
| `npx turbo run lint type-check --filter=backend --force` | exit 0 — 7/7, 0 errors, 25 pre-existing warnings, none in the touched files |
| `npx jest` (full backend) | exit 0 — 466 suites, 11206 tests |

Guard mutation, reverted after: restoring `import Router from "express"` in `notification.router.ts` fails lint with exit 1 and the message above; the fixed form passes with exit 0.

## Scope of the negative

`grep -rn 'from "express"' --include='*.ts' apps/backend/src packages`, excluding `import {` and `import type`, returns exactly two lines: this file, and `app.ts:1` (`import express from "express"`, correct usage). No other default-import-as-Router remains in `apps/backend/src` or in `packages`. I did not search `apps/frontend`, `apps/mobile` or `apps/desktop`, which do not mount express.
