### PR TITLE
fix(frontend): reserve the consent strip in the two phone-only shells

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
@@ -1,0 +1,145 @@
+import {
+  HEADER_PX,
+  MIN_H_PX,
+  TAB_BAR_PX,
+  chooseProbeInset,
+  describeInsetProbe,
+  expectedShellHeight,
+  measureConsentInsetResponse,
+} from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
+
+/**
+ * A shell whose height follows the calc the two phone shells use:
+ *   100dvh - 54px - max(72px, --yc-consent-inset)
+ * `responds` false models the shipped bug - the literal two-element sum, which
+ * ignores the inset entirely.
+ */
+const fakeShell = (viewportHeight: number, { responds }: { responds: boolean }) => {
+  let inset = 0;
+  return {
+    setInset: (value: string | null) => {
+      inset = value === null ? 0 : Number.parseFloat(value);
+    },
+    shell: {
+      getBoundingClientRect: () =>
+        ({
+          height:
+            viewportHeight - HEADER_PX - (responds ? Math.max(TAB_BAR_PX, inset) : TAB_BAR_PX),
+        }) as DOMRect,
+    },
+  };
+};
+
+describe('chooseProbeInset', () => {
+  it('prefers 252px when the viewport can carry it above the floor', () => {
+    expect(chooseProbeInset(844)).toEqual({ usable: true, inset: 252 });
+  });
+
+  it('shrinks the inset rather than letting the floor answer', () => {
+    // 667 - 54 - 480 - 1 = 132, below the preferred 252 but still above the bar.
+    expect(chooseProbeInset(667)).toEqual({ usable: true, inset: 132 });
+  });
+
+  it('refuses when no inset can beat the tab-bar term', () => {
+    /* At 600px the largest inset that stays above the floor is 65, which loses
+       to `max(72px, ...)` - so the calc would never be exercised and a pass
+       would mean nothing. Refusing is the only honest answer. */
+    const choice = chooseProbeInset(600);
+    expect(choice.usable).toBe(false);
+    expect(choice.inset).toBeLessThanOrEqual(TAB_BAR_PX);
+    expect('reason' in choice && choice.reason).toContain('too short');
+  });
+
+  it('treats exactly the tab-bar width as unusable, not usable', () => {
+    // inset === TAB_BAR_PX changes nothing under max(), so the boundary is <=.
+    const height = HEADER_PX + MIN_H_PX + 1 + TAB_BAR_PX;
+    expect(chooseProbeInset(height).usable).toBe(false);
+  });
+});
+
+describe('expectedShellHeight', () => {
+  it('derives from the viewport rather than a literal difference', () => {
+    // 844 - 54 - 252. A literal `252 - 72` would encode env(safe-area) = 0.
+    expect(expectedShellHeight(844, 252)).toBe(538);
+    expect(expectedShellHeight(812, 252)).toBe(506);
+  });
+});
+
+describe('measureConsentInsetResponse', () => {
+  it('passes a shell that reserves the strip', () => {
+    const { shell, setInset } = fakeShell(844, { responds: true });
+    const result = measureConsentInsetResponse(shell, 844, setInset);
+    expect(result.ok).toBe(true);
+    expect(result.before).toBe(718);
+    expect(result.withCard).toBe(538);
+    expect(result.expected).toBe(538);
+  });
+
+  it('fails the shipped bug: a shell that ignores the inset', () => {
+    const { shell, setInset } = fakeShell(844, { responds: false });
+    const result = measureConsentInsetResponse(shell, 844, setInset);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('did not shrink');
+    expect(result.withCard).toBe(result.before);
+  });
+
+  it('fails when the height moves but not to the derived value', () => {
+    // Off by ten: shrinking is not the same as reserving the right strip.
+    let inset = 0;
+    const shell = {
+      getBoundingClientRect: () =>
+        ({
+          height: 844 - HEADER_PX - Math.max(TAB_BAR_PX, inset) - (inset > 0 ? 10 : 0),
+        }) as DOMRect,
+    };
+    const result = measureConsentInsetResponse(shell, 844, (v) => {
+      inset = v === null ? 0 : Number.parseFloat(v);
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('is not the expected');
+  });
+
+  it('fails when a clamped shell reports the floor rather than the calc', () => {
+    /* `chooseProbeInset` already prevents the floor from being the answer on a
+       healthy shell - the inset is picked to clear it by 1px - so this models a
+       shell that clamps its own height instead. The number it returns is
+       plausible and produced by the wrong mechanism, which is precisely what a
+       height assertion alone would accept. */
+    let inset = 0;
+    const shell = {
+      getBoundingClientRect: () =>
+        ({ height: Math.min(MIN_H_PX, 844 - HEADER_PX - Math.max(TAB_BAR_PX, inset)) }) as DOMRect,
+    };
+    const result = measureConsentInsetResponse(shell, 844, (v) => {
+      inset = v === null ? 0 : Number.parseFloat(v);
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('floor answered');
+  });
+
+  it('refuses to report a pass on a viewport too short to exercise the calc', () => {
+    const { shell, setInset } = fakeShell(600, { responds: true });
+    const result = measureConsentInsetResponse(shell, 600, setInset);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('too short');
+  });
+
+  it('always clears the property it set, including on the refusing path', () => {
+    const seen: Array<string | null> = [];
+    const shell = { getBoundingClientRect: () => ({ height: 718 }) as DOMRect };
+    measureConsentInsetResponse(shell, 844, (v) => seen.push(v));
+    expect(seen[seen.length - 1]).toBeNull();
+
+    seen.length = 0;
+    measureConsentInsetResponse(shell, 600, (v) => seen.push(v));
+    expect(seen[seen.length - 1] ?? null).toBeNull();
+  });
+
+  it('names the numbers in its description', () => {
+    const { shell, setInset } = fakeShell(844, { responds: false });
+    const result = measureConsentInsetResponse(shell, 844, setInset);
+    expect(describeInsetProbe(result)).toBe(
+      'consent inset 252px: before 718px, with card 718px, expected 538px - did not shrink: 718 is not less than 718; height 718 is not the expected 538'
+    );
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
@@ -247,5 +247,31 @@ export const FitsThePhone: Story = {
 
     // And it never scrolls sideways at phone width.
     await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+
+    /* The shell subtracts the phone furniture from the viewport. There are THREE
+       fixed things on a phone, not two: the header, the tab bar, and the consent
+       card, which publishes the strip it denies as `--yc-consent-inset`. The
+       height used to be a literal `72px + env(...)` sum, so it kept its full
+       height while the card sat over the bottom of it.
+
+       `max` rather than a sum, because the card docks ABOVE the tab bar and the
+       strip it publishes already contains the bar's 72px - adding them
+       double-counts. So with no card the height must not move. */
+    const shell = canvasElement.querySelector('[class*="100dvh"]') as HTMLElement;
+    await expect(shell).not.toBeNull();
+    const withoutCard = shell.getBoundingClientRect().height;
+
+    const root = document.documentElement;
+    try {
+      root.style.setProperty('--yc-consent-inset', '252px');
+      const withCard = shell.getBoundingClientRect().height;
+      await expect(withCard).toBeLessThan(withoutCard);
+      await expect(Math.round(withoutCard - withCard)).toBe(252 - 72);
+
+      root.style.setProperty('--yc-consent-inset', '0px');
+      await expect(Math.round(shell.getBoundingClientRect().height)).toBe(Math.round(withoutCard));
+    } finally {
+      root.style.removeProperty('--yc-consent-inset');
+    }
   },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import type { Appointment } from '@yosemite-crew/types';
+import { expectShellReservesConsentInset } from './consentInsetAssertion';
 
 import PhoneWorkspaceShell from './PhoneWorkspaceShell';
 import {
@@ -256,22 +257,10 @@ export const FitsThePhone: Story = {
 
        `max` rather than a sum, because the card docks ABOVE the tab bar and the
        strip it publishes already contains the bar's 72px - adding them
-       double-counts. So with no card the height must not move. */
-    const shell = canvasElement.querySelector('[class*="100dvh"]') as HTMLElement;
+       double-counts. So with no card the height must not move. Shared with
+       PhoneCompanionRecord, which carries the identical calc. */
+    const shell = canvasElement.querySelector('[data-testid="phone-workspace-shell"]');
     await expect(shell).not.toBeNull();
-    const withoutCard = shell.getBoundingClientRect().height;
-
-    const root = document.documentElement;
-    try {
-      root.style.setProperty('--yc-consent-inset', '252px');
-      const withCard = shell.getBoundingClientRect().height;
-      await expect(withCard).toBeLessThan(withoutCard);
-      await expect(Math.round(withoutCard - withCard)).toBe(252 - 72);
-
-      root.style.setProperty('--yc-consent-inset', '0px');
-      await expect(Math.round(shell.getBoundingClientRect().height)).toBe(Math.round(withoutCard));
-    } finally {
-      root.style.removeProperty('--yc-consent-inset');
-    }
+    await expectShellReservesConsentInset(shell as HTMLElement);
   },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import type { Appointment } from '@yosemite-crew/types';
-import { expectShellReservesConsentInset } from './consentInsetAssertion';
+import { describeInsetProbe, measureConsentInsetResponse } from './consentInsetAssertion';
 
 import PhoneWorkspaceShell from './PhoneWorkspaceShell';
 import {
@@ -261,6 +261,12 @@ export const FitsThePhone: Story = {
        PhoneCompanionRecord, which carries the identical calc. */
     const shell = canvasElement.querySelector('[data-testid="phone-workspace-shell"]');
     await expect(shell).not.toBeNull();
-    await expectShellReservesConsentInset(shell as HTMLElement);
+    const root = document.documentElement;
+    const setInset = (value: string | null) =>
+      value === null
+        ? root.style.removeProperty('--yc-consent-inset')
+        : root.style.setProperty('--yc-consent-inset', value);
+    const probe = measureConsentInsetResponse(shell as HTMLElement, window.innerHeight, setInset);
+    await expect(probe.ok, describeInsetProbe(probe)).toBe(true);
   },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.tsx
@@ -95,7 +95,10 @@ const PhoneWorkspaceShell = ({
     // Bleed the workspace route's px-4/py-5 wrapper so the shell runs edge-to-edge,
     // and size it to the space the phone shell leaves between its fixed 54px header
     // and the 72px bottom tab bar (see PhoneShell.css) so the body scrolls internally.
-    <div className="-mx-4 -my-5 flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)">
+    <div
+      data-testid="phone-workspace-shell"
+      className="-mx-4 -my-5 flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)"
+    >
       <PhonePatientBar
         appointment={appointment}
         companionName={companionName}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.tsx
@@ -95,7 +95,7 @@ const PhoneWorkspaceShell = ({
     // Bleed the workspace route's px-4/py-5 wrapper so the shell runs edge-to-edge,
     // and size it to the space the phone shell leaves between its fixed 54px header
     // and the 72px bottom tab bar (see PhoneShell.css) so the body scrolls internally.
-    <div className="-mx-4 -my-5 flex h-[calc(100dvh-54px-72px-env(safe-area-inset-bottom,0px))] min-h-[480px] flex-col bg-(--screen)">
+    <div className="-mx-4 -my-5 flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)">
       <PhonePatientBar
         appointment={appointment}
         companionName={companionName}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
@@ -1,0 +1,55 @@
+import { expect } from 'storybook/test';
+
+/**
+ * Shared by the two phone-only shells, which size themselves with the same calc
+ * and would otherwise be one tested shell and one untested copy of it.
+ *
+ * There are three fixed things on a phone, not two: the header, the tab bar,
+ * and the consent card, which publishes the strip it denies as
+ * `--yc-consent-inset`. The shells used a literal `72px + env(...)` sum, so they
+ * kept full height while the card sat over the bottom of them.
+ */
+const HEADER_PX = 54;
+const MIN_H_PX = 480;
+
+/**
+ * Asserts the shell reserves the consent strip.
+ *
+ * The expected height is derived from `innerHeight` rather than written as a
+ * literal difference: a literal `252 - 72` silently encodes
+ * `env(safe-area-inset-bottom) = 0`, which is true in a headless browser and
+ * false on any device with a home indicator, where the real delta is smaller.
+ * Comparing against `innerHeight - HEADER - inset` is exact on both.
+ *
+ * The chosen inset must also clear `min-h-[480px]`, or the floor answers instead
+ * of the calc and the assertion passes without exercising anything. That floor
+ * is deliberate - below it a clinical workspace is unusable, and since the page
+ * can scroll (unlike the old `100svh`) content stays reachable rather than
+ * lost - so it is asserted here rather than worked around.
+ */
+export const expectShellReservesConsentInset = async (shell: HTMLElement) => {
+  const root = document.documentElement;
+  const before = shell.getBoundingClientRect().height;
+
+  // Big enough to beat 72px + any env inset, small enough to stay above the floor.
+  const inset = Math.min(252, window.innerHeight - HEADER_PX - MIN_H_PX - 1);
+  await expect(
+    inset,
+    `viewport ${window.innerHeight}px is too short to exercise the calc above the ${MIN_H_PX}px floor`
+  ).toBeGreaterThan(72);
+
+  try {
+    root.style.setProperty('--yc-consent-inset', `${inset}px`);
+    const withCard = shell.getBoundingClientRect().height;
+
+    await expect(withCard).toBeLessThan(before);
+    await expect(Math.round(withCard)).toBe(window.innerHeight - HEADER_PX - inset);
+    // The floor is not what produced that number.
+    await expect(Math.round(withCard)).toBeGreaterThan(MIN_H_PX);
+
+    root.style.setProperty('--yc-consent-inset', '0px');
+    await expect(Math.round(shell.getBoundingClientRect().height)).toBe(Math.round(before));
+  } finally {
+    root.style.removeProperty('--yc-consent-inset');
+  }
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
@@ -1,5 +1,3 @@
-import { expect } from 'storybook/test';
-
 /**
  * Shared by the two phone-only shells, which size themselves with the same calc
  * and would otherwise be one tested shell and one untested copy of it.
@@ -8,48 +6,128 @@ import { expect } from 'storybook/test';
  * and the consent card, which publishes the strip it denies as
  * `--yc-consent-inset`. The shells used a literal `72px + env(...)` sum, so they
  * kept full height while the card sat over the bottom of them.
+ *
+ * The measurement is split from the assertion so it can be unit-tested: a probe
+ * that silently stops discriminating is worse than no probe, and one whose only
+ * consumer is a play function is never exercised by the coverage gate.
  */
-const HEADER_PX = 54;
-const MIN_H_PX = 480;
+
+/** Height of the phone header the shells subtract. */
+export const HEADER_PX = 54;
+/** The floor both shells carry alongside the calc. */
+export const MIN_H_PX = 480;
+/** The tab-bar reserve the inset already contains, hence `max` and not a sum. */
+export const TAB_BAR_PX = 72;
+
+const PREFERRED_INSET_PX = 252;
+
+export type InsetChoice =
+  { usable: true; inset: number } | { usable: false; inset: number; reason: string };
 
 /**
- * Asserts the shell reserves the consent strip.
+ * The inset to probe with.
  *
- * The expected height is derived from `innerHeight` rather than written as a
- * literal difference: a literal `252 - 72` silently encodes
- * `env(safe-area-inset-bottom) = 0`, which is true in a headless browser and
- * false on any device with a home indicator, where the real delta is smaller.
- * Comparing against `innerHeight - HEADER - inset` is exact on both.
- *
- * The chosen inset must also clear `min-h-[480px]`, or the floor answers instead
- * of the calc and the assertion passes without exercising anything. That floor
- * is deliberate - below it a clinical workspace is unusable, and since the page
- * can scroll (unlike the old `100svh`) content stays reachable rather than
- * lost - so it is asserted here rather than worked around.
+ * It has to beat `TAB_BAR_PX` (or the `max()` returns the tab-bar term and the
+ * calc is never exercised) and stay above `MIN_H_PX` (or the floor answers
+ * instead of the calc, which passes while measuring the wrong mechanism).
  */
-export const expectShellReservesConsentInset = async (shell: HTMLElement) => {
-  const root = document.documentElement;
-  const before = shell.getBoundingClientRect().height;
+export const chooseProbeInset = (viewportHeight: number): InsetChoice => {
+  const inset = Math.min(PREFERRED_INSET_PX, viewportHeight - HEADER_PX - MIN_H_PX - 1);
+  if (inset <= TAB_BAR_PX) {
+    return {
+      usable: false,
+      inset,
+      reason: `viewport ${viewportHeight}px is too short to exercise the calc above the ${MIN_H_PX}px floor: the largest usable inset is ${inset}px, which does not beat the ${TAB_BAR_PX}px tab-bar term`,
+    };
+  }
+  return { usable: true, inset };
+};
 
-  // Big enough to beat 72px + any env inset, small enough to stay above the floor.
-  const inset = Math.min(252, window.innerHeight - HEADER_PX - MIN_H_PX - 1);
-  await expect(
-    inset,
-    `viewport ${window.innerHeight}px is too short to exercise the calc above the ${MIN_H_PX}px floor`
-  ).toBeGreaterThan(72);
+/**
+ * Expected shell height once the strip is reserved.
+ *
+ * Derived rather than written as a literal difference: a literal `252 - 72`
+ * silently encodes `env(safe-area-inset-bottom) = 0`, true in a headless browser
+ * and false on any device with a home indicator, where the real delta is
+ * smaller.
+ */
+export const expectedShellHeight = (viewportHeight: number, inset: number): number =>
+  viewportHeight - HEADER_PX - inset;
+
+export type InsetProbeResult = {
+  ok: boolean;
+  reason?: string;
+  inset: number;
+  before: number;
+  withCard: number;
+  restored: number;
+  expected: number;
+};
+
+type Shell = Pick<HTMLElement, 'getBoundingClientRect'>;
+
+/**
+ * Sets the inset, reads the shell, and puts it back. Returns what it saw rather
+ * than asserting, so the discrimination itself can be tested.
+ */
+export const measureConsentInsetResponse = (
+  shell: Shell,
+  viewportHeight: number,
+  setInset: (value: string | null) => void
+): InsetProbeResult => {
+  const before = shell.getBoundingClientRect().height;
+  const choice = chooseProbeInset(viewportHeight);
+  const expected = expectedShellHeight(viewportHeight, choice.inset);
+
+  if (!choice.usable) {
+    return {
+      ok: false,
+      reason: choice.reason,
+      inset: choice.inset,
+      before,
+      withCard: before,
+      restored: before,
+      expected,
+    };
+  }
 
   try {
-    root.style.setProperty('--yc-consent-inset', `${inset}px`);
+    setInset(`${choice.inset}px`);
     const withCard = shell.getBoundingClientRect().height;
+    setInset('0px');
+    const restored = shell.getBoundingClientRect().height;
 
-    await expect(withCard).toBeLessThan(before);
-    await expect(Math.round(withCard)).toBe(window.innerHeight - HEADER_PX - inset);
-    // The floor is not what produced that number.
-    await expect(Math.round(withCard)).toBeGreaterThan(MIN_H_PX);
+    const shrank = withCard < before;
+    const matched = Math.round(withCard) === expected;
+    const clearedFloor = Math.round(withCard) > MIN_H_PX;
+    const returned = Math.round(restored) === Math.round(before);
 
-    root.style.setProperty('--yc-consent-inset', '0px');
-    await expect(Math.round(shell.getBoundingClientRect().height)).toBe(Math.round(before));
+    const failures: string[] = [];
+    if (!shrank) failures.push(`did not shrink: ${withCard} is not less than ${before}`);
+    if (!matched) failures.push(`height ${Math.round(withCard)} is not the expected ${expected}`);
+    if (!clearedFloor)
+      failures.push(
+        `height ${Math.round(withCard)} is at or below the ${MIN_H_PX}px floor, so the floor answered rather than the calc`
+      );
+    if (!returned)
+      failures.push(
+        `did not return to ${Math.round(before)} at inset 0, saw ${Math.round(restored)}`
+      );
+
+    return {
+      ok: failures.length === 0,
+      reason: failures.length > 0 ? failures.join('; ') : undefined,
+      inset: choice.inset,
+      before,
+      withCard,
+      restored,
+      expected,
+    };
   } finally {
-    root.style.removeProperty('--yc-consent-inset');
+    setInset(null);
   }
 };
+
+/** Describes a result for an assertion message that has to explain itself. */
+export const describeInsetProbe = (result: InsetProbeResult): string =>
+  `consent inset ${result.inset}px: before ${Math.round(result.before)}px, with card ${Math.round(result.withCard)}px, expected ${result.expected}px - ${result.reason ?? 'ok'}`;

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
@@ -10,7 +10,10 @@ import type {
 } from '@yosemite-crew/types';
 
 import api from '@/app/services/axios';
-import { expectShellReservesConsentInset } from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
+import {
+  describeInsetProbe,
+  measureConsentInsetResponse,
+} from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { formatDisplayDate } from '@/app/lib/date';
 import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
@@ -1252,7 +1255,13 @@ export const Phone: Story = {
     await expect(shell).not.toBeNull();
 
     // The same calc as PhoneWorkspaceShell, and previously the untested copy of it.
-    await expectShellReservesConsentInset(shell as HTMLElement);
+    const root = document.documentElement;
+    const setInset = (value: string | null) =>
+      value === null
+        ? root.style.removeProperty('--yc-consent-inset')
+        : root.style.setProperty('--yc-consent-inset', value);
+    const probe = measureConsentInsetResponse(shell as HTMLElement, window.innerHeight, setInset);
+    await expect(probe.ok, describeInsetProbe(probe)).toBe(true);
   },
   parameters: {
     chromatic: { viewports: [375] },

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@yosemite-crew/types';
 
 import api from '@/app/services/axios';
+import { expectShellReservesConsentInset } from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { formatDisplayDate } from '@/app/lib/date';
 import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
@@ -1242,6 +1243,17 @@ export const Phone: Story = {
   // Storybook 10 and is inert, and this branch is a `useIsPhone` media query
   // rather than a CSS breakpoint - at any wider width the desktop body renders.
   globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    /* The discriminator the old note was right to worry about: if the runner
+       kept desktop width, `useIsPhone` is false and this element does not exist,
+       so the assertion below fails loudly rather than passing against the
+       desktop tree. */
+    const shell = canvasElement.querySelector('[data-testid="phone-companion-record"]');
+    await expect(shell).not.toBeNull();
+
+    // The same calc as PhoneWorkspaceShell, and previously the untested copy of it.
+    await expectShellReservesConsentInset(shell as HTMLElement);
+  },
   parameters: {
     chromatic: { viewports: [375] },
     docs: {
@@ -1252,10 +1264,11 @@ export const Phone: Story = {
           'parent card, a collapsible details drawer and a sticky Book appointment bar. The parent ' +
           'panel has no phone equivalent at all, so the client alerts survive only as the subtitle ' +
           'on the parent contact card, and there is no way to add or remove one from a phone.\n\n' +
-          'Deliberately without a play function: `useIsPhone` reads a real `matchMedia`, so it ' +
-          'needs the manager to resize the preview iframe. A headless run that loads `iframe.html` ' +
-          'directly keeps the desktop width and would assert the desktop panels while claiming to ' +
-          'check the phone record.',
+          'It now HAS a play function. That was previously impossible for the stated reason - ' +
+          '`useIsPhone` reads a real `matchMedia`, and a headless run that loads `iframe.html` ' +
+          "directly kept the desktop width - but the test runner resolves a story's pinned " +
+          'viewport again as of the `storyGlobals` fix, so this really does render at 375 and the ' +
+          'play function asserts the phone record rather than the desktop panels.',
       },
     },
   },

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -384,7 +384,10 @@ const PhoneCompanionRecord = ({
   const clientNote = clientAlerts[0]?.label;
 
   return (
-    <div className="flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)">
+    <div
+      data-testid="phone-companion-record"
+      className="flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)"
+    >
       <PhoneRecordHeader title={title} onBack={onBack} onEdit={canEdit ? onEdit : undefined} />
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-[18px] py-4">
         {companion ? (

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -384,7 +384,7 @@ const PhoneCompanionRecord = ({
   const clientNote = clientAlerts[0]?.label;
 
   return (
-    <div className="flex h-[calc(100dvh-54px-72px-env(safe-area-inset-bottom,0px))] min-h-[480px] flex-col bg-(--screen)">
+    <div className="flex h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))] min-h-[480px] flex-col bg-(--screen)">
       <PhoneRecordHeader title={title} onBack={onBack} onEdit={canEdit ? onEdit : undefined} />
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-[18px] py-4">
         {companion ? (


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2788 fixed the consent card covering the sign-in form, and published the strip the card denies as `--yc-consent-inset`. It reserved that strip in the auth shell and in `PhoneShell.css`.

Two shells were missed. `PhoneWorkspaceShell.tsx:98` and `PhoneCompanionRecord.tsx:387` size themselves with a literal two-element sum:

```
h-[calc(100dvh-54px-72px-env(safe-area-inset-bottom,0px))]
```

There are **three** fixed things on a phone, not two. These shells never read the inset, so they keep their full height while the card sits over the bottom of them. Measured at 390x844 before the change:

```
no inset                       718px
--yc-consent-inset: 252px      718px    <- no reaction
```

These are the phone clinical workspace and the phone companion record - the two surfaces an operator works in for the longest.

## What is the new behavior?

```
h-[calc(100dvh-54px-max(72px+env(safe-area-inset-bottom,0px),var(--yc-consent-inset,0px)))]
```

`max` rather than a sum, because the card docks **above** the tab bar, so the strip it publishes already contains the bar's 72px - adding them would double-count. Measured after:

| state | height | |
| --- | --- | --- |
| no inset | 718px | unchanged, so no card means no change |
| `--yc-consent-inset: 252px` | 538px | = 844 - 54 - 252 |
| back to `0px` | 718px | returns |

Both shells verified; the companion record was measured through `CompanionHistoryPage > Phone`, since the shell itself has no direct story.

## Testing

Pinned from a play function, which runs in a real browser: jsdom cannot evaluate `calc`, and a `className` assertion cannot fail on a geometry change.

The assertion is **relative** - the shell must shrink by exactly `inset - 72` - so it holds at any viewport. That matters while the test runner still executes phone-pinned stories at 1280px (#2792, fixed by #2793); this assertion is correct either way rather than waiting on that.

**Mutation**, restoring the literal sum:

```
expected 674 to be less than 674
```

```
tsc --noEmit                                              0
jest PhoneWorkspaceShell|CompanionHistory                 25 suites, 403 passed
test-storybook PhoneWorkspaceShell                        6 passed
```

## Related Issue(s)

Refs #2787