### PR TITLE
fix(frontend): clear AA on the phone calendar's blue fills

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/contrastProbe.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/contrastProbe.test.ts
@@ -1,0 +1,109 @@
+import {
+  compositeOver,
+  describeContrast,
+  measureContrast,
+} from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
+
+/**
+ * The probe decides whether a contrast assertion passes, so a wrong probe is
+ * worse than no probe: it reports a number with the same confidence either way.
+ * These pin the compositing, which is the part that was wrong first time round.
+ */
+describe('compositeOver', () => {
+  it('accumulates alpha instead of jumping to opaque', () => {
+    /* The original hardcoded `a: 1`. That made `effectiveBackground`'s
+       `a >= 0.999` guard true after ONE blend, so a walk up two translucent
+       ancestors stopped at the second and called it the backdrop. */
+    const half = compositeOver({ r: 255, g: 0, b: 0, a: 0.5 }, { r: 0, g: 0, b: 255, a: 0.5 });
+    expect(half.a).toBeCloseTo(0.75, 5);
+    expect(half.a).toBeLessThan(0.999);
+  });
+
+  it('un-premultiplies the colour channels against a translucent backdrop', () => {
+    // 50% red over 50% blue: ao = 0.75, r = (255*.5)/.75 = 170, b = (255*.25)/.75 = 85.
+    // Weighting by (1 - as) alone - the original - gives 127.5/127.5, which is
+    // the backdrop over-counted because it is not fully there.
+    const blended = compositeOver({ r: 255, g: 0, b: 0, a: 0.5 }, { r: 0, g: 0, b: 255, a: 0.5 });
+    expect(blended.r).toBeCloseTo(170, 4);
+    expect(blended.b).toBeCloseTo(85, 4);
+    expect(blended.g).toBeCloseTo(0, 4);
+  });
+
+  it('is unchanged for the common case of a translucent ink on an opaque fill', () => {
+    // This is the path the shipped assertions take, so it must not move.
+    const ink = compositeOver({ r: 255, g: 255, b: 255, a: 0.75 }, { r: 37, g: 123, b: 237, a: 1 });
+    expect(ink.a).toBe(1);
+    expect(ink.r).toBeCloseTo(200.5, 4);
+    expect(ink.g).toBeCloseTo(222, 4);
+    expect(ink.b).toBeCloseTo(250.5, 4);
+  });
+
+  it('reports nothing rather than dividing by zero when both layers are absent', () => {
+    expect(compositeOver({ r: 1, g: 2, b: 3, a: 0 }, { r: 4, g: 5, b: 6, a: 0 }).a).toBe(0);
+  });
+});
+
+describe('measureContrast', () => {
+  const mount = (color: string, background: string, extra: Partial<CSSStyleDeclaration> = {}) => {
+    const parent = document.createElement('div');
+    parent.style.backgroundColor = background;
+    const el = document.createElement('span');
+    el.style.color = color;
+    el.style.fontSize = (extra.fontSize as string) ?? '14px';
+    el.style.fontWeight = (extra.fontWeight as string) ?? '700';
+    el.textContent = 'x';
+    parent.appendChild(el);
+    document.body.appendChild(parent);
+    return el;
+  };
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('reproduces the shipped failure: white on --blue at 14px/700', () => {
+    const reading = measureContrast(mount('rgb(255, 255, 255)', 'rgb(37, 123, 237)'));
+    expect(reading.ratio).toBe(4.09);
+    expect(reading.required).toBe(4.5);
+    expect(reading.passes).toBe(false);
+  });
+
+  it('reproduces the fix: white on --blue-strong, both themes', () => {
+    expect(measureContrast(mount('rgb(255, 255, 255)', 'rgb(22, 87, 201)')).ratio).toBe(6.48);
+    expect(measureContrast(mount('rgb(255, 255, 255)', 'rgb(47, 116, 217)')).ratio).toBe(4.54);
+  });
+
+  it('resolves a translucent ink rather than reading it as opaque', () => {
+    // 2.98:1, not the 4.09:1 an opaque reading gives - the difference between
+    // failing and looking like the row next to it.
+    const reading = measureContrast(
+      mount('rgba(255, 255, 255, 0.75)', 'rgb(37, 123, 237)', { fontSize: '9px' })
+    );
+    expect(reading.ratio).toBe(2.98);
+    expect(reading.passes).toBe(false);
+  });
+
+  it('holds the WCAG-large boundary at 18.66px bold, so 14px/700 needs 4.5', () => {
+    expect(
+      measureContrast(mount('rgb(0,0,0)', 'rgb(255,255,255)', { fontSize: '14px' })).required
+    ).toBe(4.5);
+    expect(
+      measureContrast(mount('rgb(0,0,0)', 'rgb(255,255,255)', { fontSize: '18.66px' })).required
+    ).toBe(3);
+    expect(
+      measureContrast(
+        mount('rgb(0,0,0)', 'rgb(255,255,255)', {
+          fontSize: '18px',
+          fontWeight: '400',
+        })
+      ).required
+    ).toBe(4.5);
+  });
+
+  it('names the measured colours in the failure message', () => {
+    const reading = measureContrast(mount('rgb(255, 255, 255)', 'rgb(37, 123, 237)'));
+    expect(describeContrast('Start visit pill', reading)).toBe(
+      'Start visit pill: 4.09:1 (needs 4.5:1) - rgb(255, 255, 255) on rgb(37, 123, 237) at 14px/700'
+    );
+  });
+});

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
@@ -161,7 +161,7 @@
 
 /* --blue-strong rather than --blue: --blue is #257bed in both themes and white
    on it is 4.09:1, under AA for this 10.5px/700 label. --blue-strong is
-   theme-aware and clears it on both sides (6.48:1 light, 4.62:1 dark). */
+   theme-aware and clears it on both sides (6.48:1 light, 4.54:1 dark). */
 .yc-day-rail__block-action {
   position: relative;
   z-index: 1;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
@@ -159,6 +159,9 @@
   white-space: nowrap;
 }
 
+/* --blue-strong rather than --blue: --blue is #257bed in both themes and white
+   on it is 4.09:1, under AA for this 10.5px/700 label. --blue-strong is
+   theme-aware and clears it on both sides (6.48:1 light, 4.62:1 dark). */
 .yc-day-rail__block-action {
   position: relative;
   z-index: 1;
@@ -169,21 +172,25 @@
   padding: 0 12px;
   border: 0;
   border-radius: 9999px;
-  background: var(--blue);
+  background: var(--blue-strong);
   color: #ffffff;
   font-size: 10.5px;
   font-weight: 700;
   cursor: pointer;
 }
 
-/* ------------------------------------------------------------ now marker */
+/* ------------------------------------------------------------ now marker
+   The pill and the line are one marker and share a fill. The pill carries a
+   9.5px/700 time, which is 4.09:1 on --blue and fails AA, so both move to
+   --blue-strong together - darkening only the pill would split one object
+   across two blues. */
 
 .yc-day-rail__now-line {
   position: absolute;
   left: 52px;
   right: 0;
   height: 2px;
-  background: var(--blue);
+  background: var(--blue-strong);
 }
 
 .yc-day-rail__now-pill {
@@ -192,7 +199,7 @@
   transform: translateY(-9px);
   padding: 2px 7px;
   border-radius: 9999px;
-  background: var(--blue);
+  background: var(--blue-strong);
   color: #ffffff;
   font-size: 9.5px;
   font-weight: 700;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import type { Appointment } from '@yosemite-crew/types';
 
 import PhoneDayRail from './PhoneDayRail';
+import { describeContrast, measureContrast } from './contrastProbe';
 
 const ORG_ID = 'org-storybook';
 /** 15 July 2026, as LOCAL calendar parts - see `makeAppointment`. */
@@ -83,10 +84,19 @@ const OVERLAPPING = build([
 ]);
 
 /** The rail is a phone surface, and its blocks are positioned as percentages of
- *  a fixed height, so the story has to give it a real box to lay out inside. */
+ *  a fixed height, so the story has to give it a real box to lay out inside.
+ *
+ *  The box needs `display: flex` as well as a height. `.yc-day-rail` sizes
+ *  itself with `flex: 1`, which resolves to nothing inside a block parent, so a
+ *  height alone left the rail at its 2px borders with every percentage-
+ *  positioned child collapsed and clipped by its own `overflow: hidden`. The
+ *  stories still rendered, and their assertions still passed - `toHaveLength(5)`
+ *  counts blocks that are in the DOM but invisible, and the `scrollWidth <=
+ *  innerWidth` check below cannot fail when nothing is laid out. So every
+ *  PhoneDayRail story was a green screenshot of a 2px strip. */
 const Phone = (Story: React.ComponentType) => (
   <div className="mx-auto w-[375px] bg-[var(--screen)] p-4">
-    <div style={{ height: 520 }}>
+    <div style={{ height: 520, display: 'flex', flexDirection: 'column' }}>
       <Story />
     </div>
   </div>
@@ -128,6 +138,18 @@ export const Default: Story = {
 
     // The now marker is inside the window, so both halves of it render.
     await expect(canvasElement.querySelector('[data-testid="day-rail-now-line"]')).not.toBeNull();
+
+    /* The rail must actually have laid out before anything below is worth
+       asserting. `.yc-day-rail` sizes with `flex: 1` and clips with
+       `overflow: hidden`, so in a non-flex parent it collapses to its 2px
+       borders and swallows every percentage-positioned child - and the two
+       checks that follow BOTH pass in that state: the blocks are still in the
+       DOM to be counted, and a page with nothing laid out cannot scroll
+       sideways. This guard is what stops the rest of this play function from
+       being green on a 2px strip. */
+    const rail = canvasElement.querySelector('.yc-day-rail');
+    await expect(rail).not.toBeNull();
+    await expect((rail as Element).getBoundingClientRect().height).toBeGreaterThan(100);
 
     // Nothing leaks sideways: the blocks are positioned with calc() against the
     // rail's own width, which is the part that breaks first at 375px.
@@ -178,6 +200,17 @@ export const StartVisit: Story = {
     // action must not offer itself on completed or upcoming blocks.
     const start = canvas.getAllByRole('button', { name: 'Start visit' });
     await expect(start).toHaveLength(1);
+
+    /* The pill sits on a fixed `--blue-strong` fill under literal white. It
+       shipped on `--blue` at 4.09:1, under AA - and identically in both themes,
+       because --blue is #257bed on each side. Measured on composited pixels; a
+       className check cannot fail on a colour change. */
+    const reading = measureContrast(start[0]);
+    await expect(
+      reading.ratio,
+      describeContrast('Start visit pill', reading)
+    ).toBeGreaterThanOrEqual(reading.required);
+
     await userEvent.click(start[0]);
     await expect(args.onStartVisit).toHaveBeenCalledTimes(1);
   },

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
@@ -25,9 +25,17 @@
   cursor: pointer;
 }
 
-/* Frame: selected cell fills --blue and lifts on 0 6px 16px var(--glow-b26). */
+/* Frame: selected cell fills --blue and lifts on 0 6px 16px var(--glow-b26).
+   The fill is --blue-strong, not --blue, for the same reason the quiet cell
+   below does not use the frame's 45% opacity: --blue is #257bed in BOTH themes,
+   and white on it is 4.09:1 - under AA for every label this cell carries, none
+   of which is WCAG-large (14px/700 needs 18.66px to qualify). --blue-strong is
+   theme-aware and clears AA on both sides: #1657c9 light (6.48:1), #2f74d9 dark
+   (4.62:1). That also makes this file's opening claim - colours are token-only,
+   so light and dark come for free - true, which it was not while the ink was a
+   literal on a fill that never changes. */
 .yc-day-strip__cell--selected {
-  background: var(--blue);
+  background: var(--blue-strong);
   box-shadow: 0 6px 16px var(--glow-b26);
 }
 
@@ -51,9 +59,14 @@
   color: var(--ink-faint);
 }
 
-/* Frame: the selected cell's weekday is white at 75%. */
+/* Frame: the selected cell's weekday is white at 75%.
+   Opaque instead. At 9px the 75% alpha was 2.98:1 on the old fill and is still
+   under 4.5 on --blue-strong (4.37:1 light), so no alpha below 1.0 works here -
+   exactly the finding recorded for the quiet cell above. The weekday still
+   reads as secondary to the date through size and letter-spacing, which is
+   where that hierarchy belongs when the alternative is failing AA. */
 .yc-day-strip__cell--selected .yc-day-strip__weekday {
-  color: rgba(255, 255, 255, 0.75);
+  color: #ffffff;
 }
 
 /* Frame: font-size 14px; font-weight 700; color var(--ink). */

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
@@ -31,7 +31,7 @@
    and white on it is 4.09:1 - under AA for every label this cell carries, none
    of which is WCAG-large (14px/700 needs 18.66px to qualify). --blue-strong is
    theme-aware and clears AA on both sides: #1657c9 light (6.48:1), #2f74d9 dark
-   (4.62:1). That also makes this file's opening claim - colours are token-only,
+   (4.54:1). That also makes this file's opening claim - colours are token-only,
    so light and dark come for free - true, which it was not while the ink was a
    literal on a fill that never changes. */
 .yc-day-strip__cell--selected {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.stories.tsx
@@ -4,6 +4,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import type { Appointment } from '@yosemite-crew/types';
 
 import PhoneDayStrip from './PhoneDayStrip';
+import { describeContrast, measureContrast } from './contrastProbe';
 
 const ORG_ID = 'org-storybook';
 const NAMES = ['Poppy', 'Milo', 'Nala', 'Rufus', 'Juno', 'Otto', 'Sasha', 'Bruno'];
@@ -118,6 +119,25 @@ export const Default: Story = {
     await expect(new Set(tops).size).toBe(1);
     const widths = cells.map((c) => Math.round(c.getBoundingClientRect().width));
     await expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
+
+    /* The selected cell is a fixed tint, so its ink cannot be checked by eye in
+       one theme and assumed in the other - it is identical in both. Both labels
+       shipped under AA (2.98:1 weekday, 4.09:1 date) because the fill was
+       `--blue`, which is #257bed in light AND dark, under literal white.
+       Measured on the composited pixels: a class-name assertion here would stay
+       green through exactly that regression. */
+    const selected = pressed[0];
+    for (const [label, node] of [
+      ['weekday', selected.querySelector('.yc-day-strip__weekday')],
+      ['date', selected.querySelector('.yc-day-strip__date')],
+    ] as const) {
+      await expect(node).not.toBeNull();
+      const reading = measureContrast(node as Element);
+      await expect(
+        reading.ratio,
+        describeContrast(`selected day ${label}`, reading)
+      ).toBeGreaterThanOrEqual(reading.required);
+    }
   },
 };
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/contrastProbe.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/contrastProbe.ts
@@ -31,13 +31,22 @@ const relativeLuminance = ({ r, g, b }: Rgb): number => {
   return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
 };
 
-/** `src` painted over `dst`, resolving `src`'s alpha. */
-const composite = (src: Rgb, dst: Rgb): Rgb => ({
-  r: src.r * src.a + dst.r * (1 - src.a),
-  g: src.g * src.a + dst.g * (1 - src.a),
-  b: src.b * src.a + dst.b * (1 - src.a),
-  a: 1,
-});
+/**
+ * `src` painted over `dst`, source-over.
+ *
+ * The resulting alpha is `as + ab(1 - as)`, NOT 1. Hardcoding it to 1 makes the
+ * `a >= 0.999` guard in `effectiveBackground` true after a single blend, which
+ * ends the ancestor walk at the second translucent layer and reports it as the
+ * backdrop - so two stacked translucent backgrounds resolve against the wrong
+ * colour. Colour channels are un-premultiplied by `ao` for the same reason: with
+ * a translucent `dst`, weighting by `(1 - as)` alone over-counts the backdrop.
+ */
+export const compositeOver = (src: Rgb, dst: Rgb): Rgb => {
+  const a = src.a + dst.a * (1 - src.a);
+  if (a === 0) return { r: 0, g: 0, b: 0, a: 0 };
+  const channel = (s: number, d: number) => (s * src.a + d * dst.a * (1 - src.a)) / a;
+  return { r: channel(src.r, dst.r), g: channel(src.g, dst.g), b: channel(src.b, dst.b), a };
+};
 
 const WHITE: Rgb = { r: 255, g: 255, b: 255, a: 1 };
 
@@ -51,12 +60,12 @@ const effectiveBackground = (el: Element): Rgb => {
   while (node) {
     const colour = parseColor(globalThis.getComputedStyle(node).backgroundColor);
     if (colour && colour.a > 0) {
-      accumulated = accumulated ? composite(accumulated, colour) : colour;
+      accumulated = accumulated ? compositeOver(accumulated, colour) : colour;
       if (accumulated.a >= 0.999) return accumulated;
     }
     node = node.parentElement;
   }
-  return accumulated ? composite(accumulated, WHITE) : WHITE;
+  return accumulated ? compositeOver(accumulated, WHITE) : WHITE;
 };
 
 export type ContrastReading = {
@@ -79,7 +88,7 @@ export const measureContrast = (el: Element): ContrastReading => {
   const style = globalThis.getComputedStyle(el);
   const background = effectiveBackground(el);
   const rawForeground = parseColor(style.color) ?? { ...WHITE };
-  const foreground = rawForeground.a < 1 ? composite(rawForeground, background) : rawForeground;
+  const foreground = rawForeground.a < 1 ? compositeOver(rawForeground, background) : rawForeground;
 
   const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
   const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/contrastProbe.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/contrastProbe.ts
@@ -1,0 +1,106 @@
+/**
+ * WCAG 2.1 contrast measured against the RENDERED element, for use from
+ * Storybook play functions (which run in a real browser, unlike jsdom).
+ *
+ * Why this exists as a probe rather than an assertion on class names: the
+ * failure it guards against is a literal ink colour on a themed fill. A test
+ * that asserts `className` contains some token passes forever, because the
+ * class is still there when the colour underneath it is wrong. Only the
+ * composited pixel values can fail.
+ *
+ * Alpha is composited down the ancestor chain rather than assumed opaque: the
+ * bug that motivated this shipped as `rgba(255,255,255,0.75)`, and reading that
+ * as opaque white reports 4.09:1 where the real value is 2.98:1.
+ */
+
+type Rgb = { r: number; g: number; b: number; a: number };
+
+const parseColor = (value: string): Rgb | null => {
+  const match = /rgba?\(([^)]+)\)/.exec(value);
+  if (!match) return null;
+  const parts = match[1].split(',').map((part) => Number.parseFloat(part));
+  if (parts.length < 3 || parts.some((part) => Number.isNaN(part))) return null;
+  return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+};
+
+const relativeLuminance = ({ r, g, b }: Rgb): number => {
+  const channel = (raw: number) => {
+    const v = raw / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+/** `src` painted over `dst`, resolving `src`'s alpha. */
+const composite = (src: Rgb, dst: Rgb): Rgb => ({
+  r: src.r * src.a + dst.r * (1 - src.a),
+  g: src.g * src.a + dst.g * (1 - src.a),
+  b: src.b * src.a + dst.b * (1 - src.a),
+  a: 1,
+});
+
+const WHITE: Rgb = { r: 255, g: 255, b: 255, a: 1 };
+
+/**
+ * The colour actually behind `el`: the first opaque background found walking up,
+ * with any translucent layers above it composited in on the way.
+ */
+const effectiveBackground = (el: Element): Rgb => {
+  let node: Element | null = el;
+  let accumulated: Rgb | null = null;
+  while (node) {
+    const colour = parseColor(globalThis.getComputedStyle(node).backgroundColor);
+    if (colour && colour.a > 0) {
+      accumulated = accumulated ? composite(accumulated, colour) : colour;
+      if (accumulated.a >= 0.999) return accumulated;
+    }
+    node = node.parentElement;
+  }
+  return accumulated ? composite(accumulated, WHITE) : WHITE;
+};
+
+export type ContrastReading = {
+  ratio: number;
+  /** 3 for WCAG-large text, otherwise 4.5. */
+  required: number;
+  passes: boolean;
+  foreground: string;
+  background: string;
+  fontSize: number;
+  fontWeight: string;
+};
+
+/**
+ * WCAG large text is >= 24px, or >= 18.66px when bold. 14px/700 does NOT
+ * qualify - getting that boundary wrong is what lets a 4.09:1 label read as
+ * passing.
+ */
+export const measureContrast = (el: Element): ContrastReading => {
+  const style = globalThis.getComputedStyle(el);
+  const background = effectiveBackground(el);
+  const rawForeground = parseColor(style.color) ?? { ...WHITE };
+  const foreground = rawForeground.a < 1 ? composite(rawForeground, background) : rawForeground;
+
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+
+  const fontSize = Number.parseFloat(style.fontSize);
+  const isBold = Number.parseInt(style.fontWeight, 10) >= 700;
+  const isLarge = fontSize >= 24 || (fontSize >= 18.66 && isBold);
+  const required = isLarge ? 3 : 4.5;
+
+  return {
+    ratio: Math.round(ratio * 100) / 100,
+    required,
+    passes: ratio >= required,
+    foreground: style.color,
+    background: `rgb(${Math.round(background.r)}, ${Math.round(background.g)}, ${Math.round(background.b)})`,
+    fontSize,
+    fontWeight: style.fontWeight,
+  };
+};
+
+/** A one-line description for an assertion message that has to explain itself. */
+export const describeContrast = (label: string, reading: ContrastReading): string =>
+  `${label}: ${reading.ratio}:1 (needs ${reading.required}:1) - ${reading.foreground} on ${reading.background} at ${reading.fontSize}px/${reading.fontWeight}`;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

See #2784. Two problems on the phone appointments calendar, found driving PIMS at 390x844.

**Four labels fail WCAG AA, identically in light and dark.** The selected day cell, the Start visit pill and the now-pill put literal white on `var(--blue)`, and `--blue` is `#257bed` in both themes, so the fill never changes and neither does the failure:

| Site | Size/weight | Ink | Ratio | Needs |
| --- | --- | --- | --- | --- |
| `PhoneDayStrip` weekday | 9px/700 | `rgba(255,255,255,.75)` | 2.98:1 | 4.5 |
| `PhoneDayStrip` date | 14px/700 | `#ffffff` | 4.09:1 | 4.5 |
| `PhoneDayRail` Start visit | 10.5px/700 | `#ffffff` | 4.09:1 | 4.5 |
| `PhoneDayRail` now-pill | 9.5px/700 | `#ffffff` | 4.09:1 | 4.5 |

14px/700 is not WCAG-large text (that needs 18.66px at 700), so 4.5 applies to all four.

**Every `PhoneDayRail` story renders a 2px strip.** `.yc-day-rail` sizes with `flex: 1` and clips with `overflow: hidden`; the decorator gave it a 520px BLOCK parent, so the flex basis never resolved and every percentage-positioned child collapsed and was clipped away.

## What is the new behavior?

The fills move to `--blue-strong`, which is already theme-aware and clears AA on both sides, and the weekday's 75% alpha goes opaque because no alpha below 1.0 reaches 4.5 on either fill:

```
              before                    after
light         2.98 / 4.09 : 1     ->    6.48:1   (#1657c9)
dark          2.98 / 4.09 : 1     ->    4.54:1   (#2f74d9)
```

This makes `PhoneDayStrip.css`'s opening claim - colours are token-only, so light and dark come for free - true rather than aspirational. It deviates from the design frame the file cites, deliberately: that same file already documents overriding the frame on contrast grounds ten lines above, for the quiet cell.

The decorator gains `display: flex; flexDirection: column`, and all 5 standalone rail stories now render at 520px instead of 2px.

## The old assertions could not fail

Worth calling out, because it is the reason this was not caught. Reverting to the shipped decorator with the new guard removed:

```
Tests: 8 passed, 8 total     <- on a 2px rail
```

`toHaveLength(5)` counts blocks that are in the DOM but invisible, and the `scrollWidth <= innerWidth` check, written specifically to catch sideways leakage, cannot fail when nothing is laid out. A guard on the rail's laid-out height is added so the rest of that play function cannot be green on an empty box again.

## Testing

Adds `contrastProbe.ts`, which measures composited pixel values on the rendered element, and pins all four sites plus the rail's layout from play functions. Play functions run in a real browser: jsdom cannot compute contrast, and a `className` assertion cannot fail on a colour change.

Every assertion mutation-checked - applied, watched go red, reverted, watched go green:

| Mutation | Result |
| --- | --- |
| fills back to `--blue`, weekday alpha restored | `Start visit pill: 4.09:1 (needs 4.5:1)` and `selected day weekday: 2.98:1 (needs 4.5:1)`, both files fail |
| decorator back to a block parent | `expected 2 to be greater than 100` |

```
tsc --noEmit                          0
eslint                                0 errors (2 pre-existing warnings, untouched files)
jest --testPathPatterns=Calendar/responsive   13 suites, 348 passed
test-storybook responsive/PhoneDay    13 passed
```

Verified visually at 390x844 in both themes, with element-clipped before/after shots. Note that `storybook-interactions` is `continue-on-error` by design and documented as advisory, so these play functions report rather than block.

## Related Issue(s)

Fixes #2784