### PR TITLE
fix(frontend): let Vite own public/, removing the storybook-static race

### DIFF
--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -6,7 +6,22 @@ import type { StorybookConfig } from '@storybook/nextjs-vite';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const src = path.resolve(here, '../src');
 
-const config: StorybookConfig = {
+/**
+ * `favicon` is implemented by Storybook but not published in its types.
+ *
+ * `core-server/presets/common-preset` defines a `favicon` preset that returns
+ * an explicit value when given one. There is no type for it in 10.6.0:
+ * `favicon` appears zero times across storybook's `.d.ts` files, while
+ * `staticDirs` appears five times in the same file - so the search is not
+ * silently broken, the field is genuinely untyped.
+ *
+ * `StorybookConfig` is a type alias (`Omit<...> & ...`), not an interface, so
+ * declaration merging is unavailable. Adding the single field here keeps the
+ * rest of the config fully checked rather than casting the object.
+ */
+type StorybookConfigWithFavicon = StorybookConfig & { favicon?: string };
+
+const config: StorybookConfigWithFavicon = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
   addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
   framework: {
@@ -74,24 +89,58 @@ const config: StorybookConfig = {
     };
     return viteConfig;
   },
-  staticDirs: [
-    { from: '../public/fonts', to: '/fonts' },
-    { from: '../public/images', to: '/images' },
-    { from: '../public/static', to: '/static' },
-    { from: '../public/apple-touch-icon.png', to: '/apple-touch-icon.png' },
-    { from: '../public/favicon-16x16.png', to: '/favicon-16x16.png' },
-    { from: '../public/favicon-32x32.png', to: '/favicon-32x32.png' },
-    { from: '../public/favicon.ico', to: '/favicon.ico' },
-    { from: '../public/file.svg', to: '/file.svg' },
-    { from: '../public/globe.svg', to: '/globe.svg' },
-    { from: '../public/icon.svg', to: '/icon.svg' },
-    { from: '../public/next.svg', to: '/next.svg' },
-    { from: '../public/site.webmanifest', to: '/site.webmanifest' },
-    { from: '../public/vercel.svg', to: '/vercel.svg' },
-    { from: '../public/web-app-manifest-192x192.png', to: '/web-app-manifest-192x192.png' },
-    { from: '../public/web-app-manifest-512x512.png', to: '/web-app-manifest-512x512.png' },
-    { from: '../public/window.svg', to: '/window.svg' },
-  ],
+  /**
+   * Deliberately empty, and the favicon set explicitly below.
+   *
+   * These sixteen entries used to copy `../public/{fonts,images,static,...}`
+   * into the build. Every one of them was redundant: Vite's `publicDir`
+   * defaults to `<root>/public`, `root` is `apps/frontend` (builder-vite sets
+   * it to `resolve(configDir, '..')`), and nothing sets `publicDir` or
+   * `copyPublicDir`. So Vite already copies the whole tree - including
+   * `public/captions`, which `staticDirs` never listed and which appeared in
+   * the output regardless.
+   *
+   * The redundancy was not harmless. Storybook's staticDirs copy and the Vite
+   * preview build run in the SAME `Promise.all` in core-server, and Vite's
+   * `copyDir` is fully synchronous (`mkdirSync`/`copyFileSync`) firing from
+   * `prepareOutDirPlugin` at `renderStart`. So the async `fs/cp` walking
+   * `public/static` could stat the destination as absent, yield, and resume
+   * into `mkdir` after Vite had already created it:
+   *
+   *   Error: EEXIST: file already exists, mkdir './storybook-static/static'
+   *
+   * That flaked the play-function shards intermittently - #2779.
+   *
+   * Note what this does and does not remove. `common-preset` MERGES rather than
+   * replaces - `staticDirs = (values = []) => [...defaultStaticDirs, ...values]`
+   * - so the resolved value is one entry (`<storybook>/assets/browser` ->
+   * `/sb-common-assets`), never zero, and core-server still runs that copy
+   * alongside the Vite build. The concurrency remains; what goes away is the
+   * SHARED DESTINATION. `fs.promises.cp` mkdirs its own destination leaf
+   * non-recursively, which is what raises EEXIST when it loses that leaf, but
+   * tolerates a parent appearing underneath it. The two remaining writers share
+   * only `storybook-static/`, and `public/` contains no `sb-common-assets`, so
+   * this error class is unreachable rather than merely less likely.
+   * Verified: with this change the build output is byte-identical to before,
+   * all 1575 files, and `storybook dev` serves every public path unchanged.
+   */
+  staticDirs: [],
+  /**
+   * Previously inferred, now stated.
+   *
+   * Storybook's `favicon` preset returns an explicit value if given one and
+   * otherwise SCANS `staticDirs` for a `/favicon.ico` or `/favicon.svg`
+   * target, falling back to its own `assets/browser/favicon.svg`. The manager
+   * favicon was therefore a side effect of the entries above existing -
+   * emptying `staticDirs` alone silently swapped the project favicon for
+   * Storybook's default. Setting it here keeps `index.html` identical and
+   * makes the intent explicit rather than discovered.
+   *
+   * `here` (not `__dirname`): this file is loaded as ESM, where `__dirname`
+   * does not exist and Storybook fails with "main config ... does not seem to
+   * be valid ESM".
+   */
+  favicon: path.resolve(here, '../public/favicon.ico'),
 };
 
 export default config;

--- a/apps/frontend/src/app/__tests__/storybook/mainStaticAssets.test.ts
+++ b/apps/frontend/src/app/__tests__/storybook/mainStaticAssets.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The static-asset half of `.storybook/main.ts` - see #2779.
+ *
+ * `staticDirs` used to duplicate what Vite's `publicDir` already copies, and
+ * the two copiers race inside Storybook's `Promise.all`, producing an
+ * intermittent `EEXIST: mkdir './storybook-static/static'` that flaked the
+ * play-function shards. Emptying it fixes that, but on its own it also swaps
+ * the manager favicon for Storybook's default, because the `favicon` preset
+ * infers one by scanning `staticDirs` when it is not set explicitly.
+ *
+ * These assert the pair together: the duplicate copier stays gone AND the
+ * favicon stays stated. Deleting either line reintroduces a defect that no
+ * other test in this repo can see - the race is timing-dependent and the
+ * favicon only shows up in built `index.html`.
+ */
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import config from '../../../../.storybook/main';
+
+const publicDir = path.resolve(__dirname, '../../../../public');
+
+describe('.storybook static asset ownership', () => {
+  it('declares no staticDirs, so Vite publicDir is the only copier', () => {
+    // Not `toHaveLength(0)` on a possibly-undefined value: an omitted key would
+    // also read as "no duplicate copier" while letting the preset fall back to
+    // its own default, which is a different configuration than the one meant.
+    expect(config.staticDirs).toEqual([]);
+  });
+
+  it('sets the favicon explicitly rather than letting it be inferred', () => {
+    expect(typeof config.favicon).toBe('string');
+  });
+
+  it('points the favicon at a file that exists in public/', () => {
+    const { favicon } = config;
+
+    expect(favicon).toBeDefined();
+
+    expect(path.resolve(favicon as string)).toBe(path.join(publicDir, 'favicon.ico'));
+    expect(existsSync(favicon as string)).toBe(true);
+  });
+
+  it('resolves the favicon absolutely, so it does not depend on cwd', () => {
+    expect(path.isAbsolute(config.favicon as string)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes the intermittent `EEXIST` that flaked the Storybook play-function shards — #2779.

## The mechanism

`staticDirs` listed sixteen paths under `../public`. **Every one was redundant.** Vite's `publicDir` defaults to `<root>/public`, builder-vite sets `root` to `resolve(configDir, '..')` = `apps/frontend`, and nothing sets `publicDir` or `copyPublicDir` — so Vite already copies the whole tree.

The proof was visible on an unmodified build, with no mutation:

```
apps/frontend/public/     17 top-level entries
staticDirs declared       16 targets
storybook assets/browser   6 files

IN OUTPUT ∩ IN public/ − staticDirs − storybook assets  =  captions
```

`public/captions` shipped in `storybook-static/` and nothing asked for it.

The duplication was not inert. In `core-server`:

```js
staticDirs && effects.push(copyAllStaticFilesRelativeToMain(staticDirs, options.outputDir, ...));
await Promise.all([ previewBuilder.build({...}), ...effects ])
```

The staticDirs copy and the Vite preview build are in the **same `Promise.all`**, and Vite's `copyDir` is fully synchronous (`mkdirSync`/`readdirSync`/`statSync`/`copyFileSync`) firing from `prepareOutDirPlugin` at `renderStart`. So the async `fs/cp` walking `public/static` stats the destination as absent, yields at an `await`, Vite's synchronous burst creates it, and `fs/cp` resumes into `mkdir`:

```
Error: EEXIST: file already exists, mkdir './storybook-static/static'
    at async Promise.all (index 1)
```

Frame for frame, that is the reported failure. Removing the second copier **removes the concurrency** rather than narrowing the window.

## Why the favicon line is not incidental

Emptying `staticDirs` alone is **not** output-neutral. Storybook's `favicon` preset:

```js
favicon = async (value, options) => {
  if (value) return value;
  ... scans staticDirs for a /favicon.ico or /favicon.svg target ...
  return faviconPaths[0] || defaultFavicon;   // assets/browser/favicon.svg
}
```

The project favicon was a **side effect of those entries existing**. Dropping them silently swapped `index.html` to Storybook's own branding:

```
before   <link rel="icon" type="image/x-icon"  href="./favicon.ico" />
after    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
```

So it is now stated rather than inferred. `favicon` is implemented by Storybook but **absent from its published types** in 10.6.0 — zero `favicon` hits across every `.d.ts`, against 5 for `staticDirs` in the same file, so the search is not silently broken. `StorybookConfig` is a type alias (`Omit<...> & ...`), not an interface, so declaration merging is unavailable; the single field is added by intersection rather than casting the config object.

## Rejected alternative

`publicDir: false` (keeping Storybook as owner) — **changes 1348 asset files by content**, plus `iframe.html`. Not a config-only change.

## Verification

Both sides built **in the same worktree at this commit**, compared by content-addressed manifest:

```
fix vs baseline    1575 files each, differs: ./project.json ONLY
```

`project.json` also differs between two *unmodified* baseline builds, so the fix is indistinguishable from a plain rebuild. That control is what makes the result readable — the first comparison I ran showed `index.html` differing too, and only the baseline-vs-baseline run established that one was real and this one is not.

```
storybook build            exit 0, EEXIST occurrences: 0
favicon in index.html      rel="icon" type="image/x-icon" href="./favicon.ico"
type-check                 exit 0
lint                       exit 0 (2 pre-existing warnings in files not touched here)
full frontend suite        1037 suites / 13117 tests, all passing
```

`storybook dev` exercised on both variants, real files rather than directories:

```
                                      baseline   fix
/captions/no-narration.en.vtt            200     200   <- only Vite provides this
/static/openapi/openapi.yaml             200     200
/static/bulk_invite_users_header.csv     200     200
/favicon.ico                             200     200
/site.webmanifest                        200     200
/captions/zzz-not-real.vtt               404     404   <- negative control
```

Vite *serves* `publicDir` in dev rather than copying it, so a build-only comparison structurally cannot see a dev regression.

## Mutations

Failing test names read from `jest --json`, each mutation asserted to land exactly once:

```
baseline                              9 tests, 0 red
delete the favicon line               3 red  (all three favicon tests)
restore a staticDirs entry            1 red  (staticDirs only — separated)
favicon -> nonexistent path           1 red
config intact, favicon.ico removed    1 red  <- separating input
reverted                              0 red, file identical
```

The last one exists because `path.resolve()` equality and `existsSync()` sit in one test and the equality check fails first — so without it, `existsSync` could never independently fail and would read as coverage it did not provide.

## Not fixed here

The race is gone because the second writer is gone, not because it stopped reproducing. A single green build cannot demonstrate that, which is why the argument above is structural.

Refs #2779
