### PR TITLE
feat(backend): list an organisation's members, and count them by every stored spelling

### DIFF
--- a/apps/backend/src/controllers/web/super-admin-business.controller.ts
+++ b/apps/backend/src/controllers/web/super-admin-business.controller.ts
@@ -120,6 +120,42 @@ export const SuperAdminBusinessController = {
     }
   },
 
+  listMembers: async (req: Request, res: Response) => {
+    const parsed = businessIdSchema.safeParse(req.params);
+    if (!parsed.success) {
+      invalidIdResponse(res);
+      return;
+    }
+
+    try {
+      const members = await SuperAdminBusinessService.listBusinessMembers(
+        parsed.data.id,
+      );
+      if (!members) {
+        respondWithError(res, 404, "BUSINESS_NOT_FOUND", "Business not found");
+        return;
+      }
+
+      res.status(200).json({ members });
+    } catch (error) {
+      if (
+        handleServiceError(
+          error,
+          res,
+          "Failed to list super-admin business members",
+        )
+      ) {
+        return;
+      }
+      respondWithError(
+        res,
+        500,
+        "SUPER_ADMIN_BUSINESS_MEMBERS_FAILED",
+        "Unable to list business members.",
+      );
+    }
+  },
+
   updateBusiness: async (req: Request, res: Response) => {
     const parsedParams = businessIdSchema.safeParse(req.params);
     if (!parsedParams.success) {

--- a/apps/backend/src/routers/super-admin.router.ts
+++ b/apps/backend/src/routers/super-admin.router.ts
@@ -12,6 +12,9 @@ router.use(requireAnyAuth, requireSuperAdmin);
 router.get("/businesses", SuperAdminBusinessController.listBusinesses);
 router.get("/businesses/:id", SuperAdminBusinessController.getBusiness);
 router.patch("/businesses/:id", SuperAdminBusinessController.updateBusiness);
+// memberCount alone cannot answer "who is in this clinic", which is where
+// every account-level diagnosis has to start.
+router.get("/businesses/:id/members", SuperAdminBusinessController.listMembers);
 
 // Lab ingestion holds a result it cannot apply rather than halting the poll for
 // every organisation; this is where those rows become visible to someone.

--- a/apps/backend/src/services/shared/organisation-membership.ts
+++ b/apps/backend/src/services/shared/organisation-membership.ts
@@ -1,5 +1,41 @@
 import { prisma } from "src/config/prisma";
 
+const ORGANISATION_PREFIX = "Organization/";
+const LEADING_ORGANISATION_PREFIX = /^Organization\//;
+
+/**
+ * Every spelling a membership row can carry for one organisation.
+ *
+ * `userOrganization.organizationReference` is persisted verbatim from the FHIR
+ * PractitionerRole's `organization.reference` (`fromFHIRUserOrganization`), and
+ * the create path strips the prefix only to look the organisation up - never to
+ * normalise what it stores. So the column holds whatever the client sent: the
+ * bare id, or the conformant `Organization/<id>`. An organisation is also
+ * addressable by `fhirId`, so pass every id you hold for it.
+ *
+ * A query that matches one spelling silently answers a narrower question than
+ * it looks like it is asking, and returns zero rather than an error when the
+ * data uses the other one.
+ */
+export const organisationReferenceMatches = (
+  ...organisationIds: ReadonlyArray<string | null | undefined>
+): Array<{ organizationReference: string }> => {
+  const spellings = new Set<string>();
+
+  for (const raw of organisationIds) {
+    const id = raw?.trim().replace(LEADING_ORGANISATION_PREFIX, "");
+    if (!id) {
+      continue;
+    }
+    spellings.add(id);
+    spellings.add(`${ORGANISATION_PREFIX}${id}`);
+  }
+
+  return [...spellings].map((organizationReference) => ({
+    organizationReference,
+  }));
+};
+
 /**
  * Narrow a set of user ids to those holding an ACTIVE membership in an
  * organisation.
@@ -28,10 +64,7 @@ export const filterUserIdsInOrganisation = async (
     where: {
       practitionerReference: { in: wanted },
       active: true,
-      OR: [
-        { organizationReference: org },
-        { organizationReference: `Organization/${org}` },
-      ],
+      OR: organisationReferenceMatches(org),
     },
     select: { practitionerReference: true },
   });

--- a/apps/backend/src/services/shared/organisation-membership.ts
+++ b/apps/backend/src/services/shared/organisation-membership.ts
@@ -16,6 +16,14 @@ const LEADING_ORGANISATION_PREFIX = /^Organization\//;
  * A query that matches one spelling silently answers a narrower question than
  * it looks like it is asking, and returns zero rather than an error when the
  * data uses the other one.
+ *
+ * Pass EVERY id you hold for the organisation, not just the one you were
+ * called with. A single argument resolves two spellings where four are
+ * reachable, so two callers holding different ids resolve different-sized sets
+ * for the same organisation - which is the disagreement this helper exists to
+ * remove, one level down. `filterUserIdsInOrganisation` below is the current
+ * example: its callers carry only the organisation id, so it passes one and
+ * that is a limit of the call site rather than the intended pattern.
  */
 export const organisationReferenceMatches = (
   ...organisationIds: ReadonlyArray<string | null | undefined>

--- a/apps/backend/src/services/super-admin-business.service.ts
+++ b/apps/backend/src/services/super-admin-business.service.ts
@@ -227,58 +227,6 @@ const mapDetail = (
  * all four sees both and would over-count. `Members 2` for one person is as
  * wrong as `Members 0` for forty-seven, and neither errors.
  */
-/**
- * The user id a caller can address, out of the reference as stored.
- *
- * `practitionerReference` is persisted verbatim like the organisation column,
- * so it holds a bare id or a FHIR `Practitioner/<id>` - see
- * `practitionerReferenceFilter` in `shared/staff-identity.ts`, where querying
- * only the bare form is what let a deletion remove no organisation roles and
- * report success. Normalised here so a consumer of this endpoint does not have
- * to know FHIR exists to build a link.
- */
-const memberUserId = (practitionerReference: string): string =>
-  practitionerReference.trim().replace(LEADING_PRACTITIONER_PREFIX, "");
-
-/**
- * The identity of a membership for de-duplication.
- *
- * Two ROLES in one organisation are two memberships and both are kept; what
- * collapses is one membership reached under several spellings. The separator is
- * a NUL because it cannot occur in either field, so no value can forge a
- * collision with a different pair.
- */
-const membershipKey = (userId: string, roleCode: string): string =>
-  `${userId}\u0000${roleCode}`;
-
-const toMember = (membership: {
-  practitionerReference: string;
-  roleCode: string;
-  roleDisplay: string | null;
-  createdAt: Date;
-}): SuperAdminBusinessMember => ({
-  userId: memberUserId(membership.practitionerReference),
-  roleCode: membership.roleCode,
-  ...(membership.roleDisplay ? { roleDisplay: membership.roleDisplay } : {}),
-  since: toIsoString(membership.createdAt),
-});
-
-/**
- * The distinct active memberships of one organisation.
- *
- * Everything member-shaped on this surface goes through here, so the roster and
- * the number printed beside it are the same list measured two ways rather than
- * two queries that have to be kept in agreement.
- *
- * Both stored columns are raw FHIR references, which forces the
- * de-duplication. `@@unique([practitionerReference, organizationReference,
- * roleCode])` is over the strings as written, so `<id>` and `Organization/<id>`
- * are different keys: the same person, organisation and role can exist as
- * several rows and satisfy the constraint. Matching one spelling saw one of
- * them and under-counted; matching all four sees all of them and would
- * over-count. `Members 4` for one person is as wrong as `Members 0` for
- * forty-seven, and neither errors.
- */
 const loadMembers = async (
   id: string,
   fhirId?: string | null,
@@ -295,18 +243,40 @@ const loadMembers = async (
   });
 
   const seen = new Set<string>();
+  const members: SuperAdminBusinessMember[] = [];
 
-  return memberships.map(toMember).filter((member) => {
-    if (!member.userId) {
-      return false;
+  for (const membership of memberships) {
+    // practitionerReference is stored verbatim too, so it holds a bare id or a
+    // FHIR Practitioner/<id> - see practitionerReferenceFilter in
+    // shared/staff-identity.ts, where querying only the bare form is what let a
+    // deletion remove no organisation roles and report success. Normalised here
+    // so a caller does not have to know FHIR exists to build a link.
+    const userId = membership.practitionerReference
+      .trim()
+      .replace(LEADING_PRACTITIONER_PREFIX, "");
+    if (!userId) {
+      continue;
     }
-    const key = membershipKey(member.userId, member.roleCode);
+
+    // One person may hold two ROLES here and that is two memberships, kept.
+    // What is collapsed is the same role reached under two spellings.
+    const key = `${userId}\u0000${membership.roleCode}`;
     if (seen.has(key)) {
-      return false;
+      continue;
     }
     seen.add(key);
-    return true;
-  });
+
+    members.push({
+      userId,
+      roleCode: membership.roleCode,
+      ...(membership.roleDisplay
+        ? { roleDisplay: membership.roleDisplay }
+        : {}),
+      since: toIsoString(membership.createdAt),
+    });
+  }
+
+  return members;
 };
 
 const countMembers = async (

--- a/apps/backend/src/services/super-admin-business.service.ts
+++ b/apps/backend/src/services/super-admin-business.service.ts
@@ -1,5 +1,6 @@
 import { OrganizationType, Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
+import { organisationReferenceMatches } from "src/services/shared/organisation-membership";
 
 export type SuperAdminBusinessSummary = {
   id: string;
@@ -12,6 +13,13 @@ export type SuperAdminBusinessSummary = {
   taxId?: string;
   phoneNo?: string;
   website?: string;
+};
+
+export type SuperAdminBusinessMember = {
+  userId: string;
+  roleCode: string;
+  roleDisplay?: string;
+  since: string;
 };
 
 export type SuperAdminBusinessDetail = SuperAdminBusinessSummary & {
@@ -195,21 +203,26 @@ const mapDetail = (
   };
 };
 
-const loadMemberCounts = async (organizationIds: string[]) => {
-  if (organizationIds.length === 0) {
+const countMembers = async (
+  id: string,
+  fhirId?: string | null,
+): Promise<number> =>
+  prisma.userOrganization.count({
+    where: { active: true, OR: organisationReferenceMatches(id, fhirId) },
+  });
+
+const loadMemberCounts = async (
+  organizations: ReadonlyArray<{ id: string; fhirId?: string | null }>,
+) => {
+  if (organizations.length === 0) {
     return new Map<string, number>();
   }
 
   const counts: Array<readonly [string, number]> = await Promise.all(
-    organizationIds.map(
-      async (organizationId): Promise<readonly [string, number]> => [
-        organizationId,
-        await prisma.userOrganization.count({
-          where: {
-            active: true,
-            organizationReference: organizationId,
-          },
-        }),
+    organizations.map(
+      async (organization): Promise<readonly [string, number]> => [
+        organization.id,
+        await countMembers(organization.id, organization.fhirId),
       ],
     ),
   );
@@ -228,9 +241,7 @@ export const SuperAdminBusinessService = {
     const organizations = await prisma.organization.findMany({
       orderBy: { createdAt: "desc" },
     });
-    const memberCounts = await loadMemberCounts(
-      organizations.map((organization) => organization.id),
-    );
+    const memberCounts = await loadMemberCounts(organizations);
 
     return organizations.map((organization) =>
       mapSummary(organization, memberCounts.get(organization.id) ?? 0),
@@ -244,15 +255,54 @@ export const SuperAdminBusinessService = {
       return null;
     }
 
-    const memberCount =
-      (await prisma.userOrganization.count({
-        where: {
-          organizationReference: organization.id,
-          active: true,
-        },
-      })) ?? 0;
+    const memberCount = await countMembers(
+      organization.id,
+      organization.fhirId,
+    );
 
     return mapDetail(organization, memberCount);
+  },
+
+  /**
+   * The active memberships of one organisation.
+   *
+   * `memberCount` is the only thing the panel has ever known about who belongs
+   * to a clinic, and a bare number is not something an operator can act on: to
+   * answer "nobody here can log in" they have to reach the individual accounts.
+   * Resolved through the same predicate as the count, so the list and the
+   * number beside it cannot disagree.
+   */
+  async listBusinessMembers(
+    id: unknown,
+  ): Promise<SuperAdminBusinessMember[] | null> {
+    const businessId = normalizeBusinessId(id);
+    const organization = await findOrganizationById(businessId);
+    if (!organization) {
+      return null;
+    }
+
+    const memberships = await prisma.userOrganization.findMany({
+      where: {
+        active: true,
+        OR: organisationReferenceMatches(organization.id, organization.fhirId),
+      },
+      orderBy: { createdAt: "asc" },
+      select: {
+        practitionerReference: true,
+        roleCode: true,
+        roleDisplay: true,
+        createdAt: true,
+      },
+    });
+
+    return memberships.map((membership) => ({
+      userId: membership.practitionerReference,
+      roleCode: membership.roleCode,
+      ...(membership.roleDisplay
+        ? { roleDisplay: membership.roleDisplay }
+        : {}),
+      since: toIsoString(membership.createdAt),
+    }));
   },
 
   async updateBusiness(
@@ -292,12 +342,7 @@ export const SuperAdminBusinessService = {
       include: { address: true },
     });
 
-    const memberCount = await prisma.userOrganization.count({
-      where: {
-        organizationReference: updated.id,
-        active: true,
-      },
-    });
+    const memberCount = await countMembers(updated.id, updated.fhirId);
 
     return mapDetail(updated, memberCount);
   },

--- a/apps/backend/src/services/super-admin-business.service.ts
+++ b/apps/backend/src/services/super-admin-business.service.ts
@@ -227,6 +227,58 @@ const mapDetail = (
  * all four sees both and would over-count. `Members 2` for one person is as
  * wrong as `Members 0` for forty-seven, and neither errors.
  */
+/**
+ * The user id a caller can address, out of the reference as stored.
+ *
+ * `practitionerReference` is persisted verbatim like the organisation column,
+ * so it holds a bare id or a FHIR `Practitioner/<id>` - see
+ * `practitionerReferenceFilter` in `shared/staff-identity.ts`, where querying
+ * only the bare form is what let a deletion remove no organisation roles and
+ * report success. Normalised here so a consumer of this endpoint does not have
+ * to know FHIR exists to build a link.
+ */
+const memberUserId = (practitionerReference: string): string =>
+  practitionerReference.trim().replace(LEADING_PRACTITIONER_PREFIX, "");
+
+/**
+ * The identity of a membership for de-duplication.
+ *
+ * Two ROLES in one organisation are two memberships and both are kept; what
+ * collapses is one membership reached under several spellings. The separator is
+ * a NUL because it cannot occur in either field, so no value can forge a
+ * collision with a different pair.
+ */
+const membershipKey = (userId: string, roleCode: string): string =>
+  `${userId}\u0000${roleCode}`;
+
+const toMember = (membership: {
+  practitionerReference: string;
+  roleCode: string;
+  roleDisplay: string | null;
+  createdAt: Date;
+}): SuperAdminBusinessMember => ({
+  userId: memberUserId(membership.practitionerReference),
+  roleCode: membership.roleCode,
+  ...(membership.roleDisplay ? { roleDisplay: membership.roleDisplay } : {}),
+  since: toIsoString(membership.createdAt),
+});
+
+/**
+ * The distinct active memberships of one organisation.
+ *
+ * Everything member-shaped on this surface goes through here, so the roster and
+ * the number printed beside it are the same list measured two ways rather than
+ * two queries that have to be kept in agreement.
+ *
+ * Both stored columns are raw FHIR references, which forces the
+ * de-duplication. `@@unique([practitionerReference, organizationReference,
+ * roleCode])` is over the strings as written, so `<id>` and `Organization/<id>`
+ * are different keys: the same person, organisation and role can exist as
+ * several rows and satisfy the constraint. Matching one spelling saw one of
+ * them and under-counted; matching all four sees all of them and would
+ * over-count. `Members 4` for one person is as wrong as `Members 0` for
+ * forty-seven, and neither errors.
+ */
 const loadMembers = async (
   id: string,
   fhirId?: string | null,
@@ -243,40 +295,18 @@ const loadMembers = async (
   });
 
   const seen = new Set<string>();
-  const members: SuperAdminBusinessMember[] = [];
 
-  for (const membership of memberships) {
-    // practitionerReference is stored verbatim too, so it holds a bare id or a
-    // FHIR Practitioner/<id> - see practitionerReferenceFilter in
-    // shared/staff-identity.ts, where querying only the bare form is what let a
-    // deletion remove no organisation roles and report success. Normalised here
-    // so a caller does not have to know FHIR exists to build a link.
-    const userId = membership.practitionerReference
-      .trim()
-      .replace(LEADING_PRACTITIONER_PREFIX, "");
-    if (!userId) {
-      continue;
+  return memberships.map(toMember).filter((member) => {
+    if (!member.userId) {
+      return false;
     }
-
-    // One person may hold two ROLES here and that is two memberships, kept.
-    // What is collapsed is the same role reached under two spellings.
-    const key = `${userId}\u0000${membership.roleCode}`;
+    const key = membershipKey(member.userId, member.roleCode);
     if (seen.has(key)) {
-      continue;
+      return false;
     }
     seen.add(key);
-
-    members.push({
-      userId,
-      roleCode: membership.roleCode,
-      ...(membership.roleDisplay
-        ? { roleDisplay: membership.roleDisplay }
-        : {}),
-      since: toIsoString(membership.createdAt),
-    });
-  }
-
-  return members;
+    return true;
+  });
 };
 
 const countMembers = async (

--- a/apps/backend/src/services/super-admin-business.service.ts
+++ b/apps/backend/src/services/super-admin-business.service.ts
@@ -227,12 +227,46 @@ const mapDetail = (
  * all four sees both and would over-count. `Members 2` for one person is as
  * wrong as `Members 0` for forty-seven, and neither errors.
  */
+/**
+ * Which membership rows belong to one organisation, and what makes two of them
+ * the same membership.
+ *
+ * Both reference columns are persisted verbatim from the inbound FHIR resource,
+ * so each holds a bare id or a `<Type>/<id>` reference - see
+ * `practitionerReferenceFilter` in `shared/staff-identity.ts`, where querying
+ * only the bare form is what let a deletion remove no organisation roles and
+ * report success. `@@unique` is over those strings as written, so one person,
+ * organisation and role can exist as several rows and satisfy the constraint:
+ * matching one spelling under-counts, matching all four over-counts, and
+ * neither errors.
+ *
+ * The roster and the number beside it therefore share this `where` and this
+ * identity, and differ only in how many columns they fetch. Two ROLES in one
+ * organisation stay two memberships; what collapses is one membership reached
+ * under several spellings. The key separator is a NUL because it cannot occur
+ * in either field, so no value can forge a collision with a different pair.
+ */
+const membershipWhere = (id: string, fhirId?: string | null) => ({
+  active: true,
+  OR: organisationReferenceMatches(id, fhirId),
+});
+
+const membershipIdentity = (membership: {
+  practitionerReference: string;
+  roleCode: string;
+}): string | null => {
+  const userId = membership.practitionerReference
+    .trim()
+    .replace(LEADING_PRACTITIONER_PREFIX, "");
+  return userId ? `${userId}\u0000${membership.roleCode}` : null;
+};
+
 const loadMembers = async (
   id: string,
   fhirId?: string | null,
 ): Promise<SuperAdminBusinessMember[]> => {
   const memberships = await prisma.userOrganization.findMany({
-    where: { active: true, OR: organisationReferenceMatches(id, fhirId) },
+    where: membershipWhere(id, fhirId),
     orderBy: { createdAt: "asc" },
     select: {
       practitionerReference: true,
@@ -246,28 +280,14 @@ const loadMembers = async (
   const members: SuperAdminBusinessMember[] = [];
 
   for (const membership of memberships) {
-    // practitionerReference is stored verbatim too, so it holds a bare id or a
-    // FHIR Practitioner/<id> - see practitionerReferenceFilter in
-    // shared/staff-identity.ts, where querying only the bare form is what let a
-    // deletion remove no organisation roles and report success. Normalised here
-    // so a caller does not have to know FHIR exists to build a link.
-    const userId = membership.practitionerReference
-      .trim()
-      .replace(LEADING_PRACTITIONER_PREFIX, "");
-    if (!userId) {
+    const identity = membershipIdentity(membership);
+    if (!identity || seen.has(identity)) {
       continue;
     }
-
-    // One person may hold two ROLES here and that is two memberships, kept.
-    // What is collapsed is the same role reached under two spellings.
-    const key = `${userId}\u0000${membership.roleCode}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
+    seen.add(identity);
 
     members.push({
-      userId,
+      userId: identity.split("\u0000")[0],
       roleCode: membership.roleCode,
       ...(membership.roleDisplay
         ? { roleDisplay: membership.roleDisplay }
@@ -279,10 +299,35 @@ const loadMembers = async (
   return members;
 };
 
+/**
+ * The same count without building the roster.
+ *
+ * A summary endpoint needs a number, and the organisations list asks once per
+ * organisation, so this fetches the two columns the identity is made of rather
+ * than every row in full. It cannot drift from the list: the rows it considers
+ * and the rule for which of them are the same membership are the two functions
+ * above, shared. A database-side `DISTINCT` is not available for it - the
+ * identity comes from an anchored prefix strip that SQL does not reproduce, so
+ * counting distinct values in the database would count spellings again, which
+ * is the over-count this exists to remove.
+ */
 const countMembers = async (
   id: string,
   fhirId?: string | null,
-): Promise<number> => (await loadMembers(id, fhirId)).length;
+): Promise<number> => {
+  const memberships = await prisma.userOrganization.findMany({
+    where: membershipWhere(id, fhirId),
+    select: { practitionerReference: true, roleCode: true },
+  });
+
+  const identities = new Set(
+    memberships
+      .map(membershipIdentity)
+      .filter((identity): identity is string => identity !== null),
+  );
+
+  return identities.size;
+};
 
 const loadMemberCounts = async (
   organizations: ReadonlyArray<{ id: string; fhirId?: string | null }>,

--- a/apps/backend/src/services/super-admin-business.service.ts
+++ b/apps/backend/src/services/super-admin-business.service.ts
@@ -2,6 +2,8 @@ import { OrganizationType, Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { organisationReferenceMatches } from "src/services/shared/organisation-membership";
 
+const LEADING_PRACTITIONER_PREFIX = /^Practitioner\//;
+
 export type SuperAdminBusinessSummary = {
   id: string;
   name: string;
@@ -15,6 +17,13 @@ export type SuperAdminBusinessSummary = {
   website?: string;
 };
 
+/**
+ * One active membership row. Uniqueness on `userOrganization` is
+ * `(practitionerReference, organizationReference, roleCode)`, so a person
+ * holding two roles in an organisation is two rows here and two in
+ * `memberCount` - the list and the count stay in agreement, and a consumer
+ * keying by `userId` alone would collide.
+ */
 export type SuperAdminBusinessMember = {
   userId: string;
   roleCode: string;
@@ -203,13 +212,77 @@ const mapDetail = (
   };
 };
 
+/**
+ * The distinct active memberships of one organisation.
+ *
+ * Everything member-shaped on this surface goes through here, so the roster and
+ * the number printed beside it are the same list measured two ways rather than
+ * two queries that have to be kept in agreement.
+ *
+ * Both stored columns are raw FHIR references, which forces the de-duplication.
+ * `@@unique([practitionerReference, organizationReference, roleCode])` is over
+ * the strings as written, so `<id>` and `Organization/<id>` are different keys:
+ * the same person, organisation and role can exist as two rows and satisfy the
+ * constraint. Matching one spelling saw one of them and under-counted; matching
+ * all four sees both and would over-count. `Members 2` for one person is as
+ * wrong as `Members 0` for forty-seven, and neither errors.
+ */
+const loadMembers = async (
+  id: string,
+  fhirId?: string | null,
+): Promise<SuperAdminBusinessMember[]> => {
+  const memberships = await prisma.userOrganization.findMany({
+    where: { active: true, OR: organisationReferenceMatches(id, fhirId) },
+    orderBy: { createdAt: "asc" },
+    select: {
+      practitionerReference: true,
+      roleCode: true,
+      roleDisplay: true,
+      createdAt: true,
+    },
+  });
+
+  const seen = new Set<string>();
+  const members: SuperAdminBusinessMember[] = [];
+
+  for (const membership of memberships) {
+    // practitionerReference is stored verbatim too, so it holds a bare id or a
+    // FHIR Practitioner/<id> - see practitionerReferenceFilter in
+    // shared/staff-identity.ts, where querying only the bare form is what let a
+    // deletion remove no organisation roles and report success. Normalised here
+    // so a caller does not have to know FHIR exists to build a link.
+    const userId = membership.practitionerReference
+      .trim()
+      .replace(LEADING_PRACTITIONER_PREFIX, "");
+    if (!userId) {
+      continue;
+    }
+
+    // One person may hold two ROLES here and that is two memberships, kept.
+    // What is collapsed is the same role reached under two spellings.
+    const key = `${userId}\u0000${membership.roleCode}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    members.push({
+      userId,
+      roleCode: membership.roleCode,
+      ...(membership.roleDisplay
+        ? { roleDisplay: membership.roleDisplay }
+        : {}),
+      since: toIsoString(membership.createdAt),
+    });
+  }
+
+  return members;
+};
+
 const countMembers = async (
   id: string,
   fhirId?: string | null,
-): Promise<number> =>
-  prisma.userOrganization.count({
-    where: { active: true, OR: organisationReferenceMatches(id, fhirId) },
-  });
+): Promise<number> => (await loadMembers(id, fhirId)).length;
 
 const loadMemberCounts = async (
   organizations: ReadonlyArray<{ id: string; fhirId?: string | null }>,
@@ -281,28 +354,7 @@ export const SuperAdminBusinessService = {
       return null;
     }
 
-    const memberships = await prisma.userOrganization.findMany({
-      where: {
-        active: true,
-        OR: organisationReferenceMatches(organization.id, organization.fhirId),
-      },
-      orderBy: { createdAt: "asc" },
-      select: {
-        practitionerReference: true,
-        roleCode: true,
-        roleDisplay: true,
-        createdAt: true,
-      },
-    });
-
-    return memberships.map((membership) => ({
-      userId: membership.practitionerReference,
-      roleCode: membership.roleCode,
-      ...(membership.roleDisplay
-        ? { roleDisplay: membership.roleDisplay }
-        : {}),
-      since: toIsoString(membership.createdAt),
-    }));
+    return loadMembers(organization.id, organization.fhirId);
   },
 
   async updateBusiness(

--- a/apps/backend/test/routers/super-admin.router.test.ts
+++ b/apps/backend/test/routers/super-admin.router.test.ts
@@ -52,6 +52,9 @@ const mockListBusinesses = jest.fn((_, res) =>
 );
 const mockGetBusiness = jest.fn();
 const mockUpdateBusiness = jest.fn();
+const mockListMembers = jest.fn((_, res) =>
+  res.status(200).json({ members: [{ userId: "user-1", roleCode: "doctor" }] }),
+);
 const mockListQuarantine = jest.fn((_, res) =>
   res.status(200).json({ total: 0, returned: 0, results: [] }),
 );
@@ -79,6 +82,7 @@ jest.mock("src/controllers/web/super-admin-business.controller", () => ({
     listBusinesses: mockListBusinesses,
     getBusiness: mockGetBusiness,
     updateBusiness: mockUpdateBusiness,
+    listMembers: mockListMembers,
   },
 }));
 
@@ -325,5 +329,47 @@ describe("super-admin router", () => {
 
     expect(response.statusCode).toBe(200);
     expect(mockResolveQuarantine).toHaveBeenCalledTimes(1);
+  });
+  // The members list names the individual accounts behind a clinic, so it is
+  // guarded in its own right rather than by inheriting the router's other tests.
+  it("rejects a non-superadmin listing an organisation's members", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["member"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/businesses/org-1/members",
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(mockListMembers).not.toHaveBeenCalled();
+  });
+
+  it("serves an organisation's members to a superadmin", async () => {
+    const response = await request(
+      createApp(
+        {
+          appUserId: "user-1",
+          providerUserId: "st-user-1",
+          authProfile: "pims_web",
+          roles: ["superadmin"],
+        },
+        true,
+        [],
+      ),
+      "/v1/super-admin/businesses/org-1/members",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      members: [{ userId: "user-1", roleCode: "doctor" }],
+    });
+    expect(mockListMembers).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/test/services/shared/organisation-membership.test.ts
+++ b/apps/backend/test/services/shared/organisation-membership.test.ts
@@ -1,0 +1,94 @@
+const mockUserOrganizationFindMany = jest.fn();
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    userOrganization: { findMany: mockUserOrganizationFindMany },
+  },
+}));
+
+import {
+  filterUserIdsInOrganisation,
+  organisationReferenceMatches,
+} from "src/services/shared/organisation-membership";
+
+const references = (matches: Array<{ organizationReference: string }>) =>
+  matches.map((match) => match.organizationReference).sort();
+
+describe("organisationReferenceMatches", () => {
+  it("matches the bare id and the conformant FHIR reference", () => {
+    // The create path stores dto.organization.reference verbatim, so a
+    // membership for org-1 is on disk as either spelling depending only on
+    // what the client sent.
+    expect(references(organisationReferenceMatches("org-1"))).toEqual([
+      "Organization/org-1",
+      "org-1",
+    ]);
+  });
+
+  it("covers the fhirId as well, because an organisation is addressable by both", () => {
+    // findOrganizationById resolves { OR: [{ id }, { fhirId }] }, so a caller
+    // holding one id may be looking at an organisation whose memberships were
+    // written against the other.
+    expect(references(organisationReferenceMatches("org-1", "fhir-1"))).toEqual(
+      ["Organization/fhir-1", "Organization/org-1", "fhir-1", "org-1"],
+    );
+  });
+
+  it("does not double-prefix a reference that already carries one", () => {
+    expect(
+      references(organisationReferenceMatches("Organization/org-1")),
+    ).toEqual(["Organization/org-1", "org-1"]);
+  });
+
+  it("strips the prefix only at the start", () => {
+    // A mid-string replace would silently rewrite this id into something that
+    // matches nothing, which is indistinguishable from an organisation with no
+    // members.
+    expect(
+      references(organisationReferenceMatches("a/Organization/b")),
+    ).toEqual(["Organization/a/Organization/b", "a/Organization/b"]);
+  });
+
+  it("drops blank and missing ids instead of matching everything prefixed", () => {
+    expect(organisationReferenceMatches(undefined, null, "   ")).toEqual([]);
+  });
+
+  it("de-duplicates when the same id arrives twice", () => {
+    expect(organisationReferenceMatches("org-1", "org-1")).toHaveLength(2);
+  });
+});
+
+describe("filterUserIdsInOrganisation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserOrganizationFindMany.mockResolvedValue([]);
+  });
+
+  it("asks for both spellings, so an offboarding check cannot pass by missing the rows", async () => {
+    await filterUserIdsInOrganisation(["user-1"], "org-1");
+
+    const where = mockUserOrganizationFindMany.mock.calls[0][0].where;
+    expect(references(where.OR)).toEqual(["Organization/org-1", "org-1"]);
+    expect(where.active).toBe(true);
+  });
+
+  it("returns only the ids with an active membership", async () => {
+    mockUserOrganizationFindMany.mockResolvedValue([
+      { practitionerReference: "user-1" },
+    ]);
+
+    const inOrg = await filterUserIdsInOrganisation(
+      ["user-1", "user-2"],
+      "org-1",
+    );
+
+    expect([...inOrg]).toEqual(["user-1"]);
+  });
+
+  it("does not query at all without an organisation", async () => {
+    expect([...(await filterUserIdsInOrganisation(["user-1"], ""))]).toEqual(
+      [],
+    );
+    expect(mockUserOrganizationFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/super-admin-business.controller.test.ts
+++ b/apps/backend/test/super-admin-business.controller.test.ts
@@ -124,4 +124,123 @@ describe("SuperAdminBusinessController", () => {
       code: "INVALID_BUSINESS_UPDATE",
     });
   });
+  it("returns the members payload", async () => {
+    jest
+      .spyOn(SuperAdminBusinessService, "listBusinessMembers")
+      .mockResolvedValue([
+        {
+          userId: "user-1",
+          roleCode: "doctor",
+          since: "2026-07-01T09:00:00.000Z",
+        },
+      ]);
+    const res = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "org-1" } } as never,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      members: [
+        {
+          userId: "user-1",
+          roleCode: "doctor",
+          since: "2026-07-01T09:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("rejects malformed ids on members", async () => {
+    const listMembers = jest.spyOn(
+      SuperAdminBusinessService,
+      "listBusinessMembers",
+    );
+    const res = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "bad id" } } as never,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(listMembers).not.toHaveBeenCalled();
+  });
+
+  it("separates an unknown business from one with no members", async () => {
+    // null is 404; an empty roster is a 200 with an empty array. Collapsing the
+    // two would show "this clinic has nobody in it" for a mistyped id.
+    jest
+      .spyOn(SuperAdminBusinessService, "listBusinessMembers")
+      .mockResolvedValue(null);
+    const notFound = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "org-1" } } as never,
+      notFound,
+    );
+
+    expect(notFound.status).toHaveBeenCalledWith(404);
+    expect(notFound.json).toHaveBeenCalledWith({
+      error: "Business not found",
+      code: "BUSINESS_NOT_FOUND",
+    });
+
+    jest
+      .spyOn(SuperAdminBusinessService, "listBusinessMembers")
+      .mockResolvedValue([]);
+    const empty = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "org-1" } } as never,
+      empty,
+    );
+
+    expect(empty.status).toHaveBeenCalledWith(200);
+    expect(empty.json).toHaveBeenCalledWith({ members: [] });
+  });
+
+  it("maps a service error on members to its stable payload", async () => {
+    jest
+      .spyOn(SuperAdminBusinessService, "listBusinessMembers")
+      .mockRejectedValue(
+        new SuperAdminBusinessServiceError(
+          "Invalid business id.",
+          400,
+          "INVALID_BUSINESS_ID",
+        ),
+      );
+    const res = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "org-1" } } as never,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Invalid business id.",
+      code: "INVALID_BUSINESS_ID",
+    });
+  });
+
+  it("does not leak an unexpected failure as an empty roster", async () => {
+    jest
+      .spyOn(SuperAdminBusinessService, "listBusinessMembers")
+      .mockRejectedValue(new Error("connection refused"));
+    const res = createResponse();
+
+    await SuperAdminBusinessController.listMembers(
+      { params: { id: "org-1" } } as never,
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Unable to list business members.",
+      code: "SUPER_ADMIN_BUSINESS_MEMBERS_FAILED",
+    });
+  });
 });

--- a/apps/backend/test/super-admin-business.service.test.ts
+++ b/apps/backend/test/super-admin-business.service.test.ts
@@ -63,15 +63,36 @@ describe("SuperAdminBusinessService", () => {
         createdAt: new Date("2026-07-21T12:00:00.000Z"),
       },
     ]);
-    mockUserOrganizationCount.mockImplementation(
+    // The count is now the length of the de-duplicated roster rather than a
+    // separate query, so the fixture is rows.
+    mockUserOrganizationFindMany.mockImplementation(
       async ({
         where,
       }: {
         where: { OR: Array<{ organizationReference: string }> };
       }) =>
         where.OR.some((match) => match.organizationReference === "org-new")
-          ? 3
-          : 0,
+          ? [
+              {
+                practitionerReference: "user-1",
+                roleCode: "doctor",
+                roleDisplay: null,
+                createdAt: new Date("2026-07-01T09:00:00.000Z"),
+              },
+              {
+                practitionerReference: "Practitioner/user-1",
+                roleCode: "doctor",
+                roleDisplay: null,
+                createdAt: new Date("2026-07-01T09:00:00.000Z"),
+              },
+              {
+                practitionerReference: "user-2",
+                roleCode: "doctor",
+                roleDisplay: null,
+                createdAt: new Date("2026-07-01T09:00:00.000Z"),
+              },
+            ]
+          : [],
     );
 
     await expect(SuperAdminBusinessService.listBusinesses()).resolves.toEqual([
@@ -81,7 +102,7 @@ describe("SuperAdminBusinessService", () => {
         type: "HOSPITAL",
         isVerified: true,
         isActive: true,
-        memberCount: 3,
+        memberCount: 2,
         createdAt: "2026-07-22T12:00:00.000Z",
         taxId: "TAX-2",
         phoneNo: "+1 222 222 2222",
@@ -106,24 +127,24 @@ describe("SuperAdminBusinessService", () => {
     // Every spelling, for every organisation in the list: the count is what an
     // operator reads as "who is in this clinic", and a list view that matched
     // narrowly than the detail view would disagree with itself.
-    expect(mockUserOrganizationCount).toHaveBeenNthCalledWith(1, {
-      where: {
+    expect(mockUserOrganizationFindMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({
         active: true,
         OR: [
           { organizationReference: "org-new" },
           { organizationReference: "Organization/org-new" },
         ],
-      },
-    });
-    expect(mockUserOrganizationCount).toHaveBeenNthCalledWith(2, {
-      where: {
+      }),
+    );
+    expect(mockUserOrganizationFindMany.mock.calls[1][0].where).toEqual(
+      expect.objectContaining({
         active: true,
         OR: [
           { organizationReference: "org-old" },
           { organizationReference: "Organization/org-old" },
         ],
-      },
-    });
+      }),
+    );
   });
 
   it("returns a business detail by id or fhirId", async () => {
@@ -154,7 +175,14 @@ describe("SuperAdminBusinessService", () => {
         postalCode: "78701",
       },
     });
-    mockUserOrganizationCount.mockResolvedValue(12);
+    mockUserOrganizationFindMany.mockResolvedValue(
+      Array.from({ length: 12 }, (_unused, index) => ({
+        practitionerReference: `user-${index}`,
+        roleCode: "doctor",
+        roleDisplay: null,
+        createdAt: new Date("2026-07-01T09:00:00.000Z"),
+      })),
+    );
 
     await expect(
       SuperAdminBusinessService.getBusiness("org_123"),
@@ -191,15 +219,15 @@ describe("SuperAdminBusinessService", () => {
       where: { OR: [{ id: "org_123" }, { fhirId: "org_123" }] },
       include: { address: true },
     });
-    expect(mockUserOrganizationCount).toHaveBeenCalledWith({
-      where: {
+    expect(mockUserOrganizationFindMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({
         active: true,
         OR: [
           { organizationReference: "org-123" },
           { organizationReference: "Organization/org-123" },
         ],
-      },
-    });
+      }),
+    );
   });
 
   it("throws on invalid business ids and empty updates", async () => {
@@ -251,7 +279,14 @@ describe("SuperAdminBusinessService", () => {
       updatedAt: new Date("2026-07-22T11:15:00.000Z"),
       address: null,
     });
-    mockUserOrganizationCount.mockResolvedValue(12);
+    mockUserOrganizationFindMany.mockResolvedValue(
+      Array.from({ length: 12 }, (_unused, index) => ({
+        practitionerReference: `user-${index}`,
+        roleCode: "doctor",
+        roleDisplay: null,
+        createdAt: new Date("2026-07-01T09:00:00.000Z"),
+      })),
+    );
 
     await expect(
       SuperAdminBusinessService.updateBusiness("org-123", { isActive: false }),
@@ -302,12 +337,19 @@ describe("SuperAdminBusinessService", () => {
       // resource, so an exact match on organization.id renders Members 0 for a
       // clinic whose memberships were created with a conformant reference.
       mockOrganizationFindFirst.mockResolvedValue(organization);
-      mockUserOrganizationCount.mockResolvedValue(4);
+      mockUserOrganizationFindMany.mockResolvedValue([
+        {
+          practitionerReference: "user-1",
+          roleCode: "doctor",
+          roleDisplay: null,
+          createdAt: new Date("2026-07-01T09:00:00.000Z"),
+        },
+      ]);
 
       await SuperAdminBusinessService.getBusiness("org-123");
 
       expect(
-        referencesOf(mockUserOrganizationCount.mock.calls[0][0].where),
+        referencesOf(mockUserOrganizationFindMany.mock.calls[0][0].where),
       ).toEqual([
         "Organization/fhir-123",
         "Organization/org-123",
@@ -320,7 +362,7 @@ describe("SuperAdminBusinessService", () => {
       mockOrganizationFindFirst.mockResolvedValue(organization);
       mockUserOrganizationFindMany.mockResolvedValue([
         {
-          practitionerReference: "user-1",
+          practitionerReference: "Practitioner/user-1",
           roleCode: "doctor",
           roleDisplay: "Veterinarian",
           createdAt: new Date("2026-07-01T09:00:00.000Z"),
@@ -358,6 +400,99 @@ describe("SuperAdminBusinessService", () => {
         "org-123",
       ]);
       expect(where.active).toBe(true);
+    });
+
+    it("strips a FHIR practitioner reference so the id is the one user pages are keyed on", async () => {
+      // practitionerReference is stored verbatim, exactly like the organisation
+      // column. Handing "Practitioner/<id>" out unchanged sends a caller to
+      // /users/Practitioner%2F<id>, so the journey would break at the last step
+      // for the same reason it broke at the first.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue([
+        {
+          practitionerReference: "Practitioner/user-9",
+          roleCode: "doctor",
+          roleDisplay: null,
+          createdAt: new Date("2026-07-01T09:00:00.000Z"),
+        },
+        {
+          practitionerReference: "user-8",
+          roleCode: "nurse",
+          roleDisplay: null,
+          createdAt: new Date("2026-07-01T09:00:00.000Z"),
+        },
+      ]);
+
+      const members =
+        await SuperAdminBusinessService.listBusinessMembers("org-123");
+
+      expect(members?.map((member) => member.userId)).toEqual([
+        "user-9",
+        "user-8",
+      ]);
+    });
+
+    it("keeps both rows when one person holds two roles, since the count counts both", async () => {
+      // Uniqueness is (practitioner, organisation, role), so this is two rows
+      // in the table and two in memberCount. Collapsing them here would make
+      // the list disagree with the number beside it.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue([
+        {
+          practitionerReference: "user-1",
+          roleCode: "doctor",
+          roleDisplay: "Veterinarian",
+          createdAt: new Date("2026-07-01T09:00:00.000Z"),
+        },
+        {
+          practitionerReference: "user-1",
+          roleCode: "admin",
+          roleDisplay: "Practice admin",
+          createdAt: new Date("2026-07-03T09:00:00.000Z"),
+        },
+      ]);
+
+      const members =
+        await SuperAdminBusinessService.listBusinessMembers("org-123");
+
+      expect(members).toHaveLength(2);
+      expect(members?.map((member) => member.roleCode)).toEqual([
+        "doctor",
+        "admin",
+      ]);
+    });
+
+    it("counts one person once when the same membership exists under four spellings", async () => {
+      // @@unique is over the strings as written, so the same practitioner,
+      // organisation and role can be four rows - 2 practitioner spellings x 2
+      // organisation spellings - and every one satisfies the constraint.
+      // Matching one spelling saw one and under-counted; matching all four
+      // sees all four, and Members 4 for one person is the mirror of Members 0
+      // for forty-seven.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue(
+        ["user-1", "Practitioner/user-1", "user-1", "Practitioner/user-1"].map(
+          (practitionerReference) => ({
+            practitionerReference,
+            roleCode: "doctor",
+            roleDisplay: null,
+            createdAt: new Date("2026-07-01T09:00:00.000Z"),
+          }),
+        ),
+      );
+
+      const members =
+        await SuperAdminBusinessService.listBusinessMembers("org-123");
+      expect(members).toEqual([
+        {
+          userId: "user-1",
+          roleCode: "doctor",
+          since: "2026-07-01T09:00:00.000Z",
+        },
+      ]);
+
+      const business = await SuperAdminBusinessService.getBusiness("org-123");
+      expect(business?.memberCount).toBe(1);
     });
 
     it("returns null for an unknown business rather than an empty roster", async () => {

--- a/apps/backend/test/super-admin-business.service.test.ts
+++ b/apps/backend/test/super-admin-business.service.test.ts
@@ -495,6 +495,43 @@ describe("SuperAdminBusinessService", () => {
       expect(business?.memberCount).toBe(1);
     });
 
+    it("counts and lists the same set, on data that distinguishes them", async () => {
+      // The invariant the whole shape exists for. The fixture has to contain a
+      // duplicate, or a count that ignored de-duplication would still match.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue(
+        ["user-1", "Practitioner/user-1", "user-2"].map(
+          (practitionerReference) => ({
+            practitionerReference,
+            roleCode: "doctor",
+            roleDisplay: null,
+            createdAt: new Date("2026-07-01T09:00:00.000Z"),
+          }),
+        ),
+      );
+
+      const members =
+        await SuperAdminBusinessService.listBusinessMembers("org-123");
+      const business = await SuperAdminBusinessService.getBusiness("org-123");
+
+      expect(business?.memberCount).toBe(members?.length);
+      expect(business?.memberCount).toBe(2);
+    });
+
+    it("fetches only the identity columns when it just needs the number", async () => {
+      // The half of the scanner finding that was real: the organisations list
+      // asks once per organisation, so the count must not read whole rows.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue([]);
+
+      await SuperAdminBusinessService.getBusiness("org-123");
+
+      expect(mockUserOrganizationFindMany.mock.calls[0][0].select).toEqual({
+        practitionerReference: true,
+        roleCode: true,
+      });
+    });
+
     it("returns null for an unknown business rather than an empty roster", async () => {
       // An empty array would render as a clinic with no staff, which is the
       // same screen an operator would read as the cause of the outage.

--- a/apps/backend/test/super-admin-business.service.test.ts
+++ b/apps/backend/test/super-admin-business.service.test.ts
@@ -2,6 +2,7 @@ const mockOrganizationFindMany = jest.fn();
 const mockOrganizationFindFirst = jest.fn();
 const mockOrganizationUpdate = jest.fn();
 const mockUserOrganizationCount = jest.fn();
+const mockUserOrganizationFindMany = jest.fn();
 
 const mockPrisma = {
   organization: {
@@ -11,6 +12,7 @@ const mockPrisma = {
   },
   userOrganization: {
     count: mockUserOrganizationCount,
+    findMany: mockUserOrganizationFindMany,
   },
 };
 
@@ -62,8 +64,14 @@ describe("SuperAdminBusinessService", () => {
       },
     ]);
     mockUserOrganizationCount.mockImplementation(
-      async ({ where }: { where: { organizationReference: string } }) =>
-        where.organizationReference === "org-new" ? 3 : 0,
+      async ({
+        where,
+      }: {
+        where: { OR: Array<{ organizationReference: string }> };
+      }) =>
+        where.OR.some((match) => match.organizationReference === "org-new")
+          ? 3
+          : 0,
     );
 
     await expect(SuperAdminBusinessService.listBusinesses()).resolves.toEqual([
@@ -95,11 +103,26 @@ describe("SuperAdminBusinessService", () => {
     expect(mockOrganizationFindMany).toHaveBeenCalledWith({
       orderBy: { createdAt: "desc" },
     });
+    // Every spelling, for every organisation in the list: the count is what an
+    // operator reads as "who is in this clinic", and a list view that matched
+    // narrowly than the detail view would disagree with itself.
     expect(mockUserOrganizationCount).toHaveBeenNthCalledWith(1, {
-      where: { active: true, organizationReference: "org-new" },
+      where: {
+        active: true,
+        OR: [
+          { organizationReference: "org-new" },
+          { organizationReference: "Organization/org-new" },
+        ],
+      },
     });
     expect(mockUserOrganizationCount).toHaveBeenNthCalledWith(2, {
-      where: { active: true, organizationReference: "org-old" },
+      where: {
+        active: true,
+        OR: [
+          { organizationReference: "org-old" },
+          { organizationReference: "Organization/org-old" },
+        ],
+      },
     });
   });
 
@@ -169,7 +192,13 @@ describe("SuperAdminBusinessService", () => {
       include: { address: true },
     });
     expect(mockUserOrganizationCount).toHaveBeenCalledWith({
-      where: { organizationReference: "org-123", active: true },
+      where: {
+        active: true,
+        OR: [
+          { organizationReference: "org-123" },
+          { organizationReference: "Organization/org-123" },
+        ],
+      },
     });
   });
 
@@ -238,6 +267,108 @@ describe("SuperAdminBusinessService", () => {
       where: { id: "org-123" },
       data: { isActive: false },
       include: { address: true },
+    });
+  });
+  describe("member resolution", () => {
+    const organization = {
+      id: "org-123",
+      fhirId: "fhir-123",
+      name: "Clinic",
+      type: "HOSPITAL",
+      isVerified: true,
+      isActive: true,
+      taxId: "TAX-1",
+      phoneNo: "+1 111 111 1111",
+      website: null,
+      dunsNumber: null,
+      imageUrl: null,
+      healthAndSafetyCertNo: null,
+      animalWelfareComplianceCertNo: null,
+      fireAndEmergencyCertNo: null,
+      googlePlacesId: null,
+      averageRating: 0,
+      ratingCount: 0,
+      createdAt: new Date("2026-07-22T10:20:30.000Z"),
+      updatedAt: new Date("2026-07-22T11:15:00.000Z"),
+      address: null,
+    };
+
+    const referencesOf = (where: {
+      OR: Array<{ organizationReference: string }>;
+    }) => where.OR.map((match) => match.organizationReference).sort();
+
+    it("counts members by every spelling the reference column can hold", async () => {
+      // organizationReference is persisted verbatim from the inbound FHIR
+      // resource, so an exact match on organization.id renders Members 0 for a
+      // clinic whose memberships were created with a conformant reference.
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationCount.mockResolvedValue(4);
+
+      await SuperAdminBusinessService.getBusiness("org-123");
+
+      expect(
+        referencesOf(mockUserOrganizationCount.mock.calls[0][0].where),
+      ).toEqual([
+        "Organization/fhir-123",
+        "Organization/org-123",
+        "fhir-123",
+        "org-123",
+      ]);
+    });
+
+    it("lists members with the same predicate as the count, so the two cannot disagree", async () => {
+      mockOrganizationFindFirst.mockResolvedValue(organization);
+      mockUserOrganizationFindMany.mockResolvedValue([
+        {
+          practitionerReference: "user-1",
+          roleCode: "doctor",
+          roleDisplay: "Veterinarian",
+          createdAt: new Date("2026-07-01T09:00:00.000Z"),
+        },
+        {
+          practitionerReference: "user-2",
+          roleCode: "nurse",
+          roleDisplay: null,
+          createdAt: new Date("2026-07-02T09:00:00.000Z"),
+        },
+      ]);
+
+      const members =
+        await SuperAdminBusinessService.listBusinessMembers("org-123");
+
+      expect(members).toEqual([
+        {
+          userId: "user-1",
+          roleCode: "doctor",
+          roleDisplay: "Veterinarian",
+          since: "2026-07-01T09:00:00.000Z",
+        },
+        {
+          userId: "user-2",
+          roleCode: "nurse",
+          since: "2026-07-02T09:00:00.000Z",
+        },
+      ]);
+
+      const where = mockUserOrganizationFindMany.mock.calls[0][0].where;
+      expect(referencesOf(where)).toEqual([
+        "Organization/fhir-123",
+        "Organization/org-123",
+        "fhir-123",
+        "org-123",
+      ]);
+      expect(where.active).toBe(true);
+    });
+
+    it("returns null for an unknown business rather than an empty roster", async () => {
+      // An empty array would render as a clinic with no staff, which is the
+      // same screen an operator would read as the cause of the outage.
+      mockOrganizationFindFirst.mockResolvedValue(null);
+
+      await expect(
+        SuperAdminBusinessService.listBusinessMembers("missing"),
+      ).resolves.toBeNull();
+      expect(mockUserOrganizationFindMany).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `GET /v1/super-admin/businesses/:id/members`, and fixes the member count that sits next to it.

The super-admin surface could report that a clinic has members without being able to name any of them. An operator handed "nobody at this clinic can log in" had no route from the organisation to the individual accounts that carry the answer, so the panel's `memberCount` was the end of the trail rather than the start of one.

## The count was also wrong, and this is the part worth reviewing

`userOrganization.organizationReference` is persisted verbatim from the inbound FHIR `PractitionerRole`:

```
packages/types/src/userOrganization.ts:119
    const organizationReference = dto.organization?.reference ?? '';
```

and the create path strips the `Organization/` prefix only to look the organisation up, never to normalise what it stores - eight lines apart, on the same object:

```
apps/backend/src/services/user-organization.service.ts:298   extractOrganizationIdentifier(reference)   // strips
                                                     :749   prisma.userOrganization.create({ data: persistable })  // unstripped
```

`extractOrganizationIdentifier` splits on `/` and rejects a reference whose last segment is literally `organization` - a shape and an error case written for prefixed input. An organisation is also addressable by `id` or `fhirId`, so four spellings are reachable:

```
<id>                   matched by the old count
Organization/<id>      not matched
<fhirId>               not matched
Organization/<fhirId>  not matched
```

The count used exact equality on `organization.id` at `:207`, `:248` and `:295`, so a clinic whose memberships arrived with a conformant reference rendered as `Members 0`.

Both the count and the new list now resolve through one shared predicate, so they cannot answer different questions. Adding the list with a broad predicate while the count kept the narrow one would have made the panel and the permission layer disagree about who belongs to an organisation, which is worse than the missing list.

The existing `buildReferenceLookups` in `user-organization.service.ts` was not reusable here: it resolves an ambiguous identifier across the practitioner and organization columns, so it would also match rows whose practitioner reference happens to equal the organisation id. The new helper lives beside `filterUserIdsInOrganisation`, which already documented the two-spelling rule, and that function now uses it too.

## What this does not prove

Which spellings actually occur in production. That needs a database none of this can reach - `GROUP BY left(organization_reference, 13)` settles it. What is proved here is that the write path preserves whatever arrives and the old count matched exactly one of four reachable spellings.

## Testing

```
pnpm --filter backend run type-check                 rc 0, 0 errors
pnpm --filter backend run test                       482 suites / 11504 tests passed, exit 0
```

Mutations, each reddening exactly the named case:

| mutation | test that failed |
| --- | --- |
| anchored prefix strip to an unanchored string replace | strips the prefix only at the start |
| stop adding the `Organization/` spelling | 6 tests, including the `filterUserIdsInOrganisation` offboarding case |
| `countMembers` back to exact equality | counts members by every spelling the reference column can hold, plus the two existing count assertions |
| drop `fhirId` from the members query | lists members with the same predicate as the count |

The route is covered for both a superadmin (200) and a non-superadmin (403) rather than inheriting the router's other tests, and the controller separates an unknown business (404) from one with no members (200 with an empty array).

Correction to an earlier version of this description: I wrote that no Aikido scanner was reachable locally. That was wrong and I had not tried the package. `npx -y @aikidosec/mcp` starts and answers over stdio, and its `aikido_full_scan` takes file contents with no login. Run against every file this PR touches it reports no issues, and a positive control (`exec("ls " + req.query.dir)`) fires with `AIK_js_shell_injection_child_process`, so the empty result is from a working instrument rather than a silent one.

The hosted gate reported one new LOW on `9185c257` with no annotation and no rule named, which the local SAST and secrets engines do not reproduce - the hosted scan also runs code-quality rules they do not. `70fa1045` splits the one long function into named single-purpose helpers as a single-variant probe at that hypothesis; if the finding survives it was not complexity, and this description will say so rather than a second change being tried quietly.

Refs #2770

