### PR TITLE
fix(frontend): wrap the appointment overview values instead of clipping them

### DIFF
--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.stories.tsx
@@ -439,6 +439,18 @@ export const OverviewNarrow: Story = {
     await expect(panel.getByText('General practice')).toBeInTheDocument();
     await expect(panel.getByRole('button', { name: 'Room: Consult 2' })).toBeInTheDocument();
     await expect(panel.getByRole('button', { name: 'Start appointment' })).toBeEnabled();
+
+    /* "it does not truncate" was the claim above, and none of those assertions
+       could check it: `getByText` matches the DOM text node, which is complete
+       even when the paint is clipped. Chief complaint WAS truncating here,
+       losing 62px with no `title` to recover it on a surface that has no hover.
+       Measured instead - a clipped cell has more scrollWidth than clientWidth. */
+    const values = panel.getAllByTestId('overview-row-value');
+    await expect(values.length).toBeGreaterThan(0);
+    const clipped = values
+      .filter((cell) => cell.scrollWidth > cell.clientWidth + 1)
+      .map((cell) => `${cell.textContent?.trim()} (+${cell.scrollWidth - cell.clientWidth}px)`);
+    await expect(clipped).toEqual([]);
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -89,10 +89,22 @@ const getParentPhotoUrl = (
     appointmentParent?.image
   );
 
+/* The value WRAPS rather than truncating. `truncate` clips with an ellipsis and
+   no `title`, so on a phone - which has no hover - the tail of any long value is
+   simply unreachable. At 390px exactly one row overflows, and it is
+   "Chief complaint": the one free-text clinical field on this sheet, losing 62px
+   of "Limping on the left hind leg since Sunday." in both themes. A tooltip
+   would not fix that on the surface where it matters; more lines will.
+   `items-start` so the label sits against the first line of a value that now
+   runs to several, and a gap so a long label and a wrapped value cannot meet in
+   the middle. */
 const OverviewRow = ({ label, value }: OverviewRowProps) => (
-  <div className="flex items-center justify-between py-2 border-b border-card-border last:border-0">
+  <div className="flex items-start justify-between gap-3 py-2 border-b border-card-border last:border-0">
     <span className="font-satoshi text-sm font-medium text-text-secondary">{label}</span>
-    <span className="font-satoshi text-sm text-text-primary text-right max-w-[60%] truncate">
+    <span
+      data-testid="overview-row-value"
+      className="font-satoshi text-sm text-text-primary text-right max-w-[60%] break-words"
+    >
       {value || '-'}
     </span>
   </div>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass (one caveat, stated below).

## What is the current behavior?

`ViewAppointmentOverviewModal`'s `OverviewRow` renders every value with `max-w-[60%] truncate` and no `title`. `truncate` clips with an ellipsis, and a phone has no hover, so the tail of any long value is unreachable there.

Measured on the rendered DOM at 390x844, both themes - exactly one of the eleven rows overflows:

```
ok        0px  Date / Time / Duration / Speciality / Service / Emergency
CLIPPED  62px  Chief complaint    white-space: nowrap    title: none
              "Limping on the left hind leg since Sunday."
```

It is the one free-text clinical field on the sheet, and the reason a clinician opens it.

## What is the new behavior?

The value wraps instead of truncating. `items-start` so the label sits against the first line of a value that can now run to several, and a `gap-3` so a long label and a wrapped value cannot meet in the middle.

After, both themes: **0 clipped rows**, chief complaint on two lines. No other row's rendering changes - every one of them fits on a single line at 390px before and after.

## The story already claimed this, and could not check it

```
// Both columns still render in full - the layout reflows, it does not truncate.
await expect(panel.getByText('General practice')).toBeInTheDocument();
```

`getByText` matches the DOM text node, which is complete even when the paint is clipped. So the assertion written for exactly this property could not fail on it. Replaced with a measurement across every value cell:

```ts
const clipped = values.filter((cell) => cell.scrollWidth > cell.clientWidth + 1)
expect(clipped).toEqual([])
```

**Mutation**: restoring `truncate` fails it with `expected [ Array(1) ] to deeply equal []`.

## One honest caveat about CI

That play function currently fails on `dev` before it ever reaches the new assertion, because the test runner executes it at 1280px rather than the 375px it pins - #2792, fixed by #2793. With that fix applied locally this suite is **6 passed, 6 total**. Without it, the new assertion is inert in CI rather than wrong. I would merge #2793 first.

## Testing

```
tsc --noEmit                                    0
jest --testPathPatterns=ViewAppointmentOverviewModal   45 passed
test-storybook ViewAppointmentOverviewModal     6 passed   (with #2793 applied)
```

Verified visually at 390x844 in both themes.

## Related Issue(s)

Refs #2790