### PR TITLE
chore(repo): ignore derivatives of .env, not just its canonical names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ dist
 dist-ssr
 *.local
 .env
+# Any derivative of a real env file, because `cp .env .env.bak` before an edit is the
+# ordinary way somebody preserves a working config - and `.bak`, `.backup`, `.old` and
+# `.save` matched none of the rules that used to be here. Two such files were found
+# untracked and unignored in a working tree; `git add -A` would have staged both.
+.env.*
+# Sample files are the exception and stay visible, including ones added later.
+!.env.example
 .env.local
 .env.*.local
 .cache


### PR DESCRIPTION
## What

`.gitignore` covered `.env`, `.env.local` and `.env.*.local`. It did not cover `.env.bak`,
`.env.backup`, `.env.old` or `.env.save`.

A derivative is what `cp .env .env.bak` produces, which is the ordinary way somebody preserves a
working config before editing it. **Two such files were found untracked and unignored in a working
tree of this repo, and `git add -A` in that tree would have staged both.**

## Nothing has been exposed — checked, not assumed

```
tracked on origin/dev                                  0
tracked on origin/main                                 0
ever added, all refs, --diff-filter=A -- '*.env.bak'   0
```

Latent, not an incident. No rotation is needed and neither file was read. This closes the class
rather than the instance.

## Why `.env.*` plus `!.env.example`

Exactly three tracked files have a basename starting with `.env`, and all three are
`.env.example`. `apps/mobileAppYC/ios/.xcode.env` is tracked and does **not** match `.env.*`.

A `.gitignore` rule cannot untrack what is already tracked, so the existing samples were never at
risk either way — but without the re-allow a *future* `.env.example` could not be added, and the
intent would be unstated.

## Driven, before and after, in this worktree

```
BEFORE (dev's rules)   git add -An stages   .env.bak  .env.backup  .env.old  .env.save
                                            apps/backend/.env.bak
                                            packages/database/.env.bak
AFTER                  git add -An stages   only .gitignore

samples                apps/backend/.env.example                            visible
                       apps/frontend/.env.example                           visible
                       apps/mobileAppYC/config-templates/env/.env.example   visible
                       apps/mobileAppYC/ios/.xcode.env                      visible
new sample             apps/probe/.env.example (new directory)              visible
```

All six probe files were removed afterwards and verified absent by name.

## Scope

`.gitignore` only. `.env.*.local` is now subsumed by `.env.*` and left in place rather than
removed, to keep the diff to the thing being fixed.
