### PR TITLE
fix(backend): report the authentication control at startup

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,7 +1,11 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import fileUpload from "express-fileupload";
-import { getControlReports, hasFailedControl } from "./config/startup-controls";
+import {
+  getControlReports,
+  hasFailedControl,
+  recordControl,
+} from "./config/startup-controls";
 import { registerRoutes } from "./routers";
 import { StripeController } from "./controllers/web/stripe.controller";
 import { FinanceController } from "./controllers/app/finance.controller";
@@ -24,24 +28,35 @@ import {
 } from "@yosemite-crew/auth";
 import { authHooks } from "./config/auth-hooks";
 
-function isSuperTokensEnabled(): boolean {
+/**
+ * Three states, not two.
+ *
+ * `disabled` and `incomplete` both leave every /auth route a 404 while /health
+ * still answers 200, so from outside they are the same process - one of them
+ * deliberate, the other a deploy that lost a variable. The boolean this used to
+ * return computed the distinction and then threw it away.
+ */
+type AuthGate = "enabled" | "disabled" | "incomplete";
+
+function readAuthGate(): AuthGate {
   const disabled =
     process.env.SUPERTOKENS_DISABLED === "true" ||
     process.env.SUPERTOKENS_DISABLED === "1";
 
-  if (disabled) return false;
+  if (disabled) return "disabled";
 
-  return Boolean(
-    process.env.SUPERTOKENS_CONNECTION_URI &&
+  return process.env.SUPERTOKENS_CONNECTION_URI &&
     process.env.AUTH_API_DOMAIN &&
-    process.env.AUTH_WEBSITE_DOMAIN,
-  );
+    process.env.AUTH_WEBSITE_DOMAIN
+    ? "enabled"
+    : "incomplete";
 }
 
 export function createApp() {
   const app = express();
 
-  const superTokensEnabled = isSuperTokensEnabled();
+  const authGate = readAuthGate();
+  const superTokensEnabled = authGate === "enabled";
   if (superTokensEnabled) {
     // Fail fast at startup on invalid auth config (epic #1672 acceptance).
     const authConfig = readAuthConfig();
@@ -62,8 +77,21 @@ export function createApp() {
     app.use("/auth", authLimiter);
 
     registerSuperTokensBeforeRoutes(app);
+    recordControl("authentication", "applied");
   } else {
     setAuthService(null);
+    // Turning auth off is a deployment fact; booting without the env it needs
+    // is an incident nobody asked for. `failed` is what /health/controls
+    // surfaces as degraded, so a monitor sees an auth-less deploy immediately.
+    //
+    // The detail never names the missing variable: this endpoint is
+    // unauthenticated by design (see startup-controls.ts), and "incomplete" is
+    // already enough to act on.
+    if (authGate === "disabled") {
+      recordControl("authentication", "skipped", "disabled by configuration");
+    } else {
+      recordControl("authentication", "failed", "auth env incomplete");
+    }
   }
   app.use(helmet());
   app.disable("x-powered-by");

--- a/apps/backend/test/app.test.ts
+++ b/apps/backend/test/app.test.ts
@@ -71,6 +71,11 @@ jest.mock("../src/config/auth-hooks", () => ({
 }));
 
 import { createApp } from "../src/app";
+import {
+  getControlReports,
+  hasFailedControl,
+  resetControlsForTest,
+} from "../src/config/startup-controls";
 
 type Layer = {
   route?: {
@@ -317,5 +322,177 @@ describe("createApp auth wiring", () => {
 
     expect(mockInitSuperTokens).not.toHaveBeenCalled();
     expect(mockSetAuthService).toHaveBeenCalledWith(null);
+  });
+});
+
+// #2750: a missing auth variable disabled the whole SuperTokens stack with no
+// log line, no throw and no control report - so "somebody turned auth off" and
+// "a deploy lost a variable" were the same observable process from outside.
+describe("createApp reports the authentication control", () => {
+  const authEnv = {
+    SUPERTOKENS_CONNECTION_URI: "https://core.example.test",
+    AUTH_API_DOMAIN: "https://api.example.test",
+    AUTH_WEBSITE_DOMAIN: "https://web.example.test",
+  };
+  const envKeys = [
+    "SUPERTOKENS_DISABLED",
+    "SUPERTOKENS_CONNECTION_URI",
+    "AUTH_API_DOMAIN",
+    "AUTH_WEBSITE_DOMAIN",
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  const authControl = () =>
+    getControlReports().find((report) => report.name === "authentication");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetControlsForTest();
+    for (const key of envKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    resetControlsForTest();
+    for (const key of envKeys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("records applied when the auth env is complete", () => {
+    Object.assign(process.env, authEnv);
+
+    createApp();
+
+    expect(authControl()).toMatchObject({ state: "applied" });
+    expect(authControl()).not.toHaveProperty("detail");
+    expect(hasFailedControl()).toBe(false);
+  });
+
+  it("records skipped, not failed, when auth is deliberately turned off", () => {
+    Object.assign(process.env, authEnv);
+    process.env.SUPERTOKENS_DISABLED = "true";
+
+    createApp();
+
+    expect(authControl()).toMatchObject({
+      state: "skipped",
+      detail: "disabled by configuration",
+    });
+    // A kill switch somebody threw is a deployment fact, not an incident: if it
+    // paged, people would learn to ignore this endpoint.
+    expect(hasFailedControl()).toBe(false);
+  });
+
+  it("records failed when the auth env is incomplete", () => {
+    Object.assign(process.env, authEnv);
+    delete process.env.AUTH_WEBSITE_DOMAIN;
+
+    createApp();
+
+    expect(authControl()).toMatchObject({
+      state: "failed",
+      detail: "auth env incomplete",
+    });
+    expect(hasFailedControl()).toBe(true);
+  });
+
+  // The distinction the issue is about: the two unmounted boots must not read
+  // the same. Both skip the SuperTokens wiring; only one of them is a fault.
+  it("distinguishes the deliberate boot from the accidental one", () => {
+    Object.assign(process.env, authEnv);
+    process.env.SUPERTOKENS_DISABLED = "1";
+    createApp();
+    const deliberate = authControl()?.state;
+
+    resetControlsForTest();
+    jest.clearAllMocks();
+    delete process.env.SUPERTOKENS_DISABLED;
+    delete process.env.AUTH_API_DOMAIN;
+    createApp();
+    const accidental = authControl()?.state;
+
+    expect(mockRegisterSuperTokensBeforeRoutes).not.toHaveBeenCalled();
+    expect(deliberate).toBe("skipped");
+    expect(accidental).toBe("failed");
+    expect(deliberate).not.toBe(accidental);
+  });
+
+  // Precedence, and it is the case that could mask an accident: the kill switch
+  // wins over an incomplete env, so a boot that is BOTH still reports the
+  // deliberate state. That is the right way round - somebody asked for this
+  // process - but it is worth pinning rather than leaving to the read order.
+  it("reports skipped when auth is switched off and the env is incomplete too", () => {
+    process.env.SUPERTOKENS_DISABLED = "true";
+
+    createApp();
+
+    expect(authControl()).toMatchObject({
+      state: "skipped",
+      detail: "disabled by configuration",
+    });
+    expect(hasFailedControl()).toBe(false);
+  });
+
+  // /health/controls is unauthenticated by design, so the detail must never say
+  // which variable is missing - that is a map of the deployment to anyone.
+  it("never names the missing variable in the reported detail", () => {
+    Object.assign(process.env, authEnv);
+    delete process.env.SUPERTOKENS_CONNECTION_URI;
+
+    createApp();
+
+    const detail = authControl()?.detail ?? "";
+    for (const key of envKeys) {
+      expect(detail).not.toContain(key);
+    }
+    expect(detail).toBe("auth env incomplete");
+  });
+
+  it("degrades /health/controls but not /health when auth did not mount", async () => {
+    Object.assign(process.env, authEnv);
+    delete process.env.AUTH_WEBSITE_DOMAIN;
+
+    const app = createApp();
+
+    const liveness = await request(app, { path: "/health" });
+    const controls = await request(app, { path: "/health/controls" });
+    const body = JSON.parse(controls.body) as {
+      status: string;
+      controls: Array<{ name: string; state: string; detail?: string }>;
+    };
+
+    // Liveness is unchanged on purpose: the process is up, the control is not.
+    expect(liveness.statusCode).toBe(200);
+    expect(controls.statusCode).toBe(503);
+    expect(body.status).toBe("degraded");
+    expect(body.controls).toContainEqual(
+      expect.objectContaining({
+        name: "authentication",
+        state: "failed",
+        detail: "auth env incomplete",
+      }),
+    );
+  });
+
+  it("keeps /health/controls green when auth mounted", async () => {
+    Object.assign(process.env, authEnv);
+
+    const app = createApp();
+
+    const controls = await request(app, { path: "/health/controls" });
+    const body = JSON.parse(controls.body) as {
+      status: string;
+      controls: Array<{ name: string; state: string }>;
+    };
+
+    expect(controls.statusCode).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.controls).toContainEqual(
+      expect.objectContaining({ name: "authentication", state: "applied" }),
+    );
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`createApp` gates the whole SuperTokens stack on a boolean. When that boolean is
false the app skips `registerSuperTokensBeforeRoutes` and
`registerSuperTokensErrorHandler` with no log line, no thrown error and no
control report - the process starts, `/health` answers 200, and every
authentication route is a 404.

The boolean is false in two very different situations:

| Boot | `/health` | `/health/controls` | auth routes |
|---|---|---|---|
| `SUPERTOKENS_DISABLED` set - deliberate | 200 | unchanged | 404 |
| an auth variable absent - an accident | 200 | unchanged | 404 |

Nothing an operator or a monitor can reach separates *someone turned auth off*
from *a variable went missing in a deploy*. `startup-controls.ts` exists for
exactly this failure mode and says so - "a control that FAILS TO APPLY must not
look the same as one that was never asked to" - and the Stream upload policy is
registered there while authentication is not.

The gate function already computed the distinction, one line above, and then
discarded it.

## What is the new behavior?

The gate returns the three states it already knows about instead of a boolean,
and records one control:

```
SUPERTOKENS_DISABLED set  ->  skipped, "disabled by configuration"
auth env incomplete       ->  failed,  "auth env incomplete"
mounted                   ->  applied
```

`failed` is the state `hasFailedControl()` already surfaces, so
`/health/controls` answers 503 `degraded` on an auth-less deploy and a monitor
sees it from outside without anyone reading a log. `/health` is deliberately
unchanged: the process is up, the control is not.

Two deliberate choices worth flagging for review:

- **The detail never names the missing variable.** `/health/controls` is
  unauthenticated by design, and "auth env incomplete" is enough to act on.
  A test asserts none of the four variable names can appear in the detail.
- **The control is named `authentication`, not the provider.** The issue
  suggested the provider name. The endpoint is public, the control being
  reported is "authentication is mounted" rather than a vendor, and a monitor's
  alert keeps working if the provider is ever swapped.

A kill switch somebody threw stays `skipped`, not `failed` - per that file's own
reasoning, paging on a deployment fact would train people to ignore the
endpoint.

### Verification

Run in `apps/backend` on this branch:

- `npx jest` - 480 suites, 11478 tests, exit 0 (full backend suite, not a
  scoped run).
- `pnpm --filter backend run lint` - exit 0, 0 errors, 25 pre-existing warnings.
- `pnpm --filter backend run type-check` - exit 0.
- Coverage of the changed file: `app.ts` 99.2% lines, 92% branches; the two
  uncovered lines are pre-existing and untouched.
- Each of the 8 new tests was mutation-checked, and checked by which test went
  red rather than by exit code. Six mutations: dropping the `applied` record,
  swapping `skipped` for `failed` in either direction, putting a variable name
  into the detail, collapsing the gate back to two states, and making the kill
  switch depend on the env being complete. The last one is reddened by exactly
  one test - the kill-switch-plus-incomplete-env case is the only input that
  separates it from the others.

One note on running this branch locally, because the first lint run here was
misleading: in a fresh worktree `pnpm --filter backend run lint` reports
thousands of `no-unsafe-*` errors in files nobody touched, `app.ts` included.
Nothing is wrong with the code - the workspace packages are not built, so the
type-aware rules cannot resolve `@yosemite-crew/auth`. `turbo run build
--filter ./packages/*` first, and the same command exits 0. Jest likewise needs
`prisma generate` to have run in the worktree.

## Related Issue(s)

Fixes #2750
