### PR TITLE
fix(ci): block the cutover when a bundle declares a control and never reports it

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -289,7 +289,7 @@ if [ "$POST_CODE" != "404" ]; then
 fi
 
 if [ -n "$CONTROL_FAILURES" ]; then
-  echo "smoke boot came up with a security control that FAILED to apply:" >&2
+  echo "smoke boot came up with a security control that did not apply:" >&2
   while IFS= read -r control_failure; do
     echo "  $control_failure" >&2
   done <<< "$CONTROL_FAILURES"

--- a/scripts/deploy/lib/controls.sh
+++ b/scripts/deploy/lib/controls.sh
@@ -36,11 +36,26 @@
 #   named control `skipped`     ship. Auth switched off is a deployment fact,
 #                               not a fault; treating it as one is the same
 #                               mistake as ignoring the endpoint, mirrored.
-#   named control ABSENT        ship. A ROLLBACK deploys an older bundle that
-#                               never records the control, so blocking on
+#   named control ABSENT,       ship. A ROLLBACK deploys an older bundle that
+#   body has no `expected`      never records the control, so blocking on
 #                               absence would refuse the deploy most needed to
-#                               work. This is the deliberate weak spot: a bundle
-#                               that silently stops recording is not caught here.
+#                               work. Absence alone is not evidence of a fault,
+#                               and the absence of `expected` is what marks the
+#                               bundle as older than the declaration itself.
+#
+#   named control ABSENT,       ship. This bundle declares what it records and
+#   `expected` omits it         does not claim this one. Same reasoning as the
+#                               row above, arrived at positively rather than by
+#                               a missing key: what the deploy asks to block on
+#                               is not what this bundle knows how to report.
+#
+#   named control ABSENT,       BLOCK. The bundle said it would record this
+#   `expected` NAMES it         control before it answered on its port, and then
+#                               did not. That is a positive report of failure
+#                               reconstructed from two facts instead of one, and
+#                               it is why startup-controls.ts reports `expected`
+#                               alongside the reports (#2759, #2761). It used to
+#                               be indistinguishable from the two rows above.
 #   endpoint unreachable        ship. /health is already the liveness gate and
 #   or not JSON                 it runs first; a second liveness check that
 #                               guesses at a body is not one.
@@ -93,11 +108,43 @@ deploy_blocking_control_failures() {
       const reports =
         parsed && Array.isArray(parsed.controls) ? parsed.controls : [];
 
+      // What this bundle says it registers before answering on its port. A
+      // body without the key predates the declaration, and a key of the wrong
+      // shape is a body we cannot read - both ship, for the same reason an
+      // unparseable body does. Only a well-formed list can turn an absent
+      // report into a failure.
+      //
+      // The rule below is MEMBERSHIP, not presence, and that is deliberate:
+      // the question asked of each name is "did this bundle claim it", never
+      // "does this bundle have the key". Presence and an empty list therefore
+      // decide identically, and an empty-array default in place of the null
+      // below changes no answer - measured, not assumed. A presence-based
+      // rule would be broken
+      // by exactly that substitution, which is why it is not one.
+      //
+      // Array.isArray rather than truthiness is load-bearing and separate: a
+      // string also has .includes, and "authentication".includes("authentication")
+      // is true, so a malformed key would block every deploy.
+      const declared =
+        parsed && Array.isArray(parsed.expected) ? parsed.expected : null;
+
       for (const name of required) {
         const report = reports.find(
           (candidate) => candidate && candidate.name === name,
         );
-        if (!report || report.state !== "failed") continue;
+        if (!report) {
+          // Absence decides nothing by itself. It becomes a failure only when
+          // the declaration published by this same bundle contradicts it.
+          //
+          // No apostrophe and no backtick anywhere in this script: it is the
+          // argument to node -e inside a SINGLE-quoted bash string, so either
+          // one ends the quoting and the rest of the file becomes shell.
+          if (declared && declared.includes(name)) {
+            process.stdout.write(name + ": declared but never reported\n");
+          }
+          continue;
+        }
+        if (report.state !== "failed") continue;
         const detail =
           typeof report.detail === "string" && report.detail
             ? " (" + report.detail + ")"

--- a/scripts/deploy/lib/controls.sh
+++ b/scripts/deploy/lib/controls.sh
@@ -49,16 +49,21 @@
 #                               a missing key: what the deploy asks to block on
 #                               is not what this bundle knows how to report.
 #
-#   named control ABSENT,       BLOCK. The bundle said it would record this
-#   `expected` NAMES it         control before it answered on its port, and then
-#                               did not. That is a positive report of failure
+#   named control ABSENT from   BLOCK. The bundle said it would record this
+#   a READABLE controls list,   control before it answered on its port, and then
+#   `expected` NAMES it         #                               did not. That is a positive report of failure
 #                               reconstructed from two facts instead of one, and
 #                               it is why startup-controls.ts reports `expected`
 #                               alongside the reports (#2759, #2761). It used to
 #                               be indistinguishable from the two rows above.
-#   endpoint unreachable        ship. /health is already the liveness gate and
-#   or not JSON                 it runs first; a second liveness check that
-#                               guesses at a body is not one.
+#   endpoint unreachable,       ship. /health is already the liveness gate and
+#   not JSON, or JSON whose     it runs first; a second liveness check that
+#   `controls` is not an array  guesses at a body is not one. The last of those
+#                               matters because of the BLOCK row below: a
+#                               declaration can only contradict a list that was
+#                               actually read, so an unreadable `controls` makes
+#                               `expected` inert rather than damning. A readable
+#                               EMPTY list is not this case - see that row.
 #   unnamed control `failed`    ship. See the Stream reasoning above.
 #
 #   node itself cannot run      STOP THE DEPLOY, and this is the one row that is
@@ -105,8 +110,21 @@ deploy_blocking_control_failures() {
         return;
       }
 
-      const reports =
-        parsed && Array.isArray(parsed.controls) ? parsed.controls : [];
+      // Whether the list of what WAS recorded can be read at all. This used to
+      // be an inert defensive fallback - nothing distinguished an unreadable
+      // list from an empty one, because only a report positively saying
+      // failed could block and neither shape has one. Reading absence made it
+      // load-bearing, and in the wrong direction: a body with a good
+      // declaration and a controls key that is a string or missing would have
+      // blocked, which is a body we cannot read stopping the deploy. Raised in
+      // review on #2763.
+      //
+      // An EMPTY array is a different answer and still blocks: that is a list
+      // we read, saying nothing was recorded, against a bundle that said it
+      // would. Readable-and-empty is a contradiction; unreadable is not an
+      // answer at all.
+      const readable = Boolean(parsed) && Array.isArray(parsed.controls);
+      const reports = readable ? parsed.controls : [];
 
       // What this bundle says it registers before answering on its port. A
       // body without the key predates the declaration, and a key of the wrong
@@ -126,7 +144,7 @@ deploy_blocking_control_failures() {
       // string also has .includes, and "authentication".includes("authentication")
       // is true, so a malformed key would block every deploy.
       const declared =
-        parsed && Array.isArray(parsed.expected) ? parsed.expected : null;
+        readable && Array.isArray(parsed.expected) ? parsed.expected : null;
 
       for (const name of required) {
         const report = reports.find(

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -85,8 +85,20 @@ body_declaring() { # body_declaring <status> <expected-names> <control-json>...
   for part in "$@"; do
     [ -z "$joined" ] && joined="$part" || joined="$joined,$part"
   done
+  # read -ra, not `for name in $expected`. An unquoted expansion is also a
+  # pathname expansion, so a glob-shaped name would expand against whatever
+  # directory the suite happens to run from - and this is the builder every
+  # other fixture in this file asserts against. A builder whose output depends
+  # on the cwd is how each machine covers something different while every
+  # self-test passes. Same hazard #2757 deleted an SC2086 disable to remove
+  # from the call site; raised in review on #2763.
+  #
+  # The +"${...}" guard is for `set -u` on bash 3.2, where expanding an empty
+  # array is an unbound-variable error rather than nothing.
   local declared="" name
-  for name in $expected; do
+  local names_array=()
+  read -ra names_array <<< "$expected"
+  for name in ${names_array[@]+"${names_array[@]}"}; do
     [ -z "$declared" ] && declared="\"$name\"" || declared="$declared,\"$name\""
   done
   printf '{"status":"%s","controls":[%s],"expected":[%s]}' \
@@ -266,6 +278,67 @@ stream-upload-policy: declared but never reported" \
 ships "ships on the response shape a pre-#2755 bundle actually returns" \
   '{"status":"ok","controls":[{"name":"stream-upload-policy","state":"applied","at":"2026-09-04T22:21:40.663Z"}]}' \
   authentication
+
+# ---------------------------------------------------------------------------
+# A declaration can only contradict a list that was actually READ.
+#
+# Raised in review: the `controls` fallback and the `expected` fallback are
+# sibling ternaries with opposite policies, and reading absence turned the first
+# one from an inert defence into something that decides a block. Without these
+# rows, a body whose `controls` is a string stops a deploy while the line four
+# below it says a body whose `expected` is a string ships - the same malformed
+# body, opposite answers, and nothing in the suite noticing.
+#
+# The three shapes are separate cases because they reach the check differently:
+# a missing key, a wrong type, and null.
+# ---------------------------------------------------------------------------
+ships "ships when the declaration is good but there is no controls key" \
+  '{"status":"ok","expected":["authentication"]}' \
+  authentication
+
+ships "ships when the declaration is good but controls is not an array" \
+  '{"status":"ok","controls":"nope","expected":["authentication"]}' \
+  authentication
+
+ships "ships when the declaration is good but controls is null" \
+  '{"status":"ok","controls":null,"expected":["authentication"]}' \
+  authentication
+
+# The row that keeps the three above from being a blanket "any odd controls
+# ships". An EMPTY array is not an unreadable one: it is a list we read, saying
+# nothing was recorded, from a bundle that said it would record this. That is
+# the contradiction, and it is the only difference between this row and the
+# three above.
+check "blocks when a readable but empty controls list contradicts the declaration" \
+  "authentication: declared but never reported" \
+  "$(deploy_blocking_control_failures \
+      '{"status":"ok","controls":[],"expected":["authentication"]}' \
+      authentication)"
+
+# ---------------------------------------------------------------------------
+# The fixture BUILDER, not the gate. body_declaring splits its name list, and an
+# unquoted split is also a pathname expansion - so a glob-shaped name would
+# expand against whatever directory the suite runs from, and every fixture in
+# this file comes out of that builder.
+#
+# The seeded directory is load-bearing and is asserted before it is used: with
+# an EMPTY cwd an unquoted expansion also leaves `*` alone, so this test would
+# pass on the broken builder and prove nothing.
+# ---------------------------------------------------------------------------
+GLOB_SEED="$(mktemp -d)"
+: > "$GLOB_SEED/authentication"
+check "the glob fixture directory has something to expand against" \
+  "seeded" \
+  "$([ -f "$GLOB_SEED/authentication" ] && echo seeded || echo empty)"
+
+check "the fixture builder treats a glob-shaped name as a literal name" \
+  '{"status":"ok","controls":[],"expected":["*"]}' \
+  "$(cd "$GLOB_SEED" && body_declaring ok '*')"
+
+rm -rf "$GLOB_SEED"
+check "the glob fixture directory was removed, by name" \
+  "gone" \
+  "$([ -e "$GLOB_SEED" ] && echo "still there: $GLOB_SEED" || echo gone)"
 
 # ---------------------------------------------------------------------------
 # The row the table above does not decide: an unreadable BODY ships, but an

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -73,6 +73,26 @@ body() { # body <status> <control-json>...
   printf '{"status":"%s","controls":[%s]}' "$status" "$joined"
 }
 
+# The same body with the declaration #2759 added: what this bundle registers
+# before it answers on its port. Kept as a SEPARATE builder rather than an
+# optional argument to body(), so that every existing fixture above stays a
+# body with no `expected` key at all - which is the older-bundle case, and the
+# one both API hosts actually return today.
+body_declaring() { # body_declaring <status> <expected-names> <control-json>...
+  local status="$1" expected="$2"
+  shift 2
+  local joined="" part
+  for part in "$@"; do
+    [ -z "$joined" ] && joined="$part" || joined="$joined,$part"
+  done
+  local declared="" name
+  for name in $expected; do
+    [ -z "$declared" ] && declared="\"$name\"" || declared="$declared,\"$name\""
+  done
+  printf '{"status":"%s","controls":[%s],"expected":[%s]}' \
+    "$status" "$joined" "$declared"
+}
+
 control() { # control <name> <state> [detail]
   local name="$1" state="$2" detail="${3-}"
   if [ -n "$detail" ]; then
@@ -183,6 +203,69 @@ ships "ships on JSON without a controls array" \
 ships "ships when no control is named as blocking" \
   \
       "$(body degraded "$(control authentication failed 'auth env incomplete')")"
+
+# ---------------------------------------------------------------------------
+# `expected` (#2761): absence alone still ships, but absence CONTRADICTED by the
+# bundle's own declaration blocks.
+#
+# The three ship rows below are not padding around the block row - they are what
+# stops this from being "block whenever the name is missing and the key is
+# present", which passes the block row and every row above it. Each removes one
+# of the three ways a name can be missing for a reason that is not a fault.
+# ---------------------------------------------------------------------------
+check "blocks when the bundle declared the control and never reported it" \
+  "authentication: declared but never reported" \
+  "$(deploy_blocking_control_failures \
+      "$(body_declaring ok "authentication stream-upload-policy" \
+          "$(control stream-upload-policy applied)")" \
+      authentication)"
+
+# The rollback case, now stated positively: this bundle publishes its list and
+# the control is not on it, so it never claimed to record one. Distinguishing
+# this from the row above is the whole point of reading the key, and a gate that
+# ignored membership would block here and refuse the deploy.
+ships "ships when \`expected\` omits the named control, so it was never claimed" \
+  "$(body_declaring ok "stream-upload-policy" \
+      "$(control stream-upload-policy applied)")" \
+  authentication
+
+# A declaration of the wrong shape is a body we cannot read, and an unreadable
+# body ships. Without this row, `parsed.expected` being truthy would be enough,
+# and a string is truthy and has .includes.
+ships "ships when \`expected\` is present but not an array" \
+  '{"status":"ok","controls":[],"expected":"authentication"}' \
+  authentication
+
+# Declared, reported, fine. The block row above must not be reachable by the
+# declaration alone.
+ships "ships when the control is declared and did report" \
+  "$(body_declaring ok "authentication" "$(control authentication applied)")" \
+  authentication
+
+# Both kinds of failure in one body, so the two emit paths are separated: one
+# control reported `failed`, the other declared and missing. A gate wired to
+# only one of them passes one of the block rows above on its own.
+check "reports a declared-and-missing control alongside one that reported failed" \
+  "authentication: failed (auth env incomplete)
+stream-upload-policy: declared but never reported" \
+  "$(deploy_blocking_control_failures \
+      "$(body_declaring degraded "authentication stream-upload-policy" \
+          "$(control authentication failed 'auth env incomplete')")" \
+      "authentication stream-upload-policy")"
+
+# The bytes both API hosts returned on 2026-09-06, pasted rather than built -
+# a pre-#2755 bundle, which is also what a rollback to any ref before it
+# produces, so it must keep shipping.
+#
+# Stated honestly: no mutation of lib/controls.sh reddens this row without also
+# reddening the body()-built absent row above it, and I could not construct one.
+# It is subsumed. What it is here for is the fixture BUILDER: every other case
+# in this file asserts against body() output, and a builder that drifted from
+# the endpoint would take the whole suite with it. This row is the only input
+# here that the endpoint actually produced.
+ships "ships on the response shape a pre-#2755 bundle actually returns" \
+  '{"status":"ok","controls":[{"name":"stream-upload-policy","state":"applied","at":"2026-09-04T22:21:40.663Z"}]}' \
+  authentication
 
 # ---------------------------------------------------------------------------
 # The row the table above does not decide: an unreadable BODY ships, but an


### PR DESCRIPTION
Closes #2761.

`#2759` added an `expected` list to `/health/controls` so a reader could tell *"this bundle is
too old to record X"* from *"this bundle registers X and did not"* — the same bytes without it.
`startup-controls.ts` says so in its own doc comment, and names the deploy gate as the consumer.
Nothing read the key. This is the consumer.

## The rule

Absence alone still ships. Absence **contradicted by the bundle's own declaration** blocks.

| response | before | after |
|---|---|---|
| no `expected` key, control absent | ship | ship |
| `expected` not an array, control absent | ship | ship |
| `expected` omits the name, control absent | ship | ship |
| **`expected` names it, `controls` omits it** | **ship** | **BLOCK** |
| `controls` reports it `failed` | BLOCK | BLOCK |
| `controls` reports `applied`/`skipped` | ship | ship |

Row 4 is the deliberate weak spot `lib/controls.sh` documented and this closes. Rows 1–3 are why
it is not simply "block when the name is missing".

## Membership, not presence — and that distinction is measured

The question asked of each name is *did this bundle claim it*, never *does this bundle have the
key*. Presence-based sounds equivalent and is not: a bundle that publishes `expected` without the
name has not claimed it, and blocking there refuses a rollback from the other side.

Raised in review as a trap — `parsed.expected || []` collapsing **absent** into
**present-and-empty**, the same shape as `local` swallowing a status. Under a membership rule it
is inert, and I ran it rather than arguing it:

```
mutation: `: []` in place of `: null` (absent collapsed into empty)   30 passed, 0 failed
```

Green, because both make `declared.includes(name)` false. Recorded in the source so nobody
"fixes" it into a presence check, where that same substitution would be a real defect.

`Array.isArray` rather than truthiness **is** load-bearing and is a separate question: a string
also has `.includes`, and `"authentication".includes("authentication")` is true, so a malformed
key would block every deploy.

## Mutations — 6, each checked by the failing test NAME

Tree restored from a pristine copy between runs; baseline 30/30 either side; the landed line
printed before each run.

| Mutation | Reddens |
|---|---|
| declared branch unreachable (pre-#2761 behaviour) | 2 — the block row and the mixed row |
| membership ignored, any absence blocks once the key is present | **1 — `expected` omits the name** |
| truthiness instead of `Array.isArray` | 1 — `expected` present but not an array |
| absence blocks with no declaration at all | 7, incl. the rollback row |
| declaration ignored entirely, every absence emits | 8 |
| absent collapsed into present-and-empty | **0 — inert, see above** |

Row 2 is the separating input. It is the only one that fails a gate reading the key as a
membership list rather than a version marker, and every other row above passes such a gate.

**One mutation of mine was broken and I am reporting that rather than its number.** A first pass
at the `absent blocks` and `absent collapsed` rows came back **19 failed** — which reads as a
suite catching everything. It was shell escaping: `\&\&` reached the file as literal
backslash-ampersands, node threw, and stdout was empty for every case. The faithful versions are
7 and 0. A mutation that dies and a mutation the code survives are both "not the number you
meant", and here they were on opposite sides of the same run.

## Is the blocking row reachable?

Not today, and that is stated rather than implied. `EXPECTED_CONTROLS` is static, `app.ts`
records `authentication` on all three paths before `listen`, and `#2759`'s
`expected-controls.test.ts` asserts the recorded set covers the manifest at boot. This gate is
what sees it if any of that stops being true on a bundle that still deploys — which is the case
the endpoint was built for in the first place.

## The absent case, on the other hand, is live

`/health/controls` is unauthenticated by design, so both hosts can be read from outside:

```
devapi  200  {"status":"ok","controls":[{"name":"stream-upload-policy","state":"applied","at":"2026-09-04T22:21:40.663Z"}]}
api     200  {"status":"ok","controls":[{"name":"stream-upload-policy","state":"applied","at":"2026-09-02T18:03:21.052Z"}]}
```

No `authentication`, no `expected`, on either — both processes booted before `#2755` merged.
Read twice from two machines on different networks, byte-identical including both differing `at`
stamps, `Cache-Control: no-store`, cache-buster query changes nothing.

Those exact bytes are a test fixture here, pasted rather than built by `body()`. **Stated
honestly: it is subsumed** — no mutation of `lib/controls.sh` reddens it without also reddening
the `body()`-built absent row, and I could not construct one. It earns its place as the only
input in the file that the endpoint actually produced; every other case asserts against a builder
that could drift from it. It exercises the *ship* branch, so it is the control in the pair, not
the subject — the blocking body is one no host currently emits and has to be constructed.

## Also in this diff

`api-deploy.sh`: one log line, `FAILED to apply` → `did not apply`, because the message now heads
a list that can contain a control which was never recorded rather than one that tried and failed.
The sentence under it already read correctly for both.

## Verification

```
controls.test.sh    30 passed, 0 failed   (was 24)
migrate.test.sh     68 passed, 0 failed
git-sync.test.sh    16 passed, 0 failed
shellcheck -x       lib/controls.sh clean, exit 0
                    api-deploy.sh identical set to origin/dev under the same command
                    (4x SC1091, 4x SC2015, 4x SC2034) — compared against a
                    baseline extraction, not remembered
hooks               ran: gitleaks, secretlint, lint-staged; no "hooks did not run" line
HEAD                asserted in the same shell as every run
```

**One finding against myself, caught by keeping the baseline.** A comment I added *inside* the
`node -e` script introduced a new `SC2016` that `origin/dev` does not have — backticks inside a
single-quoted shell string. The file's own comment says no apostrophe and no backtick belong in
there, because either one ends the quoting and the rest of the file becomes shell; I wrote that
line and then broke it four edits later. Removed, and the script now asserts both characters are
absent at patch time. A single `shellcheck` run reporting findings would not have told me which
were mine.
