### PR TITLE
fix(frontend): take the inventory filter chips off the badge-blue pair, 3.61:1

### DIFF
--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
@@ -5,6 +5,15 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import type { InventoryFiltersState } from '@/app/features/inventory/pages/Inventory/types';
 import { defaultFilters } from '@/app/features/inventory/pages/Inventory/utils';
 import InventoryFilterModal, { type FilterChip } from './InventoryFilterModal';
+/* Cross-feature import, and deliberately so rather than a second copy: this is
+   the probe merged with #2785, and a duplicated contrast helper is how the two
+   drift apart on the thing they both exist to measure. It belongs in
+   `@/app/lib`; moving it means touching a file another desk merged an hour ago,
+   so that is a separate change and not mine to make unasked. */
+import {
+  describeContrast,
+  measureContrast,
+} from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
 
 const LOCATIONS = ['Main store', 'Pharmacy fridge', 'Surgery trolley'];
 const CATEGORIES = ['Medicine', 'Vaccine', 'Consumable'];
@@ -206,6 +215,56 @@ const findOpenDialog = async () => {
   return openDialog();
 };
 
+/** Every chip the seeded selection produces, in render order: status, then the two
+    categories, then the subcategory, then the location. */
+const CHIP_LABELS = ['low stock', 'Medicine', 'Vaccine', 'Antibiotic', 'Main store'];
+
+/**
+ * Every chip label must be readable on the chip's own composited fill.
+ *
+ * The chip shipped as `bg-badge-blue-bg text-badge-blue-text` - #eaf3ff on
+ * #007cf5 - which measures 3.61:1 at 14px/500 where 4.5:1 is required. Measured
+ * on composited pixels rather than asserted on class names: the class was
+ * present and correct-looking, and only the pixels can fail.
+ *
+ * Run from BOTH a light-pinned and a dark-pinned story. The badge-blue pair has
+ * no dark variant, so this particular defect fails identically in both - but the
+ * fix moves the chip onto `--inset`/`--ink`, which DO flip per theme (13.24:1
+ * light, 12.64:1 dark), and a single-theme reading of a theme-flipping pair only
+ * ever covers half of it. Which half would depend on the toolbar default rather
+ * than on anything the story says, which is why both stories pin `theme`.
+ */
+const expectChipLabelsReadable = async (dialog: HTMLElement) => {
+  const panel = within(dialog);
+  // The row has to be the length we think it is before a reading off it means
+  // anything: a loop over zero chips passes without measuring a single pixel, and a
+  // loop over three of five reports a clean row while two go unmeasured.
+  await expect(panel.getAllByRole('button', { name: /^Remove / })).toHaveLength(
+    CHIP_LABELS.length
+  );
+  for (const label of CHIP_LABELS) {
+    const chip = panel.getByRole('button', { name: `Remove ${label}` }).parentElement;
+    await expect(chip).not.toBeNull();
+    const reading = measureContrast(chip as Element);
+    await expect(
+      reading.ratio,
+      describeContrast(`filter chip "${label}"`, reading)
+    ).toBeGreaterThanOrEqual(reading.required);
+  }
+};
+
+/** Seeds the one state that renders the chip row; shared by the two theme stories. */
+const SELECTED_ARGS = {
+  openSections: ['stock-status', 'category'],
+  expandedCategories: ['Medicine'],
+  initialFilters: {
+    status: 'LOW_STOCK' as const,
+    categories: ['Medicine', 'Vaccine'],
+    subCategories: ['Antibiotic'],
+    locations: ['Main store'],
+  },
+};
+
 const meta = {
   title: 'Inventory/InventoryFilterModal',
   component: InventoryFilterHarness,
@@ -373,19 +432,15 @@ export const SubcategoriesExpanded: Story = {
 };
 
 export const WithSelections: Story = {
-  name: 'With chips and counts',
-  args: {
-    openSections: ['stock-status', 'category'],
-    expandedCategories: ['Medicine'],
-    initialFilters: {
-      status: 'LOW_STOCK',
-      categories: ['Medicine', 'Vaccine'],
-      subCategories: ['Antibiotic'],
-      locations: ['Main store'],
-    },
-  },
+  name: 'With chips and counts (light)',
+  args: SELECTED_ARGS,
+  /* Pinned rather than inherited. The contrast assertion below is only capable of
+     failing in light, so leaving the theme to the toolbar default makes it silently
+     vacuous the day that default changes. */
+  globals: { theme: 'light' },
   play: async () => {
-    const panel = within(openDialog());
+    const dialog = openDialog();
+    const panel = within(dialog);
     // The chip row and the "Clear all" pill exist only while something is selected.
     await expect(panel.getByRole('button', { name: 'Clear all' })).toBeInTheDocument();
     await expect(panel.getByRole('button', { name: 'Remove low stock' })).toBeInTheDocument();
@@ -398,6 +453,8 @@ export const WithSelections: Story = {
     // The nested subcategory is both checked and expanded.
     await expect(panel.getByRole('checkbox', { name: 'Antibiotic' })).toBeChecked();
     await expect(panel.getByRole('checkbox', { name: 'Medicine' })).toBeChecked();
+
+    await expectChipLabelsReadable(dialog);
     await expect(panel.getByRole('radio', { name: 'low stock' })).toBeChecked();
   },
   parameters: {
@@ -409,6 +466,30 @@ export const WithSelections: Story = {
           'rendered - the badge is a `size-5` circle inside the header row, so its presence changes ' +
           'that row rather than overlaying it. Note the collapsed Location section still counts 1 ' +
           'even with nothing on screen to explain it: that badge is the only trace of the filter.',
+      },
+    },
+  },
+};
+
+export const WithSelectionsDark: Story = {
+  name: 'With chips and counts (dark)',
+  args: SELECTED_ARGS,
+  globals: { theme: 'dark' },
+  play: async () => {
+    const dialog = openDialog();
+    // Chips only, and the count guard lives in the helper. The light story above owns
+    // the structural assertions; repeating them here would be a second copy to drift.
+    await expectChipLabelsReadable(dialog);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same seeded selection in espresso dark, and it is a real control rather than a ' +
+          'decorative twin: restoring `bg-badge-blue-bg text-badge-blue-text` fails this story at ' +
+          'the same 3.61:1 as the light one, because that pair has no dark variant. The pair the ' +
+          'fix uses does flip - `--inset`/`--ink` measures 13.24:1 in light and 12.64:1 here - so ' +
+          'this is the story that would catch the chip surface being re-tinted in dark alone.',
       },
     },
   },

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
@@ -5,11 +5,8 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 import type { InventoryFiltersState } from '@/app/features/inventory/pages/Inventory/types';
 import { defaultFilters } from '@/app/features/inventory/pages/Inventory/utils';
 import InventoryFilterModal, { type FilterChip } from './InventoryFilterModal';
-/* Cross-feature import, and deliberately so rather than a second copy: this is
-   the probe merged with #2785, and a duplicated contrast helper is how the two
-   drift apart on the thing they both exist to measure. It belongs in
-   `@/app/lib`; moving it means touching a file another desk merged an hour ago,
-   so that is a separate change and not mine to make unasked. */
+/* Shared rather than copied: two contrast helpers drift apart on the one thing
+   they both exist to measure. Relocating it to `@/app/lib` is a separate change. */
 import {
   describeContrast,
   measureContrast,
@@ -222,26 +219,19 @@ const CHIP_LABELS = ['low stock', 'Medicine', 'Vaccine', 'Antibiotic', 'Main sto
 /**
  * Every chip label must be readable on the chip's own composited fill.
  *
- * The chip shipped as `bg-badge-blue-bg text-badge-blue-text` - #eaf3ff on
- * #007cf5 - which measures 3.61:1 at 14px/500 where 4.5:1 is required. Measured
- * on composited pixels rather than asserted on class names: the class was
- * present and correct-looking, and only the pixels can fail.
+ * Measured on composited pixels rather than asserted on class names: a class name
+ * is still there when the colour under it is wrong, so only the pixels can fail.
  *
- * Run from BOTH a light-pinned and a dark-pinned story. The badge-blue pair has
- * no dark variant, so this particular defect fails identically in both - but the
- * fix moves the chip onto `--inset`/`--ink`, which DO flip per theme (13.24:1
- * light, 12.64:1 dark), and a single-theme reading of a theme-flipping pair only
- * ever covers half of it. Which half would depend on the toolbar default rather
- * than on anything the story says, which is why both stories pin `theme`.
+ * Called from a light-pinned and a dark-pinned story because the chip's colours
+ * flip per theme, and a single-theme reading of a theme-flipping pair covers half
+ * of it - with which half decided by the toolbar default rather than by the story.
  */
 const expectChipLabelsReadable = async (dialog: HTMLElement) => {
   const panel = within(dialog);
   // The row has to be the length we think it is before a reading off it means
   // anything: a loop over zero chips passes without measuring a single pixel, and a
   // loop over three of five reports a clean row while two go unmeasured.
-  await expect(panel.getAllByRole('button', { name: /^Remove / })).toHaveLength(
-    CHIP_LABELS.length
-  );
+  await expect(panel.getAllByRole('button', { name: /^Remove / })).toHaveLength(CHIP_LABELS.length);
   for (const label of CHIP_LABELS) {
     const chip = panel.getByRole('button', { name: `Remove ${label}` }).parentElement;
     await expect(chip).not.toBeNull();

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
@@ -424,9 +424,9 @@ export const SubcategoriesExpanded: Story = {
 export const WithSelections: Story = {
   name: 'With chips and counts (light)',
   args: SELECTED_ARGS,
-  /* Pinned rather than inherited. The contrast assertion below is only capable of
-     failing in light, so leaving the theme to the toolbar default makes it silently
-     vacuous the day that default changes. */
+  /* Pinned rather than inherited. The same helper runs here and in the dark story,
+     so both readings are explicit instead of resting on whatever the toolbar
+     happens to default to. */
   globals: { theme: 'light' },
   play: async () => {
     const dialog = openDialog();

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
@@ -118,21 +118,11 @@ const SelectedFilterChips = ({ selectedFilterChips }: SelectedFilterChipsProps) 
       {selectedFilterChips.map((chip) => (
         <span
           key={chip.id}
-          /* Off the badge-blue palette, because that pair cannot be made to
-             pass AA. This chip shipped as `bg-badge-blue-bg text-badge-blue-text`
-             - #eaf3ff on #007cf5 - which measures 3.61:1 in BOTH themes at
-             14px/500, where 4.5:1 is required. The pair has no dark variant, so
-             the failure is theme-independent, and re-inking it does not save it:
-             on a #007cf5 fill the best any ink can reach is 5.20:1 (pure black),
-             and white is 4.04:1 - which globals.css:1693 already recorded for
-             the neighbouring shade. So the fill has to change, and a removable
-             applied-filter chip is not a status badge; `--inset`/`--ink` is the
-             quiet surface pair and measures 13.24:1 light, 12.64:1 dark.
-             (The design system also has `--chip-selected-bg`/`--chip-selected-ink`
-             = `--ink`/`--screen`, a solid inverted pill. That is the TOGGLE chip
-             in ui/filters/FilterChip; using it here would turn a row of five
-             removable chips into five solid dark pills, which is a visual-weight
-             change rather than a contrast fix. One line if a reviewer wants it.) */
+          /* Not badge-blue: `text-badge-blue-text` on `bg-badge-blue-bg` is
+             #eaf3ff on #007cf5, which is 3.61:1 at this size where AA needs 4.5,
+             and no ink the palette uses clears it on that fill (white is 4.04).
+             So the fill changes rather than the ink, onto the surface pair the
+             other inventory badges already use. */
           className="inline-flex items-center gap-1.5 rounded-full bg-[var(--inset)] py-1 pl-3 pr-2 text-caption-1 capitalize text-[var(--ink)]"
         >
           {chip.label}
@@ -140,8 +130,7 @@ const SelectedFilterChips = ({ selectedFilterChips }: SelectedFilterChipsProps) 
             type="button"
             aria-label={`Remove ${chip.label}`}
             onClick={chip.onRemove}
-            /* Hover tint follows the chip's own ink, since the badge-blue
-               tint it used no longer appears anywhere on this chip. */
+            /* Hover tint follows the chip's ink, not the removed badge token. */
             className="inline-flex size-4 items-center justify-center rounded-full hover:bg-[var(--ink)]/10 transition-colors"
           >
             <FiX size={12} aria-hidden="true" />

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
@@ -118,14 +118,31 @@ const SelectedFilterChips = ({ selectedFilterChips }: SelectedFilterChipsProps) 
       {selectedFilterChips.map((chip) => (
         <span
           key={chip.id}
-          className="inline-flex items-center gap-1.5 rounded-full bg-[var(--inset)] text-[var(--ink)] py-1 pl-3 pr-2 text-caption-1 capitalize text-badge-blue-text"
+          /* Off the badge-blue palette, because that pair cannot be made to
+             pass AA. This chip shipped as `bg-badge-blue-bg text-badge-blue-text`
+             - #eaf3ff on #007cf5 - which measures 3.61:1 in BOTH themes at
+             14px/500, where 4.5:1 is required. The pair has no dark variant, so
+             the failure is theme-independent, and re-inking it does not save it:
+             on a #007cf5 fill the best any ink can reach is 5.20:1 (pure black),
+             and white is 4.04:1 - which globals.css:1693 already recorded for
+             the neighbouring shade. So the fill has to change, and a removable
+             applied-filter chip is not a status badge; `--inset`/`--ink` is the
+             quiet surface pair and measures 13.24:1 light, 12.64:1 dark.
+             (The design system also has `--chip-selected-bg`/`--chip-selected-ink`
+             = `--ink`/`--screen`, a solid inverted pill. That is the TOGGLE chip
+             in ui/filters/FilterChip; using it here would turn a row of five
+             removable chips into five solid dark pills, which is a visual-weight
+             change rather than a contrast fix. One line if a reviewer wants it.) */
+          className="inline-flex items-center gap-1.5 rounded-full bg-[var(--inset)] py-1 pl-3 pr-2 text-caption-1 capitalize text-[var(--ink)]"
         >
           {chip.label}
           <button
             type="button"
             aria-label={`Remove ${chip.label}`}
             onClick={chip.onRemove}
-            className="inline-flex size-4 items-center justify-center rounded-full hover:bg-badge-blue-text/15 transition-colors"
+            /* Hover tint follows the chip's own ink, since the badge-blue
+               tint it used no longer appears anywhere on this chip. */
+            className="inline-flex size-4 items-center justify-center rounded-full hover:bg-[var(--ink)]/10 transition-colors"
           >
             <FiX size={12} aria-hidden="true" />
           </button>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

> **Rewritten at `c5bf9b59d`. The previous body of this PR stated a mechanism and a
> before-number that were both wrong, and it was approved on the strength of them.**
> The retraction is at the bottom; the corrected finding is below.

## What is the current behavior?

The selected-filter chips in the inventory filter drawer render
`text-badge-blue-text` on `bg-badge-blue-bg` — `#eaf3ff` on `#007cf5` — which
measures **3.61:1** at 14px/500, where WCAG AA needs 4.5:1.

Measured on composited pixels, both themes, at 390x844:

```
                 ink              fill               ratio   needs
before  light    rgb(234,243,255) rgb(0,124,245)      3.61     4.5   FAIL
before  dark     rgb(234,243,255) rgb(0,124,245)      3.61     4.5   FAIL
```

The pair has **no dark variant** — `--color-badge-blue-bg`/`-text` are declared once
in `globals.css:476-477` with no `html[data-theme='dark']` override — so the failure
is theme-independent. Both theme-pinned stories fail identically when the classes are
restored, which is the measurement, not the grep.

## What is the new behavior?

```
after   light    rgb(29,28,27)    rgb(234,226,213)   13.24     4.5   PASS
after   dark     rgb(244,239,230) rgb(48,40,32)      12.64     4.5   PASS
```

### Why not re-ink the badge-blue pair

```
ink #eaf3ff  on #007cf5   3.61:1  FAIL
ink #ffffff  on #007cf5   4.04:1  FAIL   already recorded at globals.css:1693
ink --ink    on #007cf5   4.21:1  FAIL   the app's darkest text token
ink #000000  on #007cf5   5.20:1  PASS   the ceiling for ANY ink on this fill
```

**Correction to an earlier version of this body and my post in the channel:** I wrote
"no ink fixes it", which the last row contradicts. The accurate statement is that no
ink in the register the palette uses fixes it — every light ink fails, `--ink` fails,
and the only thing that clears 4.5 is near-black text on a saturated brand-blue pill,
which is not a design anyone would choose. That is an argument about the palette rather
than about the arithmetic, and it is the better one. The fill has to change. A removable applied-filter chip is not a status badge, so
it moves to the quiet surface pair `--inset`/`--ink`, which flips with the theme.

**This is not a new pairing invented here.** `0e5e9de36` already moved the on-hand,
available, gross-profit and margin badges off badge-blue onto exactly this pair, and
it is in this branch's ancestry. (`94c3a67c9` moved a badge-blue span without changing
the pair — it is not precedent, and crediting it was mine to correct.) This chip is
the straggler. On
`origin/dev` that leaves exactly one className string still carrying the pair —
`Inventory/index.tsx:383`, the count badge — which is #2799 and is being fixed at its
own site, not here.

The design system also has `--chip-selected-bg`/`--chip-selected-ink`
(= `--ink`/`--screen`), but that is the solid inverted pill used by the `ui/filters`
toggle chip; using it here would turn a row of five removable chips into five solid
dark pills. That is a visual-weight change rather than a contrast fix — one line if a
reviewer prefers it.

## Testing

```
tsc --noEmit                                   rc 0, 0 lines
eslint (both changed files)                    rc 0
jest --ci (whole frontend package)             1039 suites / 13147 tests passed, rc 0
test-storybook InventoryFilterModal            7 passed, 7 total, rc 0
```

### Mutation, and what each story is worth

Restoring `bg-badge-blue-bg text-badge-blue-text`:

```
WithSelections      (light-pinned)  FAILS  filter chip "low stock": 3.61:1 (needs 4.5:1)
                                           rgb(234,243,255) on rgb(0,124,245) at 14px/500
WithSelectionsDark  (dark-pinned)   FAILS  same 3.61:1 — the pair has no dark variant
Tests: 2 failed, 5 passed, 7 total
```

Both stories pin `theme` through story globals rather than inheriting the toolbar
default. **The pin is load-bearing and provably so:** with `globals: { theme: 'light' }`
on the story, an explicit `&globals=theme:dark` in the iframe URL is overridden and the
render stays light; the same URL parameter on an unpinned story does render dark
(`rgb(244,239,230)` on `rgb(48,40,32)`). So an unpinned assertion here is at the mercy
of a default rather than of anything the story says.

The helper also asserts the chip row length before measuring. That guard caught this
change measuring **three** of the five chips the seed produces — a loop over a subset
reports a clean row while the rest go unmeasured.

## Retraction of this PR's previous body

The earlier body claimed the chip carried **two** conflicting text-colour classes
(`text-[var(--ink)]` and `text-badge-blue-text`) resolved by stylesheet order, at
**1.15:1** in light and passing at 12.94:1 in dark.

None of that is true of any commit. `origin/dev` has one text colour on that chip. The
1.15/12.94 pair is `#eaf3ff` measured on the `--inset` fill:

```
#eaf3ff on --inset light rgb(234,226,213)  = 1.15   <- published as "before, light"
#eaf3ff on --inset dark  rgb(48,40,32)     = 12.94  <- published as "before, dark"
```

That is the old ink on the new fill — a state that exists in neither `dev` nor this
branch. It was **my own half-applied edit**: I had already changed the background and
not yet the ink when I took the "before" reading. Both numbers reproduce to the second
decimal from those two colours, which is how the diagnosis was confirmed rather than
guessed.

The "before" arm has to come from a clean checkout of the base commit, not from a
working tree mid-edit. The after-numbers (13.24 / 12.64) were always correct.

## Related Issue(s)

Refs #2799


---

## Head `301fed788` — rebased onto `24ed9856e`, plus one prose fix

Naming the head sha here deliberately: on this repo a rebase rewrites a review's `commit_id`
to follow the new head, so the metadata cannot tell a later reader which tree was approved.
The review body and this line can.

```
50e3db985   rebase onto 24ed9856e, patch byte-identical to what was approved at b46e41c44
301fed788   drop a story comment that still asserted the retracted mechanism (prose only)
```

The second commit answers an Aikido `AIK_AI_prefer_simplicity` MEDIUM: a comment above the
light story still read *"the contrast assertion below is only capable of failing in light"*,
which was true of the withdrawn 1.15:1 mechanism and false of the real 3.61:1 one — and it
contradicted `WithSelectionsDark` six lines below it. No code or assertion changed.

Gate and checks at this head:

```
No named external product        SUCCESS      (ran for the first time, from the rebased base)
local scan, six surfaces         exit 0       agrees with CI
tsc --noEmit                     0
test-storybook InventoryFilterModal   7 passed, 7 total
```
