### PR TITLE
test(ci): guard the two things #2757 left one refactor from inert

### DIFF
--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -318,19 +318,29 @@ fi
 # bash 5.3.15, a function returning 7, with a succeeding command as the positive
 # control on every row:
 #
-#   local out="$(crash)"        rc=0   swallowed      both shells
-#   local out=$(crash)          rc=0   swallowed      both shells
-#   local rc=0 out="$(crash)"   rc=0   swallowed      both shells
-#   local out=`crash`           rc=0   swallowed      both shells
-#   local out; out="$(crash)"   rc=7   CARRIES        both shells
-#   local out                   rc=7   CARRIES        both shells
-#   out="$(crash)"
+#   local out="$(crash)"          rc=0   swallowed    both shells
+#   local out=$(crash)            rc=0   swallowed    both shells
+#   local rc=0 out="$(crash)"     rc=0   swallowed    both shells
+#   local out=`crash`             rc=0   swallowed    both shells
+#   local out="`crash`"           rc=0   swallowed    both shells
+#   local z=1; local out="$(...)" rc=0   swallowed    both shells
+#   local out; out="$(crash)"     rc=7   CARRIES      both shells
+#   local out  <newline>  out=... rc=7   CARRIES      both shells
+#
+# The enumeration is closed rather than collected: command substitution has two
+# syntaxes, `$(...)` and backticks, each bare or double-quoted, which is four -
+# and each of those can be the first command on the line or follow a `;`. Single
+# quotes substitute nothing, so there is no status to swallow.
 #
 # So the rule is the KEYWORD plus an assignment from a substitution on the same
 # command, not one spelling of it. `[^;#]` is what keeps the two carrying forms
 # out: a `;` ends the declaration and starts a new command, which is the fix
 # itself, and a `#` is a trailing comment - the costume that has beaten the
 # guards in this file three times, and the one this pattern must not fire on.
+# `(^|;)` is why refusing to cross a `;` does not also mean failing to see past
+# one: the keyword is looked for at the start of the line OR after a `;`, and
+# `out` is not a keyword, so the fix stays silent while `; local out="$(...)"`
+# does not. Verified on BSD grep 2.6.0, GNU grep 3.11 and busybox.
 #
 # Stated cost: this bans declare-and-assign for the whole file, not just for
 # ships(), so a future `local tmp="$(mktemp -d)"` or `local tmp=$(mktemp -d)`
@@ -341,7 +351,7 @@ fi
 # Comments blanked for the same reason DEPLOY_CODE blanks them: otherwise the
 # paragraph you are reading would redden its own guard.
 TEST_CODE="$(sed -E 's/^[[:space:]]*#.*$//' "${BASH_SOURCE[0]}")"
-SWALLOWED="$(grep -nE '^[[:space:]]*(local|declare|readonly|export)[[:space:]][^;#]*=("?\$\(|`)' <<< "$TEST_CODE" || true)"
+SWALLOWED="$(grep -nE '(^|;)[[:space:]]*(local|declare|readonly|export)[[:space:]][^;#]*="?(\$\(|`)' <<< "$TEST_CODE" || true)"
 if [ -z "$SWALLOWED" ]; then
   ok "no declaration in this file swallows the status of a command substitution"
 else

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -306,23 +306,42 @@ fi
 
 # The guard above is about api-deploy.sh. This one is about THIS file, and it
 # exists because ships() only distinguishes a crash from a ship while its
-# declaration and its assignment stay on separate lines. `local out="$(...)"`
-# reports the status of `local`, which succeeds whatever the substitution did,
-# so tidying those two lines into one restores every ship row to green with the
-# crash still there - measured in review on bash 3.2 and bash 5, both swallow
-# it. It is the same shape as the `|| true` guarded at the call site above: a
-# wrapper that always succeeds, hiding the status of the thing it wraps.
+# declaration and its assignment stay on separate lines. A declaration that
+# also assigns reports the status of `local`, which succeeds whatever the
+# substitution did, so tidying those two lines into one restores every ship row
+# to green with the crash still there. It is the same shape as the `|| true`
+# guarded at the call site above: a wrapper that always succeeds, hiding the
+# status of the thing it wraps.
 #
-# Stated cost: this bans the declare-and-assign form for the whole file, not
-# just for ships(), so a future `local tmp="$(mktemp -d)"` whose status nobody
-# cares about is a false positive. The message names the line. Worth it here
-# because the form is indistinguishable from the correct one by reading, and
-# the whole point of the ships rows is a status.
+# The first version of this guard pinned one spelling and two others were green
+# with the crash in the tree - raised in review. Measured on bash 3.2.57 and
+# bash 5.3.15, a function returning 7, with a succeeding command as the positive
+# control on every row:
+#
+#   local out="$(crash)"        rc=0   swallowed      both shells
+#   local out=$(crash)          rc=0   swallowed      both shells
+#   local rc=0 out="$(crash)"   rc=0   swallowed      both shells
+#   local out=`crash`           rc=0   swallowed      both shells
+#   local out; out="$(crash)"   rc=7   CARRIES        both shells
+#   local out                   rc=7   CARRIES        both shells
+#   out="$(crash)"
+#
+# So the rule is the KEYWORD plus an assignment from a substitution on the same
+# command, not one spelling of it. `[^;#]` is what keeps the two carrying forms
+# out: a `;` ends the declaration and starts a new command, which is the fix
+# itself, and a `#` is a trailing comment - the costume that has beaten the
+# guards in this file three times, and the one this pattern must not fire on.
+#
+# Stated cost: this bans declare-and-assign for the whole file, not just for
+# ships(), so a future `local tmp="$(mktemp -d)"` or `local tmp=$(mktemp -d)`
+# whose status nobody cares about is a false positive. The message names the
+# line. Worth it here because the form is indistinguishable from the correct one
+# by reading, and the whole point of the ships rows is a status.
 #
 # Comments blanked for the same reason DEPLOY_CODE blanks them: otherwise the
 # paragraph you are reading would redden its own guard.
 TEST_CODE="$(sed -E 's/^[[:space:]]*#.*$//' "${BASH_SOURCE[0]}")"
-SWALLOWED="$(grep -nE '^[[:space:]]*local [A-Za-z_][A-Za-z0-9_]*="\$\(' <<< "$TEST_CODE" || true)"
+SWALLOWED="$(grep -nE '^[[:space:]]*(local|declare|readonly|export)[[:space:]][^;#]*=("?\$\(|`)' <<< "$TEST_CODE" || true)"
 if [ -z "$SWALLOWED" ]; then
   ok "no declaration in this file swallows the status of a command substitution"
 else

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -49,6 +49,9 @@ check() { # check <name> <expected> <actual>
 ships() {
   local name="$1" json="$2"
   shift 2
+  # Declaration only, on purpose, and on its own line: merging it into the
+  # assignment below makes `local` the command whose status is reported, and
+  # `local` always succeeds. Guarded at the bottom of this file.
   local out rc=0
   out="$(deploy_blocking_control_failures "$json" "$*")" || rc=$?
   if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
@@ -165,9 +168,23 @@ stream-upload-policy: failed (updateAppSettings rejected)" \
 # A name is a name. Nothing sets one containing a glob character, but the old
 # variadic signature forced the caller to leave its list unquoted, and this is
 # the reading of that list that a pathname expansion would have destroyed.
-ships "treats a glob-shaped name as a literal name" \
-  "$(body degraded "$(control authentication failed 'auth env incomplete')")" \
-  '*'
+#
+# The row is only a guard because of the cwd it runs in. `*` in an empty
+# directory expands to itself, so a glob-expanding implementation would pass
+# this row anywhere the expansion happens to match nothing - green for the
+# hazard it is named after. Seeding a directory holding one file named after
+# the failed control in the fixture is what makes the two implementations
+# disagree: expanded, the name matches and the helper blocks; literal, there is
+# no control called `*` and it ships. Raised in review, where the same mutation
+# was red from the repo root and green from a directory without that file.
+GLOB_CWD="$(mktemp -d)"
+trap 'rm -rf "$GLOB_CWD"' EXIT
+: > "$GLOB_CWD/authentication"
+GLOB_BODY="$(body degraded "$(control authentication failed 'auth env incomplete')")"
+GLOB_BACK="$PWD"
+cd "$GLOB_CWD"
+ships "treats a glob-shaped name as a literal name" "$GLOB_BODY" '*'
+cd "$GLOB_BACK"
 
 # /health is the liveness gate and it runs first. A body this function cannot
 # read is not a second chance to decide the process is dead.
@@ -285,6 +302,32 @@ if grep -qE 'deploy_blocking_control_failures "[^"]*CONTROLS_BODY" "[^"]*DEPLOY_
 else
   no "the blocking-control list is passed as one quoted argument" \
      "an unquoted list is also a pathname expansion; see lib/controls.sh"
+fi
+
+# The guard above is about api-deploy.sh. This one is about THIS file, and it
+# exists because ships() only distinguishes a crash from a ship while its
+# declaration and its assignment stay on separate lines. `local out="$(...)"`
+# reports the status of `local`, which succeeds whatever the substitution did,
+# so tidying those two lines into one restores every ship row to green with the
+# crash still there - measured in review on bash 3.2 and bash 5, both swallow
+# it. It is the same shape as the `|| true` guarded at the call site above: a
+# wrapper that always succeeds, hiding the status of the thing it wraps.
+#
+# Stated cost: this bans the declare-and-assign form for the whole file, not
+# just for ships(), so a future `local tmp="$(mktemp -d)"` whose status nobody
+# cares about is a false positive. The message names the line. Worth it here
+# because the form is indistinguishable from the correct one by reading, and
+# the whole point of the ships rows is a status.
+#
+# Comments blanked for the same reason DEPLOY_CODE blanks them: otherwise the
+# paragraph you are reading would redden its own guard.
+TEST_CODE="$(sed -E 's/^[[:space:]]*#.*$//' "${BASH_SOURCE[0]}")"
+SWALLOWED="$(grep -nE '^[[:space:]]*local [A-Za-z_][A-Za-z0-9_]*="\$\(' <<< "$TEST_CODE" || true)"
+if [ -z "$SWALLOWED" ]; then
+  ok "no declaration in this file swallows the status of a command substitution"
+else
+  no "no declaration in this file swallows the status of a command substitution" \
+     "$SWALLOWED"
 fi
 
 PROBE_LINE="$(grep -nE "$PROBE_RE" <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -337,10 +337,22 @@ fi
 # out: a `;` ends the declaration and starts a new command, which is the fix
 # itself, and a `#` is a trailing comment - the costume that has beaten the
 # guards in this file three times, and the one this pattern must not fire on.
-# `(^|;)` is why refusing to cross a `;` does not also mean failing to see past
-# one: the keyword is looked for at the start of the line OR after a `;`, and
-# `out` is not a keyword, so the fix stays silent while `; local out="$(...)"`
-# does not. Verified on BSD grep 2.6.0, GNU grep 3.11 and busybox.
+# Refusing to cross a `;` is not the same as failing to see past one: the
+# keyword is looked for at the start of the line OR after a `;`, and `out` is
+# not a keyword, so the fix stays silent while `; local out="$(...)"` does not.
+# The `;` alternative carries `^[^#]*` rather than being bare, because a `;`
+# INSIDE a trailing comment is not a command start - `local a=1  # x; local
+# out="$(y)"` matched under the bare form, which is the costume again, found by
+# running the false-positive set a second time after widening rather than only
+# the new positives. Verified on BSD grep 2.6.0, GNU grep 3.11 and busybox: the
+# same 11 of 20 cases match on all three.
+#
+# Two command starts remain uncovered and are left so deliberately.
+# `if true; then local out="$(...)"; fi` and `true && local out="$(...)"` both
+# swallow on both shells and both evade. Neither is a tidy-up of a two-line
+# declaration - they are new control flow - and adding `&&`, `||`, `then` and
+# `do` as anchors re-admits comment text at each of them, which is the trade
+# that has gone wrong twice in this guard already.
 #
 # Stated cost: this bans declare-and-assign for the whole file, not just for
 # ships(), so a future `local tmp="$(mktemp -d)"` or `local tmp=$(mktemp -d)`
@@ -351,7 +363,7 @@ fi
 # Comments blanked for the same reason DEPLOY_CODE blanks them: otherwise the
 # paragraph you are reading would redden its own guard.
 TEST_CODE="$(sed -E 's/^[[:space:]]*#.*$//' "${BASH_SOURCE[0]}")"
-SWALLOWED="$(grep -nE '(^|;)[[:space:]]*(local|declare|readonly|export)[[:space:]][^;#]*="?(\$\(|`)' <<< "$TEST_CODE" || true)"
+SWALLOWED="$(grep -nE '(^[[:space:]]*|^[^#]*;[[:space:]]*)(local|declare|readonly|export)[[:space:]][^;#]*="?(\$\(|`)' <<< "$TEST_CODE" || true)"
 if [ -z "$SWALLOWED" ]; then
   ok "no declaration in this file swallows the status of a command substitution"
 else


### PR DESCRIPTION
Follow-up to #2757, taking the two residuals from its review. Both are about a
test that cannot fail rather than about the gate; no behaviour changes, one file
touched, `scripts/deploy/tests/controls.test.sh`.

## 1. `ships()` was one refactor from inert

The four ship rows tell a crash from a ship by asserting `rc=0` as well as empty
output. That works only because the declaration and the assignment are on
separate lines. `local out="$(...)"` makes `local` the command whose status is
reported, and `local` succeeds whatever the substitution did — so tidying two
lines into one restores every ship row to green with the crash still there.

Measured, not argued. `try/catch` dropped from `lib/controls.sh` is a body that
stops the deploy; the mutations were printed after landing and the tree restored
from pristine copies between runs:

| | result |
|---|---|
| crash alone, this branch | **1 red** — `ships on a body that is not JSON` |
| crash + declaration tidied in, **file as merged in #2757** | **24 passed, 0 failed** |
| crash + declaration tidied in, this branch | **1 red** — `no declaration in this file swallows the status of a command substitution` |
| declaration tidied in alone, this branch | **1 red** — same row |

The middle row is the residual: the crash is present and the suite is green.
This branch still fails, by a different name.

The guard reads this file's own source with full-line comments blanked, the same
way the existing guards read `api-deploy.sh`, and for the same reason — without
the blanking the paragraph explaining the guard reddens it. Two controls:

- the banned form planted as a **full-line comment** — `25 passed, 0 failed`, so
  it reads code and not prose
- the banned form planted in **a different function** — `1 red`, so the scope is
  the file rather than `ships()`

**Stated cost.** It bans declare-and-assign for the whole file, so a future
`local tmp="$(mktemp -d)"` whose status nobody reads is a false positive — the
second control above is exactly that case. The failure message names the line.
The trade is worth it here because the two forms are indistinguishable by
reading and a status is the whole point of the ship rows.

### Widened after review: the first pattern pinned one spelling

`^[[:space:]]*local [A-Za-z_][A-Za-z0-9_]*="\$\("` required the quoted form.
Two other tidy-ups were green with the crash in the tree — the unquoted form,
which is the more common idiom, and the same-line form, which is what merging
two lines most naturally produces when `rc=0` is already there. Backtick
substitution swallows it too.

Measured on **bash 3.2.57 and bash 5.3.15**, a function returning 7, with a
succeeding command as the positive control on every row:

| form | rc | |
|---|---|---|
| `local out="$(crash)"` | 0 | swallowed, both shells |
| `local out=$(crash)` | 0 | swallowed, both shells |
| `local rc=0 out="$(crash)"` | 0 | swallowed, both shells |
| ``local out=`crash` `` | 0 | swallowed, both shells |
| `local out; out="$(crash)"` | **7** | carries, both shells |
| `local out` newline `out="$(crash)"` | **7** | carries, both shells |

The rule is the **keyword plus an assignment from a substitution on the same
command**, not one spelling of it:

```
(^[[:space:]]*|^[^#]*;[[:space:]]*)(local|declare|readonly|export)[[:space:]][^;#]*="?(\$\(|`)
```

`[^;#]` is load-bearing in both directions. A `;` ends the declaration and
starts a new command — that is the fix, spelled on one line, and it must not be
flagged. A `#` is a trailing comment, the costume that has beaten the guards in
this file three times, and the pattern must not fire on it.

Six declaration forms × crash / no-crash, each mutation printed after landing,
both files md5-restored from pristine between runs:

| form | with the crash | without |
|---|---|---|
| pristine two-line | `1 red` — `ships on a body that is not JSON` | `25 passed` |
| quoted | `1 red` — guard row | `1 red` — guard row |
| unquoted | `1 red` — guard row | `1 red` — guard row |
| same-line | `1 red` — guard row | `1 red` — guard row |
| backtick | `1 red` — guard row | `1 red` — guard row |
| **semicolon** | `1 red` — `ships on a body that is not JSON` | `25 passed` |

**The semicolon row is the separating input.** The guard is silent on it and the
crash is caught by the ship row itself — so the pattern is not a blanket ban on
`local`, it bans exactly the forms the shell measurement says swallow a status.

False positives, all `25 passed, 0 failed`: all three spellings planted as a
**full-line comment**; the **trailing-comment** costume `local zzz=1  # was:
local zzz="$(echo hi)" and local q=` + "`y`" + `; and the **semicolon fix planted in
another function**. A **backtick form in another function** is `1 red`, so the
scope is still the file.

Zero matches over the five pristine deploy scripts (`controls.test.sh`,
`lib/controls.sh`, `api-deploy.sh`, `lib/migrate.sh`, `lib/git-sync.sh`).

The stated cost gets slightly wider — `local tmp=$(mktemp -d)` unquoted is now
also a false positive — and it is the same class, not a new one.

## 2. The glob row was documentation, not a guard

`treats a glob-shaped name as a literal name` passes `*` as the required-control
name. In a directory holding nothing that matches, `*` expands to itself — so a
glob-expanding implementation passed the row from any cwd where the expansion
happened to miss, including the repo root, which is how CI runs it.

It now runs in a `mktemp -d` seeded with one file named after the failed control
in its own fixture. Expanded, the name matches that control and the helper
blocks; literal, there is no control called `*` and it ships. The two
implementations now disagree.

Mutation is an unquoted `set -- $names` in `deploy_blocking_control_failures`,
printed after landing:

| | result |
|---|---|
| glob-expanding lib, **row as merged in #2757**, cwd = repo root | **24 passed, 0 failed** |
| glob-expanding lib, this branch | **1 red**, that row by name |
| glob-expanding lib, this branch, run from `$HOME` | **1 red**, same row |
| pristine lib, this branch, from either cwd | `25 passed, 0 failed` |

The seeded directory makes the row independent of where the suite is invoked,
which the previous version was not.

Cleanup is checked by name rather than by count: with `TMPDIR` pointed at an
isolated directory the suite exits 0 and leaves that directory empty. The
`trap … EXIT` does not mask the status — a failing run still exits 1.

## Verification

```
controls 25/25   migrate 68/68   git-sync 16/16      exit 0
shellcheck       controls.test.sh identical to the merged file: one SC1091
                 (both compared at the real path, not from a copy)
```

HEAD asserted in the same shell as every run; tree verified clean by
`git status --porcelain` and both files md5-matched against pristine copies
after each mutation.


### Second widening: the enumeration closed, and seeing past a semicolon

Two more spellings swallow the status and were green under the first widened
pattern with the crash in the tree:

| | why it escaped |
|---|---|
| ``local out="`crash`"`` | `"?` sat inside the `$(` branch, so the backtick alternative was reachable only immediately after the `=` |
| `local z=1; local out="$(crash)"` | `[^;#]` refuses to cross a `;`, so it could not see a banned form after one |

Both `rc=0` on bash 3.2.57 and bash 5.3.15, succeeding command as the positive
control on every row.

**The enumeration is now closed rather than collected.** Command substitution
has two syntaxes, `$(…)` and backticks, each bare or double-quoted — four — and
each of those can start the line or follow a `;`. Single quotes substitute
nothing, so there is no status to swallow.

`(^|;)` is what lets the pattern see past a semicolon without crossing one: the
keyword must appear at the start of the line **or** right after a `;`, and `out`
is not a keyword — so `local out; out="$(…)"`, which is the fix, stays silent
while `; local out="$(…)"` does not.

Eight forms × crash / no-crash:

| form | with the crash | without |
|---|---|---|
| pristine two-line | `1 red` — `ships on a body that is not JSON` | `25 passed` |
| quoted / unquoted / same-line / backtick / **quoted-backtick** / **after-semicolon** | `1 red` — guard row, each | `1 red` — guard row, each |
| **semicolon** (the fix) | `1 red` — `ships on a body that is not JSON` | `25 passed` |

False-positive controls re-run after the widening — **this is the step the first
widening skipped** — all `25 passed, 0 failed`: all spellings as a full-line
comment; the trailing-comment costume including a quoted backtick; a semicolon
**followed by** a trailing comment. Quoted-backtick and after-semicolon forms as
code in another function are `1 red`, so the scope is still the file.

Pattern verified identical on **BSD grep 2.6.0, GNU grep 3.11 and busybox** —
`(^|;)` in an ERE alternation is the one construct here that could have differed
between the Mac it was written on and the `ubuntu-latest` that runs it.


### Third pass: a semicolon inside a trailing comment is not a command start

Found by running the false-positive set **a second time** after the previous
widening rather than only the new positives — the step that widening skipped,
and the mistake this PR's own comment had just been written to warn about.

`(^|;)` treats any semicolon as a command start, so a trailing comment
containing one re-admits the exact costume the `#` exclusion exists for:

| input | previous pattern | shipped |
|---|---|---|
| `local a=1  # x; local out="$(y)"` | **MATCH** — false positive | `-` |
| ``echo hi  # note; local q=`z` `` | **MATCH** — false positive | `-` |

Full-line comments are blanked before the match, so only trailing ones reach it.
Carrying `^[^#]*` on the semicolon alternative closes both: the prefix before
the semicolon may not contain a `#`.

Driven through the suite: the two new inputs are `1 red` under the previous
pattern and `25 passed, 0 failed` under this one, so the fix has a separating
input rather than only an argument. All eight declaration forms × crash /
no-crash unchanged; the whole false-positive set re-run and green.

Identical **11 of 20** case results on BSD grep 2.6.0, GNU grep 3.11 and
busybox — compared by matching line numbers, not by hashing outputs that carry
different headers.

### Stated residual, documented rather than closed

Two command starts still evade, both measured as swallowing on bash 3.2.57 and
5.3.15:

```
if true; then local out="$(crash)"; fi
true && local out="$(crash)"
```

Neither is a tidy-up of a two-line declaration — they are new control flow.
Anchoring on `&&`, `||`, `then` and `do` re-admits comment text at each of those
positions, which is the trade that has now gone wrong twice in this guard. The
boundary is written into the file beside the pattern.
