### PR TITLE
docs(ci): correct the deployed-sha guard comments to what the tests show

### DIFF
--- a/scripts/deploy/lib/migrate.sh
+++ b/scripts/deploy/lib/migrate.sh
@@ -101,6 +101,16 @@ deploy_deployed_sha() {
   # returning, arriving through the check meant to prevent it. Only reachable
   # through a corrupted or hand-edited record, which is precisely the case this
   # function's own comment anticipates. Raised by ankit-yc on #2732.
+  #
+  # Nearly, but not entirely, subsumed by the prefix comparison below: "dev" and
+  # "HEAD" resolve to something that does not begin with themselves, so the
+  # comparison would reject them too. One input still tells the two apart - a
+  # VALID short abbreviation, the first six characters of a real sha, which the
+  # comparison accepts and this rejects. Keeping it is the deliberate choice: a
+  # six-character prefix is one collision away from ambiguity as the repo grows,
+  # and falling back to HEAD is the safe answer when the record is that thin.
+  # An earlier version of this comment called the class dead; it is not, and the
+  # abbreviation above is the counterexample that reddens it.
   if [ "${#recorded}" -lt 7 ]; then
     recorded=""
   fi
@@ -113,8 +123,11 @@ deploy_deployed_sha() {
   # So the value is COMPARED rather than described: resolve it, then require the
   # resolved sha to begin with what was recorded. That subsumes the hex-character
   # class this replaced - a name git resolves to something not beginning with it
-  # is rejected whatever characters it holds, and no mutation could redden the
-  # class once the comparison was here, which is the definition of dead.
+  # is rejected whatever characters it holds. A ref cannot satisfy that unless it
+  # happens to be named after its own target's prefix, in which case the ref and
+  # the object agree and accepting it costs nothing - a coincidence rather than a
+  # hole, and the reason this is a comparison and not a ban on names that look
+  # like shas.
   #
   # `"$recorded"*` and not `$recorded*`: the expansion is quoted so a record
   # holding `*`, `?` or `[a-f]` is compared literally rather than as a pattern.
@@ -125,11 +138,7 @@ deploy_deployed_sha() {
   # sha or a ref name, neither of which can contain a glob metacharacter - so
   # unquoting it is green on every input I could construct. Tests asserting
   # otherwise were written for this and deleted when the mutation stayed green.
-  # The quoting stays because it is free and correct, not because it is proven. A ref cannot satisfy that
-  # unless it happens to be named after its own target's prefix, in which case
-  # the ref and the object agree and accepting it costs nothing - a coincidence
-  # rather than a hole, and the reason this is a comparison and not a ban on
-  # names that look like shas.
+  # The quoting stays because it is free and correct, not because it is proven.
   if [ -n "$recorded" ]; then
     local resolved
     resolved="$(git -C "$repo" rev-parse --verify --quiet "$recorded^{commit}" 2>/dev/null || true)"


### PR DESCRIPTION
Comment-only correction to two defects in comments on `deploy_deployed_sha`, found by QA-ing the merged result of #2732/#2735 rather than re-reading the diff.

## What was wrong

**The comment asserted a live guard was dead code.** It said no mutation could redden the `-lt 7` length class once the prefix comparison was in place, "which is the definition of dead." That is the stated justification for the guard, so leaving it standing invites someone deleting a guard that still decides an outcome.

**A sentence had been spliced onto the wrong paragraph** — a note about the prefix comparison welded to the end of the paragraph about quoting, where its "that" has no referent. Moved back.

## The counterexample, reproduced independently

A **valid six-character abbreviation of a real sha** is accepted by the prefix comparison and rejected by the length guard. Driven against a throwaway repo with two commits, the record holding a six-character prefix of the **older** one:

```
HEAD    2b6980013eb87948ce89a4206b7412fc62b76c2c
record  ef35e9        (a real abbreviation of ef35e9c0fb39…, deliberately not HEAD)

guard present  -> 2b698001…   HEAD, record rejected
guard removed  -> ef35e9c0…   a DIFFERENT commit accepted
```

Without the guard, the wrong rollback target arrives through the check that exists to stop it. The class is alive.

**My first attempt at this probe was vacuous and is worth recording.** I used a six-character prefix of `HEAD` itself, so both variants returned the same sha and the guard looked dead a second time — the fixture could not distinguish the guard from the fallback, because the fallback's own answer was the value I was testing for. Making the record disagree with `HEAD` is the whole experiment.

## Verification that this changes no behaviour

```
comment-stripped, diff against dev   identical, 94 code lines
bash -n                              clean
scripts/deploy/tests/migrate.test.sh 68 passed, 0 failed
```

## Why it is worth a PR on its own

A green mutation has two causes — dead code, or an input too weak to reach the branch — and only the first was recorded. A comment that documents the second as the first is wrong in the direction that gets acted on.
