### PR TITLE
fix(ci): take the rollback sha from the last verified cutover, not from HEAD

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -77,7 +77,7 @@ node -v
 # The commit this box is SERVING, which is not the same question as "what is
 # HEAD". Read from the record written at the last verified cutover, before
 # deploy_git_sync moves the tree - see deploy_deployed_sha for why HEAD alone is
-# wrong on every retry, and why the stamped file two lines below is not the
+# wrong on every retry, and why the stamped file written just below is not the
 # record despite looking exactly like it.
 DEPLOYED_SHA_RECORD="/tmp/api-deployed-sha.txt"
 ROLLBACK_SHA="$(deploy_deployed_sha "$DEPLOYED_SHA_RECORD" "$REPO_DIR")"

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -74,7 +74,13 @@ cd "$REPO_DIR"
 
 say "preflight"
 node -v
-ROLLBACK_SHA="$(git rev-parse HEAD)"
+# The commit this box is SERVING, which is not the same question as "what is
+# HEAD". Read from the record written at the last verified cutover, before
+# deploy_git_sync moves the tree - see deploy_deployed_sha for why HEAD alone is
+# wrong on every retry, and why the stamped file two lines below is not the
+# record despite looking exactly like it.
+DEPLOYED_SHA_RECORD="/tmp/api-deployed-sha.txt"
+ROLLBACK_SHA="$(deploy_deployed_sha "$DEPLOYED_SHA_RECORD" "$REPO_DIR")"
 echo "rollback sha: $ROLLBACK_SHA"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 echo "$ROLLBACK_SHA" > "/tmp/api-rollback-$STAMP.txt"
@@ -271,6 +277,12 @@ ss -ltn 2>/dev/null | grep -q ':8080' \
 # Past here the running process IS the new code, so the schema being ahead of it
 # is no longer true and the notice must stop claiming it.
 CUTOVER_DONE=1
+# The new code is now the thing answering, so this is the first moment it is
+# true that the box serves this commit. Recorded here and nowhere earlier: every
+# step above can still fail, and a record written before the cutover would
+# describe a deploy that did not happen - which is the exact defect that made
+# the preflight file unusable as a record.
+deploy_record_deployed_sha "$DEPLOYED_SHA_RECORD" "$(git -C "$REPO_DIR" rev-parse HEAD)"
 
 say "done"
 echo "deployed $(git -C "$REPO_DIR" rev-parse --short HEAD)  (rollback: $ROLLBACK_SHA)"

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -49,6 +49,89 @@ deploy_incoming_migrations() {
     | sort
 }
 
+# deploy_deployed_sha <record-file> [repo-dir]
+#
+# The commit this box is actually serving, for use as the rollback target and as
+# the `from` of deploy_incoming_migrations. Echoes a sha; never fails.
+#
+# WHY NOT `git rev-parse HEAD`, which is what this replaced. HEAD is the commit
+# the working tree is on, and after deploy_git_sync that is the commit being
+# DEPLOYED, not the one being served. On a first attempt the two coincide,
+# because HEAD is read before the checkout. On a RETRY after any failure at or
+# after the checkout - install, build, migration, smoke boot, cutover - the repo
+# is already on the target, so HEAD reads back the target and two things break
+# at once:
+#
+#   * deploy_incoming_migrations gets from == to and returns EMPTY, so
+#     MIGRATIONS_APPLIED stays 0 and the schema-hazard notice cannot fire while
+#     prisma is re-applying the still-pending migrations, and
+#   * every "roll back to $ROLLBACK_SHA" message names the sha being deployed,
+#     which is not a missing warning but a wrong instruction, printed at the
+#     moment someone is deciding what to do.
+#
+# WHY NOT /tmp/api-rollback-$STAMP.txt, which already exists and looks exactly
+# like this record. It is written in preflight, unconditionally, before anything
+# can fail - so a failed attempt writes one too, carrying the same stale sha.
+# Reading the newest of those rebuilds the defect inside its own fix, and does
+# it silently. The record has to be written on a VERIFIED CUTOVER and nowhere
+# else, which is what deploy_record_deployed_sha is for.
+#
+# Fixed filename rather than stamped, for the same reason: "the newest of the
+# stamped files" is a sort over a directory that also holds every failure.
+#
+# The recorded sha is re-verified against this repository before it is trusted.
+# A box restored from a backup, re-cloned, or carrying a record from a branch
+# that has since been force-pushed would otherwise hand an unresolvable sha to
+# deploy_incoming_migrations, which fails closed and takes the deploy with it.
+# An unusable record is treated as no record.
+deploy_deployed_sha() {
+  local record="${1:?record file required}"
+  local repo="${2:-.}"
+  local recorded=""
+
+  if [ -r "$record" ]; then
+    recorded="$(tr -d " \t\r\n" < "$record")"
+  fi
+
+  if [ -n "$recorded" ] \
+    && git -C "$repo" rev-parse --verify --quiet "$recorded^{commit}" >/dev/null 2>&1
+  then
+    git -C "$repo" rev-parse "$recorded^{commit}"
+    return 0
+  fi
+
+  # No usable record: a first-ever deploy on this box, or one written before
+  # this function existed. HEAD is correct here and ONLY here, because this is
+  # read before the checkout moves it.
+  git -C "$repo" rev-parse HEAD
+}
+
+# deploy_record_deployed_sha <record-file> <sha>
+#
+# Remember what this box is serving, called once the new code is verifiably the
+# thing answering - not before. Everything upstream of the cutover can still
+# fail, and a record written earlier would describe a deploy that never
+# happened, which is the failure this whole pair exists to end.
+#
+# Written to a temporary file and moved into place so a box killed mid-write
+# keeps the previous record rather than a truncated one. A record that cannot be
+# written is reported and does not fail the deploy: the cutover has already
+# succeeded by this point, and losing the deploy over a note about it would be
+# the tail wagging the dog. The cost is a stale record, which
+# deploy_deployed_sha already treats as no record.
+deploy_record_deployed_sha() {
+  local record="${1:?record file required}"
+  local sha="${2:?deployed sha required}"
+
+  if printf '%s\n' "$sha" > "$record.tmp" && mv -f "$record.tmp" "$record"; then
+    return 0
+  fi
+
+  echo "warning: could not record the deployed sha to $record" >&2
+  rm -f "$record.tmp" 2>/dev/null || true
+  return 0
+}
+
 # deploy_arm_exit_traps
 #
 # Installs every trap the deploy needs, in one place, because the arming is as

--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -89,8 +89,23 @@ deploy_deployed_sha() {
   local repo="${2:-.}"
   local recorded=""
 
-  if [ -r "$record" ]; then
+  # -f as well as -r: a directory is readable, and `tr` would put "Is a
+  # directory" on the deploy's stderr on the way to the right answer.
+  if [ -f "$record" ] && [ -r "$record" ]; then
     recorded="$(tr -d " \t\r\n" < "$record")"
+  fi
+
+  # A SHA, not a revision. `git rev-parse --verify` resolves anything git can
+  # name, so a record holding "dev" or "HEAD" would come back as the tip - which
+  # is the commit being DEPLOYED, the exact value this function exists to stop
+  # returning, arriving through the check meant to prevent it. Only reachable
+  # through a corrupted or hand-edited record, which is precisely the case this
+  # function's own comment anticipates. Raised by ankit-yc on #2732.
+  case "$recorded" in
+    *[!0-9a-f]* | "") recorded="" ;;
+  esac
+  if [ "${#recorded}" -lt 7 ]; then
+    recorded=""
   fi
 
   if [ -n "$recorded" ] \

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -813,10 +813,17 @@ fi
 # that no stand-in can exercise, and both are the whole of #2714: reading after
 # deploy_git_sync gets the target sha, and writing before CUTOVER_DONE=1 records
 # a deploy that did not happen.
-READ_LINE="$(line_of 'ROLLBACK_SHA="$(deploy_deployed_sha')"
-SYNC_LINE="$(line_of 'deploy_git_sync "$REPO_DIR"')"
+# The literal dollars are escaped in double quotes rather than written inside
+# single ones, for the same reason STAMP_TOKEN and POST_CODE_TOKEN are above:
+# a single-quoted `$REPO_DIR` is an expansion that deliberately will not happen,
+# which is exactly what SC2016 warns about and cannot be spelled otherwise.
+REPO_DIR_TOKEN="\$REPO_DIR"
+DEPLOYED_SHA_RECORD_TOKEN="\$DEPLOYED_SHA_RECORD"
+DEPLOYED_SHA_CALL_TOKEN="\$(deploy_deployed_sha"
+READ_LINE="$(line_of "ROLLBACK_SHA=\"${DEPLOYED_SHA_CALL_TOKEN}")"
+SYNC_LINE="$(line_of "deploy_git_sync \"${REPO_DIR_TOKEN}\"")"
 CUTOVER_LINE="$(line_of_exact 'CUTOVER_DONE=1')"
-WRITE_LINE="$(line_of 'deploy_record_deployed_sha "$DEPLOYED_SHA_RECORD"')"
+WRITE_LINE="$(line_of "deploy_record_deployed_sha \"${DEPLOYED_SHA_RECORD_TOKEN}\"")"
 
 if [ -n "$READ_LINE" ] && [ -n "$SYNC_LINE" ] && [ "$READ_LINE" -lt "$SYNC_LINE" ]; then
   ok "api-deploy.sh reads the deployed sha before the checkout moves the tree"

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -637,6 +637,71 @@ else
   ok "the deploy still exits non-zero"
 fi
 
+echo
+echo "deploy_deployed_sha"
+
+# The commit the box is SERVING, which stops being HEAD the moment deploy_git_sync
+# runs. Every check below is against a real git history for the same reason the
+# rest of this file is: the failure is a property of what `git rev-parse` answers
+# after a checkout, not of our wrapper.
+REC="$WORK/deployed-sha.txt"
+rm -f "$REC"
+
+check "no record: falls back to HEAD, which is right only before the checkout" \
+  "$(git -C "$REPO" rev-parse HEAD)" \
+  "$(deploy_deployed_sha "$REC" "$REPO")"
+
+deploy_record_deployed_sha "$REC" "$M1"
+check "a recorded sha is used in preference to HEAD" \
+  "$M1" "$(deploy_deployed_sha "$REC" "$REPO")"
+
+# A box restored from a backup, re-cloned, or holding a record from a branch that
+# was force-pushed. The recorded sha resolves nowhere, and handing it to
+# deploy_incoming_migrations would fail closed and take the deploy with it.
+deploy_record_deployed_sha "$REC" "0000000000000000000000000000000000000000"
+check "a recorded sha this repo does not have is treated as no record" \
+  "$(git -C "$REPO" rev-parse HEAD)" \
+  "$(deploy_deployed_sha "$REC" "$REPO")"
+
+printf '   \n' > "$REC"
+check "a blank record is treated as no record" \
+  "$(git -C "$REPO" rev-parse HEAD)" \
+  "$(deploy_deployed_sha "$REC" "$REPO")"
+
+deploy_record_deployed_sha "$REC" "$M1"
+deploy_record_deployed_sha "$REC" "$M2"
+check "a later cutover replaces the record rather than appending" \
+  "$M2" "$(deploy_deployed_sha "$REC" "$REPO")"
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION. This is #2714 and it is the reason the two functions exist.
+#
+# A deploy that fails at or after the checkout leaves the repo on the TARGET.
+# The retry then reads HEAD and gets the target, so `from` equals `to`:
+# deploy_incoming_migrations returns empty, MIGRATIONS_APPLIED never leaves 0,
+# and the schema-hazard notice cannot fire while prisma re-applies the still
+# pending migrations. The same stale value is printed as the rollback target at
+# four sites, naming the sha being deployed - a wrong instruction rather than a
+# missing warning.
+#
+# Reverting deploy_deployed_sha to `git rev-parse HEAD` turns both checks below
+# red, which is the "before" for this change.
+# ---------------------------------------------------------------------------
+rm -f "$REC"
+git_quiet -C "$REPO" checkout --quiet "$M1"          # the box is serving M1
+deploy_record_deployed_sha "$REC" "$M1"              # ... and a cutover said so
+git_quiet -C "$REPO" checkout --quiet "$M2"         # a failed attempt moved the tree
+
+RETRY_FROM="$(deploy_deployed_sha "$REC" "$REPO")"
+check "on a retry the rollback target is still the DEPLOYED sha, not HEAD" \
+  "$M1" "$RETRY_FROM"
+
+RETRY_SET="$(cd "$REPO" && deploy_incoming_migrations "$RETRY_FROM" HEAD | tr '\n' ' ')"
+check "on a retry the pending migrations are still seen" \
+  "20260102000000_second " "$RETRY_SET"
+
+git_quiet -C "$REPO" checkout --quiet "$M2"
+
 # ---------------------------------------------------------------------------
 # And the same invariant on the real file, since the behaviour above is only
 # the notice's if api-deploy.sh keeps this order: arm the trap, then raise the
@@ -741,6 +806,41 @@ if [ -n "$POST_GATE_LINE" ] && [ -n "$POST_PROBE_LINE" ] && [ -n "$CUTOVER_LINE"
 else
   no "the body-parse verdict is checked for equality, before the cutover" \
      "probe=$POST_PROBE_LINE gate=$POST_GATE_LINE cutover=$CUTOVER_LINE"
+fi
+
+# The record is only useful if it is READ before the checkout moves the tree and
+# WRITTEN only once the cutover is verified. Both are orderings in the real file
+# that no stand-in can exercise, and both are the whole of #2714: reading after
+# deploy_git_sync gets the target sha, and writing before CUTOVER_DONE=1 records
+# a deploy that did not happen.
+READ_LINE="$(line_of 'ROLLBACK_SHA="$(deploy_deployed_sha')"
+SYNC_LINE="$(line_of 'deploy_git_sync "$REPO_DIR"')"
+CUTOVER_LINE="$(line_of_exact 'CUTOVER_DONE=1')"
+WRITE_LINE="$(line_of 'deploy_record_deployed_sha "$DEPLOYED_SHA_RECORD"')"
+
+if [ -n "$READ_LINE" ] && [ -n "$SYNC_LINE" ] && [ "$READ_LINE" -lt "$SYNC_LINE" ]; then
+  ok "api-deploy.sh reads the deployed sha before the checkout moves the tree"
+else
+  no "api-deploy.sh reads the deployed sha before the checkout moves the tree" \
+     "read=$READ_LINE sync=$SYNC_LINE"
+fi
+
+if [ -n "$WRITE_LINE" ] && [ -n "$CUTOVER_LINE" ] && [ "$WRITE_LINE" -gt "$CUTOVER_LINE" ]; then
+  ok "api-deploy.sh records the deployed sha only after the cutover"
+else
+  no "api-deploy.sh records the deployed sha only after the cutover" \
+     "write=$WRITE_LINE cutover=$CUTOVER_LINE"
+fi
+
+# Fixed name, not $STAMP-keyed. "The newest of the stamped files" is the defect
+# rebuilt as a sort over a directory that also holds every failed attempt - the
+# preflight /tmp/api-rollback-$STAMP.txt is exactly that and is why it cannot be
+# the record.
+if grep -q 'DEPLOYED_SHA_RECORD="/tmp/api-deployed-sha.txt"' "$DEPLOY_SH"; then
+  ok "the deployed-sha record has a fixed name rather than a stamped one"
+else
+  no "the deployed-sha record has a fixed name rather than a stamped one" \
+     "no unstamped DEPLOYED_SHA_RECORD assignment in the file"
 fi
 
 if grep -q 'trap - EXIT' "$DEPLOY_SH"; then

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -673,6 +673,28 @@ deploy_record_deployed_sha "$REC" "$M2"
 check "a later cutover replaces the record rather than appending" \
   "$M2" "$(deploy_deployed_sha "$REC" "$REPO")"
 
+# The write happens AFTER the cutover has succeeded, so failing the deploy over
+# it would lose a working deploy to a note about one. The three checks below are
+# the whole of that promise: it returns 0, it says so, and it does not damage
+# the record that is already there. Each was green before it existed - the
+# behaviour was right in the code and held by nothing.
+UNWRITABLE="$WORK/no-such-dir/deployed-sha.txt"
+RECORD_ERR="$WORK/record-stderr.txt"
+deploy_record_deployed_sha "$UNWRITABLE" "$M1" 2>"$RECORD_ERR"
+check "a record that cannot be written does not fail the deploy" "0" "$?"
+check "and says so on stderr" "1" \
+  "$(grep -c 'could not record the deployed sha' "$RECORD_ERR")"
+
+# The temporary file is the atomicity: a box killed mid-write keeps the previous
+# record rather than a truncated one. Making the .tmp path a directory is the
+# portable way to fail that write with the record itself intact.
+deploy_record_deployed_sha "$REC" "$M1"
+mkdir -p "$REC.tmp"
+deploy_record_deployed_sha "$REC" "$M2" 2>/dev/null
+check "a failed write leaves the previous record intact" \
+  "$M1" "$(deploy_deployed_sha "$REC" "$REPO")"
+rmdir "$REC.tmp"
+
 # ---------------------------------------------------------------------------
 # THE REGRESSION. This is #2714 and it is the reason the two functions exist.
 #

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -668,6 +668,36 @@ check "a blank record is treated as no record" \
   "$(git -C "$REPO" rev-parse HEAD)" \
   "$(deploy_deployed_sha "$REC" "$REPO")"
 
+# A SHA, not a revision. `git rev-parse --verify` resolves anything git can
+# name, so a record holding a BRANCH comes back as that branch's tip - and on a
+# retry the tip of the deploy branch is the commit being deployed, which is the
+# exact value this function exists to stop returning. The check meant to make a
+# corrupt record safe was the way back to the defect.
+git_quiet -C "$REPO" branch -f old-release "$M1"
+# `oldrelease` is pure lower-case alpha, so it also pins the HEX half of the
+# guard specifically: widening the character class to a-z would accept it, and
+# it resolves away from HEAD, so the check fails rather than passing by luck.
+git_quiet -C "$REPO" branch -f oldrelease "$M1"
+for BAD in old-release oldrelease refs/heads/old-release "$(printf '%s' "$M1" | cut -c1-4)"; do
+  printf '%s\n' "$BAD" > "$REC"
+  # Each of these RESOLVES, and resolves to something that is not HEAD - so a
+  # missing guard shows up as the wrong sha rather than as the right one by
+  # coincidence. A branch name is the dangerous shape: on a retry the deploy
+  # branch's tip IS the commit being deployed.
+  check "a record holding a revision rather than a sha [$BAD] is not trusted" \
+    "$(git -C "$REPO" rev-parse HEAD)" \
+    "$(deploy_deployed_sha "$REC" "$REPO")"
+done
+
+# A directory is readable, so `-r` alone let `tr` put "Is a directory" on the
+# deploy's stderr on the way to the right answer.
+mkdir -p "$WORK/record-as-a-dir"
+DIR_ERR="$WORK/record-as-a-dir-stderr.txt"
+check "a record path that is a directory falls back without noise on stderr" \
+  "$(git -C "$REPO" rev-parse HEAD)" \
+  "$(deploy_deployed_sha "$WORK/record-as-a-dir" "$REPO" 2>"$DIR_ERR")"
+check "and writes nothing to stderr doing it" "0" "$(wc -c <"$DIR_ERR" | tr -d ' ')"
+
 deploy_record_deployed_sha "$REC" "$M1"
 deploy_record_deployed_sha "$REC" "$M2"
 check "a later cutover replaces the record rather than appending" \


### PR DESCRIPTION
Closes #2714.

Written by Claude L3 and delivered as a `git format-patch` patch — `git push` has never worked on that machine, so the author line came through `git am` rather than a push. Applied at `2d145844f`, plus one commit of mine (`f4d2608bf`, test-file quoting only) described at the bottom.

## The defect

`ROLLBACK_SHA` was captured at preflight, before `deploy_git_sync` moves the tree:

```
:77   ROLLBACK_SHA="$(git rev-parse HEAD)"      captured BEFORE the checkout
:94   deploy_git_sync "$REPO_DIR" "$GIT_REF"    the repo moves here
:100  INCOMING_MIGRATIONS="$(deploy_incoming_migrations "$ROLLBACK_SHA" HEAD)"
```

So on any **second run after a failure at or after the checkout**, `ROLLBACK_SHA` equals `HEAD`, `deploy_incoming_migrations` returns empty, `MIGRATIONS_APPLIED` never leaves 0, and **the hazard notice cannot fire while Prisma re-applies the still-pending migrations.**

And the half worth leading with: `$ROLLBACK_SHA` is printed as the rollback target at four sites. On a retry it names **the sha being deployed** — *"NOT cutting over. Rollback sha: X"* where X is X. That is not a missing warning, it is a wrong instruction, printed at the moment someone is deciding what to do.

## The constraint that shaped the fix

`/tmp/api-rollback-$STAMP.txt` already exists and looks exactly like the record a fix would want. **It is written at preflight, unconditionally** — so a failed attempt writes one too, carrying the same stale sha, and "read the newest stamped file" rebuilds the defect inside its own fix, silently. Nothing is written at cutover today.

So: written by `deploy_record_deployed_sha` at `CUTOVER_DONE=1` and nowhere earlier, under a **fixed** name rather than `$STAMP`-keyed, and read **before** `deploy_git_sync`. Pre-checkout `HEAD` is the fallback in the one case where no record exists, which is the first-ever deploy.

## Verified before, not just after

Reverting `deploy_deployed_sha` to plain `git rev-parse HEAD` — the state `dev` is in — turns **4 checks red**. A criterion is only met if it was genuinely unmet, and this is that row, reproduced independently of the author.

| Mutation | Result |
|---|---|
| **`deploy_deployed_sha` reverts to plain `HEAD`** | 52 / **4 failed** |
| the record call removed from `api-deploy.sh` | 55 / **1 failed** |
| trust an unresolvable record | 55 / 1 failed *(author's run)* |
| record appends instead of overwriting | 55 / 1 failed *(author's run)* |
| read the record after the checkout | 55 / 1 failed *(author's run)* |
| record before the cutover is verified | 55 / 1 failed *(author's run)* |
| stamp the record name | 55 / 1 failed *(author's run)* |

## The degraded paths cannot take the deploy with them

`ROLLBACK_SHA="$(deploy_deployed_sha …)"` is a command substitution under `set -euo pipefail`, so a non-zero return at preflight would kill the deploy before it did anything — and the degraded paths are where a new function is most likely to return non-zero. Measured against the real function: no record, a record this repo cannot resolve, and a blank record all return **rc=0** and fall through to `HEAD`.

## shellcheck — the check the author could not run

`shellcheck` is not installed on the authoring machine, so the findings profile against `origin/dev` was explicitly listed as not done. Run here, machine-readable format so the footer is not counted:

```
origin/dev   3 SC2015   1 SC2153   1 SC1091
as received  3 SC2016   3 SC2015   1 SC2153   1 SC1091
after f4d2608bf   3 SC2015   1 SC2153   1 SC1091      <- identical to dev
```

`--severity=warning -x` is exit 0 on both sides regardless, and nothing in CI runs shellcheck at all. The three `SC2016` were single-quoted `line_of` arguments — an expansion that deliberately will not happen — and this file had already answered that twice, in `STAMP_TOKEN` and `POST_CODE_TOKEN`. `f4d2608bf` applies that existing convention and touches nothing else.

## Suites

| Command | Result |
|---|---|
| `scripts/deploy/tests/migrate.test.sh` | exit 0 — **56 passed, 0 failed** (46 on `dev`) |
| `scripts/deploy/tests/git-sync.test.sh` | exit 0 — 16 passed, 0 failed |

`git rev-parse HEAD` confirmed either side; tree clean.

## Not verified

No live deploy was exercised. The retry state is reproduced against a real git history inside the suite, not against a box — the same limit every change to this script has had, and it is why the source-position checks in the suite exist.
