### PR TITLE
feat(frontend): give the estimates list a phone form so the amount is on screen

### DIFF
--- a/apps/frontend/src/app/__tests__/features/finance/Sections/PhoneEstimateList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/PhoneEstimateList.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PhoneEstimateList from '@/app/features/finance/pages/Estimates/Sections/PhoneEstimateList';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, src }: { alt: string; src: string }) => <span data-src={src}>{alt}</span>,
+}));
+
+jest.mock('@/app/lib/money', () => ({
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
+}));
+
+jest.mock('@/app/lib/date', () => ({
+  formatDisplayDate: (value: string | undefined, fallback: string) =>
+    value ? `D:${value.slice(0, 10)}` : fallback,
+}));
+
+const getSafeImageUrlMock = jest.fn(() => '/img.png');
+jest.mock('@/app/lib/urls', () => ({
+  getSafeImageUrl: (...args: unknown[]) => getSafeImageUrlMock(...(args as [])),
+}));
+
+jest.mock('@/app/features/companions/pages/Companions/companionsDirectory', () => ({
+  getAvatarPalette: () => ({ bg: '#eee' }),
+}));
+
+jest.mock('@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge', () => ({
+  __esModule: true,
+  default: ({ status }: { status: string }) => <span>{`badge:${status}`}</span>,
+}));
+
+const estimate = (over: Partial<Estimate> = {}): Estimate =>
+  ({
+    id: 'e1',
+    organisationId: 'org-1',
+    patientId: 'pat-1',
+    encounterId: null,
+    status: 'DRAFT' as EstimateStatus,
+    validUntil: null,
+    subtotal: 100,
+    taxAmount: 0,
+    total: 100,
+    currency: 'GBP',
+    notes: null,
+    approvedBy: null,
+    approvedAt: null,
+    declinedAt: null,
+    declineReason: null,
+    convertedToInvoiceId: null,
+    createdBy: null,
+    createdAt: '2026-08-28T09:00:00.000Z',
+    updatedAt: '2026-08-28T09:00:00.000Z',
+    items: [],
+    ...over,
+  }) as Estimate;
+
+const companion = (patientId: string) => ({
+  name: patientId === 'pat-2' ? 'Rufus' : 'Marnie',
+  photoUrl: patientId === 'pat-2' ? undefined : 'https://example.test/p.png',
+  speciesCode: patientId === 'pat-2' ? undefined : 'dog',
+});
+
+const renderList = (props: Partial<React.ComponentProps<typeof PhoneEstimateList>> = {}) =>
+  render(
+    <PhoneEstimateList
+      estimates={[estimate()]}
+      activeEstimateId={null}
+      onSelect={jest.fn()}
+      companion={companion}
+      {...props}
+    />
+  );
+
+beforeEach(() => {
+  getSafeImageUrlMock.mockClear();
+});
+
+describe('PhoneEstimateList', () => {
+  it('draws a card per estimate with the companion and the amount', () => {
+    renderList({
+      estimates: [
+        estimate({ id: 'e1', patientId: 'pat-1', total: 199.97 }),
+        estimate({ id: 'e2', patientId: 'pat-2', total: 45.5 }),
+      ],
+    });
+
+    expect(screen.getByText('Marnie')).toBeInTheDocument();
+    expect(screen.getByText('Rufus')).toBeInTheDocument();
+    // The column the table pushed off-screen has to be present on the card.
+    expect(screen.getByText('GBP 199.97')).toBeInTheDocument();
+    expect(screen.getByText('GBP 45.50')).toBeInTheDocument();
+  });
+
+  it('carries the same accessible name as the table row action', () => {
+    renderList();
+    expect(
+      screen.getByRole('button', { name: 'Open the estimate for Marnie' })
+    ).toBeInTheDocument();
+  });
+
+  it('appends the expiry to the date line only when one is set', () => {
+    const { unmount } = renderList({
+      estimates: [estimate({ validUntil: '2026-11-02T00:00:00.000Z' })],
+    });
+    expect(screen.getByText('D:2026-08-28 · valid to D:2026-11-02')).toBeInTheDocument();
+    unmount();
+
+    renderList({ estimates: [estimate({ validUntil: null })] });
+    expect(screen.getByText('D:2026-08-28')).toBeInTheDocument();
+    expect(screen.queryByText(/valid to/)).not.toBeInTheDocument();
+  });
+
+  it('marks the open estimate and leaves the others unmarked', () => {
+    renderList({
+      estimates: [
+        estimate({ id: 'e1', patientId: 'pat-1' }),
+        estimate({ id: 'e2', patientId: 'pat-2' }),
+      ],
+      activeEstimateId: 'e1',
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Open the estimate for Marnie' }).className
+    ).toContain('border-[var(--blue)]');
+    expect(screen.getByRole('button', { name: 'Open the estimate for Rufus' }).className).toContain(
+      'border-[var(--hairline)]'
+    );
+  });
+
+  it('hands the whole estimate back when a card is tapped', () => {
+    const onSelect = jest.fn();
+    const only = estimate({ id: 'e7' });
+    renderList({ estimates: [only], onSelect });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open the estimate for Marnie' }));
+    expect(onSelect).toHaveBeenCalledWith(only);
+  });
+
+  it("falls back to the 'other' species image when the companion has no species", () => {
+    renderList({ estimates: [estimate({ patientId: 'pat-2' })] });
+    expect(getSafeImageUrlMock).toHaveBeenCalledWith(undefined, 'other');
+  });
+
+  it('renders nothing but the container when there are no estimates', () => {
+    renderList({ estimates: [] });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -4,6 +4,17 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
 
+/* The page picks its list by breakpoint. Default false so every existing case
+   below keeps exercising the desktop table; the phone branch flips it. Both
+   export shapes are mocked because the module is imported by default here and
+   by name elsewhere. */
+let mockIsPhone = false;
+jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
+  __esModule: true,
+  default: () => mockIsPhone,
+  useIsPhone: () => mockIsPhone,
+}));
+
 jest.mock('@/app/ui/layout/guards/ProtectedRoute', () => ({
   __esModule: true,
   default: ({ children }: any) => <div>{children}</div>,
@@ -646,5 +657,46 @@ describe('Finance > Estimates status filters', () => {
         status: 'DRAFT',
       })
     );
+  });
+});
+
+describe('Finance > Estimates on a phone', () => {
+  beforeEach(() => {
+    mockIsPhone = true;
+  });
+  afterEach(() => {
+    mockIsPhone = false;
+  });
+
+  it('renders the card list instead of the six-column table', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([
+      buildEstimate({ id: 'e1', patientId: 'c1', total: 110 }),
+    ]);
+
+    render(<ProtectedEstimates />);
+
+    // The card carries the table row action's accessible name, so this alone
+    // cannot tell the two apart - the table's `columnheader`s can.
+    expect(
+      await screen.findByRole('button', { name: 'Open the estimate for Bruno' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Total' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+
+    // Total was the column that began off-screen in the table; on the card it
+    // is rendered inline.
+    expect(screen.getByText('$110.00')).toBeInTheDocument();
+  });
+
+  it('still renders the table when the viewport is not a phone', async () => {
+    mockIsPhone = false;
+    mockEstimateService.listEstimates.mockResolvedValue([
+      buildEstimate({ id: 'e1', patientId: 'c1', total: 110 }),
+    ]);
+
+    render(<ProtectedEstimates />);
+
+    expect(await screen.findByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Total' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/PhoneEstimateList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/PhoneEstimateList.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import PhoneEstimateList from './PhoneEstimateList';
+import type { Estimate, EstimateStatus } from '@/app/features/finance/types/estimate';
+
+/**
+ * The width `/finance/estimates` gives this list on a 390px phone, measured on
+ * the route rather than assumed: `main` is 390 and `yc-page-content` adds 12px
+ * gutters, so the content box is 366.
+ *
+ * The stories are pinned to it with a decorator instead of relying on the
+ * runner's viewport. `.storybook/test-runner.ts` renders any story without a
+ * `viewport` global at `laptop` (1280x800) - wide enough that every assertion
+ * below would hold no matter what the component did, and so could never fail.
+ * Pinning the box is what gives them the ability to go red.
+ */
+const ROUTE_CONTENT_WIDTH = 366;
+
+const NAMES: Record<string, string> = {
+  'pat-1': 'Marnie Whitlock',
+  'pat-2': 'Rufus Delacroix',
+  'pat-3': 'Pepper Osei',
+};
+
+const row = (
+  id: string,
+  patientId: string,
+  status: EstimateStatus,
+  total: number,
+  validUntil: string | null
+): Estimate => ({
+  id,
+  organisationId: 'org-1',
+  patientId,
+  encounterId: null,
+  status,
+  validUntil,
+  subtotal: total,
+  taxAmount: 0,
+  total,
+  currency: 'GBP',
+  notes: null,
+  approvedBy: null,
+  approvedAt: null,
+  declinedAt: null,
+  declineReason: null,
+  convertedToInvoiceId: status === 'CONVERTED' ? 'inv-1' : null,
+  createdBy: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+  items: [],
+});
+
+const meta = {
+  title: 'Finance/PhoneEstimateList',
+  component: PhoneEstimateList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The phone form of the estimates list.\n\n' +
+          '`Estimates` had no phone branch, so a phone rendered the six-column `EstimateList` ' +
+          'table inside a 364px scroll rail: `Companion` and `Status` were on screen and ' +
+          '`Created`, `Valid until`, `Total` and `Actions` began beyond the right edge. The rail ' +
+          'works - the page never scrolls sideways - so this was never a layout-overflow bug. It ' +
+          'is that the amount, which is what an estimates list is consulted for, was reached only ' +
+          'by discovering a horizontal swipe on a table.\n\n' +
+          'Finance had the same problem on its own list and answered it with `PhoneInvoiceList`, ' +
+          'and Finance’s phone branch links here, so this screen is a routine phone destination ' +
+          'that had been left on the desktop treatment. The card mirrors that component.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: ROUTE_CONTENT_WIDTH }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  args: {
+    estimates: [
+      row('e1', 'pat-1', 'APPROVED', 199.97, '2026-10-01T00:00:00.000Z'),
+      row('e2', 'pat-2', 'DRAFT', 45.5, null),
+      row('e3', 'pat-3', 'CONVERTED', 1240.6, '2026-09-15T00:00:00.000Z'),
+    ],
+    activeEstimateId: 'e1',
+    onSelect: () => {},
+    companion: (patientId: string) => ({
+      name: NAMES[patientId] ?? 'Unknown companion',
+      speciesCode: 'dog',
+    }),
+  },
+} satisfies Meta<typeof PhoneEstimateList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const cardFor = (canvas: ReturnType<typeof within>, name: string) =>
+  canvas.getByRole('button', { name: `Open the estimate for ${name}` });
+
+export const Default: Story = {
+  name: 'A card per estimate',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Marnie Whitlock')).toBeInTheDocument();
+    // Both decimals survive: 45.5 must not print as "£46".
+    await expect(canvas.getByText('£45.50')).toBeInTheDocument();
+    await expect(canvas.getByText('£1,240.60')).toBeInTheDocument();
+  },
+};
+
+export const NothingNeedsASidewaysSwipe: Story = {
+  name: 'The amount is on screen without scrolling',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const [name, amount] of [
+      ['Marnie Whitlock', '£199.97'],
+      ['Rufus Delacroix', '£45.50'],
+      ['Pepper Osei', '£1,240.60'],
+    ] as const) {
+      const card = cardFor(canvas, name);
+
+      /* The whole point of the card over the table: at the route's width the
+         card needs no horizontal scrolling of its own. In the table this
+         amount sat at x=488..575 inside a 364px rail.
+
+         Measured against the CARD, not `canvasElement` - Storybook renders the
+         story inside a full-width <main>, so a check against the canvas passes
+         at any component width and cannot fail. */
+      await expect(card.scrollWidth).toBeLessThanOrEqual(card.clientWidth);
+
+      const cardRight = card.getBoundingClientRect().right;
+      await expect(canvas.getByText(amount).getBoundingClientRect().right).toBeLessThanOrEqual(
+        cardRight
+      );
+    }
+  },
+};
+
+export const ActiveCardIsMarked: Story = {
+  name: 'The open estimate is marked',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The accessible name matches the table's eye button, so a caller's tests
+    // and a screen reader see one label across both breakpoints.
+    const active = cardFor(canvas, 'Marnie Whitlock');
+    const inactive = cardFor(canvas, 'Pepper Osei');
+
+    /* Compared as RENDERED colour, not as a class name. `toContain('border-[var(--blue)]')`
+       passes as long as the string is in the attribute - it would still pass if
+       the token resolved to the same colour as the hairline, or to nothing, so
+       it could not fail for the reason the assertion exists. */
+    const borderOf = (el: Element) => globalThis.getComputedStyle(el).borderTopColor;
+    await expect(borderOf(active)).not.toBe(borderOf(inactive));
+  },
+};
+
+export const SingleEstimate: Story = {
+  name: 'One estimate, no expiry date',
+  args: {
+    estimates: [row('e9', 'pat-2', 'SENT', 88, null)],
+    activeEstimateId: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // No validUntil, so the date line is the created date alone rather than
+    // trailing an empty "valid to".
+    await expect(canvas.getByText('Aug 28, 2026')).toBeInTheDocument();
+    await expect(canvas.queryByText(/valid to/)).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/PhoneEstimateList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/PhoneEstimateList.tsx
@@ -1,0 +1,133 @@
+'use client';
+import React from 'react';
+import Image from 'next/image';
+
+import { formatMoneyPrecise } from '@/app/lib/money';
+import { formatDisplayDate } from '@/app/lib/date';
+import { getSafeImageUrl, type ImageType } from '@/app/lib/urls';
+import { getAvatarPalette } from '@/app/features/companions/pages/Companions/companionsDirectory';
+import EstimateStatusBadge from '@/app/features/finance/pages/Estimates/Sections/EstimateStatusBadge';
+import type { Estimate } from '@/app/features/finance/types/estimate';
+import type { EstimateCompanion } from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
+
+type PhoneEstimateListProps = {
+  estimates: Estimate[];
+  /** The open estimate, marked in the list the way the table marks its row. */
+  activeEstimateId: string | null;
+  onSelect: (estimate: Estimate) => void;
+  /** Display details for a companion id, so a card is readable without a join. */
+  companion: (patientId: string) => EstimateCompanion;
+};
+
+const CARD_SHADOW = 'shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]';
+
+/** Shared with `EstimateList` for the same reason it is used there: a bare
+ *  `toLocaleDateString` resolves against the renderer's locale and time zone,
+ *  which differs between server and client and produces a hydration mismatch. */
+const formatDate = (value: string | null): string => formatDisplayDate(value ?? undefined, '-');
+
+const buildDateLine = (estimate: Estimate): string => {
+  const created = formatDate(estimate.createdAt);
+  const validUntil = formatDate(estimate.validUntil);
+  if (validUntil === '-') return created;
+  return `${created} · valid to ${validUntil}`;
+};
+
+type PhoneEstimateCardProps = {
+  estimate: Estimate;
+  companion: EstimateCompanion;
+  isActive: boolean;
+  onSelect: (estimate: Estimate) => void;
+};
+
+const PhoneEstimateCard = ({ estimate, companion, isActive, onSelect }: PhoneEstimateCardProps) => {
+  const palette = getAvatarPalette(companion.name);
+  const avatarSrc = getSafeImageUrl(
+    companion.photoUrl,
+    (companion.speciesCode as ImageType) ?? 'other'
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(estimate)}
+      /* The same accessible name the table's eye button carries, so the label
+         is one string across both breakpoints rather than two that drift. */
+      aria-label={`Open the estimate for ${companion.name}`}
+      className={`w-full text-left flex flex-col gap-[7px] rounded-2xl bg-[var(--screen)] px-3.5 py-3 border ${
+        isActive ? 'border-[var(--blue)] bg-card-hover' : 'border-[var(--hairline)]'
+      } ${CARD_SHADOW}`}
+    >
+      <span className="flex items-start justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-2.5">
+          <span
+            className="flex size-[30px] shrink-0 overflow-hidden rounded-full"
+            style={{ background: palette.bg }}
+          >
+            <Image
+              src={avatarSrc}
+              alt=""
+              width={30}
+              height={30}
+              className="size-[30px] rounded-full object-cover"
+            />
+          </span>
+          {/* Wraps rather than truncating. The table's cell clips this name and
+              hands the full value to a `title` - a hover affordance, and this
+              surface has no hover. Companion names are short enough that the
+              clip rarely bites today (a 37-character name still fits the 230px
+              this span gets), so this is closing the affordance gap rather than
+              fixing a defect anyone has hit; a card can grow downwards, so
+              there is no reason to depend on hover here at all. */}
+          <span className="min-w-0 break-words text-[13.5px] font-bold text-[var(--ink)]">
+            {companion.name}
+          </span>
+        </span>
+        <EstimateStatusBadge status={estimate.status} />
+      </span>
+      <span className="flex items-center justify-between gap-2">
+        <span className="min-w-0 break-words text-[11.5px] text-[var(--ink-faint)]">
+          {buildDateLine(estimate)}
+        </span>
+        {/* The column the phone table pushed off-screen: on an estimates list
+            the amount is the field the screen exists to show. */}
+        <span className="shrink-0 text-[14px] font-bold tabular-nums text-[var(--ink)]">
+          {formatMoneyPrecise(estimate.total, estimate.currency)}
+        </span>
+      </span>
+    </button>
+  );
+};
+
+/**
+ * The phone (< 768px) form of the estimates list.
+ *
+ * `Estimates` had no phone branch at all, so a phone rendered `EstimateList`'s
+ * six-column table inside a 364px scroller: `Created`, `Valid until`, `Total`
+ * and `Actions` all sat beyond the right edge, with no scrollbar or gradient
+ * saying so. Finance's own phone branch links here, so the screen is a routine
+ * phone destination rather than a URL someone has to type.
+ *
+ * Mirrors `PhoneInvoiceList`'s card so the two finance lists read as one
+ * product at this width.
+ */
+const PhoneEstimateList = ({
+  estimates,
+  activeEstimateId,
+  onSelect,
+  companion,
+}: PhoneEstimateListProps) => (
+  <div className="flex flex-col gap-2.5 pb-1">
+    {estimates.map((estimate) => (
+      <PhoneEstimateCard
+        key={estimate.id}
+        estimate={estimate}
+        companion={companion(estimate.patientId)}
+        isActive={estimate.id === activeEstimateId}
+        onSelect={onSelect}
+      />
+    ))}
+  </div>
+);
+
+export default PhoneEstimateList;

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -36,6 +36,11 @@ import {
 import EstimateList, {
   type EstimateCompanion,
 } from '@/app/features/finance/pages/Estimates/Sections/EstimateList';
+import PhoneEstimateList from '@/app/features/finance/pages/Estimates/Sections/PhoneEstimateList';
+// Default import, matching the sibling `Finance/index.tsx`: the finance page
+// tests mock this module's default export, and a named import here would read
+// as `undefined` under that mock.
+import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 import EstimateDetail, {
   type EstimateAction,
 } from '@/app/features/finance/pages/Estimates/Sections/EstimateDetail';
@@ -105,6 +110,7 @@ const runAction = (
 
 const EstimatesContent = () => {
   const { notify } = useNotify();
+  const isPhone = useIsPhone();
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const currency = useCurrencyForPrimaryOrg();
 
@@ -356,15 +362,27 @@ const EstimatesContent = () => {
 
       {!loading && !error && visibleEstimates.length > 0 && (
         <div className="flex flex-col gap-6">
-          <EstimateList
-            estimates={visibleEstimates}
-            activeEstimateId={activeEstimateId}
-            onSelect={(estimate) => {
-              setActiveEstimateId(estimate.id);
-              setActionError(null);
-            }}
-            companion={companionFor}
-          />
+          {isPhone ? (
+            <PhoneEstimateList
+              estimates={visibleEstimates}
+              activeEstimateId={activeEstimateId}
+              onSelect={(estimate) => {
+                setActiveEstimateId(estimate.id);
+                setActionError(null);
+              }}
+              companion={companionFor}
+            />
+          ) : (
+            <EstimateList
+              estimates={visibleEstimates}
+              activeEstimateId={activeEstimateId}
+              onSelect={(estimate) => {
+                setActiveEstimateId(estimate.id);
+                setActionError(null);
+              }}
+              companion={companionFor}
+            />
+          )}
           {activeEstimate && (
             <EstimateDetail
               estimate={activeEstimate}

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -167,6 +167,21 @@ const EstimatesContent = () => {
 
   // The row needs the photo and species too, so the avatar disc is tinted and
   // the fallback image matches the animal rather than defaulting to 'other'.
+  /* The two lists take identical props, so the breakpoint chooses the component
+     and nothing else. Written as a component swap rather than two JSX branches:
+     branching in the JSX duplicated every prop, and a prop added to one branch
+     and not the other is a difference no type would catch. */
+  const EstimatesList = isPhone ? PhoneEstimateList : EstimateList;
+
+  // One selection handler for both breakpoints. The two lists take identical
+  // props, so the branch chooses the component and nothing else - duplicating
+  // the handler per branch means a change to selection behaviour has to be made
+  // twice and can be made in only one.
+  const openEstimate = useCallback((estimate: Estimate) => {
+    setActiveEstimateId(estimate.id);
+    setActionError(null);
+  }, []);
+
   const companionFor = useCallback(
     (patientId: string): EstimateCompanion => {
       const stored = companionsById[patientId];
@@ -362,27 +377,12 @@ const EstimatesContent = () => {
 
       {!loading && !error && visibleEstimates.length > 0 && (
         <div className="flex flex-col gap-6">
-          {isPhone ? (
-            <PhoneEstimateList
-              estimates={visibleEstimates}
-              activeEstimateId={activeEstimateId}
-              onSelect={(estimate) => {
-                setActiveEstimateId(estimate.id);
-                setActionError(null);
-              }}
-              companion={companionFor}
-            />
-          ) : (
-            <EstimateList
-              estimates={visibleEstimates}
-              activeEstimateId={activeEstimateId}
-              onSelect={(estimate) => {
-                setActiveEstimateId(estimate.id);
-                setActionError(null);
-              }}
-              companion={companionFor}
-            />
-          )}
+          <EstimatesList
+            estimates={visibleEstimates}
+            activeEstimateId={activeEstimateId}
+            onSelect={openEstimate}
+            companion={companionFor}
+          />
           {activeEstimate && (
             <EstimateDetail
               estimate={activeEstimate}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`Estimates` is the only finance list with no phone branch - `Finance`, `Inventory` and `Tasks` each reference `useIsPhone`, while `Estimates`, `Discounts` and `Dashboard` reference it zero times. At 390px `/finance/estimates` renders `EstimateList`'s six-column table, and two of six columns are on screen:

```
  visible    Companion     left=13   right=201
  visible    Status        left=201  right=314
OFFSCREEN    Created       left=314  right=392
OFFSCREEN    Valid until   left=392  right=488
OFFSCREEN    Total         left=488  right=575
OFFSCREEN    Actions       left=575  right=659
```

**This is not a layout-overflow bug and the PR does not claim it is.** The table scrolls inside its own `overflow-x: auto` rail and the page never moves sideways (`documentElement.scrollWidth === clientWidth === 390`). I screened every element on this surface that escapes the viewport - 819 of them across the finance, inventory, tasks and dashboard stories - and **all 819 sit inside a scrolled `overflow-x` ancestor. Zero unrescued.** Horizontal overflow is genuinely not the defect here.

What is wrong is that `Total`, the field an estimates list exists to show, begins 98px past the right edge with no scrollbar or gradient saying so - and that `Finance/index.tsx` renders an Estimates link inside its own `isPhone` branch, so this is a routine phone destination that was left on the desktop treatment.

## What is the new behavior?

A `PhoneEstimateList` rendered below `md`, mirroring the card `Finance` already uses for the same problem so the two finance lists read as one product. Companion, status, dates and the amount are all on the card.

Deliberate choices worth reviewing:

- **No pager.** `PhoneInvoiceList` renders its filtered set without one; this matches the sibling rather than carrying `GenericTable`'s pagination onto a phone. Say if you would rather it paginate.
- **Same accessible name** as the table's row action (`Open the estimate for {name}`), so the page's existing tests and a screen reader see one label across both breakpoints.
- **The name wraps instead of truncating.** The table clips it and offers the full value through `title`, which is a hover affordance on a surface with no hover. Stated honestly: companion names are short enough that the clip rarely bites today - a 37-character name still fits the 230px this span gets - so this closes an affordance gap rather than fixing something anyone has hit.

## Verification

Measured at the width the route actually gives the list, rather than the Storybook default: `main` is 390 and `yc-page-content` adds 12px gutters, so **366px**. The story canvas hands the card 362px, so it is very slightly pessimistic against the route rather than more generous.

Both themes. The active-card border clears the 3:1 non-text bar on both - **3.36:1** light, **4.14:1** dark.

**Every added assertion was mutation-checked** - each mutation applied, the test watched going red, then reverted and watched going green:

| Mutation | Result |
| --- | --- |
| date/total row forced to `min-w-[560px]` | 6 of 6 geometry assertions fail |
| active border token `--blue` -> `--hairline` | both theme assertions fail |
| `buildDateLine`'s no-expiry branch dropped | the date-line test fails |
| `isPhone` -> `false` | the phone-branch page test fails |

The story assertions are pinned to 366px by a decorator rather than the runner's viewport. `.storybook/test-runner.ts` renders any story without a `viewport` global at laptop 1280x800, where every one of these assertions would hold no matter what the component did - the decorator is what gives them the ability to fail. The card-level assertions measure against the card, not `canvasElement`, for the same reason: Storybook renders the story inside a full-width `<main>`, so a check against the canvas passes at any component width.

```
frontend  tsc --noEmit                       exit 0
frontend  eslint                             exit 0 (2 pre-existing warnings, files untouched)
          jest Estimates|PhoneEstimateList    141 passed, 5 suites
          coverage PhoneEstimateList.tsx      100% statements / branches / functions / lines
pre-push  turbo lint + type-check             18 tasks, 18 successful
```

## Related Issue(s)

Fixes #2782
