### PR TITLE
fix(backend): log request failures by field rather than by object

### DIFF
--- a/apps/backend/src/services/documenso.service.ts
+++ b/apps/backend/src/services/documenso.service.ts
@@ -92,6 +92,38 @@ export type SignedDocument = {
 
 export type DocumensoExternalRole = "ADMIN" | "MANAGER" | "MEMBER";
 
+/**
+ * What is safe to log about a failed request.
+ *
+ * The raw error must never be logged here. Axios attaches the outbound request
+ * to the error as `config`, so an axios error from this file carries the
+ * Documenso API key in `config.headers.Authorization`, and the one from
+ * `generateExternalRedirectUrl` carries the external auth secret in
+ * `config.data`. The logger does not redact either: its production format is
+ * `json()`, which serialises the whole meta object, and the development
+ * format's field list replaces `req`, `res`, `request` and `response` but not
+ * `config` - it exists to keep log lines small, not to redact.
+ *
+ * So the first time a Documenso call fails is the first time the credential is
+ * written out. The four SDK calls in this file already log `.message` and
+ * `.statusCode`; this is the same treatment for the two axios ones.
+ */
+const describeError = (error: unknown) => {
+  // Read the status structurally rather than through `axios.isAxiosError`: the
+  // status is worth having and that helper is a module export a test double
+  // replaces, so depending on it makes the useful half of this untestable in
+  // the suite that has to prove the rest of it.
+  const response =
+    typeof error === "object" && error !== null && "response" in error
+      ? (error as { response?: { status?: number } }).response
+      : undefined;
+
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    status: response?.status,
+  };
+};
+
 export class DocumensoService {
   static async createDocument({
     pdf,
@@ -241,7 +273,10 @@ export class DocumensoService {
       const signeDocument = downloadResponse.data as SignedDocument;
       return signeDocument;
     } catch (error) {
-      logger.error("An unexpected error occurred:", error);
+      logger.error(
+        "Documenso signed-document download failed",
+        describeError(error),
+      );
     }
   }
 
@@ -297,7 +332,7 @@ export class DocumensoService {
 
       return `${baseUrl}${data.redirectUrl}`;
     } catch (error) {
-      logger.error("Documenso external auth error:", error);
+      logger.error("Documenso external auth error", describeError(error));
       throw error;
     }
   }

--- a/apps/backend/test/services/documenso.service.test.ts
+++ b/apps/backend/test/services/documenso.service.test.ts
@@ -126,7 +126,7 @@ describe("DocumensoService", () => {
       });
       await Service.downloadSignedDocument({ documentId: 1 });
       expect(logger.error).toHaveBeenCalledWith(
-        "An unexpected error occurred:",
+        "Documenso signed-document download failed",
         expect.objectContaining({ message: "DOCUMENSO_API_KEY is not set" }),
       );
     });
@@ -449,8 +449,43 @@ describe("DocumensoService", () => {
         );
         await DocumensoService.downloadSignedDocument({ documentId: 1 });
         expect(logger.error).toHaveBeenCalledWith(
-          "An unexpected error occurred:",
-          expect.any(Error),
+          "Documenso signed-document download failed",
+          expect.objectContaining({ message: "Download failed" }),
+        );
+      });
+
+      /*
+       * The property, not the wording. Axios hangs the outbound request off the
+       * error as `config`, so logging the error object writes
+       * `config.headers.Authorization` - the Documenso API key - into the log.
+       * The logger does not redact it: production is `json()`, which serialises
+       * the whole meta, and the development field list replaces `req`, `res`,
+       * `request` and `response` but not `config`, because it exists to keep log
+       * lines small rather than to redact.
+       *
+       * So this asserts on the SERIALISED arguments rather than on their shape:
+       * a future change that logs the raw error again reddens here whatever it
+       * calls the message.
+       */
+      it("never writes the API key into the log when the download fails", async () => {
+        const apiKeyValue = "documenso-api-key-placeholder";
+        (axios.get as jest.Mock).mockRejectedValueOnce(
+          Object.assign(new Error("Download failed"), {
+            isAxiosError: true,
+            config: {
+              url: "http://valid.com/document/1/download-beta",
+              headers: { Authorization: apiKeyValue },
+            },
+            response: { status: 502 },
+          }),
+        );
+
+        await DocumensoService.downloadSignedDocument({ documentId: 1 });
+
+        const logged = (logger.error as jest.Mock).mock.calls.at(-1);
+        expect(JSON.stringify(logged)).not.toContain(apiKeyValue);
+        expect(logged?.[1]).toEqual(
+          expect.objectContaining({ message: "Download failed", status: 502 }),
         );
       });
     });
@@ -528,8 +563,38 @@ describe("DocumensoService", () => {
           DocumensoService.generateExternalRedirectUrl({} as any),
         ).rejects.toThrow("Network Err");
         expect(logger.error).toHaveBeenCalledWith(
-          "Documenso external auth error:",
-          axError,
+          "Documenso external auth error",
+          expect.objectContaining({ message: "Network Err" }),
+        );
+      });
+
+      /*
+       * The same property on the other call site, where the credential is in
+       * the request BODY rather than a header - axios attaches that to the
+       * error as `config.data`, so the shape of the leak differs and the fix
+       * and the check do not.
+       */
+      it("never writes the external auth secret into the log when the call fails", async () => {
+        const secretValue = "external-auth-secret-placeholder";
+        (axios.post as jest.Mock).mockRejectedValueOnce(
+          Object.assign(new Error("Network Err"), {
+            isAxiosError: true,
+            config: {
+              url: "http://valid.com/api/auth/external/generate-token",
+              data: JSON.stringify({ externalSecret: secretValue }),
+            },
+            response: { status: 500 },
+          }),
+        );
+
+        await expect(
+          DocumensoService.generateExternalRedirectUrl({} as any),
+        ).rejects.toThrow("Network Err");
+
+        const logged = (logger.error as jest.Mock).mock.calls.at(-1);
+        expect(JSON.stringify(logged)).not.toContain(secretValue);
+        expect(logged?.[1]).toEqual(
+          expect.objectContaining({ message: "Network Err", status: 500 }),
         );
       });
     });


### PR DESCRIPTION
The two `axios` call sites in `documenso.service.ts` logged the caught error object:

```ts
} catch (error) {
  logger.error("An unexpected error occurred:", error);
```

**An axios error carries the outbound request on `config`** — `config.headers` and `config.data` — so logging the object writes the request alongside the message. That is more than a failure needs to say, and the fields it adds are the ones a request carries to authenticate itself.

**The logger does not narrow it.** Its production format is `json()` (`NODE_ENV !== "development"`), which serialises the whole meta object; the development format's field list replaces `req`, `res`, `request` and `response` — **but not `config`** — and its own comment says it exists to keep log lines small rather than to redact. Driven through a real winston logger built from that production branch, with a capturing transport, a placeholder value placed on `config.headers` appears in the emitted line.

The four SDK calls in this same file already log `.message` and `.statusCode`. This gives the two axios ones the same treatment through one local helper.

## The helper does not use `axios.isAxiosError`

It reads the status structurally instead. `isAxiosError` is a module export that a test double replaces, so depending on it would make the useful half of the helper untestable in the suite that has to prove the rest of it — the status came back `undefined` under the existing `jest.mock("axios")` until I stopped relying on it.

## The tests assert the property, not the wording

Two new cases drive a failure whose request config carries a placeholder — one on `config.headers` (the download path) and one on `config.data` (the external-auth path, where the credential is in the body rather than a header) — and assert that the **serialised** logger arguments do not contain it. A future change that logs the raw error again reddens them whatever it names the message.

Three existing assertions moved from the old message strings to the new shape.

## Mutations

Four, through an assert-uniqueness harness, each reverted before the next, baseline and restore both `30 passed`:

| Mutation | Result |
|---|---|
| log the raw error again on the download path | **1 failed** |
| log the raw error again on the external-auth path | **1 failed** |
| `describeError` returns the error itself | **5 failed** |
| drop `status` from `describeError` | **2 failed** |

The first two are the before-row: both are exactly what `dev` does today.

## Gates

| Command | Result |
|---|---|
| `npx jest` (full backend) | **exit 0** — 479 suites / **11459 tests** |
| `turbo run lint type-check --filter=backend --force` | **exit 0** — 7/7, **0 errors**, 25 pre-existing warnings |

`git rev-parse HEAD` confirmed either side; tree clean.

## Scope

`documenso.service.ts` is the only file in `apps/backend/src` that both imports `axios` and logs a bare error object. Files using global `fetch` are not affected by the same mechanism — a failing `fetch` throws a `TypeError` that does not carry the request — so this is a property of the client, not of logging a raw error.
