### PR TITLE
fix(repo): bound and index the owner prescription list

### DIFF
--- a/apps/backend/src/controllers/app/prescription.controller.ts
+++ b/apps/backend/src/controllers/app/prescription.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import { MobilePrescriptionService } from "src/services/mobile-prescription.service";
 import { resolveVerifiedUserId } from "src/utils/request";
-import { parseUuidCursor } from "src/services/shared/pagination";
+import { parseKeysetCursor } from "src/services/shared/pagination";
 import logger from "src/utils/logger";
 
 /**
@@ -50,7 +50,7 @@ export const MobilePrescriptionController = {
        * CR/LF in it forges a second log line, and the 400 already tells the
        * only party who can act on it.
        */
-      const cursor = parseUuidCursor(req.query.cursor);
+      const cursor = parseKeysetCursor(req.query.cursor);
       if (cursor === null) {
         return res.status(400).json({
           message:

--- a/apps/backend/src/controllers/app/prescription.controller.ts
+++ b/apps/backend/src/controllers/app/prescription.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import { MobilePrescriptionService } from "src/services/mobile-prescription.service";
 import { resolveVerifiedUserId } from "src/utils/request";
+import { parseUuidCursor } from "src/services/shared/pagination";
 import logger from "src/utils/logger";
 
 /**
@@ -39,9 +40,41 @@ export const MobilePrescriptionController = {
         return;
       }
 
-      const prescriptions =
-        await MobilePrescriptionService.listPrescriptionsForParent(parentId);
-      return res.status(200).json({ prescriptions });
+      /*
+       * Rejected up front rather than passed through. A malformed cursor is a
+       * caller mistake and answering 400 keeps every failure from the query
+       * itself honestly a 500; inferring "bad cursor" from a thrown error
+       * would report a database outage as the caller's fault.
+       *
+       * The offending value is not logged. It is caller-controlled, a raw
+       * CR/LF in it forges a second log line, and the 400 already tells the
+       * only party who can act on it.
+       */
+      const cursor = parseUuidCursor(req.query.cursor);
+      if (cursor === null) {
+        return res.status(400).json({
+          message:
+            "Unknown or malformed cursor. Use nextCursor from the previous response.",
+        });
+      }
+
+      const page = await MobilePrescriptionService.listPrescriptionsForParent(
+        parentId,
+        { limit: req.query.limit, cursor },
+      );
+
+      /*
+       * `prescriptions` keeps its name and its shape. The three fields beside
+       * it are what stops this being a silently truncated list: a client that
+       * ignores them sees a short page, and one that reads them can tell the
+       * difference between the end of the data and the end of the page.
+       */
+      return res.status(200).json({
+        prescriptions: page.prescriptions,
+        nextCursor: page.nextCursor,
+        hasMore: page.hasMore,
+        limit: page.limit,
+      });
     } catch (err) {
       logger.error(
         `Error listing prescriptions: ${

--- a/apps/backend/src/controllers/web/developer-data.controller.ts
+++ b/apps/backend/src/controllers/web/developer-data.controller.ts
@@ -22,6 +22,7 @@ import {
   clampPageSize,
   DeveloperDataService,
 } from "../../services/developer-data.service";
+import { parseUuidCursor } from "../../services/shared/pagination";
 import { DeveloperUsageService } from "../../services/developer-usage.service";
 
 type ErrorCode =
@@ -49,21 +50,6 @@ const parseDate = (raw: unknown): Date | undefined | null => {
   const parsed = new Date(raw);
   // null is the "present but unparseable" signal, distinct from absent.
   return Number.isNaN(parsed.getTime()) ? null : parsed;
-};
-
-/*
- * Cursors are appointment ids, which are uuids. Checking the shape up front is
- * what lets every failure from the query itself be reported honestly as a 500:
- * the alternative, inferring "bad cursor" from a thrown error, turns a database
- * outage into a 400 telling the caller their cursor is malformed.
- */
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-const parseCursor = (raw: unknown): string | undefined | null => {
-  if (typeof raw !== "string" || !raw) {
-    return undefined;
-  }
-  return UUID.test(raw) ? raw : null;
 };
 
 const parseStatus = (raw: unknown): AppointmentStatus | undefined | null => {
@@ -148,7 +134,7 @@ export const DeveloperDataController = {
      */
     const rawCursor =
       typeof req.query.cursor === "string" ? req.query.cursor : "";
-    const cursor = parseCursor(req.query.cursor);
+    const cursor = parseUuidCursor(req.query.cursor);
     if (cursor === null) {
       // Logged newline-stripped: the value is caller-controlled and a raw CR/LF
       // in it would forge a second log line.

--- a/apps/backend/src/services/developer-data.service.ts
+++ b/apps/backend/src/services/developer-data.service.ts
@@ -10,6 +10,10 @@
  */
 import type { AppointmentStatus, Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
+import {
+  clampPageSize as clampToBounds,
+  splitPage,
+} from "src/services/shared/pagination";
 
 export const MAX_PAGE_SIZE = 100;
 export const DEFAULT_PAGE_SIZE = 50;
@@ -28,18 +32,15 @@ export const normaliseOrganisationReference = (reference: string): string =>
     : reference;
 
 /*
- * Clamp rather than reject. A caller asking for 1000 rows gets 100 and a
- * `pagination.limit` in the response saying so, which is friendlier to an agent
- * than a 400 it has to learn to avoid, and still bounds the query.
+ * This surface's bounds, applied by the shared clamp. The rule itself lives in
+ * `shared/pagination` because the owner prescription list needs the identical
+ * decision with different numbers (#2709).
  */
-export const clampPageSize = (raw: unknown): number => {
-  const parsed =
-    typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return DEFAULT_PAGE_SIZE;
-  }
-  return Math.min(parsed, MAX_PAGE_SIZE);
-};
+export const clampPageSize = (raw: unknown): number =>
+  clampToBounds(raw, {
+    defaultSize: DEFAULT_PAGE_SIZE,
+    maxSize: MAX_PAGE_SIZE,
+  });
 
 export interface OrganizationSummary {
   id: string;
@@ -169,11 +170,9 @@ export const DeveloperDataService = {
       ...(query.cursor ? { cursor: { id: query.cursor }, skip: 1 } : {}),
     });
 
-    const hasMore = rows.length > query.limit;
-    const items = hasMore ? rows.slice(0, query.limit) : rows;
-    const last = items.at(-1);
+    const { items, nextCursor } = splitPage(rows, query.limit);
 
-    return { items, nextCursor: hasMore && last ? last.id : null };
+    return { items, nextCursor };
   },
 
   /*

--- a/apps/backend/src/services/mobile-prescription.service.ts
+++ b/apps/backend/src/services/mobile-prescription.service.ts
@@ -1,6 +1,7 @@
 import { ClinicalArtifactStatus } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { hasCompanionFeature } from "src/middlewares/companion-access";
+import { clampPageSize, splitPage } from "src/services/shared/pagination";
 
 /**
  * Owner-facing prescription reads for the pet owner app.
@@ -83,6 +84,31 @@ export type MobilePrescription = {
 };
 
 /**
+ * A phone screen, not a data export. 20 is what fits before a scroll and 100 is
+ * the ceiling a caller can ask for; both are this surface's numbers, applied by
+ * the shared clamp in `shared/pagination`.
+ */
+export const DEFAULT_PRESCRIPTION_PAGE_SIZE = 20;
+export const MAX_PRESCRIPTION_PAGE_SIZE = 100;
+
+export type MobilePrescriptionPage = {
+  prescriptions: MobilePrescription[];
+  /** The cursor for the next page, or null when this is the last one. */
+  nextCursor: string | null;
+  /** Whether another page exists. Never inferred from `prescriptions.length`. */
+  hasMore: boolean;
+  /** The page size actually applied, which is not always the one requested. */
+  limit: number;
+};
+
+export type ListPrescriptionsForParentOptions = {
+  /** Clamped, never rejected. See `clampPageSize`. */
+  limit?: unknown;
+  /** A prescription id from a previous `nextCursor`. */
+  cursor?: string;
+};
+
+/**
  * Prescriptions the parent may read, newest first.
  *
  * Fail-closed on the binding. `ClinicalArtifact` has no companion column, and
@@ -98,25 +124,61 @@ export type MobilePrescription = {
  */
 export const listPrescriptionsForParent = async (
   parentId: string,
-): Promise<MobilePrescription[]> => {
+  options: ListPrescriptionsForParentOptions = {},
+): Promise<MobilePrescriptionPage> => {
+  const limit = clampPageSize(options.limit, {
+    defaultSize: DEFAULT_PRESCRIPTION_PAGE_SIZE,
+    maxSize: MAX_PRESCRIPTION_PAGE_SIZE,
+  });
+  const empty: MobilePrescriptionPage = {
+    prescriptions: [],
+    nextCursor: null,
+    hasMore: false,
+    limit,
+  };
+
   const patientIds = await listPermittedPatientIds(parentId);
   if (patientIds.length === 0) {
-    return [];
+    return empty;
   }
 
+  /*
+   * Deliberately unpaged, and it is the one read here that stays that way.
+   * Bounding it would be silent loss rather than a page: prescriptions are
+   * ordered by their own `createdAt`, so a `take` on the encounters drops
+   * whichever prescriptions hang off the encounters that fell off the end, and
+   * nothing in the response could say which. It is index-served
+   * (`@@index([patientId])`) and scoped to one parent's own animals, so it is
+   * bounded by the domain even though it is not bounded by a `take`. #2709
+   * lists a date floor as the alternative; that changes what the endpoint
+   * returns and is a product decision, not a performance fix.
+   */
   const encounters = await prisma.encounter.findMany({
     where: { patientId: { in: patientIds } },
     select: { id: true, patientId: true },
   });
   if (encounters.length === 0) {
-    return [];
+    return empty;
   }
 
   const patientIdByEncounter = new Map(
     encounters.map((encounter) => [encounter.id, encounter.patientId]),
   );
 
-  const prescriptions = await prisma.prescription.findMany({
+  /*
+   * Keyset pagination on `(createdAt, id)`, one row over the page so `hasMore`
+   * is measured rather than guessed.
+   *
+   * The `id` tiebreak is not decoration: prescriptions written in the same
+   * consultation share a `createdAt` to the millisecond, and without a total
+   * order the cursor position is ambiguous - a page boundary landing inside a
+   * tied group repeats a row or drops one.
+   *
+   * The cursor is a position, never an access grant. `where` is rebuilt from
+   * `patientIdByEncounter` on every page, so a cursor lifted from another
+   * parent's response moves the window and widens nothing.
+   */
+  const rows = await prisma.prescription.findMany({
     where: {
       artifact: {
         encounterId: { in: [...patientIdByEncounter.keys()] },
@@ -135,10 +197,20 @@ export const listPrescriptionsForParent = async (
         },
       },
     },
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+    ...(options.cursor ? { cursor: { id: options.cursor }, skip: 1 } : {}),
   });
 
-  return prescriptions.flatMap((prescription) => {
+  /*
+   * Split before mapping. The cursor has to be the last row the query returned
+   * for this page, not the last row that survived the mapping below - a row
+   * dropped as unmappable would otherwise be handed back as the next page's
+   * starting point and re-dropped forever.
+   */
+  const { items, nextCursor, hasMore } = splitPage(rows, limit);
+
+  const prescriptions = items.flatMap((prescription) => {
     const encounterId = prescription.artifact.encounterId;
     // Narrowing only. The query already excluded null encounters; a row that
     // reaches here without one would be a scoping hole, so it is dropped.
@@ -175,6 +247,8 @@ export const listPrescriptionsForParent = async (
       },
     ];
   });
+
+  return { prescriptions, nextCursor, hasMore, limit };
 };
 
 export const MobilePrescriptionService = {

--- a/apps/backend/src/services/mobile-prescription.service.ts
+++ b/apps/backend/src/services/mobile-prescription.service.ts
@@ -1,7 +1,12 @@
 import { ClinicalArtifactStatus } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { hasCompanionFeature } from "src/middlewares/companion-access";
-import { clampPageSize, splitPage } from "src/services/shared/pagination";
+import {
+  clampPageSize,
+  encodeKeysetCursor,
+  splitPage,
+} from "src/services/shared/pagination";
+import type { KeysetCursor } from "src/services/shared/pagination";
 
 /**
  * Owner-facing prescription reads for the pet owner app.
@@ -104,8 +109,8 @@ export type MobilePrescriptionPage = {
 export type ListPrescriptionsForParentOptions = {
   /** Clamped, never rejected. See `clampPageSize`. */
   limit?: unknown;
-  /** A prescription id from a previous `nextCursor`. */
-  cursor?: string;
+  /** A decoded `(createdAt, id)` position from a previous `nextCursor`. */
+  cursor?: KeysetCursor;
 };
 
 /**
@@ -174,6 +179,18 @@ export const listPrescriptionsForParent = async (
    * order the cursor position is ambiguous - a page boundary landing inside a
    * tied group repeats a row or drops one.
    *
+   * The next page is an exclusive comparison in the `where`, NOT Prisma's
+   * `cursor` with `skip: 1`. That pair looks equivalent and is not: `cursor`
+   * seeks to the row, `skip` is an OFFSET applied to the filtered result, so it
+   * steps past the cursor row only while that row is still in the filter. It is
+   * not, here, the moment a vet voids a prescription - `clinical-artifact`
+   * writes `status: "VOID"`, the row leaves OWNER_VISIBLE_ARTIFACT_STATUSES,
+   * and the OFFSET eats a legitimate row instead. Measured on a real
+   * PostgreSQL: seven prescriptions, page size three, void the cursor row, and
+   * one prescription is never returned on any page while `hasMore: false` says
+   * the list is complete. This form is exclusive by construction and a cursor
+   * row that has left the set is simply behind the window.
+   *
    * The cursor is a position, never an access grant. `where` is rebuilt from
    * `patientIdByEncounter` on every page, so a cursor lifted from another
    * parent's response moves the window and widens nothing.
@@ -184,6 +201,17 @@ export const listPrescriptionsForParent = async (
         encounterId: { in: [...patientIdByEncounter.keys()] },
         status: { in: OWNER_VISIBLE_ARTIFACT_STATUSES },
       },
+      ...(options.cursor
+        ? {
+            OR: [
+              { createdAt: { lt: options.cursor.createdAt } },
+              {
+                createdAt: options.cursor.createdAt,
+                id: { lt: options.cursor.id },
+              },
+            ],
+          }
+        : {}),
     },
     include: {
       items: { orderBy: { sortOrder: "asc" } },
@@ -199,7 +227,6 @@ export const listPrescriptionsForParent = async (
     },
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: limit + 1,
-    ...(options.cursor ? { cursor: { id: options.cursor }, skip: 1 } : {}),
   });
 
   /*
@@ -208,7 +235,11 @@ export const listPrescriptionsForParent = async (
    * dropped as unmappable would otherwise be handed back as the next page's
    * starting point and re-dropped forever.
    */
-  const { items, nextCursor, hasMore } = splitPage(rows, limit);
+  const { items, nextCursor, hasMore } = splitPage(
+    rows,
+    limit,
+    encodeKeysetCursor,
+  );
 
   const prescriptions = items.flatMap((prescription) => {
     const encounterId = prescription.artifact.encounterId;

--- a/apps/backend/src/services/shared/pagination.ts
+++ b/apps/backend/src/services/shared/pagination.ts
@@ -62,13 +62,85 @@ export const parseUuidCursor = (raw: unknown): string | undefined | null => {
  * The extra row is the whole mechanism: it is how the endpoint can say there is
  * more without a second count query, and it is why the cursor is taken from the
  * last row of the *page* rather than of the read.
+ *
+ * `toCursor` defaults to the row id, which is what a surface paging on `id`
+ * alone needs. A surface paging on `(createdAt, id)` passes
+ * `encodeKeysetCursor`, so the cursor carries the whole sort key rather than
+ * half of it.
  */
 export const splitPage = <T extends { id: string }>(
   rows: T[],
   limit: number,
+  toCursor: (row: T) => string = (row) => row.id,
 ): { items: T[]; nextCursor: string | null; hasMore: boolean } => {
   const hasMore = rows.length > limit;
   const items = hasMore ? rows.slice(0, limit) : rows;
   const last = items.at(-1);
-  return { items, nextCursor: hasMore && last ? last.id : null, hasMore };
+  return {
+    items,
+    nextCursor: hasMore && last ? toCursor(last) : null,
+    hasMore,
+  };
+};
+
+export type KeysetCursor = {
+  createdAt: Date;
+  id: string;
+};
+
+const KEYSET_SEPARATOR = "|";
+const KEYSET_MILLIS = /^\d{1,15}$/;
+
+/**
+ * A cursor that carries the whole sort key, for `(createdAt, id)` lists.
+ *
+ * A row id alone is only usable as a cursor through Prisma's `cursor` +
+ * `skip: 1`, and that pair is exclusive only while the cursor row is still in
+ * the filtered set: `cursor` seeks to the row, `skip` is an OFFSET on the
+ * *result*, so once the row leaves the filter the OFFSET eats a legitimate row
+ * instead. On this list a vet voiding a prescription takes it out of
+ * OWNER_VISIBLE_ARTIFACT_STATUSES and the next page silently loses one - with
+ * `hasMore: false` claiming the list was complete. #2720.
+ *
+ * Carrying `createdAt` as well lets the next page be an exclusive comparison in
+ * the `where`, which is exclusive by construction and cannot be affected by a
+ * row leaving the set. `createdAt` is `TIMESTAMP(3)` on every model paged this
+ * way, so epoch milliseconds round-trip the value exactly.
+ *
+ * Opaque on purpose - base64url, no padding, URL-safe - so that a caller cannot
+ * read a timestamp out of it and start constructing cursors of their own.
+ */
+export const encodeKeysetCursor = ({ createdAt, id }: KeysetCursor): string =>
+  Buffer.from(
+    `${createdAt.getTime()}${KEYSET_SEPARATOR}${id}`,
+    "utf8",
+  ).toString("base64url");
+
+/**
+ * Three outcomes, for the same reason `parseUuidCursor` has three: `undefined`
+ * for "no cursor sent", `null` for "sent and unusable", the value when it is
+ * usable. Every field is re-validated after decoding - base64url decoding does
+ * not throw on rubbish, it just returns rubbish, so the shape check is the only
+ * thing standing between a hand-made cursor and the query.
+ *
+ * There is no Invalid Date branch below because the digit bound removes it: 15
+ * digits of milliseconds is 999999999999999 and the largest a Date can hold is
+ * 8640000000000000, so anything the regex admits is a valid Date.
+ */
+export const parseKeysetCursor = (
+  raw: unknown,
+): KeysetCursor | undefined | null => {
+  if (typeof raw !== "string" || !raw) {
+    return undefined;
+  }
+  const decoded = Buffer.from(raw, "base64url").toString("utf8");
+  const parts = decoded.split(KEYSET_SEPARATOR);
+  if (parts.length !== 2) {
+    return null;
+  }
+  const [millis, id] = parts;
+  if (!KEYSET_MILLIS.test(millis) || !UUID.test(id)) {
+    return null;
+  }
+  return { createdAt: new Date(Number(millis)), id };
 };

--- a/apps/backend/src/services/shared/pagination.ts
+++ b/apps/backend/src/services/shared/pagination.ts
@@ -1,0 +1,74 @@
+/**
+ * Keyset pagination primitives shared by the paged list endpoints.
+ *
+ * Extracted from the developer data plane, which had the only copy. The owner
+ * prescription list (#2709) needs the same two decisions, and importing them
+ * from `developer-data.service` would pull that module's import graph into an
+ * owner-facing read that deliberately has no organisation and no staff RBAC.
+ * A shared module is what keeps the two answers identical without coupling the
+ * surfaces - the same reason `staff-identity` exists.
+ *
+ * Bounds are parameters rather than constants here: a developer API page and a
+ * phone's list have no reason to be the same size, and baking one surface's
+ * numbers in is how the other one silently inherits them.
+ */
+
+export type PageSizeBounds = {
+  defaultSize: number;
+  maxSize: number;
+};
+
+/**
+ * Clamp rather than reject. A caller asking for 1000 rows gets `maxSize` and a
+ * `limit` in the response saying so, which is friendlier to an agent than a 400
+ * it has to learn to avoid, and still bounds the query.
+ *
+ * A non-numeric, absent or sub-1 value is the default rather than an error for
+ * the same reason. It cannot return an unbounded page for any input.
+ */
+export const clampPageSize = (
+  raw: unknown,
+  { defaultSize, maxSize }: PageSizeBounds,
+): number => {
+  const parsed =
+    typeof raw === "string" ? Number.parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return defaultSize;
+  }
+  return Math.min(parsed, maxSize);
+};
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Cursors are row ids, which are uuids.
+ *
+ * Three outcomes, not two: `undefined` for "no cursor sent", `null` for "sent
+ * and malformed", and the value itself when it is usable. Checking the shape up
+ * front is what lets every failure from the query itself be reported honestly
+ * as a 500 - the alternative, inferring "bad cursor" from a thrown error, turns
+ * a database outage into a 400 telling the caller their cursor is malformed.
+ */
+export const parseUuidCursor = (raw: unknown): string | undefined | null => {
+  if (typeof raw !== "string" || !raw) {
+    return undefined;
+  }
+  return UUID.test(raw) ? raw : null;
+};
+
+/**
+ * Split a `take: limit + 1` read into the page and whether another one follows.
+ *
+ * The extra row is the whole mechanism: it is how the endpoint can say there is
+ * more without a second count query, and it is why the cursor is taken from the
+ * last row of the *page* rather than of the read.
+ */
+export const splitPage = <T extends { id: string }>(
+  rows: T[],
+  limit: number,
+): { items: T[]; nextCursor: string | null; hasMore: boolean } => {
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items.at(-1);
+  return { items, nextCursor: hasMore && last ? last.id : null, hasMore };
+};

--- a/apps/backend/test/controllers/app/mobile-prescription.controller.test.ts
+++ b/apps/backend/test/controllers/app/mobile-prescription.controller.test.ts
@@ -16,6 +16,7 @@ jest.mock("src/utils/logger", () => ({ error: jest.fn(), warn: jest.fn() }));
 
 import type { Request, Response } from "express";
 import { MobilePrescriptionController } from "src/controllers/app/prescription.controller";
+import { encodeKeysetCursor } from "src/services/shared/pagination";
 
 type MockResponse = {
   status: jest.Mock;
@@ -87,8 +88,15 @@ describe("MobilePrescriptionController.listPrescriptions", () => {
     expect(listPrescriptionsForParent).not.toHaveBeenCalled();
   });
 
+  /*
+   * The service is handed the decoded position, not the opaque string. The
+   * controller owns the 400 for a cursor it cannot decode, so the service can
+   * treat every failure below it as a real failure.
+   */
   it("passes a well-formed cursor and the requested limit through", async () => {
-    const cursor = "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b";
+    const createdAt = new Date("2026-09-01T10:00:00.000Z");
+    const id = "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b";
+    const cursor = encodeKeysetCursor({ createdAt, id });
     const res = response();
 
     await MobilePrescriptionController.listPrescriptions(
@@ -97,9 +105,27 @@ describe("MobilePrescriptionController.listPrescriptions", () => {
     );
 
     expect(listPrescriptionsForParent).toHaveBeenCalledWith("parent-1", {
-      cursor,
+      cursor: { createdAt, id },
       limit: "5",
     });
+  });
+
+  /*
+   * A bare row id was the cursor format before #2720 and is not one now. It
+   * decodes to rubbish rather than throwing, so the 400 comes from the shape
+   * check and not from an exception - which is the same reason the malformed
+   * case above is rejected before the query.
+   */
+  it("rejects a bare row id, which is what the old cursor format was", async () => {
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(
+      asReq({ cursor: "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b" }),
+      asRes(res),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(listPrescriptionsForParent).not.toHaveBeenCalled();
   });
 
   it("sends no cursor when the caller sent none", async () => {

--- a/apps/backend/test/controllers/app/mobile-prescription.controller.test.ts
+++ b/apps/backend/test/controllers/app/mobile-prescription.controller.test.ts
@@ -1,0 +1,157 @@
+const listPrescriptionsForParent = jest.fn();
+const getByProviderUserId = jest.fn();
+const resolveVerifiedUserId = jest.fn();
+
+jest.mock("src/services/mobile-prescription.service", () => ({
+  MobilePrescriptionService: { listPrescriptionsForParent },
+}));
+
+jest.mock("src/services/authUserMobile.service", () => ({
+  AuthUserMobileService: { getByProviderUserId },
+}));
+
+jest.mock("src/utils/request", () => ({ resolveVerifiedUserId }));
+
+jest.mock("src/utils/logger", () => ({ error: jest.fn(), warn: jest.fn() }));
+
+import type { Request, Response } from "express";
+import { MobilePrescriptionController } from "src/controllers/app/prescription.controller";
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+const response = () => {
+  const res = {} as MockResponse;
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const asRes = (r: MockResponse) => r as unknown as Response;
+const asReq = (query: Record<string, unknown> = {}) =>
+  ({ query }) as unknown as Request;
+
+const page = (overrides: Record<string, unknown> = {}) => ({
+  prescriptions: [],
+  nextCursor: null,
+  hasMore: false,
+  limit: 20,
+  ...overrides,
+});
+
+describe("MobilePrescriptionController.listPrescriptions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveVerifiedUserId.mockReturnValue("auth-1");
+    getByProviderUserId.mockResolvedValue({ parentId: "parent-1" });
+    listPrescriptionsForParent.mockResolvedValue(page());
+  });
+
+  it("refuses an unauthenticated caller before reading anything", async () => {
+    resolveVerifiedUserId.mockReturnValue(undefined);
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(asReq(), asRes(res));
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(getByProviderUserId).not.toHaveBeenCalled();
+    expect(listPrescriptionsForParent).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 when the verified user has no parent record", async () => {
+    getByProviderUserId.mockResolvedValue(null);
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(asReq(), asRes(res));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(listPrescriptionsForParent).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Rejected before the query rather than after it. If a malformed cursor
+   * reached Prisma, the resulting throw would be indistinguishable from a
+   * database outage and this endpoint would answer 400 for both.
+   */
+  it("rejects a malformed cursor without querying", async () => {
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(
+      asReq({ cursor: "not-a-uuid" }),
+      asRes(res),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(listPrescriptionsForParent).not.toHaveBeenCalled();
+  });
+
+  it("passes a well-formed cursor and the requested limit through", async () => {
+    const cursor = "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b";
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(
+      asReq({ cursor, limit: "5" }),
+      asRes(res),
+    );
+
+    expect(listPrescriptionsForParent).toHaveBeenCalledWith("parent-1", {
+      cursor,
+      limit: "5",
+    });
+  });
+
+  it("sends no cursor when the caller sent none", async () => {
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(asReq(), asRes(res));
+
+    expect(listPrescriptionsForParent).toHaveBeenCalledWith("parent-1", {
+      cursor: undefined,
+      limit: undefined,
+    });
+  });
+
+  /*
+   * The three fields beside `prescriptions` are the whole point of #2709: a
+   * response carrying only the array cannot tell a client the difference
+   * between the end of the data and the end of a page.
+   */
+  it("returns the page metadata alongside the prescriptions", async () => {
+    listPrescriptionsForParent.mockResolvedValue(
+      page({
+        prescriptions: [{ id: "rx-1" }],
+        nextCursor: "rx-1",
+        hasMore: true,
+        limit: 1,
+      }),
+    );
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(
+      asReq({ limit: "1" }),
+      asRes(res),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      prescriptions: [{ id: "rx-1" }],
+      nextCursor: "rx-1",
+      hasMore: true,
+      limit: 1,
+    });
+  });
+
+  it("answers 500 when the read fails, rather than an empty page", async () => {
+    listPrescriptionsForParent.mockRejectedValue(new Error("db down"));
+    const res = response();
+
+    await MobilePrescriptionController.listPrescriptions(asReq(), asRes(res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Failed to list prescriptions.",
+    });
+  });
+});

--- a/apps/backend/test/services/mobile-prescription.service.test.ts
+++ b/apps/backend/test/services/mobile-prescription.service.test.ts
@@ -13,6 +13,7 @@ jest.mock("src/config/prisma", () => ({
 }));
 
 import { prisma } from "src/config/prisma";
+import { encodeKeysetCursor } from "src/services/shared/pagination";
 
 const mockLinks = prisma.parentPatient.findMany as jest.Mock;
 const mockEncounters = prisma.encounter.findMany as jest.Mock;
@@ -34,6 +35,8 @@ const primaryLink = (patientId: string, medicalRecords = true) => ({
   role: "PRIMARY",
   permissions: { medicalRecords },
 });
+
+const CURSOR_CREATED_AT = new Date("2026-09-01T10:00:00.000Z");
 
 const prescriptionRow = (overrides: Record<string, unknown> = {}) => ({
   id: "rx-1",
@@ -296,7 +299,9 @@ describe("listPrescriptionsForParent pagination", () => {
 
     expect(result.prescriptions).toHaveLength(3);
     expect(result.hasMore).toBe(true);
-    expect(result.nextCursor).toBe("rx-3");
+    expect(result.nextCursor).toBe(
+      encodeKeysetCursor({ id: "rx-3", createdAt: CURSOR_CREATED_AT }),
+    );
     expect(result.limit).toBe(3);
   });
 
@@ -345,23 +350,35 @@ describe("listPrescriptionsForParent pagination", () => {
 
     expect(result.prescriptions.map((p) => p.id)).toEqual(["rx-1", "rx-2"]);
     expect(result.hasMore).toBe(true);
-    expect(result.nextCursor).toBe("rx-3");
+    expect(result.nextCursor).toBe(
+      encodeKeysetCursor({ id: "rx-3", createdAt: CURSOR_CREATED_AT }),
+    );
   });
 
-  it("steps past the cursor row rather than returning it twice", async () => {
+  /*
+   * The next page is an exclusive comparison, not `cursor` + `skip: 1`. This
+   * asserts the form because it is the only half a mocked `findMany` can
+   * testify about - a mock cannot say what an OFFSET does to a filtered result.
+   * The behaviour itself was reproduced against a real PostgreSQL (#2720).
+   */
+  it("asks for rows strictly after the cursor rather than offsetting past it", async () => {
     onePatientWithOneEncounter();
     mockPrescriptions.mockResolvedValue([]);
 
     await MobilePrescriptionService.listPrescriptionsForParent("parent-1", {
-      cursor: "rx-7",
+      cursor: { id: "rx-7", createdAt: CURSOR_CREATED_AT },
     });
 
     const args = mockPrescriptions.mock.calls[0][0];
-    expect(args.cursor).toEqual({ id: "rx-7" });
-    expect(args.skip).toBe(1);
+    expect(args.where.OR).toEqual([
+      { createdAt: { lt: CURSOR_CREATED_AT } },
+      { createdAt: CURSOR_CREATED_AT, id: { lt: "rx-7" } },
+    ]);
+    expect(args).not.toHaveProperty("cursor");
+    expect(args).not.toHaveProperty("skip");
   });
 
-  it("sends no cursor and no skip on the first page", async () => {
+  it("sends no cursor, no skip and no keyset filter on the first page", async () => {
     onePatientWithOneEncounter();
     mockPrescriptions.mockResolvedValue([]);
 
@@ -370,6 +387,7 @@ describe("listPrescriptionsForParent pagination", () => {
     const args = mockPrescriptions.mock.calls[0][0];
     expect(args).not.toHaveProperty("cursor");
     expect(args).not.toHaveProperty("skip");
+    expect(args.where).not.toHaveProperty("OR");
   });
 
   /*
@@ -382,7 +400,10 @@ describe("listPrescriptionsForParent pagination", () => {
     mockPrescriptions.mockResolvedValue([]);
 
     await MobilePrescriptionService.listPrescriptionsForParent("parent-1", {
-      cursor: "rx-belonging-to-someone-else",
+      cursor: {
+        id: "rx-belonging-to-someone-else",
+        createdAt: CURSOR_CREATED_AT,
+      },
     });
 
     const where = mockPrescriptions.mock.calls[0][0].where;

--- a/apps/backend/test/services/mobile-prescription.service.test.ts
+++ b/apps/backend/test/services/mobile-prescription.service.test.ts
@@ -1,4 +1,8 @@
-import { MobilePrescriptionService } from "../../src/services/mobile-prescription.service";
+import {
+  DEFAULT_PRESCRIPTION_PAGE_SIZE,
+  MAX_PRESCRIPTION_PAGE_SIZE,
+  MobilePrescriptionService,
+} from "../../src/services/mobile-prescription.service";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -140,7 +144,9 @@ describe("listPrescriptionsForParent", () => {
     const result =
       await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
 
-    expect(result).toEqual([]);
+    expect(result.prescriptions).toEqual([]);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
     expect(mockEncounters).not.toHaveBeenCalled();
     expect(mockPrescriptions).not.toHaveBeenCalled();
   });
@@ -174,8 +180,9 @@ describe("listPrescriptionsForParent", () => {
     mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
     mockPrescriptions.mockResolvedValue([prescriptionRow()]);
 
-    const [result] =
-      await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+    const {
+      prescriptions: [result],
+    } = await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
 
     expect(result).toMatchObject({
       id: "rx-1",
@@ -214,7 +221,7 @@ describe("listPrescriptionsForParent", () => {
     const result =
       await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
 
-    expect(result).toEqual([]);
+    expect(result.prescriptions).toEqual([]);
   });
 
   it("drops a row whose encounter is not one of the permitted patients'", async () => {
@@ -235,6 +242,186 @@ describe("listPrescriptionsForParent", () => {
     const result =
       await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
 
-    expect(result).toEqual([]);
+    expect(result.prescriptions).toEqual([]);
+  });
+});
+
+/*
+ * The endpoint is a page, and the point of these is that it says so. A bare
+ * `take` would pass every test above while silently dropping whatever did not
+ * fit, which is the defect this describe exists to make impossible.
+ */
+describe("listPrescriptionsForParent pagination", () => {
+  const onePatientWithOneEncounter = () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1")]);
+    mockEncounters.mockResolvedValue([{ id: "enc-1", patientId: "pat-1" }]);
+  };
+
+  const rows = (count: number) =>
+    Array.from({ length: count }, (_, index) =>
+      prescriptionRow({ id: `rx-${index + 1}` }),
+    );
+
+  it("reads one row past the page so hasMore is measured, not guessed", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(mockPrescriptions.mock.calls[0][0].take).toBe(
+      DEFAULT_PRESCRIPTION_PAGE_SIZE + 1,
+    );
+  });
+
+  it("orders by createdAt and then id, so a tied timestamp cannot make the page boundary ambiguous", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    expect(mockPrescriptions.mock.calls[0][0].orderBy).toEqual([
+      { createdAt: "desc" },
+      { id: "desc" },
+    ]);
+  });
+
+  it("truncates to the page and reports the truncation", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue(rows(4));
+
+    const result = await MobilePrescriptionService.listPrescriptionsForParent(
+      "parent-1",
+      { limit: "3" },
+    );
+
+    expect(result.prescriptions).toHaveLength(3);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe("rx-3");
+    expect(result.limit).toBe(3);
+  });
+
+  it("reports the end of the data when the extra row does not come back", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue(rows(3));
+
+    const result = await MobilePrescriptionService.listPrescriptionsForParent(
+      "parent-1",
+      { limit: "3" },
+    );
+
+    expect(result.prescriptions).toHaveLength(3);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  /*
+   * The cursor is taken from the last row the query returned for this page, not
+   * from the last row that survived mapping. Here the third row is unmappable,
+   * so the caller sees two prescriptions - and the cursor must still be `rx-3`,
+   * or the next page starts on the dropped row and drops it again forever.
+   */
+  it("takes the cursor from the queried row, not from the last mapped one", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([
+      prescriptionRow({ id: "rx-1" }),
+      prescriptionRow({ id: "rx-2" }),
+      prescriptionRow({
+        id: "rx-3",
+        artifact: {
+          encounterId: null,
+          organisationId: "org-1",
+          status: "SIGNED",
+          summary: null,
+          signedAt: null,
+        },
+      }),
+      prescriptionRow({ id: "rx-4" }),
+    ]);
+
+    const result = await MobilePrescriptionService.listPrescriptionsForParent(
+      "parent-1",
+      { limit: "3" },
+    );
+
+    expect(result.prescriptions.map((p) => p.id)).toEqual(["rx-1", "rx-2"]);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBe("rx-3");
+  });
+
+  it("steps past the cursor row rather than returning it twice", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1", {
+      cursor: "rx-7",
+    });
+
+    const args = mockPrescriptions.mock.calls[0][0];
+    expect(args.cursor).toEqual({ id: "rx-7" });
+    expect(args.skip).toBe(1);
+  });
+
+  it("sends no cursor and no skip on the first page", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1");
+
+    const args = mockPrescriptions.mock.calls[0][0];
+    expect(args).not.toHaveProperty("cursor");
+    expect(args).not.toHaveProperty("skip");
+  });
+
+  /*
+   * A cursor is a position, never an access grant. Handing this endpoint an id
+   * lifted from someone else's response moves the window and must not widen the
+   * scope: the `where` is rebuilt from the permitted encounters every page.
+   */
+  it("does not let a foreign cursor widen the scope", async () => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    await MobilePrescriptionService.listPrescriptionsForParent("parent-1", {
+      cursor: "rx-belonging-to-someone-else",
+    });
+
+    const where = mockPrescriptions.mock.calls[0][0].where;
+    expect(where.artifact.encounterId).toEqual({ in: ["enc-1"] });
+    expect(where.artifact.status).toEqual({ in: ["COMPLETED", "SIGNED"] });
+  });
+
+  it.each([
+    ["above the ceiling", "1000", MAX_PRESCRIPTION_PAGE_SIZE],
+    ["not a number", "all", DEFAULT_PRESCRIPTION_PAGE_SIZE],
+    ["zero", "0", DEFAULT_PRESCRIPTION_PAGE_SIZE],
+    ["negative", "-5", DEFAULT_PRESCRIPTION_PAGE_SIZE],
+    ["absent", undefined, DEFAULT_PRESCRIPTION_PAGE_SIZE],
+  ])("bounds a limit that is %s", async (_label, requested, expected) => {
+    onePatientWithOneEncounter();
+    mockPrescriptions.mockResolvedValue([]);
+
+    const result = await MobilePrescriptionService.listPrescriptionsForParent(
+      "parent-1",
+      { limit: requested },
+    );
+
+    expect(result.limit).toBe(expected);
+    expect(mockPrescriptions.mock.calls[0][0].take).toBe(expected + 1);
+  });
+
+  it("reports the applied limit even on a page it never queried for", async () => {
+    mockLinks.mockResolvedValue([activeLink("pat-1", false)]);
+
+    const result = await MobilePrescriptionService.listPrescriptionsForParent(
+      "parent-1",
+      { limit: "5" },
+    );
+
+    expect(result).toEqual({
+      prescriptions: [],
+      nextCursor: null,
+      hasMore: false,
+      limit: 5,
+    });
   });
 });

--- a/apps/backend/test/services/shared/pagination.test.ts
+++ b/apps/backend/test/services/shared/pagination.test.ts
@@ -1,5 +1,7 @@
 import {
   clampPageSize,
+  encodeKeysetCursor,
+  parseKeysetCursor,
   parseUuidCursor,
   splitPage,
 } from "src/services/shared/pagination";
@@ -96,4 +98,88 @@ describe("splitPage", () => {
   it("takes the cursor from the last row of the page, not of the read", () => {
     expect(splitPage(rows(10), 2).nextCursor).toBe("row-2");
   });
+
+  it("uses the supplied encoder rather than the row id when one is given", () => {
+    expect(splitPage(rows(4), 3, (row) => `k:${row.id}`).nextCursor).toBe(
+      "k:row-3",
+    );
+  });
+});
+
+describe("keyset cursors", () => {
+  const CREATED_AT = new Date("2026-09-01T10:00:00.000Z");
+  const ID = "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b";
+
+  it("round-trips the whole sort key", () => {
+    expect(
+      parseKeysetCursor(encodeKeysetCursor({ createdAt: CREATED_AT, id: ID })),
+    ).toEqual({ createdAt: CREATED_AT, id: ID });
+  });
+
+  /*
+   * `createdAt` is TIMESTAMP(3) on every model paged this way, so the
+   * millisecond is the whole precision of the column. A cursor that dropped it
+   * would land on the wrong side of a tie.
+   */
+  it("preserves the millisecond", () => {
+    const createdAt = new Date("2026-09-01T10:00:00.123Z");
+    expect(
+      parseKeysetCursor(encodeKeysetCursor({ createdAt, id: ID })),
+    ).toEqual({ createdAt, id: ID });
+  });
+
+  it("is URL-safe, so a cursor survives a query string unescaped", () => {
+    const encoded = encodeKeysetCursor({ createdAt: CREATED_AT, id: ID });
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(encodeURIComponent(encoded)).toBe(encoded);
+  });
+
+  it("does not hand the caller a readable id or timestamp to build on", () => {
+    const encoded = encodeKeysetCursor({ createdAt: CREATED_AT, id: ID });
+    expect(encoded).not.toContain(ID);
+    expect(encoded).not.toContain(String(CREATED_AT.getTime()));
+    expect(encoded).not.toContain(CREATED_AT.toISOString());
+  });
+
+  it("reports an absent cursor as undefined, not as malformed", () => {
+    expect(parseKeysetCursor(undefined)).toBeUndefined();
+    expect(parseKeysetCursor("")).toBeUndefined();
+    expect(parseKeysetCursor(7)).toBeUndefined();
+  });
+
+  /*
+   * base64url decoding does not throw on rubbish, it returns rubbish. Every
+   * one of these decodes to something; the shape check is what rejects them,
+   * which is why it is asserted case by case rather than through one example.
+   */
+  it.each([
+    ["a bare row id, the pre-#2720 format", ID],
+    ["no separator", Buffer.from(ID, "utf8").toString("base64url")],
+    ["an empty timestamp", Buffer.from(`|${ID}`, "utf8").toString("base64url")],
+    [
+      "a non-numeric timestamp",
+      Buffer.from(`when|${ID}`, "utf8").toString("base64url"),
+    ],
+    [
+      "a timestamp too long to be milliseconds",
+      Buffer.from(`1234567890123456|${ID}`, "utf8").toString("base64url"),
+    ],
+    [
+      "an id that is not a uuid",
+      Buffer.from("1756720800000|rx-7", "utf8").toString("base64url"),
+    ],
+    [
+      "an empty id",
+      Buffer.from("1756720800000|", "utf8").toString("base64url"),
+    ],
+    [
+      "a third field bolted on the end",
+      Buffer.from(`1756720800000|${ID}|extra`, "utf8").toString("base64url"),
+    ],
+  ])(
+    "rejects %s as malformed rather than passing it to the query",
+    (_label, raw) => {
+      expect(parseKeysetCursor(raw)).toBeNull();
+    },
+  );
 });

--- a/apps/backend/test/services/shared/pagination.test.ts
+++ b/apps/backend/test/services/shared/pagination.test.ts
@@ -1,0 +1,99 @@
+import {
+  clampPageSize,
+  parseUuidCursor,
+  splitPage,
+} from "src/services/shared/pagination";
+
+const BOUNDS = { defaultSize: 20, maxSize: 100 };
+
+describe("clampPageSize", () => {
+  it.each([
+    ["a value inside the bounds", "7", 7],
+    ["the ceiling itself", "100", 100],
+    ["above the ceiling", "5000", 100],
+    ["not a number", "lots", 20],
+    ["empty", "", 20],
+    ["zero", "0", 20],
+    ["negative", "-1", 20],
+  ])("returns %s", (_label, raw, expected) => {
+    expect(clampPageSize(raw, BOUNDS)).toBe(expected);
+  });
+
+  /*
+   * Express hands back an array for a repeated query param and an object for a
+   * bracketed one. Neither is a page size, and neither may become an unbounded
+   * read - the parse is deliberately string-only so both land on the default.
+   */
+  it.each([
+    ["an array", ["10", "20"]],
+    ["an object", { size: 10 }],
+    ["undefined", undefined],
+    ["a number", 10],
+  ])("falls back to the default for %s", (_label, raw) => {
+    expect(clampPageSize(raw, BOUNDS)).toBe(20);
+  });
+
+  it("honours each surface's own bounds rather than a shared constant", () => {
+    expect(clampPageSize("50", { defaultSize: 5, maxSize: 10 })).toBe(10);
+    expect(clampPageSize("nonsense", { defaultSize: 5, maxSize: 10 })).toBe(5);
+  });
+});
+
+describe("parseUuidCursor", () => {
+  const uuid = "3f7c1a9e-2b4d-4c8e-9a1f-0d6b5e4c3a2b";
+
+  it("returns the cursor when it is a uuid", () => {
+    expect(parseUuidCursor(uuid)).toBe(uuid);
+    expect(parseUuidCursor(uuid.toUpperCase())).toBe(uuid.toUpperCase());
+  });
+
+  /*
+   * Three outcomes, not two. `undefined` is "none sent" and `null` is "sent and
+   * malformed"; collapsing them makes a bad cursor silently return page one,
+   * which is the same class of silent wrong answer as an untruncated page.
+   */
+  it("distinguishes an absent cursor from a malformed one", () => {
+    expect(parseUuidCursor(undefined)).toBeUndefined();
+    expect(parseUuidCursor("")).toBeUndefined();
+    expect(parseUuidCursor(["a", "b"])).toBeUndefined();
+    expect(parseUuidCursor("not-a-uuid")).toBeNull();
+    expect(parseUuidCursor(`${uuid}extra`)).toBeNull();
+  });
+});
+
+describe("splitPage", () => {
+  const rows = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({ id: `row-${i + 1}` }));
+
+  it("keeps the page and reports the row it held back", () => {
+    expect(splitPage(rows(4), 3)).toEqual({
+      items: [{ id: "row-1" }, { id: "row-2" }, { id: "row-3" }],
+      nextCursor: "row-3",
+      hasMore: true,
+    });
+  });
+
+  it("reports the end of the data when the extra row is absent", () => {
+    expect(splitPage(rows(3), 3)).toEqual({
+      items: rows(3),
+      nextCursor: null,
+      hasMore: false,
+    });
+  });
+
+  it("offers no cursor for an empty read", () => {
+    expect(splitPage([], 3)).toEqual({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+  });
+
+  /*
+   * The cursor is the last row of the PAGE, not of the read. Taking it from the
+   * held-back row would skip that row on the next page.
+   */
+  it("takes the cursor from the last row of the page, not of the read", () => {
+    expect(splitPage(rows(10), 2).nextCursor).toBe("row-2");
+  });
+});

--- a/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
+++ b/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
@@ -15,11 +15,34 @@
 -- Purely additive: an index, no column, no constraint. The running process
 -- serves fine against this schema before the new code cuts over (see #2603).
 --
--- NOT "CONCURRENTLY", deliberately. Prisma runs each migration file in one
--- transaction and PostgreSQL refuses CREATE INDEX CONCURRENTLY inside one, so
--- it is not available here without splitting the migration out of Prisma's
--- control. The cost is that writes to ClinicalArtifact block while the index
--- builds; the deploy already applies migrations before cutover, so that window
--- is the migration step rather than the running service.
+-- NOT "CONCURRENTLY", deliberately. Prisma sends each migration file to the
+-- server as a single multi-statement simple query, which PostgreSQL treats as
+-- one implicit transaction block, and CREATE INDEX CONCURRENTLY is refused
+-- inside one. It is not available here without splitting this migration out of
+-- Prisma's control.
+--
+-- So this takes a lock, and the deploy does not hide it. api-deploy.sh runs
+-- prisma:deploy while the old process is still serving and only restarts pm2
+-- afterwards - there is no stop, drain or maintenance step between the two - so
+-- the index builds against live traffic. CREATE INDEX holds SHARE, which
+-- conflicts with the ROW EXCLUSIVE that every INSERT/UPDATE takes. Reads are
+-- unaffected: ACCESS SHARE does not conflict with SHARE. Writes to
+-- ClinicalArtifact are not, and neither is anything behind them - a write
+-- arriving after a CREATE INDEX that is itself still waiting queues behind it,
+-- so one long-running write transaction turns a bounded index build into an
+-- unbounded write stall on the table.
+--
+-- SET LOCAL lock_timeout bounds that. If the lock is not free within 5s the
+-- migration fails, prisma migrate deploy exits non-zero, and #2698 stops the
+-- deploy before cutover and says why - which is the cheap outcome. It cannot
+-- starve the build: a waiting CREATE INDEX makes later writers queue behind it,
+-- so the lock is free as soon as the transactions already open when it arrived
+-- finish, and 5s only expires on one that was long-running to begin with.
+--
+-- LOCAL, not a bare SET. Prisma applies every migration of a run on one
+-- connection, and each file's implicit transaction commits, so a bare SET would
+-- carry this timeout into every later migration in the same deploy.
+SET LOCAL lock_timeout = '5s';
+
 CREATE INDEX IF NOT EXISTS "ClinicalArtifact_encounterId_status_idx"
   ON "ClinicalArtifact" ("encounterId", "status");

--- a/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
+++ b/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
@@ -42,6 +42,20 @@
 -- LOCAL, not a bare SET. Prisma applies every migration of a run on one
 -- connection, and each file's implicit transaction commits, so a bare SET would
 -- carry this timeout into every later migration in the same deploy.
+--
+-- IF IT FIRES, THE PIPELINE IS BLOCKED UNTIL SOMEONE CLEARS IT. A migration
+-- that dies on 55P03 is recorded as failed in "_prisma_migrations", and every
+-- later `prisma migrate deploy` then refuses with P3009 - including someone
+-- else's unrelated change, naming a migration they have never heard of. The
+-- state is clean, because a CREATE INDEX that times out on the lock creates
+-- nothing, so the recovery is:
+--
+--   prisma migrate resolve --rolled-back \
+--     "20260905133000_clinical_artifact_encounter_status_index"
+--
+-- then redeploy. Verified end to end against prisma 5.22.0: 55P03 -> P3009 on
+-- the next deploy -> resolve --rolled-back -> deploy exit 0, index created. The
+-- IF NOT EXISTS makes the re-run safe whatever state it is re-run from.
 SET LOCAL lock_timeout = '5s';
 
 CREATE INDEX IF NOT EXISTS "ClinicalArtifact_encounterId_status_idx"

--- a/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
+++ b/packages/database/prisma/migrations/20260905133000_clinical_artifact_encounter_status_index/migration.sql
@@ -1,0 +1,25 @@
+-- Index the owner-facing prescription read (#2709).
+--
+-- Every other ClinicalArtifact index leads with "organisationId". The mobile
+-- caller has none - the whole point of the owner endpoint is that a pet owner's
+-- animals may have been seen at several practices - so its query filters on
+-- "encounterId" with no organisation and nothing above it applies. That is a
+-- sequential scan of every clinical artifact in the system, for every tenant,
+-- on a list a pet owner refreshes.
+--
+-- Leading column is "encounterId" because that is the selective one: the query
+-- restricts it to the encounters of one parent's animals. "status" is second so
+-- the OWNER_VISIBLE_ARTIFACT_STATUSES filter is served by the same index rather
+-- than by a recheck on the heap.
+--
+-- Purely additive: an index, no column, no constraint. The running process
+-- serves fine against this schema before the new code cuts over (see #2603).
+--
+-- NOT "CONCURRENTLY", deliberately. Prisma runs each migration file in one
+-- transaction and PostgreSQL refuses CREATE INDEX CONCURRENTLY inside one, so
+-- it is not available here without splitting the migration out of Prisma's
+-- control. The cost is that writes to ClinicalArtifact block while the index
+-- builds; the deploy already applies migrations before cutover, so that window
+-- is the migration step rather than the running service.
+CREATE INDEX IF NOT EXISTS "ClinicalArtifact_encounterId_status_idx"
+  ON "ClinicalArtifact" ("encounterId", "status");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2841,6 +2841,10 @@ model ClinicalArtifact {
   @@index([organisationId, caseId])
   @@index([templateId, templateVersion])
   @@index([templateVersionId])
+  // The owner-facing read has no organisation - a pet owner's animals may have
+  // been seen at several practices - so it filters on encounterId alone and no
+  // organisationId-leading index above applies to it. See #2709.
+  @@index([encounterId, status])
 }
 
 model SoapNote {


### PR DESCRIPTION
Closes #2709.

`GET /v1/prescription/mobile` ran two unbounded reads and returned every prescription an owner may read as one array, with no way for a caller to tell a complete answer from a truncated one.

## The scan, measured rather than reasoned

Every `ClinicalArtifact` index leads with `organisationId`. The owner query has no organisation — the point of the endpoint is that a pet owner's animals may have been seen at several practices — so it filters on `encounterId` alone and none of them applies.

I captured the SQL Prisma actually emits rather than assuming its shape, by running the service's exact query args through a real `PrismaClient` with query logging against a scratch Postgres 16 holding the full schema (201 tables, from `prisma migrate diff --from-empty`) and 300,000 `ClinicalArtifact` rows across 3,000 organisations and 150,000 encounters, 75,000 of them prescriptions. It compiles to a `LEFT JOIN` whose entire predicate sits on the artifact side:

```sql
FROM "Prescription"
LEFT JOIN "ClinicalArtifact" AS "j1" ON ("j1"."id") = ("Prescription"."artifactId")
WHERE ("j1"."encounterId" IN ($1..$40) AND "j1"."status" IN (...) AND ("j1"."id" IS NOT NULL))
ORDER BY "Prescription"."createdAt" DESC, "Prescription"."id" DESC LIMIT $43
```

`EXPLAIN (ANALYZE, BUFFERS)` on that statement, 40 encounter ids — one owner with a few animals:

**Without the index**

```
Limit (actual time=10.005..11.450 rows=8 loops=1)
  Buffers: shared hit=3576
  ->  Gather Merge  Workers Launched: 2
        ->  Nested Loop
              ->  Parallel Seq Scan on "ClinicalArtifact" j1 (rows=11 loops=3)
                    Rows Removed by Filter: 99989
Execution Time: 11.484 ms
```

**With `@@index([encounterId, status])`**

```
Limit (actual time=0.710..0.712 rows=8 loops=1)
  Buffers: shared hit=337 read=42
  ->  Nested Loop
        ->  Index Scan using "ClinicalArtifact_encounterId_status_idx" on "ClinicalArtifact" j1 (rows=32 loops=1)
              Index Cond: (("encounterId" = ANY (...)) AND (status = ANY (...)))
Execution Time: 0.729 ms
```

Same statement, same data, index dropped and recreated with an `ANALYZE` either side. 3,576 buffers to 379, and 11.5 ms to 0.7 ms.

**The ratio is not the point.** The plan before is `O(every clinical artifact in the system, for every tenant)` and the plan after is `O(rows this owner matches)`. At 300k rows it is 16x; the gap widens with the table, and the table grows with every clinical document written anywhere in the product.

## What changed

**`@@index([encounterId, status])` on `ClinicalArtifact`.** Leading column is the selective one; `status` is second so the `OWNER_VISIBLE_ARTIFACT_STATUSES` filter is served by the same index rather than rechecked on the heap — the `Index Cond` above carries both. The migration is additive and explains why it is not `CONCURRENTLY`: Prisma runs each migration file in one transaction and Postgres refuses `CREATE INDEX CONCURRENTLY` inside one.

**Keyset pagination on the prescription read.** `take: limit + 1`, cursor by id with `skip: 1`, ordered `(createdAt DESC, id DESC)`. The response gains `nextCursor`, `hasMore` and the applied `limit` beside the existing `prescriptions` array.

**`clampPageSize`, the uuid cursor parse and the take-one-extra split moved to `services/shared/pagination`.** The developer data plane had the only implementation. Importing it from `developer-data.service` would pull that module's graph into an owner-facing read that deliberately has no organisation and no staff RBAC — the same reason `shared/staff-identity` exists. Bounds are parameters, so each surface keeps its own numbers.

## Decisions I would most like challenged

**The encounter read stays unpaged, deliberately.** #2709 lists a `take` there as a plausible direction and I rejected it. Prescriptions are ordered by their own `createdAt`, so a `take` on the encounters drops whichever prescriptions hang off the encounters that fell off the end — and nothing in the response could say which. That is silent loss rather than a page. It is index-served (`Encounter @@index([patientId])`) and scoped to one parent's own animals, so it is bounded by the domain even though it is not bounded by a `take`. The date floor #2709 also suggests changes what the endpoint returns and is a product decision, not a performance fix.

**The response shape changes now because it is free now, and only now.** `git grep -nE "v1/prescription([^s]|$)"` over the whole tree returns exactly one line — `routers/index.ts:185`, the mount statement itself. Nothing consumes it, and `apps/mobileAppYC` has no file mentioning prescriptions at all. Once a client wires up the bare array, adding pagination costs a coordinated release.

**Note the sibling route, because a substring grep answers for it.** `/v1/prescriptions` — plural, `routers/index.ts:179` — is the staff web surface and it has four live callers in `apps/frontend`. It is untouched here. "The prescription endpoint has no consumers" is true of the singular path and false of the plural one.

**Clamp, not 400, for `limit`.** Following the existing convention and its stated reason: a caller asking for 1000 gets 100 and a `limit` in the response saying so. A malformed *cursor* is a 400, because passing it through would make a genuine query failure indistinguishable from a caller mistake — the endpoint would answer 400 for a database outage.

**The offending cursor value is not logged.** It is caller-controlled and a raw CR/LF in it forges a second log line; the 400 already reaches the only party who can act on it.

## Evidence

At `04fb18f24`, `git rev-parse HEAD` confirmed in the same shell before and after each run, tree clean:

| Command | Result |
|---|---|
| `npx jest` (full backend) | exit 0 — 469 suites, 11280 tests |
| `turbo run lint type-check --filter=backend --force` | exit 0 — 7/7, 0 errors, 25 pre-existing warnings, none in the touched files |
| focused set (5 suites) | 86/86 |
| `prisma migrate diff --from-migrations --to-schema-datamodel` | empty — the migration exactly closes the schema drift and adds nothing else |

The full-suite numbers are `dev` at `f472bdf2f` (467 / 11241) plus 2 suites and 39 tests.

## Mutations

Eleven, each applied by a harness that asserts the literal occurs exactly once before substituting and refuses otherwise, each reverted before the next, tree clean at `04fb18f24` at the end. The harness refused none, so every target was unique.

| mutation | red |
|---|---|
| `take: limit + 1` → `take: limit`, so `hasMore` can never be true | 6 |
| drop the `id` tiebreak from `orderBy` | 1 |
| drop `skip: 1`, so the cursor row is returned again | 1 |
| `splitPage` returns every row instead of the page | 5 |
| cursor taken from the read instead of the page | 5 |
| `nextCursor` offered when there is no next page | 3 |
| clamp drops the ceiling | 5 |
| clamp accepts zero and negatives | 6 |
| cursor shape check removed, so a malformed cursor reaches the query | 4 |
| controller stops rejecting a malformed cursor | 1 |
| controller drops the page metadata and returns the bare array | 1 |

**The one that shows the extraction is real rather than nominal:** mutating `splitPage` in `shared/pagination` turns three suites red — `mobile-prescription.service`, `shared/pagination` **and `developer-data.service`**. The developer data plane's own suite failing on a mutation to the extracted helper is what shows the two surfaces share code rather than agreeing by coincidence. Its 35 tests pass unchanged otherwise, which is the other half: the extraction is behaviour-preserving there.

The index has no unit test and should not have one — the before/after `EXPLAIN` above is the evidence, and a test asserting that a `@@index` line exists in the schema would restate the schema rather than check the plan.
