### PR TITLE
feat(frontend): give the insurance claims list a phone form so status is on screen

### DIFF
--- a/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
@@ -3,6 +3,17 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
+/* The results section picks its list by breakpoint. Default false so every case
+   below keeps exercising the desktop table; the phone branch flips it. Both
+   export shapes are mocked because the module is imported by default here and
+   by name elsewhere. */
+let mockIsPhone = false;
+jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
+  __esModule: true,
+  default: () => mockIsPhone,
+  useIsPhone: () => mockIsPhone,
+}));
+
 // Renders children so the gated action row is exercised; the permission logic
 // itself is covered by PermissionGate's own tests.
 jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
@@ -373,5 +384,46 @@ describe('InsuranceClaims create form', () => {
       'The submitted amount must be above zero.'
     );
     expect(onCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('InsuranceClaims on a phone', () => {
+  beforeEach(() => {
+    mockIsPhone = true;
+  });
+  afterEach(() => {
+    mockIsPhone = false;
+  });
+
+  it('renders the card list instead of the seven-column table', () => {
+    setup();
+
+    // The card carries the table row action's accessible name, so that alone
+    // cannot tell the two apart - the table's own roles can.
+    expect(
+      screen.getByRole('button', { name: 'Open the claim for Bought By Many' })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Status' })).not.toBeInTheDocument();
+
+    /* Status was the column that began 103px off-screen in the table; on the
+       card it leads the row. Scoped to the card rather than the document: the
+       status pill renders the label in a nested span, so a bare getByText
+       matches twice and cannot say WHICH card carries it. */
+    const partiallyApproved = screen
+      .getAllByRole('button', { name: /^Open the claim for / })
+      .find((card) => card.textContent?.includes('Partially approved'));
+    expect(partiallyApproved).toBeDefined();
+    expect(
+      within(partiallyApproved as HTMLElement).getAllByText('Partially approved').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('still renders the table when the viewport is not a phone', () => {
+    mockIsPhone = false;
+    setup();
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/PhoneInsuranceClaimList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/PhoneInsuranceClaimList.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PhoneInsuranceClaimList from '@/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+jest.mock('@/app/lib/money', () => ({
+  formatMoneyPrecise: (amount: number, currency: string) =>
+    `${currency} ${Number(amount).toFixed(2)}`,
+}));
+
+jest.mock(
+  '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge',
+  () => ({
+    __esModule: true,
+    default: ({ status }: { status: string }) => <span>{`badge:${status}`}</span>,
+  })
+);
+
+const claim = (over: Partial<InsuranceClaim> = {}): InsuranceClaim =>
+  ({
+    id: 'c1',
+    organisationId: 'org-1',
+    patientId: 'pat-1',
+    insurerName: 'Petplan',
+    policyNumber: 'POL-9911',
+    claimNumber: 'CLM-2026-004',
+    submittedAmount: 420,
+    approvedAmount: null,
+    paidAmount: null,
+    currency: 'GBP',
+    status: 'SUBMITTED',
+    createdAt: '2026-08-28T09:00:00.000Z',
+    updatedAt: '2026-08-28T09:00:00.000Z',
+    ...over,
+  }) as InsuranceClaim;
+
+const renderList = (props: Partial<React.ComponentProps<typeof PhoneInsuranceClaimList>> = {}) =>
+  render(
+    <PhoneInsuranceClaimList
+      claims={[claim()]}
+      activeClaimId={null}
+      onSelect={jest.fn()}
+      {...props}
+    />
+  );
+
+describe('PhoneInsuranceClaimList', () => {
+  it('leads each card with the insurer and the status the table hid', () => {
+    renderList();
+    expect(screen.getByText('Petplan')).toBeInTheDocument();
+    expect(screen.getByText('badge:SUBMITTED')).toBeInTheDocument();
+  });
+
+  it('carries the same accessible name as the table row action', () => {
+    renderList();
+    expect(screen.getByRole('button', { name: 'Open the claim for Petplan' })).toBeInTheDocument();
+  });
+
+  describe('the settled figure', () => {
+    it('prefers paid over approved and submitted', () => {
+      renderList({
+        claims: [claim({ submittedAmount: 420, approvedAmount: 300, paidAmount: 275 })],
+      });
+      expect(screen.getByText('Paid')).toBeInTheDocument();
+      expect(screen.getByText('GBP 275.00')).toBeInTheDocument();
+      expect(screen.queryByText('GBP 300.00')).not.toBeInTheDocument();
+      expect(screen.queryByText('GBP 420.00')).not.toBeInTheDocument();
+    });
+
+    it('falls back to approved when nothing is paid', () => {
+      renderList({
+        claims: [claim({ submittedAmount: 420, approvedAmount: 300, paidAmount: null })],
+      });
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+      expect(screen.getByText('GBP 300.00')).toBeInTheDocument();
+    });
+
+    it('falls back to the submitted ask when neither is set', () => {
+      renderList({
+        claims: [claim({ submittedAmount: 420, approvedAmount: null, paidAmount: null })],
+      });
+      expect(screen.getByText('Submitted')).toBeInTheDocument();
+      expect(screen.getByText('GBP 420.00')).toBeInTheDocument();
+    });
+
+    it('shows a paid figure of zero rather than falling through to approved', () => {
+      // `paidAmount: 0` is a real settlement - a nullish check is required here,
+      // and a falsy one would report the approved figure as if it had been paid.
+      renderList({ claims: [claim({ approvedAmount: 300, paidAmount: 0 })] });
+      expect(screen.getByText('Paid')).toBeInTheDocument();
+      expect(screen.getByText('GBP 0.00')).toBeInTheDocument();
+    });
+  });
+
+  it('appends the claim number to the policy only when one has been issued', () => {
+    const { unmount } = renderList({ claims: [claim({ claimNumber: 'CLM-2026-004' })] });
+    expect(screen.getByText('POL-9911 · CLM-2026-004')).toBeInTheDocument();
+    unmount();
+
+    renderList({ claims: [claim({ claimNumber: null })] });
+    expect(screen.getByText('POL-9911')).toBeInTheDocument();
+  });
+
+  it('marks the open claim and leaves the others unmarked', () => {
+    renderList({
+      claims: [claim({ id: 'c1' }), claim({ id: 'c2', insurerName: 'Agria' })],
+      activeClaimId: 'c1',
+    });
+    expect(screen.getByRole('button', { name: 'Open the claim for Petplan' }).className).toContain(
+      'border-[var(--blue)]'
+    );
+    expect(screen.getByRole('button', { name: 'Open the claim for Agria' }).className).toContain(
+      'border-[var(--hairline)]'
+    );
+  });
+
+  it('hands the whole claim back when a card is tapped', () => {
+    const onSelect = jest.fn();
+    const only = claim({ id: 'c9' });
+    renderList({ claims: [only], onSelect });
+    fireEvent.click(screen.getByRole('button', { name: 'Open the claim for Petplan' }));
+    expect(onSelect).toHaveBeenCalledWith(only);
+  });
+
+  it('renders nothing but the container when there are no claims', () => {
+    renderList({ claims: [] });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/InsuranceClaims.tsx
@@ -3,6 +3,8 @@ import React, { useMemo } from 'react';
 import InsuranceClaimsHeader from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader';
 import InsuranceClaimsStates from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates';
 import InsuranceClaimList from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList';
+import PhoneInsuranceClaimList from '@/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList';
+import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 import InsuranceClaimDetail, {
   type ClaimAction,
 } from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail';
@@ -59,37 +61,44 @@ type InsuranceClaimsResultsProps = Pick<
   | 'actionError'
 > & { activeClaim: InsuranceClaim | null };
 
-const InsuranceClaimsResults = (props: InsuranceClaimsResultsProps) => (
-  <>
-    <InsuranceClaimsStates
-      loading={props.loading}
-      error={props.error}
-      onReload={props.onReload}
-      isEmpty={props.claims.length === 0}
-      emptyMessage={props.emptyMessage}
-    />
-    {!props.loading && !props.error && props.claims.length > 0 && (
-      <div className="flex flex-col gap-6">
-        <InsuranceClaimList
-          claims={props.claims}
-          activeClaimId={props.activeClaimId}
-          onSelect={props.onSelect}
-        />
-        {props.activeClaim && (
-          <InsuranceClaimDetail
-            claim={props.activeClaim}
-            companionName={props.companionName(props.activeClaim.patientId)}
-            pendingAction={props.pendingAction}
-            onSubmit={props.onSubmitClaim}
-            onCancel={props.onCancelClaim}
-            onUpdateStatus={props.onUpdateStatus}
-            error={props.actionError}
+const InsuranceClaimsResults = (props: InsuranceClaimsResultsProps) => {
+  /* The two lists take identical props, so the breakpoint chooses the component
+     and nothing else. Written as a swap rather than two JSX branches: branching
+     duplicates every prop, and a prop added to one arm and not the other is a
+     difference no type catches. */
+  const ClaimList = useIsPhone() ? PhoneInsuranceClaimList : InsuranceClaimList;
+  return (
+    <>
+      <InsuranceClaimsStates
+        loading={props.loading}
+        error={props.error}
+        onReload={props.onReload}
+        isEmpty={props.claims.length === 0}
+        emptyMessage={props.emptyMessage}
+      />
+      {!props.loading && !props.error && props.claims.length > 0 && (
+        <div className="flex flex-col gap-6">
+          <ClaimList
+            claims={props.claims}
+            activeClaimId={props.activeClaimId}
+            onSelect={props.onSelect}
           />
-        )}
-      </div>
-    )}
-  </>
-);
+          {props.activeClaim && (
+            <InsuranceClaimDetail
+              claim={props.activeClaim}
+              companionName={props.companionName(props.activeClaim.patientId)}
+              pendingAction={props.pendingAction}
+              onSubmit={props.onSubmitClaim}
+              onCancel={props.onCancelClaim}
+              onUpdateStatus={props.onUpdateStatus}
+              error={props.actionError}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+};
 
 /**
  * The Insurance claims screen: the same header anatomy as Finance and Estimates,

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import PhoneInsuranceClaimList from './PhoneInsuranceClaimList';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+/**
+ * The width `/finance/insurance-claims` gives this list on a 390px phone,
+ * measured on the route: `main` is 390 and `yc-page-content` adds 12px gutters,
+ * so the content box is 366.
+ *
+ * Pinned with a decorator rather than a `viewport` global. Two reasons, and the
+ * second is the load-bearing one:
+ *
+ *  - `.storybook/test-runner.ts` falls back to `laptop` (1280x800) for any story
+ *    without a viewport pin, which is wide enough that every assertion below
+ *    would hold no matter what the component did.
+ *  - that hook reads `storyContext.globals`, and Storybook 10 carries the
+ *    annotation as `storyGlobals`, so the pin does not currently apply at all.
+ *    A decorator is the only width these stories are actually given.
+ */
+const ROUTE_CONTENT_WIDTH = 366;
+
+const claim = (
+  id: string,
+  insurerName: string,
+  status: InsuranceClaimStatus,
+  amounts: { submitted: number; approved?: number | null; paid?: number | null },
+  claimNumber: string | null
+): InsuranceClaim =>
+  ({
+    id,
+    organisationId: 'org-1',
+    patientId: 'pat-1',
+    invoiceId: null,
+    encounterId: null,
+    insurerName,
+    policyNumber: 'PS-2291',
+    claimNumber,
+    submittedAmount: amounts.submitted,
+    approvedAmount: amounts.approved ?? null,
+    paidAmount: amounts.paid ?? null,
+    currency: 'GBP',
+    status,
+    submittedAt: null,
+    approvedAt: null,
+    createdAt: '2026-08-28T09:00:00.000Z',
+    updatedAt: '2026-08-28T09:00:00.000Z',
+  }) as InsuranceClaim;
+
+const meta = {
+  title: 'Finance/PhoneInsuranceClaimList',
+  component: PhoneInsuranceClaimList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The phone form of the insurance claims list.\n\n' +
+          '`InsuranceClaims` had no phone branch, so a phone rendered the seven-column table ' +
+          'inside a 364px scroll rail with `Approved`, `Paid`, `Status` and `Actions` past the ' +
+          'right edge - `Status` starting 103px out. The rail works and the page never scrolled ' +
+          'sideways; the defect was that the column the list is consulted for was behind an ' +
+          'undiscoverable swipe.\n\n' +
+          'The card leads with status for that reason, and shows one money figure rather than ' +
+          'three: whichever the claim has reached (paid, else approved, else the submitted ask), ' +
+          'labelled so the number is never ambiguous.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: ROUTE_CONTENT_WIDTH }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  args: {
+    claims: [
+      claim('c1', 'Petsure', 'DRAFT', { submitted: 420 }, null),
+      claim(
+        'c2',
+        'Bought By Many',
+        'PARTIALLY_APPROVED',
+        { submitted: 980, approved: 640 },
+        'BBM-8841'
+      ),
+      claim('c3', 'Agria', 'PAID', { submitted: 1240.6, approved: 1240.6, paid: 1100 }, 'AG-5512'),
+    ],
+    activeClaimId: 'c2',
+    onSelect: () => {},
+  },
+} satisfies Meta<typeof PhoneInsuranceClaimList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const cardFor = (canvas: ReturnType<typeof within>, insurer: string) =>
+  canvas.getByRole('button', { name: `Open the claim for ${insurer}` });
+
+export const Default: Story = {
+  name: 'A card per claim',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(cardFor(canvas, 'Petsure')).toBeInTheDocument();
+    // Minor units survive: 1100 must not print as "£1,100" without decimals.
+    expect(cardFor(canvas, 'Agria').textContent).toContain('£1,100.00');
+  },
+};
+
+export const StatusIsOnScreen: Story = {
+  name: 'Status and the amount need no sideways swipe',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const insurer of ['Petsure', 'Bought By Many', 'Agria']) {
+      const card = cardFor(canvas, insurer);
+
+      /* The defect this component exists to fix. In the table Status sat at
+         x=493..659 and Actions at x=659..744, inside a 364px rail.
+
+         Measured against the CARD, not `canvasElement`: Storybook renders the
+         story inside a full-width <main>, so a check against the canvas passes
+         at any component width and could never fail. */
+      expect(card.scrollWidth).toBeLessThanOrEqual(card.clientWidth);
+    }
+  },
+};
+
+export const OneFigurePerCard: Story = {
+  name: 'The figure shown is the furthest the claim has got',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Paid wins over approved and submitted, and says so.
+    const paid = cardFor(canvas, 'Agria').textContent ?? '';
+    expect(paid).toContain('Paid');
+    expect(paid).toContain('£1,100.00');
+    expect(paid).not.toContain('£1,240.60');
+
+    // Approved wins over the submitted ask.
+    const approved = cardFor(canvas, 'Bought By Many').textContent ?? '';
+    expect(approved).toContain('Approved');
+    expect(approved).toContain('£640.00');
+    expect(approved).not.toContain('£980.00');
+
+    // Nothing settled yet, so the ask is what is shown.
+    const draft = cardFor(canvas, 'Petsure').textContent ?? '';
+    expect(draft).toContain('Submitted');
+    expect(draft).toContain('£420.00');
+  },
+};
+
+export const ActiveCardIsMarked: Story = {
+  name: 'The open claim is marked',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Compared as RENDERED colour, not as a class name: a `toContain` on the
+       className passes as long as the string is present, so it would still pass
+       if the token resolved to the hairline colour or to nothing. */
+    const borderOf = (el: Element) => globalThis.getComputedStyle(el).borderTopColor;
+    expect(borderOf(cardFor(canvas, 'Bought By Many'))).not.toBe(
+      borderOf(cardFor(canvas, 'Agria'))
+    );
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/PhoneInsuranceClaimList.tsx
@@ -1,0 +1,113 @@
+'use client';
+import React from 'react';
+
+import { formatMoneyPrecise } from '@/app/lib/money';
+import InsuranceClaimStatusBadge from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+type PhoneInsuranceClaimListProps = {
+  claims: InsuranceClaim[];
+  /** The open claim, marked in the list the way the table marks its row. */
+  activeClaimId: string | null;
+  onSelect: (claim: InsuranceClaim) => void;
+};
+
+const CARD_SHADOW = 'shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]';
+
+/**
+ * The settled figure a claim is judged on, and its label.
+ *
+ * The table gives Submitted, Approved and Paid three columns of equal weight.
+ * A card cannot, and equal weight is not what an operator wants anyway: what
+ * matters is how far the claim has got. Paid wins if present, then approved,
+ * then the submitted ask - and the label says which, so a number is never
+ * ambiguous about what it represents.
+ */
+const settledFigure = (claim: InsuranceClaim): { label: string; value: string } => {
+  /* No dash branch, unlike the table's money cell. The table renders Approved
+     and Paid as their own columns and each can be null; here every path has
+     already established the figure it formats, so a nullable helper would be a
+     branch nothing can reach. */
+  const format = (amount: number) => formatMoneyPrecise(amount, claim.currency);
+  if (claim.paidAmount != null) return { label: 'Paid', value: format(claim.paidAmount) };
+  if (claim.approvedAmount != null)
+    return { label: 'Approved', value: format(claim.approvedAmount) };
+  return { label: 'Submitted', value: format(claim.submittedAmount) };
+};
+
+type PhoneInsuranceClaimCardProps = {
+  claim: InsuranceClaim;
+  isActive: boolean;
+  onSelect: (claim: InsuranceClaim) => void;
+};
+
+const PhoneInsuranceClaimCard = ({ claim, isActive, onSelect }: PhoneInsuranceClaimCardProps) => {
+  const figure = settledFigure(claim);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(claim)}
+      /* The same accessible name the table's eye button carries, so the label is
+         one string across both breakpoints rather than two that drift. */
+      aria-label={`Open the claim for ${claim.insurerName}`}
+      className={`w-full text-left flex flex-col gap-[7px] rounded-2xl bg-[var(--screen)] px-3.5 py-3 border ${
+        isActive ? 'border-[var(--blue)] bg-card-hover' : 'border-[var(--hairline)]'
+      } ${CARD_SHADOW}`}
+    >
+      <span className="flex items-start justify-between gap-2">
+        {/* Wraps rather than clipping. The table truncates both of these and
+            offers the full value through `title`, which needs a hover this
+            surface does not have; a card can grow downwards instead. */}
+        <span className="min-w-0 break-words text-[13.5px] font-bold text-[var(--ink)]">
+          {claim.insurerName}
+        </span>
+        {/* Status leads the card because it is the column the table pushed
+            furthest off-screen, and the one a claims list is opened to read. */}
+        <InsuranceClaimStatusBadge status={claim.status} />
+      </span>
+      <span className="flex items-center justify-between gap-2">
+        <span className="min-w-0 break-words text-[11.5px] text-[var(--ink-faint)]">
+          {claim.claimNumber ? `${claim.policyNumber} · ${claim.claimNumber}` : claim.policyNumber}
+        </span>
+        <span className="shrink-0 text-right">
+          <span className="block text-[10px] text-[var(--ink-faint)]">{figure.label}</span>
+          <span className="block text-[14px] font-bold tabular-nums text-[var(--ink)]">
+            {figure.value}
+          </span>
+        </span>
+      </span>
+    </button>
+  );
+};
+
+/**
+ * The phone (< 768px) form of the insurance claims list.
+ *
+ * `InsuranceClaims` had no phone branch, so a phone rendered
+ * `InsuranceClaimList`'s seven-column table inside a 364px rail with `Approved`,
+ * `Paid`, `Status` and `Actions` past the right edge - `Status` starting 103px
+ * out. The rail scrolls, so the page never moved sideways; the problem was that
+ * the decisive column was behind an undiscoverable swipe.
+ *
+ * Mirrors `PhoneEstimateList` and `PhoneInvoiceList` so the finance lists read
+ * as one product at this width.
+ */
+const PhoneInsuranceClaimList = ({
+  claims,
+  activeClaimId,
+  onSelect,
+}: PhoneInsuranceClaimListProps) => (
+  <div className="flex flex-col gap-2.5 pb-1">
+    {claims.map((claim) => (
+      <PhoneInsuranceClaimCard
+        key={claim.id}
+        claim={claim}
+        isActive={claim.id === activeClaimId}
+        onSelect={onSelect}
+      />
+    ))}
+  </div>
+);
+
+export default PhoneInsuranceClaimList;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`InsuranceClaims` has zero `useIsPhone` references, so a 390px phone renders `InsuranceClaimList`'s seven-column table inside a 364px scroll rail:

```
  visible    Insurer / policy   left=13   right=161
  visible    Claim no.          left=161  right=248
  visible    Submitted          left=248  right=339
OFFSCREEN    Approved           left=339  right=426
OFFSCREEN    Paid               left=426  right=493
OFFSCREEN    Status             left=493  right=659
OFFSCREEN    Actions            left=659  right=744
```

**Not a layout-overflow bug, and the PR does not claim it is.** The rail scrolls and the page does not (`documentElement.scrollWidth === clientWidth === 390`). I screened every viewport escape across the finance, inventory, tasks and dashboard stories - 819 of them - and all 819 sit inside a scrolled `overflow-x` ancestor. Zero unrescued.

What is wrong is that `Status` begins 103px past the edge behind an undiscoverable swipe. On a claims list that is the one field that cannot be inferred from anywhere else, which makes it a worse hide than `Total` was on estimates (#2782).

**How this was found is worth recording**, because it is the same mistake the sibling issue warns about. When I filed #2782 I quoted the Estimates link in `Finance/index.tsx`'s `isPhone` branch and then reasoned about the other routes from memory. That branch renders **three** links. Re-reading the eight lines rather than remembering them turned up this screen, which I had never rendered.

## What is the new behavior?

`PhoneInsuranceClaimList` below `md`, mirroring `PhoneEstimateList` and `PhoneInvoiceList`.

- **Status leads the card**, because it is the column the table pushed furthest off-screen.
- **One money figure, not three.** Paid if present, else approved, else the submitted ask - each labelled, so a number is never ambiguous about what it represents. A card cannot give three amounts equal weight, and equal weight is not what an operator wants: what matters is how far the claim has got.
- **Same accessible name** as the table's row action, so the page's existing tests and a screen reader see one label across both breakpoints.
- Insurer and policy **wrap rather than clipping**. The table truncates both and offers the full value through `title`, which needs a hover this surface does not have.

**Deliberately no nullable money helper.** The table needs one because Approved and Paid are their own columns and each can be null. Here every path has already established the figure it formats, so the dash branch was unreachable - the first version scored 92.85% branches on exactly that dead arm. Deleted rather than tested; writing a test to reach dead code is how the arm survives.

## Verification

Measured at the width the route gives the list - `main` 390, `yc-page-content` 12px gutters, so **366px** - in both themes.

**Every added assertion mutation-checked.** Each mutation applied, watched go red, reverted, watched go green:

| Mutation | Result |
| --- | --- |
| `paidAmount != null` -> `paidAmount` (falsy) | the paid-zero test fails |
| paid/approved precedence flipped | 2 tests fail |
| claim-number join always applied | the policy-line test fails |
| component swap pinned to the desktop table | the phone-branch page test fails |

The `paidAmount: 0` case is the one worth having: a settled-for-nothing claim is real, and a falsy check reports the *approved* figure as if it had been paid.

Story assertions are pinned to 366px by a decorator rather than a `viewport` global, for two reasons. `.storybook/test-runner.ts` falls back to laptop 1280x800 for an unpinned story, where every geometry assertion here would hold regardless of what the component did. And that hook reads `storyContext.globals` while Storybook 10 carries the annotation as `storyGlobals`, so viewport pins are currently inert - a decorator is the only width these stories are actually given.

```
frontend  tsc --noEmit                     exit 0
frontend  eslint                           exit 0 (2 pre-existing warnings, files untouched)
          jest InsuranceClaims             34 passed, 2 suites
          coverage PhoneInsuranceClaimList 100% statements / branches / functions / lines
```

## Related Issue(s)

Fixes #2786
