### PR TITLE
fix(frontend): stop the consent card sitting on the phone sign-in button

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Cookies.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Cookies.test.tsx
@@ -99,4 +99,115 @@ describe('Cookies Component', () => {
 
     setItemSpy.mockRestore();
   });
+
+  /**
+   * The card is `position: fixed` and opaque, so on a phone it lands on
+   * whatever is centred underneath it - at 390x844 that measured as 0% of the
+   * sign-in submit button being tappable. It publishes the strip it denies so
+   * a shell pinned to 100svh can reserve it; these tests are about the value
+   * it publishes, not about the class list that positions it.
+   */
+  describe('the viewport strip it reserves', () => {
+    const PHONE_QUERY = '(max-width: 767px)';
+
+    const mockViewport = ({
+      isPhone,
+      innerHeight,
+      cardTop,
+      cardHeight,
+    }: {
+      isPhone: boolean;
+      innerHeight: number;
+      cardTop: number;
+      /**
+       * Deliberately NOT `innerHeight - cardTop`. The card is docked 84px above
+       * the bottom, so the strip it denies is taller than the card itself - and
+       * a fixture where the two are equal cannot tell a correct reservation
+       * from one that reserves only the card.
+       */
+      cardHeight: number;
+    }) => {
+      (globalThis.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+        matches: query === PHONE_QUERY ? isPhone : false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      Object.defineProperty(globalThis, 'innerHeight', {
+        writable: true,
+        configurable: true,
+        value: innerHeight,
+      });
+      return jest
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          top: cardTop,
+          bottom: cardTop + cardHeight,
+          height: cardHeight,
+        } as DOMRect);
+    };
+
+    const inset = () => document.documentElement.style.getPropertyValue('--yc-consent-inset');
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      document.documentElement.style.removeProperty('--yc-consent-inset');
+    });
+
+    it('reserves everything from the card top to the bottom of a phone viewport', () => {
+      const rect = mockViewport({ isPhone: true, innerHeight: 844, cardTop: 508, cardHeight: 252 });
+
+      render(<Cookies />);
+
+      // 844 - 508 = 336, and the card itself is only 252 tall. The extra 84 is
+      // the tab-bar reserve the card is docked above, which is not somewhere
+      // content can go either.
+      expect(inset()).toBe('336px');
+      rect.mockRestore();
+    });
+
+    it('reserves nothing on desktop, where the card is placed clear of the page', () => {
+      const rect = mockViewport({
+        isPhone: false,
+        innerHeight: 900,
+        cardTop: 494,
+        cardHeight: 276,
+      });
+
+      render(<Cookies />);
+
+      expect(inset()).toBe('');
+      rect.mockRestore();
+    });
+
+    it('gives the strip back once a choice has been made', async () => {
+      const rect = mockViewport({ isPhone: true, innerHeight: 844, cardTop: 508, cardHeight: 252 });
+
+      render(<Cookies />);
+      expect(inset()).toBe('336px');
+
+      fireEvent.click(screen.getByRole('button', { name: /Accept/ }));
+
+      await waitFor(() => {
+        expect(inset()).toBe('');
+      });
+      rect.mockRestore();
+    });
+
+    it('gives the strip back when it unmounts with the choice still open', () => {
+      const rect = mockViewport({ isPhone: true, innerHeight: 844, cardTop: 508, cardHeight: 252 });
+
+      const { unmount } = render(<Cookies />);
+      expect(inset()).toBe('336px');
+
+      unmount();
+
+      expect(inset()).toBe('');
+      rect.mockRestore();
+    });
+  });
 });

--- a/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
+++ b/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
@@ -182,7 +182,19 @@ export function AuthShell({ brand, topRight, children }: Readonly<AuthShellProps
     <div
       data-authgrid="true"
       data-yc-theme
-      style={{ display: 'grid', gridTemplateColumns: '1.06fr 1fr', minHeight: '100svh' }}
+      /* `--yc-consent-inset` is the strip the phone consent card denies (0 when
+         it is absent or on desktop). Reserving it as padding inside a
+         border-box `100svh` means the form centres in what is left, and if the
+         form no longer fits the shell grows past the viewport and the page
+         scrolls - either way the submit button stays reachable. Without it the
+         card lands on the centred form and 0% of the button is tappable. */
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1.06fr 1fr',
+        minHeight: '100svh',
+        boxSizing: 'border-box',
+        paddingBottom: 'var(--yc-consent-inset, 0px)',
+      }}
     >
       <div data-brandpanel="true" style={BRAND_PANEL_STYLE}>
         <div

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
@@ -1,8 +1,9 @@
 'use client';
-import React, { useSyncExternalStore } from 'react';
+import React, { useEffect, useRef, useSyncExternalStore } from 'react';
 import Image from 'next/image';
 
 import { getStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { PHONE_MEDIA_QUERY } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import { COOKIE_CONSENT_KEY } from '@/app/lib/posthog';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
@@ -18,6 +19,18 @@ const subscribeToConsent = (onChange: () => void): (() => void) => {
   globalThis.window?.addEventListener('storage', onChange);
   return () => globalThis.window?.removeEventListener('storage', onChange);
 };
+
+/**
+ * The strip of viewport the card denies, published so a shell that cannot
+ * scroll can reserve it.
+ *
+ * Measured rather than derived from the class list: the card's height depends
+ * on how the copy wraps, which depends on the viewport (252px at 390px wide,
+ * 276px at 360px). Everything from the card's top edge to the bottom of the
+ * viewport is denied, not just the card itself - below it sits the tab-bar
+ * reserve, which is not somewhere content can go either.
+ */
+const CONSENT_INSET_PROPERTY = '--yc-consent-inset';
 
 const getConsentSnapshot = () => getStorageItem('local', COOKIE_CONSENT_KEY);
 const getServerConsentSnapshot = () => null;
@@ -37,6 +50,36 @@ const Cookies = () => {
     getServerConsentSnapshot
   );
   const showCookiePopup = !consent;
+  const cardRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const clear = () => root.style.removeProperty(CONSENT_INSET_PROPERTY);
+    const card = cardRef.current;
+    if (!card) return clear;
+
+    const publish = () => {
+      // Re-read the breakpoint on every publish rather than once at mount:
+      // desktop places the card clear of page content and has nothing to
+      // reserve, and a rotation crosses that boundary without remounting.
+      if (!globalThis.matchMedia?.(PHONE_MEDIA_QUERY).matches) {
+        clear();
+        return;
+      }
+      const denied = globalThis.innerHeight - card.getBoundingClientRect().top;
+      root.style.setProperty(CONSENT_INSET_PROPERTY, `${Math.max(0, Math.ceil(denied))}px`);
+    };
+
+    publish();
+    const observer = new ResizeObserver(publish);
+    observer.observe(card);
+    globalThis.addEventListener('resize', publish);
+    return () => {
+      observer.disconnect();
+      globalThis.removeEventListener('resize', publish);
+      clear();
+    };
+  }, [showCookiePopup]);
 
   if (!showCookiePopup) return null;
 
@@ -47,6 +90,7 @@ const Cookies = () => {
        as part of the page - only fits once there is room for both, so it comes
        back at `md`. */
     <aside
+      ref={cardRef}
       aria-label="Cookie consent"
       className="fixed inset-x-4 bottom-[calc(84px+env(safe-area-inset-bottom,0px))] z-9999 md:inset-x-auto md:left-20 md:bottom-32.5"
     >


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

On a phone, a first visit to `/signin` cannot be completed. The consent card is a 252px opaque `position: fixed` card at `z-9999` spanning y=508..760 at 390x844, and the submit button sits at y=566..622 inside it. Hit-tested across the button's face with `document.elementFromPoint`, 0% of it is tappable, and the auth shell is pinned to `100svh` so no scroll position moves it clear.

Desktop is unaffected and is the control - at `md` the card is placed to the left of the centred form and the same probe returns 100%.

The placement it inherited reasons carefully about the 72px tab bar and the home indicator BELOW the card and says nothing about what is above it, so it clears its own furniture and lands on the form.

## What is the new behavior?

The card publishes the strip of viewport it denies - everything from its top edge to the bottom of the viewport, measured rather than derived, because its height depends on how the copy wraps (252px at 390 wide, 276px at 360). The auth shell reserves that strip as border-box padding, so the form centres in what is left, and when the form no longer fits, the shell grows past the viewport and the page scrolls.

Measured on one production build. A/B by zeroing the reserved padding in the page, so nothing but the fix differs between the two rows:

| viewport | variant | page scrolls | face tappable at rest | best over every scroll position |
| --- | --- | --- | --- | --- |
| 390x844 | before | no | 0% | 0% |
| 390x844 | after | yes | 100% | 100% at scrollY=0 |
| 360x740 | before | no | 0% | 0% |
| 360x740 | after | yes | 0% | 100% at scrollY=130 |

The probe carries a positive control that runs before it reports - a synthetic covered button must read `centreHits=false face=0%` and an uncovered one `true / 100%` - because a clean hit-test result is worthless from an instrument that cannot produce a dirty one.

### What this does not fix

At 360x740 the card is 276px tall and the form cannot fit above it, so the screen still opens with the button covered. It is now reachable - a 130px scroll clears it completely, where before no scroll position existed. Clearing it at rest as well means shrinking the phone card, which means cutting consent copy. That is a product call and is deliberately not made here.

## Tests

Three new cases in the existing `Cookies` suite, on the value published rather than on the class list that positions the card. Every one mutation-checked - mutation applied, watched go red, reverted, watched go green:

| Mutation | Result |
| --- | --- |
| phone gate removed, so desktop publishes too | 1 failed |
| reserve the card's own height instead of the denied strip | 3 failed |
| unmount cleanup dropped | 1 failed |

The second mutation initially survived: the first fixture set the card's height equal to the denied strip, so a reservation of the wrong quantity produced the same number. The fixture now gives them different values (252px card, 336px strip), which is the 84px tab-bar reserve the card is docked above.

A fourth mutation - dropping the clear in the no-card branch - could not be killed, because the effect cleanup has already cleared by the time that branch runs. The branch was redundant, so it is removed rather than covered by a test written to reach dead code.

`Cookies.tsx`: 100% statements, 100% branches, 100% lines, functions 8/9 (the uncovered one is the pre-existing SSR snapshot for `useSyncExternalStore`, unreachable in jsdom).

## Verification

- `npx tsc --noemit` from `apps/frontend` - exit 0
- `pnpm --filter frontend run lint` - exit 0, 0 errors, 2 pre-existing warnings elsewhere
- `pnpm --filter frontend run test -- --testPathPatterns="Cookies|AuthShell"` - 12 passed
- `next build` - exit 0; the A/B numbers above were re-measured on the exact bundle this PR ships, after the last source change
- pre-push monorepo lint and type-check - passed
- Aikido was not run locally: no MCP server is configured on this machine and there is no local scan script for the frontend. The PR scan is the first Aikido pass on this change.

Fixes #2787