### PR TITLE
feat(backend): declare the controls /health/controls expects to report

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,6 +3,7 @@ import rateLimit from "express-rate-limit";
 import fileUpload from "express-fileupload";
 import {
   getControlReports,
+  getExpectedControls,
   hasFailedControl,
   recordControl,
 } from "./config/startup-controls";
@@ -241,6 +242,11 @@ export function createApp() {
     return res.status(degraded ? 503 : 200).json({
       status: degraded ? "degraded" : "ok",
       controls: getControlReports(),
+      // What this bundle registers, always sent. A reader comparing the two
+      // lists can tell a control that is missing from one that never existed
+      // in this version - the absence of this key is the version marker, so it
+      // must not depend on anything.
+      expected: getExpectedControls(),
     });
   });
 

--- a/apps/backend/src/config/startup-controls.ts
+++ b/apps/backend/src/config/startup-controls.ts
@@ -14,6 +14,32 @@
  * This deliberately does not stop the boot. A Stream outage should not take the
  * API down - it should be VISIBLE.
  */
+/**
+ * The controls this process registers before it answers on its port.
+ *
+ * Reported alongside the reports themselves, because a response that lists only
+ * what WAS recorded cannot distinguish "this bundle is too old to record X"
+ * from "this bundle registers X and did not". Those are the same bytes, and the
+ * deploy gate has to ship on the first and stop on the second: absence of this
+ * key is what marks an older bundle, so it must never be conditional.
+ *
+ * A MANIFEST rather than a declare() call beside each recordControl. Putting the
+ * declaration next to the recording makes them impossible to drift apart - and
+ * also makes the declaration vanish exactly when the code path is skipped,
+ * which is the case a deploy gate most needs to see. The cost is that this list
+ * can go stale, and a name left here after its control is deleted would block
+ * every deploy forever, so test/config/expected-controls.test.ts boots the app
+ * in each configuration and asserts the recorded set covers this one.
+ *
+ * Anything added here must be recorded BEFORE app.listen - see that same file.
+ */
+export const EXPECTED_CONTROLS = [
+  "authentication",
+  "stream-upload-policy",
+] as const;
+
+export const getExpectedControls = (): string[] => [...EXPECTED_CONTROLS];
+
 export type ControlState = "applied" | "failed" | "skipped";
 
 export type ControlReport = {

--- a/apps/backend/test/app.test.ts
+++ b/apps/backend/test/app.test.ts
@@ -72,6 +72,7 @@ jest.mock("../src/config/auth-hooks", () => ({
 
 import { createApp } from "../src/app";
 import {
+  EXPECTED_CONTROLS,
   getControlReports,
   hasFailedControl,
   resetControlsForTest,
@@ -463,12 +464,16 @@ describe("createApp reports the authentication control", () => {
     const body = JSON.parse(controls.body) as {
       status: string;
       controls: Array<{ name: string; state: string; detail?: string }>;
+      expected: string[];
     };
 
     // Liveness is unchanged on purpose: the process is up, the control is not.
     expect(liveness.statusCode).toBe(200);
     expect(controls.statusCode).toBe(503);
     expect(body.status).toBe("degraded");
+    // Sent on the degraded response too: a reader comparing the two lists needs
+    // it most exactly when something is wrong.
+    expect(body.expected).toEqual([...EXPECTED_CONTROLS]);
     expect(body.controls).toContainEqual(
       expect.objectContaining({
         name: "authentication",
@@ -487,6 +492,7 @@ describe("createApp reports the authentication control", () => {
     const body = JSON.parse(controls.body) as {
       status: string;
       controls: Array<{ name: string; state: string }>;
+      expected: string[];
     };
 
     expect(controls.statusCode).toBe(200);
@@ -494,5 +500,21 @@ describe("createApp reports the authentication control", () => {
     expect(body.controls).toContainEqual(
       expect.objectContaining({ name: "authentication", state: "applied" }),
     );
+    expect(body.expected).toEqual([...EXPECTED_CONTROLS]);
+  });
+
+  // #2758: the deploy gate ships when a named control is absent, because a
+  // rollback deploys a bundle that never recorded it. This key is what lets the
+  // gate tell that apart from a bundle that should have recorded it and did
+  // not - so its ABSENCE is the version marker, and it must not be conditional
+  // on state, on configuration, or on anything else.
+  it("declares the controls it registers on every boot, including an auth-less one", async () => {
+    const app = createApp();
+
+    const controls = await request(app, { path: "/health/controls" });
+    const body = JSON.parse(controls.body) as { expected: string[] };
+
+    expect(body.expected).toEqual([...EXPECTED_CONTROLS]);
+    expect(body.expected).toContain("authentication");
   });
 });

--- a/apps/backend/test/config/expected-controls.test.ts
+++ b/apps/backend/test/config/expected-controls.test.ts
@@ -277,5 +277,9 @@ describe("every declared control is recorded before the port answers", () => {
     expect(recordedAtListen.sort()).toEqual(
       expect.arrayContaining([...EXPECTED_CONTROLS]),
     );
+    // Equality on this path too, not only the configured one. The kill switch
+    // is the configuration most likely to grow a branch of its own, and an
+    // undeclared control recorded only there would otherwise be uncovered.
+    expect(recordedAtListen.sort()).toEqual(getExpectedControls().sort());
   });
 });

--- a/apps/backend/test/config/expected-controls.test.ts
+++ b/apps/backend/test/config/expected-controls.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The two things `expected` on /health/controls silently depends on.
+ *
+ * The deploy gate (scripts/deploy/lib/controls.sh) blocks when the response
+ * declares a control and does not report it. That is only a fault signal if
+ * (1) the manifest never names a control nothing records, and (2) everything it
+ * names is recorded before the port answers - a control registered after
+ * `listen`, or from a background task, would be legitimately absent when the
+ * smoke probe runs 25 seconds into the boot, and would block a healthy deploy.
+ *
+ * Both are asserted here as behaviour. The ordering one deliberately drives the
+ * real bootstrap rather than reading main.ts: a source check would stay green
+ * for any refactor that kept the two lines in order while changing when they
+ * actually resolve.
+ */
+const mockInitQueues = jest.fn().mockResolvedValue(undefined);
+const mockClosePdfBrowser = jest.fn().mockResolvedValue(undefined);
+const mockUpdateAppSettings = jest.fn();
+const mockListen = jest.fn();
+
+jest.mock("stream-chat", () => ({
+  StreamChat: {
+    getInstance: jest.fn(() => ({ updateAppSettings: mockUpdateAppSettings })),
+  },
+}));
+
+// The provider package, not the wiring: createApp's own recordControl calls are
+// what is under test, and SuperTokens' real init reaches for an SMTP config that
+// has nothing to do with the ordering being asserted. Same mock shape as
+// app.test.ts.
+jest.mock("@yosemite-crew/auth", () => ({
+  AuthService: class {
+    constructor(public readonly provider: unknown) {}
+  },
+  createAuthProvider: jest.fn(() => ({ name: "supertokens" })),
+  readAuthConfig: jest.fn(() => ({ provider: "supertokens" })),
+  initSuperTokens: jest.fn(),
+  registerSuperTokensBeforeRoutes: jest.fn(),
+  registerSuperTokensErrorHandler: jest.fn(),
+  setAuthService: jest.fn(),
+  validateAuthConfig: jest.fn(),
+}));
+
+// The route tree, for the same reason app.test.ts mocks it: registering every
+// router drags in every controller and service, and none of them record a
+// control. What stays real is app.ts itself, which is where the recording is.
+// Nothing in this suite talks to a queue, but importing the real app and the
+// real main pulls modules that construct a bullmq Queue at import time, and the
+// redis client it opens outlives the suite and logs into whatever runs next.
+// Mocked at the library boundary so a new import path cannot reintroduce it.
+jest.mock("bullmq", () => ({
+  Queue: class {
+    add = jest.fn();
+    close = jest.fn();
+    on = jest.fn();
+  },
+  Worker: class {
+    on = jest.fn();
+    close = jest.fn();
+  },
+  QueueEvents: class {
+    on = jest.fn();
+    close = jest.fn();
+  },
+}));
+
+jest.mock("src/routers", () => ({ registerRoutes: jest.fn() }));
+jest.mock("src/controllers/web/stripe.controller", () => ({
+  StripeController: { webhook: jest.fn(), connectWebhook: jest.fn() },
+}));
+jest.mock("src/controllers/web/documenso.controller", () => ({
+  DocumensoWebhookController: { handle: jest.fn() },
+}));
+jest.mock("src/controllers/app/finance.controller", () => ({
+  FinanceController: { webhook: jest.fn() },
+}));
+jest.mock("src/controllers/app/chatWebhook.controller", () => ({
+  ChatWebhookController: { handleStreamEvent: jest.fn() },
+}));
+// The last of app.ts's direct controller imports, and the one that reaches a
+// queue client: unmocked it opens a redis connection that outlives the suite
+// and logs into whatever runs next.
+jest.mock("src/controllers/web/developer-billing.controller", () => ({
+  DeveloperBillingController: { webhook: jest.fn() },
+}));
+
+jest.mock("src/queues", () => ({ initQueues: mockInitQueues }));
+jest.mock("src/workers", () => ({}));
+jest.mock("src/services/formPDF.service", () => ({
+  closePdfBrowser: mockClosePdfBrowser,
+}));
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { configureStreamUploadPolicy } from "src/config/stream-upload-policy";
+import { createApp } from "src/app";
+import {
+  EXPECTED_CONTROLS,
+  getControlReports,
+  getExpectedControls,
+  resetControlsForTest,
+} from "src/config/startup-controls";
+
+const AUTH_ENV = {
+  SUPERTOKENS_CONNECTION_URI: "https://core.example.test",
+  AUTH_API_DOMAIN: "https://api.example.test",
+  AUTH_WEBSITE_DOMAIN: "https://web.example.test",
+};
+
+const ENV_KEYS = [
+  "SUPERTOKENS_DISABLED",
+  "SUPERTOKENS_CONNECTION_URI",
+  "AUTH_API_DOMAIN",
+  "AUTH_WEBSITE_DOMAIN",
+  "STREAM_API_KEY",
+  "STREAM_API_SECRET",
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+const recordedNames = () => getControlReports().map((report) => report.name);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetControlsForTest();
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  mockUpdateAppSettings.mockResolvedValue({});
+});
+
+afterEach(() => {
+  resetControlsForTest();
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe("the expected-controls manifest stays honest", () => {
+  // Every configuration, not just the happy one: a control that is only
+  // recorded on its success path would leave the manifest naming something
+  // absent, and the gate would block a deploy that is fine.
+  const bootConfigurations: Array<[string, () => void]> = [
+    [
+      "auth configured, Stream configured",
+      () => {
+        Object.assign(process.env, AUTH_ENV);
+        process.env.STREAM_API_KEY = "key";
+        process.env.STREAM_API_SECRET = "secret";
+      },
+    ],
+    [
+      "auth switched off, Stream credentials absent",
+      () => {
+        process.env.SUPERTOKENS_DISABLED = "true";
+      },
+    ],
+    [
+      "auth env incomplete, Stream rejecting",
+      () => {
+        process.env.SUPERTOKENS_CONNECTION_URI =
+          AUTH_ENV.SUPERTOKENS_CONNECTION_URI;
+        process.env.STREAM_API_KEY = "key";
+        process.env.STREAM_API_SECRET = "secret";
+        mockUpdateAppSettings.mockRejectedValue(new Error("rejected"));
+      },
+    ],
+  ];
+
+  it.each(bootConfigurations)(
+    "records every declared control when booted with %s",
+    async (_name, setEnv) => {
+      setEnv();
+
+      await configureStreamUploadPolicy();
+      createApp();
+
+      expect(recordedNames().sort()).toEqual(
+        expect.arrayContaining([...EXPECTED_CONTROLS]),
+      );
+    },
+  );
+
+  it("declares every control it records, so nothing is reported undeclared", async () => {
+    Object.assign(process.env, AUTH_ENV);
+    process.env.STREAM_API_KEY = "key";
+    process.env.STREAM_API_SECRET = "secret";
+
+    await configureStreamUploadPolicy();
+    createApp();
+
+    // The other direction from the test above. A control recorded but not
+    // declared is not a deploy hazard, but it means the manifest has stopped
+    // describing the process and the next reader cannot trust either list.
+    expect(getExpectedControls().sort()).toEqual(recordedNames().sort());
+  });
+});
+
+describe("every declared control is recorded before the port answers", () => {
+  // main.ts is not exported and `void startServer()` runs on import, so the
+  // bootstrap is driven by importing it with only the heavy externals mocked.
+  // createApp and configureStreamUploadPolicy are the REAL ones: what is under
+  // test is when their recordings land relative to listen, and a mock of either
+  // would be asserting about the mock.
+  const bootAndSnapshotAtListen = async (): Promise<string[]> => {
+    let recordedAtListen: string[] = [];
+
+    jest.isolateModules(() => {
+      // isolateModules gives main.ts a FRESH registry, so the startup-controls
+      // it records into is not the instance imported at the top of this file.
+      // Reading the outer one here would report an empty set for every boot -
+      // a test that passes only when the ordering it checks is broken. Read the
+      // instance the bootstrap actually writes to.
+      const isolated = require("src/config/startup-controls") as {
+        getControlReports: typeof getControlReports;
+      };
+
+      mockListen.mockImplementation((_port: unknown, callback?: () => void) => {
+        recordedAtListen = isolated
+          .getControlReports()
+          .map((report) => report.name);
+        if (callback) callback();
+        return { close: jest.fn() };
+      });
+
+      jest.doMock("src/app", () => {
+        const actual = jest.requireActual("src/app") as {
+          createApp: typeof createApp;
+        };
+        return {
+          createApp: () => {
+            actual.createApp();
+            return { listen: mockListen };
+          },
+        };
+      });
+
+      require("src/main");
+    });
+
+    // startServer awaits initQueues and configureStreamUploadPolicy before it
+    // reaches listen, so the assertion has to happen after those microtasks.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    return recordedAtListen;
+  };
+
+  it("has recorded every declared control by the time listen is called", async () => {
+    Object.assign(process.env, AUTH_ENV);
+    process.env.STREAM_API_KEY = "key";
+    process.env.STREAM_API_SECRET = "secret";
+
+    const recordedAtListen = await bootAndSnapshotAtListen();
+
+    expect(mockListen).toHaveBeenCalledTimes(1);
+    expect(recordedAtListen.sort()).toEqual(
+      expect.arrayContaining([...EXPECTED_CONTROLS]),
+    );
+  });
+
+  it("records them before listen even when every control is in a non-applied state", async () => {
+    process.env.SUPERTOKENS_DISABLED = "true";
+
+    const recordedAtListen = await bootAndSnapshotAtListen();
+
+    expect(mockListen).toHaveBeenCalledTimes(1);
+    expect(recordedAtListen.sort()).toEqual(
+      expect.arrayContaining([...EXPECTED_CONTROLS]),
+    );
+  });
+});

--- a/apps/backend/test/config/expected-controls.test.ts
+++ b/apps/backend/test/config/expected-controls.test.ts
@@ -260,6 +260,12 @@ describe("every declared control is recorded before the port answers", () => {
     expect(recordedAtListen.sort()).toEqual(
       expect.arrayContaining([...EXPECTED_CONTROLS]),
     );
+    // Equality, not containment, and measured on the REAL boot rather than on
+    // the two calls this file drives by hand. The manifest-honesty tests above
+    // can only see controls recorded by createApp and configureStreamUploadPolicy,
+    // so a third control registered anywhere else in the bootstrap would pass
+    // every one of them. This is the assertion that sees it.
+    expect(recordedAtListen.sort()).toEqual(getExpectedControls().sort());
   });
 
   it("records them before listen even when every control is in a non-applied state", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`/health/controls` reports only what **was** recorded. So "this bundle is too old
to record `authentication`" and "this bundle registers `authentication` and did
not" are the same bytes, and the deploy gate in #2757 has to ship on the first
and stop on the second. It ships on both - the blind spot that gate documents in
its own table.

## What is the new behavior?

The process also declares what it registers:

```jsonc
{
  "status": "ok",
  "controls": [ { "name": "authentication", "state": "applied", "at": "…" } ],
  "expected": ["authentication", "stream-upload-policy"]
}
```

**The absence of the key is the version marker**, so it is sent
unconditionally - on the degraded response, on an auth-less boot, in every
configuration. A gate can then treat "declared and not reported" as a positive
failure while "no `expected` key at all" stays a rollback to an older bundle.

**A manifest, not a `declare()` beside each `recordControl`.** Co-locating them
makes drift impossible, and also makes the declaration vanish exactly when the
code path is skipped - which is the case a deploy gate most needs to see. The
cost is staleness: a name left here after its control is deleted would block
every deploy forever.

That cost is paid by tests rather than by a comment:

- **Honesty, both directions.** The app is booted in three configurations - auth
  configured, auth switched off with no Stream credentials, auth env incomplete
  with Stream rejecting - and the recorded set must cover the declared set in
  each. A separate test asserts the reverse, that nothing is recorded
  undeclared, so the manifest cannot silently stop describing the process.
- **Ordering.** A control recorded after `listen` would be legitimately absent
  when the smoke probe runs 25 seconds into a boot, and would block a healthy
  deploy. The test drives the real bootstrap - `main.ts` imported with only the
  heavy externals mocked - and snapshots the recorded set at the moment `listen`
  is called. That snapshot is also asserted **equal** to the declared set, not
  merely to contain it: the two honesty tests above drive `createApp` and
  `configureStreamUploadPolicy` by hand and can only see what those two record,
  so a control registered anywhere else in the bootstrap would pass all of them.
  A `recordControl` added to `main.ts` and left out of the manifest reddens this
  assertion and nothing else. Asserted on **both** ordering boots - the
  configured one and the kill-switch one - since `SUPERTOKENS_DISABLED` is the
  configuration most likely to grow a branch of its own.

The ordering test deliberately does **not** read `main.ts`. A source check
would stay green for any refactor that kept the two lines in order while
changing when they actually resolve - which is exactly what the second mutation
below does.

**Not in this change:** the `lib/controls.sh` table row. The gate must keep
treating a missing `expected` key as *ship* until the hosts are running a bundle
that sends one, so that is a separate PR after this lands.

### Verification

- `npx jest` full backend suite - 481 suites, 11485 tests, exit 0 (at
  `0458c26a6`)
- `pnpm --filter backend run lint` - exit 0, 0 errors, 25 pre-existing warnings
- `pnpm --filter backend run type-check` - exit 0
- Coverage of the changed files: `startup-controls.ts` 100% lines and branches;
  `app.ts` 99.22% lines, 92.85% branches, the two uncovered lines pre-existing

**Six mutations, each checked by which test went red rather than by exit code:**

| Mutation | Reddens |
|---|---|
| `configureStreamUploadPolicy` moved after `listen` | both ordering tests |
| the same call left un-`await`ed | the ordering test whose control is genuinely async - the other stays green, correctly, because the credentials-absent path records before its first `await` |
| manifest names a control nothing records | 6 tests |
| manifest drops a control that is recorded | the reverse-direction honesty test |
| `expected` omitted from the response | 3 tests |
| `expected` sent only when healthy | 2, including the degraded one |

### Two known limits, stated rather than left to be found

`listen` in the ordering test is a mock, so what is proven is that the
recordings precede the **call** to `listen` - not that they precede the socket
accepting a connection. Those are the same thing here because `app.listen` is
the last statement in `startServer` and nothing after it records. Narrowed in
review: moving a declared control *into the listen callback* is also caught,
because the snapshot is taken before the mock invokes it, so what remains
uncovered is only code after `app.listen(...)` returns.

Second, and less obvious: `jest.isolateModules` is only active while its
callback runs, and `void startServer()` executes synchronously up to its first
`await`. A control registered by a module that `main.ts` resolves **lazily**,
during the async tail, would land in the outer module registry - a different
`startup-controls` singleton with a different Map - and be invisible to this
test rather than weakly covered. Nothing does that today; every recorder is
reached through a top-level import, which resolves inside the isolated
registry. This limit was found by a reviewer's third mutation form and is the
same mechanism as the defect in the first draft of this test, pointing the
other way: that one *read* the outer instance, this one would *write* it.

**One defect found in my own test and worth stating.** The ordering test first
read the control reports from the module imported at the top of the file, while
`jest.isolateModules` gives `main.ts` a *fresh* registry - so it was reading an
instance nothing had written to and reported `[]` for every boot. It passed
`expect(listen).toHaveBeenCalled()` and failed only because the array was empty;
had the assertion been `not.toContain`, it would have passed forever while
measuring nothing. It now reads the instance the bootstrap actually writes to.

**And one about hygiene rather than correctness.** Importing the real `app` and
`main` pulls modules that construct a bullmq `Queue` at import, whose redis
client outlives the suite and logs into whatever runs next. Measured across full
runs: 34-38 late-log warnings on the untouched baseline, 44 and 78 with this
suite added, 32 with `bullmq` mocked at the library boundary. Nothing failed in
any of those runs - `481 passed` each time - but the suite should not be adding
to it.

## Related Issue(s)

Fixes #2758
