### PR TITLE
fix(backend): parse the co-parent permission body instead of casting it

### DIFF
--- a/apps/backend/src/controllers/app/parent-companion.controller.ts
+++ b/apps/backend/src/controllers/app/parent-companion.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { z } from "zod";
 import logger from "../../utils/logger";
 import {
   ParentCompanionService,
@@ -7,6 +8,38 @@ import {
 import { ParentService } from "src/services/parent.service";
 import type { ParentCompanionPermissions } from "@yosemite-crew/types";
 import type { AuthenticatedRequest } from "src/middlewares/auth";
+
+/*
+ * `ParentPatient.permissions` is the input to an authorisation decision -
+ * `companion-access.ts` reads it on every companion-gated route - so the body
+ * that writes it is a trust boundary and gets parsed, not cast. A cast checks
+ * nothing at runtime, and the previous one let any JSON object through to be
+ * merged over the stored record verbatim (#2710).
+ *
+ * `satisfies` rather than a hand-kept list: adding a key to
+ * `ParentCompanionPermissions` without adding it here, or leaving one here that
+ * the type no longer has, is a compile error. The alternative is a list that
+ * silently stops covering the feature someone added last week.
+ */
+const PERMISSION_SHAPE = {
+  assignAsPrimaryParent: z.boolean(),
+  emergencyBasedPermissions: z.boolean(),
+  appointments: z.boolean(),
+  companionProfile: z.boolean(),
+  documents: z.boolean(),
+  expenses: z.boolean(),
+  tasks: z.boolean(),
+  chatWithVet: z.boolean(),
+  medicalRecords: z.boolean(),
+} satisfies Record<keyof ParentCompanionPermissions, z.ZodBoolean>;
+
+/*
+ * Strict, so an unrecognised key is a 400 rather than a silent drop. A caller
+ * who sends `medicalRecods: false` has made a mistake that matters, and
+ * answering 200 to it would report a permission change that never happened.
+ * Every key is optional because a PATCH may carry one.
+ */
+const permissionUpdateSchema = z.object(PERMISSION_SHAPE).partial().strict();
 
 const resolveAuthenticatedUserId = (req: Request): string | undefined => {
   const userId = (req as AuthenticatedRequest).userId;
@@ -103,9 +136,6 @@ export const ParentCompanionController = {
         authUserId!,
       );
       const { patientId, targetParentId } = req.params;
-      const updates = (
-        typeof req.body === "object" && req.body ? req.body : {}
-      ) as Partial<ParentCompanionPermissions>;
 
       if (!requestingParent) {
         return res
@@ -118,6 +148,23 @@ export const ParentCompanionController = {
           .status(400)
           .json({ message: "Invalid parent or companion ID." });
       }
+
+      /*
+       * Parsed after the auth and id checks, so an unauthenticated caller
+       * learns nothing about the body's shape. The offending body is not
+       * logged - it is caller-controlled, and the 400 already reaches the only
+       * party who can act on it.
+       */
+      const parsedUpdates = permissionUpdateSchema.safeParse(
+        typeof req.body === "object" && req.body ? req.body : {},
+      );
+      if (!parsedUpdates.success) {
+        return res.status(400).json({
+          message: "Invalid permissions payload.",
+          errors: z.flattenError(parsedUpdates.error),
+        });
+      }
+      const updates: Partial<ParentCompanionPermissions> = parsedUpdates.data;
 
       const updated = await ParentCompanionService.updatePermissions(
         resolveParentId(requestingParent),

--- a/apps/backend/src/services/parent-companion.service.ts
+++ b/apps/backend/src/services/parent-companion.service.ts
@@ -67,6 +67,44 @@ const PRIMARY_PARENT_PERMISSIONS: ParentCompanionPermissions = {
   medicalRecords: true,
 };
 
+/*
+ * The permission keys, taken from BASE_PERMISSIONS rather than written out
+ * again, so the set cannot drift from the type that defines it.
+ */
+const PERMISSION_KEYS = Object.keys(
+  BASE_PERMISSIONS,
+) as (keyof ParentCompanionPermissions)[];
+
+/**
+ * Reduce a permission record to exactly the known keys, as booleans.
+ *
+ * `permissions` is a Json column and the input to an authorisation decision, so
+ * what gets stored has to be the nine keys and nothing else. The controller
+ * rejects an unrecognised key at the boundary (#2710); this is the half that
+ * also covers what is already in the row, because the merge that writes it
+ * spreads the stored record and would carry any existing junk forward for ever.
+ *
+ * Applied at the two points that decide what leaves this module - the record
+ * written, and the record returned - and nowhere in between. Normalising the
+ * stored record on the way into that merge as well was a second copy of the
+ * same guarantee: mutating either one alone left every test green, which is
+ * what said one of them was redundant rather than untested.
+ *
+ * `=== true` rather than a truthiness test, deliberately: it is the same
+ * predicate `isGranted` in companion-access.ts applies, so a stored value that
+ * would deny at the gate is stored as a denial rather than as something the UI
+ * might render as a grant. Anything unrecognised is dropped, and anything
+ * missing is `false` - both the safe direction.
+ */
+const normalizePermissions = (value: unknown): ParentCompanionPermissions => {
+  const source = (value ?? {}) as Record<string, unknown>;
+  const normalized = {} as ParentCompanionPermissions;
+  for (const key of PERMISSION_KEYS) {
+    normalized[key] = source[key] === true;
+  }
+  return normalized;
+};
+
 const buildPermissions = (
   role: ParentCompanionRole,
   overrides?: Partial<ParentCompanionPermissions>,
@@ -104,7 +142,7 @@ const toCompanionParentLink = (
   parentId: record.parentId,
   role: record.role,
   status: record.status,
-  permissions: record.permissions as unknown as ParentCompanionPermissions,
+  permissions: normalizePermissions(record.permissions),
   invitedByParentId: record.invitedByParentId ?? undefined,
   acceptedAt: record.acceptedAt?.toISOString(),
   createdAt: record.createdAt?.toISOString(),
@@ -450,10 +488,10 @@ export const ParentCompanionService = {
       );
     }
 
-    const mergedPermissions: ParentCompanionPermissions = {
+    const mergedPermissions = normalizePermissions({
       ...targetPermissions,
       ...updates,
-    };
+    });
 
     if (isCurrentlyPrimary) {
       mergedPermissions.assignAsPrimaryParent = true;

--- a/apps/backend/test/controllers/parent-companion.controller.test.ts
+++ b/apps/backend/test/controllers/parent-companion.controller.test.ts
@@ -410,6 +410,112 @@ describe("ParentCompanionController.updatePermissions", () => {
     expect(jsonMock).toHaveBeenCalledWith(updated);
   });
 
+  /*
+   * `ParentPatient.permissions` is what companion-access.ts reads on every
+   * companion-gated route, so the body that writes it is parsed rather than
+   * cast (#2710). These three are the boundary: an unknown key, a non-boolean,
+   * and the full known set.
+   */
+  it("400s on an unrecognised key rather than storing it", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockedParentService.findByLinkedUserId as any).mockResolvedValue({
+      id: OWNER_PARENT_ID,
+    });
+    req.body = { appointments: true, isSuperUser: true };
+
+    await ParentCompanionController.updatePermissions(
+      req as Request,
+      res as Response,
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(mockedLinkService.updatePermissions).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A silent drop would answer 200 to a caller who mistyped a feature name,
+   * reporting a permission change that never happened.
+   */
+  it("400s rather than silently dropping a mistyped feature name", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockedParentService.findByLinkedUserId as any).mockResolvedValue({
+      id: OWNER_PARENT_ID,
+    });
+    req.body = { medicalRecods: false };
+
+    await ParentCompanionController.updatePermissions(
+      req as Request,
+      res as Response,
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(mockedLinkService.updatePermissions).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a string", "true"],
+    ["a number", 1],
+    ["null", null],
+    ["an object", {}],
+  ])(
+    "400s when a permission is %s rather than a boolean",
+    async (_l, value) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockedParentService.findByLinkedUserId as any).mockResolvedValue({
+        id: OWNER_PARENT_ID,
+      });
+      req.body = { appointments: value };
+
+      await ParentCompanionController.updatePermissions(
+        req as Request,
+        res as Response,
+      );
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(mockedLinkService.updatePermissions).not.toHaveBeenCalled();
+    },
+  );
+
+  /*
+   * The schema must not be narrower than the type it guards: a feature the
+   * product ships and the schema does not know is a 400 on a legitimate call.
+   */
+  it("accepts every known permission key", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockedParentService.findByLinkedUserId as any).mockResolvedValue({
+      id: OWNER_PARENT_ID,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockedLinkService.updatePermissions as any).mockResolvedValue(
+      buildLink(OUTSIDER_PARENT_ID, "ACTIVE"),
+    );
+    const everyKey = {
+      assignAsPrimaryParent: false,
+      emergencyBasedPermissions: true,
+      appointments: true,
+      companionProfile: true,
+      documents: true,
+      expenses: true,
+      tasks: true,
+      chatWithVet: true,
+      medicalRecords: true,
+    };
+    req.body = everyKey;
+
+    await ParentCompanionController.updatePermissions(
+      req as Request,
+      res as Response,
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(mockedLinkService.updatePermissions).toHaveBeenCalledWith(
+      OWNER_PARENT_ID,
+      OUTSIDER_PARENT_ID,
+      PATIENT_ID,
+      everyKey,
+    );
+  });
+
   it("treats a non-object body as an empty update set", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockedParentService.findByLinkedUserId as any).mockResolvedValue({

--- a/apps/backend/test/services/parent-companion.service.test.ts
+++ b/apps/backend/test/services/parent-companion.service.test.ts
@@ -847,6 +847,13 @@ describe("ParentCompanionService.updatePermissions", () => {
     );
 
     expect(mockedPrisma.$transaction).not.toHaveBeenCalled();
+    /*
+     * Every key, including `medicalRecords`, which the stored record above does
+     * not have. A row written before that key existed used to keep the gap for
+     * ever, because the merge spread the stored record and nothing filled it in
+     * - so the record disagreed with the type and with what the UI renders,
+     * while `isGranted` answered `false` either way (#2710).
+     */
     expect(mockedPrisma.parentPatient.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "co-link" },
@@ -860,11 +867,100 @@ describe("ParentCompanionService.updatePermissions", () => {
             expenses: false,
             tasks: false,
             chatWithVet: false,
+            medicalRecords: false,
           },
         },
       }),
     );
     expect(result.role).toBe("CO_PARENT");
+  });
+
+  /*
+   * The stored record is a Json column and the input to an authorisation
+   * decision, so what gets written back is reduced to the known keys as
+   * booleans - not merely what arrived on this request (#2710). These two cover
+   * what is already in the row, which the controller's schema cannot reach.
+   */
+  it("drops unrecognised keys that are already in the stored record", async () => {
+    mockedPrisma.parentPatient.findFirst
+      .mockResolvedValueOnce({ id: "co-link" })
+      .mockResolvedValueOnce(
+        linkRecord({
+          id: "co-link",
+          parentId: "parent-2",
+          permissions: {
+            assignAsPrimaryParent: false,
+            appointments: true,
+            isSuperUser: true,
+            "../../etc": "anything",
+          },
+        }),
+      );
+    mockedPrisma.parentPatient.update.mockResolvedValueOnce(
+      linkRecord({ id: "co-link", parentId: "parent-2" }),
+    );
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
+
+    await ParentCompanionService.updatePermissions(
+      "parent-1",
+      "parent-2",
+      "patient-1",
+      { documents: true },
+    );
+
+    const written = mockedPrisma.parentPatient.update.mock.calls[0][0] as {
+      data: { permissions: Record<string, unknown> };
+    };
+    expect(Object.keys(written.data.permissions).sort()).toEqual([
+      "appointments",
+      "assignAsPrimaryParent",
+      "chatWithVet",
+      "companionProfile",
+      "documents",
+      "emergencyBasedPermissions",
+      "expenses",
+      "medicalRecords",
+      "tasks",
+    ]);
+    expect(written.data.permissions.appointments).toBe(true);
+    expect(written.data.permissions.documents).toBe(true);
+  });
+
+  /*
+   * `=== true`, the same predicate `isGranted` applies, so a stored value that
+   * would deny at the gate is stored as a denial rather than as something a UI
+   * might render as a grant.
+   */
+  it.each([
+    ["a string", "true"],
+    ["a number", 1],
+    ["an object", {}],
+  ])("stores %s in an existing record as false", async (_label, value) => {
+    mockedPrisma.parentPatient.findFirst
+      .mockResolvedValueOnce({ id: "co-link" })
+      .mockResolvedValueOnce(
+        linkRecord({
+          id: "co-link",
+          parentId: "parent-2",
+          permissions: { assignAsPrimaryParent: false, appointments: value },
+        }),
+      );
+    mockedPrisma.parentPatient.update.mockResolvedValueOnce(
+      linkRecord({ id: "co-link", parentId: "parent-2" }),
+    );
+    mockedPrisma.parent.findUnique.mockResolvedValueOnce(null);
+
+    await ParentCompanionService.updatePermissions(
+      "parent-1",
+      "parent-2",
+      "patient-1",
+      { documents: true },
+    );
+
+    const written = mockedPrisma.parentPatient.update.mock.calls[0][0] as {
+      data: { permissions: Record<string, unknown> };
+    };
+    expect(written.data.permissions.appointments).toBe(false);
   });
 
   it("keeps the primary flag set when updating the acting primary's own permissions", async () => {
@@ -900,7 +996,14 @@ describe("ParentCompanionService.updatePermissions", () => {
         data: {
           permissions: {
             assignAsPrimaryParent: true,
+            emergencyBasedPermissions: false,
+            appointments: false,
+            companionProfile: false,
             documents: false,
+            expenses: false,
+            tasks: false,
+            chatWithVet: false,
+            medicalRecords: false,
           },
         },
       }),
@@ -1058,6 +1161,44 @@ describe("ParentCompanionService link queries", () => {
     });
     expect(result[0].parent?.email).toBe("jane@example.com");
     expect(result[1].parent).toBeUndefined();
+  });
+
+  /*
+   * The record that leaves this module is normalised as well as the one that
+   * enters it. A row written before `medicalRecords` existed, or carrying a key
+   * nothing recognises, would otherwise be handed to a client as the shape of
+   * `ParentCompanionPermissions` while being neither (#2710).
+   */
+  it("returns a legacy stored record as the known keys and nothing else", async () => {
+    mockedPrisma.parentPatient.findMany.mockResolvedValueOnce([
+      linkRecord({
+        id: "link-1",
+        permissions: {
+          assignAsPrimaryParent: false,
+          appointments: true,
+          documents: "yes",
+          isSuperUser: true,
+        },
+      }),
+    ]);
+
+    const [link] = await ParentCompanionService.getLinksForParent("parent-1");
+
+    expect(Object.keys(link.permissions).sort()).toEqual([
+      "appointments",
+      "assignAsPrimaryParent",
+      "chatWithVet",
+      "companionProfile",
+      "documents",
+      "emergencyBasedPermissions",
+      "expenses",
+      "medicalRecords",
+      "tasks",
+    ]);
+    expect(link.permissions.appointments).toBe(true);
+    // `"yes"` is not a grant at the gate, so it is not one in the response.
+    expect(link.permissions.documents).toBe(false);
+    expect(link.permissions.medicalRecords).toBe(false);
   });
 
   it("returns a parent's links without hydrating contact details", async () => {


### PR DESCRIPTION
Closes #2710.

`ParentPatient.permissions` is the input to an authorisation decision — `companion-access.ts` reads it on every companion-gated route — and `updatePermissions` cast an unknown request body to `Partial<ParentCompanionPermissions>` and let the service spread it over the stored record. A cast checks nothing at runtime, so arbitrary keys and non-boolean values persisted into that record.

## The boundary

The controller parses the body against the nine known permission keys instead of casting it.

**Strict rather than stripping.** A caller who sends `medicalRecods: false` has made a mistake that matters; answering 200 to it would report a permission change that never happened. That is the same silent-success shape the repo has been closing elsewhere, so an unrecognised key is a 400.

**The schema cannot drift from the type it guards.** The key list carries `satisfies Record<keyof ParentCompanionPermissions, z.ZodBoolean>`. Verified both directions rather than asserted:

| Mutation | `tsc` |
|---|---|
| remove `medicalRecords` from the schema | **TS1360** — does not satisfy the expected type |
| add `isSuperUser`, which the type does not have | **TS2353** — object literal may only specify known properties |

A hand-kept list would go quietly out of date the first time someone adds a feature.

## The write, and the read

The service reduces what it writes and what it returns to exactly those keys as booleans, with `=== true` — the same predicate `isGranted` applies, so a stored value that would deny at the gate is stored as a denial rather than as something a UI might render as a grant.

That also fills in a key added after a row was written. `medicalRecords` is absent from records the old merge kept spreading forward, so the stored record disagreed with its own type indefinitely.

## Mutations

Seven, through an assert-uniqueness harness, each reverted before the next, harness refused none, baseline and restore both `135 passed`:

| Mutation | Result |
|---|---|
| drop `.strict()`, so unknown keys are silently stripped | **2 failed** |
| `z.boolean()` → `z.any()` | **4 failed** |
| drop a key from the schema | **1 failed** |
| ignore the parse failure and pass the body through | **6 failed** |
| skip normalising the merged record | **6 failed** |
| normalise with truthiness instead of `=== true` | **3 failed** |
| skip normalising on the link read path | **1 failed** |

**Three more were green on the first pass and are not in this diff.** Normalising the stored record on the way into the merge, and again inside `buildPermissions`, were second copies of a guarantee the write site already makes — mutating either one alone left every test green, which is what said they were redundant rather than untested. The third green was the return path, which was genuinely untested; it has a test now. A branch no mutation can redden is either a missing test or dead code, and the harness is what tells you which.

## Gates

| Command | Result |
|---|---|
| `npx jest` (full backend) | **exit 0** — 469 suites / **11307 tests** |
| `turbo run lint type-check --filter=backend --force` | **exit 0** — 7/7, **0 errors**, 25 pre-existing warnings |

`git rev-parse HEAD` confirmed in the same shell either side of each; tree clean.

## Not fixed here

A PRIMARY link carrying `medicalRecords: false` is still reachable, and `companion-access.ts` documents that it must still pass — a primary's permission set describes what they have *delegated*. That is the product's model, not a validation gap, and pinning it would change behaviour rather than validate input.
