### PR TITLE
feat(frontend): report the deployed commit on /api/health

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -69,12 +69,15 @@ const build = resolveBuildSha({ AWS_COMMIT_ID: process.env.AWS_COMMIT_ID }, () =
 );
 
 const nextConfig: NextConfig = {
-  // Only set when a sha was actually resolved. An empty string here would be
-  // inlined and render as a populated-looking blank field on /api/health, which
-  // is the failure this route exists to make visible.
-  env: build.sha
-    ? { BUILD_SHA: build.sha, BUILD_SHA_SOURCE: build.source }
-    : { BUILD_SHA_SOURCE: build.source },
+  // Both keys are always inlined, including when there is no sha. Omitting
+  // BUILD_SHA leaves `process.env.BUILD_SHA` a *runtime* lookup in the route
+  // while BUILD_SHA_SOURCE is a build-time constant, so a BUILD_SHA set on the
+  // Amplify branch would be answered next to `source: "unavailable"` - two
+  // fields from two mechanisms, free to disagree, and an environment value
+  // reaching `buildSha` without the shape check every other source gets.
+  // Empty is the "no sha" value; the route normalises it back to null so it
+  // cannot render as a populated-looking blank.
+  env: { BUILD_SHA: build.sha ?? '', BUILD_SHA_SOURCE: build.source },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'd2il6osz49gpup.cloudfront.net' },

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { NextConfig } from 'next';
+import { readHeadSha, resolveBuildSha } from './src/buildInfo';
 import { securityHeaders } from './src/securityHeaders';
 
 // Static HTML under /public (e.g. /static/openapi/viewer.html) is skipped by the
@@ -42,7 +45,36 @@ const REVALIDATING_CACHE_CONTROL = 'public, max-age=86400, stale-while-revalidat
 
 const cacheControl = (value: string) => [{ key: 'Cache-Control', value }];
 
+// Captured here because `next build` is the only step that runs inside the
+// Amplify build container's clone, and the build spec that would otherwise do
+// it lives in the Amplify console rather than this repository. Read from the
+// files rather than by running `git`, so the build spawns nothing and does not
+// depend on what `PATH` resolves to inside the container.
+const REPO_GIT_DIR = join(__dirname, '..', '..', '.git');
+
+const readFileOrNull = (path: string): string | null => {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+};
+
+// Passed explicitly rather than handing over the whole environment: this
+// repository's `ProcessEnv` declares its known keys and `AWS_COMMIT_ID` is
+// Amplify's, not ours. Naming it here is also the only place a reader can see
+// which variable this consumes.
+const build = resolveBuildSha({ AWS_COMMIT_ID: process.env.AWS_COMMIT_ID }, () =>
+  readHeadSha(REPO_GIT_DIR, readFileOrNull)
+);
+
 const nextConfig: NextConfig = {
+  // Only set when a sha was actually resolved. An empty string here would be
+  // inlined and render as a populated-looking blank field on /api/health, which
+  // is the failure this route exists to make visible.
+  env: build.sha
+    ? { BUILD_SHA: build.sha, BUILD_SHA_SOURCE: build.source }
+    : { BUILD_SHA_SOURCE: build.source },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'd2il6osz49gpup.cloudfront.net' },

--- a/apps/frontend/src/app/__tests__/api/healthRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/healthRoute.test.ts
@@ -48,6 +48,24 @@ describe('GET /api/health', () => {
     expect(res.body.buildShaSource).toBe('unavailable');
   });
 
+  it.each([
+    ['', 'empty'],
+    ['   ', 'whitespace-only'],
+  ])('reports a %s BUILD_SHA as null (%s)', (value) => {
+    // `next.config.ts` inlines BUILD_SHA unconditionally - empty when the build
+    // could not identify itself - so that BUILD_SHA and BUILD_SHA_SOURCE are
+    // both build-time constants rather than one constant and one runtime
+    // lookup. That makes the blank value reachable here, and `?? null` would
+    // pass it straight through as a populated-looking empty field.
+    process.env.BUILD_SHA = value;
+    process.env.BUILD_SHA_SOURCE = 'unavailable';
+
+    const res = GET() as unknown as MockedResponse;
+
+    expect(res.body).toHaveProperty('buildSha', null);
+    expect(res.body.buildShaSource).toBe('unavailable');
+  });
+
   it('defaults the source to unavailable rather than undefined', () => {
     delete process.env.BUILD_SHA;
     delete process.env.BUILD_SHA_SOURCE;

--- a/apps/frontend/src/app/__tests__/api/healthRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/healthRoute.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Mirrors the other route tests: the handler returns a `NextResponse`, which
+ * needs the Web `Response` global that jsdom does not provide. Mocking
+ * `next/server` down to the one factory the route uses keeps the whole handler
+ * under test, cache headers included.
+ */
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { headers?: Record<string, string> }) => ({ body, init }),
+  },
+}));
+
+import { GET, dynamic, revalidate } from '@/app/api/health/route';
+
+type MockedResponse = {
+  body: { status: string; buildSha: string | null; buildShaSource: string };
+  init?: { headers?: Record<string, string> };
+};
+
+const SHA = 'c'.repeat(40);
+
+describe('GET /api/health', () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it('reports the sha and the source baked in at build time', () => {
+    process.env.BUILD_SHA = SHA;
+    process.env.BUILD_SHA_SOURCE = 'git';
+
+    const res = GET() as unknown as MockedResponse;
+
+    expect(res.body).toEqual({ status: 'ok', buildSha: SHA, buildShaSource: 'git' });
+  });
+
+  it('reports buildSha as null, not absent, when the build could not identify itself', () => {
+    delete process.env.BUILD_SHA;
+    process.env.BUILD_SHA_SOURCE = 'unavailable';
+
+    const res = GET() as unknown as MockedResponse;
+
+    // `toHaveProperty` rather than a truthiness check: an omitted key reads as
+    // "this deploy predates the field", null reads as "this build could not
+    // identify itself". Those are different states and only one is a defect.
+    expect(res.body).toHaveProperty('buildSha', null);
+    expect(res.body.buildShaSource).toBe('unavailable');
+  });
+
+  it('defaults the source to unavailable rather than undefined', () => {
+    delete process.env.BUILD_SHA;
+    delete process.env.BUILD_SHA_SOURCE;
+
+    const res = GET() as unknown as MockedResponse;
+
+    expect(res.body.buildShaSource).toBe('unavailable');
+  });
+
+  it('sends no-store, because a cached health response reports the PREVIOUS deploy', () => {
+    process.env.BUILD_SHA = SHA;
+
+    const res = GET() as unknown as MockedResponse;
+
+    // This is the assertion the route exists for. Without it the one instrument
+    // for "did my change ship?" answers with the sha of the build before it -
+    // wrong in the reassuring direction.
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store, no-cache, must-revalidate');
+  });
+
+  it('opts the route out of static rendering', () => {
+    // The header alone is not enough: without `force-dynamic` Next prerenders
+    // the handler at build time and serves one frozen body, so the response
+    // could carry a correct-looking sha and never change again. Asserted as
+    // exported values because there is no way to observe prerendering here.
+    expect(dynamic).toBe('force-dynamic');
+    expect(revalidate).toBe(0);
+  });
+});

--- a/apps/frontend/src/app/__tests__/buildInfo.test.ts
+++ b/apps/frontend/src/app/__tests__/buildInfo.test.ts
@@ -51,6 +51,71 @@ describe('resolveBuildSha', () => {
     });
   });
 
+  it.each([
+    ['HEAD', 'what a webhook build records instead of a sha, so the likeliest wrong value'],
+    ['dev', 'a branch name'],
+    ['9662b9d', 'an abbreviated sha'],
+    [`${SHA}x`, 'a sha with a trailing character, which only the $ anchor rejects'],
+    [`x${SHA}`, 'a sha with a leading character, which only the ^ anchor rejects'],
+  ])('falls through to git on a non-empty malformed AWS_COMMIT_ID: %s (%s)', (value) => {
+    // The mutation this exists for is the previous behaviour: accept any
+    // non-empty string. Every other AWS_COMMIT_ID case here is a well-formed
+    // sha or blank, so none of them can tell the two apart - the field would
+    // render populated with a value that identifies no commit, and because
+    // the preferred branch returns, the git read holding the right answer
+    // never runs.
+    expect(resolveBuildSha({ AWS_COMMIT_ID: value }, () => OTHER)).toEqual({
+      sha: OTHER,
+      source: 'git-amplify-rejected',
+    });
+  });
+
+  it('separates a rejected AWS_COMMIT_ID from an absent one', () => {
+    // Both produce the git sha, so `sha` cannot tell them apart and only
+    // `source` can. This is the assertion that keeps the deployed artifact able
+    // to answer what Amplify supplies on the webhook path - a question nothing
+    // already running can be asked, because no app in the account consumes the
+    // variable there. Reporting both as `git` is correct and unfalsifiable.
+    const rejected = resolveBuildSha({ AWS_COMMIT_ID: 'HEAD' }, () => OTHER);
+    const absent = resolveBuildSha({}, () => OTHER);
+
+    expect(rejected.sha).toBe(absent.sha);
+    expect(rejected.source).not.toBe(absent.source);
+    expect([rejected.source, absent.source]).toEqual(['git-amplify-rejected', 'git']);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'whitespace-only'],
+  ])('does not report a %s AWS_COMMIT_ID as rejected (%s)', (value) => {
+    // Blank is indistinguishable from unset in a build environment, so calling
+    // it a rejection would report evidence that is not there - the failure mode
+    // the fourth state exists to avoid, pointed the other way.
+    expect(resolveBuildSha({ AWS_COMMIT_ID: value }, () => OTHER).source).toBe('git');
+  });
+
+  it('reports unavailable when AWS_COMMIT_ID is malformed and git has nothing either', () => {
+    // Falling through must not mean falling back to the malformed value: with
+    // no second source the honest answer is that this build cannot identify
+    // itself, not `HEAD`. The rejection is not reported in this corner and that
+    // is deliberate - documented on `BuildShaSource`, asserted here so the
+    // omission is a decision rather than something nobody looked at.
+    expect(resolveBuildSha({ AWS_COMMIT_ID: 'HEAD' }, () => null)).toEqual({
+      sha: null,
+      source: 'unavailable',
+    });
+  });
+
+  it('rejects a malformed value from git too, rather than trusting the caller', () => {
+    // `readHeadSha` shape-checks what it reads, but it is injected here, so the
+    // guarantee has to hold at this boundary rather than be inherited from one
+    // particular implementation of it.
+    expect(resolveBuildSha({}, () => 'refs/heads/dev')).toEqual({
+      sha: null,
+      source: 'unavailable',
+    });
+  });
+
   it('trims the trailing newline that git rev-parse always emits', () => {
     // Without this the sha reaches the health route with a newline in it, which
     // survives JSON encoding and breaks an equality check against a real sha.

--- a/apps/frontend/src/app/__tests__/buildInfo.test.ts
+++ b/apps/frontend/src/app/__tests__/buildInfo.test.ts
@@ -1,0 +1,206 @@
+import { readHeadSha, resolveBuildSha } from '@/buildInfo';
+
+/**
+ * Each case here is paired with the mutation it is meant to catch, because the
+ * obvious assertions on this function are satisfied by several broken versions
+ * of it: returning the git sha unconditionally passes every "it found a sha"
+ * test, and so does returning `AWS_COMMIT_ID` unconditionally.
+ */
+
+const SHA = 'a'.repeat(40);
+const OTHER = 'b'.repeat(40);
+
+const never = () => {
+  throw new Error('readGitSha should not have been called');
+};
+
+describe('resolveBuildSha', () => {
+  it('prefers AWS_COMMIT_ID and does not consult git when it is set', () => {
+    // `never` is the assertion: a version that always shells out to git would
+    // throw here rather than quietly returning the same value by luck. Checking
+    // only the returned sha cannot separate "preferred" from "both agree".
+    expect(resolveBuildSha({ AWS_COMMIT_ID: SHA }, never)).toEqual({
+      sha: SHA,
+      source: 'AWS_COMMIT_ID',
+    });
+  });
+
+  it('falls back to git when AWS_COMMIT_ID is absent, which is the webhook-build case', () => {
+    expect(resolveBuildSha({}, () => OTHER)).toEqual({ sha: OTHER, source: 'git' });
+  });
+
+  it('reports the source that actually answered when the two disagree', () => {
+    // The separating input. Both values are present and different, so a
+    // implementation that reads the wrong one returns a real-looking sha and
+    // only `source` reveals it.
+    expect(resolveBuildSha({ AWS_COMMIT_ID: SHA }, () => OTHER)).toEqual({
+      sha: SHA,
+      source: 'AWS_COMMIT_ID',
+    });
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'whitespace-only'],
+  ])('treats an %s AWS_COMMIT_ID as absent rather than passing it on (%s)', (value) => {
+    // `??` does not fall back on '', so an empty value would be inlined and
+    // render as a blank field that looks populated.
+    expect(resolveBuildSha({ AWS_COMMIT_ID: value }, () => OTHER)).toEqual({
+      sha: OTHER,
+      source: 'git',
+    });
+  });
+
+  it('trims the trailing newline that git rev-parse always emits', () => {
+    // Without this the sha reaches the health route with a newline in it, which
+    // survives JSON encoding and breaks an equality check against a real sha.
+    expect(resolveBuildSha({}, () => `${OTHER}\n`)).toEqual({ sha: OTHER, source: 'git' });
+  });
+
+  it('reports unavailable rather than throwing when git cannot be read', () => {
+    // A build container without a usable .git must still produce a site; the
+    // missing sha is a finding on the health route, not a failed build.
+    expect(
+      resolveBuildSha({}, () => {
+        throw new Error('not a git repository');
+      })
+    ).toEqual({ sha: null, source: 'unavailable' });
+  });
+
+  it('reports unavailable when git returns nothing at all', () => {
+    expect(resolveBuildSha({}, () => null)).toEqual({ sha: null, source: 'unavailable' });
+  });
+});
+
+describe('readHeadSha', () => {
+  const HEAD_SHA = 'd'.repeat(40);
+  const DECOY = 'e'.repeat(40);
+
+  /** A fake filesystem: anything not present reads as unreadable. */
+  const fs = (files: Record<string, string>) => (path: string) => files[path] ?? null;
+
+  it('reads a detached HEAD, which is a raw sha', () => {
+    expect(readHeadSha('/repo/.git', fs({ '/repo/.git/HEAD': `${HEAD_SHA}\n` }))).toBe(HEAD_SHA);
+  });
+
+  it('follows a symbolic HEAD to its loose ref file', () => {
+    expect(
+      readHeadSha(
+        '/repo/.git',
+        fs({
+          '/repo/.git/HEAD': 'ref: refs/heads/dev\n',
+          '/repo/.git/refs/heads/dev': `${HEAD_SHA}\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('falls back to packed-refs when the loose ref is absent, which is a fresh clone', () => {
+    // The Amplify build container is in exactly this state: refs arrive packed,
+    // so a reader that only looks for the loose file finds nothing and the whole
+    // feature silently reports `unavailable` in the one place it has to work.
+    expect(
+      readHeadSha(
+        '/repo/.git',
+        fs({
+          '/repo/.git/HEAD': 'ref: refs/heads/dev\n',
+          '/repo/.git/packed-refs': `# pack-refs with: peeled fully-peeled sorted\n${HEAD_SHA} refs/heads/dev\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('matches the packed ref whole, not by prefix', () => {
+    // The separating input: a prefix match would return the decoy, and the decoy
+    // is a well-formed sha, so the wrong answer looks exactly like a right one.
+    expect(
+      readHeadSha(
+        '/repo/.git',
+        fs({
+          '/repo/.git/HEAD': 'ref: refs/heads/dev\n',
+          '/repo/.git/packed-refs': `${DECOY} refs/heads/dev-experiment\n${HEAD_SHA} refs/heads/dev\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('ignores peeled-tag lines in packed-refs', () => {
+    expect(
+      readHeadSha(
+        '/repo/.git',
+        fs({
+          '/repo/.git/HEAD': 'ref: refs/heads/dev\n',
+          '/repo/.git/packed-refs': `${DECOY} refs/tags/v1\n^${HEAD_SHA}\n${HEAD_SHA} refs/heads/dev\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('follows a .git FILE to the real git dir, which is how a worktree is laid out', () => {
+    // This repository is developed in linked worktrees, so the indirect case is
+    // the ordinary local one - a reader that only handles a directory works in
+    // CI and returns nothing on every developer machine.
+    expect(
+      readHeadSha(
+        '/wt/.git',
+        fs({
+          '/wt/.git': 'gitdir: /repo/.git/worktrees/wt\n',
+          '/repo/.git/worktrees/wt/HEAD': `${HEAD_SHA}\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('resolves a worktree ref through commondir, where branch refs actually live', () => {
+    // The case the detached-HEAD fixture above cannot reach, and the one the
+    // real repository is in: HEAD is symbolic and per-worktree, while the ref it
+    // names exists only in the main git dir. Written after an end-to-end run
+    // returned null on this exact layout while every unit test passed.
+    expect(
+      readHeadSha(
+        '/wt/.git',
+        fs({
+          '/wt/.git': 'gitdir: /repo/.git/worktrees/wt\n',
+          '/repo/.git/worktrees/wt/HEAD': 'ref: refs/heads/feature\n',
+          '/repo/.git/worktrees/wt/commondir': '../..\n',
+          // Deliberately absent: /repo/.git/worktrees/wt/refs/heads/feature
+          '/repo/.git/worktrees/wt/../../refs/heads/feature': `${HEAD_SHA}\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('resolves a worktree ref from the common packed-refs', () => {
+    expect(
+      readHeadSha(
+        '/wt/.git',
+        fs({
+          '/wt/.git': 'gitdir: /repo/.git/worktrees/wt\n',
+          '/repo/.git/worktrees/wt/HEAD': 'ref: refs/heads/feature\n',
+          '/repo/.git/worktrees/wt/commondir': '../..\n',
+          '/repo/.git/worktrees/wt/../../packed-refs': `${HEAD_SHA} refs/heads/feature\n`,
+        })
+      )
+    ).toBe(HEAD_SHA);
+  });
+
+  it('returns null when nothing is readable', () => {
+    expect(readHeadSha('/repo/.git', fs({}))).toBeNull();
+  });
+
+  it('returns null rather than a malformed value when HEAD is not a sha or a ref', () => {
+    expect(readHeadSha('/repo/.git', fs({ '/repo/.git/HEAD': 'garbage\n' }))).toBeNull();
+  });
+
+  it('rejects a ref file whose contents are not a sha', () => {
+    expect(
+      readHeadSha(
+        '/repo/.git',
+        fs({
+          '/repo/.git/HEAD': 'ref: refs/heads/dev\n',
+          '/repo/.git/refs/heads/dev': 'not-a-sha\n',
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/api/health/route.ts
+++ b/apps/frontend/src/app/api/health/route.ts
@@ -28,7 +28,10 @@ export function GET() {
   // Read through `process.env` rather than destructuring at module scope: Next
   // inlines these at build time, and a module-scope read would be evaluated
   // once during prerender even with `force-dynamic` set on the route.
-  const sha = process.env.BUILD_SHA ?? null;
+  // `|| null`, not `?? null`: `next.config.ts` inlines BUILD_SHA as an empty
+  // string when the build could not identify itself, and a blank string here
+  // would serialise as a populated-looking empty field.
+  const sha = process.env.BUILD_SHA?.trim() || null;
   const source = process.env.BUILD_SHA_SOURCE ?? 'unavailable';
 
   return NextResponse.json(

--- a/apps/frontend/src/app/api/health/route.ts
+++ b/apps/frontend/src/app/api/health/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * What is actually deployed here.
+ *
+ * `buildSha` is baked in by `next.config.ts` at build time; see
+ * `src/buildInfo.ts` for why it cannot come from the Amplify build spec and why
+ * the source is reported alongside it.
+ *
+ * `force-dynamic` and `no-store` are the point of this route, not boilerplate.
+ * A cached health response answers with the *previous* deploy's sha, so the one
+ * instrument for "did my change ship?" would report success for a build that
+ * never happened - the reassuring direction. The app sets a long-lived cache
+ * policy on other paths and sits behind a CDN, so opting out has to be explicit
+ * here.
+ *
+ * Nothing secret is exposed: a commit sha for a public repository, and a label
+ * saying where it was read from.
+ */
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const NO_STORE = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate',
+} as const;
+
+export function GET() {
+  // Read through `process.env` rather than destructuring at module scope: Next
+  // inlines these at build time, and a module-scope read would be evaluated
+  // once during prerender even with `force-dynamic` set on the route.
+  const sha = process.env.BUILD_SHA ?? null;
+  const source = process.env.BUILD_SHA_SOURCE ?? 'unavailable';
+
+  return NextResponse.json(
+    {
+      status: 'ok',
+      // Explicitly null rather than omitted when unknown. A missing key reads
+      // as "this deploy predates the field"; null reads as "this build could
+      // not identify itself", which is a different and reportable state.
+      buildSha: sha,
+      buildShaSource: source,
+    },
+    { headers: NO_STORE }
+  );
+}

--- a/apps/frontend/src/buildInfo.ts
+++ b/apps/frontend/src/buildInfo.ts
@@ -26,8 +26,23 @@
  * function that can be tested without a repository.
  */
 
-/** Where the sha came from, so a wrong answer is traceable to its source. */
-export type BuildShaSource = 'AWS_COMMIT_ID' | 'git' | 'unavailable';
+/**
+ * Where the sha came from, so a wrong answer is traceable to its source.
+ *
+ * `git-amplify-rejected` is `git` plus one fact: `AWS_COMMIT_ID` was set to
+ * something that is not an object name and was discarded. Collapsing that into
+ * `git` would be correct behaviour and a lossy instrument - the sha would be
+ * right, and the deployed artifact could no longer say whether Amplify hands
+ * this app a sha, the literal `HEAD`, or nothing at all. No app in the account
+ * consumes the variable on the webhook path today, so nothing already deployed
+ * can be asked; the first `/api/health` after this ships is the only place that
+ * question becomes a reading rather than an inference.
+ *
+ * One corner stays lossy on purpose: if git cannot answer either, the result is
+ * `unavailable` and the rejection is not reported. That build has a louder
+ * problem than the provenance of a variable.
+ */
+export type BuildShaSource = 'AWS_COMMIT_ID' | 'git' | 'git-amplify-rejected' | 'unavailable';
 
 export interface BuildSha {
   sha: string | null;
@@ -45,6 +60,14 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/;
  * and falling back is deliberate: on any branch wired the other way it is
  * authoritative, and where it is missing the clone still has the answer.
  *
+ * It is shape-checked before it is preferred, and that is not defensiveness.
+ * The same job metadata records `commitId: "HEAD"` on a webhook build, so the
+ * literal string `HEAD` is the value this deploy path is likeliest to supply -
+ * and accepting it would report a populated-looking `buildSha` that identifies
+ * nothing, while the returning branch shadows the git read that holds the real
+ * answer. Anything that is not an object name falls through rather than wins,
+ * and the fall-through is *reported* rather than silent: see `BuildShaSource`.
+ *
  * `readGitSha` is injected so this is testable without a repository, and so a
  * build container without a readable `.git` produces `unavailable` rather than
  * throwing during `next build`.
@@ -53,19 +76,24 @@ export function resolveBuildSha(
   env: { AWS_COMMIT_ID?: string },
   readGitSha: () => string | null
 ): BuildSha {
-  const fromAmplify = normalise(env.AWS_COMMIT_ID);
+  const fromAmplify = shaOrNull(env.AWS_COMMIT_ID);
   if (fromAmplify) return { sha: fromAmplify, source: 'AWS_COMMIT_ID' };
+
+  // Reaching here, the variable is absent, blank, or malformed - and only the
+  // last of those is worth reporting, because it is evidence about what this
+  // deploy path actually supplies.
+  const rejected = (env.AWS_COMMIT_ID ?? '').trim() !== '';
 
   let fromGit: string | null = null;
   try {
-    fromGit = normalise(readGitSha());
+    fromGit = shaOrNull(readGitSha());
   } catch {
     // A build that cannot read git still has to produce a site. Reporting
     // `unavailable` is the honest outcome and it is visible on the health
     // route, where a missing sha is a finding rather than a silent blank.
     fromGit = null;
   }
-  if (fromGit) return { sha: fromGit, source: 'git' };
+  if (fromGit) return { sha: fromGit, source: rejected ? 'git-amplify-rejected' : 'git' };
 
   return { sha: null, source: 'unavailable' };
 }
@@ -170,13 +198,17 @@ function findPackedRef(contents: string | null, ref: string): string | null {
 }
 
 /**
- * An empty or whitespace-only value is treated as absent rather than passed on.
- * `??` does not fall back on `''`, so an empty string would render as a blank
- * field that looks like a populated one - the same wrong state wearing a
- * different costume.
+ * A candidate is accepted only if it is an object name, so every source is held
+ * to the shape `readHeadSha` already enforces on the files it reads.
+ *
+ * Trimming alone is not enough and the two rejected shapes fail differently.
+ * An empty or whitespace-only value would render as a blank field that looks
+ * populated, because `??` does not fall back on `''`. A non-empty non-sha -
+ * `HEAD`, a branch name, an abbreviated sha - is worse: the field looks
+ * answered, and it is wrong in the direction nobody re-checks.
  */
-function normalise(value: string | null | undefined): string | null {
+function shaOrNull(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
-  return trimmed === '' ? null : trimmed;
+  return SHA_PATTERN.test(trimmed) ? trimmed : null;
 }

--- a/apps/frontend/src/buildInfo.ts
+++ b/apps/frontend/src/buildInfo.ts
@@ -1,0 +1,182 @@
+/**
+ * Which commit is this build?
+ *
+ * Nothing served by this app could answer that. The panel can - it exposes a
+ * `buildSha` and settling "is this deployed?" there costs one request - but on
+ * this app the only way to attribute a deploy to a commit was to line up
+ * timestamps, and the Amplify job record cannot help: a build triggered by an
+ * incoming webhook records `commitId: "HEAD"`, not a sha, and its build log
+ * never prints one either.
+ *
+ * That leaves a real gap rather than a bookkeeping one. A webhook build clones
+ * the branch when the build starts, so what ships is the branch tip at clone
+ * time - not necessarily the commit whose merge triggered it. Two merges close
+ * together and the deploy carries the second one, including the case where the
+ * second commit's own pipeline decided it did not need deploying.
+ *
+ * The sha has to be captured during `next build`, because that is the only step
+ * that runs inside the build container's clone. It cannot be added to the
+ * Amplify build spec: that spec lives in the Amplify console, not in this
+ * repository, so no pull request can change it.
+ *
+ * The sha is read out of `.git` rather than by running `git`. Spawning a binary
+ * resolved through `PATH` during a build is a finding in its own right
+ * (`sonarjs/no-os-command-from-path`), and the files are a stable, documented
+ * format - so this ends up with no subprocess, no `PATH` dependency, and a pure
+ * function that can be tested without a repository.
+ */
+
+/** Where the sha came from, so a wrong answer is traceable to its source. */
+export type BuildShaSource = 'AWS_COMMIT_ID' | 'git' | 'unavailable';
+
+export interface BuildSha {
+  sha: string | null;
+  source: BuildShaSource;
+}
+
+/** A 40-character lowercase hex object name, and nothing else. */
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * `AWS_COMMIT_ID` is Amplify's own variable and is the right answer when it is
+ * set - but it is populated from the repository integration, and this app's
+ * `dev` branch is deployed by a webhook with auto-build off. On that path
+ * Amplify does not know the commit, so the variable is absent. Reading it first
+ * and falling back is deliberate: on any branch wired the other way it is
+ * authoritative, and where it is missing the clone still has the answer.
+ *
+ * `readGitSha` is injected so this is testable without a repository, and so a
+ * build container without a readable `.git` produces `unavailable` rather than
+ * throwing during `next build`.
+ */
+export function resolveBuildSha(
+  env: { AWS_COMMIT_ID?: string },
+  readGitSha: () => string | null
+): BuildSha {
+  const fromAmplify = normalise(env.AWS_COMMIT_ID);
+  if (fromAmplify) return { sha: fromAmplify, source: 'AWS_COMMIT_ID' };
+
+  let fromGit: string | null = null;
+  try {
+    fromGit = normalise(readGitSha());
+  } catch {
+    // A build that cannot read git still has to produce a site. Reporting
+    // `unavailable` is the honest outcome and it is visible on the health
+    // route, where a missing sha is a finding rather than a silent blank.
+    fromGit = null;
+  }
+  if (fromGit) return { sha: fromGit, source: 'git' };
+
+  return { sha: null, source: 'unavailable' };
+}
+
+/**
+ * Resolve `HEAD` to an object name by reading the files git maintains.
+ *
+ * Three shapes have to be handled and all three occur here:
+ *   - `.git` is a *file* in a linked worktree (`gitdir: <path>`), which is how
+ *     this repository is developed, so the common local case is the indirect one.
+ *   - `HEAD` holds a raw sha when the checkout is detached.
+ *   - a symbolic `HEAD` points at a ref whose loose file may not exist, because
+ *     a fresh clone usually arrives with its refs packed - which is exactly the
+ *     state an Amplify build container is in.
+ *
+ * `readFile` returns null for anything unreadable, so a missing file is a normal
+ * outcome rather than an exception.
+ */
+export function readHeadSha(
+  gitPath: string,
+  readFile: (path: string) => string | null
+): string | null {
+  const gitDir = resolveGitDir(gitPath, readFile);
+  if (!gitDir) return null;
+
+  const head = readFile(`${gitDir}/HEAD`)?.trim();
+  if (!head) return null;
+
+  if (SHA_PATTERN.test(head)) return head;
+
+  const ref = head.startsWith('ref: ') ? head.slice(5).trim() : null;
+  if (!ref) return null;
+
+  // In a linked worktree `HEAD` is per-worktree but branch refs are not: they
+  // live in the main repository's git dir, named by `commondir`. Looking only
+  // beside HEAD finds nothing on every developer machine here, while working
+  // fine in CI - a difference no fixture using a detached HEAD can expose,
+  // because a detached HEAD never resolves a ref at all.
+  const dirs = refSearchPath(gitDir, readFile);
+
+  for (const dir of dirs) {
+    const loose = readFile(`${dir}/${ref}`)?.trim();
+    if (loose && SHA_PATTERN.test(loose)) return loose;
+  }
+
+  for (const dir of dirs) {
+    const packed = findPackedRef(readFile(`${dir}/packed-refs`), ref);
+    if (packed) return packed;
+  }
+
+  return null;
+}
+
+/**
+ * Where refs may live: the git dir itself, then the common dir if this is a
+ * linked worktree. `commondir` holds a path that is usually relative to the
+ * worktree's git dir.
+ */
+function refSearchPath(gitDir: string, readFile: (path: string) => string | null): string[] {
+  const common = readFile(`${gitDir}/commondir`)?.trim();
+  if (!common) return [gitDir];
+
+  const resolved = common.startsWith('/') ? common : `${gitDir}/${common}`;
+  return resolved === gitDir ? [gitDir] : [gitDir, resolved];
+}
+
+/** `.git` is a directory in a normal clone and a pointer file in a worktree. */
+function resolveGitDir(gitPath: string, readFile: (path: string) => string | null): string | null {
+  const pointer = readFile(`${gitPath}/HEAD`);
+  if (pointer !== null) return gitPath;
+
+  const link = readFile(gitPath)?.trim();
+  if (link?.startsWith('gitdir: ')) return link.slice(8).trim();
+
+  return null;
+}
+
+/**
+ * `packed-refs` is one `<sha> <ref>` per line, with comment lines and `^`
+ * peeled-tag lines mixed in. The ref is matched whole rather than by prefix:
+ * `refs/heads/dev` must not be answered by `refs/heads/dev-experiment`.
+ *
+ * Neither comment lines nor peeled-tag lines need a guard of their own. A
+ * peeled line carries no space, and a comment's first field is not a sha, so
+ * the separator check and the sha-shape check below already reject both.
+ * Explicit `#` and `^` guards were written first and then removed: no input
+ * could make either one decide the outcome, so they read as protections while
+ * being incapable of failing. The behaviour they described is still asserted.
+ */
+function findPackedRef(contents: string | null, ref: string): string | null {
+  if (!contents) return null;
+
+  for (const line of contents.split('\n')) {
+    const space = line.indexOf(' ');
+    if (space === -1) continue;
+    if (line.slice(space + 1).trim() !== ref) continue;
+    const sha = line.slice(0, space).trim();
+    if (SHA_PATTERN.test(sha)) return sha;
+  }
+
+  return null;
+}
+
+/**
+ * An empty or whitespace-only value is treated as absent rather than passed on.
+ * `??` does not fall back on `''`, so an empty string would render as a blank
+ * field that looks like a populated one - the same wrong state wearing a
+ * different costume.
+ */
+function normalise(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}


### PR DESCRIPTION
## What

Nothing this app serves could say which commit it was built from. `/api/health` now answers:

```json
{ "status": "ok", "buildSha": "9662b9d…", "buildShaSource": "git" }
```

## Why it is not bookkeeping

Amplify cannot answer it either. A build triggered by an **incoming webhook** records `commitId: "HEAD"` — the literal string — and its build log never prints a sha. Measured on job 480 for this app's `dev` branch. The panel's app is wired through the GitHub integration and does carry real commit ids, which is why the panel is answerable and this one was not.

Worse, a webhook build clones the branch **when the build starts**, so what ships is the branch tip at clone time, not necessarily the commit whose merge triggered it. On job 480 the clone happened 42s after the trigger and the next merge landed 2m09s later — a merge inside that window would have shipped a commit whose own CD run had decided `should_deploy=false`.

## Where the sha comes from, and why not the build spec

`next build` is the only step that runs inside the build container's clone. The Amplify build spec — which is where you would normally do this — lives in the Amplify console, **not in this repository**, so no pull request can change it. Hence `next.config.ts`.

It reads `.git` directly rather than running `git`. Spawning a `PATH`-resolved binary during a build is its own finding (`sonarjs/no-os-command-from-path`, which flagged the first version), and the files are a documented format — so there is no subprocess, no `PATH` dependency, and the resolver is a pure function testable without a repository.

`AWS_COMMIT_ID` wins where Amplify does know the commit. `buildShaSource` reports which one answered, so a wrong sha is traceable to its origin rather than being an anonymous string.

## The route is `force-dynamic` + `no-store`, and that is the feature

A cached health response answers with the **previous** deploy's sha. The one instrument for "did my change ship?" would then report success for a build that never happened — wrong in the reassuring direction. Both are asserted.

## Verification

Full frontend suite at this commit: **1036 suites / 13101 tests, all passing.** Lint and type-check clean.

Production build, and the part that matters is that the sha is really in the artifact:

```
pnpm run build                        rc=0
build report                          ƒ /api/health        <- Dynamic, not ○ Static
grep <real HEAD sha> .next            .next/server/app/api/health/route.js   FOUND
```

### Mutation results — every new assertion shown to fail

Each mutation asserted to land exactly once, failing test **names** captured from jest `--json` rather than an exit code.

| mutation | red test |
| --- | --- |
| prefer git over `AWS_COMMIT_ID` | prefers AWS_COMMIT_ID… / reports the source that actually answered |
| `normalise` stops trimming | whitespace-only AWS_COMMIT_ID… / trims the trailing newline |
| remove the try/catch | reports unavailable rather than throwing |
| drop `commondir` resolution | resolves a worktree ref through commondir / …from the common packed-refs |
| common dir searched for loose refs only | resolves a worktree ref from the common packed-refs |
| packed ref matched by prefix | matches the packed ref whole, not by prefix |
| drop `.git`-as-a-file handling | follows a .git FILE… / resolves a worktree ref through commondir |
| stop validating loose ref contents | rejects a ref file whose contents are not a sha |
| drop the `no-store` headers | sends no-store, because a cached health response reports the PREVIOUS deploy |
| `dynamic = 'auto'` | opts the route out of static rendering |
| omit `buildSha` instead of nulling it | reports buildSha as null, not absent |

### Two things the mutation run changed about the code

**A bug that only an end-to-end run could find.** Every unit test passed while `readHeadSha` returned `null` against this repository's actual layout. The worktree fixture used a *detached* HEAD, which never resolves a ref at all — so it agreed with an implementation that could not resolve one. In a linked worktree `HEAD` is per-worktree but branch refs live in the main git dir, named by `commondir`. Fixed, and the fixture that models the real layout is now in the suite.

**Two guards removed for being unfalsifiable.** `startsWith('#')` and `startsWith('^')` in the `packed-refs` parser both stayed green under mutation: a peeled line carries no space and a comment's first field is not a sha, so the separator and sha-shape checks already reject them. I could not construct an input that made either one decide the outcome. They read as protections while being incapable of failing, so they are gone and the reason is recorded in the file. The behaviour they described is still asserted.

## Review round 2 — `48bf3370`

Two findings from the review at `a419e312`, both fixed, both in the same family: an environment value reaching `buildSha` without the shape check every other source gets.

### Blocking — `AWS_COMMIT_ID` was preferred without being shape-checked

`readHeadSha` validates everything it reads against `SHA_PATTERN`; `resolveBuildSha` validated nothing on the source it prefers. Only empty and whitespace were rejected, so any non-empty string won — and because the preferred branch *returns*, the git read holding the right answer never ran. The likeliest wrong value is named in this PR's own header comment: a webhook build records `commitId: "HEAD"`, and `AWS_COMMIT_ID` comes from the same job metadata. The route would have answered `{"buildSha":"HEAD","buildShaSource":"AWS_COMMIT_ID"}` — populated-looking, identifying no commit, on the one instrument nobody double-checks.

Every candidate is now held to the object-name shape. The suite could not see this: every `AWS_COMMIT_ID` case was a well-formed sha or blank, so no test could disagree with "accept any non-empty string". Five malformed cases added — `HEAD`, a branch name, an abbreviated sha, and one each for the `^` and `$` anchors.

### The rejection is reported, not silent

Collapsing "malformed" into plain `git` is correct behaviour and a lossy instrument. No app in this account consumes `AWS_COMMIT_ID` on the webhook path, so nothing already deployed can be asked what Amplify supplies there — and this fix is the only place that question becomes a reading rather than an inference. `BuildShaSource` gains one member, `git-amplify-rejected`: same sha, and `source` is the only field that can separate a rejected value from an absent one.

One corner stays lossy on purpose and is asserted as such: if git cannot answer either, the result is `unavailable` and the rejection is not reported. That build has a louder problem.

### Non-blocking — `BUILD_SHA` was a runtime lookup when no sha resolved

The `env` block omitted `BUILD_SHA` when `build.sha` was null, so `process.env.BUILD_SHA` stayed a runtime read in the route while `BUILD_SHA_SOURCE` was inlined — two fields from two mechanisms, free to disagree. A `BUILD_SHA` set on the Amplify branch would have been reported next to `buildShaSource: "unavailable"`. Both keys are now always inlined; empty is the no-sha value and the route normalises it back to null (`|| null`, not `?? null`).

### Evidence at `48bf3370`

Read out of the built artifact rather than reasoned from the diff. Production build with `AWS_COMMIT_ID=HEAD`, `.next/server/app/api/health/route.js`:

```
buildSha:"a419e31275354518486d719c7c93e07d02f3cf18".trim()||null,
buildShaSource:"git-amplify-rejected"
```

Second production build with the git dir made unreadable, same file:

```
buildSha:"".trim()||null,buildShaSource:"unavailable"
process.env.BUILD_SHA remaining in the built route:  0
```

That second grep is the non-blocking fix demonstrated rather than described: the lookup is gone, not merely unlikely to fire.

| mutation | red test |
| --- | --- |
| drop the `SHA_PATTERN` check (the previous behaviour) | 5 malformed cases / separates a rejected AWS_COMMIT_ID from an absent one / rejects a malformed value from git too / reports unavailable when… git has nothing either |
| collapse the rejected source back into `git` | 5 malformed cases / separates a rejected AWS_COMMIT_ID from an absent one |
| treat a blank `AWS_COMMIT_ID` as a rejection | does not report a %s AWS_COMMIT_ID as rejected (empty, whitespace-only) / treats an %s AWS_COMMIT_ID as absent |
| route back to `?? null` | reports a %s BUILD_SHA as null (empty, whitespace-only) |

Failing test **names** captured from jest `--json`, mutations reverted and re-run green between each. Full frontend suite at `48bf3370`: **1036 suites / 13113 tests passing**, lint and types clean, both production builds `rc=0`.

## Scope

This reports the sha; it does not close the other half of the gap — the CD workflow asserts the Amplify webhook returned 2xx and never observes whether the job succeeded, so a failed deploy leaves CI green. That needs its own change.

