### PR TITLE
fix(ci): compare the deployed-sha record instead of describing it

### DIFF
--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -101,18 +101,41 @@ deploy_deployed_sha() {
   # returning, arriving through the check meant to prevent it. Only reachable
   # through a corrupted or hand-edited record, which is precisely the case this
   # function's own comment anticipates. Raised by ankit-yc on #2732.
-  case "$recorded" in
-    *[!0-9a-f]* | "") recorded="" ;;
-  esac
   if [ "${#recorded}" -lt 7 ]; then
     recorded=""
   fi
 
-  if [ -n "$recorded" ] \
-    && git -C "$repo" rev-parse --verify --quiet "$recorded^{commit}" >/dev/null 2>&1
-  then
-    git -C "$repo" rev-parse "$recorded^{commit}"
-    return 0
+  # Shape is necessary and not sufficient: a BRANCH whose name is seven or more
+  # hex characters passes every check above and is then resolved as a ref, so
+  # `deadbeef` comes back as whatever that branch points at. Raised by ankit-yc
+  # on #2733 after the shape guard landed.
+  #
+  # So the value is COMPARED rather than described: resolve it, then require the
+  # resolved sha to begin with what was recorded. That subsumes the hex-character
+  # class this replaced - a name git resolves to something not beginning with it
+  # is rejected whatever characters it holds, and no mutation could redden the
+  # class once the comparison was here, which is the definition of dead.
+  #
+  # `"$recorded"*` and not `$recorded*`: the expansion is quoted so a record
+  # holding `*`, `?` or `[a-f]` is compared literally rather than as a pattern.
+  #
+  # NOT PINNED BY THE SUITE, deliberately, and this is the honest reason rather
+  # than an omission: no input can tell the two spellings apart here. To reach
+  # the comparison a record must first RESOLVE, and a value git resolves is a
+  # sha or a ref name, neither of which can contain a glob metacharacter - so
+  # unquoting it is green on every input I could construct. Tests asserting
+  # otherwise were written for this and deleted when the mutation stayed green.
+  # The quoting stays because it is free and correct, not because it is proven. A ref cannot satisfy that
+  # unless it happens to be named after its own target's prefix, in which case
+  # the ref and the object agree and accepting it costs nothing - a coincidence
+  # rather than a hole, and the reason this is a comparison and not a ban on
+  # names that look like shas.
+  if [ -n "$recorded" ]; then
+    local resolved
+    resolved="$(git -C "$repo" rev-parse --verify --quiet "$recorded^{commit}" 2>/dev/null || true)"
+    case "$resolved" in
+      "$recorded"*) printf '%s\n' "$resolved"; return 0 ;;
+    esac
   fi
 
   # No usable record: a first-ever deploy on this box, or one written before

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -689,6 +689,33 @@ for BAD in old-release oldrelease refs/heads/old-release "$(printf '%s' "$M1" | 
     "$(deploy_deployed_sha "$REC" "$REPO")"
 done
 
+# Shape is necessary and not sufficient. A BRANCH whose name is seven or more
+# hex characters passes every shape check and is then resolved as a ref, so the
+# guard that rejects `old-release` accepts `deadbeef`. #2733.
+#
+# The fixture has to disagree for this to mean anything: the branch points at M1
+# and HEAD is elsewhere, so a missing comparison returns M1 - the wrong sha -
+# rather than HEAD by coincidence.
+git_quiet -C "$REPO" branch -f deadbeef "$M1"
+git_quiet -C "$REPO" branch -f abcdefabc "$M1"
+for HEXREF in deadbeef abcdefabc; do
+  printf '%s\n' "$HEXREF" > "$REC"
+  check "a hex-NAMED branch [$HEXREF] is not trusted as a deployed sha" \
+    "$(git -C "$REPO" rev-parse HEAD)" \
+    "$(deploy_deployed_sha "$REC" "$REPO")"
+done
+
+# The one case the comparison lets through, and it is a coincidence rather than
+# a hole: a branch named after its own target's prefix. The ref and the object
+# agree, so the answer is the same either way and accepting it costs nothing.
+# Pinned so that narrowing this later is a decision rather than a side effect.
+M1_PREFIX="$(printf '%s' "$M1" | cut -c1-8)"
+git_quiet -C "$REPO" branch -f "$M1_PREFIX" "$M1"
+printf '%s\n' "$M1_PREFIX" > "$REC"
+check "a branch named after its own target's prefix resolves to that target" \
+  "$M1" "$(deploy_deployed_sha "$REC" "$REPO")"
+git_quiet -C "$REPO" branch -D "$M1_PREFIX" >/dev/null 2>&1
+
 # A directory is readable, so `-r` alone let `tr` put "Is a directory" on the
 # deploy's stderr on the way to the right answer.
 mkdir -p "$WORK/record-as-a-dir"


### PR DESCRIPTION

Closes #2733. Found by ankit-yc on #2732, after the shape guard it reviews had landed.

## The gap

The shape guard rejects `dev` and `HEAD~1` and accepts `deadbeef`. A branch whose name
is seven or more hex characters passes every character and length check and is then
resolved as a **ref**:

```
branch deadbeef -> an older commit
  record "deadbeef"    ->  the BRANCH's commit     <- passes the shape guard
  record "abcdefabc"   ->  the BRANCH's commit
```

Two contrived things at once — a corrupted record **and** a hex-named branch — which is
why this is a follow-up and was not a merge blocker.

## The change

Resolve the record, then require the resolved sha to begin with what was recorded. The
guard stops describing the value and compares it.

The **hex-character class comes out**. Once the comparison is there, no mutation can
redden it — a name git resolves to something not beginning with it is rejected whatever
characters it holds. Keeping a guard nothing can falsify is how the file accumulates
checks that look like coverage.

The **length floor stays** and is red on its own: it stops a four-character prefix being
resolved and then accepted, which the comparison alone would allow.

**One case is let through and it is pinned as deliberate:** a branch named after its own
target's prefix. The ref and the object agree, so the answer is identical either way — a
coincidence rather than a hole, and asserted so that narrowing it later is a decision.

## Evidence

At `803a6b6b3`, tree clean, HEAD confirmed either side:

| Command | Result |
|---|---|
| `migrate.test.sh` | exit 0 — **68/68** (65 on dev) |
| `git-sync.test.sh` | exit 0 — 16/16 |

| Mutation | Result |
|---|---|
| **revert to resolve-and-trust — the before** | 62 / **6 failed** |
| accept any resolution (drop the comparison) | 62 / **6 failed** |
| drop the length floor | 67 / **1 failed** |
| `-f` back to `-r` | 67 / **1 failed** |

## Not proven, stated rather than omitted

`"$recorded"*` is quoted so a record holding a glob metacharacter is compared literally.
**No test pins that, and the reason is that no input can tell the two spellings apart:**
to reach the comparison a record must first resolve, and a value git resolves is a sha or
a ref name, neither of which can contain a metacharacter. Tests asserting it were written
and deleted when the mutation stayed green. The quoting stays because it is free and
correct, not because it is proven.

`shellcheck` is not installed on the machine this was written on; the findings profile
against `origin/dev` has not been compared.
