### PR TITLE
fix(ci): gate the api cutover on named startup controls

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -60,6 +60,12 @@ jobs:
       # it is here rather than mocked.
       - name: Run deploy migration tests
         run: ./scripts/deploy/tests/migrate.test.sh
+      # This suite needs node, for the same reason the gate uses it: the cutover
+      # decision is made by parsing a JSON body, and a gate that mis-parses is
+      # worse than no gate. ubuntu-latest ships one, and the deploy host proves
+      # it has one by booting the bundle before this check ever runs.
+      - name: Run deploy startup-control gate tests
+        run: ./scripts/deploy/tests/controls.test.sh
 
   deploy:
     # Only ever on an explicit dispatch. The pull_request trigger above exists for

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -50,11 +50,17 @@ SMOKE_PORT="${4:-8099}"
 
 NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
 
+# Which startup controls stop a cutover. A LIST of names, never the aggregate
+# /health/controls status - see lib/controls.sh for why the aggregate is the
+# wrong gate. Overridable so an environment that genuinely runs without one of
+# these does not need a code change to deploy.
+DEPLOY_BLOCKING_CONTROLS="${DEPLOY_BLOCKING_CONTROLS:-authentication}"
+
 # lib/ has to travel WITH this script. Copying api-deploy.sh alone leaves this
 # looking for a helper that is not on the box, and bash exits before preflight
 # with a bare "No such file or directory" - so say what is actually wrong.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-for helper in git-sync migrate; do
+for helper in git-sync migrate controls; do
   if [ ! -r "$SCRIPT_DIR/lib/$helper.sh" ]; then
     echo "missing $SCRIPT_DIR/lib/$helper.sh" >&2
     echo "Copy the whole scripts/deploy directory to the host, not just this file." >&2
@@ -65,6 +71,8 @@ done
 . "$SCRIPT_DIR/lib/git-sync.sh"
 # shellcheck source=lib/migrate.sh
 . "$SCRIPT_DIR/lib/migrate.sh"
+# shellcheck source=lib/controls.sh
+. "$SCRIPT_DIR/lib/controls.sh"
 export PATH="$NODE_BIN:$PATH"
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
 
@@ -244,6 +252,19 @@ POST_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
   -X POST -H 'content-type: application/json' -d '{"smoke":true}' \
   "http://127.0.0.1:$SMOKE_PORT/v1/definitely-not-a-route" || echo 000)"
 echo "  body parse -> $POST_CODE"
+# Which security controls actually applied in THIS environment, read from the
+# process that is about to serve traffic, while a rollback is still free.
+#
+# /health above is liveness and answers 200 for a process whose entire /auth
+# surface is 404 - by design, since #2750 deliberately left it alone. The body
+# is printed whatever it says; only a NAMED control reporting `failed` stops the
+# cutover, and lib/controls.sh holds the reasoning for every case that does not.
+# The 503 this returns when degraded is why there is no -f and no code check
+# here: the body is the signal, not the status.
+CONTROLS_BODY="$(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health/controls" || echo '')"
+echo "  controls -> ${CONTROLS_BODY:-<unreachable>}"
+# shellcheck disable=SC2086 # deliberately word-split: this is a list of names
+CONTROL_FAILURES="$(deploy_blocking_control_failures "$CONTROLS_BODY" $DEPLOY_BLOCKING_CONTROLS)"
 # Reports, never gates - the `|| true` is what makes that true, and it is
 # deliberate: this is a second signal for whoever reads the log, and POST_CODE
 # above is the gate.
@@ -259,6 +280,16 @@ fi
 if [ "$POST_CODE" != "404" ]; then
   echo "smoke boot could not parse a request body ($POST_CODE, expected 404)" >&2
   echo "- every GET probe passes a bundle that 500s on every write." >&2
+  echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  exit 1
+fi
+
+if [ -n "$CONTROL_FAILURES" ]; then
+  echo "smoke boot came up with a security control that FAILED to apply:" >&2
+  while IFS= read -r control_failure; do
+    echo "  $control_failure" >&2
+  done <<< "$CONTROL_FAILURES"
+  echo "- the process starts and /health answers 200 with the control absent." >&2
   echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
   exit 1
 fi

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -268,8 +268,7 @@ echo "  body parse -> $POST_CODE"
 # EXIT trap turns that into a stop notice with the rollback sha.
 CONTROLS_BODY="$(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health/controls" || echo '')"
 echo "  controls -> ${CONTROLS_BODY:-<unreachable>}"
-# shellcheck disable=SC2086 # deliberately word-split: this is a list of names
-CONTROL_FAILURES="$(deploy_blocking_control_failures "$CONTROLS_BODY" $DEPLOY_BLOCKING_CONTROLS)"
+CONTROL_FAILURES="$(deploy_blocking_control_failures "$CONTROLS_BODY" "$DEPLOY_BLOCKING_CONTROLS")"
 # Reports, never gates - the `|| true` is what makes that true, and it is
 # deliberate: this is a second signal for whoever reads the log, and POST_CODE
 # above is the gate.

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -261,6 +261,11 @@ echo "  body parse -> $POST_CODE"
 # cutover, and lib/controls.sh holds the reasoning for every case that does not.
 # The 503 this returns when degraded is why there is no -f and no code check
 # here: the body is the signal, not the status.
+#
+# The assignment below is deliberately NOT tolerant. An unreadable body ships -
+# that decision is in lib/controls.sh - but a helper that cannot RUN stops the
+# deploy here, because set -e carries a command substitution's status and the
+# EXIT trap turns that into a stop notice with the rollback sha.
 CONTROLS_BODY="$(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health/controls" || echo '')"
 echo "  controls -> ${CONTROLS_BODY:-<unreachable>}"
 # shellcheck disable=SC2086 # deliberately word-split: this is a list of names

--- a/scripts/deploy/lib/controls.sh
+++ b/scripts/deploy/lib/controls.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Which startup controls stop a cutover, and - more importantly - which do not.
+#
+# /health/controls exists so a security control that FAILED TO APPLY does not
+# look like one that was never asked to (apps/backend/src/config/startup-controls.ts).
+# The deploy's smoke boot runs the real bundle against the real environment
+# before cutover, which is the one moment a rollback is still free, and until
+# now it read only /health - which answers 200 for a process whose entire /auth
+# surface is 404, because /health is liveness and was designed to.
+#
+# The obvious wiring is wrong. /health/controls returns 503 whenever ANY control
+# is `failed`, and stream-upload-policy records `failed` when Stream's
+# updateAppSettings rejects. startup-controls.ts is explicit that this must not
+# take the API down - "a Stream outage should not take the API down, it should
+# be VISIBLE" - so gating cutover on the aggregate would convert a third-party
+# outage into a blocked deploy, which is that decision inverted.
+#
+# Hence: NAMED controls, and a rule stated as a positive rather than a negative.
+
+# deploy_blocking_control_failures <controls-json> [name ...]
+#
+# Echoes one line per named control that positively reports `failed`. Echoes
+# nothing - and so ships - in every other case:
+#
+#   named control `failed`      BLOCK. The only blocking state.
+#   named control `skipped`     ship. Auth switched off is a deployment fact,
+#                               not a fault; treating it as one is the same
+#                               mistake as ignoring the endpoint, mirrored.
+#   named control ABSENT        ship. A ROLLBACK deploys an older bundle that
+#                               never records the control, so blocking on
+#                               absence would refuse the deploy most needed to
+#                               work. This is the deliberate weak spot: a bundle
+#                               that silently stops recording is not caught here.
+#   endpoint unreachable        ship. /health is already the liveness gate and
+#   or not JSON                 it runs first; a second liveness check that
+#                               guesses at a body is not one.
+#   unnamed control `failed`    ship. See the Stream reasoning above.
+#
+# The caller prints the body either way, so every one of those cases is
+# reported. What this function decides is only which of them stops the deploy.
+#
+# Node rather than sed: the shape is ours, but a gate that mis-parses is worse
+# than no gate, and the box already proved node works by booting the bundle on
+# the smoke port two lines earlier.
+deploy_blocking_control_failures() {
+  local json="${1-}"
+  shift || true
+
+  # Both short-circuits only avoid a pointless subprocess: node reaches the same
+  # answer for an unparseable body and for an empty name list. Neither carries
+  # any part of the decision above, and removing them changes no test.
+  [ -n "$json" ] || return 0
+  [ "$#" -gt 0 ] || return 0
+
+  DEPLOY_REQUIRED_CONTROLS="$*" node -e '
+    let raw = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { raw += chunk; });
+    process.stdin.on("end", () => {
+      const required = (process.env.DEPLOY_REQUIRED_CONTROLS || "")
+        .split(/\s+/)
+        .filter(Boolean);
+
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return;
+      }
+
+      const reports =
+        parsed && Array.isArray(parsed.controls) ? parsed.controls : [];
+
+      for (const name of required) {
+        const report = reports.find(
+          (candidate) => candidate && candidate.name === name,
+        );
+        if (!report || report.state !== "failed") continue;
+        const detail =
+          typeof report.detail === "string" && report.detail
+            ? " (" + report.detail + ")"
+            : "";
+        process.stdout.write(name + ": failed" + detail + "\n");
+      }
+    });
+  ' <<< "$json"
+}

--- a/scripts/deploy/lib/controls.sh
+++ b/scripts/deploy/lib/controls.sh
@@ -18,7 +18,16 @@
 #
 # Hence: NAMED controls, and a rule stated as a positive rather than a negative.
 
-# deploy_blocking_control_failures <controls-json> [name ...]
+# deploy_blocking_control_failures <controls-json> <blocking-names>
+#
+# <blocking-names> is ONE argument: a whitespace-separated list. It used to be
+# variadic, which forced the caller to leave its list unquoted for word
+# splitting - and an unquoted expansion is also a pathname expansion, so a name
+# containing a glob character would have expanded against the deploy host's
+# working directory before this function ever saw it. Nothing sets such a name,
+# and no test here can distinguish it because the expansion happens at the call
+# site rather than in here. Taking one quoted argument removes the exposure by
+# construction instead: node does the splitting, on whitespace, below.
 #
 # Echoes one line per named control that positively reports `failed`. Echoes
 # nothing - and so ships - in every other case:
@@ -57,15 +66,15 @@
 # the smoke port two lines earlier.
 deploy_blocking_control_failures() {
   local json="${1-}"
-  shift || true
+  local names="${2-}"
 
   # Both short-circuits only avoid a pointless subprocess: node reaches the same
   # answer for an unparseable body and for an empty name list. Neither carries
   # any part of the decision above, and removing them changes no test.
   [ -n "$json" ] || return 0
-  [ "$#" -gt 0 ] || return 0
+  [ -n "$names" ] || return 0
 
-  DEPLOY_REQUIRED_CONTROLS="$*" node -e '
+  DEPLOY_REQUIRED_CONTROLS="$names" node -e '
     let raw = "";
     process.stdin.setEncoding("utf8");
     process.stdin.on("data", (chunk) => { raw += chunk; });

--- a/scripts/deploy/lib/controls.sh
+++ b/scripts/deploy/lib/controls.sh
@@ -37,6 +37,18 @@
 #                               guesses at a body is not one.
 #   unnamed control `failed`    ship. See the Stream reasoning above.
 #
+#   node itself cannot run      STOP THE DEPLOY, and this is the one row that is
+#                               not decided here. Command substitution in an
+#                               assignment carries the command's status, so
+#                               api-deploy.sh's `set -e` fires before the cutover
+#                               checks and the EXIT trap prints the rollback sha.
+#                               Deliberate: an unreadable BODY is a fact about
+#                               the process, but an interpreter that will not
+#                               start is a gate that could not run, and a gate
+#                               that could not run is not a gate that passed.
+#                               The smoke boot proved node works two lines
+#                               earlier, so reaching this is genuinely anomalous.
+#
 # The caller prints the body either way, so every one of those cases is
 # reported. What this function decides is only which of them stops the deploy.
 #

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -16,6 +16,18 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 DEPLOY_SH="$HERE/../api-deploy.sh"
 
+# api-deploy.sh with full-line comments BLANKED, line numbering preserved.
+#
+# Every guard below reads this rather than the file. The first version of the
+# probe guard grepped the file and stayed green with the probe deleted, because
+# the reasoning written above the probe names the same path twice - a check that
+# could not see the thing it was named after, reporting on prose in the same
+# file. Blanking rather than deleting keeps the line numbers, which the ordering
+# guard needs. Trailing comments on code lines are left alone: stripping those
+# means parsing quoting, and the failure that actually happened was a full-line
+# one.
+DEPLOY_CODE="$(sed -E 's/^[[:space:]]*#.*$//' "$DEPLOY_SH")"
+
 PASS=0
 FAIL=0
 
@@ -202,28 +214,27 @@ echo "api-deploy.sh wiring"
 # above the probe names that path twice, so a bare string search stays green
 # with the probe deleted. It did, the first time this was written.
 PROBE_RE='curl .*SMOKE_PORT/health/controls'
-if grep -qE "$PROBE_RE" "$DEPLOY_SH"; then
+if grep -qE "$PROBE_RE" <<< "$DEPLOY_CODE"; then
   ok "api-deploy.sh curls /health/controls"
 else
   no "api-deploy.sh curls /health/controls" "no curl of that path in the file"
 fi
 
-if grep -q 'DEPLOY_BLOCKING_CONTROLS:-authentication' "$DEPLOY_SH"; then
+if grep -q 'DEPLOY_BLOCKING_CONTROLS:-authentication' <<< "$DEPLOY_CODE"; then
   ok "authentication is a blocking control by default"
 else
   no "authentication is a blocking control by default" \
      "no DEPLOY_BLOCKING_CONTROLS default naming it"
 fi
 
-if grep -q 'deploy_blocking_control_failures' "$DEPLOY_SH"; then
+if grep -q 'deploy_blocking_control_failures' <<< "$DEPLOY_CODE"; then
   ok "api-deploy.sh asks which named controls block the cutover"
 else
   no "api-deploy.sh asks which named controls block the cutover" \
      "the helper is never called"
 fi
 
-if grep -qE 'CONTROL_FAILURES.*exit 1|exit 1.*CONTROL_FAILURES' "$DEPLOY_SH" \
-  || awk '/if \[ -n "\$CONTROL_FAILURES" \]/,/^fi$/' "$DEPLOY_SH" | grep -q 'exit 1'; then
+if awk '/if \[ -n "\$CONTROL_FAILURES" \]/,/^fi$/' <<< "$DEPLOY_CODE" | grep -q 'exit 1'; then
   ok "a blocking control failure stops the cutover"
 else
   no "a blocking control failure stops the cutover" \
@@ -237,7 +248,7 @@ fi
 # missing result rather than a failure.
 # `|| true` on the assignment would turn the stop above into a ship, which is
 # the one regression that cannot be seen by running the function.
-ASSIGN_LINE="$(grep -nE 'CONTROL_FAILURES=.*deploy_blocking_control_failures' "$DEPLOY_SH" || true)"
+ASSIGN_LINE="$(grep -nE 'CONTROL_FAILURES=.*deploy_blocking_control_failures' <<< "$DEPLOY_CODE" || true)"
 if [ -n "$ASSIGN_LINE" ] && ! printf '%s' "$ASSIGN_LINE" | grep -q '||'; then
   ok "the helper's exit status is not swallowed at the call site"
 else
@@ -245,8 +256,8 @@ else
      "assignment line: ${ASSIGN_LINE:-<not found>}"
 fi
 
-PROBE_LINE="$(grep -nE "$PROBE_RE" "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
-KILL_LINE="$(grep -nE 'kill .*SMOKE_PID' "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
+PROBE_LINE="$(grep -nE "$PROBE_RE" <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"
+KILL_LINE="$(grep -nE 'kill .*SMOKE_PID' <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"
 if [ -n "$PROBE_LINE" ] && [ -n "$KILL_LINE" ] && [ "$PROBE_LINE" -lt "$KILL_LINE" ]; then
   ok "the controls probe runs before the smoke process is killed"
 else

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -38,6 +38,26 @@ check() { # check <name> <expected> <actual>
   if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "expected '$2', got '$3'"; fi
 }
 
+# ships <name> <controls-json> [required-name...]
+#
+# "Ships" is TWO facts and empty output is only one of them. A helper that
+# crashes also writes nothing to stdout, and a crash is the opposite of a ship:
+# api-deploy.sh runs under set -e, so a non-zero status here stops the deploy.
+# Asserting emptiness alone let four of these pass in a world where three of
+# them stop the cutover - raised in review, and the exact distinction the
+# node-missing probe below was already making in the other direction.
+ships() {
+  local name="$1" json="$2"
+  shift 2
+  local out rc=0
+  out="$(deploy_blocking_control_failures "$json" "$*")" || rc=$?
+  if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    ok "$name"
+  else
+    no "$name" "expected an empty result and exit 0, got rc=$rc out='$out'"
+  fi
+}
+
 # A body in the shape /health/controls actually returns. Built rather than
 # pasted so a test cannot quietly assert against a body the endpoint never
 # produces: name/state/detail and the `at` stamp are all present, and `status`
@@ -92,34 +112,30 @@ check "names the control without a detail when the report carries none" \
 # Auth deliberately switched off is a deployment fact. Blocking on it would
 # make the kill switch unusable, which is the same error as ignoring the
 # endpoint entirely, pointing the other way.
-check "ships when the named control was deliberately skipped" \
-  "" \
-  "$(deploy_blocking_control_failures \
+ships "ships when the named control was deliberately skipped" \
+  \
       "$(body ok "$(control authentication skipped 'disabled by configuration')")" \
-      authentication)"
+      authentication
 
-check "ships when the named control applied" \
-  "" \
-  "$(deploy_blocking_control_failures \
+ships "ships when the named control applied" \
+  \
       "$(body ok "$(control authentication applied)")" \
-      authentication)"
+      authentication
 
 # A rollback deploys a bundle from before the control existed. Blocking on an
 # absent report would refuse the one deploy that most needs to work, so absence
 # ships - and this is the gate's deliberate blind spot, not an accident.
-check "ships when the named control is absent, so a rollback is not refused" \
-  "" \
-  "$(deploy_blocking_control_failures \
+ships "ships when the named control is absent, so a rollback is not refused" \
+  \
       "$(body ok "$(control stream-upload-policy applied)")" \
-      authentication)"
+      authentication
 
 # The whole reason this is a named list and not the aggregate: `status` is
 # already "degraded" in this body, and it must not stop the deploy.
-check "ships when an unnamed control failed, even though the aggregate is degraded" \
-  "" \
-  "$(deploy_blocking_control_failures \
+ships "ships when an unnamed control failed, even though the aggregate is degraded" \
+  \
       "$(body degraded "$(control stream-upload-policy failed 'updateAppSettings rejected')")" \
-      authentication)"
+      authentication
 
 # Both failed: one blocks, one does not, in a single body. The pair is what
 # separates "reads the named control" from "reads the first control".
@@ -133,11 +149,9 @@ check "blocks on the named control only, when both named and unnamed failed" \
 
 # A prefix match would block on this and be wrong. Exercised with a name that
 # CONTAINS the required one, because a substring test passes every case above.
-check "matches a control name exactly rather than by prefix" \
-  "" \
-  "$(deploy_blocking_control_failures \
-      "$(body degraded "$(control authentication-provider failed 'rejected')")" \
-      authentication)"
+ships "matches a control name exactly rather than by prefix" \
+  "$(body degraded "$(control authentication-provider failed 'rejected')")" \
+  authentication
 
 check "reports every named control that failed, not just the first" \
   "authentication: failed (auth env incomplete)
@@ -146,26 +160,29 @@ stream-upload-policy: failed (updateAppSettings rejected)" \
       "$(body degraded \
           "$(control authentication failed 'auth env incomplete')" \
           "$(control stream-upload-policy failed 'updateAppSettings rejected')")" \
-      authentication stream-upload-policy)"
+      "authentication stream-upload-policy")"
+
+# A name is a name. Nothing sets one containing a glob character, but the old
+# variadic signature forced the caller to leave its list unquoted, and this is
+# the reading of that list that a pathname expansion would have destroyed.
+ships "treats a glob-shaped name as a literal name" \
+  "$(body degraded "$(control authentication failed 'auth env incomplete')")" \
+  '*'
 
 # /health is the liveness gate and it runs first. A body this function cannot
 # read is not a second chance to decide the process is dead.
-check "ships on a body that is not JSON" \
-  "" \
-  "$(deploy_blocking_control_failures '<html>502 Bad Gateway</html>' authentication)"
+ships "ships on a body that is not JSON" \
+  '<html>502 Bad Gateway</html>' authentication
 
-check "ships on an empty body" \
-  "" \
-  "$(deploy_blocking_control_failures '' authentication)"
+ships "ships on an empty body" \
+  '' authentication
 
-check "ships on JSON without a controls array" \
-  "" \
-  "$(deploy_blocking_control_failures '{"status":"ok"}' authentication)"
+ships "ships on JSON without a controls array" \
+  '{"status":"ok"}' authentication
 
-check "ships when no control is named as blocking" \
-  "" \
-  "$(deploy_blocking_control_failures \
-      "$(body degraded "$(control authentication failed 'auth env incomplete')")")"
+ships "ships when no control is named as blocking" \
+  \
+      "$(body degraded "$(control authentication failed 'auth env incomplete')")"
 
 # ---------------------------------------------------------------------------
 # The row the table above does not decide: an unreadable BODY ships, but an
@@ -213,7 +230,13 @@ echo "api-deploy.sh wiring"
 # Matched on the curl itself, not on the string /health/controls: the reasoning
 # above the probe names that path twice, so a bare string search stays green
 # with the probe deleted. It did, the first time this was written.
-PROBE_RE='curl .*SMOKE_PORT/health/controls'
+# Anchored to the shape of the STATEMENT, not to a substring anywhere on the
+# line. Blanking full-line comments left one costume uncovered: a trailing
+# comment on a code line - `CONTROLS_BODY=""  # was: curl … /health/controls` -
+# satisfied both this guard and the ordering one, because PROBE_LINE resolved to
+# the comment and the comment is still above the kill. Third instance of the
+# same bug; this closes it without parsing quoting.
+PROBE_RE='^[[:space:]]*CONTROLS_BODY="\$\(curl .*SMOKE_PORT/health/controls'
 if grep -qE "$PROBE_RE" <<< "$DEPLOY_CODE"; then
   ok "api-deploy.sh curls /health/controls"
 else
@@ -254,6 +277,14 @@ if [ -n "$ASSIGN_LINE" ] && ! printf '%s' "$ASSIGN_LINE" | grep -q '||'; then
 else
   no "the helper's exit status is not swallowed at the call site" \
      "assignment line: ${ASSIGN_LINE:-<not found>}"
+fi
+
+if grep -qE 'deploy_blocking_control_failures "[^"]*CONTROLS_BODY" "[^"]*DEPLOY_BLOCKING_CONTROLS"' \
+  <<< "$DEPLOY_CODE"; then
+  ok "the blocking-control list is passed as one quoted argument"
+else
+  no "the blocking-control list is passed as one quoted argument" \
+     "an unquoted list is also a pathname expansion; see lib/controls.sh"
 fi
 
 PROBE_LINE="$(grep -nE "$PROBE_RE" <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -155,6 +155,42 @@ check "ships when no control is named as blocking" \
   "$(deploy_blocking_control_failures \
       "$(body degraded "$(control authentication failed 'auth env incomplete')")")"
 
+# ---------------------------------------------------------------------------
+# The row the table above does not decide: an unreadable BODY ships, but an
+# interpreter that will not start stops the deploy. api-deploy.sh runs under
+# set -e and an assignment carries its command substitution's status, so this
+# function returning non-zero is the stop.
+#
+# Run inside a command substitution so the stripped PATH cannot outlive the
+# probe: a variable assignment preceding a FUNCTION call persists in bash, and
+# the subshell is what contains it. PATH is checked afterwards rather than
+# assumed.
+# ---------------------------------------------------------------------------
+FAILING_BODY="$(body degraded "$(control authentication failed 'auth env incomplete')")"
+PATH_BEFORE="$PATH"
+
+NODE_GONE_RC=0
+NODE_GONE_OUT="$(PATH=/nonexistent-for-this-probe \
+  deploy_blocking_control_failures "$FAILING_BODY" authentication 2>/dev/null)" \
+  || NODE_GONE_RC=$?
+
+if [ "$NODE_GONE_RC" -ne 0 ]; then
+  ok "stops the deploy when the helper cannot run at all"
+else
+  no "stops the deploy when the helper cannot run at all" \
+     "returned 0 with output '$NODE_GONE_OUT'"
+fi
+
+# The positive control for the probe above. Without it, a harness that broke the
+# call in some other way would look exactly like a node that would not start.
+check "the same body and a working node returns the blocking line" \
+  "authentication: failed (auth env incomplete)" \
+  "$(deploy_blocking_control_failures "$FAILING_BODY" authentication)"
+
+check "the probe did not leak its stripped PATH into the rest of the suite" \
+  "$PATH_BEFORE" \
+  "$PATH"
+
 echo
 echo "api-deploy.sh wiring"
 
@@ -199,6 +235,16 @@ fi
 # `|| true` because set -o pipefail turns "no match" into an abort, which would
 # stop the run before this test could report - a deleted probe would then be a
 # missing result rather than a failure.
+# `|| true` on the assignment would turn the stop above into a ship, which is
+# the one regression that cannot be seen by running the function.
+ASSIGN_LINE="$(grep -nE 'CONTROL_FAILURES=.*deploy_blocking_control_failures' "$DEPLOY_SH" || true)"
+if [ -n "$ASSIGN_LINE" ] && ! printf '%s' "$ASSIGN_LINE" | grep -q '||'; then
+  ok "the helper's exit status is not swallowed at the call site"
+else
+  no "the helper's exit status is not swallowed at the call site" \
+     "assignment line: ${ASSIGN_LINE:-<not found>}"
+fi
+
 PROBE_LINE="$(grep -nE "$PROBE_RE" "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
 KILL_LINE="$(grep -nE 'kill .*SMOKE_PID' "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
 if [ -n "$PROBE_LINE" ] && [ -n "$KILL_LINE" ] && [ "$PROBE_LINE" -lt "$KILL_LINE" ]; then

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Regression tests for the cutover gate on startup controls.
+#
+# What is pinned here is not "does it parse JSON" but the SHIP list. A gate that
+# blocks too much is not a safer gate - it refuses rollbacks and it turns a
+# third-party outage into a stuck deploy - so every non-blocking case below is a
+# deliberate decision from lib/controls.sh, and each one is a separate test
+# because each one can be broken on its own.
+#
+# Usage: scripts/deploy/tests/controls.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/controls.sh"
+
+DEPLOY_SH="$HERE/../api-deploy.sh"
+
+PASS=0
+FAIL=0
+
+ok() { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL + 1)); }
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "expected '$2', got '$3'"; fi
+}
+
+# A body in the shape /health/controls actually returns. Built rather than
+# pasted so a test cannot quietly assert against a body the endpoint never
+# produces: name/state/detail and the `at` stamp are all present, and `status`
+# is the aggregate the gate deliberately ignores.
+body() { # body <status> <control-json>...
+  local status="$1"
+  shift
+  local joined=""
+  local part
+  for part in "$@"; do
+    [ -z "$joined" ] && joined="$part" || joined="$joined,$part"
+  done
+  printf '{"status":"%s","controls":[%s]}' "$status" "$joined"
+}
+
+control() { # control <name> <state> [detail]
+  local name="$1" state="$2" detail="${3-}"
+  if [ -n "$detail" ]; then
+    printf '{"name":"%s","state":"%s","detail":"%s","at":"2026-09-05T23:00:00.000Z"}' \
+      "$name" "$state" "$detail"
+  else
+    printf '{"name":"%s","state":"%s","at":"2026-09-05T23:00:00.000Z"}' "$name" "$state"
+  fi
+}
+
+# The two blocking cases below are also the positive control for every SHIP
+# case: they use fixtures of the same shape, so a body this suite could not
+# parse at all would fail them rather than turning the ships into vacuous
+# passes.
+echo "deploy_blocking_control_failures"
+
+# ---------------------------------------------------------------------------
+# The case the gate exists for: the smoke boot came up with no authentication
+# and said so, before cutover, while the rollback is still free.
+# ---------------------------------------------------------------------------
+check "blocks when a named control reports failed" \
+  "authentication: failed (auth env incomplete)" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded "$(control authentication failed 'auth env incomplete')")" \
+      authentication)"
+
+check "names the control without a detail when the report carries none" \
+  "authentication: failed" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded "$(control authentication failed)")" \
+      authentication)"
+
+# ---------------------------------------------------------------------------
+# Everything below SHIPS, and each line is a decision rather than an oversight.
+# ---------------------------------------------------------------------------
+
+# Auth deliberately switched off is a deployment fact. Blocking on it would
+# make the kill switch unusable, which is the same error as ignoring the
+# endpoint entirely, pointing the other way.
+check "ships when the named control was deliberately skipped" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body ok "$(control authentication skipped 'disabled by configuration')")" \
+      authentication)"
+
+check "ships when the named control applied" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body ok "$(control authentication applied)")" \
+      authentication)"
+
+# A rollback deploys a bundle from before the control existed. Blocking on an
+# absent report would refuse the one deploy that most needs to work, so absence
+# ships - and this is the gate's deliberate blind spot, not an accident.
+check "ships when the named control is absent, so a rollback is not refused" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body ok "$(control stream-upload-policy applied)")" \
+      authentication)"
+
+# The whole reason this is a named list and not the aggregate: `status` is
+# already "degraded" in this body, and it must not stop the deploy.
+check "ships when an unnamed control failed, even though the aggregate is degraded" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded "$(control stream-upload-policy failed 'updateAppSettings rejected')")" \
+      authentication)"
+
+# Both failed: one blocks, one does not, in a single body. The pair is what
+# separates "reads the named control" from "reads the first control".
+check "blocks on the named control only, when both named and unnamed failed" \
+  "authentication: failed (auth env incomplete)" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded \
+          "$(control stream-upload-policy failed 'updateAppSettings rejected')" \
+          "$(control authentication failed 'auth env incomplete')")" \
+      authentication)"
+
+# A prefix match would block on this and be wrong. Exercised with a name that
+# CONTAINS the required one, because a substring test passes every case above.
+check "matches a control name exactly rather than by prefix" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded "$(control authentication-provider failed 'rejected')")" \
+      authentication)"
+
+check "reports every named control that failed, not just the first" \
+  "authentication: failed (auth env incomplete)
+stream-upload-policy: failed (updateAppSettings rejected)" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded \
+          "$(control authentication failed 'auth env incomplete')" \
+          "$(control stream-upload-policy failed 'updateAppSettings rejected')")" \
+      authentication stream-upload-policy)"
+
+# /health is the liveness gate and it runs first. A body this function cannot
+# read is not a second chance to decide the process is dead.
+check "ships on a body that is not JSON" \
+  "" \
+  "$(deploy_blocking_control_failures '<html>502 Bad Gateway</html>' authentication)"
+
+check "ships on an empty body" \
+  "" \
+  "$(deploy_blocking_control_failures '' authentication)"
+
+check "ships on JSON without a controls array" \
+  "" \
+  "$(deploy_blocking_control_failures '{"status":"ok"}' authentication)"
+
+check "ships when no control is named as blocking" \
+  "" \
+  "$(deploy_blocking_control_failures \
+      "$(body degraded "$(control authentication failed 'auth env incomplete')")")"
+
+echo
+echo "api-deploy.sh wiring"
+
+# The function is inert unless the script probes the endpoint and acts on the
+# result. Each of these three has been forgotten separately in review of similar
+# gates: probing but not gating, gating but never probing, and gating on the
+# aggregate `status` after all.
+# Matched on the curl itself, not on the string /health/controls: the reasoning
+# above the probe names that path twice, so a bare string search stays green
+# with the probe deleted. It did, the first time this was written.
+PROBE_RE='curl .*SMOKE_PORT/health/controls'
+if grep -qE "$PROBE_RE" "$DEPLOY_SH"; then
+  ok "api-deploy.sh curls /health/controls"
+else
+  no "api-deploy.sh curls /health/controls" "no curl of that path in the file"
+fi
+
+if grep -q 'DEPLOY_BLOCKING_CONTROLS:-authentication' "$DEPLOY_SH"; then
+  ok "authentication is a blocking control by default"
+else
+  no "authentication is a blocking control by default" \
+     "no DEPLOY_BLOCKING_CONTROLS default naming it"
+fi
+
+if grep -q 'deploy_blocking_control_failures' "$DEPLOY_SH"; then
+  ok "api-deploy.sh asks which named controls block the cutover"
+else
+  no "api-deploy.sh asks which named controls block the cutover" \
+     "the helper is never called"
+fi
+
+if grep -qE 'CONTROL_FAILURES.*exit 1|exit 1.*CONTROL_FAILURES' "$DEPLOY_SH" \
+  || awk '/if \[ -n "\$CONTROL_FAILURES" \]/,/^fi$/' "$DEPLOY_SH" | grep -q 'exit 1'; then
+  ok "a blocking control failure stops the cutover"
+else
+  no "a blocking control failure stops the cutover" \
+     "no exit 1 guarded by CONTROL_FAILURES"
+fi
+
+# The probe has to happen while the smoke process is still up. Ordering is the
+# whole of it: after the kill, the curl answers 000 and the gate is decorative.
+# `|| true` because set -o pipefail turns "no match" into an abort, which would
+# stop the run before this test could report - a deleted probe would then be a
+# missing result rather than a failure.
+PROBE_LINE="$(grep -nE "$PROBE_RE" "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
+KILL_LINE="$(grep -nE 'kill .*SMOKE_PID' "$DEPLOY_SH" | head -1 | cut -d: -f1 || true)"
+if [ -n "$PROBE_LINE" ] && [ -n "$KILL_LINE" ] && [ "$PROBE_LINE" -lt "$KILL_LINE" ]; then
+  ok "the controls probe runs before the smoke process is killed"
+else
+  no "the controls probe runs before the smoke process is killed" \
+     "probe=$PROBE_LINE kill=$KILL_LINE"
+fi
+
+echo
+printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`api-deploy.sh` boots the new bundle on a spare port before cutover - the one
moment a rollback is still free - and reads two things from it: `/health`, and a
POST to a bogus route that exercises the body parser.

Neither can see a process that came up without authentication. `/health` answers
200 for a bundle whose entire `/auth` surface is 404, deliberately: #2750 left
liveness alone on purpose. Since #2750 the process reports the difference on
`/health/controls`, and at `bffd96987` nothing in the repository reads it. So a
deploy that lost an auth variable cuts over green and is visible only to a
monitor that does not exist yet.

## What is the new behavior?

The smoke step probes `/health/controls` while the process is still up, prints
the body whatever it says, and blocks the cutover on **named** controls.

**Not the aggregate.** `/health/controls` answers 503 whenever *any* control is
`failed`, and `stream-upload-policy` records `failed` when Stream's
`updateAppSettings` rejects. `startup-controls.ts` is explicit that this must
not take the API down - "a Stream outage should not take the API down, it should
be VISIBLE" - so gating cutover on the aggregate would invert that decision and
turn a third-party outage into a stuck deploy.

Blocking is therefore stated as a positive: **only a named control positively
reporting `failed` stops the cutover.** Everything else ships, and each of these
is a decision rather than an oversight:

| Case | Cutover | Why |
|---|---|---|
| named control `failed` | **blocked** | the state this exists for |
| named control `skipped` | ships | auth switched off is a deployment fact, not a fault |
| named control **absent** | ships | a rollback deploys a bundle from before the control existed |
| endpoint unreadable | ships | `/health` is already the liveness gate and runs first |
| unnamed control `failed` | ships | the Stream reasoning above |
| the helper **crashes** | **blocked** | a crash writes nothing to stdout either, and it is not a ship |
| the helper cannot **run** | **blocked** | a gate that could not run is not a gate that passed |

The last row is the one the table first left implicit, and it is decided by the
call site rather than by the helper: `set -e` carries a command substitution's
status, so a `node` that will not start stops the script before the cutover
checks and the EXIT trap prints the rollback sha. An unreadable *body* is a fact
about the process and ships; an interpreter that will not start is not. Raised
in review, and pinned three ways rather than asserted.

The absent case is the deliberate blind spot and the one most worth arguing
about: blocking on it is superficially right, since an absent control is exactly
what #2750 was about, but it would make the gate refuse the one deploy that most
needs to work. A bundle that silently stops recording the control is therefore
not caught here. Reviewers who would rather have it the other way should say so -
it is one branch.

The name list is `DEPLOY_BLOCKING_CONTROLS`, defaulting to `authentication`, so
an environment that genuinely runs without one does not need a code change to
deploy.

The decision lives in `scripts/deploy/lib/controls.sh` with its own suite, the
same shape as `lib/migrate.sh` and `tests/migrate.test.sh`, so the ship list is
pinned rather than inline in the gate. `node` rather than `sed`, because a gate
that mis-parses is worse than no gate and the box has just proved node works by
booting the bundle.

### Verification

- `scripts/deploy/tests/controls.test.sh` - 24 passed, 0 failed (new)
- `scripts/deploy/tests/migrate.test.sh` - 68 passed, 0 failed
- `scripts/deploy/tests/git-sync.test.sh` - 16 passed, 0 failed
- `shellcheck -x` on `api-deploy.sh` is unchanged from `bffd96987`: 4 SC2015,
  all pre-existing. `lib/controls.sh` is clean. `tests/controls.test.sh` reports
  only the 2 SC1091 path-resolution notes the existing test files also report.

**18 mutations, each checked by which test went red rather than by exit code.**
One per decision in the table: blocking on `skipped`, blocking on absence,
blocking on `applied`, prefix-matching the name, matching any failed control
regardless of name, reading only the first required name, blocking on an
unparseable body, dropping the detail, printing a detail that is not there,
deleting the probe, moving the probe after the process is killed, emptying the
default name list, removing the `exit 1`, never calling the helper, the helper
swallowing its own non-zero status, and the call site swallowing it with
`|| true`.

Two things worth reporting against myself:

- The first version of the wiring guard grepped for the string
  `/health/controls`, and **stayed green with the probe deleted** - the
  reasoning above the probe names that path twice. Matching the `curl` instead
  fixed that instance and left the class: four more guards grep the same file,
  and any of them can be satisfied by a comment somebody writes later. They now
  read a copy of the script with full-line comments **blanked** - blanked, not
  removed, so the line numbers still line up for the ordering guard. Separating
  input, run both ways: delete the probe and leave a comment carrying the same
  text. Against the previous guards that is 22 passed, exit 0 - a deleted probe
  reported as present. Against these it reddens two tests by name.
- The first "absence blocks" mutation crashed node instead of implementing the
  behaviour, so it proved nothing about that test. Re-run as a correct
  implementation, it reddens the absence test by name.

- Two tests are **not** separately pinned and I could not find an input that
  separates them: "ships on an empty body" and "ships when no control is named".
  Removing either short-circuit changes no test, because node reaches the same
  answer. They are documented in the source as short-circuits that carry no part
  of the decision.

The `node` probe strips PATH inside a command substitution, because a variable
assignment preceding a *function* call persists in bash - the subshell is what
contains it, and the suite asserts PATH afterwards rather than assuming that. It
runs beside a positive control on the same fixture, so "node would not start"
cannot be confused with "the harness broke the call some other way".

## A follow-up this deliberately does not do

The absent case is ambiguous only because the response lists what *was*
recorded. If the process also declared what it *expects* to record, then
"expected names it and controls omit it" becomes a positive failure while "no
`expected` key at all" stays the marker of an older bundle - closing the blind
spot without touching the rollback case. That is a change to
`startup-controls.ts` with its own tests and belongs in its own issue.

What should **not** be done, because it will occur to the next reader: the
script has the deployed source on the box and could `git grep` for the
`recordControl` call to decide whether the bundle ought to have reported one.
That is a substring test on source standing in for a fact about a running
process, and it breaks on a rename that changes no behaviour.

Not established, and unchanged from the issue: whether any environment currently
boots with an incomplete auth env. That needs someone who can read the deploy
host.

### Three things raised in review and taken as commits

**A ship is two facts and the suite was asserting one.** The four SHIP rows
checked that stdout was empty - and a helper that *crashes* writes nothing to
stdout either, while a crash stops the deploy rather than shipping it. Dropping
the `try/catch` around `JSON.parse` left the suite at `22 passed` with a body
that would have halted a cutover. The instrument was already in the file: the
node-missing probe captures the status for exactly this distinction, pointed the
other way. `ships` now requires an empty result **and** a zero status - with the
declaration and the assignment on separate lines, because `local out="$(...)"`
reports the status of `local`, not of the substitution (measured on bash 3.2 and
bash 5.3; the swallow happens on both).

**The probe guard had one costume left.** Blanking full-line comments did not
cover a TRAILING comment on a code line: `CONTROLS_BODY=""  # was: curl … ` kept
both the probe guard and the ordering guard green with the probe deleted,
because the probe line resolved to the comment and the comment is still above
the kill. It is now anchored to the shape of the statement. **The trade, stated
because it will fire one day:** the guard now pins the variable name and the
assignment form, so refactoring the curl into a helper function would redden it -
a false positive on a working probe, and the right trade only because prose has
fooled this guard twice already.

**The blocking-control list is one quoted argument.** The variadic signature
forced the caller to leave its list unquoted for word splitting, and an unquoted
expansion is also a **pathname** expansion - a name containing a glob character
would have expanded against the deploy host's working directory before the
helper saw it. Nothing sets such a name, and no test could distinguish it
because the expansion happened at the call site rather than in the function.
`node` already splits on whitespace, so one quoted argument removes the exposure
by construction and takes the `SC2086` disable with it.

## Related Issue(s)

Fixes #2756
