### PR TITLE
fix(backend): quarantine an unmappable IDEXX result instead of halting every poll

### DIFF
--- a/apps/backend/src/controllers/web/super-admin-lab-ingestion.controller.ts
+++ b/apps/backend/src/controllers/web/super-admin-lab-ingestion.controller.ts
@@ -1,0 +1,36 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import logger from "src/utils/logger";
+import { LabIngestionQuarantineService } from "src/services/lab-ingestion-quarantine.service";
+
+// Constrained rather than free text: the value goes into a `where` clause, and
+// the set of providers this poller talks to is closed.
+const querySchema = z.object({
+  provider: z.enum(["IDEXX"]).optional(),
+});
+
+export const SuperAdminLabIngestionController = {
+  listQuarantine: async (req: Request, res: Response) => {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "Unknown provider.",
+        code: "INVALID_LAB_PROVIDER",
+      });
+      return;
+    }
+
+    try {
+      const quarantine = await LabIngestionQuarantineService.listUnresolved(
+        parsed.data.provider,
+      );
+      res.status(200).json(quarantine);
+    } catch (error) {
+      logger.error("Failed to list quarantined lab results", error);
+      res.status(500).json({
+        error: "Unable to list quarantined lab results.",
+        code: "LAB_QUARANTINE_LIST_FAILED",
+      });
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/super-admin-lab-ingestion.controller.ts
+++ b/apps/backend/src/controllers/web/super-admin-lab-ingestion.controller.ts
@@ -9,6 +9,12 @@ const querySchema = z.object({
   provider: z.enum(["IDEXX"]).optional(),
 });
 
+// The rows are uuid-keyed, so anything else is a malformed request rather than
+// a miss - answered as such instead of being sent to the database.
+const idSchema = z.object({
+  id: z.uuid(),
+});
+
 export const SuperAdminLabIngestionController = {
   listQuarantine: async (req: Request, res: Response) => {
     const parsed = querySchema.safeParse(req.query);
@@ -30,6 +36,41 @@ export const SuperAdminLabIngestionController = {
       res.status(500).json({
         error: "Unable to list quarantined lab results.",
         code: "LAB_QUARANTINE_LIST_FAILED",
+      });
+    }
+  },
+
+  resolveQuarantine: async (req: Request, res: Response) => {
+    const parsed = idSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "Invalid quarantine id.",
+        code: "INVALID_QUARANTINE_ID",
+      });
+      return;
+    }
+
+    try {
+      const resolved = await LabIngestionQuarantineService.resolve(
+        parsed.data.id,
+      );
+      if (!resolved) {
+        // One status for both, deliberately: an id that does not exist and one
+        // already resolved are the same outcome for the caller, and telling
+        // them apart would report on rows they did not ask about.
+        res.status(404).json({
+          error: "No unresolved quarantined result with that id.",
+          code: "QUARANTINE_NOT_FOUND",
+        });
+        return;
+      }
+
+      res.status(200).json({ id: parsed.data.id, resolved: true });
+    } catch (error) {
+      logger.error("Failed to resolve a quarantined lab result", error);
+      res.status(500).json({
+        error: "Unable to resolve the quarantined lab result.",
+        code: "LAB_QUARANTINE_RESOLVE_FAILED",
       });
     }
   },

--- a/apps/backend/src/routers/super-admin.router.ts
+++ b/apps/backend/src/routers/super-admin.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { SuperAdminBusinessController } from "src/controllers/web/super-admin-business.controller";
+import { SuperAdminLabIngestionController } from "src/controllers/web/super-admin-lab-ingestion.controller";
 import { requireAnyAuth } from "src/middlewares/auth";
 import { requireSuperAdmin } from "src/middlewares/super-admin";
 
@@ -11,5 +12,12 @@ router.use(requireAnyAuth, requireSuperAdmin);
 router.get("/businesses", SuperAdminBusinessController.listBusinesses);
 router.get("/businesses/:id", SuperAdminBusinessController.getBusiness);
 router.patch("/businesses/:id", SuperAdminBusinessController.updateBusiness);
+
+// Lab ingestion holds a result it cannot apply rather than halting the poll for
+// every organisation; this is where those rows become visible to someone.
+router.get(
+  "/lab-ingestion/quarantine",
+  SuperAdminLabIngestionController.listQuarantine,
+);
 
 export default router;

--- a/apps/backend/src/routers/super-admin.router.ts
+++ b/apps/backend/src/routers/super-admin.router.ts
@@ -19,5 +19,11 @@ router.get(
   "/lab-ingestion/quarantine",
   SuperAdminLabIngestionController.listQuarantine,
 );
+// Without a writer for resolvedAt the list can only ever grow, so the count an
+// operator reads as severity could never fall.
+router.patch(
+  "/lab-ingestion/quarantine/:id/resolve",
+  SuperAdminLabIngestionController.resolveQuarantine,
+);
 
 export default router;

--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -331,6 +331,22 @@ type UnapplicableResult = {
  * model comment), because collapsing two rows onto a key is exactly the silent
  * loss it exists to prevent.
  */
+/**
+ * NOT `async`, and not `await`ed. A `PrismaPromise` is lazy - the write does not
+ * run until `$transaction` runs it - so returning the unexecuted operation IS
+ * the atomicity, not a tidiness choice.
+ *
+ * Making this `async` fires every write eagerly, outside the transaction, and
+ * hands `$transaction` an array of already-running plain Promises. No test here
+ * can catch that: a mocked `create` is eager either way, so the array
+ * `$transaction` receives looks identical. What catches it is `tsc` - Prisma
+ * brands `PrismaPromise` with `[Symbol.toStringTag]`, so a plain Promise is a
+ * type error at the call site.
+ *
+ * Which means a cast on that call would remove the only gate holding this
+ * property, with every test still green. If you meet a type error there, it is
+ * telling you the writes stopped being atomic.
+ */
 const quarantineOperation = (
   batchId: string,
   result: IdexxResult,

--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -178,6 +178,7 @@ type ResultOrderContext = {
   appointmentId: string | null;
   createdByUserId: string | null;
   patientId: string | null;
+  labOrderId: string | null;
   unmappedStatus: boolean;
 };
 
@@ -189,6 +190,7 @@ const syncLabOrderFromResult = async (
     appointmentId: null,
     createdByUserId: null,
     patientId: null,
+    labOrderId: null,
     unmappedStatus: false,
   };
 
@@ -199,6 +201,7 @@ const syncLabOrderFromResult = async (
     where: { idexxOrderId: orderId },
   });
 
+  context.labOrderId = order?.id ?? null;
   context.organisationId = order?.organisationId ?? null;
   context.appointmentId = order?.appointmentId ?? null;
   context.createdByUserId = order?.createdByUserId ?? null;
@@ -297,6 +300,101 @@ const maybeCreateResultArtifacts = async (
   }
 };
 
+/**
+ * Why a result was held. A plain string rather than a Prisma enum so a new
+ * reason needs no migration; every value in use is named here.
+ */
+export const QUARANTINE_REASON_UNMAPPED_STATUS = "UNMAPPED_RESULT_STATUS";
+
+type UnapplicableResult = {
+  result: IdexxResult;
+  context: ResultOrderContext;
+};
+
+/**
+ * Record a result the mapper could not apply, so the rest of its batch can be
+ * confirmed.
+ *
+ * IDEXX confirms a BATCH, and `pollLatest` builds ONE client from
+ * `IDEXX_GLOBAL_USERNAME` with `organisationId` derived per result. So refusing
+ * to confirm a batch containing an unapplicable row does not hold up one
+ * clinic's queue - it holds up every clinic's, indefinitely, because the
+ * unconfirmed batch is re-fetched on the next poll and meets the same row
+ * again.
+ *
+ * Writing the row here is what makes confirming the rest safe. The LabOrder
+ * transition is still not applied - that part of #2699 is unchanged and
+ * deliberate - but it is now held in a queryable place with the payload needed
+ * to replay it, rather than depending on the batch being re-sent forever.
+ *
+ * `create`, not `upsert`: this table has no unique key on purpose (see the
+ * model comment), because collapsing two rows onto a key is exactly the silent
+ * loss it exists to prevent.
+ */
+const quarantineResult = async (
+  batchId: string,
+  result: IdexxResult,
+  context: ResultOrderContext,
+  reason: string,
+) => {
+  await prisma.labResultQuarantine.create({
+    data: {
+      provider: "IDEXX",
+      batchId,
+      // Null rather than "" when the provider sent nothing usable: an absent id
+      // is worth seeing as absent.
+      resultId: coerceString(result.resultId),
+      orderId: coerceString(result.orderId),
+      labOrderId: context.labOrderId,
+      organisationId: context.organisationId,
+      reason,
+      externalStatus: coerceString(result.status),
+      statusDetail: coerceString(result.statusDetail),
+      modality: coerceString(result.modality),
+      payload: toJsonInput(result),
+    },
+  });
+};
+
+/**
+ * Hold every result in this batch the mapper could not apply.
+ *
+ * Answers the only question the caller has: is this batch now safe to confirm.
+ * False means nothing is holding the skipped transition, so confirming would
+ * lose it - fall back to leaving the batch for the next poll. That stalls
+ * ingestion for every organisation, which is bad, and still better than
+ * confirming a batch whose skipped transition is recorded nowhere at all.
+ */
+const quarantineUnapplicable = async (
+  batchId: string,
+  unapplicable: UnapplicableResult[],
+): Promise<boolean> => {
+  if (unapplicable.length === 0) return true;
+
+  try {
+    for (const { result, context } of unapplicable) {
+      await quarantineResult(
+        batchId,
+        result,
+        context,
+        QUARANTINE_REASON_UNMAPPED_STATUS,
+      );
+    }
+  } catch (err) {
+    logger.error(
+      "IDEXX batch left unconfirmed: could not quarantine an unmapped result",
+      { batchId, err },
+    );
+    return false;
+  }
+
+  logger.error(
+    "IDEXX results quarantined: a result status did not map to a LabOrder status",
+    { batchId, quarantined: unapplicable.length },
+  );
+  return true;
+};
+
 const processIdexxResult = async (
   client: IdexxResultsClient,
   result: IdexxResult,
@@ -305,7 +403,7 @@ const processIdexxResult = async (
   const resultId = coerceStringOrEmpty(result.resultId);
   await upsertLabResult(result, resultId, context.organisationId);
   await maybeCreateResultArtifacts(client, result, resultId, context);
-  return context.unmappedStatus;
+  return context;
 };
 
 const recordBatchSyncState = async (
@@ -357,22 +455,19 @@ export const IdexxResultsService = {
         break;
       }
 
-      let hasUnmappedResult = false;
+      const unapplicable: UnapplicableResult[] = [];
       for (const result of results as IdexxResult[]) {
-        const unmapped = await processIdexxResult(client, result);
-        hasUnmappedResult ||= unmapped;
+        const context = await processIdexxResult(client, result);
+        if (context.unmappedStatus) {
+          unapplicable.push({ result, context });
+        }
       }
 
-      // Confirming tells IDEXX the batch was consumed and stops it being re-sent, so a batch
-      // we only half-applied must not be confirmed: the LabOrder status transition for the
-      // unmapped row was skipped and would be lost for good. Leave it for the next poll and
-      // stop here. Polling stays stuck on this batch until mapResultStatusToLabOrder learns
-      // the status, which is the intent - the warning above names the status to add.
-      if (hasUnmappedResult) {
-        logger.error(
-          "IDEXX batch left unconfirmed: a result status did not map to a LabOrder status",
-          { batchId },
-        );
+      // Confirming tells IDEXX the batch was consumed and stops it being re-sent, so the
+      // transition we skipped must be held somewhere we control BEFORE the batch is
+      // confirmed - otherwise it is lost for good, which is the failure #2699 exists to
+      // stop. Quarantine first, confirm second, and stop here if the first did not happen.
+      if (!(await quarantineUnapplicable(batchId, unapplicable))) {
         break;
       }
 

--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -330,8 +330,7 @@ type UnapplicableResult = {
  * `create`, not `upsert`: this table has no unique key on purpose (see the
  * model comment), because collapsing two rows onto a key is exactly the silent
  * loss it exists to prevent.
- */
-/**
+ *
  * NOT `async`, and not `await`ed. A `PrismaPromise` is lazy - the write does not
  * run until `$transaction` runs it - so returning the unexecuted operation IS
  * the atomicity, not a tidiness choice.

--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -331,13 +331,13 @@ type UnapplicableResult = {
  * model comment), because collapsing two rows onto a key is exactly the silent
  * loss it exists to prevent.
  */
-const quarantineResult = async (
+const quarantineOperation = (
   batchId: string,
   result: IdexxResult,
   context: ResultOrderContext,
   reason: string,
-) => {
-  await prisma.labResultQuarantine.create({
+) =>
+  prisma.labResultQuarantine.create({
     data: {
       provider: "IDEXX",
       batchId,
@@ -354,7 +354,6 @@ const quarantineResult = async (
       payload: toJsonInput(result),
     },
   });
-};
 
 /**
  * Hold every result in this batch the mapper could not apply.
@@ -372,14 +371,26 @@ const quarantineUnapplicable = async (
   if (unapplicable.length === 0) return true;
 
   try {
-    for (const { result, context } of unapplicable) {
-      await quarantineResult(
-        batchId,
-        result,
-        context,
-        QUARANTINE_REASON_UNMAPPED_STATUS,
-      );
-    }
+    // One transaction, not a loop of writes. A loop that fails part-way leaves
+    // the earlier rows committed, returns false, and the batch is correctly
+    // left unconfirmed - so the next poll re-fetches the same batch and writes
+    // those rows AGAIN, once per poll, unbounded while the failure persists.
+    // That inflates `total`, which is the single number an operator uses to
+    // judge how bad this is. All-or-nothing also makes the fallback exactly the
+    // previous behaviour rather than the previous behaviour plus orphans.
+    //
+    // This costs the no-unique-key decision nothing: that is about two distinct
+    // rows in one batch, this is about one row written twice across polls.
+    await prisma.$transaction(
+      unapplicable.map(({ result, context }) =>
+        quarantineOperation(
+          batchId,
+          result,
+          context,
+          QUARANTINE_REASON_UNMAPPED_STATUS,
+        ),
+      ),
+    );
   } catch (err) {
     logger.error(
       "IDEXX batch left unconfirmed: could not quarantine an unmapped result",

--- a/apps/backend/src/services/lab-ingestion-quarantine.service.ts
+++ b/apps/backend/src/services/lab-ingestion-quarantine.service.ts
@@ -43,9 +43,7 @@ export const LabIngestionQuarantineService = {
    * decide "which status value is missing from the mapper" is in the columns
    * below, so reading the payload is not required to act on one of these.
    */
-  async listUnresolved(
-    provider: string = DEFAULT_PROVIDER,
-  ): Promise<{
+  async listUnresolved(provider: string = DEFAULT_PROVIDER): Promise<{
     total: number;
     returned: number;
     results: QuarantinedResultSummary[];
@@ -76,5 +74,29 @@ export const LabIngestionQuarantineService = {
     ]);
 
     return { total, returned: rows.length, results: rows };
+  },
+
+  /**
+   * Mark a held row as dealt with.
+   *
+   * Without this the `resolvedAt` column has no writer, so `listUnresolved` is
+   * `listAll` and `total` can only ever go up - "981 stuck rows" would come to
+   * mean "981 rows we have ever held", and the number that exists to tell an
+   * operator the severity would stop being able to fall.
+   *
+   * `updateMany` with `resolvedAt: null` in the `where` rather than `update` on
+   * the id alone: resolving is idempotent, and the count distinguishes "there
+   * was something to resolve" from "already resolved or no such row" without a
+   * second read. Note that a bare `update` would also throw rather than answer.
+   *
+   * Returns whether this call is the one that resolved it.
+   */
+  async resolve(id: string): Promise<boolean> {
+    const { count } = await prisma.labResultQuarantine.updateMany({
+      where: { id, resolvedAt: null },
+      data: { resolvedAt: new Date() },
+    });
+
+    return count > 0;
   },
 };

--- a/apps/backend/src/services/lab-ingestion-quarantine.service.ts
+++ b/apps/backend/src/services/lab-ingestion-quarantine.service.ts
@@ -1,0 +1,80 @@
+import { prisma } from "src/config/prisma";
+
+/**
+ * Results a provider sent that we could not apply, and which are therefore
+ * waiting on a human.
+ *
+ * This is the operator half of the quarantine: without it, "ingestion has a
+ * stuck row" exists only as a `logger.error` line, and nobody finds out until a
+ * clinic asks where a result went.
+ */
+
+const DEFAULT_PROVIDER = "IDEXX";
+
+// A bounded read on purpose. This is a list endpoint over a table that grows
+// with provider mistakes, and an unbounded one is the defect recorded in #2709.
+// `total` is reported separately so a truncated page is visible as truncated
+// rather than looking like the whole picture.
+const MAX_ROWS = 200;
+
+export type QuarantinedResultSummary = {
+  id: string;
+  provider: string;
+  batchId: string;
+  resultId: string | null;
+  orderId: string | null;
+  labOrderId: string | null;
+  organisationId: string | null;
+  reason: string;
+  externalStatus: string | null;
+  statusDetail: string | null;
+  modality: string | null;
+  createdAt: Date;
+};
+
+export const LabIngestionQuarantineService = {
+  /**
+   * Unresolved rows, oldest first - the oldest is the one that has been waiting
+   * longest, which is the one an operator wants to see at the top.
+   *
+   * The provider `payload` is deliberately NOT selected. This endpoint is
+   * super-admin and therefore cross-tenant, and the payload is the raw provider
+   * body: patient name, client name, clinical detail. Everything needed to
+   * decide "which status value is missing from the mapper" is in the columns
+   * below, so reading the payload is not required to act on one of these.
+   */
+  async listUnresolved(
+    provider: string = DEFAULT_PROVIDER,
+  ): Promise<{
+    total: number;
+    returned: number;
+    results: QuarantinedResultSummary[];
+  }> {
+    const where = { provider, resolvedAt: null };
+
+    const [total, rows] = await Promise.all([
+      prisma.labResultQuarantine.count({ where }),
+      prisma.labResultQuarantine.findMany({
+        where,
+        orderBy: { createdAt: "asc" },
+        take: MAX_ROWS,
+        select: {
+          id: true,
+          provider: true,
+          batchId: true,
+          resultId: true,
+          orderId: true,
+          labOrderId: true,
+          organisationId: true,
+          reason: true,
+          externalStatus: true,
+          statusDetail: true,
+          modality: true,
+          createdAt: true,
+        },
+      }),
+    ]);
+
+    return { total, returned: rows.length, results: rows };
+  },
+};

--- a/apps/backend/test/controllers/web/super-admin-lab-ingestion.controller.test.ts
+++ b/apps/backend/test/controllers/web/super-admin-lab-ingestion.controller.test.ts
@@ -7,6 +7,7 @@ import logger from "src/utils/logger";
 jest.mock("src/services/lab-ingestion-quarantine.service", () => ({
   LabIngestionQuarantineService: {
     listUnresolved: jest.fn(),
+    resolve: jest.fn(),
   },
 }));
 
@@ -89,5 +90,57 @@ describe("SuperAdminLabIngestionController.listQuarantine", () => {
       "Failed to list quarantined lab results",
       expect.any(Error),
     );
+  });
+});
+
+describe("SuperAdminLabIngestionController.resolveQuarantine", () => {
+  const ID = "3f1c2b4e-9a7d-4c11-8f2a-5b6d7e8f9a0b";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedService.resolve.mockResolvedValue(true as never);
+  });
+
+  it("resolves a held row", async () => {
+    const { res, status, json } = buildResponse();
+
+    await SuperAdminLabIngestionController.resolveQuarantine(
+      { params: { id: ID } } as unknown as Request,
+      res,
+    );
+
+    expect(mockedService.resolve).toHaveBeenCalledWith(ID);
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ id: ID, resolved: true });
+  });
+
+  // The rows are uuid-keyed, so a malformed id is a bad request rather than a
+  // miss - and it is answered without reaching the database at all.
+  it("refuses a malformed id instead of querying on it", async () => {
+    const { res, status } = buildResponse();
+
+    await SuperAdminLabIngestionController.resolveQuarantine(
+      { params: { id: "not-a-uuid" } } as unknown as Request,
+      res,
+    );
+
+    expect(mockedService.resolve).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it("answers 404 when there was nothing unresolved to resolve", async () => {
+    mockedService.resolve.mockResolvedValue(false as never);
+    const { res, status, json } = buildResponse();
+
+    await SuperAdminLabIngestionController.resolveQuarantine(
+      { params: { id: ID } } as unknown as Request,
+      res,
+    );
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({
+      error: "No unresolved quarantined result with that id.",
+      code: "QUARANTINE_NOT_FOUND",
+    });
   });
 });

--- a/apps/backend/test/controllers/web/super-admin-lab-ingestion.controller.test.ts
+++ b/apps/backend/test/controllers/web/super-admin-lab-ingestion.controller.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import type { Request, Response } from "express";
+import { SuperAdminLabIngestionController } from "src/controllers/web/super-admin-lab-ingestion.controller";
+import { LabIngestionQuarantineService } from "src/services/lab-ingestion-quarantine.service";
+import logger from "src/utils/logger";
+
+jest.mock("src/services/lab-ingestion-quarantine.service", () => ({
+  LabIngestionQuarantineService: {
+    listUnresolved: jest.fn(),
+  },
+}));
+
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockedService = jest.mocked(LabIngestionQuarantineService);
+const mockedLogger = jest.mocked(logger);
+
+const buildResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json })) as unknown as Response["status"];
+  return { res: { status, json } as unknown as Response, status, json };
+};
+
+describe("SuperAdminLabIngestionController.listQuarantine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedService.listUnresolved.mockResolvedValue({
+      total: 1,
+      returned: 1,
+      results: [],
+    } as never);
+  });
+
+  it("returns the unresolved rows for the default provider", async () => {
+    const { res, status, json } = buildResponse();
+
+    await SuperAdminLabIngestionController.listQuarantine(
+      { query: {} } as Request,
+      res,
+    );
+
+    expect(mockedService.listUnresolved).toHaveBeenCalledWith(undefined);
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ total: 1, returned: 1, results: [] });
+  });
+
+  // The provider goes straight into a `where`, and the set this poller talks to is closed,
+  // so it is validated against that set rather than trimmed and trusted.
+  it("refuses a provider it does not know instead of querying on it", async () => {
+    const { res, status, json } = buildResponse();
+
+    await SuperAdminLabIngestionController.listQuarantine(
+      { query: { provider: "not-a-provider" } } as unknown as Request,
+      res,
+    );
+
+    expect(mockedService.listUnresolved).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      error: "Unknown provider.",
+      code: "INVALID_LAB_PROVIDER",
+    });
+  });
+
+  it("does not leak the underlying failure to the caller", async () => {
+    mockedService.listUnresolved.mockRejectedValue(
+      new Error("relation does not exist") as never,
+    );
+    const { res, status, json } = buildResponse();
+
+    await SuperAdminLabIngestionController.listQuarantine(
+      { query: {} } as Request,
+      res,
+    );
+
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      error: "Unable to list quarantined lab results.",
+      code: "LAB_QUARANTINE_LIST_FAILED",
+    });
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      "Failed to list quarantined lab results",
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/backend/test/routers/super-admin.router.test.ts
+++ b/apps/backend/test/routers/super-admin.router.test.ts
@@ -55,6 +55,9 @@ const mockUpdateBusiness = jest.fn();
 const mockListQuarantine = jest.fn((_, res) =>
   res.status(200).json({ total: 0, returned: 0, results: [] }),
 );
+const mockResolveQuarantine = jest.fn((_, res) =>
+  res.status(200).json({ resolved: true }),
+);
 
 jest.mock("@yosemite-crew/auth", () => ({
   createSessionMiddleware: mockCreateSessionMiddleware,
@@ -82,6 +85,7 @@ jest.mock("src/controllers/web/super-admin-business.controller", () => ({
 jest.mock("src/controllers/web/super-admin-lab-ingestion.controller", () => ({
   SuperAdminLabIngestionController: {
     listQuarantine: mockListQuarantine,
+    resolveQuarantine: mockResolveQuarantine,
   },
 }));
 
@@ -92,14 +96,18 @@ type MockResponse = {
   body: string;
 };
 
-const request = async (app: Express, path: string): Promise<MockResponse> => {
+const request = async (
+  app: Express,
+  path: string,
+  method = "GET",
+): Promise<MockResponse> => {
   const socket = new PassThrough();
   (socket as PassThrough & { remoteAddress?: string }).remoteAddress =
     "127.0.0.1";
   const requestSocket = socket as unknown as Socket;
 
   const req = new IncomingMessage(requestSocket);
-  req.method = "GET";
+  req.method = method;
   req.url = path;
   req.headers = {};
   req.socket = requestSocket;
@@ -274,5 +282,48 @@ describe("super-admin router", () => {
       results: [],
     });
     expect(mockListQuarantine).toHaveBeenCalledTimes(1);
+  });
+
+  // Resolving is the only write on this surface and it clears a row out of the
+  // operator's severity count, so the guard on it is asserted separately rather
+  // than inferred from the read above.
+  it("rejects a non-superadmin resolving a quarantined result", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["member"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/lab-ingestion/quarantine/q-1/resolve",
+      "PATCH",
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockResolveQuarantine).not.toHaveBeenCalled();
+  });
+
+  it("lets a superadmin resolve a quarantined result", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["superadmin"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/lab-ingestion/quarantine/q-1/resolve",
+      "PATCH",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(mockResolveQuarantine).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/test/routers/super-admin.router.test.ts
+++ b/apps/backend/test/routers/super-admin.router.test.ts
@@ -52,6 +52,9 @@ const mockListBusinesses = jest.fn((_, res) =>
 );
 const mockGetBusiness = jest.fn();
 const mockUpdateBusiness = jest.fn();
+const mockListQuarantine = jest.fn((_, res) =>
+  res.status(200).json({ total: 0, returned: 0, results: [] }),
+);
 
 jest.mock("@yosemite-crew/auth", () => ({
   createSessionMiddleware: mockCreateSessionMiddleware,
@@ -73,6 +76,12 @@ jest.mock("src/controllers/web/super-admin-business.controller", () => ({
     listBusinesses: mockListBusinesses,
     getBusiness: mockGetBusiness,
     updateBusiness: mockUpdateBusiness,
+  },
+}));
+
+jest.mock("src/controllers/web/super-admin-lab-ingestion.controller", () => ({
+  SuperAdminLabIngestionController: {
+    listQuarantine: mockListQuarantine,
   },
 }));
 
@@ -218,5 +227,52 @@ describe("super-admin router", () => {
       businesses: [{ id: "org-1" }],
     });
     expect(mockListBusinesses).toHaveBeenCalledTimes(1);
+  });
+
+  // The guard is `router.use(...)` above every route, so a new route inherits it - but
+  // "inherits it" is the kind of thing that is true until someone mounts a route above the
+  // use(). The quarantine list is cross-tenant lab data, so it is asserted rather than
+  // assumed.
+  it("rejects a non-superadmin on the lab ingestion quarantine list", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["member"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/lab-ingestion/quarantine",
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockListQuarantine).not.toHaveBeenCalled();
+  });
+
+  it("serves the lab ingestion quarantine list to a superadmin", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["superadmin"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/lab-ingestion/quarantine",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      total: 0,
+      returned: 0,
+      results: [],
+    });
+    expect(mockListQuarantine).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/test/services/idexx-results.service.test.ts
+++ b/apps/backend/test/services/idexx-results.service.test.ts
@@ -39,6 +39,9 @@ jest.mock("src/config/prisma", () => ({
     labResultSyncState: {
       upsert: jest.fn(),
     },
+    labResultQuarantine: {
+      create: jest.fn(),
+    },
     task: {
       findFirst: jest.fn(),
     },
@@ -121,6 +124,7 @@ describe("IdexxResultsService", () => {
     mockedPrisma.labOrder.update.mockResolvedValue({} as any);
     mockedPrisma.labResult.upsert.mockResolvedValue({} as any);
     mockedPrisma.labResultSyncState.upsert.mockResolvedValue({} as any);
+    mockedPrisma.labResultQuarantine.create.mockResolvedValue({} as any);
     mockedPrisma.task.findFirst.mockResolvedValue(null as any);
     mockedPrisma.document.findFirst.mockResolvedValue(null as any);
     mockedDocumentService.create.mockResolvedValue({} as any);
@@ -214,9 +218,75 @@ describe("IdexxResultsService", () => {
     );
   });
 
-  // Confirming the batch tells IDEXX it was consumed, so a batch whose LabOrder transition we
-  // skipped must stay unconfirmed - otherwise the transition is lost for good.
-  it("leaves a batch unconfirmed when a result status does not map", async () => {
+  // The poll is GLOBAL - one client from IDEXX_GLOBAL_USERNAME, organisationId derived per
+  // result - and IDEXX confirms a BATCH. So refusing to confirm because one row did not map
+  // does not hold up one clinic's queue, it holds up every clinic's, indefinitely: the
+  // unconfirmed batch is re-fetched next poll and meets the same row again. The row is held
+  // instead, and the rest of the batch goes through.
+  it("quarantines an unmapped result and confirms the rest of the batch", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          resultId: "result-1",
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          statusDetail: "awaiting pathologist",
+          modality: "REFERENCE_LAB",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(1, 1);
+
+    // The transition is still NOT applied - that part of #2699 is deliberate and unchanged.
+    expect(mockedPrisma.labOrder.update).not.toHaveBeenCalled();
+
+    // It is held somewhere queryable instead, with the payload needed to replay it.
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        provider: "IDEXX",
+        batchId: "batch-1",
+        resultId: "result-1",
+        orderId: "order-1",
+        labOrderId: "lab-order-1",
+        organisationId: "org-1",
+        reason: "UNMAPPED_RESULT_STATUS",
+        externalStatus: "REQUIRES_REVIEW",
+        statusDetail: "awaiting pathologist",
+        modality: "REFERENCE_LAB",
+        payload: expect.objectContaining({ resultId: "result-1" }),
+      }),
+    });
+
+    // And ingestion continues, which is the whole point.
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
+    expect(mockedPrisma.labResultSyncState.upsert).toHaveBeenCalled();
+
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      "IDEXX result status did not map to a LabOrder status",
+      expect.objectContaining({
+        resultId: "result-1",
+        orderId: "order-1",
+        status: "REQUIRES_REVIEW",
+      }),
+    );
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      "IDEXX results quarantined: a result status did not map to a LabOrder status",
+      { batchId: "batch-1", quarantined: 1 },
+    );
+  });
+
+  // The fallback, and the reason the order is quarantine-then-confirm rather than the
+  // reverse. If nothing is holding the skipped transition, confirming would lose it for
+  // good - so a failed quarantine write returns to the old behaviour: stall, loudly.
+  it("does not confirm a batch when the quarantine write fails", async () => {
+    mockedPrisma.labResultQuarantine.create.mockRejectedValue(
+      new Error("database unavailable") as never,
+    );
     mockGetLatestResults.mockResolvedValue({
       batchId: "batch-1",
       hasMoreResults: false,
@@ -233,21 +303,59 @@ describe("IdexxResultsService", () => {
 
     await IdexxResultsService.pollLatest(1, 1);
 
-    expect(mockedPrisma.labOrder.update).not.toHaveBeenCalled();
+    // Both assertions are needed: confirming alone would not prove the batch was not
+    // consumed if the sync state had advanced anyway.
     expect(mockConfirmLatestBatch).not.toHaveBeenCalled();
     expect(mockedPrisma.labResultSyncState.upsert).not.toHaveBeenCalled();
-    expect(mockedLogger.warn).toHaveBeenCalledWith(
-      "IDEXX result status did not map to a LabOrder status",
-      expect.objectContaining({
-        resultId: "result-1",
-        orderId: "order-1",
-        status: "REQUIRES_REVIEW",
-      }),
-    );
     expect(mockedLogger.error).toHaveBeenCalledWith(
-      "IDEXX batch left unconfirmed: a result status did not map to a LabOrder status",
-      { batchId: "batch-1" },
+      "IDEXX batch left unconfirmed: could not quarantine an unmapped result",
+      expect.objectContaining({ batchId: "batch-1" }),
     );
+  });
+
+  // One row per unapplicable result, including when the provider sent no result id at all.
+  // An upsert key would collapse these two onto one row, which is the silent loss the whole
+  // change exists to prevent - hence no unique key on the table.
+  it("records every unmapped result in a batch, including ones with no result id", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+        {
+          orderId: "order-2",
+          status: "SOMETHING_NEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-2" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(2, 1);
+
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenCalledTimes(2);
+    const reasons = mockedPrisma.labResultQuarantine.create.mock.calls.map(
+      (call) =>
+        (call[0] as { data: { resultId: unknown; orderId: unknown } }).data,
+    );
+    // Null, not "": an id the provider never sent is worth seeing as absent.
+    expect(reasons).toEqual([
+      expect.objectContaining({ resultId: null, orderId: "order-1" }),
+      expect.objectContaining({ resultId: null, orderId: "order-2" }),
+    ]);
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
+  });
+
+  it("does not quarantine a result whose status maps", async () => {
+    await IdexxResultsService.pollLatest(1, 1);
+
+    expect(mockedPrisma.labResultQuarantine.create).not.toHaveBeenCalled();
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
   });
 
   // The result row itself still lands, so an unmapped status is not a lost result - but the
@@ -279,7 +387,10 @@ describe("IdexxResultsService", () => {
     expect(mockedDocumentService.create).not.toHaveBeenCalled();
   });
 
-  it("holds back a mixed batch, applying the rows that do map", async () => {
+  // The mixed batch is the realistic case: one clinic's unrecognised status arriving
+  // alongside other clinics' ordinary results. Before the quarantine, the whole batch was
+  // held for the one row - which is the outage.
+  it("applies the rows that do map in a mixed batch, and holds only the one that does not", async () => {
     mockGetLatestResults.mockResolvedValue({
       batchId: "batch-1",
       hasMoreResults: false,
@@ -304,6 +415,10 @@ describe("IdexxResultsService", () => {
     await IdexxResultsService.pollLatest(2, 1);
 
     expect(mockedPrisma.labOrder.update).toHaveBeenCalledTimes(1);
-    expect(mockConfirmLatestBatch).not.toHaveBeenCalled();
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenCalledTimes(1);
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ resultId: "result-2" }),
+    });
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
   });
 });

--- a/apps/backend/test/services/idexx-results.service.test.ts
+++ b/apps/backend/test/services/idexx-results.service.test.ts
@@ -42,6 +42,7 @@ jest.mock("src/config/prisma", () => ({
     labResultQuarantine: {
       create: jest.fn(),
     },
+    $transaction: jest.fn(),
     task: {
       findFirst: jest.fn(),
     },
@@ -125,6 +126,10 @@ describe("IdexxResultsService", () => {
     mockedPrisma.labResult.upsert.mockResolvedValue({} as any);
     mockedPrisma.labResultSyncState.upsert.mockResolvedValue({} as any);
     mockedPrisma.labResultQuarantine.create.mockResolvedValue({} as any);
+    // Behaves like the real client: runs what it is handed, all or nothing.
+    (mockedPrisma.$transaction as unknown as jest.Mock).mockImplementation(
+      async (ops: unknown) => Promise.all(ops as Promise<unknown>[]),
+    );
     mockedPrisma.task.findFirst.mockResolvedValue(null as any);
     mockedPrisma.document.findFirst.mockResolvedValue(null as any);
     mockedDocumentService.create.mockResolvedValue({} as any);
@@ -284,7 +289,7 @@ describe("IdexxResultsService", () => {
   // reverse. If nothing is holding the skipped transition, confirming would lose it for
   // good - so a failed quarantine write returns to the old behaviour: stall, loudly.
   it("does not confirm a batch when the quarantine write fails", async () => {
-    mockedPrisma.labResultQuarantine.create.mockRejectedValue(
+    (mockedPrisma.$transaction as unknown as jest.Mock).mockRejectedValue(
       new Error("database unavailable") as never,
     );
     mockGetLatestResults.mockResolvedValue({
@@ -348,6 +353,41 @@ describe("IdexxResultsService", () => {
       expect.objectContaining({ resultId: null, orderId: "order-1" }),
       expect.objectContaining({ resultId: null, orderId: "order-2" }),
     ]);
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
+  });
+
+  // Every held row in ONE write, because the fallback is only "the previous
+  // behaviour" if a part-way failure leaves nothing behind. A loop of creates
+  // commits the earlier rows, returns false, and the next poll re-fetches the
+  // same batch and writes them again - once per poll, unbounded, inflating the
+  // one number an operator reads as severity.
+  it("writes every held row in a single transaction", async () => {
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          resultId: "result-1",
+          orderId: "order-1",
+          status: "REQUIRES_REVIEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+        {
+          resultId: "result-2",
+          orderId: "order-2",
+          status: "SOMETHING_NEW",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-2" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(2, 1);
+
+    const transaction = mockedPrisma.$transaction as unknown as jest.Mock;
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect((transaction.mock.calls[0][0] as unknown[]).length).toBe(2);
     expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
   });
 

--- a/apps/backend/test/services/lab-ingestion-quarantine.service.test.ts
+++ b/apps/backend/test/services/lab-ingestion-quarantine.service.test.ts
@@ -7,6 +7,7 @@ jest.mock("src/config/prisma", () => ({
     labResultQuarantine: {
       count: jest.fn(),
       findMany: jest.fn(),
+      updateMany: jest.fn(),
     },
   },
 }));
@@ -71,5 +72,38 @@ describe("LabIngestionQuarantineService.listUnresolved", () => {
     };
     expect(call.select.payload).toBeUndefined();
     expect(call.select.externalStatus).toBe(true);
+  });
+});
+
+describe("LabIngestionQuarantineService.resolve", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPrisma.labResultQuarantine.updateMany.mockResolvedValue({
+      count: 1,
+    } as never);
+  });
+
+  // resolvedAt is in the `where`, not only the `data`. Without it a second call
+  // would move the timestamp forward and report success again, so "resolved" and
+  // "resolved by this call" would be indistinguishable.
+  it("resolves only a row nobody has resolved yet", async () => {
+    await expect(LabIngestionQuarantineService.resolve("q-1")).resolves.toBe(
+      true,
+    );
+
+    expect(mockedPrisma.labResultQuarantine.updateMany).toHaveBeenCalledWith({
+      where: { id: "q-1", resolvedAt: null },
+      data: { resolvedAt: expect.any(Date) },
+    });
+  });
+
+  it("reports no-op when nothing matched, rather than throwing", async () => {
+    mockedPrisma.labResultQuarantine.updateMany.mockResolvedValue({
+      count: 0,
+    } as never);
+
+    await expect(
+      LabIngestionQuarantineService.resolve("q-missing"),
+    ).resolves.toBe(false);
   });
 });

--- a/apps/backend/test/services/lab-ingestion-quarantine.service.test.ts
+++ b/apps/backend/test/services/lab-ingestion-quarantine.service.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import { prisma } from "src/config/prisma";
+import { LabIngestionQuarantineService } from "src/services/lab-ingestion-quarantine.service";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    labResultQuarantine: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe("LabIngestionQuarantineService.listUnresolved", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPrisma.labResultQuarantine.count.mockResolvedValue(0 as never);
+    mockedPrisma.labResultQuarantine.findMany.mockResolvedValue([] as never);
+  });
+
+  it("reads only rows nobody has resolved yet, for the requested provider", async () => {
+    await LabIngestionQuarantineService.listUnresolved();
+
+    expect(mockedPrisma.labResultQuarantine.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider: "IDEXX", resolvedAt: null },
+      }),
+    );
+    expect(mockedPrisma.labResultQuarantine.count).toHaveBeenCalledWith({
+      where: { provider: "IDEXX", resolvedAt: null },
+    });
+  });
+
+  // #2709 is the same defect in the other direction: a list endpoint with no bound. This
+  // table grows with provider mistakes, so the read is capped and the cap is asserted.
+  it("bounds the read and reports the true total separately", async () => {
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      id: `q-${index}`,
+    }));
+    mockedPrisma.labResultQuarantine.count.mockResolvedValue(981 as never);
+    mockedPrisma.labResultQuarantine.findMany.mockResolvedValue(rows as never);
+
+    const result = await LabIngestionQuarantineService.listUnresolved();
+
+    expect(mockedPrisma.labResultQuarantine.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 200 }),
+    );
+    // A truncated page has to be visible as truncated, or 981 stuck rows read as 200.
+    expect(result.total).toBe(981);
+    expect(result.returned).toBe(200);
+  });
+
+  it("returns the oldest first, because that is the one that has waited longest", async () => {
+    await LabIngestionQuarantineService.listUnresolved();
+
+    expect(mockedPrisma.labResultQuarantine.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: "asc" } }),
+    );
+  });
+
+  // This endpoint is super-admin, so it is cross-tenant. The stored payload is the raw
+  // provider body - patient name, client name, clinical detail - and none of it is needed to
+  // decide which status value the mapper is missing.
+  it("never selects the raw provider payload", async () => {
+    await LabIngestionQuarantineService.listUnresolved();
+
+    const call = mockedPrisma.labResultQuarantine.findMany.mock.calls[0][0] as {
+      select: Record<string, boolean>;
+    };
+    expect(call.select.payload).toBeUndefined();
+    expect(call.select.externalStatus).toBe(true);
+  });
+});

--- a/packages/database/prisma/migrations/20260905130000_lab_result_quarantine/migration.sql
+++ b/packages/database/prisma/migrations/20260905130000_lab_result_quarantine/migration.sql
@@ -1,0 +1,47 @@
+-- Hold an IDEXX result that could not be applied, instead of refusing the batch.
+--
+-- IDEXX confirms a BATCH, not a row, and the poll is global: one client built
+-- from IDEXX_GLOBAL_USERNAME, with organisationId derived per result. So
+-- leaving a batch unconfirmed because one row's status did not map halts lab
+-- ingestion for EVERY organisation until the mapper learns that value - the
+-- unconfirmed batch is re-fetched next poll and hits the same row again.
+-- Recording the row here is what makes confirming the rest of the batch safe:
+-- the skipped transition is held and replayable, not lost.
+--
+-- Purely additive. A new table is invisible to the currently running code, so
+-- this is safe to apply before the cutover and safe to leave behind on a
+-- rollback; nothing existing is altered, renamed or constrained.
+--
+-- No unique key on purpose. The failure this table exists to prevent is a
+-- result disappearing silently, and an upsert key would do exactly that to two
+-- rows in one batch that both arrived without a resultId.
+CREATE TABLE IF NOT EXISTS "LabResultQuarantine" (
+  "id"             TEXT         NOT NULL,
+  "provider"       TEXT         NOT NULL,
+  "batchId"        TEXT         NOT NULL,
+  "resultId"       TEXT,
+  "orderId"        TEXT,
+  "labOrderId"     TEXT,
+  "organisationId" TEXT,
+  "reason"         TEXT         NOT NULL,
+  "externalStatus" TEXT,
+  "statusDetail"   TEXT,
+  "modality"       TEXT,
+  "payload"        JSONB,
+  "resolvedAt"     TIMESTAMP(3),
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"      TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "LabResultQuarantine_pkey" PRIMARY KEY ("id")
+);
+
+-- The operator read is "what is still stuck for this provider", so resolvedAt
+-- follows provider in the index rather than standing alone.
+CREATE INDEX IF NOT EXISTS "LabResultQuarantine_provider_resolvedAt_idx"
+  ON "LabResultQuarantine" ("provider", "resolvedAt");
+
+CREATE INDEX IF NOT EXISTS "LabResultQuarantine_provider_resultId_idx"
+  ON "LabResultQuarantine" ("provider", "resultId");
+
+CREATE INDEX IF NOT EXISTS "LabResultQuarantine_organisationId_idx"
+  ON "LabResultQuarantine" ("organisationId");

--- a/packages/database/prisma/migrations/20260905130000_lab_result_quarantine/migration.sql
+++ b/packages/database/prisma/migrations/20260905130000_lab_result_quarantine/migration.sql
@@ -35,6 +35,9 @@ CREATE TABLE IF NOT EXISTS "LabResultQuarantine" (
   CONSTRAINT "LabResultQuarantine_pkey" PRIMARY KEY ("id")
 );
 
+-- Deny direct Supabase PostgREST access; the API connects as the owning role.
+ALTER TABLE "LabResultQuarantine" ENABLE ROW LEVEL SECURITY;
+
 -- The operator read is "what is still stuck for this provider", so resolvedAt
 -- follows provider in the index rather than standing alone.
 CREATE INDEX IF NOT EXISTS "LabResultQuarantine_provider_resolvedAt_idx"

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -427,6 +427,49 @@ model LabResult {
   @@index([organisationId])
 }
 
+/// A provider result that could not be applied, held aside so that one
+/// unrecognised value cannot stop ingestion for every organisation.
+///
+/// IDEXX confirms a BATCH, not a row, and the poll is global - one client built
+/// from IDEXX_GLOBAL_USERNAME, with organisationId derived per result. Refusing
+/// to confirm a batch containing an unapplicable row therefore halts lab results
+/// for every clinic until the mapper learns the value. Recording the row here is
+/// what makes confirming the rest of the batch safe: the transition is held, not
+/// lost.
+///
+/// Deliberately has NO unique key. The failure this table exists to prevent is a
+/// result disappearing silently, and an upsert key would do exactly that to two
+/// rows in one batch that both arrived without a resultId. A duplicate is cheap;
+/// a dropped row is the bug.
+model LabResultQuarantine {
+  id             String    @id @default(uuid())
+  provider       String
+  batchId        String
+  /// Whatever the provider supplied. Null when it supplied nothing usable,
+  /// which is itself worth seeing rather than coercing to an empty string.
+  resultId       String?
+  orderId        String?
+  labOrderId     String?
+  organisationId String?
+  /// Why it was held. A plain string rather than an enum so a new reason needs
+  /// no migration; the values in use are named as constants in
+  /// idexx-results.service.ts.
+  reason         String
+  externalStatus String?
+  statusDetail   String?
+  modality       String?
+  /// The provider payload as received, so the row can be replayed once the
+  /// mapper is extended.
+  payload        Json?
+  resolvedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@index([provider, resolvedAt])
+  @@index([provider, resultId])
+  @@index([organisationId])
+}
+
 model LabResultSyncState {
   id            String    @id @default(uuid())
   provider      String    @unique


### PR DESCRIPTION
Closes #2708.

## The outage

`pollLatest` builds **one** client from `IDEXX_GLOBAL_USERNAME`, the batch loop is global, and `organisationId` is derived per result. IDEXX confirms a **batch**, not a row. So #2699's fail-closed `break` does not hold up *a* queue — it holds up **every organisation's**, indefinitely: the unconfirmed batch is re-fetched on the next poll and meets the same unmappable row again. One unrecognised status value from one clinic stops lab results for all clinics until `mapResultStatusToLabOrder` learns it and ships.

## What this does not change

The fail-closed choice is right and is untouched. An unmappable status still does **not** write a `LabOrder` transition. Losing a transition silently is worse than stalling, and that remains true.

What changes is where the skipped transition lives. It is now held in `LabResultQuarantine` with the provider payload needed to replay it, and *that is what makes confirming the rest of the batch safe*. Order is load-bearing and asserted: **quarantine first, confirm second.** If the quarantine write fails there is nowhere holding the transition, so the poll falls back to exactly the previous behaviour and leaves the batch unconfirmed — stalling everyone is bad, and better than confirming a batch whose skipped transition is recorded nowhere at all.

## Decisions worth a reviewer's eye

**`LabResultQuarantine` has no unique key, on purpose.** The failure this table exists to prevent is a result disappearing silently, and an upsert key would do exactly that to two rows in one batch that both arrived without a `resultId`. A duplicate row is cheap; a dropped one is the bug. `create`, never `upsert`.

**A missing `resultId` is stored as `null`, not `""`.** An id the provider never sent is worth seeing as absent rather than as an empty one.

**The operator surface, because a `logger.error` is not an operational signal.** `GET /v1/super-admin/lab-ingestion/quarantine`, behind the existing `router.use(requireAnyAuth, requireSuperAdmin)`. Three deliberate constraints:

- **Bounded at 200**, with the true `total` reported separately — #2709 is the same defect in the other direction, and a truncated page that does not say it is truncated reads as the whole picture.
- **It never selects the stored `payload`.** This endpoint is super-admin and therefore cross-tenant; the payload is the raw provider body — patient name, client name, clinical detail — and nothing in it is needed to decide which status value the mapper is missing.
- **`provider` is validated against a closed set**, not trimmed and trusted, because it goes straight into a `where`.

**The migration is purely additive.** A new table is invisible to the currently running code, so it is safe to apply before the cutover and safe to leave behind on a rollback; nothing existing is altered, renamed or constrained. Both indexes and the table use `IF NOT EXISTS`.

## What is deliberately not here

**Replay is not automated.** Replaying a quarantined row requires the mapper to have learned the status and been deployed, at which point the payload is on hand and the action is a decision rather than a retry. Building an automatic replay before anyone has seen one of these rows would be guessing at the shape of the recovery.

**No paging or resolve endpoint.** The read is bounded and reports its total; if the total is routinely over 200 the right response is to fix the mapper, not to page through the backlog.

## Evidence

At `872b99cd7`, rebased onto `dev` after #2699 merged, `git rev-parse HEAD` confirmed in the same shell before and after each run:

| Command | Result |
|---|---|
| `npx jest` (full backend) | exit 0 — **468 suites / 11238 tests** |
| `turbo run lint type-check --filter=backend --force` | exit 0 — 7/7, **0 errors**, 25 pre-existing warnings, none in the touched files |
| `prisma validate` | schema is valid |
| `prisma generate` | exit 0 |

The change adds exactly 2 suites and 12 tests, counted per suite: `idexx-results.service` 6 → 9, `routers/super-admin` 4 → 6, plus new `lab-ingestion-quarantine.service` (4) and `super-admin-lab-ingestion.controller` (3).

Eight mutations, each reverted with `git checkout 872b99cd7 -- <file>` before the next, 22/22 on the focused set either side:

| Mutation | Red |
|---|---|
| confirm the batch even when the quarantine write failed | 1 |
| drop the `labResultQuarantine.create` | 4 |
| coerce a missing `resultId` to `""` instead of `null` | 1 |
| remove `take: MAX_ROWS` from the list read | 1 |
| add `payload: true` to the select | 1 |
| drop `resolvedAt: null` from the `where` | 1 |
| mount the quarantine route **above** `router.use(requireSuperAdmin)` | 1 |
| widen the `provider` query param to `z.string()` | 1 |

The route-above-the-guard mutation is the one I would not have shipped without: `router.use(...)` sits above every route today, so the new one inherits the guard — which stays true only until someone mounts a route above it. This is cross-tenant lab data, so it is asserted rather than assumed.

**A correction on my own mutation run, since it nearly produced a false negative.** My first attempt at the `resultId` mutation reported green. The mutation had matched a *different* `resultId: coerceString(...)` line — the one in `syncLabOrderFromResult`'s `logger.warn`, which no test asserts on — so it never touched the quarantine write. Re-applied to the correct line it turns 1 red. A mutation that silently lands somewhere else looks exactly like a test that does not enforce anything.

**Not claimed:** the route is absent from `openapi.yaml`, as is every other `super-admin` route — `grep -n "super-admin" apps/frontend/public/static/openapi/openapi.yaml` returns nothing. The OpenAPI Drift check reports "mounted but absent from the spec" non-fatally, so a green tick there is not documentation coverage. Documenting that whole router is out of scope here.
