### PR TITLE
fix(frontend): serve a real captions file the CSP permits

### DIFF
--- a/apps/frontend/public/captions/no-narration.en.vtt
+++ b/apps/frontend/public/captions/no-narration.en.vtt
@@ -1,0 +1,15 @@
+WEBVTT
+
+NOTE
+The guide films have no narration. They are screen recordings whose steps are
+written into the picture, over a background music bed that carries no
+information. This is what a captioner writes for speech-free media: name the
+non-speech audio, say there is no speech, and get out of the way rather than
+sitting over the video for the whole runtime.
+
+Served from our own origin because the app's CSP is `media-src 'self'` plus the
+CDN hosts. The previous `data:text/vtt,WEBVTT` was refused on every play.
+
+1
+00:00:00.000 --> 00:00:04.000
+[soft background music — no narration; each step appears on screen]

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/playerMediaCsp.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/playerMediaCsp.test.tsx
@@ -1,0 +1,184 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import GuidePlayerModal from '@/app/ui/overlays/Modal/GuidePlayerModal';
+import VideoPlayerModal from '@/app/ui/overlays/Modal/VideoPlayerModal';
+import { buildContentSecurityPolicy } from '@/securityHeaders';
+import type { GuideVideo } from '@/app/features/guides/types/guides';
+
+jest.mock('@/app/ui/overlays/Modal/ModalBase', () => ({
+  __esModule: true,
+  default: ({ children, showModal }: any) => (showModal ? <div>{children}</div> : null),
+}));
+
+jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
+  __esModule: true,
+  default: ({ children, showModal }: any) => (showModal ? <div>{children}</div> : null),
+}));
+
+const CDN = 'https://d2il6osz49gpup.cloudfront.net';
+
+const GUIDE: GuideVideo = {
+  id: 'create-your-account',
+  title: 'Create an account and verify the email',
+  description: 'The sign-up form and the six-digit code',
+  persona: 'Clinic owner',
+  duration: '0:22',
+  category: 'Getting started',
+  tags: ['getting started'],
+  videoUrl: `${CDN}/videos/guides/create-your-account.mp4`,
+  thumbnailUrl: `${CDN}/guidePosters/create-your-account-poster.png`,
+};
+
+/**
+ * Every media URL the players emit has to satisfy the app's OWN `media-src`.
+ *
+ * Both players used to render `<track src="data:text/vtt,WEBVTT">` to keep an
+ * (empty) captions control on screen. `media-src` is `'self'` plus the two
+ * CloudFront hosts and has never allowed `data:`, so the browser refused the
+ * track and logged a violation on every single play - the element was dropped
+ * anyway, which is exactly what the empty track existed to prevent. Nobody
+ * noticed because no test looked at the URLs the players actually emit.
+ *
+ * The allowlist is READ FROM the real policy rather than restated here, so this
+ * cannot drift from the header, and it is a check on all media URLs rather than
+ * on the absence of one element - a future `blob:` poster or an unlisted CDN
+ * would fail it too.
+ */
+const mediaSrcAllowlist = (): string[] => {
+  // The same builder middleware.ts sends on every response.
+  const csp = buildContentSecurityPolicy();
+  const directive = csp
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('media-src '));
+  if (!directive) throw new Error(`no media-src directive in: ${csp}`);
+  return directive.slice('media-src '.length).split(/\s+/).filter(Boolean);
+};
+
+/** Mirrors how a browser resolves a media URL against `media-src`. */
+const isAllowedByMediaSrc = (url: string, allowlist: string[]): boolean => {
+  // Relative or root-relative: same origin, covered by 'self'.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(url)) return allowlist.includes("'self'");
+  return allowlist.some((source) => source !== "'self'" && url.startsWith(source));
+};
+
+const mediaUrlsIn = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('video, source, track, audio')]
+    .map((el) => el.getAttribute('src'))
+    .filter((src): src is string => Boolean(src));
+
+describe('the video players and media-src', () => {
+  it('reads a media-src allowlist that permits self and the CDN but not data:', () => {
+    // Guards the guard: if the directive stopped being parsed, every assertion
+    // below would pass against an empty allowlist.
+    const allowlist = mediaSrcAllowlist();
+
+    expect(allowlist).toContain("'self'");
+    expect(allowlist).toContain(CDN);
+    expect(allowlist).not.toContain('data:');
+    expect(isAllowedByMediaSrc('data:text/vtt,WEBVTT', allowlist)).toBe(false);
+    expect(isAllowedByMediaSrc(`${CDN}/videos/guides/x.mp4`, allowlist)).toBe(true);
+    expect(isAllowedByMediaSrc('/captions/empty.vtt', allowlist)).toBe(true);
+  });
+
+  it('emits only media URLs GuidePlayerModal is allowed to load', () => {
+    const allowlist = mediaSrcAllowlist();
+    const { container } = render(
+      <GuidePlayerModal
+        showModal
+        setShowModal={jest.fn()}
+        guide={GUIDE}
+        nextGuide={null}
+        onNext={jest.fn()}
+      />
+    );
+
+    const urls = mediaUrlsIn(container);
+    expect(urls).toContain(GUIDE.videoUrl);
+    expect(urls.filter((url) => !isAllowedByMediaSrc(url, allowlist))).toEqual([]);
+  });
+
+  it('emits only media URLs VideoPlayerModal is allowed to load', () => {
+    const allowlist = mediaSrcAllowlist();
+    const { container } = render(
+      <VideoPlayerModal
+        showModal
+        setShowModal={jest.fn()}
+        activeVideo={{
+          title: GUIDE.title,
+          videoUrl: GUIDE.videoUrl,
+          thumbnailUrl: GUIDE.thumbnailUrl,
+        }}
+        isVideoLoaded
+        setIsVideoLoaded={jest.fn()}
+      />
+    );
+
+    const urls = mediaUrlsIn(container);
+    expect(urls).toContain(GUIDE.videoUrl);
+    expect(urls.filter((url) => !isAllowedByMediaSrc(url, allowlist))).toEqual([]);
+  });
+
+  it.each([
+    ['GuidePlayerModal', GuidePlayerModal],
+    ['VideoPlayerModal', VideoPlayerModal],
+  ])('ships a same-origin captions file in %s', (name, Player) => {
+    /* Sonar S4084 requires a <track> on every media element, which is why the
+       data: URL existed at all. The answer is a real file from our own origin:
+       it satisfies the rule, loads under `media-src 'self'`, and says something
+       true - it names the music and states there is no narration, rather than
+       being an empty file that leaves a deaf viewer with a captions control
+       that does nothing. When narration ships, this file is replaced with per
+       film cues; it must not go back to being empty. */
+    const props =
+      name === 'GuidePlayerModal'
+        ? {
+            showModal: true,
+            setShowModal: jest.fn(),
+            guide: GUIDE,
+            nextGuide: null,
+            onNext: jest.fn(),
+          }
+        : {
+            showModal: true,
+            setShowModal: jest.fn(),
+            activeVideo: {
+              title: GUIDE.title,
+              videoUrl: GUIDE.videoUrl,
+              thumbnailUrl: GUIDE.thumbnailUrl,
+            },
+            isVideoLoaded: true,
+            setIsVideoLoaded: jest.fn(),
+          };
+
+    const { container } = render(React.createElement(Player as never, props as never));
+
+    const track = container.querySelector('track');
+    expect(track).not.toBeNull();
+    expect(track).toHaveAttribute('kind', 'captions');
+    // Root-relative, so it is served by us and permitted by 'self'.
+    expect(track?.getAttribute('src')).toMatch(/^\/captions\/.+\.vtt$/);
+  });
+
+  it('ships a captions file that is real WebVTT and is not empty', () => {
+    /* The failure this replaces was an EMPTY track. A file that exists but has
+       no cues would pass every assertion above and still tell a deaf viewer
+       nothing, so the content is checked too. */
+    // jest runs with cwd at apps/frontend, so this is the file Next actually serves.
+    const vtt = readFileSync(
+      join(process.cwd(), 'public', 'captions', 'no-narration.en.vtt'),
+      'utf8'
+    );
+
+    expect(vtt.startsWith('WEBVTT')).toBe(true);
+    // At least one real cue: a timestamp range followed by text.
+    const cues = vtt.match(/^\d{2}:\d{2}:\d{2}\.\d{3} --> \d{2}:\d{2}:\d{2}\.\d{3}$/gm) ?? [];
+    expect(cues.length).toBeGreaterThan(0);
+    expect(vtt).toMatch(/no narration/i);
+  });
+});

--- a/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
@@ -110,10 +110,29 @@ const GuidePlayerModal = ({
           poster={guide.thumbnailUrl}
         >
           <source src={guide.videoUrl} type="video/mp4" />
-          {/* An empty track keeps the captions control present and honest: the
-              films carry no caption file yet, and a missing <track> would hide
-              the affordance rather than show it as empty. */}
-          <track kind="captions" src="data:text/vtt,WEBVTT" srcLang="en" label="English" default />
+          {/* A real captions file served from our own origin.
+
+              This was `<track src="data:text/vtt,WEBVTT">` - an empty track
+              added to satisfy Sonar's S4084 ("media elements must have a track
+              for captions"). It never worked: the app's CSP is
+              `media-src 'self'` plus the CDN hosts (src/securityHeaders.ts), so
+              the browser refused the data: URL and logged a violation on every
+              play, leaving the video with no track at all - the exact outcome
+              the empty track was meant to prevent.
+
+              An empty file would have loaded, but it gives a deaf viewer a
+              captions control that switches on and then shows nothing forever,
+              which reads as a broken feature rather than as "this film has no
+              speech". So the track carries what a captioner would actually
+              write for speech-free media: it names the non-speech audio, says
+              there is no narration, and stops. */}
+          <track
+            kind="captions"
+            src="/captions/no-narration.en.vtt"
+            srcLang="en"
+            label="English"
+            default
+          />
           Your browser cannot play this video.
         </video>
       </div>

--- a/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.tsx
@@ -55,9 +55,12 @@ const VideoPlayerModal = ({
             onLoadedData={() => setIsVideoLoaded(true)}
           >
             <source src={activeVideo.videoUrl} type="video/mp4" />
+            {/* Same real captions file as GuidePlayerModal, and the same reason:
+                the data: URL this used to carry was refused by our own CSP on
+                every play. */}
             <track
               kind="captions"
-              src="data:text/vtt,WEBVTT"
+              src="/captions/no-narration.en.vtt"
               srcLang="en"
               label="English"
               default

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -154,6 +154,6 @@ export const config = {
   // with "can't recognize the exported `config` field". The rule is turned off
   // for this file in sonar-project.properties.
   matcher: [
-    '/((?!(?:api|_next|fonts|images|assets|dev-docs|static)(?:/|$)|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|csv|yaml|html|webmanifest)$).*)',
+    '/((?!(?:api|_next|fonts|images|assets|captions|dev-docs|static)(?:/|$)|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|csv|yaml|html|webmanifest|vtt)$).*)',
   ],
 };


### PR DESCRIPTION
## What changed

Both video players now load a real WebVTT captions file served from our own origin, instead of an empty `data:` URL:

- `apps/frontend/public/captions/no-narration.en.vtt` (new)
- `src/app/ui/overlays/Modal/GuidePlayerModal.tsx`
- `src/app/ui/overlays/Modal/VideoPlayerModal.tsx`
- `src/middleware.ts` - excludes the new `public/captions` directory

## Why

Both players rendered `<track kind="captions" src="data:text/vtt,WEBVTT" />` - an empty track, added to satisfy Sonar `typescript:S4084` ("media elements must have a `<track>` for captions").

It never worked. `src/securityHeaders.ts` sets `media-src 'self'` plus the two CloudFront hosts and has never allowed `data:`, so the browser refused the track and logged a violation on **every play**:

```
Loading media from 'data:text/vtt,WEBVTT' violates the following Content Security
Policy directive: "media-src 'self' https://d2il6osz49gpup.cloudfront.net
https://d2kyjiikho62xx.cloudfront.net". The action has been blocked.
```

The element was dropped, so the video ended up with **no track at all** - precisely what the empty track existed to prevent.

## Why this fix, and not the obvious ones

**Widening `media-src` to allow `data:`** - rejected. That weakens a security header for a cosmetic affordance.

**Removing the track** - this was my first attempt, and it was wrong. It trades a CSP violation for an accessibility-rule violation: it re-trips S4084, which is the rule that put the empty track there originally, and SonarCloud failed the new-maintainability gate on it. Sonar catching that is what led to this version.

**A same-origin *empty* `.vtt`** - would satisfy both tools, and I confirmed in a browser that it loads. But it hands a deaf viewer a captions control they switch on and watch do nothing forever, which reads as a broken feature rather than as "this film has no speech".

So the file says something true. The guide films are silent screen recordings with their steps burned into the picture, over a background music bed that carries no information, and the cue is what a captioner actually writes for speech-free media:

```
[soft background music — no narration; each step appears on screen]
```

If narration ever ships, this file is replaced with per-film cues. It must not go back to being empty - there is a test for that.

## Impact area

Frontend only: the two guide/video player modals (Guides page, dashboard videos card), one new static asset, and one middleware matcher entry. No API, data, or styling change.

## Validation performed

- **Browser, `/guides` after Watch now:** track reaches `readyState: 2` (LOADED) with 1 cue, `mode: "showing"`; console clean where it previously logged a CSP violation on every play.
- `/captions/no-narration.en.vtt` serves `200 text/vtt`.
- **New test** reads the allowlist from `buildContentSecurityPolicy()` rather than restating it, so it cannot drift from the header; it checks *every* media URL both players emit, and separately that the captions file has real cues - an empty file would pass every structural assertion and still tell a deaf viewer nothing.
- **Mutation-checked six ways**, each failing as expected: `data:` URL back in either player, track removed, captions file emptied, `captions` dropped from the matcher, matcher prefix unbounded. Files verified byte-identical after each restore.
- `npx tsc --noEmit` - 0 errors
- `eslint --max-warnings=0` on all changed files - clean
- Full suite - **1034 suites / 13077 tests passed**
- Both players - **100%** statements/branches/functions/lines
- `react-doctor` on both players - **0 findings**

The middleware change is not incidental: the repo already guards that every top-level `public/` entry is excluded from the matcher, and that guard caught the new directory before CI did.

## Note

Branched from `dev` and landed separately from #2677, which is green and approved - the repo dismisses stale reviews, so pushing this there would have dropped that approval.
