### PR TITLE
test(ci): arm the real deploy exit handler instead of a copy of it

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -109,29 +109,19 @@ else
   echo "this deploy adds no migrations - the schema does not move"
 fi
 
-# Said on the way out, not from the branches that remembered to say it.
+# The handler itself is `deploy_on_exit` in lib/migrate.sh, so the test suite
+# can arm the real one instead of a hand-written copy of it. The state it reads
+# - MIGRATIONS_APPLIED, CUTOVER_DONE, ROLLBACK_SHA, INCOMING_MIGRATIONS - is set
+# above; SMOKE_PID is set and cleared around the boot below.
 #
-# This script runs under `set -e`, so a command that simply fails ends it where
-# it stands. Hanging the notice off the two branches that test a status meant
-# every other exit between the migration and the cutover was silent - including
-# the likeliest one of all, `prisma migrate deploy` halting part-way through and
-# leaving the earlier migrations applied. An EXIT trap cannot be walked past.
-#
-# It also owns the smoke process, so there is one handler rather than an
-# arm/disarm pair around the boot that a later edit could fall out of.
-on_exit() {
-  local status=$?
-
-  if [ -n "$SMOKE_PID" ]; then
-    kill "$SMOKE_PID" 2>/dev/null || true
-  fi
-
-  # Deliberate word splitting - one argument per migration. Prisma directory
-  # names are <timestamp>_<snake_case>, so there is nothing here to glob.
-  # shellcheck disable=SC2086
-  deploy_stop_notice "$status" "$MIGRATIONS_APPLIED" "$CUTOVER_DONE" \
-    "$ROLLBACK_SHA" $INCOMING_MIGRATIONS
-}
+# Why a trap at all: this script runs under `set -e`, so a command that simply
+# fails ends it where it stands. Hanging the notice off the two branches that
+# test a status meant every other exit between the migration and the cutover was
+# silent - including the likeliest one of all, `prisma migrate deploy` halting
+# part-way through and leaving the earlier migrations applied. An EXIT trap
+# cannot be walked past. It also owns the smoke process, so there is one handler
+# rather than an arm/disarm pair around the boot that a later edit could fall
+# out of.
 
 say "install"
 pnpm install --frozen-lockfile
@@ -189,7 +179,7 @@ fi
 # Prisma fails having applied nothing, and over-reporting a schema hazard is the
 # safe direction. A deploy that carries no migrations cannot move the schema at
 # all, so it stays silent.
-trap on_exit EXIT
+trap deploy_on_exit EXIT
 if [ -n "$INCOMING_MIGRATIONS" ]; then
   MIGRATIONS_APPLIED=1
 fi

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -49,6 +49,43 @@ deploy_incoming_migrations() {
     | sort
 }
 
+# deploy_on_exit
+#
+# The EXIT trap api-deploy.sh installs before it lets the schema move.
+#
+# Lives here rather than in api-deploy.sh because the test that proves the
+# notice survives `set -e` cannot run api-deploy.sh - it wants pm2, node, a
+# database and a box. It used to hand-write its own copy of this handler, which
+# meant the only thing tying the copy to the real one was a grep on line
+# ordering, and transposing the two flags in the real one left the whole suite
+# green while inverting the notice: fires only after a verified cutover, silent
+# exactly when the schema is ahead. Three positional flags of the same type and
+# nothing to catch a swap. Now there is one handler, so there is one place for
+# the order to be wrong and a test that exercises it.
+#
+# Reads the caller's state rather than taking arguments, because an EXIT trap
+# has no arguments to take. Callers must set MIGRATIONS_APPLIED, CUTOVER_DONE,
+# ROLLBACK_SHA and INCOMING_MIGRATIONS before arming it; under `set -u` a
+# missing one aborts loudly, which is the right direction - the alternative is a
+# default, and the only sensible default for "did the schema move" is the silent
+# one.
+#
+# SMOKE_PID is the exception and IS defaulted: no smoke process is a normal
+# state for most of the script's life, not a caller mistake.
+deploy_on_exit() {
+  local status=$?
+
+  if [ -n "${SMOKE_PID:-}" ]; then
+    kill "$SMOKE_PID" 2>/dev/null || true
+  fi
+
+  # Deliberate word splitting - one argument per migration. Prisma directory
+  # names are <timestamp>_<snake_case>, so there is nothing here to glob.
+  # shellcheck disable=SC2086
+  deploy_stop_notice "$status" "$MIGRATIONS_APPLIED" "$CUTOVER_DONE" \
+    "$ROLLBACK_SHA" $INCOMING_MIGRATIONS
+}
+
 # deploy_stop_notice <exit-status> <migrations-applied> <cutover-done> <rollback-sha> <migration>...
 #
 # Whether an exiting deploy owes the operator the hazard notice.

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -233,6 +233,84 @@ case "$STOP_NOTICE" in
   *) no "passes every migration through to the notice" "$STOP_NOTICE" ;;
 esac
 
+echo
+echo "deploy_on_exit"
+
+# The handler api-deploy.sh actually arms, exercised directly.
+#
+# deploy_stop_notice takes three positional flags of the same type, and nothing
+# - not the shell, not shellcheck - catches a transposition. The suite could
+# not either, while the test hand-wrote its own copy of this handler and the
+# only thing tying the copy to the real one was a grep on line ordering.
+# Swapping the two flags in the real handler inverts the notice completely:
+# fires only after a verified cutover, silent exactly when the schema is ahead.
+#
+# So each flag is varied independently against the real function. It reads the
+# caller's state rather than taking arguments, because an EXIT trap has none.
+on_exit_fired() { # on_exit_fired <status> <migrations-applied> <cutover-done>
+  local out
+  out="$(
+    MIGRATIONS_APPLIED="$2" \
+    CUTOVER_DONE="$3" \
+    ROLLBACK_SHA=abc1234 \
+    INCOMING_MIGRATIONS="20260102000000_second" \
+    bash -c '
+      set -u
+      . "'"$HERE"'/../lib/migrate.sh"
+      ( exit '"$1"' )
+      deploy_on_exit
+    ' 2>&1 >/dev/null
+  )"
+  if [ -n "$out" ]; then echo yes; else echo no; fi
+}
+
+check "the real handler fires when migrations applied and no cutover" \
+  "yes" "$(on_exit_fired 1 1 0)"
+check "the real handler is silent after a verified cutover" \
+  "no" "$(on_exit_fired 1 1 1)"
+check "the real handler is silent when the schema never moved" \
+  "no" "$(on_exit_fired 1 0 0)"
+check "the real handler is silent on a clean exit" \
+  "no" "$(on_exit_fired 0 1 0)"
+
+# The two silent cases above are what make a transposition red: swapping
+# MIGRATIONS_APPLIED and CUTOVER_DONE turns "silent after a verified cutover"
+# into a notice and "fires when migrations applied" into silence.
+
+ON_EXIT_OUT="$(
+  MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=deadbee \
+  INCOMING_MIGRATIONS="20260102000000_second 20260103000000_third" \
+  bash -c '
+    set -u
+    . "'"$HERE"'/../lib/migrate.sh"
+    ( exit 1 )
+    deploy_on_exit
+  ' 2>&1 >/dev/null
+)"
+case "$ON_EXIT_OUT" in
+  *deadbee*20260102000000_second*20260103000000_third*)
+    ok "the real handler passes the rollback sha and every migration through" ;;
+  *) no "the real handler passes the rollback sha and every migration through" \
+       "$ON_EXIT_OUT" ;;
+esac
+
+# SMOKE_PID is the one piece of state the handler defaults, because "no smoke
+# process" is a normal state for most of the script rather than a caller
+# mistake. Everything else is deliberately undefaulted so `set -u` refuses
+# rather than silently choosing the silent answer.
+if MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+   INCOMING_MIGRATIONS="20260102000000_second" \
+   bash -c '
+     set -u
+     . "'"$HERE"'/../lib/migrate.sh"
+     ( exit 1 )
+     deploy_on_exit
+   ' >/dev/null 2>&1; then
+  ok "the real handler tolerates an unset SMOKE_PID"
+else
+  no "the real handler tolerates an unset SMOKE_PID" "it failed under set -u"
+fi
+
 # ---------------------------------------------------------------------------
 # The regression itself.
 #
@@ -253,16 +331,12 @@ set -euo pipefail
 
 MIGRATIONS_APPLIED=0
 CUTOVER_DONE=0
+ROLLBACK_SHA=abc1234
 INCOMING_MIGRATIONS="20260102000000_second"
 
-on_exit() {
-  local status=\$?
-  # shellcheck disable=SC2086
-  deploy_stop_notice "\$status" "\$MIGRATIONS_APPLIED" "\$CUTOVER_DONE" \\
-    abc1234 \$INCOMING_MIGRATIONS
-}
-
-trap on_exit EXIT
+# The REAL handler, armed the way api-deploy.sh arms it. A hand-written copy
+# here is what let a transposition of its two flags stay green.
+trap deploy_on_exit EXIT
 MIGRATIONS_APPLIED=1
 # Stands in for prisma halting part-way: two applied, then a bare failure.
 echo "applied 20260101000000_first"
@@ -304,7 +378,7 @@ DEPLOY_SH="$HERE/../api-deploy.sh"
 # the whole suite through `set -e` on the assignment below.
 line_of() { grep -n -m1 -F "$1" "$DEPLOY_SH" | cut -d: -f1 || true; }
 
-TRAP_LINE="$(line_of 'trap on_exit EXIT')"
+TRAP_LINE="$(line_of 'trap deploy_on_exit EXIT')"
 FLAG_LINE="$(line_of 'MIGRATIONS_APPLIED=1')"
 DEPLOY_LINE="$(line_of 'run prisma:deploy')"
 

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -319,6 +319,56 @@ else
   no "the real handler tolerates an unset SMOKE_PID" "it failed under set -u"
 fi
 
+# The handler has TWO jobs, and every check above exercises only one. Deleting
+# the kill outright left the whole suite green, which made "the smoke process is
+# reaped on any exit" a claim the comment makes and nothing tests. The stakes
+# are a deploy that fails for a reason nothing in its output names: an orphaned
+# smoke process holds :8099, so the NEXT deploy's boot cannot bind, /health
+# answers 000 and it correctly refuses to cut over - failing closed, and failing
+# opaque.
+#
+# `wait` rather than `kill -0`, because a killed child is a zombie until it is
+# reaped and `kill -0` reports a zombie as alive. The status distinguishes the
+# two outcomes: 143 is SIGTERM, 0 is "it ran to completion untouched".
+SMOKE_WAIT_STATUS="$(
+  MIGRATIONS_APPLIED=0 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="" \
+  bash -c '
+    set -u
+    . "'"$HERE"'/../lib/migrate.sh"
+    sleep 2 &
+    SMOKE_PID=$!
+    deploy_on_exit
+    wait "$SMOKE_PID" 2>/dev/null
+    echo "$?"
+  ' 2>/dev/null || echo aborted
+)"
+check "the real handler kills the smoke process" "143" "$SMOKE_WAIT_STATUS"
+
+# And the kill must not be able to swallow the notice. api-deploy.sh runs under
+# `set -e`, so an unguarded `kill` of a process that has already exited would
+# end the handler where it stands - before the notice, on the exit path the
+# notice exists for. `|| true` is what stops that, and nothing tested it.
+DEAD_PID_NOTICE="$(
+  MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="20260102000000_second" \
+  bash -c '
+    set -eu
+    . "'"$HERE"'/../lib/migrate.sh"
+    sleep 0 &
+    SMOKE_PID=$!
+    wait "$SMOKE_PID" 2>/dev/null || true
+    trap deploy_on_exit EXIT
+    false
+  ' 2>&1 >/dev/null || true
+)"
+case "$DEAD_PID_NOTICE" in
+  *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*)
+    ok "a smoke process that has already exited does not swallow the notice" ;;
+  *) no "a smoke process that has already exited does not swallow the notice" \
+       "stderr was: $DEAD_PID_NOTICE" ;;
+esac
+
 # ---------------------------------------------------------------------------
 # The regression itself.
 #

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -369,6 +369,36 @@ case "$DEAD_PID_NOTICE" in
        "stderr was: $DEAD_PID_NOTICE" ;;
 esac
 
+# The reap runs BEFORE the notice, and that order is load-bearing rather than
+# stylistic. Moving the kill below the notice is green today - every branch of
+# deploy_stop_notice returns 0, so nothing after it is skipped. But under
+# `set -e` the day one of them returns non-zero, a handler in that order stops
+# at the notice and never reaps, and neither change on its own fails anything:
+# the reorder is green now, and the `return 1` would be green in a handler that
+# reaps first. This pins the order by supplying the half that does not exist
+# yet.
+#
+# It stubs both sides deliberately - `kill` so the ordering is observable
+# without a real child, deploy_stop_notice so it can fail - and runs the real
+# deploy_on_exit between them. So it testifies about the order of the two
+# statements and nothing else; that the kill actually kills is the check above,
+# which is why both are here.
+REAP_ORDER="$(
+  MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="20260102000000_second" \
+  bash -c '
+    set -eu
+    . "'"$HERE"'/../lib/migrate.sh"
+    kill() { echo REAPED; }
+    deploy_stop_notice() { echo NOTICE; return 1; }
+    SMOKE_PID=4242
+    trap deploy_on_exit EXIT
+    false
+  ' 2>/dev/null || true
+)"
+check "the reap cannot be swallowed by a notice that fails" \
+  "REAPED NOTICE" "$(printf '%s' "$REAP_ORDER" | tr '\n' ' ' | sed 's/ $//')"
+
 # ---------------------------------------------------------------------------
 # The regression itself.
 #

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -247,6 +247,11 @@ echo "deploy_on_exit"
 #
 # So each flag is varied independently against the real function. It reads the
 # caller's state rather than taking arguments, because an EXIT trap has none.
+# Matches the NOTICE, not merely "something reached stderr". A `set -u` abort
+# inside the handler also writes to stderr, and reading that as "the notice
+# fired" would make three of the four checks below pass for the wrong reason -
+# and turn red for the wrong reason too, which is worse. `|| true` because a
+# probe that dies must report as a failed check rather than end the suite.
 on_exit_fired() { # on_exit_fired <status> <migrations-applied> <cutover-done>
   local out
   out="$(
@@ -259,9 +264,12 @@ on_exit_fired() { # on_exit_fired <status> <migrations-applied> <cutover-done>
       . "'"$HERE"'/../lib/migrate.sh"
       ( exit '"$1"' )
       deploy_on_exit
-    ' 2>&1 >/dev/null
+    ' 2>&1 >/dev/null || true
   )"
-  if [ -n "$out" ]; then echo yes; else echo no; fi
+  case "$out" in
+    *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*) echo yes ;;
+    *) echo no ;;
+  esac
 }
 
 check "the real handler fires when migrations applied and no cutover" \
@@ -285,7 +293,7 @@ ON_EXIT_OUT="$(
     . "'"$HERE"'/../lib/migrate.sh"
     ( exit 1 )
     deploy_on_exit
-  ' 2>&1 >/dev/null
+  ' 2>&1 >/dev/null || true
 )"
 case "$ON_EXIT_OUT" in
   *deadbee*20260102000000_second*20260103000000_third*)


### PR DESCRIPTION
Closes #2713.

## What was wrong

`migrate.test.sh` proved the schema hazard notice survives `set -e` by generating a stand-in script that **hand-wrote its own `on_exit`**. The real handler lived in `api-deploy.sh`, and the only thing tying the two together was a `grep` on line ordering.

So transposing the real handler's two flags left the suite at **25 passed, 0 failed** — while inverting the notice completely: it would fire only *after* a verified cutover and stay silent exactly when the schema is ahead of the running code, which is the entire defect it exists to announce. `deploy_stop_notice` takes three positional flags of the same type; nothing catches a swap — not the shell, not shellcheck, not the tests.

## What this does

`on_exit` moves into `lib/migrate.sh` as **`deploy_on_exit`**, beside the two functions it calls and for the same reason those are there: so it can be exercised without pm2, node, a database and a box. `api-deploy.sh` arms it. The stand-in arms it. One handler, one place for the order to be wrong, and tests that vary each flag against the **real** function rather than a lookalike.

It reads the caller's state rather than taking arguments, because an EXIT trap has none to take. `MIGRATIONS_APPLIED`, `CUTOVER_DONE`, `ROLLBACK_SHA` and `INCOMING_MIGRATIONS` are deliberately **undefaulted**, so `set -u` refuses rather than silently choosing the silent answer to "did the schema move". `SMOKE_PID` **is** defaulted, because no smoke process is a normal state for most of the run rather than a caller mistake.

The grep-based ordering assertion stays. It now checks something the stand-in genuinely cannot: that `api-deploy.sh` arms the trap and raises the flag *before* the migration runs. That ordering only exists in the real script, and running the real script needs a live box.

## Evidence

At `e35e77c03`, `git rev-parse HEAD` confirmed in the same shell before and after each run, tree clean:

| Command | Result |
|---|---|
| `scripts/deploy/tests/migrate.test.sh` | **31/31**, exit 0 (was 25) |
| `scripts/deploy/tests/git-sync.test.sh` | 16/16, exit 0 |
| `scripts/ci/classify-migration.test.mjs` | 36 pass, 0 fail |
| `shellcheck -x` on all three changed files, run from `scripts/deploy` | **0 warnings, 0 errors** — three pre-existing SC2015 infos on untouched lines |

Eight mutations, applied through a harness that asserts the target occurs **exactly once** and refuses the edit otherwise, each reverted with `git checkout e35e77c03 -- <file>` before the next, 31/31 either side:

| Mutation | Red before | Red now |
|---|---|---|
| **transpose the two flags in the real handler** | **0** | **3** |
| drop the `SMOKE_PID` default | — | 4 |
| `MIGRATIONS_APPLIED=1` moved back after `prisma:deploy` | 1 | 1 |
| `trap deploy_on_exit EXIT` deleted | 1 | 1 |
| cutover guard dropped from `deploy_stop_notice` | 1 | 2 |
| status guard dropped | 1 | 2 |
| applied guard dropped | 1 | 2 |
| `trap - EXIT` re-added to `api-deploy.sh` | 1 | 1 |

The first row is the issue's acceptance criterion. The three that went 1 → 2 did so because the new `deploy_on_exit` cases exercise the same conditions through the real handler as well as through `deploy_stop_notice` directly.

## A defect the mutations found in the tests I was adding

The `SMOKE_PID` mutation initially **aborted the suite** instead of failing a check, and turned three unrelated checks red on the way. Two causes, both mine and both fixed in `e35e77c03`:

- `on_exit_fired` reported "the notice fired" for **any** stderr. A `set -u` abort inside the handler also writes to stderr, so three silent-case checks were answering on the wrong signal — passing for the wrong reason, which means they would also fail for the wrong reason. It now matches the notice text.
- The command substitutions were unguarded, so a probe that died ended the whole suite under `set -e`. Now `|| true`, the same reason `line_of` already carries it.

Worth stating plainly: a test asserting on "something was printed" rather than on *what* was printed is the same defect shape this PR exists to close, and I wrote it in the commit that closes it. The mutation is what found it.

## What is not here

`#2712` (the smoke probe never sends a body) and `#2714` (`ROLLBACK_SHA` is read before `deploy_git_sync`, so the notice is blind on a retry) are both in this same ~200-line script and are deliberately left for after this lands, rather than opened as parallel PRs that would spend their time rebasing over each other.
