### PR TITLE
refactor(backend): share one currency-aware Stripe minor-units converter

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -13,6 +13,7 @@ import { prisma } from "src/config/prisma";
 import logger from "src/utils/logger";
 import { FinanceEventService } from "./events";
 import { roundMoney } from "./pricing";
+import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
 import { markInvoiceTreatmentItemsSettled } from "./settlement";
 
 type PaymentLineSummary = {
@@ -721,47 +722,6 @@ type CheckoutLineItemSource = {
   unitPrice?: number;
   discountPercent?: number;
 };
-
-/**
- * Currencies Stripe treats as ZERO-DECIMAL: the API takes the amount in the
- * currency's own units, not in hundredths.
- *
- * Multiplying by 100 unconditionally overcharges every one of them by 100x -
- * a 1,000 JPY invoice would be submitted as 100,000 JPY. The currency became
- * configurable per invoice, so this is no longer hypothetical.
- *
- * https://docs.stripe.com/currencies#zero-decimal
- */
-const ZERO_DECIMAL_CURRENCIES = new Set([
-  "bif",
-  "clp",
-  "djf",
-  "gnf",
-  "jpy",
-  "kmf",
-  "krw",
-  "mga",
-  "pyg",
-  "rwf",
-  // NOT "ugx". Stripe's Special cases: UGX "became a zero-decimal currency, but
-  // backwards compatibility requires you to represent it as a two-decimal value,
-  // where the decimal amount is always 00. To charge 5 UGX, provide an amount
-  // value of 500." It was in this set, so a UGX invoice was submitted at a
-  // hundredth of its value. ISK carries the identical rule and is correctly
-  // absent - the same exception was applied to one and not the other.
-  // https://docs.stripe.com/currencies#special-cases
-  "vnd",
-  "vuv",
-  "xaf",
-  "xof",
-  "xpf",
-]);
-
-/** An amount in the smallest unit Stripe accepts for `currency`. */
-const toStripeMinorUnits = (amount: number, currency: string): number =>
-  ZERO_DECIMAL_CURRENCIES.has(currency.trim().toLowerCase())
-    ? Math.round(amount)
-    : Math.round(amount * 100);
 
 // Charge the full bill as itemised, pre-tax lines (letting Stripe apply tax)
 // UNLESS we must charge a remaining/adjusted balance instead: when a prior

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -17,6 +17,7 @@ import { NotificationService } from "./notification.service";
 
 import { prisma } from "src/config/prisma";
 import { getOrgBillingCurrency } from "src/utils/billing";
+import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
 import { recomputeOrganizationVerification } from "./organization-verification.service";
 import { Prisma } from "@prisma/client";
 
@@ -57,10 +58,6 @@ const getStripeClient = () => {
   stripeClient = new Stripe(apiKey, { apiVersion: "2026-01-28.clover" });
   return stripeClient;
 };
-
-function toStripeAmount(amount: number): number {
-  return Math.round(amount * 100);
-}
 
 // Settlement must use what Stripe actually captured, never the invoice total.
 const resolveCapturedAmount = (
@@ -487,8 +484,8 @@ export const StripeService = {
     if (!organisation?.stripeAccountId)
       throw new Error("Organisation has no Stripe account");
 
-    const amount = toStripeAmount(service.cost);
     const currency = await getOrgBillingCurrency(appointment.organisationId);
+    const amount = toStripeMinorUnits(service.cost, currency);
 
     const { parentId, patientId } = extractAppointmentPatientRefs(appointment);
     const companionId = patientId ?? "";

--- a/apps/backend/src/utils/stripe-minor-units.ts
+++ b/apps/backend/src/utils/stripe-minor-units.ts
@@ -16,6 +16,12 @@
 // to represent it as a two-decimal value, where the decimal amount is always
 // 00." Both are therefore scaled like a two-decimal currency.
 // https://docs.stripe.com/currencies#special-cases
+//
+// Read the name precisely: this is "currencies whose CHARGE amount is
+// unscaled", not "Stripe's zero-decimal currencies". HUF and TWD are
+// zero-decimal for PAYOUTS and are deliberately absent here, because Stripe
+// takes two-decimal amounts when charging them. Anyone adding payout support
+// and reading this set as the general answer gets those two backwards.
 const ZERO_DECIMAL_CURRENCIES = new Set([
   "bif",
   "clp",

--- a/apps/backend/src/utils/stripe-minor-units.ts
+++ b/apps/backend/src/utils/stripe-minor-units.ts
@@ -12,9 +12,9 @@
 //
 // Two currencies that ARE zero-decimal in ISO 4217 are deliberately absent,
 // because Stripe's Special cases override the general rule for them: UGX and
-// ISK "became a zero-decimal currency, but backwards compatibility requires you
-// to represent it as a two-decimal value, where the decimal amount is always
-// 00." Both are therefore scaled like a two-decimal currency.
+// ISK "transitioned to a zero-decimal currency, but backwards compatibility
+// requires you to represent it as a two-decimal value, where the decimal amount
+// is always 00." Both are therefore scaled like a two-decimal currency.
 // https://docs.stripe.com/currencies#special-cases
 //
 // Read the name precisely: this is "currencies whose CHARGE amount is
@@ -22,6 +22,17 @@
 // zero-decimal for PAYOUTS and are deliberately absent here, because Stripe
 // takes two-decimal amounts when charging them. Anyone adding payout support
 // and reading this set as the general answer gets those two backwards.
+//
+// The UGX entry carries one further rule that this function does not implement
+// and callers summing minor units across invoice lines must not assume away:
+// where an invoice amount is fractional after prorations, coupons or taxes,
+// Stripe rounds it to the nearest multiple of 100 itself and credits or debits
+// the difference to the customer balance.
+//
+// Every entry below was verified against the English source on 2026-09-05. The
+// docs default their language to the detected region, so an unqualified fetch
+// returns a translated page and reads as a transient failure it is not:
+// https://docs.stripe.com/currencies?locale=en-US
 const ZERO_DECIMAL_CURRENCIES = new Set([
   "bif",
   "clp",

--- a/apps/backend/src/utils/stripe-minor-units.ts
+++ b/apps/backend/src/utils/stripe-minor-units.ts
@@ -1,0 +1,41 @@
+// The integer amount Stripe accepts for a currency, which is not the same
+// question as how a human reads that amount. Display formatting is CLDR's
+// answer and lives in the frontend's own money helper; this is Stripe's answer
+// and belongs nowhere near it. The two look like duplicates and are not, so
+// this module is named after the API it serves rather than after "money".
+//
+// Kept free of imports on purpose. The pure pricing modules that need it must
+// not gain a database dependency to convert a number.
+
+// Currencies Stripe accepts as a whole number of major units, so the amount is
+// submitted unscaled. https://docs.stripe.com/currencies#zero-decimal
+//
+// Two currencies that ARE zero-decimal in ISO 4217 are deliberately absent,
+// because Stripe's Special cases override the general rule for them: UGX and
+// ISK "became a zero-decimal currency, but backwards compatibility requires you
+// to represent it as a two-decimal value, where the decimal amount is always
+// 00." Both are therefore scaled like a two-decimal currency.
+// https://docs.stripe.com/currencies#special-cases
+const ZERO_DECIMAL_CURRENCIES = new Set([
+  "bif",
+  "clp",
+  "djf",
+  "gnf",
+  "jpy",
+  "kmf",
+  "krw",
+  "mga",
+  "pyg",
+  "rwf",
+  "vnd",
+  "vuv",
+  "xaf",
+  "xof",
+  "xpf",
+]);
+
+/** An amount in the smallest unit Stripe accepts for `currency`. */
+export const toStripeMinorUnits = (amount: number, currency: string): number =>
+  ZERO_DECIMAL_CURRENCIES.has(currency.trim().toLowerCase())
+    ? Math.round(amount)
+    : Math.round(amount * 100);

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -1970,12 +1970,13 @@ describe("FinancePaymentService", () => {
   });
 
   // The other half of the same rule, and the half the JPY test cannot reach.
-  // Stripe's Special cases: UGX "became a zero-decimal currency, but backwards
-  // compatibility requires you to represent it as a two-decimal value, where the
-  // decimal amount is always 00. To charge 5 UGX, provide an amount value of
-  // 500." ISK carries the identical rule and is correctly absent from the set;
-  // ugx was in it, so a UGX invoice was submitted at a hundredth of its value.
-  // https://docs.stripe.com/currencies#special-cases
+  // Stripe's Special cases: UGX "transitioned to a zero-decimal currency, but
+  // backwards compatibility requires you to represent it as a two-decimal value,
+  // where the decimal amount is always 00. For example, to charge 5 UGX, provide
+  // an amount value of 500." ISK carries the identical rule and is correctly
+  // absent from the set; ugx was in it, so a UGX invoice was submitted at a
+  // hundredth of its value.
+  // https://docs.stripe.com/currencies?locale=en-US#special-cases
   it("submits UGX as a two-decimal value, which Stripe requires despite it being zero-decimal", async () => {
     const stripeClient = {
       checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -395,6 +395,41 @@ describe("StripeService", () => {
       );
     });
 
+    // The appointment path converted with a currency-blind x100 while resolving
+    // the org's currency on the very next line. A zero-decimal org was charged a
+    // hundred times the service cost, and nothing asserted the amount reaching
+    // Stripe - the test above pins only the absence of transfer_data.
+    it("submits a zero-decimal appointment cost unscaled", async () => {
+      (prisma.appointment.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "appt_jpy",
+        status: "REQUESTED",
+        organisationId: "org_jpy",
+        appointmentType: { id: "service_jpy" },
+        companion: { id: "comp_1", parent: { id: "parent_1" } },
+      });
+      (prisma.service.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: "service_jpy",
+        cost: 1000,
+      });
+      (prisma.organization.findUnique as jest.Mock).mockResolvedValueOnce({
+        stripeAccountId: "acct_jpy",
+      });
+      (
+        prisma.organizationBilling.findUnique as jest.Mock
+      ).mockResolvedValueOnce({ currency: "jpy" });
+      mStripe.paymentIntents.create.mockResolvedValueOnce({
+        id: "pi_jpy",
+        client_secret: "cs_jpy",
+      });
+
+      await StripeService.createPaymentIntentForAppointment("appt_jpy");
+
+      expect(mStripe.paymentIntents.create).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 1000, currency: "jpy" }),
+        { stripeAccount: "acct_jpy" },
+      );
+    });
+
     it("should throw if appointment not found", async () => {
       (prisma.appointment.findUnique as jest.Mock).mockResolvedValueOnce(null);
       await expect(

--- a/apps/backend/test/utils/stripe-minor-units.test.ts
+++ b/apps/backend/test/utils/stripe-minor-units.test.ts
@@ -1,0 +1,48 @@
+import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
+
+describe("toStripeMinorUnits", () => {
+  it("scales a two-decimal currency by a hundred", () => {
+    expect(toStripeMinorUnits(12.34, "usd")).toBe(1234);
+  });
+
+  it("submits a zero-decimal currency unscaled", () => {
+    expect(toStripeMinorUnits(1000, "jpy")).toBe(1000);
+  });
+
+  // Stripe's Special cases override the zero-decimal rule for these two, so
+  // they are scaled despite ISO 4217 calling them zero-decimal. Both are
+  // pinned: UGX was in the set and overcharged by a hundred, ISK never was,
+  // and one test per class is what let that asymmetry survive.
+  it("scales UGX, which Stripe requires as a two-decimal value", () => {
+    expect(toStripeMinorUnits(5, "ugx")).toBe(500);
+  });
+
+  it("scales ISK, which carries the identical special case", () => {
+    expect(toStripeMinorUnits(5, "isk")).toBe(500);
+  });
+
+  it("matches the currency regardless of case or surrounding space", () => {
+    expect(toStripeMinorUnits(1000, " JPY ")).toBe(1000);
+  });
+
+  it("always hands Stripe an integer", () => {
+    expect(Number.isInteger(toStripeMinorUnits(0.1 + 0.2, "usd"))).toBe(true);
+    expect(toStripeMinorUnits(0.1 + 0.2, "usd")).toBe(30);
+  });
+
+  // KNOWN DRIFT, pinned as it behaves rather than as it should. 8.165 * 100 is
+  // 816.4999999999999 in binary floating point, so the multiply-then-round loses
+  // the cent that a decimal reading of 8.165 would keep. Deliberately NOT fixed
+  // here: this promotion moves a function between files without changing what any
+  // caller is charged, and correcting the drift changes money at all six call
+  // sites, which deserves its own change and its own review. The value below is
+  // the current answer, so a future fix will redden this test and be forced to
+  // say so rather than sliding through.
+  it("loses a cent on a half-cent float (known, unfixed)", () => {
+    expect(toStripeMinorUnits(8.165, "usd")).toBe(816);
+  });
+
+  it("treats an unknown currency as two-decimal", () => {
+    expect(toStripeMinorUnits(1, "zzz")).toBe(100);
+  });
+});

--- a/apps/backend/test/utils/stripe-minor-units.test.ts
+++ b/apps/backend/test/utils/stripe-minor-units.test.ts
@@ -30,6 +30,16 @@ describe("toStripeMinorUnits", () => {
     expect(toStripeMinorUnits(0.1 + 0.2, "usd")).toBe(30);
   });
 
+  // The same guarantee on the OTHER branch, which the test above does not
+  // reach: it only exercises `usd`, so the rounding on the unscaled branch was
+  // pinned by nothing and could be deleted with every test still green. Stripe
+  // rejects a non-integer amount, and this branch is reachable with one --
+  // `Service.cost` is a Float, so a 1000.5 JPY service is a real input.
+  it("rounds a fractional zero-decimal amount rather than passing it through", () => {
+    expect(toStripeMinorUnits(1000.5, "jpy")).toBe(1001);
+    expect(Number.isInteger(toStripeMinorUnits(1000.5, "jpy"))).toBe(true);
+  });
+
   // KNOWN DRIFT, pinned as it behaves rather than as it should. 8.165 * 100 is
   // 816.4999999999999 in binary floating point, so the multiply-then-round loses
   // the cent that a decimal reading of 8.165 would keep. Deliberately NOT fixed


### PR DESCRIPTION
## The bug this turned out to contain

#2736 was filed as a de-duplication. It is also a second money bug, in the opposite direction to #2739.

`stripe.service.ts` converted an appointment cost with a currency-blind `Math.round(amount * 100)` on the line *immediately above* the one that resolved the organisation's billing currency. A zero-decimal organisation was charged **a hundred times** the service cost.

Before-row, on unmodified dev with only this PR's test file:

```
● submits a zero-decimal appointment cost unscaled
    - Expected: {"amount": 1000,   "currency": "jpy", ...}
    + Received: {"amount": 100000, "currency": "jpy", ...}
```

A ¥1,000 appointment submitted to Stripe as ¥100,000. Nothing caught it because the only existing assertion on that call checks `expect.not.objectContaining({ transfer_data })` — the amount reaching Stripe was never asserted at all.

## What changed

The correct, currency-aware converter already existed: file-private in `services/finance/payment.ts`, five call sites, exported nowhere. That is *why* a second currency-blind one grew beside it. So this promotes the existing one rather than adding a third.

- **New** `src/utils/stripe-minor-units.ts` — the promoted converter and its set.
- `finance/payment.ts` — local copy deleted, imports the shared one. Five call sites unchanged.
- `stripe.service.ts` — `toStripeAmount` deleted, its single call site migrated. The `currency` line moved above the `amount` line; neither depends on the other.

**Placement.** Not `utils/billing.ts`, despite that being the currency module and already imported by this file: it imports `prisma`, and `finance/tax.ts` — the next consumer — is a pure calculation module with no database dependency. A number conversion should not drag the database into it.

**Naming.** `stripe-minor-units`, not `money`. The frontend's `money.ts` is `Intl` display formatting with **zero** conversions to minor units; it answers "how do I show this to a human" where this answers "what integer does Stripe accept". They look like duplicates and are not, and a future "we have two money helpers, let us merge them" is the plausible next mistake. The name makes it hard to make by accident. This helper must not be folded into that one.

## Guarding the direction the bug came from

The set was pinned against *removing* a correct entry and not against *adding* a wrong one — which is how both UGX and this class arrive. Measured: adding `isk` or `gbp` left the suite fully green.

This adds an explicit **ISK** case, which carries the identical Stripe special-case rule to UGX and was previously protected only by a comment. Mutations against the new unit tests:

| Mutation | Result |
|---|---|
| always `×100` (kill the zero-decimal branch) | **2 failed** |
| put `"ugx"` back | **1 failed** |
| **add `"isk"`** | **1 failed** (was green before this PR) |
| drop `.trim().toLowerCase()` | **1 failed** |
| restore | 8/8 green |

## Evidence

| | |
|---|---|
| full backend suite | **exit 0** — 480 suites / 11469 tests |
| `turbo run lint type-check --filter=backend --force` | **exit 0** — 7/7, 0 errors, 25 pre-existing warnings |

`git rev-parse HEAD` checked either side of the run, tree clean both times.

Run independently a second time before this was opened, on the commit on this branch, `git rev-parse HEAD`
checked either side and the tree clean both times: **480 suites / 11469 tests exit 0**, lint and type-check
**7/7, 0 errors**.

**Mutation matrix over the shared converter**, each mutation asserting it applied to exactly one occurrence
before substituting, and the file restored from a pristine copy between runs. Baseline and restore are both
249/249 across `stripe-minor-units.test.ts`, `stripe.service.test.ts` and `finance.payment.test.ts`:

| Mutation | Tests failed |
|---|---|
| always `× 100` (drop the ternary) | **4** |
| put `"ugx"` back into the set | **2** |
| add `"isk"` to the set | **1** |
| drop `.trim().toLowerCase()` | **1** |

Every branch of the converter is reddened by at least one mutation, **including adding a wrong entry** —
which is the direction the UGX bug arrived through and the direction #2739's tests did not cover. Measured on
`dev` before this change, `add "isk"` was green.

## Deliberately not done

- **`finance/tax.ts` still scales with a bare `×100`,** in both directions, at six sites. It is not a two-line swap: `allocateInvoiceDiscountAcrossLines` converts to minor units, allocates a discount with remainder distribution, and converts back, with no currency parameter. Doing it correctly means allocating in the currency's *real* minor unit — for a zero-decimal currency the current code distributes remainders at 1/100th of the smallest unit that exists — and needs a reverse converter that does not exist yet. That is its own change with its own review, and it is a correctness question, not a tidying one.
- **`inventory-consumption.service.ts:434` `resolvePriceCents` is out of scope** and named rather than missed: zero Stripe references, zero currency references.
- **The reverse `/100` direction is untouched** — seven sites in `stripe.service.ts` alone. No existing currency-aware counterpart to promote.
- **The half-cent float drift is pinned as it behaves, not as it should.** `toStripeMinorUnits(8.165, "usd")` returns `816`, because `8.165 * 100` is `816.4999999999999`. Fixing it changes money at every call site. The test asserts `816` so a future fix reddens it and has to say so.

## Not established

~~The remaining fourteen entries in the set are unaudited.~~ **Discharged.** The list was read in
English in a browser at `docs.stripe.com/currencies?locale=en-US` (`document.documentElement.lang`
= `en-US`) and diffed against the set programmatically:

```
our set  (15): bif clp djf gnf jpy kmf krw mga pyg rwf vnd vuv xaf xof xpf
stripe   (16): + ugx, which carries a special case

in ours, not on Stripe's list             : NONE
unexplained omissions (would undercharge) : NONE
wrongly present despite a special case    : NONE
```

Verbatim from the source, and it is the exact fixture the tests use:

> "UGX transitioned to a zero-decimal currency, but backwards compatibility requires you to
> represent it as a two-decimal value, where the decimal amount is always `00`. For example, **to
> charge 5 UGX, provide an `amount` value of `500`.**"

**Why every automated fetch came back Spanish, since it was never a transient failure:** the docs
carry region and language as two independent controls and default the language to the detected
region. The right page in the wrong language looks exactly like a flaky fetch and is not one.

**One thing the source says that this set's name does not.** HUF and TWD are zero-decimal for
**payouts**, not for charges — "even though you can charge two-decimal amounts". Both are correctly
absent, but for a reason the code does not state. This set is *"currencies whose charge amount is
unscaled"*, not *"Stripe's zero-decimal currencies"*, and anyone adding payout support who reads it
as the latter gets HUF and TWD backwards. Worth a sentence in the module comment.
