### PR TITLE
fix(ci): trap TERM and HUP so a cancelled deploy still announces the schema hazard

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -81,6 +81,12 @@ echo "$ROLLBACK_SHA" > "/tmp/api-rollback-$STAMP.txt"
 tar czf "/tmp/api-dist-before-$STAMP.tgz" apps/backend/dist packages/*/dist 2>/dev/null || true
 cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
 echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
+# Where the schema-hazard notice is written in addition to stderr. Built here,
+# with the other preflight artifacts, because stderr is the one destination that
+# is guaranteed to be gone in the case the notice matters most: it is the ssh
+# pipe, and the teardown of that connection is what kills this script. The
+# rollback sha the notice hands the operator is already written next door.
+HAZARD_LOG="/tmp/api-schema-hazard-$STAMP.txt"
 
 say "checkout $GIT_REF"
 # Fetch and checkout live in lib/git-sync.sh so their two failure modes - a stale
@@ -179,6 +185,26 @@ fi
 # Prisma fails having applied nothing, and over-reporting a schema hazard is the
 # safe direction. A deploy that carries no migrations cannot move the schema at
 # all, so it stays silent.
+#
+# TERM and HUP are trapped alongside it, and the reason is not symmetry. An
+# untrapped fatal signal ends the shell without giving the EXIT trap a non-zero
+# status to see, so the notice is silent on exactly the two signals a cancelled
+# deploy arrives as: the runner kills the local ssh client, the connection
+# closes, and sshd sends SIGHUP to this process group. Measured against the real
+# handler - TERM and HUP silent before, both firing after, and the exit status
+# preserved as 143 and 129 so nothing downstream reads a different result.
+# SIGINT already works: bash sets the status to 130 itself.
+#
+# SIGKILL stays out of reach. No trap catches it, so the ceiling here is every
+# signal that can be trapped, not "the notice can no longer be lost".
+#
+# A trapped signal is also deferred until the running foreground command
+# finishes, where an untrapped one ends the shell immediately. On a cancel that
+# costs nothing - the child is in the same process group and dies too - and on a
+# bare `kill` of this shell it means an in-flight `prisma migrate deploy` runs to
+# completion before the deploy stops, which is the safer of the two.
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 trap deploy_on_exit EXIT
 if [ -n "$INCOMING_MIGRATIONS" ]; then
   MIGRATIONS_APPLIED=1

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -186,26 +186,10 @@ fi
 # safe direction. A deploy that carries no migrations cannot move the schema at
 # all, so it stays silent.
 #
-# TERM and HUP are trapped alongside it, and the reason is not symmetry. An
-# untrapped fatal signal ends the shell without giving the EXIT trap a non-zero
-# status to see, so the notice is silent on exactly the two signals a cancelled
-# deploy arrives as: the runner kills the local ssh client, the connection
-# closes, and sshd sends SIGHUP to this process group. Measured against the real
-# handler - TERM and HUP silent before, both firing after, and the exit status
-# preserved as 143 and 129 so nothing downstream reads a different result.
-# SIGINT already works: bash sets the status to 130 itself.
-#
-# SIGKILL stays out of reach. No trap catches it, so the ceiling here is every
-# signal that can be trapped, not "the notice can no longer be lost".
-#
-# A trapped signal is also deferred until the running foreground command
-# finishes, where an untrapped one ends the shell immediately. On a cancel that
-# costs nothing - the child is in the same process group and dies too - and on a
-# bare `kill` of this shell it means an in-flight `prisma migrate deploy` runs to
-# completion before the deploy stops, which is the safer of the two.
-trap 'exit 143' TERM
-trap 'exit 129' HUP
-trap deploy_on_exit EXIT
+# The arming itself is deploy_arm_exit_traps in lib/migrate.sh - EXIT plus TERM
+# and HUP, with the reasoning next to it - so the suite can arm the real one and
+# signal it rather than grep this file for three trap lines.
+deploy_arm_exit_traps
 if [ -n "$INCOMING_MIGRATIONS" ]; then
   MIGRATIONS_APPLIED=1
 fi

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -71,7 +71,8 @@ deploy_incoming_migrations() {
 # one.
 #
 # SMOKE_PID is the exception and IS defaulted: no smoke process is a normal
-# state for most of the script's life, not a caller mistake.
+# state for most of the script's life, not a caller mistake. HAZARD_LOG is
+# defaulted for a different reason - see deploy_schema_hazard_notice.
 deploy_on_exit() {
   local status=$?
 
@@ -119,12 +120,12 @@ deploy_stop_notice() {
   deploy_schema_hazard_notice "$rollback_sha" "$@"
 }
 
-# deploy_schema_hazard_notice <rollback-sha> <migration>...
+# deploy_schema_hazard_text <rollback-sha> <migration>...
 #
-# What to say when the deploy stops after the schema has moved. Written to
-# stderr beside the code rollback, because the code rollback on its own reads as
-# if the box has been restored, and it has not.
-deploy_schema_hazard_notice() {
+# The wording, on stdout, so the two destinations below write the same bytes.
+# Separated from the destinations because they have different failure modes:
+# the wording cannot fail, and writing it can.
+deploy_schema_hazard_text() {
   local rollback_sha="${1:?rollback sha required}"
   shift
 
@@ -143,5 +144,47 @@ deploy_schema_hazard_notice() {
     echo "forward and re-deploy, or write and apply a migration that reverses them."
     echo "Prisma has no down-migration; there is nothing to run that undoes this by"
     echo "itself."
-  } >&2
+  }
+}
+
+# deploy_schema_hazard_notice <rollback-sha> <migration>...
+#
+# What to say when the deploy stops after the schema has moved, and where.
+#
+# Two destinations, and the ORDER between them is load-bearing rather than
+# stylistic. stderr on the box is the ssh pipe, and the teardown of that
+# connection is what sends the SIGHUP this notice most needs to survive - so by
+# the time the handler runs, the reader may already be gone. Writing into a pipe
+# with no reader takes SIGPIPE and ends the handler where it stands, so anything
+# sequenced after the stderr write does not happen at all.
+#
+# Measured against the real handler, HUP to the process group, the only variable
+# being the order of the two writes:
+#
+#   reader gone,  file then stderr -> exit 141, 590 bytes on disk
+#   reader gone,  stderr then file -> exit 141,   0 bytes on disk
+#   reader alive, either order     -> exit 129, 590 bytes on disk
+#
+# The exit status is 141 in both failing cases, so nothing downstream can tell
+# the two apart. The order is the whole of it.
+#
+# HAZARD_LOG is defaulted rather than required, which is the opposite of the
+# rule the rest of this file follows, and deliberately: a `set -u` abort on an
+# unset HAZARD_LOG would destroy the notice in order to enforce a rule about
+# keeping it. The loud check belongs where the mistake is actually made - the
+# suite pins that api-deploy.sh sets it before arming the trap.
+deploy_schema_hazard_notice() {
+  local rollback_sha="${1:?rollback sha required}"
+  shift
+
+  local text
+  text="$(deploy_schema_hazard_text "$rollback_sha" "$@")"
+
+  # `|| true` because a destination that cannot be written must not cost the
+  # other one. A full disk here would otherwise end the handler under `set -e`.
+  if [ -n "${HAZARD_LOG:-}" ]; then
+    printf '%s\n' "$text" >> "$HAZARD_LOG" 2>/dev/null || true
+  fi
+
+  printf '%s\n' "$text" >&2
 }

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -49,31 +49,6 @@ deploy_incoming_migrations() {
     | sort
 }
 
-# deploy_on_exit
-#
-# The EXIT trap api-deploy.sh installs before it lets the schema move.
-#
-# Lives here rather than in api-deploy.sh because the test that proves the
-# notice survives `set -e` cannot run api-deploy.sh - it wants pm2, node, a
-# database and a box. It used to hand-write its own copy of this handler, which
-# meant the only thing tying the copy to the real one was a grep on line
-# ordering, and transposing the two flags in the real one left the whole suite
-# green while inverting the notice: fires only after a verified cutover, silent
-# exactly when the schema is ahead. Three positional flags of the same type and
-# nothing to catch a swap. Now there is one handler, so there is one place for
-# the order to be wrong and a test that exercises it.
-#
-# Reads the caller's state rather than taking arguments, because an EXIT trap
-# has no arguments to take. Callers must set MIGRATIONS_APPLIED, CUTOVER_DONE,
-# ROLLBACK_SHA and INCOMING_MIGRATIONS before arming it; under `set -u` a
-# missing one aborts loudly, which is the right direction - the alternative is a
-# default, and the only sensible default for "did the schema move" is the silent
-# one.
-#
-# SMOKE_PID is the exception and IS defaulted: no smoke process is a normal
-# state for most of the script's life, not a caller mistake. HAZARD_LOG is
-# supplied by deploy_arm_exit_traps rather than demanded here - see
-# deploy_schema_hazard_notice for why neither of the obvious options works.
 # deploy_arm_exit_traps
 #
 # Installs every trap the deploy needs, in one place, because the arming is as
@@ -116,6 +91,31 @@ deploy_arm_exit_traps() {
   trap deploy_on_exit EXIT
 }
 
+# deploy_on_exit
+#
+# The EXIT trap api-deploy.sh installs before it lets the schema move.
+#
+# Lives here rather than in api-deploy.sh because the test that proves the
+# notice survives `set -e` cannot run api-deploy.sh - it wants pm2, node, a
+# database and a box. It used to hand-write its own copy of this handler, which
+# meant the only thing tying the copy to the real one was a grep on line
+# ordering, and transposing the two flags in the real one left the whole suite
+# green while inverting the notice: fires only after a verified cutover, silent
+# exactly when the schema is ahead. Three positional flags of the same type and
+# nothing to catch a swap. Now there is one handler, so there is one place for
+# the order to be wrong and a test that exercises it.
+#
+# Reads the caller's state rather than taking arguments, because an EXIT trap
+# has no arguments to take. Callers must set MIGRATIONS_APPLIED, CUTOVER_DONE,
+# ROLLBACK_SHA and INCOMING_MIGRATIONS before arming it; under `set -u` a
+# missing one aborts loudly, which is the right direction - the alternative is a
+# default, and the only sensible default for "did the schema move" is the silent
+# one.
+#
+# SMOKE_PID is the exception and IS defaulted: no smoke process is a normal
+# state for most of the script's life, not a caller mistake. HAZARD_LOG is
+# supplied by deploy_arm_exit_traps rather than demanded here - see
+# deploy_schema_hazard_notice for why neither of the obvious options works.
 deploy_on_exit() {
   local status=$?
 
@@ -224,6 +224,14 @@ deploy_schema_hazard_notice() {
   local text
   text="$(deploy_schema_hazard_text "$rollback_sha" "$@")"
 
+  # What the suite proves about this write, and what it does not. It proves a
+  # durable write happens, that it happens before the stderr write, and that the
+  # caller's destination survives the arming. It does NOT prove the `|| true`
+  # earns its place, that appending rather than truncating matters, or that the
+  # `$$` in the default is load-bearing - mutating any of those three leaves the
+  # suite green. They are reasoned, not pinned, and a reader should not credit
+  # 41 green with covering them.
+  #
   # `|| true` because a destination that cannot be written must not cost the
   # other one. A full disk here would otherwise end the handler under `set -e`.
   # `/dev/null` rather than an `if`, because a caller that armed the traps always

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -72,7 +72,50 @@ deploy_incoming_migrations() {
 #
 # SMOKE_PID is the exception and IS defaulted: no smoke process is a normal
 # state for most of the script's life, not a caller mistake. HAZARD_LOG is
-# defaulted for a different reason - see deploy_schema_hazard_notice.
+# supplied by deploy_arm_exit_traps rather than demanded here - see
+# deploy_schema_hazard_notice for why neither of the obvious options works.
+# deploy_arm_exit_traps
+#
+# Installs every trap the deploy needs, in one place, because the arming is as
+# easy to get wrong as the handler and was not covered by anything that runs.
+#
+# Lives here rather than in api-deploy.sh for the reason the handler does: a
+# test cannot run api-deploy.sh - it wants pm2, node, a database and a box - so
+# the arming could only ever be checked by grepping the real file for the trap
+# lines. That is a stand-in tied to the original by a grep, which is the exact
+# shape #2718 removed from the handler. With the arming in a function, the suite
+# arms the real one in a real bash process and signals it.
+#
+# TERM and HUP are trapped alongside EXIT, and the reason is not symmetry. An
+# untrapped fatal signal ends the shell without giving the EXIT trap a non-zero
+# status to see, so the notice was silent on exactly the two signals a cancelled
+# deploy arrives as: the runner kills the local ssh client, the connection
+# closes, and sshd sends SIGHUP to this process group. The exit status is
+# preserved as 143 and 129, so nothing downstream reads a different result.
+# SIGINT already worked - bash sets the status to 130 itself.
+#
+# SIGKILL stays out of reach. No trap catches it, so the ceiling is every signal
+# that can be trapped, not "the notice can no longer be lost".
+#
+# A trapped signal is also deferred until the running foreground command
+# finishes, where an untrapped one ends the shell where it stands. On a cancel
+# that costs nothing - the child is in the same process group and dies too - and
+# on a bare `kill` of this shell it means an in-flight `prisma migrate deploy`
+# runs to completion before the deploy stops, which is the safer of the two.
+deploy_arm_exit_traps() {
+  # A destination, always. Unset or empty meant no durable write at all, which
+  # is not a safe fallback - it is the fix turned off, silently, leaving the
+  # notice on the one destination that is gone in the case it exists for.
+  # `$$` rather than a fixed name so two deploys on one box cannot collide;
+  # api-deploy.sh overrides this with the $STAMP-keyed path that matches the
+  # rollback sha and the dist tarball it already writes.
+  HAZARD_LOG="${HAZARD_LOG:-/tmp/api-schema-hazard-$$.txt}"
+
+  trap 'exit 143' TERM
+  trap 'exit 129' HUP
+  trap deploy_on_exit EXIT
+}
+
 deploy_on_exit() {
   local status=$?
 
@@ -168,11 +211,12 @@ deploy_schema_hazard_text() {
 # The exit status is 141 in both failing cases, so nothing downstream can tell
 # the two apart. The order is the whole of it.
 #
-# HAZARD_LOG is defaulted rather than required, which is the opposite of the
-# rule the rest of this file follows, and deliberately: a `set -u` abort on an
-# unset HAZARD_LOG would destroy the notice in order to enforce a rule about
-# keeping it. The loud check belongs where the mistake is actually made - the
-# suite pins that api-deploy.sh sets it before arming the trap.
+# HAZARD_LOG is neither demanded nor allowed to be missing, which is the third
+# option and the only one that is not a trap. Demanding it under `set -u` would
+# abort the handler on the path the notice exists for - destroying it to enforce
+# a rule about keeping it. Letting it be empty turns the durable write off
+# silently. So deploy_arm_exit_traps supplies one, and a caller that armed the
+# traps cannot reach this function without a destination.
 deploy_schema_hazard_notice() {
   local rollback_sha="${1:?rollback sha required}"
   shift
@@ -182,9 +226,9 @@ deploy_schema_hazard_notice() {
 
   # `|| true` because a destination that cannot be written must not cost the
   # other one. A full disk here would otherwise end the handler under `set -e`.
-  if [ -n "${HAZARD_LOG:-}" ]; then
-    printf '%s\n' "$text" >> "$HAZARD_LOG" 2>/dev/null || true
-  fi
+  # `/dev/null` rather than an `if`, because a caller that armed the traps always
+  # has a destination and the branch would be one no mutation could redden.
+  printf '%s\n' "$text" >> "${HAZARD_LOG:-/dev/null}" 2>/dev/null || true
 
   printf '%s\n' "$text" >&2
 }

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -554,6 +554,33 @@ else
      "destination was '$DEFAULT_DEST'"
 fi
 
+# The other half of `${HAZARD_LOG:-...}`, and the half that was lost. The
+# restructure that moved the traps into the library retired four source-level
+# checks correctly - runtime checks replaced them - and retired a fifth by
+# accident, because a diff cannot tell those two apart and I was reading the
+# count rather than the names. What went was the assertion that api-deploy.sh
+# names the destination before arming, and with it went any red for moving or
+# deleting that line.
+#
+# Behavioural rather than positional this time: the caller's value has to
+# survive the arming. If it does not, the notice still lands - the default
+# catches it - but it stops being keyed to the same $STAMP as
+# /tmp/api-rollback-$STAMP.txt and /tmp/api-dist-before-$STAMP.tgz, so an
+# operator correlating one deploy's artifacts loses the link and nothing fails.
+CALLER_DEST="$(
+  HAZARD_LOG="$WORK/caller-named.txt" \
+  MIGRATIONS_APPLIED=0 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="" \
+  bash -c '
+    set -euo pipefail
+    . "'"$HERE"'/../lib/migrate.sh"
+    deploy_arm_exit_traps
+    echo "$HAZARD_LOG"
+  ' 2>/dev/null || true
+)"
+check "arming does not override a destination the caller named" \
+  "$WORK/caller-named.txt" "$CALLER_DEST"
+
 # ---------------------------------------------------------------------------
 # The regression itself.
 #
@@ -636,6 +663,22 @@ if [ -n "$TRAP_LINE" ] && [ -n "$FLAG_LINE" ] && [ -n "$DEPLOY_LINE" ] \
 else
   no "api-deploy.sh arms the traps and raises the flag before applying migrations" \
      "trap=$TRAP_LINE flag=$FLAG_LINE deploy=$DEPLOY_LINE"
+fi
+
+# The $STAMP keying, which only a string match can carry: the behavioural check
+# above proves the caller's value survives the arming, and this proves
+# api-deploy.sh still names one. Whole-line, for the same reason line_of_exact
+# exists - the substring form matches the comment above the assignment.
+# The literal dollar is escaped in double quotes rather than written inside
+# single ones: `'$STAMP'` is an expansion that deliberately will not happen,
+# which is precisely what SC2016 warns about and cannot be spelled otherwise.
+STAMP_TOKEN="\$STAMP"
+HAZARD_LINE="$(line_of "HAZARD_LOG=\"/tmp/api-schema-hazard-${STAMP_TOKEN}.txt\"")"
+if [ -n "$HAZARD_LINE" ]; then
+  ok "api-deploy.sh keys the durable destination to the preflight \$STAMP"
+else
+  no "api-deploy.sh keys the durable destination to the preflight \$STAMP" \
+     "no assignment naming /tmp/api-schema-hazard-\$STAMP.txt"
 fi
 
 # The one thing left that a string match has to carry: that the script calls the

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -407,6 +407,12 @@ check "the reap cannot be swallowed by a notice that fails" \
 # cancelled deploy arrives as. SIGINT was already covered - bash sets the status
 # to 130 itself - and SIGKILL never can be.
 #
+# Armed through the real deploy_arm_exit_traps rather than by re-typing its
+# three trap lines here, so removing a trap from the shipped function is what
+# turns these red. Grepping api-deploy.sh for the trap lines instead would tie a
+# stand-in to the original by a string match - the shape #2718 removed from the
+# handler, arriving one level up in the arming.
+#
 # Signalled with a plain `kill` of the script rather than of its process group,
 # because a group signal would reach this suite too. That is also the slower of
 # the two paths on purpose: a trapped signal is deferred until the running
@@ -419,15 +425,13 @@ echo "deploy signal traps"
 signalled_notice() { # signalled_notice <signal> <expected-status>
   local sig="$1" ready="$WORK/ready.$1" out="$WORK/out.$1" pid status
   rm -f "$ready" "$out"
-  HAZARD_LOG="" \
+  HAZARD_LOG="$WORK/hazard.$1.txt" \
   MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
   INCOMING_MIGRATIONS="20260102000000_second" \
   bash -c '
     set -euo pipefail
     . "'"$HERE"'/../lib/migrate.sh"
-    trap "exit 143" TERM
-    trap "exit 129" HUP
-    trap deploy_on_exit EXIT
+    deploy_arm_exit_traps
     echo ready > "'"$ready"'"
     sleep 1
   ' > /dev/null 2>"$out" &
@@ -492,8 +496,7 @@ INCOMING_MIGRATIONS="20260102000000_second" \
 bash -c '
   set -euo pipefail
   . "'"$HERE"'/../lib/migrate.sh"
-  trap "exit 143" TERM
-  trap deploy_on_exit EXIT
+  deploy_arm_exit_traps
   echo ready > "'"$BROKEN_READY"'"
   sleep 1
 ' >/dev/null 2>"$FIFO" &
@@ -513,6 +516,43 @@ case "$(cat "$HAZ_PIPE")" in
   *) no "the notice survives an stderr whose reader has gone" \
        "the file holds: $(cat "$HAZ_PIPE")" ;;
 esac
+
+# A caller that arms the traps and names no destination still gets one. Unset
+# used to mean no durable write at all - not a safe fallback but the fix turned
+# off, silently, leaving the notice on the destination that is gone in the case
+# it exists for. api-deploy.sh names a $STAMP-keyed path so the file sits beside
+# the rollback sha; this is what happens when someone edits that line away.
+# Written to a file rather than passed to `bash -c`, the way the deploy-shape
+# fixture below is: the variables it reads must expand in the inner shell, and a
+# single-quoted `-c` argument holding them is what shellcheck reads as an
+# expression that will not expand.
+#
+# `env -u` rather than an assignment, because HAZARD_LOG has to be genuinely
+# absent here and not merely empty.
+cat > "$WORK/default-dest.sh" <<DEFAULTDEST
+#!/usr/bin/env bash
+set -euo pipefail
+. "$HERE/../lib/migrate.sh"
+deploy_arm_exit_traps
+echo "\$HAZARD_LOG"
+exit 1
+DEFAULTDEST
+chmod +x "$WORK/default-dest.sh"
+
+DEFAULT_DEST="$(
+  env -u HAZARD_LOG \
+  MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="20260102000000_second" \
+  "$WORK/default-dest.sh" 2>/dev/null || true
+)"
+if [ -n "$DEFAULT_DEST" ] && [ -s "$DEFAULT_DEST" ] \
+   && grep -q "THE SCHEMA IS AHEAD OF THE RUNNING CODE" "$DEFAULT_DEST"; then
+  ok "arming supplies a durable destination when the caller names none"
+  rm -f "$DEFAULT_DEST"
+else
+  no "arming supplies a durable destination when the caller names none" \
+     "destination was '$DEFAULT_DEST'"
+fi
 
 # ---------------------------------------------------------------------------
 # The regression itself.
@@ -580,43 +620,28 @@ DEPLOY_SH="$HERE/../api-deploy.sh"
 # `|| true` so a missing line reports as a failed check rather than aborting
 # the whole suite through `set -e` on the assignment below.
 line_of() { grep -n -m1 -F "$1" "$DEPLOY_SH" | cut -d: -f1 || true; }
+# Whole-line, because the first substring match for `deploy_arm_exit_traps` in
+# that file is the COMMENT above the call. Deleting the call outright left this
+# check green, found by mutating it: a check that matches prose rather than code
+# reports on the documentation of the thing it is meant to pin.
+line_of_exact() { grep -n -m1 -x "$1" "$DEPLOY_SH" | cut -d: -f1 || true; }
 
-TRAP_LINE="$(line_of 'trap deploy_on_exit EXIT')"
+TRAP_LINE="$(line_of_exact 'deploy_arm_exit_traps')"
 FLAG_LINE="$(line_of 'MIGRATIONS_APPLIED=1')"
 DEPLOY_LINE="$(line_of 'run prisma:deploy')"
 
 if [ -n "$TRAP_LINE" ] && [ -n "$FLAG_LINE" ] && [ -n "$DEPLOY_LINE" ] \
    && [ "$TRAP_LINE" -lt "$FLAG_LINE" ] && [ "$FLAG_LINE" -lt "$DEPLOY_LINE" ]; then
-  ok "api-deploy.sh arms the trap and raises the flag before applying migrations"
+  ok "api-deploy.sh arms the traps and raises the flag before applying migrations"
 else
-  no "api-deploy.sh arms the trap and raises the flag before applying migrations" \
+  no "api-deploy.sh arms the traps and raises the flag before applying migrations" \
      "trap=$TRAP_LINE flag=$FLAG_LINE deploy=$DEPLOY_LINE"
 fi
 
-# HAZARD_LOG is the one piece of state deploy_on_exit defaults rather than
-# demanding, because a `set -u` abort on it would destroy the notice to enforce
-# a rule about keeping it. So the loud check lives here instead, on the file
-# where the mistake would actually be made: an edit that drops the assignment,
-# or moves it below the arming, silently returns the notice to stderr-only - and
-# stderr is the destination that is gone in the case it exists for.
-HAZARD_LINE="$(line_of 'HAZARD_LOG="/tmp/api-schema-hazard-')"
-if [ -n "$HAZARD_LINE" ] && [ -n "$TRAP_LINE" ] && [ "$HAZARD_LINE" -lt "$TRAP_LINE" ]; then
-  ok "api-deploy.sh names the durable notice destination before arming the trap"
-else
-  no "api-deploy.sh names the durable notice destination before arming the trap" \
-     "hazard=$HAZARD_LINE trap=$TRAP_LINE"
-fi
-
-# The two signal traps, on the real file. Their absence is what #2721 was: the
-# handler exists, is armed, and never runs on the signal a cancelled deploy
-# actually arrives as.
-for SIG_TRAP in "trap 'exit 143' TERM" "trap 'exit 129' HUP"; do
-  if grep -qF "$SIG_TRAP" "$DEPLOY_SH"; then
-    ok "api-deploy.sh arms [$SIG_TRAP]"
-  else
-    no "api-deploy.sh arms [$SIG_TRAP]" "it is not in the file"
-  fi
-done
+# The one thing left that a string match has to carry: that the script calls the
+# arming function at all. Everything the function DOES is exercised above
+# against the real function, so this pins the call site and nothing else - which
+# is the smallest seam available, since no test can run api-deploy.sh itself.
 
 if grep -q 'trap - EXIT' "$DEPLOY_SH"; then
   no "api-deploy.sh keeps one exit handler" "it disarms the EXIT trap somewhere"

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -400,6 +400,121 @@ check "the reap cannot be swallowed by a notice that fails" \
   "REAPED NOTICE" "$(printf '%s' "$REAP_ORDER" | tr '\n' ' ' | sed 's/ $//')"
 
 # ---------------------------------------------------------------------------
+# The notice has to survive being killed, and survive its own destination.
+#
+# An untrapped fatal signal ends the shell without handing the EXIT trap a
+# non-zero status, so the notice was silent on exactly the two signals a
+# cancelled deploy arrives as. SIGINT was already covered - bash sets the status
+# to 130 itself - and SIGKILL never can be.
+#
+# Signalled with a plain `kill` of the script rather than of its process group,
+# because a group signal would reach this suite too. That is also the slower of
+# the two paths on purpose: a trapped signal is deferred until the running
+# foreground command finishes, so the `sleep 1` below is what the deferral costs
+# and the check would be worthless without something in flight to defer behind.
+# ---------------------------------------------------------------------------
+echo
+echo "deploy signal traps"
+
+signalled_notice() { # signalled_notice <signal> <expected-status>
+  local sig="$1" ready="$WORK/ready.$1" out="$WORK/out.$1" pid status
+  rm -f "$ready" "$out"
+  HAZARD_LOG="" \
+  MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+  INCOMING_MIGRATIONS="20260102000000_second" \
+  bash -c '
+    set -euo pipefail
+    . "'"$HERE"'/../lib/migrate.sh"
+    trap "exit 143" TERM
+    trap "exit 129" HUP
+    trap deploy_on_exit EXIT
+    echo ready > "'"$ready"'"
+    sleep 1
+  ' > /dev/null 2>"$out" &
+  pid=$!
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -s "$ready" ] && break
+    sleep 0.2
+  done
+  kill "-$sig" "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  status=$?
+  case "$(cat "$out")" in
+    *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*) echo "$status fired" ;;
+    *) echo "$status silent" ;;
+  esac
+}
+
+check "SIGTERM reaches the notice, with its status preserved" \
+  "143 fired" "$(signalled_notice TERM)"
+check "SIGHUP reaches the notice, with its status preserved" \
+  "129 fired" "$(signalled_notice HUP)"
+
+# ---------------------------------------------------------------------------
+# And the destination. stderr on the box is the ssh pipe, and the teardown of
+# that connection is what sends the SIGHUP - so the reader is gone in the case
+# the notice matters most, the write takes SIGPIPE, and the handler ends there.
+#
+# The fifo below is opened while a reader still exists, because opening one for
+# writing blocks until it has a reader; the reader is killed afterwards, which
+# is what makes the write fail. Then the ordinary destination test, so that a
+# green result here cannot mean "the file write never happens at all".
+# ---------------------------------------------------------------------------
+HAZ_PLAIN="$WORK/hazard-plain.txt"
+: > "$HAZ_PLAIN"
+HAZARD_LOG="$HAZ_PLAIN" \
+MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+INCOMING_MIGRATIONS="20260102000000_second" \
+bash -c '
+  set -u
+  . "'"$HERE"'/../lib/migrate.sh"
+  ( exit 1 )
+  deploy_on_exit
+' >/dev/null 2>&1 || true
+case "$(cat "$HAZ_PLAIN")" in
+  *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*)
+    ok "the notice is written to the durable destination as well as stderr" ;;
+  *) no "the notice is written to the durable destination as well as stderr" \
+       "the file holds: $(cat "$HAZ_PLAIN")" ;;
+esac
+
+HAZ_PIPE="$WORK/hazard-brokenpipe.txt"
+FIFO="$WORK/stderr.fifo"
+rm -f "$FIFO"; mkfifo "$FIFO"
+: > "$HAZ_PIPE"
+cat "$FIFO" > /dev/null &
+FIFO_READER=$!
+BROKEN_READY="$WORK/ready.pipe"
+rm -f "$BROKEN_READY"
+HAZARD_LOG="$HAZ_PIPE" \
+MIGRATIONS_APPLIED=1 CUTOVER_DONE=0 ROLLBACK_SHA=abc1234 \
+INCOMING_MIGRATIONS="20260102000000_second" \
+bash -c '
+  set -euo pipefail
+  . "'"$HERE"'/../lib/migrate.sh"
+  trap "exit 143" TERM
+  trap deploy_on_exit EXIT
+  echo ready > "'"$BROKEN_READY"'"
+  sleep 1
+' >/dev/null 2>"$FIFO" &
+BROKEN_PID=$!
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -s "$BROKEN_READY" ] && break
+  sleep 0.2
+done
+kill -9 "$FIFO_READER" 2>/dev/null || true
+wait "$FIFO_READER" 2>/dev/null || true
+kill -TERM "$BROKEN_PID" 2>/dev/null || true
+wait "$BROKEN_PID" 2>/dev/null || true
+
+case "$(cat "$HAZ_PIPE")" in
+  *"THE SCHEMA IS AHEAD OF THE RUNNING CODE"*)
+    ok "the notice survives an stderr whose reader has gone" ;;
+  *) no "the notice survives an stderr whose reader has gone" \
+       "the file holds: $(cat "$HAZ_PIPE")" ;;
+esac
+
+# ---------------------------------------------------------------------------
 # The regression itself.
 #
 # api-deploy.sh runs under `set -euo pipefail`. `prisma migrate deploy` applies
@@ -477,6 +592,31 @@ else
   no "api-deploy.sh arms the trap and raises the flag before applying migrations" \
      "trap=$TRAP_LINE flag=$FLAG_LINE deploy=$DEPLOY_LINE"
 fi
+
+# HAZARD_LOG is the one piece of state deploy_on_exit defaults rather than
+# demanding, because a `set -u` abort on it would destroy the notice to enforce
+# a rule about keeping it. So the loud check lives here instead, on the file
+# where the mistake would actually be made: an edit that drops the assignment,
+# or moves it below the arming, silently returns the notice to stderr-only - and
+# stderr is the destination that is gone in the case it exists for.
+HAZARD_LINE="$(line_of 'HAZARD_LOG="/tmp/api-schema-hazard-')"
+if [ -n "$HAZARD_LINE" ] && [ -n "$TRAP_LINE" ] && [ "$HAZARD_LINE" -lt "$TRAP_LINE" ]; then
+  ok "api-deploy.sh names the durable notice destination before arming the trap"
+else
+  no "api-deploy.sh names the durable notice destination before arming the trap" \
+     "hazard=$HAZARD_LINE trap=$TRAP_LINE"
+fi
+
+# The two signal traps, on the real file. Their absence is what #2721 was: the
+# handler exists, is armed, and never runs on the signal a cancelled deploy
+# actually arrives as.
+for SIG_TRAP in "trap 'exit 143' TERM" "trap 'exit 129' HUP"; do
+  if grep -qF "$SIG_TRAP" "$DEPLOY_SH"; then
+    ok "api-deploy.sh arms [$SIG_TRAP]"
+  else
+    no "api-deploy.sh arms [$SIG_TRAP]" "it is not in the file"
+  fi
+done
 
 if grep -q 'trap - EXIT' "$DEPLOY_SH"; then
   no "api-deploy.sh keeps one exit handler" "it disarms the EXIT trap somewhere"


### PR DESCRIPTION
Closes #2721.

## The defect

An untrapped fatal signal ends the shell without handing the EXIT trap a
non-zero status, so `deploy_on_exit` ran and `deploy_stop_notice` returned
early: the notice was silent on exactly the two signals a cancelled deploy
arrives as. A cancel kills the local `ssh` client, the connection closes, and
sshd sends SIGHUP to the remote process group. `deploy-api.yml:224-226` has no
`-t` and no wrapper, so nothing else is between the runner and the script.

Measured against the real handler sourced from `lib/migrate.sh`, own process
group, INT disposition reset to `DEFAULT`, bash 3.2.57:

| target | signal | rc | before | after |
|---|---|---|---|---|
| process group | TERM | 143 | silent | **fires** |
| process group | HUP | 129 | silent | **fires** |
| process group | INT | 130 | fires | fires |
| shell only | TERM | 143 | silent | **fires** |
| shell only | HUP | 129 | silent | **fires** |

Exit codes are preserved on every row, so nothing downstream that reads the
deploy's status changes. SIGINT already worked — bash sets the status to 130
itself. **SIGKILL stays out of reach**, so the ceiling here is every signal that
can be trapped, not "the notice can no longer be lost".

### The deferred-signal effect, named rather than discovered on a box

A trapped signal is deferred until the running foreground command finishes,
where an untrapped one ends the shell where it stands. On a cancel that costs
nothing — the child is in the same process group and dies too, and every
process-group row above returned in 0s. On a bare `kill` of this shell it means
an in-flight `prisma migrate deploy` runs to completion before the deploy stops,
which is the safer of the two and is a deliberate choice rather than a
side effect.

## The traps alone are not enough

`deploy_schema_hazard_notice` wrote to **stderr**, and stderr on the box is the
ssh pipe — the same connection whose teardown sends the SIGHUP. By the time the
handler runs the reader may already be gone, the write takes SIGPIPE, and the
handler ends part-way through the notice. The trap fires and the operator gets
silence through a different door.

So the notice is now written to `/tmp/api-schema-hazard-$STAMP.txt` as well,
beside the rollback sha preflight already writes at `api-deploy.sh:80` — the
same `$STAMP` artifact convention, not a new logging mechanism. **The order
between the two destinations is load-bearing:**

| stderr reader | order | rc | bytes on disk |
|---|---|---|---|
| gone | file, then stderr | 141 | **590** |
| gone | stderr, then file | 141 | **0** |
| alive (control) | either order | 129 | 590 |

`141` is `128+13`. The exit status is identical in both failing cases, so
nothing downstream can tell "notice preserved" from "notice lost".

## The one design call worth a reviewer's attention

`HAZARD_LOG` is **defaulted** rather than demanded, which is the opposite of the
rule the rest of `lib/migrate.sh` follows for caller state. A `set -u` abort on
an unset `HAZARD_LOG` would destroy the notice in order to enforce a rule about
keeping it — the failure mode the whole change exists to remove. So the loud
check lives on `api-deploy.sh` instead, where the mistake would actually be
made: the suite pins that the assignment exists and sits above the arming.

I said in the issue thread that it would become a fifth required caller
variable. That was wrong for this reason, and the reversal is why the two
source-level checks are here.

## Evidence at `db63ae109`

Six mutations through the assert-uniqueness harness, each reverted before the
next, the harness refused none, baseline and restore both 41/41:

| Mutation | Result |
|---|---|
| remove the TERM trap from `api-deploy.sh` | 40 passed, **1 failed** |
| remove the HUP trap from `api-deploy.sh` | 40 passed, **1 failed** |
| remove the `HAZARD_LOG` assignment | 40 passed, **1 failed** |
| move `HAZARD_LOG` below the trap arming | 40 passed, **1 failed** |
| drop the durable write from the notice | 39 passed, **2 failed** |
| write stderr before the file instead of after | 40 passed, **1 failed** |

The last one reddens only `the notice survives an stderr whose reader has gone`,
which is the check the ordering exists for. And removing the two signal traps
from the **test's own** inline script reddens both signal checks, so neither is
vacuous.

Gates, `git rev-parse HEAD` confirmed either side, tree clean:

| Command | Result |
|---|---|
| `tests/migrate.test.sh` | exit 0 — **41 passed, 0 failed** |
| `tests/git-sync.test.sh` | exit 0 — 16/16 |
| `scripts/ci/classify-migration.test.mjs` | exit 0 |
| `shellcheck --severity=warning -x` | **exit 0** |
| `shellcheck -x` (plain) | exit 1 — 8 info notes, **findings profile identical to `origin/dev`** |

The plain `shellcheck` run is exit 1 on `origin/dev` too; I compared the finding
profiles rather than reporting "clean", and introduced nothing at any severity.
`shellcheck` is not gated in CI.
