### PR TITLE
fix(backend): submit UGX as a two-decimal amount, as Stripe requires

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -743,7 +743,13 @@ const ZERO_DECIMAL_CURRENCIES = new Set([
   "mga",
   "pyg",
   "rwf",
-  "ugx",
+  // NOT "ugx". Stripe's Special cases: UGX "became a zero-decimal currency, but
+  // backwards compatibility requires you to represent it as a two-decimal value,
+  // where the decimal amount is always 00. To charge 5 UGX, provide an amount
+  // value of 500." It was in this set, so a UGX invoice was submitted at a
+  // hundredth of its value. ISK carries the identical rule and is correctly
+  // absent - the same exception was applied to one and not the other.
+  // https://docs.stripe.com/currencies#special-cases
   "vnd",
   "vuv",
   "xaf",

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -1969,6 +1969,61 @@ describe("FinancePaymentService", () => {
     expect(sessionArgs.line_items[0].price_data.unit_amount).toBe(1000);
   });
 
+  // The other half of the same rule, and the half the JPY test cannot reach.
+  // Stripe's Special cases: UGX "became a zero-decimal currency, but backwards
+  // compatibility requires you to represent it as a two-decimal value, where the
+  // decimal amount is always 00. To charge 5 UGX, provide an amount value of
+  // 500." ISK carries the identical rule and is correctly absent from the set;
+  // ugx was in it, so a UGX invoice was submitted at a hundredth of its value.
+  // https://docs.stripe.com/currencies#special-cases
+  it("submits UGX as a two-decimal value, which Stripe requires despite it being zero-decimal", async () => {
+    const stripeClient = {
+      checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },
+      paymentIntents: { create: jest.fn(), retrieve: jest.fn() },
+      refunds: { create: jest.fn() },
+    };
+    __setFinanceStripeClientForTests(stripeClient);
+
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_ugx",
+      totalAmount: 5,
+      currency: "ugx",
+      status: "AWAITING_PAYMENT",
+      paymentCollectionMethod: "PAYMENT_LINK",
+      organisationId: "org_1",
+      appointmentId: "",
+      parentId: "",
+      items: [{ name: "Consult", quantity: 1, unitPrice: 5, total: 5 }],
+      taxTotal: 0,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    (prisma.organization.findUnique as jest.Mock).mockResolvedValueOnce({
+      stripeAccountId: "acct_ugx",
+    });
+    (prisma.creditNote.findMany as jest.Mock).mockResolvedValueOnce([]);
+    (prisma.payment.findMany as jest.Mock).mockResolvedValueOnce([]);
+    (prisma.paymentAttempt.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.paymentAttempt.create as jest.Mock).mockResolvedValueOnce({
+      id: "pa_ugx",
+    });
+    stripeClient.checkout.sessions.create.mockResolvedValueOnce({
+      id: "cs_ugx",
+      url: "https://checkout.test/ugx",
+    });
+
+    await FinancePaymentService.createCheckoutSessionForInvoice("inv_ugx");
+
+    const [sessionArgs] = stripeClient.checkout.sessions.create.mock
+      .calls[0] as [
+      { line_items: Array<{ price_data: { unit_amount: number } }> },
+    ];
+    // 5 UGX, not 5 minor units.
+    expect(sessionArgs.line_items[0].price_data.unit_amount).toBe(500);
+  });
+
   it("charges the current invoice balance when discounts change the raw item total", async () => {
     const stripeClient = {
       checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },


### PR DESCRIPTION
Refs #2736. Found while scoping that issue; **separable from it on purpose** — this is a
one-line charging fix and #2736 is a refactor across three files and a package boundary.

## The bug, live rather than latent

`ZERO_DECIMAL_CURRENCIES` in `finance/payment.ts` contained `"ugx"`, so
`toStripeMinorUnits` returned the major amount unscaled and **every UGX charge went out at a
hundredth of its value.**

Stripe's Special cases say the opposite of what the ISO 4217 exponent implies:

> UGX became a zero-decimal currency, but backwards compatibility requires you to represent
> it as a two-decimal value, where the decimal amount is always 00. **To charge 5 UGX, provide
> an `amount` value of 500.**

**ISK carries the identical rule and is correctly absent from the set.** The same exception was
applied to one currency and not the other, in the same list, by the same author.

Reachable by configuration, not by code change: `invoice.currency` is `String @default("usd")`
with no enum or allowlist, and `toStripeMinorUnits` is called from five places —
`:821` checkout line items, `:838` discounted unit amounts, `:907` deposits, `:1368` payment
intents, `:1735` refunds.

## Why the existing test could not catch it

There is exactly one test on this mechanism and it uses **JPY** — a currency that must *not* be
scaled. UGX must be. **A test named for one direction cannot fail on the other**, and one
example per class is what let the second entry through.

## Evidence

Run twice, independently — the change was written twice in parallel before either author saw
the other's, and the version here is the one with the better commit
message. Both runs agree. Numbers below are from the commit on this branch, `git rev-parse HEAD`
checked in the same shell before and after, tree clean:

| Command | Result |
|---|---|
| `npx jest` (full backend, not scoped) | **exit 0** — 479 suites / **11460 tests** |
| `turbo run lint type-check --filter=backend --force` | **exit 0** — 7/7, 0 errors, 25 pre-existing warnings |

**The before-row is an observable wrong number, not a missing module.** Mutation-checked on the
exact commit by putting `"ugx"` back into the set:

```
● submits UGX as a two-decimal value, which Stripe requires despite it being zero-decimal
  Expected: 500
  Received: 5
Tests: 1 failed, 1 passed
```

**The 1 passed is the JPY test, green under the same mutation** — which is the point above,
demonstrated rather than argued.

## Not established

The Stripe docs page came back as the Spanish localisation on all three fetches; the Special
cases text is unambiguous but it is a translation. **Someone with a browser should confirm the
UGX row in English before this merges.** Taken on this evidence because the direction of the
error is undercharging and the citation is the repo's own — the URL was in the comment above the
set the whole time.

The zero-decimal *list itself* renders as links on that page and never resolved in any fetch, so
**the remaining fifteen entries are unverified**, and there is no second source inside the repo
to check them against: nothing else encodes currency decimals for settlement.
`apps/frontend/src/app/lib/money.ts` looks like a second implementation and is not one — it is
`Intl.NumberFormat` display formatting with no conversion to minor units, answering "how do I
show this to a human" where this set answers "what integer does Stripe accept". **They must not
be merged.** Stripe's list, ISO 4217 and CLDR give three different answers and only the first is
what these call sites need.

The rest of the zero-decimal set is **unverified against Stripe's current published list** —
this change removes one entry it contradicts and does not audit the other fifteen.
