### PR TITLE
fix(ci): teach the migration gate that access is a way to break deployed code

### DIFF
--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -257,8 +257,17 @@ const addColumnClauses = (upper) => upper.split('ADD COLUMN').slice(1);
  *                                    flagged.
  *   ALTER DEFAULT PRIVILEGES       - governs objects created later. It cannot
  *                                    change what the deployed code reads today.
+ *
+ * Those four are safe by PostgreSQL's own semantics. One more is excluded on a
+ * weaker footing and the difference is worth keeping visible:
+ *
  *   SECURITY LABEL                 - does nothing without a label provider, and
- *                                    none is configured on this database.
+ *                                    none is configured on this database. That
+ *                                    is a fact about this deployment with
+ *                                    nothing in this repository pinning it -
+ *                                    the same footing as the premise under the
+ *                                    ENABLE rule, not the same as the four
+ *                                    above. Raised by ankit-yc on #2731.
  *
  * These read the same normalised statement text as the rules above, so they
  * inherit that machinery exactly: a hazard word in a comment is not a hazard,
@@ -286,7 +295,12 @@ const ACCESS_RULES = [
   {
     dimension: 'access',
     kind: 'changes an object owner',
-    test: (u) => /\bOWNER TO\b/.test(u),
+    // REASSIGN OWNED BY is OWNER TO applied to every object a role owns, in one
+    // statement - and on this database that is the single statement that takes
+    // all eleven row-level-security tables out of the API's sight at once,
+    // because every one of them rests on the owner bypass. Its sibling in the
+    // same command family, DROP OWNED BY, is already below.
+    test: (u) => /\bOWNER TO\b/.test(u) || u.includes('REASSIGN OWNED BY'),
   },
   {
     dimension: 'access',
@@ -304,7 +318,12 @@ const ACCESS_RULES = [
   {
     dimension: 'access',
     kind: 'removes a role or its ability to connect',
-    test: (u) => u.includes('DROP ROLE') || (u.includes('ALTER ROLE') && u.includes('NOLOGIN')),
+    // CONNECTION LIMIT 0 denies every new connection as completely as NOLOGIN
+    // does. Anchored on the zero: a positive limit is a cap, and -1 is the
+    // default meaning no limit at all.
+    test: (u) =>
+      u.includes('DROP ROLE') ||
+      (u.includes('ALTER ROLE') && (u.includes('NOLOGIN') || /\bCONNECTION LIMIT 0\b/.test(u))),
   },
 ];
 
@@ -332,6 +351,13 @@ const RULES = [
   {
     kind: 'adds a required column with no default',
     test: (u) => addColumnClauses(u).some((c) => c.includes('NOT NULL') && !c.includes('DEFAULT')),
+  },
+  {
+    // Not an access change - the object still exists and the grants are
+    // unchanged - but a deployed query naming it unqualified stops resolving,
+    // which is the same break by a different route.
+    kind: 'moves an object to another schema',
+    test: (u) => u.includes('SET SCHEMA'),
   },
   ...ACCESS_RULES,
 ];

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -291,7 +291,18 @@ const ACCESS_RULES = [
     test: (u) =>
       u.includes('FORCE ROW LEVEL SECURITY') && !u.includes('NO FORCE ROW LEVEL SECURITY'),
   },
-  { dimension: 'access', kind: 'revokes a privilege', test: (u) => /\bREVOKE\b/.test(u) },
+  {
+    dimension: 'access',
+    kind: 'revokes a privilege',
+    // Except inside ALTER DEFAULT PRIVILEGES, which is excluded below and was
+    // being flagged here anyway: that statement governs objects created later,
+    // so it cannot change what the deployed code reads today whichever verb it
+    // carries. The exclusion comment said so and the rule did not - and the
+    // test written for it used the GRANT form, which this rule was never going
+    // to match, so it agreed with the comment while the code disagreed.
+    // Raised by the Aikido review of #2731.
+    test: (u) => /\bREVOKE\b/.test(u) && !u.includes('ALTER DEFAULT PRIVILEGES'),
+  },
   {
     dimension: 'access',
     kind: 'changes an object owner',

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -257,6 +257,14 @@ const addColumnClauses = (upper) => upper.split('ADD COLUMN').slice(1);
  *                                    flagged.
  *   ALTER DEFAULT PRIVILEGES       - governs objects created later. It cannot
  *                                    change what the deployed code reads today.
+ *   SECURITY LABEL                 - does nothing without a label provider, and
+ *                                    none is configured on this database.
+ *
+ * These read the same normalised statement text as the rules above, so they
+ * inherit that machinery exactly: a hazard word in a comment is not a hazard,
+ * and one inside a string literal is - because a DO block's DDL lives in a
+ * literal, which is the trade stripSqlComments documents. Pinned both ways in
+ * the tests so an access rule cannot quietly diverge from a shape rule.
  */
 const ACCESS_RULES = [
   {

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -321,9 +321,16 @@ const ACCESS_RULES = [
     // CONNECTION LIMIT 0 denies every new connection as completely as NOLOGIN
     // does. Anchored on the zero: a positive limit is a cap, and -1 is the
     // default meaning no limit at all.
+    //
+    // ROLE|USER because they are exact aliases in PostgreSQL rather than near
+    // synonyms - ALTER USER and DROP USER are the same statements - so matching
+    // one spelling is matching half the language. `0+` for the same reason a
+    // word boundary alone is not enough: CONNECTION LIMIT 00 is still zero.
+    // Both raised by ankit-yc on #2731.
     test: (u) =>
-      u.includes('DROP ROLE') ||
-      (u.includes('ALTER ROLE') && (u.includes('NOLOGIN') || /\bCONNECTION LIMIT 0\b/.test(u))),
+      /\bDROP (ROLE|USER)\b/.test(u) ||
+      (/\bALTER (ROLE|USER)\b/.test(u) &&
+        (u.includes('NOLOGIN') || /\bCONNECTION LIMIT 0+\b/.test(u))),
   },
 ];
 

--- a/scripts/ci/classify-migration.mjs
+++ b/scripts/ci/classify-migration.mjs
@@ -217,6 +217,89 @@ const addColumnClauses = (upper) => upper.split('ADD COLUMN').slice(1);
  * ALTER TYPE ... RENAME TO is here: Prisma sends enum values with an explicit
  * cast to the type name, so a deployed client keeps naming the old type.
  */
+/**
+ * The second way a migration breaks deployed code, and the one the rules above
+ * cannot see: it leaves every object exactly as it was and changes who may read
+ * it.
+ *
+ * `ALTER TABLE "X" FORCE ROW LEVEL SECURITY` alters no column, drops nothing and
+ * renames nothing, so every rule above passes it as additive. On a table with no
+ * policies it takes every row out of the running code's sight at the moment it
+ * commits - before the cutover, and permanently if the deploy then stops. That
+ * is precisely the failure this gate exists to stop, arriving through a door it
+ * was not watching.
+ *
+ * CI CANNOT CATCH THESE FOR YOU, WHICH IS WHY THEY ARE HERE. The migration
+ * workflow connects as `postgres`, and a table's owner bypasses row-level
+ * security - so a test that applies one of these and then reads a row passes in
+ * CI whatever it would do in production. A static rule and a written declaration
+ * are the only checks available; there is no dynamic one to fall back on.
+ *
+ * Whether ENABLE alone is survivable turns on which role the API connects as,
+ * and that is recorded nowhere in this repository - `apps/backend/.env.example`
+ * names no database connection variable at all. So it cannot be settled from the
+ * diff, which is exactly the case the declaration is for: the migrations already
+ * doing this assert "the API connects as the owning role" in prose, and this
+ * asks for that assertion in a form a reviewer is shown.
+ *
+ * Deliberately NOT here, because each of these widens access or touches nothing
+ * that exists:
+ *   GRANT                          - adds a privilege.
+ *   DISABLE / NO FORCE ROW LEVEL   - restores the bypass rather than removing it.
+ *     SECURITY                       Both contain a flagged phrase as a
+ *                                    substring, so the tests below anchor on the
+ *                                    negating word rather than searching for the
+ *                                    positive one.
+ *   CREATE POLICY, permissive      - on an RLS table with no policies, a
+ *                                    permissive policy is the difference between
+ *                                    seeing nothing and seeing something. AS
+ *                                    RESTRICTIVE is the narrowing form and IS
+ *                                    flagged.
+ *   ALTER DEFAULT PRIVILEGES       - governs objects created later. It cannot
+ *                                    change what the deployed code reads today.
+ */
+const ACCESS_RULES = [
+  {
+    dimension: 'access',
+    kind: 'enables row-level security',
+    // No guard against DISABLE, deliberately: "DISABLE" does not contain
+    // "ENABLE" as a substring, so the plain match is already exact. NO FORCE
+    // below DOES contain FORCE and therefore needs one - the asymmetry is real
+    // and a guard here would be a branch no mutation could redden.
+    test: (u) => u.includes('ENABLE ROW LEVEL SECURITY'),
+  },
+  {
+    dimension: 'access',
+    kind: 'removes the owner bypass on row-level security',
+    test: (u) =>
+      u.includes('FORCE ROW LEVEL SECURITY') && !u.includes('NO FORCE ROW LEVEL SECURITY'),
+  },
+  { dimension: 'access', kind: 'revokes a privilege', test: (u) => /\bREVOKE\b/.test(u) },
+  {
+    dimension: 'access',
+    kind: 'changes an object owner',
+    test: (u) => /\bOWNER TO\b/.test(u),
+  },
+  {
+    dimension: 'access',
+    kind: 'narrows or removes a row-level policy',
+    test: (u) =>
+      u.includes('DROP POLICY') ||
+      u.includes('ALTER POLICY') ||
+      (u.includes('CREATE POLICY') && u.includes('AS RESTRICTIVE')),
+  },
+  {
+    dimension: 'access',
+    kind: 'drops objects owned by a role',
+    test: (u) => u.includes('DROP OWNED BY'),
+  },
+  {
+    dimension: 'access',
+    kind: 'removes a role or its ability to connect',
+    test: (u) => u.includes('DROP ROLE') || (u.includes('ALTER ROLE') && u.includes('NOLOGIN')),
+  },
+];
+
 const RULES = [
   { kind: 'drops a table', test: (u) => u.includes('DROP TABLE') },
   { kind: 'drops a column', test: (u) => u.includes('DROP COLUMN') },
@@ -242,6 +325,7 @@ const RULES = [
     kind: 'adds a required column with no default',
     test: (u) => addColumnClauses(u).some((c) => c.includes('NOT NULL') && !c.includes('DEFAULT')),
   },
+  ...ACCESS_RULES,
 ];
 
 /**
@@ -255,7 +339,11 @@ export const classifyMigrationSql = (sql) => {
     const upper = normalise(statement);
     for (const rule of RULES) {
       if (rule.test(upper)) {
-        hazards.push({ kind: rule.kind, statement: statement.replace(/\s+/g, ' ').trim() });
+        hazards.push({
+          kind: rule.kind,
+          dimension: rule.dimension ?? 'shape',
+          statement: statement.replace(/\s+/g, ' ').trim(),
+        });
       }
     }
   }
@@ -365,8 +453,17 @@ const main = (paths) => {
     }
 
     failed += 1;
+    // "the schema" is wrong for an access hazard: FORCE ROW LEVEL SECURITY
+    // alters nothing about the schema and takes every row out of the running
+    // code's sight anyway. Naming the right one is what tells the reader which
+    // of the two paragraphs below applies to them.
+    const changes = review.hazards.some((h) => h.dimension === 'access')
+      ? review.hazards.every((h) => h.dimension === 'access')
+        ? 'changes who may read the schema'
+        : 'changes the schema and who may read it'
+      : 'changes the schema';
     console.log(
-      `::error file=${path}::${review.name} changes the schema in a way the deployed code may not survive.`
+      `::error file=${path}::${review.name} ${changes} in a way the deployed code may not survive.`
     );
     console.log(listed);
 
@@ -387,6 +484,16 @@ const main = (paths) => {
     console.log(`    remove the old thing in a later release), or say why no deployed reader`);
     console.log(`    names what this changes, in the migration itself:`);
     console.log(`      -- ${DECLARATION_MARKER} <why the deployed code keeps working>`);
+
+    if (review.hazards.some((h) => h.dimension === 'access')) {
+      console.log(`    An access hazard above changes no column and drops nothing, so the`);
+      console.log(`    expand step does not apply to it - what changes is which rows the`);
+      console.log(`    connecting role can see, at the moment the statement commits.`);
+      console.log(`    NOTE THAT CI CANNOT CHECK THIS ONE FOR YOU: the migration job connects`);
+      console.log(`    as postgres, and a table's owner bypasses row-level security, so a test`);
+      console.log(`    that applies this and reads a row passes here whatever production does.`);
+      console.log(`    Say which role the API connects as and why this leaves its reads intact.`);
+    }
   }
 
   if (failed > 0) {

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -463,3 +463,36 @@ test('access rules inherit the comment and literal handling, unchanged', () => {
 test('SECURITY LABEL is not flagged', () => {
   assert.deepEqual(kinds(`SECURITY LABEL FOR selinux ON TABLE "Appointment" IS 'x';`), []);
 });
+
+// Three statements that mean what a rule above means and did not match it.
+// Raised by ankit-yc reviewing #2731, and each is one entry rather than a new
+// concept - which is the test of whether the dimension is real.
+
+test('REASSIGN OWNED BY is an owner change, in bulk', () => {
+  // OWNER TO applied to every object a role owns. On this database that is the
+  // one statement that takes all eleven row-level-security tables out of the
+  // API's sight at once, since every one rests on the owner bypass.
+  assert.deepEqual(kinds('REASSIGN OWNED BY app_role TO other_role;'), ['changes an object owner']);
+});
+
+test('CONNECTION LIMIT 0 locks a role out; a positive limit does not', () => {
+  assert.deepEqual(kinds('ALTER ROLE app_role CONNECTION LIMIT 0;'), [
+    'removes a role or its ability to connect',
+  ]);
+  // A cap is not a lockout, and -1 is the default meaning no limit at all.
+  assert.deepEqual(kinds('ALTER ROLE app_role CONNECTION LIMIT 10;'), []);
+  assert.deepEqual(kinds('ALTER ROLE app_role CONNECTION LIMIT -1;'), []);
+});
+
+test('moving an object to another schema is a hazard, and a shape one', () => {
+  // The object still exists and its grants are unchanged, so this is not an
+  // access change - but a deployed query naming it unqualified stops resolving.
+  const [hazard] = classifyMigrationSql('ALTER TABLE "X" SET SCHEMA hidden;');
+  assert.equal(hazard.kind, 'moves an object to another schema');
+  assert.equal(hazard.dimension, 'shape');
+  // IN SCHEMA is not SET SCHEMA.
+  assert.deepEqual(
+    kinds('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO r;'),
+    []
+  );
+});

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -375,6 +375,19 @@ test('ALTER DEFAULT PRIVILEGES is not a hazard - it cannot change what is read t
     kinds('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO app_readonly;'),
     []
   );
+  // The REVOKE form is the one that mattered: the GRANT form above agrees with
+  // the exclusion whether or not the exclusion exists, because no rule here
+  // matches GRANT. Only this input can tell the two apart.
+  assert.deepEqual(
+    kinds('ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM PUBLIC;'),
+    []
+  );
+  assert.deepEqual(
+    kinds('ALTER DEFAULT PRIVILEGES FOR ROLE app REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;'),
+    []
+  );
+  // And a plain REVOKE is still a hazard - the exclusion is scoped, not a hole.
+  assert.deepEqual(kinds('REVOKE ALL ON "Appointment" FROM PUBLIC;'), ['revokes a privilege']);
 });
 
 test('access hazards are tagged as such, so the report can name the right thing', () => {

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -388,6 +388,26 @@ test('ALTER DEFAULT PRIVILEGES is not a hazard - it cannot change what is read t
   );
   // And a plain REVOKE is still a hazard - the exclusion is scoped, not a hole.
   assert.deepEqual(kinds('REVOKE ALL ON "Appointment" FROM PUBLIC;'), ['revokes a privilege']);
+
+  // The exclusion is a substring test, so an object name containing the
+  // excluded text is what tells a narrow exclusion from a wide one: widening it
+  // to `ALTER` alone leaves every other case in this test passing and quietly
+  // excuses these two. Raised by ankit-yc on #2731.
+  assert.deepEqual(kinds('REVOKE ALL ON "alter_log" FROM PUBLIC;'), ['revokes a privilege']);
+  assert.deepEqual(kinds('REVOKE ALL ON "altered_records" FROM PUBLIC;'), ['revokes a privilege']);
+
+  // Nor can the exclusion be borrowed from a neighbouring statement or from a
+  // comment: statements are split, and comments are stripped before matching.
+  assert.deepEqual(
+    kinds(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM PUBLIC;\n' +
+        'REVOKE ALL ON "Appointment" FROM PUBLIC;'
+    ),
+    ['revokes a privilege']
+  );
+  assert.deepEqual(kinds('-- ALTER DEFAULT PRIVILEGES\nREVOKE ALL ON "Appointment" FROM PUBLIC;'), [
+    'revokes a privilege',
+  ]);
 });
 
 test('access hazards are tagged as such, so the report can name the right thing', () => {

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -313,3 +313,90 @@ test('every hazard reports the statement that caused it', () => {
   // line in the CI log.
   assert.equal(hazard.statement, 'ALTER TABLE "Invoice" DROP COLUMN "old"');
 });
+
+// The access dimension (#2724). These statements change no object's shape, so
+// every rule above passes them - and on a table with no policies the first one
+// takes every row out of the running code's sight the moment it commits.
+//
+// They are also the hazards CI cannot check dynamically: the migration job
+// connects as `postgres` and a table's owner bypasses row-level security, so a
+// test that applied one of these and read a row would pass here whatever it
+// would do in production. The classification IS the check.
+
+test('forcing row-level security is a hazard, and lifting it is not', () => {
+  assert.deepEqual(kinds('ALTER TABLE "Appointment" FORCE ROW LEVEL SECURITY;'), [
+    'removes the owner bypass on row-level security',
+  ]);
+  // NO FORCE contains FORCE, so a substring search would report the reverse of
+  // what this statement does.
+  assert.deepEqual(kinds('ALTER TABLE "Appointment" NO FORCE ROW LEVEL SECURITY;'), []);
+});
+
+test('enabling row-level security is a hazard, and disabling it is not', () => {
+  assert.deepEqual(kinds('ALTER TABLE "Appointment" ENABLE ROW LEVEL SECURITY;'), [
+    'enables row-level security',
+  ]);
+  assert.deepEqual(kinds('ALTER TABLE "Appointment" DISABLE ROW LEVEL SECURITY;'), []);
+});
+
+test('revoking is a hazard, granting is not', () => {
+  assert.deepEqual(kinds('REVOKE ALL ON "Appointment" FROM PUBLIC;'), ['revokes a privilege']);
+  assert.deepEqual(kinds('GRANT SELECT ON "Appointment" TO app_readonly;'), []);
+});
+
+test('changing an object owner is a hazard - it moves the row-level bypass', () => {
+  assert.deepEqual(kinds('ALTER TABLE "Appointment" OWNER TO app_readonly;'), [
+    'changes an object owner',
+  ]);
+});
+
+test('a restrictive policy narrows and is a hazard; a permissive one does not', () => {
+  assert.deepEqual(kinds('CREATE POLICY tenant ON "Appointment" AS RESTRICTIVE USING (false);'), [
+    'narrows or removes a row-level policy',
+  ]);
+  // On an RLS table with no policies, a permissive policy is the difference
+  // between seeing nothing and seeing something.
+  assert.deepEqual(kinds('CREATE POLICY tenant ON "Appointment" USING (true);'), []);
+  assert.deepEqual(kinds('DROP POLICY tenant ON "Appointment";'), [
+    'narrows or removes a row-level policy',
+  ]);
+});
+
+test('removing a role or what it owns is a hazard', () => {
+  assert.deepEqual(kinds('DROP OWNED BY app_user;'), ['drops objects owned by a role']);
+  assert.deepEqual(kinds('ALTER ROLE app_user NOLOGIN;'), [
+    'removes a role or its ability to connect',
+  ]);
+  assert.deepEqual(kinds('DROP ROLE app_user;'), ['removes a role or its ability to connect']);
+});
+
+test('ALTER DEFAULT PRIVILEGES is not a hazard - it cannot change what is read today', () => {
+  assert.deepEqual(
+    kinds('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO app_readonly;'),
+    []
+  );
+});
+
+test('access hazards are tagged as such, so the report can name the right thing', () => {
+  const [access] = classifyMigrationSql('ALTER TABLE "Appointment" FORCE ROW LEVEL SECURITY;');
+  const [shape] = classifyMigrationSql('ALTER TABLE "Appointment" DROP COLUMN "notes";');
+  assert.equal(access.dimension, 'access');
+  assert.equal(shape.dimension, 'shape');
+});
+
+test('an access hazard needs a declaration like any other', () => {
+  const undeclared = reviewMigration({
+    name: 'm',
+    sql: 'ALTER TABLE "Appointment" ENABLE ROW LEVEL SECURITY;',
+  });
+  assert.equal(undeclared.verdict, 'undeclared');
+
+  const declared = reviewMigration({
+    name: 'm',
+    sql:
+      '-- deployed-code-survives: the API connects as the owning role, which bypasses\n' +
+      '--   row-level security, so its reads are unaffected.\n' +
+      'ALTER TABLE "Appointment" ENABLE ROW LEVEL SECURITY;',
+  });
+  assert.equal(declared.verdict, 'ok');
+});

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -496,3 +496,26 @@ test('moving an object to another schema is a hazard, and a shape one', () => {
     []
   );
 });
+
+// ALTER USER and DROP USER are exact aliases for ALTER ROLE and DROP ROLE in
+// PostgreSQL, not near synonyms, so matching one spelling matches half the
+// language. Raised by ankit-yc reviewing #2731.
+test('the role rule matches the USER spelling too', () => {
+  for (const spelling of ['ROLE', 'USER']) {
+    assert.deepEqual(kinds(`ALTER ${spelling} app_role NOLOGIN;`), [
+      'removes a role or its ability to connect',
+    ]);
+    assert.deepEqual(kinds(`ALTER ${spelling} app_role CONNECTION LIMIT 0;`), [
+      'removes a role or its ability to connect',
+    ]);
+    assert.deepEqual(kinds(`DROP ${spelling} app_role;`), [
+      'removes a role or its ability to connect',
+    ]);
+    // Still a cap rather than a lockout in either spelling.
+    assert.deepEqual(kinds(`ALTER ${spelling} app_role CONNECTION LIMIT 10;`), []);
+  }
+  // A padded zero is still zero; `\b` alone could not see it.
+  assert.deepEqual(kinds('ALTER USER app_role CONNECTION LIMIT 00;'), [
+    'removes a role or its ability to connect',
+  ]);
+});

--- a/scripts/ci/classify-migration.test.mjs
+++ b/scripts/ci/classify-migration.test.mjs
@@ -400,3 +400,66 @@ test('an access hazard needs a declaration like any other', () => {
   });
   assert.equal(declared.verdict, 'ok');
 });
+
+// The access rules are a predicate over SQL text, so what matters is not the
+// seven spellings in the tests above but whether a real migration can say the
+// same thing and slip past. These are the forms this repo's migrations and
+// Prisma actually emit.
+
+test('access rules see through schema qualifiers, case, line breaks and DO blocks', () => {
+  assert.deepEqual(kinds('ALTER TABLE public."Appointment" FORCE ROW LEVEL SECURITY;'), [
+    'removes the owner bypass on row-level security',
+  ]);
+  assert.deepEqual(kinds('alter table "Appointment" enable row level security;'), [
+    'enables row-level security',
+  ]);
+  assert.deepEqual(kinds('ALTER TABLE "Appointment"\n  FORCE ROW LEVEL\n  SECURITY;'), [
+    'removes the owner bypass on row-level security',
+  ]);
+  // DDL executed from a string inside a DO block is why stripSqlComments leaves
+  // literals intact; the access rules inherit that and must not miss it.
+  assert.deepEqual(
+    kinds(`DO $$ BEGIN EXECUTE 'ALTER TABLE "X" FORCE ROW LEVEL SECURITY'; END $$;`),
+    ['removes the owner bypass on row-level security']
+  );
+  assert.deepEqual(kinds('ALTER TABLE IF EXISTS "Appointment" ENABLE ROW LEVEL SECURITY;'), [
+    'enables row-level security',
+  ]);
+});
+
+test('an owner change is caught on any object, not just a table', () => {
+  assert.deepEqual(kinds('ALTER SEQUENCE "Appointment_id_seq" OWNER TO app_user;'), [
+    'changes an object owner',
+  ]);
+  assert.deepEqual(kinds('ALTER VIEW "v" OWNER TO app_user;'), ['changes an object owner']);
+});
+
+test('a wholesale REVOKE is caught', () => {
+  assert.deepEqual(kinds('REVOKE ALL ON ALL TABLES IN SCHEMA public FROM app_readonly;'), [
+    'revokes a privilege',
+  ]);
+});
+
+// Both halves of this are the file's existing trade rather than anything the
+// access rules introduce, and the assertions are paired so they stay that way:
+// comments are stripped, so prose about a hazard is not one; string literals
+// are NOT, because a DO block's DDL lives in one, so a hazard word inside a
+// literal reports. An access rule behaves exactly as a shape rule does here.
+test('access rules inherit the comment and literal handling, unchanged', () => {
+  const inComment = (phrase) => `-- we had to ${phrase}\nALTER TABLE "A" ADD COLUMN "b" TEXT;`;
+  const inLiteral = (phrase) => `INSERT INTO "Audit" ("note") VALUES ('we had to ${phrase}');`;
+
+  assert.deepEqual(kinds(inComment('DROP COLUMN x')), []);
+  assert.deepEqual(kinds(inComment('REVOKE ALL on x')), []);
+
+  assert.deepEqual(kinds(inLiteral('DROP COLUMN x')), ['drops a column']);
+  assert.deepEqual(kinds(inLiteral('REVOKE ALL on x')), ['revokes a privilege']);
+});
+
+// SECURITY LABEL is the one access-adjacent statement not covered, and it is
+// out on purpose: it does nothing without a label provider (selinux, anon) and
+// none is configured on this database. Pinned so that changing the answer is a
+// decision rather than a side effect of widening a pattern.
+test('SECURITY LABEL is not flagged', () => {
+  assert.deepEqual(kinds(`SECURITY LABEL FOR selinux ON TABLE "Appointment" IS 'x';`), []);
+});


### PR DESCRIPTION
Closes #2724.

`classify-migration.mjs` asks whether a migration changes the **shape** of an object. It never asks whether it changes **access** to one, so an entire family of statements came back `additive only`.

Measured, with both controls:

| Statement | before |
|---|---|
| `ALTER TABLE … FORCE ROW LEVEL SECURITY` | `additive only`, exit 0 |
| `ALTER TABLE … ENABLE ROW LEVEL SECURITY` | `additive only`, exit 0 |
| `REVOKE ALL ON … FROM PUBLIC` | `additive only`, exit 0 |
| `ALTER TABLE … OWNER TO` | `additive only`, exit 0 |
| `DROP POLICY` / `DROP OWNED BY` | `additive only`, exit 0 |
| `ALTER ROLE … NOLOGIN` | `additive only`, exit 0 |
| `ALTER TABLE … ADD COLUMN` | `additive only`, exit 0 — **control, correctly passes** |
| `ALTER TABLE … DROP COLUMN` | hazard, exit 1 — **control, correctly fails** |

`FORCE ROW LEVEL SECURITY` is the sharpest of them: it alters no column, drops nothing and renames nothing, and on a table with no policies it takes every row out of the running code's sight at the moment it commits — before the cutover, and permanently if the deploy then stops. That is exactly the failure this gate exists to stop, arriving through a door it was not watching.

## A dimension, not three regexes

Seven rules, tagged `dimension: 'access'`. The gap is not "three statements are missing" — it is that the classifier reasons about objects and never about who may read them, so a patch per statement family would be behind the next statement before it shipped.

**Deliberately not flagged**, each for a reason stated in the file:

- `GRANT` — adds a privilege.
- `DISABLE` / `NO FORCE ROW LEVEL SECURITY` — restore the bypass rather than removing it.
- a **permissive** `CREATE POLICY` — on an RLS table with no policies it is the difference between seeing nothing and seeing something. `AS RESTRICTIVE` is the narrowing form and **is** flagged.
- `ALTER DEFAULT PRIVILEGES` — governs objects created later; it cannot change what the deployed code reads today.

## The report names the right thing

"Changes the schema" is false for an access hazard, so the message is now one of `changes the schema`, `changes who may read the schema`, or `changes the schema and who may read it`.

The guidance for an access hazard adds the fact its reader most needs:

> NOTE THAT CI CANNOT CHECK THIS ONE FOR YOU: the migration job connects as postgres, and a table's owner bypasses row-level security, so a test that applies this and reads a row passes here whatever production does.

That is not a caveat, it is the reason these rules are static. `.github/workflows/_migration.yaml` sets `POSTGRES_USER: postgres` and both `DATABASE_URL` and `DIRECT_URL` to that role, so CI is structurally blind to this class. There is no dynamic check to fall back on; the classification **is** the check. *(Established by Claude L3 in the issue thread.)*

## The premise I could not settle, stated rather than assumed

Whether `ENABLE` alone is survivable turns on which role the API connects as in production. **That is recorded nowhere in this repository** — `apps/backend/.env.example` names 64 keys and not one is a database connection variable. So it cannot be settled from a diff, which is precisely the case the written declaration exists for: the migrations already doing this assert *"the API connects as the owning role"* in prose, and this asks for that assertion in a form a reviewer is shown before approving.

If that assertion is ever found to be wrong, the eleven existing `ENABLE` statements are a live problem and this PR is the smaller half. I could not determine which, and I would rather say so than pick the convenient branch.

## Blast radius, measured

Over all **166** migrations in the repo: **11** carry an access hazard, all of them `ENABLE ROW LEVEL SECURITY`, none declared. There is no `FORCE`, `REVOKE` or `OWNER TO` anywhere in the history.

The gate only ever sees migrations **added** by a pull request (`--diff-filter=A` in `_migration.yaml:153`), so this is prospective and reds nothing already merged.

## Mutations

Nine, through an assert-uniqueness harness, each reverted before the next, harness refused none, baseline and restore both `45 pass / 0 fail`:

| Mutation | Result |
|---|---|
| drop the `NO FORCE` guard | **1 failed** |
| widen `ENABLE` to any `ROW LEVEL SECURITY` statement | **2 failed** |
| `REVOKE` rule also matches `GRANT` | **2 failed** |
| policy rule fires on any `CREATE POLICY` | **1 failed** |
| remove the `OWNER TO` rule | **1 failed** |
| remove the `DROP ROLE` / `NOLOGIN` rule | **1 failed** |
| tag everything as an access hazard | **1 failed** |
| tag nothing, so the report cannot tell them apart | **1 failed** |
| flag `ALTER DEFAULT PRIVILEGES` too | **1 failed** |

**One guard came out because no mutation could redden it.** `DISABLE` does not contain `ENABLE` as a substring, so the plain match was already exact and the guard was dead code — while `NO FORCE` *does* contain `FORCE`, and its guard is proven load-bearing by the first row. The asymmetry is now a comment in the file rather than a symmetric pair of guards, one of which checked nothing.

## Gates

| Command | Result |
|---|---|
| `pnpm run test:scripts` (what `_core.yaml` runs) | **exit 0** — 300 tests, 0 failed |
| `node --test scripts/ci/classify-migration.test.mjs` | exit 0 — 45 pass |
| `turbo run lint --filter=backend --force` | exit 0 — 0 errors, 25 pre-existing warnings |
| `scripts/deploy/tests/migrate.test.sh` | exit 0 — 41/41 |
| `prettier --check` on both files | clean |

`git rev-parse HEAD` confirmed either side; tree clean.
