### PR TITLE
test(mobile): pin the SegmentedControl selected-state border

### DIFF
--- a/apps/mobileAppYC/__tests__/components/common/SegmentedControl.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/common/SegmentedControl.test.tsx
@@ -48,6 +48,43 @@ describe('SegmentedControl', () => {
     );
   });
 
+  // The selected state is carried by the border, not by the fill. The
+  // component's own note records why: screen and inset are near-identical, so
+  // the background alone conveys nothing, and the card shadow that used to
+  // carry it does not read on a dark ground. Deleting borderWidth and
+  // borderColor from segmentActive left this suite, PreferencesScreen and
+  // Step5Screen all green at 37/37 - the accessibility fix shipped without
+  // anything that would notice it going away.
+  //
+  // borderColor is compared against the mock theme's own token rather than a
+  // literal, and the token is in the mock for this assertion to mean anything:
+  // without it both sides are undefined and the check passes on a component
+  // that names no colour at all.
+  it('carries the selected state on the border, not only the fill', () => {
+    const {getByTestId} = render(
+      <SegmentedControl
+        testID="seg"
+        options={options}
+        value="upcoming"
+        onChange={jest.fn()}
+      />,
+    );
+    const activeStyle = StyleSheet.flatten(
+      getByTestId('seg-upcoming').props.style,
+    );
+    const inactiveStyle = StyleSheet.flatten(
+      getByTestId('seg-past').props.style,
+    );
+
+    expect(activeStyle.borderWidth).toBe(1);
+    expect(activeStyle.borderColor).toBe(
+      mockTheme.colors.segmentSelectedBorder,
+    );
+    expect(mockTheme.colors.segmentSelectedBorder).toBeDefined();
+    expect(inactiveStyle.borderWidth).toBeUndefined();
+    expect(inactiveStyle.borderColor).toBeUndefined();
+  });
+
   it('fires onChange with the tapped value', () => {
     const onChange = jest.fn();
     const {getByTestId} = render(

--- a/apps/mobileAppYC/__tests__/setup/mockTheme.ts
+++ b/apps/mobileAppYC/__tests__/setup/mockTheme.ts
@@ -593,6 +593,7 @@ export const createMockTheme = () => ({
     hairline: '#E5DCCF',
     controlBorder: '#977F62',
     hairlineHover: '#D6D1CD',
+    segmentSelectedBorder: '#837D76',
     divider: '#D6D1CD',
     ink: '#1D1C1B',
     inkBody: '#302F2E',


### PR DESCRIPTION
Recovers the content of an orphaned branch from the retired graphloop
(`0dd8c84b6`), whose commits exist on no remote. **Written fresh, not
cherry-picked** — the component has since moved to
`src/shared/components/common/SegmentedControl/` and the original patch does not
apply.

## The gap, reproduced before writing anything

The border and the `segmentSelectedBorder` token are already on `dev`. Nothing
protects them. Deleting `borderWidth` and `borderColor` from `segmentActive` on
`origin/dev` leaves every suite that renders the component green:

```
SegmentedControl.test.tsx + PreferencesScreen.test.tsx + Step5Screen.test.tsx
  -> 3 suites, 37 passed, 0 failed
```

So the accessibility fix could be removed by a tidy-up and no gate would say so.
`accessibilityState.selected` is already set and asserted on both segments, so
the exposure is purely visual — the kind a unit test can hold and a reader
cannot.

## Why the border rather than the fill

The component's own note records it: `screen` and `inset` are near-identical, so
the background conveys nothing on its own, and the card shadow that used to
carry the selected state does not read on a dark ground.

**This PR pins the border that exists; it does not adjudicate whether it is the
right border.** The contrast question the original branch raised is a design
question and stays open.

## The mock theme token is not cosmetic

Without it the assertion is vacuous. `theme.colors.segmentSelectedBorder`
resolves to `undefined` on the component *and*
`mockTheme.colors.segmentSelectedBorder` is `undefined`, so comparing them
passes on a component that names no colour at all. The explicit
`toBeDefined()` is what turns that into a failure, and the last mutation below
is what proves the line is load-bearing rather than decorative.

## Mutations

Assert-uniqueness harness, each reverted before the next, the harness refused
none, baseline and restore both **38/38** across the three suites:

| Mutation | Result |
|---|---|
| delete the border from `segmentActive` | 37 passed, **1 failed** |
| point `borderColor` at a different token | 37 passed, **1 failed** |
| `borderWidth: 1` → `0` | 37 passed, **1 failed** |
| remove `segmentSelectedBorder` from `mockTheme` | 37 passed, **1 failed** |

Without the `toBeDefined()` line the last row is green — both sides of the
`borderColor` comparison become `undefined` together.

## Gates

| Command | Result |
|---|---|
| `jest` (the three suites) | **exit 0** — 38/38 |
| `turbo run lint type-check --filter=mobileAppYC --force` | **exit 0** — 4/4 |

`git rev-parse HEAD` confirmed either side, tree clean, remote head confirmed
with `ls-remote`.

**One note for whoever removes the bundle:** the fetch command in the rescue
instructions uses the short branch name, but the bundles are prefixed
`Yosemite-Crew-loop-`, so `git fetch [redacted: local path]<name>.bundle`
fails with "repository does not exist".
