### PR TITLE
fix(ci): annotate every cutover stop so a gate stop is not read as a flaky deploy

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -269,6 +269,31 @@ echo "  body parse -> $POST_CODE"
 CONTROLS_BODY="$(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health/controls" || echo '')"
 echo "  controls -> ${CONTROLS_BODY:-<unreachable>}"
 CONTROL_FAILURES="$(deploy_blocking_control_failures "$CONTROLS_BODY" "$DEPLOY_BLOCKING_CONTROLS")"
+# Every cutover stop below emits a GitHub Actions error annotation as well as
+# the human lines. Not decoration: all six workflow_dispatch failures this
+# workflow has ever had failed on the step "Deploy over SSH", and so does every
+# stop below, because this script runs inside that step. Step name, job name and
+# red X are therefore identical to a routine deploy failure, and the natural
+# response to a familiar failure is to re-run it rather than read it. An
+# annotation is what puts the reason on the run summary instead of only inside
+# an expanded log.
+#
+# STDOUT, and the human lines stay on stderr. GitHub documents workflow commands
+# as reaching the runner over stdout and does not mention stderr. The three
+# preflight key checks in deploy-api.yml are the nearest precedent in this file
+# and they write to stderr - but raised in review: not one of them has ever
+# fired, so that is an unexercised convention rather than evidence. The rest of
+# the repo (promotion-guard.yml, _migration.yaml, the release workflows) uses
+# stdout, which is also what the docs say.
+#
+# Emitted unconditionally rather than gated on $GITHUB_ACTIONS. That variable is
+# NOT forwarded across the ssh in deploy-api.yml - only REQUIRE_PROMOTED_FROM is
+# - so gating on it would switch the annotation off permanently and silently,
+# which is the failure mode this whole file exists to avoid. Run by hand, the
+# line is one extra line of log next to the message it duplicates.
+#
+# On stdout, not stderr, and single-line: annotation data may not contain a raw
+# newline, which is why the control list is joined below rather than looped.
 # Reports, never gates - the `|| true` is what makes that true, and it is
 # deliberate: this is a second signal for whoever reads the log, and POST_CODE
 # above is the gate.
@@ -278,6 +303,7 @@ SMOKE_PID=""
 sleep 2
 if [ "$CODE" != "200" ]; then
   echo "smoke boot failed - NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  echo "::error::Smoke boot did not answer 200 (got $CODE). NOT cutting over. Rollback sha: $ROLLBACK_SHA"
   exit 1
 fi
 
@@ -285,6 +311,7 @@ if [ "$POST_CODE" != "404" ]; then
   echo "smoke boot could not parse a request body ($POST_CODE, expected 404)" >&2
   echo "- every GET probe passes a bundle that 500s on every write." >&2
   echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  echo "::error::Smoke boot could not parse a request body ($POST_CODE, expected 404) - every GET probe passes a bundle that 500s on every write. NOT cutting over. Rollback sha: $ROLLBACK_SHA"
   exit 1
 fi
 
@@ -295,6 +322,7 @@ if [ -n "$CONTROL_FAILURES" ]; then
   done <<< "$CONTROL_FAILURES"
   echo "- the process starts and /health answers 200 with the control absent." >&2
   echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  echo "::error::Security control did not apply: $(printf '%s' "$CONTROL_FAILURES" | tr '\n' ';' | sed 's/;/; /g; s/; $//'). NOT cutting over. Rollback sha: $ROLLBACK_SHA"
   exit 1
 fi
 

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -322,7 +322,7 @@ if [ -n "$CONTROL_FAILURES" ]; then
   done <<< "$CONTROL_FAILURES"
   echo "- the process starts and /health answers 200 with the control absent." >&2
   echo "NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
-  echo "::error::Security control did not apply: $(printf '%s' "$CONTROL_FAILURES" | tr '\n' ';' | sed 's/;/; /g; s/; $//'). NOT cutting over. Rollback sha: $ROLLBACK_SHA"
+  echo "::error::Security control did not apply: $(printf '%s' "$CONTROL_FAILURES" | awk 'NR > 1 { printf "; " } { printf "%s", $0 }'). NOT cutting over. Rollback sha: $ROLLBACK_SHA"
   exit 1
 fi
 

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -593,14 +593,46 @@ done
 
 # Stream, not just presence. GitHub documents workflow commands as reaching the
 # runner over stdout and never mentions stderr, so an annotation redirected to
-# stderr may be a plain log line - which would be the quietest possible failure
-# for a change whose entire purpose is to be more visible. Raised in review,
-# along with the finding that the stderr precedents in deploy-api.yml have never
-# fired, so they are an unexercised convention rather than evidence.
-CUTOVER_ANNOTATIONS_ON_STDERR="$(grep -c '::error::.*>&2' <<< "$CUTOVER_REGION" || true)"
-check "the annotations go to stdout, where workflow commands are read" \
-  "0 redirected to stderr" \
-  "$CUTOVER_ANNOTATIONS_ON_STDERR redirected to stderr"
+# stderr may be a plain log line - the quietest possible failure for a change
+# whose entire purpose is to be more visible.
+#
+# Redirection is NOT line-local, and the first version of this guard was. Three
+# spellings put the same annotation on stderr and only one is on the same line
+# as it:
+#
+#   echo "::error::…" >&2          line-local, trailing
+#   >&2 echo "::error::…"          line-local, leading
+#   { echo "::error::…" ; } >&2    ENCLOSING - and this is the house style:
+#                                  deploy-api.yml:106-121 wraps all three of its
+#                                  preflight annotations in exactly this shape.
+#
+# So the form most likely to be written here is the one a line-local grep cannot
+# see, and someone writing it would be following the convention this file's own
+# comment names. Raised in review.
+#
+# The enclosure check tracks ONE level of brace group, which is all this region
+# has and all the house style uses. A group nested inside another group would
+# not be seen; that is a limit of a source guard, not a case anyone writes here.
+# It deliberately fires only on a group that CONTAINS an annotation, so a future
+# brace group wrapping ordinary human lines is not a false positive.
+CUTOVER_STDERR_INLINE="$(grep -cE '(::error::.*>&[12]|>&[12].*::error::)' \
+  <<< "$CUTOVER_REGION" || true)"
+
+CUTOVER_STDERR_ENCLOSED="$(awk '
+  /^[[:space:]]*\{[[:space:]]*$/ { inside = 1; buf = ""; next }
+  inside && /^[[:space:]]*\}[[:space:]]*>&[12]/ {
+    if (buf ~ /::error::/) { bad++ }
+    inside = 0; buf = ""; next
+  }
+  inside { buf = buf $0 "\n"; next }
+  END { print bad + 0 }
+' <<< "$CUTOVER_REGION")"
+
+check "no annotation is redirected to stderr on its own line" \
+  "0 inline" "$CUTOVER_STDERR_INLINE inline"
+
+check "no annotation is redirected to stderr by an enclosing group" \
+  "0 enclosed" "$CUTOVER_STDERR_ENCLOSED enclosed"
 
 # The parity guard, and it is not subsumed by the three above: a FOURTH stop
 # added later without an annotation reddens only this one. That is the case

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -605,22 +605,36 @@ done
 #   { echo "::error::…" ; } >&2    ENCLOSING - and this is the house style:
 #                                  deploy-api.yml:106-121 wraps all three of its
 #                                  preflight annotations in exactly this shape.
+#   ( echo "::error::…" ) >&2      ENCLOSING, subshell. Same construct, different
+#                                  bracket; raised in review after the first
+#                                  enclosure check tracked braces only.
+#   exec >&2                       redirects the whole shell and takes out all
+#                                  THREE annotations at once, from a line that
+#                                  names none of them.
+#
+# All four measured on this machine with a plain echo as the control:
+#   plain echo   stdout=[::error::X]  stderr=[]
+#   the four     stdout=[]            stderr=[::error::X]
 #
 # So the form most likely to be written here is the one a line-local grep cannot
 # see, and someone writing it would be following the convention this file's own
 # comment names. Raised in review.
 #
-# The enclosure check tracks ONE level of brace group, which is all this region
-# has and all the house style uses. A group nested inside another group would
-# not be seen; that is a limit of a source guard, not a case anyone writes here.
-# It deliberately fires only on a group that CONTAINS an annotation, so a future
-# brace group wrapping ordinary human lines is not a false positive.
+# The enclosure check tracks ONE level of group, brace or subshell. It fires only
+# on a group that CONTAINS an annotation - a group wrapping ordinary human lines
+# is not a false positive, which is why it is a containment test rather than a
+# match on the closing line.
+#
+# The boundary, stated rather than left to be found: an opening bracket that is
+# not alone on its line never opens the tracker, and a group nested inside
+# another group is not seen. A guard that reads lines cannot follow a shell's
+# file descriptors, and that is where this technique ends.
 CUTOVER_STDERR_INLINE="$(grep -cE '(::error::.*>&[12]|>&[12].*::error::)' \
   <<< "$CUTOVER_REGION" || true)"
 
 CUTOVER_STDERR_ENCLOSED="$(awk '
-  /^[[:space:]]*\{[[:space:]]*$/ { inside = 1; buf = ""; next }
-  inside && /^[[:space:]]*\}[[:space:]]*>&[12]/ {
+  /^[[:space:]]*[({][[:space:]]*$/ { inside = 1; buf = ""; next }
+  inside && /^[[:space:]]*[)}][[:space:]]*>&[12]/ {
     if (buf ~ /::error::/) { bad++ }
     inside = 0; buf = ""; next
   }
@@ -633,6 +647,24 @@ check "no annotation is redirected to stderr on its own line" \
 
 check "no annotation is redirected to stderr by an enclosing group" \
   "0 enclosed" "$CUTOVER_STDERR_ENCLOSED enclosed"
+
+# The one evasion worth a line of its own rather than a paragraph of boundary:
+# `exec >&2` redirects the whole shell, so it takes out all three annotations
+# from a line that names none of them - and every other guard here stays green,
+# because each one asks about a SITE and this is not a site.
+#
+# Scanned over the WHOLE script rather than the cutover region, and that is the
+# point rather than caution. The first version read the region and the mutation
+# came back green: a shell redirect applies from wherever it appears onward, so
+# `exec >&2` a few lines ABOVE the region - which is where anyone would put it -
+# disables all three annotations while sitting outside the text being searched.
+# Driven both ways: inside the region 1 red, above it 0 red under the regional
+# version. There is no `exec` anywhere in api-deploy.sh or lib/ today, so a
+# whole-file check has nothing to false-positive on.
+DEPLOY_EXEC_REDIRECT="$(grep -cE '^[[:space:]]*exec[[:space:]]+>&?[12&]' \
+  <<< "$DEPLOY_CODE" || true)"
+check "the deploy script does not redirect the whole shell" \
+  "0 shell redirects" "$DEPLOY_EXEC_REDIRECT shell redirects"
 
 # The parity guard, and it is not subsumed by the three above: a FOURTH stop
 # added later without an annotation reddens only this one. That is the case

--- a/scripts/deploy/tests/controls.test.sh
+++ b/scripts/deploy/tests/controls.test.sh
@@ -527,6 +527,88 @@ else
      "$SWALLOWED"
 fi
 
+# ---------------------------------------------------------------------------
+# Every cutover stop must annotate, not just the controls one.
+#
+# All six workflow_dispatch failures this workflow has ever had failed on the
+# step "Deploy over SSH", and so does every stop in this region - the script
+# runs inside that step. Step name, job name and red X are identical to a
+# routine deploy failure, so without a run-summary annotation the reason is
+# only inside an expanded log. The preflight key checks in deploy-api.yml
+# already annotate; these three were the exception, and the asymmetry was the
+# finding rather than any one stop.
+# ---------------------------------------------------------------------------
+# Anchored with index() on -v values rather than a single-quoted regex: the
+# needle contains a literal dollar, and spelling that inside single quotes is an
+# SC2016 on a line where the dollar is deliberate.
+CUTOVER_REGION="$(awk \
+  -v start="if [ \"\$CODE\" != \"200\" ]" \
+  -v stop='say "cutover"' \
+  'index($0, start) == 1 { f = 1 } f { print } f && index($0, stop) == 1 { exit }' \
+  <<< "$DEPLOY_CODE")"
+
+# Vacuity canary. Everything below is counted out of this region, and an awk
+# range that matched nothing produces zero stops and zero annotations - which
+# is parity, and would report a completely unguarded file as guarded.
+check "the cutover region was actually extracted" \
+  "found" \
+  "$(printf '%s' "$CUTOVER_REGION" | grep -q 'say "cutover"' && echo found || echo empty)"
+
+CUTOVER_STOPS=0
+CUTOVER_ANNOTATED=0
+cutover_block=""
+while IFS= read -r cutover_line; do
+  cutover_block="$cutover_block$cutover_line
+"
+  if [ "$cutover_line" = "fi" ]; then
+    case "$cutover_block" in
+      *"exit 1"*)
+        CUTOVER_STOPS=$((CUTOVER_STOPS + 1))
+        case "$cutover_block" in
+          *'::error::'*) CUTOVER_ANNOTATED=$((CUTOVER_ANNOTATED + 1)) ;;
+        esac
+        ;;
+    esac
+    cutover_block=""
+  fi
+done <<< "$CUTOVER_REGION"
+
+# Named individually as well as counted, because a count says how many and not
+# which - and the controls stop is the one this branch of work added, so it is
+# the one most likely to be the only one done.
+for cutover_guard in \
+  'CODE" != "200:the smoke-boot status stop' \
+  'POST_CODE" != "404:the request-body stop' \
+  "n \"\$CONTROL_FAILURES:the startup-controls stop"; do
+  cutover_needle="${cutover_guard%%:*}"
+  cutover_name="${cutover_guard#*:}"
+  if awk -v n="$cutover_needle" 'index($0, n) {f=1} f {print} f && /^fi$/ {exit}' \
+      <<< "$CUTOVER_REGION" | grep -q '::error::'; then
+    ok "$cutover_name emits a run-summary annotation"
+  else
+    no "$cutover_name emits a run-summary annotation" \
+       "no ::error:: between that condition and its fi"
+  fi
+done
+
+# Stream, not just presence. GitHub documents workflow commands as reaching the
+# runner over stdout and never mentions stderr, so an annotation redirected to
+# stderr may be a plain log line - which would be the quietest possible failure
+# for a change whose entire purpose is to be more visible. Raised in review,
+# along with the finding that the stderr precedents in deploy-api.yml have never
+# fired, so they are an unexercised convention rather than evidence.
+CUTOVER_ANNOTATIONS_ON_STDERR="$(grep -c '::error::.*>&2' <<< "$CUTOVER_REGION" || true)"
+check "the annotations go to stdout, where workflow commands are read" \
+  "0 redirected to stderr" \
+  "$CUTOVER_ANNOTATIONS_ON_STDERR redirected to stderr"
+
+# The parity guard, and it is not subsumed by the three above: a FOURTH stop
+# added later without an annotation reddens only this one. That is the case
+# this exists for - the three named rows describe today.
+check "every cutover stop that exits emits a run-summary annotation" \
+  "$CUTOVER_STOPS stops, $CUTOVER_STOPS annotated" \
+  "$CUTOVER_STOPS stops, $CUTOVER_ANNOTATED annotated"
+
 PROBE_LINE="$(grep -nE "$PROBE_RE" <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"
 KILL_LINE="$(grep -nE 'kill .*SMOKE_PID' <<< "$DEPLOY_CODE" | head -1 | cut -d: -f1 || true)"
 if [ -n "$PROBE_LINE" ] && [ -n "$KILL_LINE" ] && [ "$PROBE_LINE" -lt "$KILL_LINE" ]; then


### PR DESCRIPTION
Refs #2764.

## The problem, measured rather than argued

```
all 6 workflow_dispatch failures this workflow has ever had   step "Deploy over SSH"
  33627412850  33627289875  33627112116  33620397620  33567704148  32783760381
a cutover stop                                                step "Deploy over SSH"
```

`api-deploy.sh` runs inside that step, so **the step name, the job name and the red X of a gate
stop are identical to every failure this workflow has ever had.** The natural response to a
familiar failure is to re-run it rather than read it, and without an annotation the reason is
only inside an expanded log.

**All three stops, not just the startup-controls one.** `deploy-api.yml` annotates its three
preflight key checks (`:108`, `:129`, `:144`) and none of the three cutover stops
(`api-deploy.sh:280/287/297`) did. **The asymmetry was the finding** — fixing only the row this
line of work added would have left the other two silent for the same reason.

## Two decisions that are not obvious

**Stdout, with the human-readable lines left on stderr.** Workflow commands are documented as
reaching the runner over stdout; stderr is not mentioned. Raised in review: the stderr
precedents in `deploy-api.yml` **have never fired**, so they are an unexercised convention rather
than evidence — the nearest thing this file has to a precedent is the one thing that cannot
corroborate itself. There is a guard pinning the stream, not only the presence.

**Unconditional, not gated on `$GITHUB_ACTIONS`.** That variable is *not* forwarded across the
`ssh` in `deploy-api.yml` — the only one that crosses is `REQUIRE_PROMOTED_FROM`:

```
ssh … "chmod +x /tmp/yc-deploy/api-deploy.sh && REQUIRE_PROMOTED_FROM='$PROMOTION_BRANCH' …"
```

So gating on it would switch this off permanently and silently, which is the failure mode the
file exists to avoid. Run by hand, the line is one extra line of log beside the message it
duplicates.

## Stated limit: the over-SSH case is unverified and cannot be verified from here

The annotation is written by a script running on the remote host; its stdout returns through the
local `ssh` process, which is the step's stdout. **I believe the runner parses it. Nobody here
has observed that specific path. The first dispatch is what confirms it.**

The failure mode is benign: an unparsed `::error::` is a literal line in the log, which is
exactly where the message already is. So this is safe to ship unproven — but it is unproven, and
the stdout decision above matters precisely so that a first dispatch failing to annotate points
at the SSH boundary rather than at a stream choice made against the docs.

> **Corrected 2026-09-06, after merge.** This section originally read *"no `::error::` in this
> repo has ever produced an annotation — every failed run examined shows only `Process completed
> with exit code N`."* **That is false**, and it was an unscoped negative drawn from the runs I
> happened to examine.
>
> `promotion-guard.yml:105,115,120` are plain `echo "::error::…"` inside a `run:` step with no
> `>&2` — the same construct as the three cutover stops — and three failed runs each carry the
> workflow's own message as an annotation:
>
> ```
> 33304690565  job 99239026328   main only accepts merges from dev, but this PR's head is
>                                'claude/install-skills-a09751'. …
> 31963982037  job 95206177187   A fork branch (OctoBored/Yosemite-Crew:…) cannot merge into
>                                main. Target dev instead.
> 31719017835  job 94510951098   main only accepts merges from dev, but this PR's head is
>                                'test/guard-probe'. …
> ```
>
> **So a `run:` step's shell writing `::error::` to stdout annotates in this repository, and the
> shell path is the observed-working part.** The last paragraph above stands and is now
> established rather than merely argued: **the ssh boundary is the only unverified element**, and
> if the first dispatch does not annotate, that is where to look. Independently re-derived by a
> second reader. Detail in #2764.

## The half that keeps this from being critical

The diagnosis is not only in the printed body. Each stop already carries its reason at the point
of failure, and **a re-dispatch is idempotent** — the same bundle stops the same way and reprints
it. A re-run costs a person's second attempt, not the information.

## Guards and mutations

```
controls.test.sh   44 passed, 0 failed   (was 38)
migrate 68/68      git-sync 16/16        exit 0
```

| Mutation | Reddens |
|---|---|
| annotation removed from the smoke-boot status stop | 2 — its own row and parity |
| annotation removed from the request-body stop | 2 — its own row and parity |
| annotation removed from the startup-controls stop | 2 — its own row and parity |
| a **fourth** stop added with no annotation | **1 — parity only** |
| an annotation redirected to `>&2` | **1 — the stream row only** |
| the region extractor anchored on nothing | 4 — the canary and the three named rows |

**Row 4 is why parity is not subsumed** by the three named rows: they describe today, and a stop
added later is the case the guard exists for.

**Row 6 is why the vacuity canary earns its line, and the number that shows it is the one that
stayed green:**

```
region extractor matches nothing:
  the cutover region was actually extracted            FAIL
  the three named stop rows                            FAIL
  every cutover stop that exits emits an annotation    ok    <- 0 stops, 0 annotated IS parity
```

**A parity check over an empty set passes.** Without the canary, breaking the extractor would
report a completely unguarded file as guarded.

## Verification

```
shellcheck -x   api-deploy.sh    identical set to origin/dev at the real path (SC1091/2015/2034)
                controls.test.sh identical set to origin/dev at the real path (2x SC1091)
annotation streams, driven       stdout: the ::error:: line   stderr: the human line
the joined control list          single line, 0 newlines, no trailing separator, 1 and 3 entries
hooks ran                        gitleaks, secretlint, lint-staged, commitlint
HEAD asserted in the same shell as every run; tree clean
```

**Two of my own mistakes this round, both caught by a guard rather than by review.** A mutation
of the region extractor **failed to apply** and said so instead of returning a green — the assert
on the substitution count is the only reason that was visible. And I introduced **2x SC2016** by
spelling a literal `$CODE` inside a single-quoted awk pattern; rewritten with `-v` and `index()`,
which is also the form the per-stop guards already used.

