### PR TITLE
ci(repo): gate named external products on every pull request

### DIFF
--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -197,3 +197,26 @@ jobs:
           # and one the step above failed to write is exit 2 rather than a
           # surface quietly missing from the run.
           node scripts/ci/forbidden-terms.mjs scan --dir "${RUNNER_TEMP}/surfaces"
+          # Evidence that the scan happened, read by the last step. Written only
+          # after a clean exit, so it records a scan rather than an attempt.
+          touch "${RUNNER_TEMP}/scanned"
+
+      # No `if:`, deliberately. Every step above is conditional on the trigger,
+      # so a `workflow_dispatch` run - or any future edit that skips them -
+      # checks out, arms, self-tests and then SUCCEEDS having read no surface at
+      # all. This job's own rule is that exit 1 is a finding, exit 2 is a guard
+      # that could not run, and both are red: a run that scanned nothing is the
+      # second of those and must not be reported as the first.
+      #
+      # So a manual dispatch is a smoke test of the secrets and ends red on
+      # purpose, with the self-test's result above it, which is the honest
+      # report for it.
+      - name: Refuse to report clean without having scanned
+        run: |
+          set -euo pipefail
+          if [ ! -f "${RUNNER_TEMP}/scanned" ]; then
+            echo "forbidden-terms: no surface was scanned in this run." >&2
+            echo "A green check here would mean 'nothing found' when it means 'nothing looked at'." >&2
+            exit 1
+          fi
+          echo 'forbidden-terms: surfaces scanned.'

--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -192,6 +192,7 @@ jobs:
         env:
           FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
         run: |
+          set -euo pipefail
           # A directory rather than a list of surfaces, so this step cannot
           # short-pass the guard. Every surface the script knows about is read,
           # and one the step above failed to write is exit 2 rather than a

--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -1,0 +1,199 @@
+name: Forbidden Terms
+
+# Both repositories are public. Prior art may be studied freely; the source may
+# never be NAMED - in code, comments, tests, fixtures, docs, commit messages,
+# branch names, or pull-request text.
+#
+# scripts/ci/forbidden-terms.mjs is the implementation and carries the reasoning
+# for every decision here; scripts/ci/forbidden-terms.test.mjs pins the
+# machinery with a synthetic pattern and runs first, because a guard whose own
+# tests are broken has no business reporting on a pull request.
+#
+# The same gate runs on the other public repository in this organisation, and the
+# two secrets hold ONE pattern covering both products' prior art. A control
+# present on one of two public repositories invites exactly the mistake it
+# prevents. The guard and its tests are the same file in both; the must-pass
+# corpus is this repository's own prose, and this workflow is written against
+# this repository's conventions rather than copied - there is no zizmor gate
+# here, so the acceptance record that accompanies `pull_request_target` over
+# there lives in this header instead.
+#
+# ---------------------------------------------------------------------------
+# WHY pull_request_target, AND THE CONSTRAINT THAT MAKES IT SAFE
+# ---------------------------------------------------------------------------
+#
+# The pattern IS the term list, so it cannot be committed to a public
+# repository; it has to be a secret. GitHub deliberately withholds secrets from
+# `pull_request` runs triggered by a FORK, which would leave the pattern empty
+# on exactly the contributions that most need checking - an outside contributor
+# has no local hook at all. An empty pattern is not a no-op: one formulation
+# matches every line and another matches none, so it either fails every pull
+# request or passes every one silently.
+#
+# `pull_request_target` runs in the BASE repository's context and does carry
+# secrets. It is safe ONLY because of what this job does and does not do:
+#
+#   * it checks out the BASE repository, and reads the head only as DATA,
+#     through `git` on refs/pull/<n>/head
+#   * it runs no install, no build, no test of the head, no repo-provided
+#     script from the head, no action pinned by the head - nothing from the
+#     pull request's package.json or its workflows
+#   * it greps, and it exits
+#
+# THE MOMENT A STEP RUNS HEAD-PROVIDED CODE, A FORK CAN READ THE SECRET.
+# If you are adding a step here, that is the rule you are working against, and
+# it is the whole reason this trigger is acceptable. This repository has no
+# workflow-security audit to record that acceptance for you, so it is recorded
+# here: any step that executes code, an action or a script coming from the pull
+# request head voids the argument above, and the answer then is to restructure
+# the workflow rather than to keep the trigger.
+#
+# ---------------------------------------------------------------------------
+# MASKING
+# ---------------------------------------------------------------------------
+#
+# GitHub masks the LITERAL secret value and nothing derived from it, so the
+# decoded pattern is unmasked unless we mask it ourselves. Both forms are
+# masked below, and `set -x` must never appear in this job. Masking is a
+# backstop and not the design: the guard reports a surface, a file and a line,
+# and never the match.
+#
+# ---------------------------------------------------------------------------
+# ROTATION
+# ---------------------------------------------------------------------------
+#
+# If the term list changes, BOTH secrets change together and every open pull
+# request's result for this check goes stale - re-run it rather than trusting a
+# green from before the rotation.
+
+on:
+  pull_request_target:
+    # `edited` is load-bearing. The event payload carries the title and body AT
+    # TRIGGER TIME, so without it the highest-visibility surface we have is
+    # checked once and then left editable.
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: forbidden-terms-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  forbidden-terms:
+    name: No named external product
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # read refs; this job writes nothing back
+
+    steps:
+      # The BASE repository, so the guard, its tests and the must-pass corpus
+      # are the reviewed versions rather than whatever the pull request says
+      # they are. A pull request cannot edit the thing that checks it.
+      - name: Checkout base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # The runner's system Node. The guard is dependency-free by design, so
+      # there is nothing to install - which is also the security constraint.
+      - name: Test the guard itself
+        run: node --test scripts/ci/forbidden-terms.test.mjs
+
+      - name: Arm the pattern
+        env:
+          PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+          CORPUS_B64: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
+        run: |
+          set -euo pipefail
+          # Mask the encoded forms too: base64 of a word list is as good a
+          # starting point for someone curious as the plaintext, and it costs
+          # nothing.
+          echo "::add-mask::${PATTERN_B64}"
+          echo "::add-mask::${CORPUS_B64}"
+          PATTERN=$(printf '%s' "${PATTERN_B64}" | base64 -d 2>/dev/null || true)
+          CORPUS=$(printf '%s' "${CORPUS_B64}" | base64 -d 2>/dev/null || true)
+          # Mask the decoded values BEFORE they are used for anything at all.
+          [ -n "${PATTERN}" ] && echo "::add-mask::${PATTERN}"
+          [ -n "${CORPUS}" ] && while IFS= read -r entry; do
+            [ -n "${entry}" ] && echo "::add-mask::${entry}"
+          done <<< "${CORPUS}"
+          echo 'armed'
+
+      # The job asserts ITSELF before it asserts anything about the pull
+      # request: the pattern compiles, it catches every known positive, it stays
+      # silent on this repository's own prose, and the corpus is not truncated.
+      # An empty or rotated secret is red here rather than quietly green there.
+      #
+      # MIN_CORPUS is in the clear on purpose. A number is not a term list, and
+      # it turns "the secret lost half its entries" from silent into red. Six
+      # because the pattern carries six alternatives; raise it with the corpus,
+      # never lower it to make a run pass.
+      - name: Self-test
+        env:
+          FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+          FORBIDDEN_TERMS_CORPUS_B64: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
+        run: node scripts/ci/forbidden-terms.mjs selftest --min-corpus 6
+
+      # refs/pull/<n>/head exists in the BASE repository for every pull request,
+      # forks included, so the head arrives without adding the fork as a remote
+      # and without any of its code running.
+      - name: Fetch the pull request head as data
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "+refs/heads/${BASE_REF}:refs/remotes/origin/gate-base"
+          git fetch --no-tags --quiet origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/gate-head"
+
+      # Three dots: the diff from the MERGE BASE, which is what this pull
+      # request adds rather than how it differs from a base that has moved on.
+      #
+      # It is also what answers the promotion case. A term that reached `dev`
+      # through an earlier pull request sits in the BASE of every later `dev`
+      # comparison and is never looked at again - but a `main` pull request's
+      # merge base is the previous promotion, so the whole of `dev` since then
+      # is in scope. That is why this workflow is required on BOTH branches.
+      - name: Collect the surfaces
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/surfaces"
+          MERGE_BASE=$(git merge-base refs/remotes/origin/gate-base refs/remotes/origin/gate-head)
+          git diff --unified=0 --diff-filter=ACMR "${MERGE_BASE}" refs/remotes/origin/gate-head \
+            > "${RUNNER_TEMP}/surfaces/diff"
+          git diff --name-only --diff-filter=ACMR "${MERGE_BASE}" refs/remotes/origin/gate-head \
+            > "${RUNNER_TEMP}/surfaces/names"
+          git log --format=%B "${MERGE_BASE}..refs/remotes/origin/gate-head" \
+            > "${RUNNER_TEMP}/surfaces/messages"
+          # Through env and never interpolated into the script: the title and
+          # body are attacker-controlled text, and this file is the one place in
+          # the repository where that text meets a shell.
+          printf '%s\n' "${PR_HEAD_REF}" > "${RUNNER_TEMP}/surfaces/branch"
+          printf '%s\n' "${PR_TITLE}" > "${RUNNER_TEMP}/surfaces/title"
+          printf '%s\n' "${PR_BODY}" > "${RUNNER_TEMP}/surfaces/body"
+
+      # Exit 1 is a finding, exit 2 is a guard that could not run. Both are red,
+      # and neither is reported as clean.
+      - name: Scan every surface
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+        run: |
+          # A directory rather than a list of surfaces, so this step cannot
+          # short-pass the guard. Every surface the script knows about is read,
+          # and one the step above failed to write is exit 2 rather than a
+          # surface quietly missing from the run.
+          node scripts/ci/forbidden-terms.mjs scan --dir "${RUNNER_TEMP}/surfaces"

--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -9,44 +9,121 @@ name: Forbidden Terms
 # machinery with a synthetic pattern and runs first, because a guard whose own
 # tests are broken has no business reporting on a pull request.
 #
-# The same gate runs on the other public repository in this organisation, and the
-# two secrets hold ONE pattern covering both products' prior art. A control
-# present on one of two public repositories invites exactly the mistake it
-# prevents. The guard and its tests are the same file in both; the must-pass
-# corpus is this repository's own prose, and this workflow is written against
-# this repository's conventions rather than copied - there is no zizmor gate
-# here, so the acceptance record that accompanies `pull_request_target` over
-# there lives in this header instead.
-#
 # ---------------------------------------------------------------------------
-# WHY pull_request_target, AND THE CONSTRAINT THAT MAKES IT SAFE
+# WHY pull_request, AND WHAT A FORK GETS
 # ---------------------------------------------------------------------------
 #
 # The pattern IS the term list, so it cannot be committed to a public
-# repository; it has to be a secret. GitHub deliberately withholds secrets from
-# `pull_request` runs triggered by a FORK, which would leave the pattern empty
-# on exactly the contributions that most need checking - an outside contributor
-# has no local hook at all. An empty pattern is not a no-op: one formulation
-# matches every line and another matches none, so it either fails every pull
-# request or passes every one silently.
+# repository; it has to be a secret. GitHub withholds secrets from
+# `pull_request` runs triggered by a FORK, so on a fork this job has no pattern
+# and the self-test below exits 2 - a guard that could not run, which this file
+# treats as red. That is the honest report for it: an outside contribution
+# needs a maintainer, and it is never silently green.
 #
-# `pull_request_target` runs in the BASE repository's context and does carry
-# secrets. It is safe ONLY because of what this job does and does not do:
+# This USED to be `pull_request_target`, which runs in the base repository's
+# context and does carry secrets on a fork. It was safe only by a convention
+# written in this comment - check out the base, read the head as data, run
+# nothing from the head - and CodeQL was right that a convention is not a
+# mechanism: `actions/untrusted-checkout/high`, this file, the head fetch.
+# One future step running anything head-provided would hand a fork the secret,
+# and nothing but review stood between us and that step.
 #
-#   * it checks out the BASE repository, and reads the head only as DATA,
-#     through `git` on refs/pull/<n>/head
-#   * it runs no install, no build, no test of the head, no repo-provided
-#     script from the head, no action pinned by the head - nothing from the
-#     pull request's package.json or its workflows
-#   * it greps, and it exits
+# Be accurate about what changed, because it is narrower than the rule's
+# wording: the head is never checked out and never runs, so `later potential
+# execution` is the heuristic's assumption rather than a fact about this file.
+# Nothing here was leaking. THE PROPERTY WAS HELD BY PROSE AND IS NOW HELD BY
+# THE TRIGGER - that is the whole before-and-after, and it is worth having.
 #
-# THE MOMENT A STEP RUNS HEAD-PROVIDED CODE, A FORK CAN READ THE SECRET.
-# If you are adding a step here, that is the rule you are working against, and
-# it is the whole reason this trigger is acceptable. This repository has no
-# workflow-security audit to record that acceptance for you, so it is recorded
-# here: any step that executes code, an action or a script coming from the pull
-# request head voids the argument above, and the answer then is to restructure
-# the workflow rather than to keep the trigger.
+# THE SIBLING REPOSITORY MADE THIS TRADE FIRST AND REFUSED TO LET IT TRAVEL,
+# so it is made again here, on this repository's own count. Its header says
+# red-on-fork is free there because it has never had a fork pull request, and
+# says in the same breath that the answer there is not evidence about this one.
+#
+# Counted here, 2026-09-06, over all 1,601 pull requests this repository has
+# ever had:
+#
+#   596 came from a fork and 536 of those merged - a third of the merged work,
+#       across 22 named external authors
+#   the monthly curve is 54, 15, 32, 11, 17, 36, 28, 4 for 2026-01..08, and the
+#       most recent fork pull request is #2219, 2026-08-16, three weeks ago
+#
+# So the cost is real historically and near zero now, and the two halves point
+# opposite ways. What settles it is a third fact rather than a bigger number:
+# `No named external product` IS NOT A REQUIRED STATUS CHECK on either branch -
+# `dev` requires `CI Required` and `Supply Chain Required`, `main` requires
+# `Only dev may merge into main`. A fork therefore gets a visible red that
+# reports honestly and blocks nothing, and a maintainer who wants it green
+# pushes the branch to this repository and opens the pull request from there.
+#
+# THAT IS ALSO WHAT MAKES THIS PARAGRAPH EXPIRE. The moment this context is
+# added to either ruleset, red-on-fork stops being advisory and starts being a
+# merge block on a third of this repository's merged history, and the trade has
+# to be made a third time. Do not add the context without reading this.
+#
+# ---------------------------------------------------------------------------
+# TWO THINGS NOT TO DO WHEN THE FORK RED BECOMES ANNOYING
+# ---------------------------------------------------------------------------
+#
+# 1. DO NOT MAKE THE JOB `skip` WHEN THE SECRET IS ABSENT. A skipped job
+#    SATISFIES a required status check - only a context that never reports
+#    blocks - so that convenience turns this guard into one that passes hardest
+#    in exactly the case where it did not run. It will look like tidying up.
+#    Red is the correct report for a guard that could not run.
+#
+# 2. DO NOT COLLECT THE SURFACES FROM THE PULL REQUEST FILES API in order to
+#    keep a privileged trigger and drop the untrusted ref. Measured on the
+#    SIBLING repository's largest pull request, its #230 - the count belongs to
+#    that repository and has not been re-measured here, because the mechanism is
+#    the API's and not this repository's: 506 changed files, fully paginated, and
+#    NINE come back with no `patch` field at all. A scanner reading those is
+#    handed nothing for nine files and writes its `scanned` receipt having
+#    looked at neither surface - the exact state the last step exists to
+#    refuse, arriving through the data source instead of through the filter.
+#    Whether that API represents a symlink type change the way `--diff-filter=T`
+#    does is untested, not fine.
+#
+# WHAT IS KEPT FROM THE OLD DESIGN, because it is worth keeping on its own:
+#
+#   * the checkout is pinned to the BASE commit, so the guard, its tests and
+#     the must-pass corpus are the reviewed versions rather than whatever the
+#     pull request says they are. A pull request still cannot edit the thing
+#     that checks it. Under this trigger that pin is LOAD-BEARING rather than
+#     redundant: the default here is the MERGE ref, which carries the head's
+#     copy of the guard.
+#   * the head is fetched as DATA through refs/pull/<n>/head and never merged,
+#     built, installed or executed.
+#
+# ---------------------------------------------------------------------------
+# THE ONE EXECUTION SINK THAT IS NOT A STEP, AND ITS PRECONDITION
+# ---------------------------------------------------------------------------
+#
+# A `git diff` is itself an execution sink if an external diff or `textconv`
+# driver is attached to a path, and this job's whole body is `git diff` and
+# `git log`. It needs BOTH of these, and a fork can write neither:
+#
+#   * a `diff=`/`textconv` attribute on some path in `.gitattributes`, AND
+#   * a `diff.<driver>.command` in git CONFIG
+#
+# A fork cannot reach either, and the reason is worth stating rather than
+# assuming: git resolves attributes from the WORKING TREE, not from the commits
+# being diffed. A `.gitattributes` that exists only in the pull request's head
+# commit is `unspecified` for this diff and its driver never runs - measured,
+# both directions, with the positive control asserted. And git never reads
+# config out of a repository tree at all, so the second lock has no key in a
+# commit under any circumstances.
+#
+# So this is a precondition on the BASE, not a property of the trigger:
+# adding a `diff=`/`textconv` attribute to this repository's own
+# `.gitattributes` and configuring the driver turns these `git diff` lines into
+# an execution sink WITHOUT ANYONE TOUCHING THIS FILE. Checked on this
+# repository rather than carried over from the sibling, whose tree is not this
+# one: the single tracked `.gitattributes` carries `* text=auto eol=lf` and
+# twelve `binary` lines for image, font and PDF extensions, there is no `diff=`
+# or `textconv` attribute anywhere in a tracked file, and no tracked config
+# defines a driver. `binary` is the opposite of the hazard - it expands to
+# `-diff` and turns those paths into "Binary files differ", which the `names`
+# surface still sees. This survives the move off `pull_request_target` because
+# it was never about the trigger.
 #
 # ---------------------------------------------------------------------------
 # MASKING
@@ -67,7 +144,7 @@ name: Forbidden Terms
 # green from before the rotation.
 
 on:
-  pull_request_target:
+  pull_request:
     # `edited` is load-bearing. The event payload carries the title and body AT
     # TRIGGER TIME, so without it the highest-visibility surface we have is
     # checked once and then left editable.
@@ -98,8 +175,72 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The BASE commit, explicitly. `pull_request` checks out the MERGE ref
+          # by default, which contains the head's version of this guard and of
+          # its tests - so the default would let a pull request supply the code
+          # that checks it. `workflow_dispatch` carries no pull request and falls
+          # back to the ref it was dispatched on.
+          ref: ${{ github.event.pull_request.base.sha || github.ref }}
           persist-credentials: false
           fetch-depth: 0
+
+      # EVERY precondition, reported together, before anything that can die on
+      # one of them. The steps below fail fast and in order, so the FIRST thing
+      # missing is the only thing anyone learns - and on the pull request that
+      # introduces this guard that first thing is the guard's own test file,
+      # absent from the base by design. Six runs died there, and the message
+      # written to tell a maintainer the secrets are missing was never printed
+      # by any of them. A guard that cannot run should say what it needs, not
+      # the first thing it happened to touch. Raised in review.
+      #
+      # `set -u` and NOT `-e`: an early exit here is the defect this step
+      # exists to remove.
+      - name: Preconditions
+        env:
+          FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+          FORBIDDEN_TERMS_CORPUS_B64: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
+          # The script cannot tell an empty secret from a fork; this job can.
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+          missing=0
+
+          for f in scripts/ci/forbidden-terms.mjs scripts/ci/forbidden-terms.test.mjs \
+                   scripts/ci/forbidden-terms-allowed-prose.txt; do
+            if [ ! -f "$f" ]; then
+              echo "forbidden-terms: '$f' is not on the base branch." >&2
+              missing=1
+            fi
+          done
+          if [ "${missing}" = "1" ]; then
+            echo "This job checks out the BASE deliberately, so a pull request cannot edit" >&2
+            echo "the thing that checks it. Expected on the pull request that INTRODUCES the" >&2
+            echo "guard, and on the first port to another repository: merge it, or dispatch" >&2
+            echo "this workflow from a branch that already has it." >&2
+          fi
+
+          if [ -z "${FORBIDDEN_TERMS_PATTERN_B64:-}" ] || [ -z "${FORBIDDEN_TERMS_CORPUS_B64:-}" ]; then
+            missing=1
+            echo "forbidden-terms: no pattern and/or corpus available to this run." >&2
+            if [ "${IS_FORK:-}" = "true" ]; then
+              echo "CAUSE: this pull request comes from a fork, and GitHub withholds secrets" >&2
+              echo "from a fork's pull_request run. Nothing you change on your branch will" >&2
+              echo "turn this green - a maintainer has to review the named-product rule by" >&2
+              echo "hand before merging. Do not go looking for a word: the other red this job" >&2
+              echo "produces names the surface, the file and the line." >&2
+            else
+              echo "CAUSE: this is not a fork, so the secret is missing from the repository" >&2
+              echo "itself. A maintainer has to create both FORBIDDEN_TERMS_* repository" >&2
+              echo "secrets; until then this gate has never run, on any pull request. Do not" >&2
+              echo "work around it by making this job skip - see the header." >&2
+            fi
+          fi
+
+          if [ "${missing}" = "1" ]; then
+            echo "forbidden-terms: exit 2 - a guard that could not run, which is red and not clean." >&2
+            exit 2
+          fi
+          echo 'forbidden-terms: preconditions met.'
 
       # The runner's system Node. The guard is dependency-free by design, so
       # there is nothing to install - which is also the security constraint.
@@ -139,13 +280,15 @@ jobs:
         env:
           FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
           FORBIDDEN_TERMS_CORPUS_B64: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
-        run: node scripts/ci/forbidden-terms.mjs selftest --min-corpus 6
+        run: |
+          set -euo pipefail
+          node scripts/ci/forbidden-terms.mjs selftest --min-corpus 6
 
       # refs/pull/<n>/head exists in the BASE repository for every pull request,
       # forks included, so the head arrives without adding the fork as a remote
       # and without any of its code running.
       - name: Fetch the pull request head as data
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -163,7 +306,7 @@ jobs:
       # merge base is the previous promotion, so the whole of `dev` since then
       # is in scope. That is why this workflow is required on BOTH branches.
       - name: Collect the surfaces
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -172,9 +315,17 @@ jobs:
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/surfaces"
           MERGE_BASE=$(git merge-base refs/remotes/origin/gate-base refs/remotes/origin/gate-head)
-          git diff --unified=0 --diff-filter=ACMR "${MERGE_BASE}" refs/remotes/origin/gate-head \
+          # ACMRT, and the T is load-bearing. A commit that replaces a regular
+          # file with a SYMLINK is a type change: without T the path is not new
+          # so it never reaches `names`, its content never reaches `diff`, and
+          # the scanner is handed nothing to be silent about - so the run is
+          # green and writes its `scanned` receipt having looked at neither
+          # surface. That is the exact state the last step exists to refuse,
+          # arriving through the filter rather than through a skipped step. The
+          # symlink TARGET is the term, and with T it is an added line.
+          git diff --unified=0 --diff-filter=ACMRT "${MERGE_BASE}" refs/remotes/origin/gate-head \
             > "${RUNNER_TEMP}/surfaces/diff"
-          git diff --name-only --diff-filter=ACMR "${MERGE_BASE}" refs/remotes/origin/gate-head \
+          git diff --name-only --diff-filter=ACMRT "${MERGE_BASE}" refs/remotes/origin/gate-head \
             > "${RUNNER_TEMP}/surfaces/names"
           git log --format=%B "${MERGE_BASE}..refs/remotes/origin/gate-head" \
             > "${RUNNER_TEMP}/surfaces/messages"
@@ -188,7 +339,7 @@ jobs:
       # Exit 1 is a finding, exit 2 is a guard that could not run. Both are red,
       # and neither is reported as clean.
       - name: Scan every surface
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           FORBIDDEN_TERMS_PATTERN_B64: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
         run: |
@@ -197,10 +348,36 @@ jobs:
           # short-pass the guard. Every surface the script knows about is read,
           # and one the step above failed to write is exit 2 rather than a
           # surface quietly missing from the run.
-          node scripts/ci/forbidden-terms.mjs scan --dir "${RUNNER_TEMP}/surfaces"
-          # Evidence that the scan happened, read by the last step. Written only
-          # after a clean exit, so it records a scan rather than an attempt.
-          touch "${RUNNER_TEMP}/scanned"
+          #
+          # THE RECEIPT KEYS ON WHAT THE SCRIPT SAID, NOT ON HOW IT EXITED. The
+          # marker used to be written on any clean exit, and a clean exit is not
+          # a scan: a `node` invocation that never reaches `main` exits 0 having
+          # read nothing, `set -e` cannot tell that from a real run, and the
+          # refusal below then finds the marker and passes. That was reachable -
+          # measured on node v22.23.2, the entry-point guard compared
+          # `argv[1]` to the module path and the two disagree through a symlink,
+          # so the same file behind a link ran nothing and exited 0. The guard is
+          # fixed; this line is the half that does not depend on having thought
+          # of the particular way it happens.
+          #
+          # `surfaces read` is the sentence the script prints only after all six
+          # surfaces have been read. No pipeline, so `$?` stays the script's and
+          # a finding (exit 1) or a guard that could not run (exit 2) still fails
+          # the step through `set -e` before this line is reached.
+          scan_output=$(node scripts/ci/forbidden-terms.mjs scan --dir "${RUNNER_TEMP}/surfaces")
+          printf '%s\n' "${scan_output}"
+          case "${scan_output}" in
+            *'surfaces read'*)
+              # Evidence that the scan happened, read by the last step.
+              touch "${RUNNER_TEMP}/scanned"
+              ;;
+            *)
+              echo "forbidden-terms: the scan exited 0 without reporting that it read the" >&2
+              echo "surfaces, so nothing here can say what it looked at. Exit 2 - a guard" >&2
+              echo "that could not run, which is red and not clean." >&2
+              exit 2
+              ;;
+          esac
 
       # No `if:`, deliberately. Every step above is conditional on the trigger,
       # so a `workflow_dispatch` run - or any future edit that skips them -

--- a/scripts/ci/forbidden-terms-allowed-prose.txt
+++ b/scripts/ci/forbidden-terms-allowed-prose.txt
@@ -1,0 +1,62 @@
+# Must-pass corpus for the forbidden-terms gate.
+#
+# Every line below is REAL PROSE ALREADY IN THIS REPOSITORY, copied verbatim.
+# None of it names an external product, and the gate must stay silent on all of
+# it.
+#
+# Why this file is checked in while the must-block half is not: the must-block
+# half IS the term list, and committing it to a public repository publishes
+# exactly what the pattern exists to withhold. That half lives with the pattern
+# in a repository secret. This half is the reviewable one, and it is not the
+# consolation half - broadening a pattern under deadline pressure is what makes
+# it fire on ordinary prose, and this is the file that catches that, in the
+# open, where a reviewer can see what "our own documentation" actually says.
+#
+# Drawn from real sentences rather than invented near-misses on purpose:
+# invented ones drift towards what the author imagines the pattern does. A test
+# asserts every line here appears verbatim in a tracked file, so an approximation
+# is caught rather than trusted.
+#
+# A line matched here is a FALSE POSITIVE in the pattern, not a bug in the
+# prose. Fix the pattern.
+
+# README.md
+<h1 align="center">Open-Source Operating System for Animal Health</h1>
+and the open platform that grows around it.
+Most veterinary software asks a clinic to bend around the vendor: rigid subscriptions, closed data, and a roadmap someone else owns. Yosemite Crew inverts that. The clinical record is yours, the schema is open, the integration surface speaks [FHIR R4](https://hl7.org/fhir/R4/), and the entire platform is yours to fork, extend, or run yourself.
+**Customization & integration.** Open source means no rigid subscription lock-in, and a system you can shape to how your practice actually works.
+- Before opening a pull request, run the same gates CI will run.
+Open source is a promise about how the code is kept, not only about who can read it. Every change entering `dev` passes the same gates.
+The YOSEMITE CREW name, logo, and branding are **not** covered by the open source license. Commercial use of the branding requires a separate commercial license. See [License.txt](./License.txt) for the full terms.
+
+# CONTRIBUTING.md
+If you find a bug, please open an issue with clear reproduction steps, expected behavior, and actual behavior.
+If you already have a fix, you can open a PR and link the issue.
+If you want to propose a feature, open an issue first so maintainers and contributors can align on scope before implementation.
+Before opening a PR, run:
+Open PRs against the `dev` branch unless maintainers request otherwise.
+- If you accidentally commit a secret, rotate it immediately and open a security report per [SECURITY.md](./SECURITY.md).
+- Open a GitHub issue for bugs/features.
+
+# CODE_OF_CONDUCT.md
+The focus of both contributors and maintainers is on acting and interacting in ways that promote an open, welcoming, friendly, diverse, inclusive, and healthy community.
+
+# apps/backend/README.md
+This is the backend API server for Yosemite Crew (YC), the open-source veterinary practice management (PIMS) platform. It is an Express.js + TypeScript service that exposes the FHIR (Fast Healthcare Interoperability Resources) endpoints consumed by the web frontend and mobile app. For agent and contributor conventions (architecture layers, validation, logging, background jobs), see [`AGENTS.md`](./AGENTS.md) and [`SKILLS.md`](./SKILLS.md).
+`LOCAL_DEVELOPMENT=true` switches on local-only behaviour: it opens CORS to `localhost:3000` (`src/app.ts`) and mounts the local-only MFA debug endpoint `POST /v1/auth/mfa/totp/debug/create-device`, which creates a TOTP device without the full enrolment flow. Both are keyed on this flag rather than on `NODE_ENV`, so a deployed tier running `NODE_ENV=development` never gets them. Set it only for a local run.
+
+# apps/desktop/README.md
+The native desktop app for the open-source veterinary Practice Information Management System.<br />
+> Part of the [Yosemite Crew](https://github.com/YosemiteCrew/Yosemite-Crew) monorepo - the open-source operating system for animal health. This package is the **desktop client** for clinic staff. Looking for the web platform, mobile app, or backend? See the [root README](https://github.com/YosemiteCrew/Yosemite-Crew#readme).
+It's the same PIMS your team knows, plus the things only a native app can do: it **keeps working when the Wi-Fi doesn't**, opens charts and appointments in **real tabs**, fires **native notifications** for lab results and messages, prints labels and records, and stays **signed in across launches**. Records sync back automatically when you're back online.
+<sub><b>The full PIMS in native tabs</b> - every workflow opens in its own tab; split two side by side.</sub>
+
+# .claude/skills/frontend-sonar/SKILL.md
+The SonarCloud frontend project is the source of truth for open issues and security hotspots.
+- Add `open` attribute — without it the browser hides the element.
+
+# .claude/skills/mobile-patterns/SKILL.md
+Never mix Redux and local `useState` for the same piece of data. Local state is for ephemeral UI state (modal open, input focus). Shared/persisted state goes in Redux.
+
+# .claude/skills/agent-loop/SKILL.md
+- Check open PRs targeting `dev` for overlap with the files you plan to touch (for

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -54,7 +54,11 @@ const CORPUS_ENV = 'FORBIDDEN_TERMS_CORPUS_B64';
 
 const ALLOWED_PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-prose.txt');
 
-const SURFACES = new Set(['diff', 'names', 'messages', 'branch', 'title', 'body']);
+/**
+ * The surfaces `scan` reads, by fixed name. EXPORTED so the test can assert the
+ * shape of the entries against this object rather than against a copy of it.
+ */
+export const SURFACES = new Set(['diff', 'names', 'messages', 'branch', 'title', 'body']);
 
 /** Raised for anything that means "the guard could not run" - always exit 2. */
 class GuardError extends Error {}

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+// Forbidden-terms gate.
+//
+// Both repositories are public. Prior art may be studied freely; the source may
+// never be NAMED - not in code, comments, tests, fixtures, docs, commit
+// messages, branch names, or pull-request text. Until this script existed the
+// rule was enforced by a git hook on three laptops, and a hook is a reminder
+// rather than a gate: `pnpm install` runs husky's `prepare`, which rewrites
+// `core.hooksPath` for the whole clone, and the guard is disarmed until somebody
+// notices. That happened seven times in one day and reached a commit once.
+//
+// WHAT THIS SCRIPT MUST NEVER DO
+//
+//   * print a match, or any substring of one
+//   * print the pattern, decoded or encoded
+//   * write either to a file, an output, or a job summary
+//
+// A guard whose failure output is the list of terms is worse than no guard: the
+// run log of a public repository is a published artifact in a way a terminal is
+// not. Findings therefore carry a SURFACE, a FILE and a LINE and nothing else.
+// That is enough to act on, because the author knows what they wrote.
+//
+// WHY THE PATTERN IS AN ENVIRONMENT VARIABLE AND NOT A FILE
+//
+// The pattern is the term list. Committing it to a public repository publishes
+// exactly what it exists to withhold, so it arrives as a base64 blob in a
+// repository secret and is decoded here. The must-block corpus is a second blob
+// for the same reason. The must-PASS corpus is checked in
+// (forbidden-terms-allowed-prose.txt) because it names nothing.
+//
+// ERRORING IS NOT FINDING. Exit 2 means the guard could not run - no pattern, a
+// pattern that will not compile, a corpus that came back short, a self-test that
+// failed. Exit 1 means it ran and found something. Exit 0 means it ran and did
+// not. A caller that treats 2 as clean has reintroduced the failure this whole
+// script exists to remove.
+//
+// Usage:
+//   node scripts/ci/forbidden-terms.mjs selftest --min-corpus <n>
+//   node scripts/ci/forbidden-terms.mjs scan --dir <directory>
+//
+// The directory holds one file per surface, named for it: diff, names,
+// messages, branch, title, body. ALL SIX are read and a missing one is exit 2 -
+// the caller does not get to choose which surfaces are checked, because a
+// caller that can omit one is a caller that will. `diff` expects unified diff
+// text and reports the file and line of the ADDED line, which is why it is a
+// surface of its own rather than another blob of text.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const PATTERN_ENV = 'FORBIDDEN_TERMS_PATTERN_B64';
+const CORPUS_ENV = 'FORBIDDEN_TERMS_CORPUS_B64';
+
+const ALLOWED_PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-prose.txt');
+
+const SURFACES = new Set(['diff', 'names', 'messages', 'branch', 'title', 'body']);
+
+/** Raised for anything that means "the guard could not run" - always exit 2. */
+class GuardError extends Error {}
+
+/**
+ * Decodes a base64 blob from the environment.
+ *
+ * An absent or empty value is an ERROR and not an empty pattern. `new
+ * RegExp('')` matches every line and `grep -E ''` matches every line, while
+ * some formulations match nothing: one fails every pull request and the other
+ * passes every pull request silently. Both are wrong, and the silent one is the
+ * failure mode this script was written to end.
+ */
+function decodeRequired(name) {
+  const raw = process.env[name];
+  if (!raw || raw.trim() === '') {
+    throw new GuardError(`${name} is unset or empty. The gate cannot run without it.`);
+  }
+  let decoded;
+  try {
+    decoded = Buffer.from(raw.trim(), 'base64').toString('utf8');
+  } catch {
+    throw new GuardError(`${name} is not valid base64.`);
+  }
+  if (decoded.trim() === '') {
+    throw new GuardError(`${name} decoded to nothing. A rotated or truncated secret is an error.`);
+  }
+  return decoded.trim();
+}
+
+/**
+ * The pattern, compiled case-insensitively because the terms are words.
+ *
+ * Deliberately NOT global. `RegExp.prototype.test` on a `g` regex carries
+ * `lastIndex` between calls, so adding `g` here would make every other entry in
+ * `scanSurface`'s filter invisible - a guard that checks half its input and says
+ * nothing about the half it skipped.
+ */
+export function compilePattern(source) {
+  try {
+    return new RegExp(source, 'i');
+  } catch (error) {
+    // The message of a failed RegExp constructor QUOTES THE PATTERN. Never let
+    // it out - report that it did not compile and nothing about what it was.
+    throw new GuardError(`The pattern does not compile as a regular expression: ${error.name}.`);
+  }
+}
+
+/** Non-comment, non-blank lines. Shared by both corpora. */
+export function corpusLines(text) {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'));
+}
+
+// ---------------------------------------------------------------------------
+// Surfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * Added lines of a unified diff, carrying the file and line they land on.
+ *
+ * Only added lines, because a term being REMOVED is the fix, not the offence.
+ *
+ * `+++ b/path` is the header rather than an addition, and it is told apart from
+ * an addition BY POSITION, not by content: git writes an added line whose text
+ * begins `++ ` as `+++ `, which `startsWith('+++ ')` cannot distinguish from a
+ * header. The first version of this function did exactly that, and it failed in
+ * both directions at once - the line carrying the term was never scanned, and
+ * `file` became a line of the pull request's own diff, which the report then
+ * PRINTED. A guard that publishes diff content into a public log on an unusual
+ * input is worse than one that misses, because the miss is at least silent.
+ *
+ * Position is taken from the hunk header's own declared counts rather than from
+ * `diff --git`, which needs no assumption about which optional lines git chose
+ * to emit: `@@ -a,b +c,d @@` says how many lines the hunk owns, so a `+++ `
+ * inside that debt is an addition and one after it is discharged is a header.
+ *
+ * Found in review by Claude L2, against real `git diff --unified=0` output
+ * rather than a fixture - which is also why the fixtures here are approximations
+ * that the naive positional fix appears to fail.
+ */
+export function addedLines(diff) {
+  const out = [];
+  let file = '';
+  let lineNumber = 0;
+  // How many old-side and new-side lines the current hunk still owes. Zero on
+  // both means we are between hunks, which is the only place a header can be.
+  let owedOld = 0;
+  let owedNew = 0;
+
+  for (const line of diff.split('\n')) {
+    const hunk = /^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+    if (hunk) {
+      // A count omitted from the header means one line, not none.
+      owedOld = hunk[1] === undefined ? 1 : Number(hunk[1]);
+      lineNumber = Number(hunk[2]);
+      owedNew = hunk[3] === undefined ? 1 : Number(hunk[3]);
+      continue;
+    }
+
+    if (owedOld <= 0 && owedNew <= 0) {
+      // Between hunks: `diff --git`, `index`, `--- a/path`, `+++ b/path`.
+      if (line.startsWith('+++ ')) {
+        const target = line.slice(4).trim();
+        file = target === '/dev/null' ? '' : target.replace(/^b\//, '');
+      }
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      out.push({ file: file || '(unknown file)', line: lineNumber, text: line.slice(1) });
+      lineNumber += 1;
+      owedNew -= 1;
+      continue;
+    }
+    // A removed line does not advance the new-file counter.
+    if (line.startsWith('-')) {
+      owedOld -= 1;
+      continue;
+    }
+    // `\ No newline at end of file` belongs to neither side.
+    if (line.startsWith('\\')) continue;
+    // Context: it advances both sides.
+    lineNumber += 1;
+    if (owedNew > 0) owedNew -= 1;
+    if (owedOld > 0) owedOld -= 1;
+  }
+  return out;
+}
+
+/** Every surface reduces to this: a list of {file, line, text} to match against. */
+function entriesFor(surface, text) {
+  if (surface === 'diff') return addedLines(text);
+  return text
+    .split('\n')
+    .map((value, index) => ({ file: surface, line: index + 1, text: value }))
+    .filter((entry) => entry.text.trim() !== '');
+}
+
+/**
+ * Findings carry where and never what. `text` is deliberately dropped here
+ * rather than at the print site: a value that is never returned cannot be
+ * logged by a later edit that forgets why.
+ */
+export function scanSurface(pattern, surface, text) {
+  return entriesFor(surface, text)
+    .filter((entry) => pattern.test(entry.text))
+    .map((entry) => ({ surface, file: entry.file, line: entry.line }));
+}
+
+// ---------------------------------------------------------------------------
+// Self-test: the job asserts itself before it asserts anything about the diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Proves the guard is armed. Without this an empty, rotated or truncated secret
+ * is a silently green pull request, which is failure mode six of the six this
+ * gate replaces - the fix having the same defect as the thing it fixed.
+ *
+ * `minCorpus` is written in the workflow IN THE CLEAR. A number is not a term
+ * list, and it turns "the secret lost half its entries" from silent into red.
+ */
+export function selfTest({ pattern, blockCorpus, passCorpus, minCorpus }) {
+  const problems = [];
+
+  if (blockCorpus.length < minCorpus) {
+    problems.push(
+      `the must-block corpus decoded to ${blockCorpus.length} entries, fewer than the ${minCorpus} ` +
+        'this workflow expects: the secret is truncated, rotated or stale'
+    );
+  }
+
+  // Known positives: every one must be caught. Reported by INDEX, never by value.
+  const missed = blockCorpus
+    .map((entry, index) => (pattern.test(entry) ? null : index + 1))
+    .filter((index) => index !== null);
+  if (missed.length > 0) {
+    problems.push(
+      `the pattern does not match must-block corpus entries at position(s) ${missed.join(', ')}`
+    );
+  }
+
+  // Known negatives: the repository's own prose. A hit here is an over-broad
+  // pattern, which is the failure that gets a gate switched off.
+  const tripped = passCorpus
+    .map((entry, index) => (pattern.test(entry) ? index + 1 : null))
+    .filter((index) => index !== null);
+  if (tripped.length > 0) {
+    problems.push(
+      `the pattern matches this repository's own prose at ${ALLOWED_PROSE} ` +
+        `line(s) ${tripped.join(', ')}: it is too broad, and a gate that fires on ` +
+        'ordinary documentation is a gate somebody switches off'
+    );
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function readAllowedProse() {
+  try {
+    return corpusLines(readFileSync(ALLOWED_PROSE, 'utf8'));
+  } catch {
+    throw new GuardError(`Cannot read the must-pass corpus at ${ALLOWED_PROSE}.`);
+  }
+}
+
+function runSelfTest(argv) {
+  const flag = argv.indexOf('--min-corpus');
+  const minCorpus = flag === -1 ? Number.NaN : Number(argv[flag + 1]);
+  if (!Number.isInteger(minCorpus) || minCorpus < 1) {
+    throw new GuardError(
+      'selftest needs --min-corpus <n>, a positive integer written in the clear.'
+    );
+  }
+  const pattern = compilePattern(decodeRequired(PATTERN_ENV));
+  const blockCorpus = corpusLines(decodeRequired(CORPUS_ENV));
+  const passCorpus = readAllowedProse();
+
+  const problems = selfTest({ pattern, blockCorpus, passCorpus, minCorpus });
+  if (problems.length > 0) {
+    for (const problem of problems) process.stderr.write(`forbidden-terms: ${problem}\n`);
+    throw new GuardError(
+      'The guard failed its own self-test and has reported nothing about this pull request.'
+    );
+  }
+  process.stdout.write(
+    `forbidden-terms: armed - pattern compiled, ${blockCorpus.length} known positives all matched, ` +
+      `${passCorpus.length} lines of this repository's own prose all clean.\n`
+  );
+  return 0;
+}
+
+/**
+ * Reads a DIRECTORY and scans every surface in SURFACES, by fixed name.
+ *
+ * It took a list of `<surface>=<file>` pairs first, and that was the same
+ * defect as the ones this repository spent the day finding: the caller decided
+ * what got checked, nothing asserted the caller passed them all, and dropping
+ * `body=` from the workflow left the scan reporting
+ * "clean - no named external product on any checked surface" while the pull
+ * request body carried one. The word "checked" was doing silent work.
+ *
+ * A directory of fixed names cannot be short-passed. There is no argument to
+ * omit, so the coverage is a property of this file rather than of the workflow
+ * that calls it - and a surface the collector failed to write is an unreadable
+ * file, which is already exit 2.
+ */
+function runScan(argv) {
+  const flag = argv.indexOf('--dir');
+  const dir = flag === -1 ? '' : (argv[flag + 1] ?? '');
+  if (dir === '') {
+    throw new GuardError('scan needs --dir <directory> holding one file per surface.');
+  }
+  const pattern = compilePattern(decodeRequired(PATTERN_ENV));
+
+  const findings = [];
+  for (const surface of SURFACES) {
+    const file = path.join(dir, surface);
+    let text;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch {
+      // A surface that cannot be read is an error. Treating it as empty is how
+      // a guard reports "clean" about something it never looked at.
+      throw new GuardError(`Cannot read the '${surface}' surface from ${file}.`);
+    }
+    findings.push(...scanSurface(pattern, surface, text));
+  }
+
+  if (findings.length === 0) {
+    process.stdout.write(
+      `forbidden-terms: clean - ${SURFACES.size} surfaces read, no named external product on any of them.\n`
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    `forbidden-terms: BLOCKED - a named external product appears on ${findings.length} line(s).\n\n`
+  );
+  for (const finding of findings) {
+    // Only the diff surface has a file of its own; for the others the "file" IS
+    // the surface, and `[names] names:1` reads worse than `[names] entry 1`.
+    const where =
+      finding.file === finding.surface
+        ? `entry ${finding.line}`
+        : `${finding.file}:${finding.line}`;
+    process.stderr.write(`  [${finding.surface}] ${where}\n`);
+  }
+  process.stderr.write(
+    '\nThese repositories are public. Draw on prior art freely; never name the source in code,\n' +
+      'comments, tests, fixtures, docs, commit messages, branch names or pull-request text.\n' +
+      'Describe the behaviour and the clinical need instead.\n\n' +
+      'The match itself is deliberately not printed: this log is public.\n'
+  );
+  return 1;
+}
+
+function main(argv) {
+  const [command, ...rest] = argv;
+  try {
+    if (command === 'selftest') return runSelfTest(rest);
+    if (command === 'scan') return runScan(rest);
+    process.stderr.write(
+      'Usage: forbidden-terms.mjs selftest --min-corpus <n> | scan --dir <directory>\n'
+    );
+    return 2;
+  } catch (error) {
+    if (error instanceof GuardError) {
+      process.stderr.write(`forbidden-terms: ${error.message}\n`);
+      return 2;
+    }
+    throw error;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -45,7 +45,7 @@
 // text and reports the file and line of the ADDED line, which is why it is a
 // surface of its own rather than another blob of text.
 
-import { readFileSync } from 'node:fs';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -97,6 +97,24 @@ function decodeRequired(name) {
  * `scanSurface`'s filter invisible - a guard that checks half its input and says
  * nothing about the half it skipped.
  */
+/**
+ * The pattern, compiled case-insensitively because the terms are words.
+ *
+ * `'i'` AND NOT `'iu'`, and the absence is load-bearing rather than an
+ * oversight. The `u` flag changes case folding on the HAYSTACK, so
+ * `PATTERN_SHAPE` cannot see it - it constrains the pattern, and this is the one
+ * axis that is not about the pattern at all. Under `iu`, `k` matches U+212A
+ * KELVIN SIGN; under `i` it does not, and neither does the machine-local hook's
+ * POSIX `grep -inE`. So the missing `u` is what makes "one value used twice"
+ * true rather than "two implementations that agree on ASCII".
+ *
+ * Driven with the haystack asserted by its bytes: `61e284aa62`, `/k/i` false,
+ * `/k/iu` true, `/usr/bin/grep -inE k` no match, and both controls (`aKb`
+ * matching everywhere, `azb` nowhere). Raised in review. `PATTERN_SHAPE` two
+ * dozen lines below carries `/u` legitimately - it has no haystack of untrusted
+ * text - so harmonising the two reads like tidying up, which is why there is a
+ * behavioural case pinning this one.
+ */
 export function compilePattern(source) {
   try {
     return new RegExp(source, 'i');
@@ -105,6 +123,59 @@ export function compilePattern(source) {
     // it out - report that it did not compile and nothing about what it was.
     throw new GuardError(`The pattern does not compile as a regular expression: ${error.name}.`);
   }
+}
+
+/**
+ * The only pattern shape this guard accepts: a `|` alternation of literal words
+ * over `[A-Za-z0-9 -]`.
+ *
+ * Two separate jobs, one predicate, and it is not a coincidence that the same
+ * character set answers both.
+ *
+ * FIRST, the two implementations agree ON CONSTRUCTS. This pattern is consumed
+ * twice - here through `new RegExp(source, 'i')`, and by the machine-local hook
+ * through `grep -inE`, which is POSIX ERE. `\b`, `\d`, a quantifier or a class
+ * can mean different things in the two dialects, and then the value is a
+ * TRANSLATION between them rather than one value used twice. Inside this
+ * alphabet there is no construct they can disagree about.
+ *
+ * BE PRECISE ABOUT WHAT THAT DOES NOT COVER, because the narrower statement is
+ * the true one and the wider one was written here first. Removing construct
+ * disagreement does not make the two implementations identical: they can still
+ * differ on the SAME in-shape value, because case folding is a property of the
+ * engine and the locale rather than of the pattern. Measured - `s` against
+ * U+017F LATIN SMALL LETTER LONG S is no match for `new RegExp(s,'i')` and for
+ * BSD grep in every locale (this is what our machines have, bytes `61c5bf62`
+ * verified by `od`, with `aSb`/`azb` controls on both sides), and a MATCH for
+ * GNU grep 3.8 under `LC_ALL=C.UTF-8`. Reported by another machine; not
+ * reproducible here, where there is no GNU grep.
+ *
+ * So the agreement rests partly on which `grep` is on `PATH`, and
+ * `PATTERN_SHAPE` cannot reach that. It is not pinned by a test because a CI
+ * test would assert GNU grep's behaviour, which is not the implementation the
+ * claim is about. The direction is harmless: grep matching MORE means a local
+ * hook false-positives, never that something CI would block gets through.
+ *
+ * SECOND, `alternativesIn` below is exact. Counting by splitting on `|` is
+ * right for a plain alternation and wrong the moment a group, an escaped pipe
+ * or a class containing one appears.
+ *
+ * It fails CLOSED: a pattern outside this shape is a red self-test with an
+ * explanation, never a silently weaker check. If a future pattern genuinely
+ * needs a metacharacter, this predicate and `alternativesIn` are what has to
+ * change, deliberately and together.
+ */
+export const PATTERN_SHAPE = /^[A-Za-z0-9 -]+(\|[A-Za-z0-9 -]+)*$/u;
+
+/**
+ * How many alternatives a pattern claims.
+ *
+ * Sound ONLY for a source satisfying {@link PATTERN_SHAPE}, which is why the
+ * caller checks that first and skips this when it fails - a count taken from an
+ * unconstrained pattern is a plausible number rather than an answer.
+ */
+export function alternativesIn(source) {
+  return source.split('|').length;
 }
 
 /** Non-comment, non-blank lines. Shared by both corpora. */
@@ -233,6 +304,67 @@ export function selfTest({ pattern, blockCorpus, passCorpus, minCorpus }) {
     );
   }
 
+  // The pattern's own shape, and then what the shape makes countable.
+  //
+  // This closes the direction the corpus check cannot see. The known-positives
+  // pass below walks the CORPUS, so it answers "the pattern catches everything
+  // the corpus knows about" and is blind to the converse: an alternative added
+  // to the pattern with no corresponding entry is never exercised by anything,
+  // and a typo in it protects nothing while looking exactly like a term that is
+  // guarded.
+  //
+  // The message never quotes the pattern - the failed-compile path one screen up
+  // exists for the same reason - so it names the constraint and the counts.
+  if (!PATTERN_SHAPE.test(pattern.source)) {
+    problems.push(
+      'the pattern is not a plain alternation of literal words over [A-Za-z0-9 -]. ' +
+        'That shape is what lets this guard use one value in two regular-expression ' +
+        'dialects and count its alternatives; outside it, neither is sound. Rewrite the ' +
+        'pattern, or change PATTERN_SHAPE and alternativesIn together and deliberately'
+    );
+  } else {
+    // Every alternative must be exercised by SOME corpus entry, reported by
+    // index. This is the check that answers the question; the count below is a
+    // weaker proxy for it.
+    //
+    // A count is green on a corpus that piles up on one alternative - three
+    // spellings of one term and none of another satisfies `3 >= 3` while two
+    // alternatives are checked by nothing, which is precisely the state a typo
+    // in a new alternative produces. Raised in review, driven, and it is the
+    // per-pattern-versus-per-part distinction one level down: one hit satisfies
+    // the whole and hides the parts.
+    //
+    // `compilePattern` rather than a second `new RegExp(...)`, so the flags can
+    // never drift from the ones the real pattern is built with - and it is safe
+    // here only because the shape holds: outside it `acme\` throws and `acme+`
+    // compiles into something else.
+    const alternatives = pattern.source.split('|');
+    const unexercised = alternatives
+      .map((alternative, index) =>
+        blockCorpus.some((entry) => compilePattern(alternative).test(entry)) ? null : index + 1
+      )
+      .filter((index) => index !== null);
+    if (unexercised.length > 0) {
+      problems.push(
+        `the must-block corpus exercises no entry for the pattern's alternative(s) at ` +
+          `position(s) ${unexercised.join(', ')}: nothing checks that they match anything`
+      );
+    }
+
+    // The weaker proxy, kept deliberately rather than as a second detector. It
+    // enforces one corpus entry per alternative, which is what makes the
+    // by-index messages above legible to whoever maintains the corpus - and it
+    // catches a corpus authored with fewer entries than terms before anyone has
+    // to read an index at all.
+    const claimed = alternativesIn(pattern.source);
+    if (blockCorpus.length < claimed) {
+      problems.push(
+        `the pattern claims ${claimed} alternatives and the must-block corpus has ` +
+          `${blockCorpus.length} entries, so at least one alternative is checked by nothing`
+      );
+    }
+  }
+
   // Known positives: every one must be caught. Reported by INDEX, never by value.
   const missed = blockCorpus
     .map((entry, index) => (pattern.test(entry) ? null : index + 1))
@@ -320,16 +452,44 @@ function runScan(argv) {
   }
   const pattern = compilePattern(decodeRequired(PATTERN_ENV));
 
+  // RESOLVE ONCE, THEN CHANGE INTO IT, so the six reads below take the SURFACES
+  // constants themselves and nothing built from `--dir`. The docstring above
+  // says the coverage is a property of this file rather than of the caller, and
+  // until now that was true of the LOOP while the read still took a path joined
+  // from the caller's argument. Both are constants now.
+  //
+  // A missing directory is reported as a missing DIRECTORY. It used to surface
+  // as `Cannot read the 'diff' surface` - the first thing the loop happened to
+  // touch - which is the same defect the workflow's Preconditions step was
+  // rewritten to remove: a guard that cannot run should say what it needs.
+  let root;
+  try {
+    root = realpathSync(dir);
+  } catch {
+    throw new GuardError(`Cannot read the surface directory ${dir}.`);
+  }
+  process.chdir(root);
+
   const findings = [];
   for (const surface of SURFACES) {
-    const file = path.join(dir, surface);
     let text;
     try {
-      text = readFileSync(file, 'utf8');
-    } catch {
+      // `lstat` and not `stat`: `readFileSync` FOLLOWS a symlink, so a surface
+      // that is a link is read as though it were the surface, and the guard
+      // reports on a file nobody collected. The collector writes six plain
+      // files, but the read site is what decides that rather than the step that
+      // wrote them - the same reason the checkout is pinned to the base.
+      if (!lstatSync(surface).isFile()) {
+        throw new GuardError(
+          `The '${surface}' surface is not a regular file. A surface must be a plain file in ${root}.`
+        );
+      }
+      text = readFileSync(surface, 'utf8');
+    } catch (error) {
+      if (error instanceof GuardError) throw error;
       // A surface that cannot be read is an error. Treating it as empty is how
       // a guard reports "clean" about something it never looked at.
-      throw new GuardError(`Cannot read the '${surface}' surface from ${file}.`);
+      throw new GuardError(`Cannot read the '${surface}' surface from ${root}.`);
     }
     findings.push(...scanSurface(pattern, surface, text));
   }
@@ -380,6 +540,52 @@ function main(argv) {
   }
 }
 
-if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
-  process.exit(main(process.argv.slice(2)));
+// Compared by REAL path, both sides. Node resolves the ESM main entry to its
+// realpath while `process.argv[1]` keeps the path as it was typed, so invoked
+// through a symlink the two disagree, `main` never runs, and the process exits
+// 0 having done nothing. Measured on node v22.23.2: direct invocation runs and
+// the same file reached through a link is silent with status 0.
+//
+// That is the one exit code the workflow's `scanned` receipt cannot interpret -
+// a clean exit is not a scan - so the receipt no longer keys on it either. Both
+// halves are needed: this one stops the no-op, and the receipt stops the NEXT
+// way a no-op exits 0.
+//
+// BOTH sides, and any symlinked COMPONENT counts - the script does not have to
+// be the link. `path.resolve` is purely lexical and never touches the
+// filesystem, so a real script reached through a linked parent directory fails
+// the comparison exactly as a linked script does, with nothing linked inside
+// the repository and nothing in the diff. There is a live instance of that on
+// every machine here: `$TMPDIR` sits behind `/var -> /private/var`.
+//
+// Falls back to the lexical pair rather than throwing. A realpath that fails
+// means the entry has gone missing under us, which is not a reason to make
+// importing this module for its pure helpers fail at load.
+//
+// Written inline rather than as a `realOrLexical(candidate)` helper on purpose,
+// and measured rather than assumed: the helper form scores an
+// AIK_ts_generic_path_traversal on its `path.resolve(candidate)`, because that
+// rule counts parameter hops into a path operation rather than where the value
+// came from. Same reason the surface loop above reads constants after a chdir.
+//
+// Both or neither. Assigning the two separately would leave one real and one
+// lexical if the first call threw, which is the mismatch this whole comparison
+// exists to avoid.
+const entryPoint = process.argv[1];
+if (entryPoint) {
+  let entryId = path.resolve(entryPoint);
+  let selfId = path.resolve(import.meta.filename);
+  try {
+    const entryResolved = realpathSync(entryPoint);
+    const selfResolved = realpathSync(import.meta.filename);
+    entryId = entryResolved;
+    selfId = selfResolved;
+  } catch {
+    // Keep the lexical pair. Wrong through a symlink, which is the behaviour
+    // this block replaced, but a comparison that cannot run is not a reason to
+    // fail at import.
+  }
+  if (entryId === selfId) {
+    process.exit(main(process.argv.slice(2)));
+  }
 }

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -452,6 +452,27 @@ function runScan(argv) {
   }
   const pattern = compilePattern(decodeRequired(PATTERN_ENV));
 
+  // THE SHAPE IS ENFORCED HERE TOO, AND NOT ONLY IN `selftest`.
+  //
+  // `PATTERN_SHAPE` is what keeps this regular expression free of the nested
+  // quantifiers and ambiguous groups that backtrack exponentially, and every
+  // string it is about to run against - the diff, the branch name, the title,
+  // the body - comes from the pull request. In the workflow the self-test runs
+  // first, so a pathological pattern is already red before this line is
+  // reached; but that is an ORDER OF STEPS in another file, which is the same
+  // kind of guarantee this commit exists to stop relying on. A caller that runs
+  // `scan` without `selftest` gets the check anyway.
+  //
+  // Deliberate divergence from the sibling repository, whose copy has this
+  // predicate only in `selfTest`. It belongs in both; the sibling should take
+  // it rather than this one give it back.
+  if (!PATTERN_SHAPE.test(pattern.source)) {
+    throw new GuardError(
+      'the pattern is not a plain alternation of literal words over [A-Za-z0-9 -], ' +
+        'and this scan will not run an unconstrained expression over pull-request text'
+    );
+  }
+
   // RESOLVE ONCE, THEN CHANGE INTO IT, so the six reads below take the SURFACES
   // constants themselves and nothing built from `--dir`. The docstring above
   // says the coverage is a property of this file rather than of the caller, and

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -45,7 +45,7 @@
 // text and reports the file and line of the ADDED line, which is why it is a
 // surface of its own rather than another blob of text.
 
-import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { closeSync, constants, fstatSync, openSync, readFileSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -494,23 +494,48 @@ function runScan(argv) {
   const findings = [];
   for (const surface of SURFACES) {
     let text;
+    let fd;
     try {
-      // `lstat` and not `stat`: `readFileSync` FOLLOWS a symlink, so a surface
-      // that is a link is read as though it were the surface, and the guard
-      // reports on a file nobody collected. The collector writes six plain
-      // files, but the read site is what decides that rather than the step that
-      // wrote them - the same reason the checkout is pinned to the base.
-      if (!lstatSync(surface).isFile()) {
+      // ONE handle, opened once, checked and read through the same descriptor.
+      //
+      // This used to be `lstatSync(surface).isFile()` followed by
+      // `readFileSync(surface)`, which is two resolutions of one name: the
+      // check answers about whatever the path meant then, the read about
+      // whatever it means now, and a surface swapped for a symlink in between
+      // is read as its target while the guard believes it checked a plain file.
+      // `js/file-system-race`, and the window is real rather than theoretical -
+      // the surfaces live in a directory this process chdir'd into.
+      //
+      // `O_NOFOLLOW` is also STRICTER than the lstat it replaces: the kernel
+      // refuses the open rather than this code refusing the result, so there is
+      // no window at all. ELOOP is that refusal and keeps the message the lstat
+      // check gave, because it means the same thing to whoever reads it.
+      try {
+        fd = openSync(surface, constants.O_RDONLY | constants.O_NOFOLLOW);
+      } catch (error) {
+        if (error?.code === 'ELOOP') {
+          throw new GuardError(
+            `The '${surface}' surface is not a regular file. A surface must be a plain file in ${root}.`
+          );
+        }
+        throw error;
+      }
+      // Still needed after the open: `O_NOFOLLOW` rules out a symlink and
+      // nothing else. A directory, a fifo or a device opens fine and would be
+      // read as a surface.
+      if (!fstatSync(fd).isFile()) {
         throw new GuardError(
           `The '${surface}' surface is not a regular file. A surface must be a plain file in ${root}.`
         );
       }
-      text = readFileSync(surface, 'utf8');
+      text = readFileSync(fd, 'utf8');
     } catch (error) {
       if (error instanceof GuardError) throw error;
       // A surface that cannot be read is an error. Treating it as empty is how
       // a guard reports "clean" about something it never looked at.
       throw new GuardError(`Cannot read the '${surface}' surface from ${root}.`);
+    } finally {
+      if (fd !== undefined) closeSync(fd);
     }
     findings.push(...scanSurface(pattern, surface, text));
   }

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -461,6 +461,53 @@ test('the pull_request_target job runs nothing the head can choose', () => {
   );
 });
 
+test('the step that refuses a run which scanned nothing is not itself skippable', () => {
+  // `No `if:`, deliberately` is the enforcement, and it is a paragraph three
+  // lines above the fact it asserts. Adding that one line is the likeliest edit
+  // in the file rather than a contrived one: every other step concerning the
+  // pull request carries exactly that `if:`, the refusal is the single step
+  // without one, and adding it makes the job MORE internally consistent. The
+  // job then checks out, arms, self-tests, skips all three scan steps, skips
+  // the refusal, and reports clean having read nothing.
+  //
+  // Keyed on the marker rather than on the step's name: the name is prose and
+  // can be reworded, the marker is the mechanism.
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const body = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/u.test(line))
+    .join('\n');
+
+  const steps = body.split(/^ {6}- name: /mu).slice(1);
+
+  // Zero rather than a threshold. Any count above zero also fires when the
+  // split read FEWER steps than expected, which is a different defect with a
+  // better message below, so it would steal the failure from the assertion
+  // that names the cause.
+  assert.notEqual(steps.length, 0, 'no steps parsed out of the job: this test is reading nothing');
+
+  const MARKER = '"${RUNNER_TEMP}/scanned"';
+  const writes = steps.filter((step) => step.includes(`touch ${MARKER}`));
+  const reads = steps.filter((step) => step.includes(`-f ${MARKER}`));
+
+  assert.equal(
+    writes.length,
+    1,
+    'exactly one step may write the scanned marker: a second one records a scan that did not happen'
+  );
+  assert.equal(
+    reads.length,
+    1,
+    'exactly one step must read the scanned marker: with none, a run that scanned nothing reports clean'
+  );
+  assert.doesNotMatch(
+    reads[0],
+    /^\s*if:/mu,
+    'the step refusing a run that scanned nothing is itself conditional, so the run it exists ' +
+      'to catch skips it too and the job reports clean having read no surface'
+  );
+});
+
 // ---------------------------------------------------------------------------
 // The must-pass corpus is what it claims to be
 // ---------------------------------------------------------------------------

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -292,10 +292,13 @@ test('every surface is a bare filename', () => {
   // a separator or a `..` reads a file the collector never wrote. Cardinality
   // pins WHICH surfaces are read; nothing above pins their SHAPE. `../body` is
   // caught several other ways because the file does not exist under the fixture
-  // root - which is a fact about where the test writes its files, not about this
-  // set. `./body` is the case that shows what this assertion is for: it resolves
-  // to the SAME file, every other test stays green, and only a statement about
-  // the shape of the entry sees it at all.
+  // root - a fact about where the test writes its files, not about this set.
+  // `./title` is the case that shows what this assertion is for: it resolves to
+  // the SAME file, every other test stays green (28 / 1), and only a statement
+  // about the shape of the entry sees it at all. NOT `./body`, which is 27 / 2
+  // because it also trips the exit-2 test - and that one matches
+  // `Cannot read the 'body' surface`, a hardcoded name in an error message
+  // rather than anything about containment.
   //
   // HALF of the argument that the file-inclusion finding on that join is
   // unreachable, and the half that is checked. The join has two operands. This

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -392,7 +392,7 @@ test('selftest without --min-corpus exits 2', () => {
 });
 
 test("this repository's own prose passes every surface", () => {
-  const prose = execFileSync('cat', [PROSE], { encoding: 'utf8' });
+  const prose = readFileSync(PROSE, 'utf8');
   const dir = surfaceDir({ body: prose, messages: prose, title: prose });
   const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
   assert.equal(result.code, 0);
@@ -506,6 +506,17 @@ test('the step that refuses a run which scanned nothing is not itself skippable'
     'the step refusing a run that scanned nothing is itself conditional, so the run it exists ' +
       'to catch skips it too and the job reports clean having read no surface'
   );
+  // `if:` is not the only line that unmakes this step. `continue-on-error: true`
+  // leaves it running, leaves it red in the log, and concludes the JOB as
+  // success - so the refusal still reports "nothing was scanned" and the check
+  // beside it is green anyway. Both edits end in a clean report over an unread
+  // pull request; only the first one is visible in the step's condition.
+  assert.doesNotMatch(
+    reads[0],
+    /^\s*continue-on-error:/mu,
+    'the step refusing a run that scanned nothing cannot fail the job, so its refusal is ' +
+      'printed into a log nothing reads and the check reports clean regardless'
+  );
 
   // The reader being unconditional and the writer being the step that actually
   // scans are two halves of one property, and only the first half was asserted.
@@ -516,17 +527,36 @@ test('the step that refuses a run which scanned nothing is not itself skippable'
   // Keyed on the scan command rather than on the step's `if:`, for the same reason
   // the marker was preferred to the step name: the trigger expression is one
   // rewording away, the scan invocation is the mechanism.
-  assert.match(
-    writes[0],
-    // Not `mjs scan` adjacently: reordering the subcommand after the flag is a
-    // legal, behaviour-preserving edit of the same command, and rejecting it
-    // would be a false red on a correct workflow - the failure mode that gets a
-    // check deleted rather than the one that lets a defect through. `\bscan\b`
-    // does not match the marker path `.../scanned`, which is the only other
-    // occurrence in any step.
-    /forbidden-terms\.mjs\b[\s\S]*?\bscan\b/u,
+  // Not `mjs scan` adjacently: reordering the subcommand after the flag is a
+  // legal, behaviour-preserving edit of the same command, and rejecting it
+  // would be a false red on a correct workflow - the failure mode that gets a
+  // check deleted rather than the one that lets a defect through. `\bscan\b`
+  // does not match the marker path `.../scanned`, which is the only other
+  // occurrence in any step.
+  const invocation = /forbidden-terms\.mjs\b[\s\S]*?\bscan\b/u.exec(writes[0]);
+  assert.ok(
+    invocation,
     'the scanned marker is written by a step that does not run the scan, so it records that ' +
       'a run reached that line rather than that a scan succeeded, and the refusal below passes'
+  );
+
+  // The comment beside the `touch` makes two claims and the assertion above
+  // pins only the first. `Written only after a clean exit, so it records a scan
+  // rather than an attempt` is the second, and it is the ORDER of two lines in
+  // one step - the cheapest thing in this file to change by accident.
+  //
+  // Neither half is a defect alone. `touch` above the scan is still red today,
+  // because a failing scan fails the step and the refusal never gets to decide;
+  // `continue-on-error: true` on the scan step is still red today, because
+  // `set -e` skips the `touch` and the refusal turns the job red on the missing
+  // marker. Together they are fail-open: the marker is already written, the
+  // failure is swallowed, and the job reports CLEAN on a run that found a term.
+  // The order is the half that is free to move, which is why it must not be the
+  // unchecked one.
+  assert.ok(
+    invocation.index < writes[0].indexOf(`touch ${MARKER}`),
+    'the scanned marker is written before the scan runs, so it records an attempt rather than ' +
+      'a clean exit and any later edit that stops a failed scan failing the step reports clean'
   );
 });
 
@@ -539,7 +569,7 @@ test('every must-pass line is real prose from a tracked file', () => {
   // near-misses drift towards what the author imagines the pattern does, and a
   // corpus of those proves nothing about the documentation a false positive
   // would actually fire on.
-  const lines = corpusLines(execFileSync('cat', [PROSE], { encoding: 'utf8' }));
+  const lines = corpusLines(readFileSync(PROSE, 'utf8'));
   assert.ok(lines.length >= 20, `expected a corpus worth having, got ${lines.length} lines`);
 
   // The exclusion has to exclude THIS file, and two ways it stops doing so are

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -382,10 +382,19 @@ test('every must-pass line is real prose from a tracked file', () => {
 
   const missing = lines.filter((line) => {
     try {
-      execFileSync('git', ['grep', '-qF', '--', line], {
-        cwd: path.join(import.meta.dirname, '..', '..'),
-        stdio: 'ignore',
-      });
+      // EXCLUDING the corpus itself. Without the pathspec this file is a tracked
+      // file, so every line in it proves its own presence and an invented
+      // sentence passes - the assertion satisfied by the very document it is
+      // meant to be checking. Found by mutation: appending a sentence that
+      // appears nowhere else left all 26 cases green.
+      execFileSync(
+        'git',
+        ['grep', '-qF', '--', line, ':(exclude)scripts/ci/forbidden-terms-allowed-prose.txt'],
+        {
+          cwd: path.join(import.meta.dirname, '..', '..'),
+          stdio: 'ignore',
+        }
+      );
       return false;
     } catch {
       return true;

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -12,7 +12,7 @@
 
 import { execFileSync } from 'node:child_process';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -37,6 +37,28 @@ const PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-prose.txt'
  * again - the defect this exclusion exists to fix, restored by the fix.
  */
 const PROSE_PATHSPEC = `:(exclude)${path.relative(ROOT, PROSE)}`;
+const WORKFLOW = path.join(ROOT, '.github', 'workflows', 'forbidden-terms.yml');
+
+/** The only action the job may run, pinned by SHA. */
+const PINNED_CHECKOUT = 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1';
+
+/**
+ * Tokens that must not appear in the job body, and what each one would cost.
+ *
+ * NOT a general workflow linter, and it must not become one. The whole list is
+ * "things that run code the pull-request head can choose", because that is the
+ * single condition the `pull_request_target` argument rests on. A broader
+ * version would be a second, worse check wearing the same name.
+ */
+const VOIDS_THE_ACCEPTANCE = [
+  // `pnpm` before `npm `, because 'pnpm install' contains 'npm ' and the
+  // message should name the token the line actually uses.
+  ['pnpm', "an install runs the head's package.json and its lifecycle scripts"],
+  ['npm ', "an install runs the head's package.json and its lifecycle scripts"],
+  ['yarn ', "an install runs the head's package.json and its lifecycle scripts"],
+  ['npx ', 'npx fetches and executes a package the head can name'],
+  ['set -x', 'tracing prints the decoded pattern before masking can help'],
+];
 
 /** Stands in for the real term list. Names nothing that exists. */
 const SYNTHETIC = 'acmehealth|acme health|acme-health';
@@ -375,6 +397,68 @@ test("this repository's own prose passes every surface", () => {
   const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
   assert.equal(result.code, 0);
   assert.match(result.stdout, /clean/);
+});
+
+// ---------------------------------------------------------------------------
+// The pull_request_target acceptance
+// ---------------------------------------------------------------------------
+
+test('the pull_request_target job runs nothing the head can choose', () => {
+  // The workflow header argues that this trigger is safe because the job runs
+  // no install, no build, no head-provided script and no action pinned by the
+  // head. That argument IS the control, and until this case existed it was a
+  // paragraph: the next person adding a step reads it, agrees, and is still the
+  // only thing enforcing it.
+  //
+  // An exemption is the cheapest place to put an unchecked claim, because the
+  // claim is the reason you are allowed to skip the check. Half of this one is
+  // a fact a machine can settle, so it is settled here - with no dependency,
+  // because the job's own test step deliberately runs before any install.
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+
+  // Comments stripped first, so the header may keep DISCUSSING `set -x` without
+  // this check firing on the very sentence explaining why not to write it. A
+  // guard that scans a file for a token will find the prose about the token,
+  // which is a hazard specific to a codebase that writes its reasoning down.
+  const body = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/u.test(line))
+    .join('\n');
+
+  // The canary. A moved or renamed workflow throws on read, which is loud; this
+  // catches the quiet one - a body that is no longer this trigger, leaving every
+  // assertion below true of something else.
+  assert.match(
+    body,
+    /^\s*pull_request_target:$/mu,
+    'the job body does not declare pull_request_target: this test is reading the wrong thing'
+  );
+
+  const uses = [...body.matchAll(/^\s*uses:\s*(\S+)/gmu)].map((match) => match[1]);
+  assert.deepEqual(
+    uses,
+    [PINNED_CHECKOUT],
+    `this job may run one action and only ${PINNED_CHECKOUT}: anything else, or the same ` +
+      'action unpinned, is code this workflow does not control running beside the secret'
+  );
+
+  for (const [token, cost] of VOIDS_THE_ACCEPTANCE) {
+    assert.ok(
+      !body.includes(token),
+      `the job runs \`${token}\`, which voids the pull_request_target acceptance: ${cost}`
+    );
+  }
+
+  assert.doesNotMatch(
+    body,
+    /^\s*ref:/mu,
+    'the checkout takes a ref: the guard would come from the tree it is meant to be checking'
+  );
+  assert.match(
+    body,
+    /^\s*persist-credentials:\s*false$/mu,
+    'the checkout leaves a credential in the tree for later steps to reach'
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -506,6 +506,28 @@ test('the step that refuses a run which scanned nothing is not itself skippable'
     'the step refusing a run that scanned nothing is itself conditional, so the run it exists ' +
       'to catch skips it too and the job reports clean having read no surface'
   );
+
+  // The reader being unconditional and the writer being the step that actually
+  // scans are two halves of one property, and only the first half was asserted.
+  // Move the `touch` into the unconditional self-test step and every assertion
+  // above still holds - one writer, one reader, reader carries no `if:` - while a
+  // `workflow_dispatch` run records a scan it never ran and the refusal passes.
+  //
+  // Keyed on the scan command rather than on the step's `if:`, for the same reason
+  // the marker was preferred to the step name: the trigger expression is one
+  // rewording away, the scan invocation is the mechanism.
+  assert.match(
+    writes[0],
+    // Not `mjs scan` adjacently: reordering the subcommand after the flag is a
+    // legal, behaviour-preserving edit of the same command, and rejecting it
+    // would be a false red on a correct workflow - the failure mode that gets a
+    // check deleted rather than the one that lets a defect through. `\bscan\b`
+    // does not match the marker path `.../scanned`, which is the only other
+    // occurrence in any step.
+    /forbidden-terms\.mjs\b[\s\S]*?\bscan\b/u,
+    'the scanned marker is written by a step that does not run the scan, so it records that ' +
+      'a run reached that line rather than that a scan succeeded, and the refusal below passes'
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -290,12 +290,21 @@ test('a clean run says how many surfaces it read', () => {
 test('every surface is a bare filename', () => {
   // `runScan` builds each path as path.join(dir, surface), so an entry carrying
   // a separator or a `..` reads a file the collector never wrote. Cardinality
-  // pins WHICH surfaces are read; nothing above pins their SHAPE - an escaping
-  // entry is caught today only because path.join(tmpdir, '../../etc/passwd')
-  // happens not to exist under the fixture root, which is a fact about where
-  // the test writes its files rather than about this set. It is also the whole
-  // of the argument that the file-inclusion finding on that join is
-  // unreachable: the only variable in it is `dir`, and this is what says so.
+  // pins WHICH surfaces are read; nothing above pins their SHAPE. `../body` is
+  // caught several other ways because the file does not exist under the fixture
+  // root - which is a fact about where the test writes its files, not about this
+  // set. `./body` is the case that shows what this assertion is for: it resolves
+  // to the SAME file, every other test stays green, and only a statement about
+  // the shape of the entry sees it at all.
+  //
+  // HALF of the argument that the file-inclusion finding on that join is
+  // unreachable, and the half that is checked. The join has two operands. This
+  // pins the set: every entry is a bare name, so no entry can escape `dir`. It
+  // says NOTHING about the call site - a second caller-controlled operand added
+  // to the same `path.join` leaves this suite at 29/0. No assertion here can
+  // reach that: a dormant variable has no behaviour to observe, and a source
+  // regex over `path.join(dir, surface)` goes red on renaming the loop variable,
+  // which is a legal edit. That half is held by review and by nothing else.
   assert.notEqual(SURFACES.size, 0, 'no surfaces: this test is reading nothing');
   for (const surface of SURFACES) {
     assert.equal(path.basename(surface), surface, `'${surface}' is not a bare filename`);

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -26,8 +26,17 @@ import {
   selfTest,
 } from './forbidden-terms.mjs';
 
+const ROOT = path.join(import.meta.dirname, '..', '..');
 const SCRIPT = path.join(import.meta.dirname, 'forbidden-terms.mjs');
 const PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-prose.txt');
+/**
+ * The corpus, excluded from its own verbatim check. DERIVED from {@link PROSE}
+ * rather than written out a second time: a `:(exclude)` pathspec matching no
+ * file is not an error to git, so a second spelling of this path could quietly
+ * stop excluding anything and every corpus line would prove its own presence
+ * again - the defect this exclusion exists to fix, restored by the fix.
+ */
+const PROSE_PATHSPEC = `:(exclude)${path.relative(ROOT, PROSE)}`;
 
 /** Stands in for the real term list. Names nothing that exists. */
 const SYNTHETIC = 'acmehealth|acme health|acme-health';
@@ -380,6 +389,27 @@ test('every must-pass line is real prose from a tracked file', () => {
   const lines = corpusLines(execFileSync('cat', [PROSE], { encoding: 'utf8' }));
   assert.ok(lines.length >= 20, `expected a corpus worth having, got ${lines.length} lines`);
 
+  // The exclusion has to exclude THIS file, and two ways it stops doing so are
+  // both silent: a pathspec naming a path nothing tracks is a no-op to git, and
+  // one naming a different tracked file excludes the wrong thing. Either way
+  // every corpus line proves its own presence again, and a rail that excludes
+  // nothing looks exactly like one with nothing to exclude.
+  //
+  // Asserted off PROSE_PATHSPEC itself rather than off PROSE, because the value
+  // that can be wrong is the one the search will use. A property of the correct
+  // value says nothing about the value actually being evaluated.
+  const excludedPath = PROSE_PATHSPEC.replace(/^:\(exclude\)/u, '');
+  assert.equal(
+    excludedPath,
+    path.relative(ROOT, PROSE),
+    'the corpus exclusion names some other file, so the corpus is still searching itself'
+  );
+  assert.notEqual(
+    execFileSync('git', ['ls-files', '--', excludedPath], { cwd: ROOT, encoding: 'utf8' }).trim(),
+    '',
+    `${PROSE_PATHSPEC} names a path git does not track: the exclusion is a no-op`
+  );
+
   const missing = lines.filter((line) => {
     try {
       // EXCLUDING the corpus itself. Without the pathspec this file is a tracked
@@ -387,14 +417,10 @@ test('every must-pass line is real prose from a tracked file', () => {
       // sentence passes - the assertion satisfied by the very document it is
       // meant to be checking. Found by mutation: appending a sentence that
       // appears nowhere else left all 26 cases green.
-      execFileSync(
-        'git',
-        ['grep', '-qF', '--', line, ':(exclude)scripts/ci/forbidden-terms-allowed-prose.txt'],
-        {
-          cwd: path.join(import.meta.dirname, '..', '..'),
-          stdio: 'ignore',
-        }
-      );
+      execFileSync('git', ['grep', '-qF', '--', line, PROSE_PATHSPEC], {
+        cwd: ROOT,
+        stdio: 'ignore',
+      });
       return false;
     } catch {
       return true;

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -24,6 +24,7 @@ import {
   corpusLines,
   scanSurface,
   selfTest,
+  SURFACES,
 } from './forbidden-terms.mjs';
 
 const ROOT = path.join(import.meta.dirname, '..', '..');
@@ -284,6 +285,26 @@ test('a clean run says how many surfaces it read', () => {
   });
   assert.equal(result.code, 0);
   assert.match(result.stdout, /6 surfaces read/);
+});
+
+test('every surface is a bare filename', () => {
+  // `runScan` builds each path as path.join(dir, surface), so an entry carrying
+  // a separator or a `..` reads a file the collector never wrote. Cardinality
+  // pins WHICH surfaces are read; nothing above pins their SHAPE - an escaping
+  // entry is caught today only because path.join(tmpdir, '../../etc/passwd')
+  // happens not to exist under the fixture root, which is a fact about where
+  // the test writes its files rather than about this set. It is also the whole
+  // of the argument that the file-inclusion finding on that join is
+  // unreachable: the only variable in it is `dir`, and this is what says so.
+  assert.notEqual(SURFACES.size, 0, 'no surfaces: this test is reading nothing');
+  for (const surface of SURFACES) {
+    assert.equal(path.basename(surface), surface, `'${surface}' is not a bare filename`);
+    assert.equal(
+      surface === '.' || surface === '..',
+      false,
+      `'${surface}' resolves outside the surface directory`
+    );
+  }
 });
 
 test('a pattern that does not compile is reported without quoting the pattern', () => {

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -12,7 +12,15 @@
 
 import { execFileSync } from 'node:child_process';
 import assert from 'node:assert/strict';
-import { lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -892,6 +900,26 @@ test('a surface that is a SYMLINK exits 2 rather than being followed', () => {
   // Not 0 AND not 1: following the link is exit 0 here, so asserting "not
   // clean" alone would also pass on a run that found the term through some
   // other path. This pins that the LINK was refused.
+  assert.doesNotMatch(result.stdout, /clean/);
+});
+
+test('a surface that is a DIRECTORY exits 2 rather than being read', () => {
+  // `O_NOFOLLOW` refuses a symlink and nothing else. A directory opens without
+  // error on both Linux and macOS, so the `fstat` after the open is what stops
+  // it - and without that check the failure mode differs per platform rather
+  // than being refused outright, which is the least useful kind of guard.
+  //
+  // The rest of the directory is deliberately a clean, complete set of
+  // surfaces, so a run that skipped this one instead of failing would report
+  // "clean - 6 surfaces read" and look like a pass.
+  const dir = surfaceDir({});
+  rmSync(path.join(dir, 'body'));
+  mkdirSync(path.join(dir, 'body'));
+
+  const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /The 'body' surface is not a regular file/);
   assert.doesNotMatch(result.stdout, /clean/);
 });
 

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -12,7 +12,7 @@
 
 import { execFileSync } from 'node:child_process';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -208,7 +208,7 @@ test('the parse agrees with real git diff output, not just with fixtures', () =>
 
   const diff = execFileSync(
     'git',
-    ['diff', '--unified=0', '--diff-filter=ACMR', 'HEAD~1', 'HEAD'],
+    ['diff', '--unified=0', '--diff-filter=ACMRT', 'HEAD~1', 'HEAD'],
     {
       cwd: repo,
       encoding: 'utf8',
@@ -219,6 +219,75 @@ test('the parse agrees with real git diff output, not just with fixtures', () =>
     { surface: 'diff', file: 'a.md', line: 3 },
     { surface: 'diff', file: 'a.md', line: 4 },
     { surface: 'diff', file: 'b.md', line: 2 },
+  ]);
+});
+
+test('a file REPLACED BY A SYMLINK is a type change, and T is what sees it', () => {
+  // The filter the workflow passes is the guard's real reach, so it is pinned
+  // against real git rather than against a fixture that agrees with it.
+  //
+  // Replacing a regular file with a symlink is `T`. Without T in the filter the
+  // path is not new so it never reaches `names`, its content never reaches
+  // `diff`, and the scanner is handed nothing to be silent about - a green run
+  // that wrote its `scanned` receipt having looked at neither surface. The
+  // symlink TARGET carries the term.
+  //
+  // Both halves are asserted: ACMR sees NOTHING, which is the defect, and
+  // ACMRT sees the path and the target. An assertion on ACMRT alone cannot
+  // tell this fix from not making it.
+  const repo = mkdtempSync(path.join(os.tmpdir(), 'forbidden-terms-symlink-'));
+  const git = (...args) => execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+  git('init', '-q', '-b', 'main', '.');
+  git('config', 'user.email', 'guard@example.invalid');
+  git('config', 'user.name', 'Guard Test');
+  writeFileSync(path.join(repo, 'note.md'), 'harmless\n');
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  rmSync(path.join(repo, 'note.md'));
+  symlinkSync('acmehealth-prior-art.md', path.join(repo, 'note.md'));
+  git('add', '-A');
+  git('commit', '-q', '-m', 'type change');
+
+  const surfaces = (filter) => ({
+    diff: execFileSync(
+      'git',
+      ['diff', '--unified=0', `--diff-filter=${filter}`, 'HEAD~1', 'HEAD'],
+      { cwd: repo, encoding: 'utf8' }
+    ),
+    names: execFileSync(
+      'git',
+      ['diff', '--name-only', `--diff-filter=${filter}`, 'HEAD~1', 'HEAD'],
+      { cwd: repo, encoding: 'utf8' }
+    ),
+  });
+
+  // git agrees this is a type change and not something else.
+  assert.equal(
+    execFileSync('git', ['diff', '--name-status', 'HEAD~1', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim(),
+    'T\tnote.md'
+  );
+
+  // The defect: the old filter hands the scanner two empty surfaces.
+  const before = surfaces('ACMR');
+  assert.equal(before.diff, '');
+  assert.equal(before.names, '');
+  assert.deepEqual(scanSurface(pattern, 'diff', before.diff), []);
+  assert.deepEqual(scanSurface(pattern, 'names', before.names), []);
+
+  // The fix. Note WHICH surface catches it: the path `note.md` is innocent, so
+  // `names` correctly finds nothing even with T - it is the symlink TARGET that
+  // names the term, and that reaches the scanner only as an added line on the
+  // diff surface. Asserting a `names` finding here would have been asserting
+  // the wrong mechanism and would pass for the wrong reason on any path that
+  // happened to be named badly.
+  const after = surfaces('ACMRT');
+  assert.equal(after.names.trim(), 'note.md');
+  assert.deepEqual(scanSurface(pattern, 'names', after.names), []);
+  assert.deepEqual(scanSurface(pattern, 'diff', after.diff), [
+    { surface: 'diff', file: 'note.md', line: 1 },
   ]);
 });
 
@@ -330,6 +399,74 @@ test('a pattern that does not compile is reported without quoting the pattern', 
 });
 
 // ---------------------------------------------------------------------------
+// The flags, which PATTERN_SHAPE cannot see
+// ---------------------------------------------------------------------------
+//
+// The shape predicate constrains the PATTERN. `compilePattern`'s flags are the
+// other half of what the guard matches with, and one of them acts on the
+// HAYSTACK, where no constraint on the pattern can reach it. Found by mutating
+// the module against this file: `'i'` -> `'iu'` was green on all 47 tests.
+//
+// `g` and `y` are already pinned, because both carry `lastIndex` between calls
+// and the surface tests go red. `s`, `m` and `d` are invisible and that is
+// CORRECT rather than a gap: `s` changes only `.`, `m` changes only `^` and
+// `$`, and `d` changes only what `exec` returns, so inside the accepted
+// alphabet all three are inert - the shape predicate doing exactly its job.
+// `u` is the exception, because it changes CASE FOLDING, and folding reads the
+// input rather than the pattern.
+
+/**
+ * Code points that ONLY full Unicode case folding maps onto an ASCII letter.
+ *
+ * Written as escapes rather than literally, because the assertion is about a
+ * specific code point and a raw one is indistinguishable on screen from the
+ * letter it folds to - a fixture nobody can check by reading it.
+ */
+const FOLD_ONLY_TO_ASCII = [
+  ['KELVIN SIGN', '\u212A', 'k'],
+  ['LATIN SMALL LETTER LONG S', '\u017F', 's'],
+];
+
+for (const [name, char, ascii] of FOLD_ONLY_TO_ASCII) {
+  test(`case folding stops at ASCII: ${name}`, () => {
+    const p = compilePattern(`acme${ascii}are`);
+
+    // Positive controls: `i` is present and doing its job, so a `false` below
+    // is this code point and not a pattern that matches nothing.
+    assert.equal(p.test(`acme${ascii}are`), true, 'the ASCII spelling must match');
+    assert.equal(p.test(`ACME${ascii.toUpperCase()}ARE`), true, 'upper case must match');
+
+    // The assertion. `u` folds this code point onto its ASCII letter, and the
+    // guard would then match a string the machine-local `grep -inE` does not -
+    // making the secret a TRANSLATION between the two implementations rather
+    // than one value used twice, which is the whole argument for PATTERN_SHAPE.
+    assert.equal(p.test(`acme${char}are`), false, `${name} must not fold onto '${ascii}'`);
+
+    // ...and the control that earns that `false`. Built from a literal `'iu'`
+    // rather than from `compilePattern`, so it cannot inherit the change it
+    // exists to detect. Without it, a code point that folds under NEITHER flag
+    // would pass this test while proving nothing about `u`.
+    assert.equal(
+      new RegExp(`acme${ascii}are`, 'iu').test(`acme${char}are`),
+      true,
+      `fixture is vacuous: ${name} does not fold onto '${ascii}' even with the u flag`
+    );
+  });
+}
+
+test('the pattern is matched case-insensitively', () => {
+  // Named for the flag it is about. Dropping the `i` does redden one row of the
+  // accepted-shape table below, but that row is called `the shape accepts upper
+  // case` and is about the ALPHABET - so the only test that currently sees this
+  // mutation reports the wrong cause for it.
+  const p = compilePattern('acmekare|acme care');
+  for (const spelling of ['ACMEKARE', 'AcMeKaRe', 'ACME CARE', 'Acme Care']) {
+    assert.equal(p.test(spelling), true, `${spelling} must match`);
+  }
+  assert.equal(p.test('acme fare'), false, 'control: not every string matches');
+});
+
+// ---------------------------------------------------------------------------
 // The self-test
 // ---------------------------------------------------------------------------
 
@@ -337,7 +474,15 @@ const passCorpus = ['open an issue', 'open standards', 'the door opens'];
 
 test('a healthy pattern and corpus produce no problems', () => {
   assert.deepEqual(
-    selfTest({ pattern, blockCorpus: ['acmehealth', 'acme health'], passCorpus, minCorpus: 2 }),
+    selfTest({
+      pattern,
+      // One entry per alternative. It was two against a three-alternative
+      // pattern until the arity check was added and reddened this very case -
+      // the guard's own fixture was an instance of the gap it now closes.
+      blockCorpus: ['acmehealth', 'acme health', 'acme-health'],
+      passCorpus,
+      minCorpus: 2,
+    }),
     []
   );
 });
@@ -345,7 +490,11 @@ test('a healthy pattern and corpus produce no problems', () => {
 test('a known positive the pattern misses is a problem, reported by position', () => {
   const problems = selfTest({
     pattern,
-    blockCorpus: ['acmehealth', 'acme  health'],
+    // Entry 2 is deliberately mangled so the pattern misses it. Every
+    // alternative still needs an entry of its OWN behind it, or the
+    // per-alternative check fires too and this case stops being about the
+    // missed positive - which is what happened when that check was added.
+    blockCorpus: ['acmehealth', 'acme  health', 'acme-health', 'acme health'],
     passCorpus,
     minCorpus: 2,
   });
@@ -357,21 +506,304 @@ test('a known positive the pattern misses is a problem, reported by position', (
 test('a corpus shorter than the declared minimum is a problem', () => {
   // The truncated-secret case. Nothing else notices it: a short corpus still
   // passes every entry it has.
-  const problems = selfTest({ pattern, blockCorpus: ['acmehealth'], passCorpus, minCorpus: 2 });
+  //
+  // The corpus is long enough for the ARITY check on purpose - one entry per
+  // alternative - so the single problem below is the floor and only the floor.
+  // A two-entry corpus would fire both and `problems.length === 1` would be
+  // asserting that two independent checks happen to be one.
+  const problems = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth', 'acme health', 'acme-health'],
+    passCorpus,
+    minCorpus: 5,
+  });
   assert.equal(problems.length, 1);
-  assert.match(problems[0], /1 entries, fewer than the 2/);
+  assert.match(problems[0], /3 entries, fewer than the 5/);
 });
 
 test('a pattern that matches this repository own prose is a problem', () => {
-  const broad = compilePattern('open[ -]?[a-z]+');
+  // Over-broad WITHIN the accepted shape, which is the realistic version: a
+  // term that is also an ordinary phrase in this repository's own writing. The
+  // previous fixture used `open[ -]?[a-z]+`, and once the shape assertion
+  // existed that raised two problems - so the case would have been asserting
+  // that over-breadth and a bad shape are one thing.
+  const broad = compilePattern('open an issue|open standards');
   const problems = selfTest({
     pattern: broad,
-    blockCorpus: ['open acme'],
+    // Matched by the pattern, so the known-positives pass stays silent and the
+    // one problem below is over-breadth alone. Two entries for two alternatives.
+    blockCorpus: ['open an issue now', 'open standards body'],
     passCorpus,
     minCorpus: 1,
   });
   assert.equal(problems.length, 1);
-  assert.match(problems[0], /line\(s\) 1, 2, 3/);
+  assert.match(problems[0], /line\(s\) 1, 2/);
+  assert.doesNotMatch(problems[0], /plain alternation/u, 'this case must not be a shape failure');
+});
+
+test('the compiled pattern folds case the way the other implementation does', () => {
+  // `'i'` and NOT `'iu'`, pinned behaviourally rather than by reading the flags
+  // string - the flags are two characters that read like a tidy-up next to the
+  // `/u` on PATTERN_SHAPE twenty lines away, and PATTERN_SHAPE cannot see this
+  // because `u` changes folding on the HAYSTACK rather than on the pattern.
+  //
+  // Under `iu`, `k` matches U+212A KELVIN SIGN. Under `i` it does not, and
+  // neither does the machine-local hook's POSIX `grep -inE`. So the missing `u`
+  // is what makes "one secret used in two implementations" true rather than
+  // "two implementations that agree on ASCII". Raised in review.
+  const kelvin = 'a\u212Ab';
+
+  // The haystack asserted by its BYTES. A literal that silently degraded to
+  // ASCII would make every row below pass for the wrong reason - which is how
+  // this was first measured wrongly.
+  assert.equal(Buffer.from(kelvin, 'utf8').toString('hex'), '61e284aa62');
+
+  assert.equal(compilePattern('k').test(kelvin), false, 'the u flag has been added');
+  // Controls: the same pattern on an ordinary capital, and on a letter it must
+  // never match. Without them a compiled pattern that matches nothing at all
+  // would satisfy the row above.
+  assert.equal(compilePattern('k').test('aKb'), true);
+  assert.equal(compilePattern('k').test('azb'), false);
+});
+
+// ---------------------------------------------------------------------------
+// The direction the corpus pass cannot see
+// ---------------------------------------------------------------------------
+
+test('an alternative no corpus entry exercises is a problem, reported by position', () => {
+  // The gap the COUNT cannot see, and the count is green on exactly this input.
+  // Three entries against three alternatives satisfies `3 >= 3` while two
+  // alternatives are matched by nothing - three spellings of one term and none
+  // of another, which is what a corpus of variants naturally drifts into.
+  // Raised in review after the count shipped.
+  const problems = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth', 'acmehealth ltd', 'a acmehealth thing'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1, 'the count must stay silent here, or this proves nothing');
+  assert.match(problems[0], /alternative\(s\) at position\(s\) 2, 3/);
+  assert.equal(problems[0].toLowerCase().includes('acme'), false);
+});
+
+test('an alternative is exercised only if the pattern MATCHES the entry, not if it contains it', () => {
+  // Substring containment looks strictly simpler here and cannot throw, which
+  // is why it is the tempting shape. It fails OPEN in the one check whose job
+  // is to find unexercised alternatives: `'k'` is contained in nothing here,
+  // but U+212A KELVIN SIGN is a character `includes` sees as different and a
+  // case-folding `includes()` implementation would not.
+  //
+  // Driven the other way round, which is the version that fails: the entry
+  // holds the KELVIN SIGN, the alternative is `k`. `entry.includes('k')` is
+  // false and so is the regex, so both agree - the divergence needs the FOLDING
+  // that `includes` does not do. So the case that separates them is an entry
+  // differing only by case, where `includes` says unexercised and the pattern
+  // matches it.
+  //
+  // Without this the substitution is still caught, but by a case about the
+  // ACCEPTED ALPHABET, which names the wrong cause. Raised against my own
+  // matrix.
+  const problems = selfTest({
+    pattern: compilePattern('acmehealth'),
+    blockCorpus: ['ACMEHEALTH'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.deepEqual(problems, [], 'a case-differing entry exercises the alternative');
+});
+
+test('a corpus shorter than the alternation is a problem even when all of it is exercised', () => {
+  // The count's own separating input, and it is what shows the two checks are
+  // not one. A single entry containing every term exercises all three
+  // alternatives, so the per-alternative check is silent - and the corpus is
+  // still one entry against three terms, which is what the count is for.
+  const problems = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth and acme health and acme-health'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /claims 3 alternatives and the must-block corpus has 1/);
+});
+
+test('a corpus ONE short of the alternation fires, which is the boundary itself', () => {
+  // Weakening the count to `< claimed - 1` was green on everything until this
+  // existed: the two-short case below still fires under that mutation, and the
+  // equal case is silent under both, so nothing sat on the boundary. Two
+  // entries covering all three alternatives keeps the per-alternative check
+  // quiet, so the single problem is the count and only the count.
+  const problems = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth and acme health', 'acme-health'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /claims 3 alternatives and the must-block corpus has 2/);
+});
+
+test('a corpus two short of the alternation still fires, which separates removed from off-by-one', () => {
+  // Every other fixture is exactly one short, so deleting the count and
+  // weakening it to `< claimed - 1` redden an identical set and the two are
+  // indistinguishable. At two short the weakened form still fires and the
+  // deleted one does not. Raised in review; six lines of fixture.
+  const problems = selfTest({
+    pattern: compilePattern('acmehealth|acme health|acme-health|acme  health'),
+    blockCorpus: ['acmehealth and acme health and acme-health and acme  health'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /claims 4 alternatives and the must-block corpus has 1/);
+});
+
+test('the floor, the count and the per-alternative check are three checks, not one', () => {
+  // Each fires alone on an input the other two are silent on. Without this the
+  // three could be one check wearing three messages, which is what the count
+  // alone looked like until the per-alternative check was driven.
+
+  // BOTH secrets truncating together: a pattern cut to one alternative against
+  // a corpus cut to one entry satisfies `1 >= 1` and exercises that
+  // alternative, so only the literal floor in the workflow sees the shrink.
+  const bothShrank = selfTest({
+    pattern: compilePattern('acmehealth'),
+    blockCorpus: ['acmehealth'],
+    passCorpus,
+    minCorpus: 3,
+  });
+  assert.equal(bothShrank.length, 1);
+  assert.match(bothShrank[0], /1 entries, fewer than the 3/);
+
+  // A corpus over the floor and long enough for the count, piling on one
+  // alternative: only the per-alternative check sees it.
+  const pileup = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth', 'acmehealth ltd', 'a acmehealth thing'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(pileup.length, 1);
+  assert.match(pileup[0], /position\(s\) 2, 3/);
+
+  // One entry exercising every alternative: only the count sees it.
+  const short = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth and acme health and acme-health'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(short.length, 1);
+  assert.match(short[0], /must-block corpus has 1/);
+});
+
+// ---------------------------------------------------------------------------
+// The shape predicate itself
+// ---------------------------------------------------------------------------
+//
+// PATTERN_SHAPE is now load-bearing for two separate checks - one value read in
+// two regular-expression dialects, and `alternativesIn` splitting on `|` - so a
+// predicate that quietly admits one more construct makes both unsound while
+// every other test stays green.
+//
+// One fixture cannot pin it. The case above violates the shape in three ways at
+// once (a leading `(`, a trailing `)`, a group), so a predicate that has lost
+// only its `^`, only its `$` or only one excluded character still rejects it and
+// the case still passes. These tables are one row per construct and one row per
+// anchor, so a single lost admission has somewhere to show up.
+
+const REJECTED_SHAPES = [
+  // Splitting on `|` is inexact for all of these: the escaped pipe is ONE
+  // alternative that splits into two, and a class or a group can hide a pipe.
+  ['an escaped pipe', String.raw`acme\|health`, 'acme|health'],
+  ['a character class', 'acme[ -]health|acme health', 'acme health'],
+  ['a quantifier', 'acmes?health|acme health', 'acmehealth'],
+  ['a wildcard', 'acme.health|acme health', 'acmexhealth'],
+  // Anchors, one end each. Both ends bad at once cannot separate them.
+  // An ordinary character that is simply not in the alphabet, so these two rows
+  // are about the ANCHOR and nothing else - a metacharacter here would redden
+  // for a second reason and stop separating a lost `^` from a lost `$`.
+  ['an excluded character at the start only', '_acmehealth|acme health', '_acmehealth'],
+  ['an excluded character at the end only', 'acmehealth|acme health_', 'acmehealth'],
+];
+
+for (const [construct, source, entry] of REJECTED_SHAPES) {
+  test(`the shape refuses ${construct}`, () => {
+    const problems = selfTest({
+      pattern: compilePattern(source),
+      // Matched by the pattern, so known-positives stays silent and the single
+      // problem is the shape alone.
+      blockCorpus: [entry],
+      passCorpus,
+      minCorpus: 1,
+    });
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /plain alternation of literal words/);
+    assert.equal(problems[0].toLowerCase().includes('acme'), false);
+  });
+}
+
+const ACCEPTED_SHAPES = [
+  // The positive half. Without it the predicate can narrow to admit only what
+  // SYNTHETIC happens to use - which is letters, a space and a hyphen, and no
+  // digit at all - and nothing notices.
+  ['a digit', 'acme2health', 'acme2health'],
+  ['a space', 'acme health', 'acme health'],
+  ['a hyphen', 'acme-health', 'acme-health'],
+  ['a leading hyphen', '-acmehealth', '-acmehealth'],
+  ['a trailing hyphen', 'acmehealth-', 'acmehealth-'],
+  ['upper case', 'AcmeHealth', 'acmehealth'],
+];
+
+for (const [construct, source, entry] of ACCEPTED_SHAPES) {
+  test(`the shape accepts ${construct}`, () => {
+    assert.deepEqual(
+      selfTest({
+        pattern: compilePattern(source),
+        blockCorpus: [entry],
+        passCorpus,
+        minCorpus: 1,
+      }),
+      []
+    );
+  });
+}
+
+test('a corpus with more entries than alternatives is fine', () => {
+  // The arity check reads "at LEAST one entry per alternative", and nothing
+  // pinned the "at least". Every other fixture has the corpus exactly equal to
+  // the alternative count or exactly short of it, so `<` and `!==` are the same
+  // check on all of them - and `!==` would go red on a corpus that carries two
+  // spellings of one term, with a message saying an alternative is unchecked
+  // when the opposite is true.
+  assert.deepEqual(
+    selfTest({
+      pattern,
+      blockCorpus: ['acmehealth', 'acme health', 'acme-health', 'the acmehealth product'],
+      passCorpus,
+      minCorpus: 1,
+    }),
+    []
+  );
+});
+
+test('a pattern outside the accepted shape is refused, and says why without quoting it', () => {
+  // Fails CLOSED. Counting alternatives by splitting on `|` is exact for a plain
+  // alternation and wrong for a group, an escaped pipe or a class containing
+  // one - and the same alphabet is what lets one value serve both this
+  // `new RegExp(source, 'i')` and the machine-local hook's POSIX `grep -inE`.
+  // So the shape carries two jobs and a pattern outside it makes neither sound.
+  const problems = selfTest({
+    pattern: compilePattern('(acmehealth|acme health)'),
+    blockCorpus: ['acmehealth', 'acme health'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /plain alternation of literal words/);
+  // Never quote the pattern, the same rule the failed-compile path follows.
+  assert.equal(problems[0].toLowerCase().includes('acme'), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -397,14 +829,112 @@ for (const [name, env] of [
   });
 }
 
-test('a directory that does not exist exits 2, not 0', () => {
+test('a directory that does not exist exits 2 and names the DIRECTORY', () => {
   // Treating an unreadable surface as empty is how a guard reports clean about
   // something it never looked at.
   const result = run(['scan', '--dir', '/nonexistent/surfaces'], {
     FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
   });
   assert.equal(result.code, 2);
-  assert.match(result.stderr, /Cannot read the 'diff' surface/);
+  assert.match(result.stderr, /Cannot read the surface directory/);
+  // The absence is the point. This used to report `Cannot read the 'diff'
+  // surface` - the first name the loop happened to touch - which sends whoever
+  // reads it looking for a file when the whole directory is missing. Asserting
+  // only the new message would stay green if the old one came back alongside
+  // it.
+  assert.doesNotMatch(result.stderr, /Cannot read the '\w+' surface/u);
+});
+
+test('a surface that is a SYMLINK exits 2 rather than being followed', () => {
+  // `readFileSync` follows links, so without the `lstat` check this run reads
+  // the link's target, finds nothing in it, and exits 0 with
+  // "clean - 6 surfaces read". The target here is deliberately clean and the
+  // real surface deliberately is not: a guard that reports clean about a file
+  // nobody collected is the exact failure this script exists to remove, and it
+  // arrives through the filesystem rather than through an argument.
+  const dir = surfaceDir({ body: 'acmehealth is named here' });
+  const elsewhere = path.join(mkdtempSync(path.join(os.tmpdir(), 'ft-target-')), 'clean.txt');
+  writeFileSync(elsewhere, 'nothing named in this file\n');
+  rmSync(path.join(dir, 'body'));
+  symlinkSync(elsewhere, path.join(dir, 'body'));
+
+  const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /The 'body' surface is not a regular file/);
+  // Not 0 AND not 1: following the link is exit 0 here, so asserting "not
+  // clean" alone would also pass on a run that found the term through some
+  // other path. This pins that the LINK was refused.
+  assert.doesNotMatch(result.stdout, /clean/);
+});
+
+test('invoked through a SYMLINK the CLI still runs', () => {
+  // Node resolves the ESM main entry to its realpath while `process.argv[1]`
+  // keeps the path as typed, so an entry-point guard comparing them with
+  // `path.resolve` is FALSE through a link: `main` never runs and the process
+  // exits 0 having done nothing.
+  //
+  // Exit 0 is the failure here, which is why the assertion is on a case that
+  // must be NON-zero. A clean scan would also exit 0 and could not separate the
+  // two. `scan` with no `--dir` is exit 2 when the CLI runs at all, and silence
+  // with status 0 when it does not - and status 0 is what the workflow's
+  // `scanned` receipt used to read as evidence of a scan.
+  const link = path.join(mkdtempSync(path.join(os.tmpdir(), 'ft-link-')), 'forbidden-terms.mjs');
+  symlinkSync(SCRIPT, link);
+
+  let code = 0;
+  let stderr = '';
+  try {
+    execFileSync(process.execPath, [link, 'scan'], {
+      encoding: 'utf8',
+      env: { ...process.env, FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    code = error.status;
+    stderr = error.stderr ?? '';
+  }
+
+  assert.equal(code, 2, 'the CLI did not run at all through the link: it exited 0 in silence');
+  assert.match(stderr, /--dir/u);
+});
+
+test('invoked through a symlinked PARENT DIRECTORY the CLI still runs', () => {
+  // The script does not have to be the link. `path.resolve` never touches the
+  // filesystem, so a REAL script reached through a linked parent fails the same
+  // comparison - with nothing linked inside the repository and nothing in the
+  // diff to notice. This one is separating rather than additional: a guard that
+  // resolves only the script's own last component passes the case above and
+  // still no-ops here.
+  //
+  // There is a live instance of this layout on every machine here, which is how
+  // it was found: `$TMPDIR` sits behind `/var -> /private/var` on macOS, so a
+  // rig placed there reproduces the bug with nothing linked at all.
+  const linkedParent = path.join(mkdtempSync(path.join(os.tmpdir(), 'ft-dir-')), 'ci');
+  symlinkSync(path.dirname(SCRIPT), linkedParent);
+  const viaParent = path.join(linkedParent, path.basename(SCRIPT));
+  assert.equal(
+    lstatSync(viaParent).isSymbolicLink(),
+    false,
+    'this case is meant to reach a REAL file through a linked parent; the file itself is a link, ' +
+      'so it cannot separate an ancestor-aware guard from a last-component one'
+  );
+
+  let code = 0;
+  let stderr = '';
+  try {
+    execFileSync(process.execPath, [viaParent, 'scan'], {
+      encoding: 'utf8',
+      env: { ...process.env, FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    code = error.status;
+    stderr = error.stderr ?? '';
+  }
+
+  assert.equal(code, 2, 'the CLI did not run through the linked parent: it exited 0 in silence');
+  assert.match(stderr, /--dir/u);
 });
 
 test('scan without --dir exits 2', () => {
@@ -433,15 +963,14 @@ test("this repository's own prose passes every surface", () => {
 });
 
 // ---------------------------------------------------------------------------
-// The pull_request_target acceptance
+// The trigger, and the guard coming from the reviewed tree
 // ---------------------------------------------------------------------------
 
-test('the pull_request_target job runs nothing the head can choose', () => {
-  // The workflow header argues that this trigger is safe because the job runs
-  // no install, no build, no head-provided script and no action pinned by the
-  // head. That argument IS the control, and until this case existed it was a
-  // paragraph: the next person adding a step reads it, agrees, and is still the
-  // only thing enforcing it.
+test('the job is unprivileged and runs nothing the head can choose', () => {
+  // The workflow header argues that this job runs no install, no build, no
+  // head-provided script and no action pinned by the head. That argument IS the
+  // control, and until this case existed it was a paragraph: the next person
+  // adding a step reads it, agrees, and is still the only thing enforcing it.
   //
   // An exemption is the cheapest place to put an unchecked claim, because the
   // claim is the reason you are allowed to skip the check. Half of this one is
@@ -463,8 +992,19 @@ test('the pull_request_target job runs nothing the head can choose', () => {
   // assertion below true of something else.
   assert.match(
     body,
-    /^\s*pull_request_target:$/mu,
-    'the job body does not declare pull_request_target: this test is reading the wrong thing'
+    /^\s*pull_request:$/mu,
+    'the job body does not declare pull_request: this test is reading the wrong thing'
+  );
+  // The regression this whole change exists to prevent. `pull_request_target`
+  // runs in the base context WITH secrets on a fork, which is why it was here -
+  // and why CodeQL called it `actions/untrusted-checkout/high`. Reinstating it
+  // hands a fork the pattern the moment any step touches head-provided code,
+  // and the assertion above cannot see it: `pull_request_target:` does not match
+  // `pull_request:$`, so without this line a revert is silently green.
+  assert.doesNotMatch(
+    body,
+    /^\s*pull_request_target:/mu,
+    'the job is back on pull_request_target: the secret is reachable from a fork again'
   );
 
   const uses = [...body.matchAll(/^\s*uses:\s*(\S+)/gmu)].map((match) => match[1]);
@@ -478,20 +1018,63 @@ test('the pull_request_target job runs nothing the head can choose', () => {
   for (const [token, cost] of VOIDS_THE_ACCEPTANCE) {
     assert.ok(
       !body.includes(token),
-      `the job runs \`${token}\`, which voids the pull_request_target acceptance: ${cost}`
+      `the job runs \`${token}\`, which voids the acceptance for running beside the secret: ${cost}`
     );
   }
 
-  assert.doesNotMatch(
+  // INVERTED by the move off `pull_request_target`, and the inversion is the
+  // point. That trigger checks out the base by default, so a bare checkout was
+  // correct and a `ref:` was the hazard. `pull_request` checks out the MERGE
+  // ref by default - the head's version of this guard and of this very test -
+  // so here the bare checkout is the hazard and the pin is the control.
+  assert.match(
     body,
-    /^\s*ref:/mu,
-    'the checkout takes a ref: the guard would come from the tree it is meant to be checking'
+    /^\s*ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\b/mu,
+    'the checkout is not pinned to the base commit: the guard would come from the tree ' +
+      'it is meant to be checking, and a pull request could pass itself'
   );
   assert.match(
     body,
     /^\s*persist-credentials:\s*false$/mu,
     'the checkout leaves a credential in the tree for later steps to reach'
   );
+});
+
+test('every diff the job collects passes a filter that includes type changes', () => {
+  // The symlink case above proves what `T` buys, against real git - but it
+  // hardcodes the filter, so reverting the workflow to `ACMR` leaves it green.
+  // That is the same shape as a guard that enumerates only the doors it already
+  // knows about: the behaviour is pinned and the USE of it is not.
+  //
+  // So this reads the filter the job actually passes. Keyed on `--diff-filter=`
+  // rather than on the exact string, because the set may legitimately grow -
+  // what may not happen is `T` leaving it.
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const body = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/u.test(line))
+    .join('\n');
+
+  const filters = [...body.matchAll(/--diff-filter=([A-Za-z]+)/gu)].map((match) => match[1]);
+
+  // Zero rather than a threshold, and it is the canary that matters most here:
+  // a rename of the step, a move to a script, or a filter dropped entirely all
+  // land as an empty list, and an empty list satisfies a `for` loop silently.
+  assert.notEqual(
+    filters.length,
+    0,
+    'no --diff-filter found in the job: this test is reading nothing, and a diff with no filter ' +
+      'at all is a different defect than the one below'
+  );
+
+  for (const filter of filters) {
+    assert.ok(
+      filter.includes('T'),
+      `--diff-filter=${filter} omits T: a file replaced by a symlink is a type change, so its ` +
+        'path never reaches `names` and its target never reaches `diff`, and the run is green ' +
+        'having looked at neither'
+    );
+  }
 });
 
 test('the step that refuses a run which scanned nothing is not itself skippable', () => {
@@ -518,6 +1101,27 @@ test('the step that refuses a run which scanned nothing is not itself skippable'
   // better message below, so it would steal the failure from the assertion
   // that names the cause.
   assert.notEqual(steps.length, 0, 'no steps parsed out of the job: this test is reading nothing');
+
+  // The same defect one scope out, and the one this file could not previously
+  // see. Everything below reasons about STEPS; a job-level `if:` skips all of
+  // them at once, and a SKIPPED job SATISFIES a required status check - only a
+  // context that never reports blocks. So the check goes green having run
+  // nothing, which is strictly worse than the step-level version below because
+  // there is not even a red step to notice.
+  //
+  // It is also the likeliest edit for a good reason rather than a contrived
+  // one: this gate is red on every fork pull request by design, and
+  // `if: github.event.pull_request.head.repo.fork == false` is what somebody
+  // reaches for to make that stop. It will look like tidying up.
+  //
+  // Job keys sit at four spaces here; a step's own `if:` is at eight, so this
+  // cannot fire on the three that legitimately carry one.
+  assert.doesNotMatch(
+    body,
+    /^ {4}if:/mu,
+    'the job carries a job-level `if:`: a skipped job satisfies a required check, so the ' +
+      'gate would report green having scanned nothing'
+  );
 
   const MARKER = '"${RUNNER_TEMP}/scanned"';
   const writes = steps.filter((step) => step.includes(`touch ${MARKER}`));
@@ -590,6 +1194,35 @@ test('the step that refuses a run which scanned nothing is not itself skippable'
     invocation.index < writes[0].indexOf(`touch ${MARKER}`),
     'the scanned marker is written before the scan runs, so it records an attempt rather than ' +
       'a clean exit and any later edit that stops a failed scan failing the step reports clean'
+  );
+
+  // A CLEAN EXIT IS NOT A SCAN, and the two assertions above cannot tell them
+  // apart: both are satisfied by `node ...; touch marker`, which records that a
+  // process reached that line. A `node` invocation that never reaches `main`
+  // exits 0 having read nothing, `set -e` sees success, and the refusal below
+  // finds the marker and passes. So the receipt must key on something only a
+  // real scan produces.
+  //
+  // Paired deliberately with the run below. Asserting only that the workflow
+  // mentions the sentence pins the workflow against a string the script might
+  // not print - which fails closed rather than open, but is still a gate nobody
+  // can pass. Asserting only that the script prints it pins nothing about the
+  // receipt. Together they say: the thing the workflow waits for is the thing
+  // the script emits.
+  const CLEAN_SENTENCE = 'surfaces read';
+  assert.ok(
+    writes[0].includes(CLEAN_SENTENCE),
+    'the scanned marker is written without checking what the scan REPORTED, so a run that ' +
+      'exited 0 without reading a surface records a scan and the refusal below passes'
+  );
+  const clean = run(['scan', '--dir', surfaceDir()], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+  });
+  assert.equal(clean.code, 0);
+  assert.ok(
+    clean.stdout.includes(CLEAN_SENTENCE),
+    'the script no longer prints the sentence the workflow gates its receipt on, so every ' +
+      'clean run now exits 2 on a scan that actually happened'
   );
 });
 

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -1,0 +1,395 @@
+// Tests for the forbidden-terms gate.
+//
+// The real pattern is a repository secret and is deliberately not available
+// here. That is not a gap: these tests pin the MACHINERY with a synthetic
+// pattern, in the open, where the assertions can be read. The real pattern's
+// behaviour is pinned by the `selftest` command, which runs in CI where the
+// secret exists and asserts the pattern against both corpora before the job
+// looks at a single line of the pull request.
+//
+// Splitting it that way is the point: everything testable without the secret is
+// tested without the secret.
+
+import { execFileSync } from 'node:child_process';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import test from 'node:test';
+
+import {
+  addedLines,
+  compilePattern,
+  corpusLines,
+  scanSurface,
+  selfTest,
+} from './forbidden-terms.mjs';
+
+const SCRIPT = path.join(import.meta.dirname, 'forbidden-terms.mjs');
+const PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-prose.txt');
+
+/** Stands in for the real term list. Names nothing that exists. */
+const SYNTHETIC = 'acmehealth|acme health|acme-health';
+const pattern = compilePattern(SYNTHETIC);
+
+/** Runs the CLI and returns its exit code and streams. */
+function run(args, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    return { code: error.status, stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+  }
+}
+
+const b64 = (value) => Buffer.from(value, 'utf8').toString('base64');
+
+/**
+ * Writes a full set of surface files and returns the directory.
+ *
+ * Every surface is written even when a case only cares about one, because that
+ * is what the CLI now requires - and requiring it is the point: a caller that
+ * can leave one out is a caller that will.
+ */
+function surfaceDir(overrides = {}) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'forbidden-terms-'));
+  for (const surface of ['diff', 'names', 'messages', 'branch', 'title', 'body']) {
+    writeFileSync(path.join(dir, surface), overrides[surface] ?? '');
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// The diff surface
+// ---------------------------------------------------------------------------
+
+test('added lines carry the file and the line they land on', () => {
+  const diff = [
+    'diff --git a/docs/one.md b/docs/one.md',
+    '--- a/docs/one.md',
+    '+++ b/docs/one.md',
+    '@@ -10,2 +10,3 @@',
+    ' context line',
+    '+added on eleven',
+    ' another context line',
+    '@@ -40,1 +41,2 @@',
+    '-removed line',
+    '+added on forty-one',
+    '',
+  ].join('\n');
+
+  assert.deepEqual(addedLines(diff), [
+    { file: 'docs/one.md', line: 11, text: 'added on eleven' },
+    { file: 'docs/one.md', line: 41, text: 'added on forty-one' },
+  ]);
+});
+
+test('a removed line does not advance the new-file line number', () => {
+  // Without this the numbers drift by one per deletion, and a finding sends the
+  // author to a line that says something else - which reads as a false positive
+  // and gets the gate distrusted rather than the term removed.
+  const diff = ['+++ b/a.ts', '@@ -1,4 +1,3 @@', ' one', '-two', '-three', '+two prime', ''].join(
+    '\n'
+  );
+  assert.deepEqual(addedLines(diff), [{ file: 'a.ts', line: 2, text: 'two prime' }]);
+});
+
+test('the +++ header is not itself an added line', () => {
+  // It starts with '+' and names a path. Matching it would report every renamed
+  // file as a finding.
+  const diff = [
+    '--- /dev/null',
+    '+++ b/acmehealth-notes.md',
+    '@@ -0,0 +1,1 @@',
+    '+content',
+    '',
+  ].join('\n');
+  const found = scanSurface(pattern, 'diff', diff);
+  assert.deepEqual(found, []);
+});
+
+test('an added line whose own content starts with ++ is an addition, not a header', () => {
+  // The case that separates the two readings. `the +++ header is not itself an
+  // added line` above is satisfied by BOTH a parser that skips headers and one
+  // that skips anything shaped like one, because it only ever presents a real
+  // header. This one presents an addition git wrote as `+++ `.
+  //
+  // The broken reading failed in both directions at once: the line carrying the
+  // term went unscanned, AND `file` became that line of the diff, which the
+  // report prints - publishing pull-request content into a public log.
+  const diff = [
+    'diff --git a/a.md b/a.md',
+    '--- a/a.md',
+    '+++ b/a.md',
+    '@@ -2,0 +3,2 @@ two',
+    // git writes an added line as `+` plus its content, so a line whose text
+    // begins `++ ` reaches the parser as `+++ ` - indistinguishable from the
+    // header by content, which is the whole defect.
+    '+++ this line names acmehealth',
+    '+plain acme health line',
+    '',
+  ].join('\n');
+
+  assert.deepEqual(addedLines(diff), [
+    { file: 'a.md', line: 3, text: '++ this line names acmehealth' },
+    { file: 'a.md', line: 4, text: 'plain acme health line' },
+  ]);
+
+  // Both lines are found, and no finding carries diff content as its file.
+  const found = scanSurface(pattern, 'diff', diff);
+  assert.deepEqual(found, [
+    { surface: 'diff', file: 'a.md', line: 3 },
+    { surface: 'diff', file: 'a.md', line: 4 },
+  ]);
+});
+
+test('a hunk header with an omitted count owns one line', () => {
+  // git writes `@@ -1,0 +2 @@` rather than `+2,1`. Reading the absent count as
+  // zero ends the hunk before its only addition, and the addition is then
+  // header territory.
+  const diff = ['+++ b/b.md', '@@ -1,0 +2 @@ b one', '+acmehealth in b', ''].join('\n');
+  assert.deepEqual(addedLines(diff), [{ file: 'b.md', line: 2, text: 'acmehealth in b' }]);
+});
+
+test('the parse agrees with real git diff output, not just with fixtures', () => {
+  // Every other case here is a hand-written approximation of git, and the
+  // defect this file now pins was found against real output and hidden by a
+  // fixture. So one case pays for a repository.
+  const repo = mkdtempSync(path.join(os.tmpdir(), 'forbidden-terms-git-'));
+  const git = (...args) => execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+  git('init', '-q', '-b', 'main', '.');
+  git('config', 'user.email', 'guard@example.invalid');
+  git('config', 'user.name', 'Guard Test');
+  writeFileSync(path.join(repo, 'a.md'), 'one\ntwo\n');
+  writeFileSync(path.join(repo, 'b.md'), 'b one\n');
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  writeFileSync(path.join(repo, 'a.md'), 'one\ntwo\n++ names acmehealth\nplain acme health\n');
+  writeFileSync(path.join(repo, 'b.md'), 'b one\nacme-health in b\n');
+  git('add', '-A');
+  git('commit', '-q', '-m', 'change');
+
+  const diff = execFileSync(
+    'git',
+    ['diff', '--unified=0', '--diff-filter=ACMR', 'HEAD~1', 'HEAD'],
+    {
+      cwd: repo,
+      encoding: 'utf8',
+    }
+  );
+
+  assert.deepEqual(scanSurface(pattern, 'diff', diff), [
+    { surface: 'diff', file: 'a.md', line: 3 },
+    { surface: 'diff', file: 'a.md', line: 4 },
+    { surface: 'diff', file: 'b.md', line: 2 },
+  ]);
+});
+
+test('a file NAMED after a forbidden term is caught by the names surface', () => {
+  // Which is why `names` exists: the diff surface deliberately ignores the
+  // header that carries the path, so the path is checked as its own surface.
+  const found = scanSurface(pattern, 'names', 'docs/acmehealth-notes.md\ndocs/fine.md\n');
+  assert.deepEqual(found, [{ surface: 'names', file: 'names', line: 1 }]);
+});
+
+test('multiple files in one diff each report their own path', () => {
+  const diff = [
+    '+++ b/first.ts',
+    '@@ -1,0 +1,1 @@',
+    '+see acme health for prior art',
+    '+++ b/second.ts',
+    '@@ -5,0 +5,1 @@',
+    '+also acmehealth',
+    '',
+  ].join('\n');
+  assert.deepEqual(scanSurface(pattern, 'diff', diff), [
+    { surface: 'diff', file: 'first.ts', line: 1 },
+    { surface: 'diff', file: 'second.ts', line: 5 },
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// What a finding may contain
+// ---------------------------------------------------------------------------
+
+test('a finding carries where and never what', () => {
+  // The load-bearing assertion of the whole file. This log is public: a finding
+  // that carried the matched text would publish the term list one blocked pull
+  // request at a time.
+  const [finding] = scanSurface(pattern, 'title', 'feat(api): port the acme health chart layout');
+  assert.deepEqual(Object.keys(finding).sort(), ['file', 'line', 'surface']);
+  assert.equal(JSON.stringify(finding).toLowerCase().includes('acme'), false);
+});
+
+test('the whole blocked-run output never contains the term', () => {
+  const dir = surfaceDir({ body: 'ported from acme health, which is the thing not to write' });
+  const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+  assert.equal(result.code, 1);
+  assert.equal(`${result.stdout}${result.stderr}`.toLowerCase().includes('acme'), false);
+});
+
+test('a surface left out of the directory is exit 2, not a clean run', () => {
+  // The defect this CLI shape exists to remove. When `scan` took a list of
+  // `<surface>=<file>` pairs, dropping one from the workflow left the run
+  // reporting clean while that surface carried the term - the caller decided
+  // the coverage and nothing asserted it had passed them all.
+  const dir = surfaceDir({ body: 'acmehealth' });
+  execFileSync('rm', [path.join(dir, 'body')]);
+  const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /Cannot read the 'body' surface/);
+});
+
+test('a clean run says how many surfaces it read', () => {
+  // "no named external product on any CHECKED surface" was true of a run that
+  // checked five of six. The count is what makes the sentence answerable.
+  const result = run(['scan', '--dir', surfaceDir()], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+  });
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /6 surfaces read/);
+});
+
+test('a pattern that does not compile is reported without quoting the pattern', () => {
+  // The RegExp constructor's own message quotes the source. Letting it out
+  // would publish the term list on the one run where the secret is malformed.
+  assert.throws(
+    () => compilePattern('acme(health'),
+    (error) =>
+      !error.message.toLowerCase().includes('acme') && /does not compile/.test(error.message)
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The self-test
+// ---------------------------------------------------------------------------
+
+const passCorpus = ['open an issue', 'open standards', 'the door opens'];
+
+test('a healthy pattern and corpus produce no problems', () => {
+  assert.deepEqual(
+    selfTest({ pattern, blockCorpus: ['acmehealth', 'acme health'], passCorpus, minCorpus: 2 }),
+    []
+  );
+});
+
+test('a known positive the pattern misses is a problem, reported by position', () => {
+  const problems = selfTest({
+    pattern,
+    blockCorpus: ['acmehealth', 'acme  health'],
+    passCorpus,
+    minCorpus: 2,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /position\(s\) 2/);
+  assert.equal(problems[0].toLowerCase().includes('acme'), false);
+});
+
+test('a corpus shorter than the declared minimum is a problem', () => {
+  // The truncated-secret case. Nothing else notices it: a short corpus still
+  // passes every entry it has.
+  const problems = selfTest({ pattern, blockCorpus: ['acmehealth'], passCorpus, minCorpus: 2 });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /1 entries, fewer than the 2/);
+});
+
+test('a pattern that matches this repository own prose is a problem', () => {
+  const broad = compilePattern('open[ -]?[a-z]+');
+  const problems = selfTest({
+    pattern: broad,
+    blockCorpus: ['open acme'],
+    passCorpus,
+    minCorpus: 1,
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /line\(s\) 1, 2, 3/);
+});
+
+// ---------------------------------------------------------------------------
+// Erroring is not finding
+// ---------------------------------------------------------------------------
+
+for (const [name, env] of [
+  ['absent', {}],
+  ['empty', { FORBIDDEN_TERMS_PATTERN_B64: '' }],
+  ['whitespace', { FORBIDDEN_TERMS_PATTERN_B64: '   ' }],
+  ['decoding to nothing', { FORBIDDEN_TERMS_PATTERN_B64: b64('   ') }],
+]) {
+  test(`a pattern that is ${name} exits 2, not 0`, () => {
+    // An empty pattern is not a no-op: one formulation matches every line and
+    // another matches none. The second is a silently green pull request on
+    // exactly the contributions that most need checking.
+    const result = run(['scan', '--dir', surfaceDir()], {
+      FORBIDDEN_TERMS_PATTERN_B64: undefined,
+      ...env,
+    });
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /unset or empty|decoded to nothing/);
+  });
+}
+
+test('a directory that does not exist exits 2, not 0', () => {
+  // Treating an unreadable surface as empty is how a guard reports clean about
+  // something it never looked at.
+  const result = run(['scan', '--dir', '/nonexistent/surfaces'], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+  });
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /Cannot read the 'diff' surface/);
+});
+
+test('scan without --dir exits 2', () => {
+  const result = run(['scan'], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /--dir/);
+});
+
+test('selftest without --min-corpus exits 2', () => {
+  // The number is the only thing standing between a truncated secret and a
+  // green run, so it is required rather than defaulted.
+  const result = run(['selftest'], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+    FORBIDDEN_TERMS_CORPUS_B64: b64('acmehealth'),
+  });
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /--min-corpus/);
+});
+
+test("this repository's own prose passes every surface", () => {
+  const prose = execFileSync('cat', [PROSE], { encoding: 'utf8' });
+  const dir = surfaceDir({ body: prose, messages: prose, title: prose });
+  const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /clean/);
+});
+
+// ---------------------------------------------------------------------------
+// The must-pass corpus is what it claims to be
+// ---------------------------------------------------------------------------
+
+test('every must-pass line is real prose from a tracked file', () => {
+  // The corpus is only evidence if it is the repository's own writing. Invented
+  // near-misses drift towards what the author imagines the pattern does, and a
+  // corpus of those proves nothing about the documentation a false positive
+  // would actually fire on.
+  const lines = corpusLines(execFileSync('cat', [PROSE], { encoding: 'utf8' }));
+  assert.ok(lines.length >= 20, `expected a corpus worth having, got ${lines.length} lines`);
+
+  const missing = lines.filter((line) => {
+    try {
+      execFileSync('git', ['grep', '-qF', '--', line], {
+        cwd: path.join(import.meta.dirname, '..', '..'),
+        stdio: 'ignore',
+      });
+      return false;
+    } catch {
+      return true;
+    }
+  });
+  assert.deepEqual(missing, [], 'these corpus lines appear in no tracked file');
+});

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -845,6 +845,33 @@ test('a directory that does not exist exits 2 and names the DIRECTORY', () => {
   assert.doesNotMatch(result.stderr, /Cannot read the '\w+' surface/u);
 });
 
+test('scan refuses a pattern outside PATTERN_SHAPE, without needing selftest first', () => {
+  // The shape is what keeps this expression free of the nested quantifiers that
+  // backtrack exponentially over pull-request text. In the workflow `selftest`
+  // runs first and would already be red - but that is an ORDER OF STEPS in
+  // another file, and a property held by step order is held by nothing this
+  // file can assert. So `scan` refuses on its own.
+  //
+  // The surfaces are clean and would scan to exit 0, so a green here would mean
+  // the unconstrained pattern RAN. The control below is the same directory with
+  // an in-shape pattern.
+  const dir = surfaceDir({ title: 'a harmless title' });
+
+  const refused = run(['scan', '--dir', dir], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64('(a+)+b'),
+  });
+  assert.equal(refused.code, 2, 'a catastrophic pattern must not reach the scan');
+  assert.match(refused.stderr, /plain alternation of literal words/);
+  // Never the pattern itself, for the same reason the failed-compile path
+  // reports only the error name.
+  assert.doesNotMatch(refused.stderr, /\(a\+\)\+b/u);
+
+  const control = run(['scan', '--dir', dir], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+  });
+  assert.equal(control.code, 0, 'control: the same directory scans clean in shape');
+});
+
 test('a surface that is a SYMLINK exits 2 rather than being followed', () => {
   // `readFileSync` follows links, so without the `lstat` check this run reads
   // the link's target, finds nothing in it, and exits 0 with


### PR DESCRIPTION
## Update at `499779bb1` — the trigger changed, and the approval before it is stale

`actions/untrusted-checkout/high` (CodeQL alert 1354) fired on the head fetch under `pull_request_target`, and the answer here is the same one the sibling repository reached an hour earlier: **move to `pull_request` and let the trigger hold the property the header was holding in prose.**

Be accurate about what was wrong. The head was never checked out and never ran, so `later potential execution` is the heuristic's assumption and not a fact about this file — nothing was leaking. What was true is that the guarantee was a paragraph asking the next editor not to add a step, and one such step would hand a fork the secret.

**Measured, not assumed, that this clears it.** The sibling's merged copy of this same workflow, under `pull_request`, was analysed by the same CodeQL pack at its merge commit: `/language:actions`, `results_count: 0`. That repository has zero `actions/` alerts in any state, and its `codeql.yml` analyses `actions` — so the zero is a result and not an unindexed language.

### The fork trade, made again on this repository's numbers

The sibling's header makes this trade and then explicitly refuses to let it travel: red-on-fork is free there because it has never had a fork pull request, and it says in the same breath that its answer is not evidence about this repository. It is not. Counted here over all 1,601 pull requests:

```
596 from a fork, 536 merged        a third of the merged work, 22 named external authors
monthly 2026-01..08               54  15  32  11  17  36  28  4
most recent fork pull request     #2219, 2026-08-16
```

Historically expensive, currently near zero, and the two halves point opposite ways. What settles it is a third fact: **`No named external product` is not a required status check on either branch** — `dev` requires `CI Required` and `Supply Chain Required`, `main` requires `Only dev may merge into main`. A fork gets a visible red that reports honestly and blocks nothing. The header records when that stops being true: adding this context to a ruleset turns red-on-fork into a merge block on a third of this repository's merged history.

### The three scanner findings, and one of them has no test

| finding | change | mutation |
| --- | --- | --- |
| Aikido medium ×2, file inclusion | the surface read takes constants after a `chdir` instead of a path joined from `--dir` | **stays green** — see below |
| Aikido low, unbounded backtracking | `PATTERN_SHAPE` constrains the pattern to a plain alternation of literal words | 7 tests red |
| — | a surface that is a symlink is exit 2, not followed | `a surface that is a SYMLINK exits 2 rather than being followed` |

**The file-inclusion fix is behaviourally unfalsifiable and should be described as such.** Reverting it to `readFileSync(path.join(root, surface))` breaks no test, because the behaviour is identical — the surface names were always constants from `SURFACES`, and the finding is about a taint rule counting parameter hops rather than about a reachable read. Its only evidence is a scanner verdict. The neighbouring pull request on this repository removed two guards this hour for exactly this property, so it is worth being explicit that this one is kept for a different reason: it is not a guard, it is the shape the rule can see.

Also ported, each on its own merit rather than to clear a finding:

- `--diff-filter=ACMRT`. A file replaced by a **symlink** is a type change: without `T` the path is not new, so it never reaches `names`, its content never reaches `diff`, and the run is green having looked at neither. The symlink target is the term.
- the `scanned` receipt keys on what the script printed, not on how it exited — a clean exit is not a scan.
- the entry-point comparison uses `realpath` on both sides, so the script reached through a linked path cannot exit 0 having run nothing.

Two claims in the ported header were measurements of the sibling's tree and are re-anchored rather than carried over: the pull-request files API count is attributed to it and explicitly not re-measured here, and the `.gitattributes` precondition is checked against **this** repository, which carries twelve `binary` macros the sibling does not.

### What this run of the gate will do, predicted before it runs

Under `pull_request` the workflow now triggers from the head, so **the gate finally runs on its own pull request — and it will be red at `Preconditions`**, naming both causes: the guard's three files are not on the base branch, and neither secret exists. That is the designed report for a guard that cannot run, and it is the same red the sibling saw on all ten of its runs.

### Second commit `dc86b7b5d` — the shape is enforced in `scan`, not only in `selftest`

Aikido's remaining LOW is the unconstrained-backtracking one, and the honest state of it before this commit was: `PATTERN_SHAPE` closes it, but only because the workflow runs `Self-test` before `Scan every surface`. **A property held by an order of steps in another file is held by nothing this script can assert** — which is the same shape as the header paragraph this branch just replaced with a trigger. `scan` now refuses an out-of-shape pattern itself, with a control on the same directory so a green cannot mean the surfaces were unreadable.

Deliberate divergence from the sibling, whose copy has the predicate only in `selfTest`. It belongs in both.

### Verification

```
node --test scripts/ci/forbidden-terms.test.mjs     59 pass  0 fail
prettier --check on all three files                 clean
mutations, each landing once and reddening only its own test
  --diff-filter=ACMRT -> ACMR                       not ok 56
  pull_request -> pull_request_target               not ok 55
  an if: on the refusal step                        not ok 57
  drop the lstat symlink check                      not ok 49
  disable PATTERN_SHAPE                             not ok 30, 31, 32, 33 (+3)
  revert the chdir/constant read                    GREEN — reported above
  disable the scan-side shape refusal                not ok 49
restored                                            59 pass  0 fail
```

Scanner delta measured at `499779bb1`, before the second commit:

```
Analyze (actions)      completed/success      alert 1354 gone from refs/pull/2727/merge
                       the only open alerts left on that ref are six pre-existing
                       dependency rows in node_modules and pnpm-lock, none of them
                       actions/ and none introduced here
Aikido                 2 MEDIUM + 2 LOW  ->  1 new LOW
                       both file-inclusion mediums cleared
No named external      RED at Preconditions, exactly as predicted, naming both causes
```

Aikido posts **no inline comment and no check annotation** for the remaining LOW on this head — it is enumerated only in its own dashboard. Its `No issues were solved` line is also wrong on this scan, since two mediums demonstrably went away, so the count going `2M+2L -> 1L` is the evidence and its solved-counter is not.

The approval at `294311124` predates all of this and `dev` dismisses stale reviews on push, so this needs a fresh review from someone who is not me.

---

## Do not merge until two repository secrets exist

`FORBIDDEN_TERMS_PATTERN_B64` and `FORBIDDEN_TERMS_CORPUS_B64`, on this repository. The job is designed to go **red** when either is absent — that is the whole point — so merging it before they are created turns every open pull request red.

Neither is a credential; a leak costs the confidentiality of a word list. But they are secrets on a public repository and creating them is not an agent's call.

The sibling pull request on this organisation's other public repository is waiting on the same two secrets. **The two are one control**, holding one pattern that covers both products' prior art, and the reason both exist is that a control present on one of two public repositories invites exactly the mistake it prevents.

## Why this is not "fix the hook again"

Prior art may be studied freely; the source may never be **named** — in code, comments, tests, fixtures, docs, commit messages, branch names, or pull-request text. Until now that was enforced by a git hook on three laptops.

A hook on a laptop is a reminder, not a gate. Any pnpm command that runs the `prepare` lifecycle script rewrites `core.hooksPath` for the whole clone — one value per repository, read by every worktree — and the out-of-tree guard is disarmed until somebody notices. Reproduced again while building this branch:

```
hooks before: <out-of-tree guard>
hooks after:  .husky/_
```

`pnpm install` does it. So does `pnpm --filter=… --prod --legacy deploy`, which nobody would think to check after. Ten sightings in a single day, one of which reached a commit, and four other ways the local chain was found failing open — every one silent, every one found by accident while doing something else.

The hooks stay. They are good at stopping you pushing something you would then have to rewrite history for. They stop being the thing we rely on.

## What it checks

| surface | local hook | this job |
| --- | --- | --- |
| added lines in the diff | yes | yes |
| file names | yes | yes |
| commit messages | yes | yes, whole range |
| branch name | yes | yes |
| **pull-request title** | **no — never passes through a git hook** | **yes** |
| **pull-request body** | **no — same** | **yes** |

Still uncovered, and named so nobody assumes otherwise: issue bodies, issue comments, review comments, and `gh pr edit` outside a re-trigger.

## Why `pull_request_target`, and the constraint that makes it safe

The pattern *is* the list it exists to withhold, so it has to be a secret. GitHub deliberately withholds secrets from a `pull_request` run triggered by a **fork** — precisely the contribution with no local hook behind it. Under `pull_request` the pattern would be empty exactly where it is needed most, and an empty pattern is not a no-op: one formulation matches every line and another matches none, so it either fails every pull request or passes every one silently.

`pull_request_target` carries secrets. It is safe **only** because of what this job does and does not do:

- it checks out the **base** repository, so the guard, its tests and the corpus are the reviewed versions rather than whatever the pull request says they are
- it reads the head **as data**, through `refs/pull/<n>/head` in the base repository
- it runs no install, no build, no head-provided script, no action pinned by the head
- it greps, and it exits

**This repository has no workflow-security audit, so that acceptance is recorded in the workflow header rather than in a tool's allowlist**, together with the condition that voids it: any step that executes code, an action or a script coming from the head. That is the difference a reviewer should check hardest here, because nothing mechanical will check it for you. Run locally for evidence rather than assurance: `zizmor --persona=pedantic --min-severity=low` reports exactly one finding on this file, `dangerous-triggers`, and nothing else — no template injection, no credential persistence. Every payload value reaches the shell through `env:`.

## The job asserts itself before it asserts anything about the diff

`selftest` checks that the pattern compiles, catches every known positive, stays silent on this repository's own prose, and that the corpus is not short. `--min-corpus 6` is written in the workflow **in the clear**: a number is not a word list, and it turns "the secret lost half its entries" from silent into red.

Rehearsed with a synthetic pattern against this repository's real corpus:

| state | result |
| --- | --- |
| armed | exit 0 — `6 known positives all matched, 25 lines of this repository's own prose all clean` |
| corpus truncated to 2 | **exit 2** — `fewer than the 6 this workflow expects` |
| pattern widened to `open[ -]?[a-z]+` | **exit 2** — trips 21 of the 25 lines of our own documentation |

A false positive is therefore a corpus bug with a fix and a test, rather than an argument about loosening the control.

**Exit 0 clean, exit 1 found, exit 2 could not run.** A caller that treats 2 as clean has reintroduced the failure this replaces.

## A finding says where and never what

A public run log is a published artifact in a way a terminal is not, so a guard whose failure output is the list of terms is worse than no guard. Findings carry a surface, a file and a line; the matched text is dropped where the finding is built rather than where it is printed.

## What is a port and what is a copy

The guard and its tests are the **same file** in both repositories, deliberately. What differs, and why:

- **the must-pass corpus is this repository's own prose** — 25 lines from `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, the app READMEs and the agent skills, each copied verbatim, with a test asserting every one appears in a tracked file
- **the workflow is written against this repository's conventions**, not copied: there is no zizmor gate here, so the acceptance lives in the header
- `scripts/ci/*.test.mjs` is already globbed by `test:scripts`, so no wiring was needed

## The defect I found while porting, now fixed in both

The corpus test asserted every line appears verbatim in a tracked file — **and the corpus file is a tracked file.** So every line proved its own presence: appending a sentence that appears nowhere else in the repository left all 26 cases green. The assertion was satisfied by the very document it exists to check.

Fixed with a pathspec excluding the corpus from its own search. Mutation red in both repositories now: `these corpus lines appear in no tracked file`.

## Evidence at `1cd1b15`

`git rev-parse HEAD` read before and after, tree clean:

- `node --test scripts/ci/forbidden-terms.test.mjs` — **26 pass, 0 fail**
- `pnpm run test:scripts` — 28 suites, **317 pass, 0 fail** (this file is picked up by the existing glob)
- `actionlint` on the workflow — exit 0
- `prettier --check` on all four new files — clean
- eslint `--max-warnings=0` on both `.mjs` files — exit 0, via lint-staged at commit

**One thing I did not make green and am not claiming:** `pnpm run format:check` exits 1 on this branch, and it does so on `dev` too — 428 files, all under `packages/types` and elsewhere I have not touched. `format:check` is not part of `verify`, which is why it has drifted. Not this pull request's to fix; saying it so the number is not a surprise.

