### PR TITLE
fix(ci): POST a body to the smoke boot before cutting over

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -207,12 +207,53 @@ echo "  /health -> $CODE"
 # HTML 404 on a bogus path proves the probe was not just hitting a catch-all.
 echo "  real route : $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/pet-passport/mobile/companion/probe" | head -c 60)"
 echo "  bogus route: $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/definitely-not-a-route" | head -c 30)"
-grep -iE 'ERR_REQUIRE_ESM|Cannot find module|FATAL ERROR' /tmp/api-smoke.log | head -5 || true
+# Every probe above is a GET, so nothing here parses a request body - and a
+# bundle whose body parser is broken answers all of them correctly. #2690 moved
+# `raw-body` across a major with two workspace patches to body-parser for the
+# CommonJS/ESM interop; if that ever stops applying the symptom is
+# `getBody is not a function` on every request CARRYING a body, which is a total
+# write outage that /health reports as 200.
+#
+# POSTed to the path that matches nothing, on purpose: `express.json()` is
+# mounted app-level (app.ts:161) ahead of registerRoutes (:178), so the body is
+# parsed before routing, before auth and before any handler. So this exercises
+# the parser while touching no route, no database and no credentials - and the
+# smoke boot runs against the real database with migrations already applied,
+# which is why "touches nothing" is the requirement.
+#
+# The content-type and the body are both load-bearing. `express.json()` decides
+# by content-type, so a bare `curl -X POST` short-circuits the parser and
+# returns the SAME 404 without ever calling raw-body - a probe that passes
+# whether or not the thing it tests works. Measured on express 4.21.2 with
+# body-parser 1.20.6:
+#
+#   no body, no content-type        -> 404   parser short-circuits
+#   content-type json, valid body   -> 404   read path exercised
+#   content-type json, invalid body -> 400
+#   broken interop, any of the above -> 500
+#
+# Compared for EQUALITY with 404 rather than inequality with 500: a malformed
+# body is a 400 and a hang is the 000 below, and `!= 500` would pass both.
+POST_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+  -X POST -H 'content-type: application/json' -d '{"smoke":true}' \
+  "http://127.0.0.1:$SMOKE_PORT/v1/definitely-not-a-route" || echo 000)"
+echo "  body parse -> $POST_CODE"
+# Reports, never gates - the `|| true` is what makes that true, and it is
+# deliberate: this is a second signal for whoever reads the log, and POST_CODE
+# above is the gate.
+grep -iE 'ERR_REQUIRE_ESM|Cannot find module|FATAL ERROR|getBody is not a function' /tmp/api-smoke.log | head -5 || true
 kill "$SMOKE_PID" 2>/dev/null || true
 SMOKE_PID=""
 sleep 2
 if [ "$CODE" != "200" ]; then
   echo "smoke boot failed - NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  exit 1
+fi
+
+if [ "$POST_CODE" != "404" ]; then
+  echo "smoke boot could not parse a request body ($POST_CODE, expected 404)" >&2
+  echo "- every GET probe passes a bundle that 500s on every write." >&2
+  echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
   exit 1
 fi
 

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -686,6 +686,63 @@ fi
 # against the real function, so this pins the call site and nothing else - which
 # is the smallest seam available, since no test can run api-deploy.sh itself.
 
+# ---------------------------------------------------------------------------
+# The pre-cutover body-parse probe (#2712).
+#
+# Source-level, and that is the right tool here rather than a compromise: what
+# is being pinned IS the text of a curl invocation in a script no test can run.
+# The failure modes are all in the invocation, so a decision function extracted
+# from it would pin none of them.
+#
+# Each assertion below names a way the probe can be present and prove nothing,
+# and each one is mutation-tested in the commit that added it.
+# ---------------------------------------------------------------------------
+POST_PROBE_LINE="$(line_of 'POST_CODE=')"
+# The literal dollar is escaped in double quotes rather than written inside
+# single ones, for the same reason STAMP_TOKEN is above: `'"'"'$POST_CODE'"'"'` is an
+# expansion that deliberately will not happen, which is what SC2016 warns about.
+POST_CODE_TOKEN="\$POST_CODE"
+POST_GATE_LINE="$(line_of "\"${POST_CODE_TOKEN}\" != \"404\"")"
+CUTOVER_LINE="$(line_of 'say "cutover"')"
+
+# Scoped to the probe's own lines, not to the file. Grepping the whole script
+# for `|| echo 000` passes on /health's probe, which has one - so deleting the
+# fallback from THIS probe left the check green. Found by mutating it, and it is
+# the same defect as a grep matching the comment above the line it pins: a check
+# satisfied by something other than the thing it is about.
+POST_PROBE="$(sed -n '/^POST_CODE=/,/)"$/p' "$DEPLOY_SH")"
+
+probe_has() { # probe_has <label> <fixed-string>
+  if printf '%s' "$POST_PROBE" | grep -qF -- "$2"; then
+    ok "the body-parse probe $1"
+  else
+    no "the body-parse probe $1" "not found in the probe: $2"
+  fi
+}
+
+# A bare `-X POST` returns the same 404 as a healthy one while short-circuiting
+# express.json() entirely, because the parser dispatches on content-type. The
+# probe would then pass whether or not raw-body works.
+probe_has "sends a content type" "content-type: application/json"
+probe_has "sends a body" "-d '{\"smoke\":true}'"
+# A probe whose status is printed rather than captured cannot fail a deploy -
+# which is what the other two route probes in that section do - and one with no
+# fallback reports an empty string on a hang, which is not 404 but is also not
+# a code anyone can read.
+probe_has "captures a status code" "%{http_code}"
+probe_has "falls back to 000 on a hang" "|| echo 000"
+
+# Equality with 404, not inequality with 500: a malformed body is a 400 and a
+# hang is 000, and `!= 500` would let both through.
+if [ -n "$POST_GATE_LINE" ] && [ -n "$POST_PROBE_LINE" ] && [ -n "$CUTOVER_LINE" ] \
+   && [ "$POST_PROBE_LINE" -lt "$POST_GATE_LINE" ] \
+   && [ "$POST_GATE_LINE" -lt "$CUTOVER_LINE" ]; then
+  ok "the body-parse verdict is checked for equality, before the cutover"
+else
+  no "the body-parse verdict is checked for equality, before the cutover" \
+     "probe=$POST_PROBE_LINE gate=$POST_GATE_LINE cutover=$CUTOVER_LINE"
+fi
+
 if grep -q 'trap - EXIT' "$DEPLOY_SH"; then
   no "api-deploy.sh keeps one exit handler" "it disarms the EXIT trap somewhere"
 else


### PR DESCRIPTION
Closes #2712.

## The gap

Every pre-cutover probe was a GET, so a bundle whose body parser is broken
answers all of them correctly and the deploy cuts over. #2690 moved `raw-body`
across a major with two workspace patches to `body-parser` for the CommonJS/ESM
interop; if that ever stops applying, the symptom is `getBody is not a function`
on every request **carrying a body** — a total write outage that `/health`
reports as 200.

## Why this route

`express.json()` is mounted **app-level** at `apps/backend/src/app.ts:161` and
`registerRoutes(app)` is at `:178`, so the body is parsed **before** routing,
auth and any handler. POSTing to the path that matches nothing therefore
exercises the parser while touching no route, no database and no credentials —
which matters because the smoke boot runs against the real database with
migrations already applied.

## The way this probe would have been useless

`express.json()` dispatches on **content-type**, so a bare `curl -X POST`
short-circuits the parser and returns the **same 404** without ever calling
`raw-body`. Measured on express 4.21.2 / body-parser 1.20.6:

| request | status |
|---|---|
| no body, no content-type | 404 — **parser short-circuits** |
| content-type json, empty body | 404 — read path exercised |
| content-type json, invalid json | 400 |
| content-type json, valid json | 404 |
| broken interop, any of the above | 500 |

Rows one and four are the same status code and only one proves anything, so the
content-type header and the `-d` body are both load-bearing.

The invalid-JSON row's `SyntaxError` stack runs
`body-parser@1.20.6_patch_hash=…/lib/read.js` → `raw-body@4.0.0/dist/index.js`,
so the probe demonstrably reaches the patched pair rather than some other
resolution of `raw-body`.

**Equality with 404, not inequality with 500**: a malformed body is a 400 and a
hang is the `000` fallback, and `!= 500` passes both.

## The part that changes the issue's proposed fix

The other two route probes in that section **print** their response and nothing
compares it, and the smoke-log grep ends in `|| true`. Before this commit
**only `/health`'s status code could stop a cutover** — so a probe added
"alongside the existing GETs" in the same style would have been a fourth line
nobody checks, which is the shape the issue opens with. This one is captured and
joins the `if`.

`getBody is not a function` is added to the log grep as a second signal, with a
comment saying plainly that the line reports and does not gate.

## The checks, and one of them was green

Source-level, and that is the right tool rather than a compromise here: what is
pinned **is** the text of a curl invocation in a script no test can run, so a
decision function extracted from it would pin none of the failure modes.

They are scoped to the probe's own lines rather than to the file. Grepping the
whole script for `|| echo 000` passes on `/health`'s probe, which has one — so
deleting the fallback from *this* probe left the suite green. Found by mutating
it, and it is the same defect as a grep matching the comment above the line it
pins: a check satisfied by something other than the thing it is about.

| Mutation | Result |
|---|---|
| drop the content-type header | 45 passed, **1 failed** |
| drop the `-d` body (bare `-X POST`) | 45 passed, **1 failed** |
| drop the `\|\| echo 000` fallback | 45 passed, **1 failed** — **green before scoping** |
| gate on `!= 500` instead of `!= 404` | 45 passed, **1 failed** |
| print the probe instead of capturing it | 41 passed, **5 failed** |

Assert-uniqueness harness, each reverted before the next, the harness refused
none, baseline and restore both **46/46**.

## Gates at `cf65d7f4e`

| Command | Result |
|---|---|
| `tests/migrate.test.sh` | **exit 0** — 46/46 |
| `tests/git-sync.test.sh` | exit 0 — 16/16 |
| `scripts/ci/classify-migration.test.mjs` | exit 0 |
| `shellcheck --severity=warning -x` | **exit 0** |
| `shellcheck -x` (plain) | exit 1 — findings profile **identical to `origin/dev`** |

## Not verified

The deployed bundle's own module resolution. The 500 row is the error path
raised inside the parsing middleware rather than a real interop break — faithful
because the real failure throws synchronously there and Express forwards it the
same way, and nothing in `apps/backend/src` intercepts except the SuperTokens
handler, which forwards non-SuperTokens errors. That last point is checked, not
assumed.
