### PR TITLE
fix(backend): resolve the AP licence authority in one place, and treat blank as absent

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -128,7 +128,7 @@ SUPERADMIN_CONTACT_INTAKE_KEY=""
 AP_BASE_URL=""                  # Full public URL of this instance, e.g. https://api.yosemitecrew.com
 AP_ENABLED="true"               # Set to "false" to disable AP endpoints
 AP_AUTO_APPROVE_FOLLOWS="false" # Set to "true" to auto-accept incoming Follow requests
-AP_LICENSE_AUTHORITY_URL=""     # Base URL for license JWK + revocation endpoints, served by SuperAdmin (default: https://admin.yosemitecrew.com)
+AP_LICENSE_AUTHORITY_URL=""     # Base URL for the license JWK, revocation list AND federation directory, all served by SuperAdmin. Blank or unset means https://admin.yosemitecrew.com
 
 # --- Developer portal billing (pay as you go) -------------------------------
 # Stripe secret key for the account that owns the developer-portal products.

--- a/apps/backend/src/services/activitypub.service.ts
+++ b/apps/backend/src/services/activitypub.service.ts
@@ -42,6 +42,7 @@ import {
   guardedHttpsAgent,
 } from "src/utils/ap-url-guard";
 import { ApDeliveryQueue } from "src/queues/ap-delivery.queue";
+import { apAuthorityBase } from "src/services/ap-authority";
 
 // ─── Actor management ─────────────────────────────────────────────────────────
 
@@ -985,12 +986,6 @@ export interface DirectoryClinic {
   handle: string;
 }
 
-function directoryAuthorityBase(): string {
-  return (
-    process.env.AP_LICENSE_AUTHORITY_URL ?? "https://api.yosemitecrew.com"
-  ).replace(/\/$/, "");
-}
-
 const DIRECTORY_CACHE_TTL_MS = 60_000;
 const directoryCache = new Map<string, CachedPromise<DirectoryClinic[]>>();
 const DIRECTORY_CACHE_OPTIONS = { maxEntries: 8, pruneIntervalMs: 60_000 };
@@ -1038,7 +1033,7 @@ export async function setDirectoryListing(
   // accepts. Writing locally first would leave the settings toggle claiming the
   // clinic is listed whenever the authority is unreachable, which is the one
   // state a user cannot diagnose or correct from the UI.
-  const res = await fetch(`${directoryAuthorityBase()}/api/directory/listing`, {
+  const res = await fetch(`${apAuthorityBase()}/api/directory/listing`, {
     method: "PUT",
     headers: {
       Authorization: `Bearer ${actor.licenseToken}`,
@@ -1092,7 +1087,7 @@ export async function listDirectory(
       orgId,
       DIRECTORY_CACHE_TTL_MS,
       async () => {
-        const res = await fetch(`${directoryAuthorityBase()}/api/directory`, {
+        const res = await fetch(`${apAuthorityBase()}/api/directory`, {
           headers: {
             ...(licenseToken
               ? { Authorization: `Bearer ${licenseToken}` }

--- a/apps/backend/src/services/ap-authority.ts
+++ b/apps/backend/src/services/ap-authority.ts
@@ -1,0 +1,52 @@
+import logger from "src/utils/logger";
+
+/**
+ * Base URL of the ActivityPub licence authority.
+ *
+ * The authority is SuperAdmin, not this API: it serves the licence JWKS, the
+ * revocation list and the federation clinic directory. Every consumer must
+ * resolve it the same way, which is why this lives in one place.
+ *
+ * It did not, and the divergence was not cosmetic. `ap-license.service` defaulted
+ * to the authority while `activitypub.service` still defaulted to this API's own
+ * host, which serves none of those routes - so with the variable unset, licence
+ * verification and the directory pointed at two different hosts and the directory
+ * fetched a 404. One variable, two destinations, and only one of them was fixed
+ * when the default was corrected.
+ *
+ * `??` is not enough either. It falls back only on `null`/`undefined`, and
+ * `apps/backend/.env.example` ships `AP_LICENSE_AUTHORITY_URL=""`, so a
+ * deployment that copied it gets the empty string passed straight through. The
+ * result is not a wrong host - it is `fetch("/api/ap/signing-key.json")`, which
+ * throws `TypeError: Failed to parse URL` and surfaces three layers down as
+ * `[AP license] token invalid`. An empty value must mean "not configured".
+ */
+export const DEFAULT_AP_AUTHORITY_URL = "https://admin.yosemitecrew.com";
+
+/**
+ * Resolves the configured authority, or the default when it is absent, blank or
+ * unusable.
+ *
+ * A value that does not parse as a URL falls back rather than propagating, and
+ * says so once at the point of the decision. Propagating it only moves the
+ * failure to whichever fetch happens first, where the message names a URL rather
+ * than a variable. The value is not logged: an authority URL is not a secret,
+ * but a mistyped one can carry `user:password@host`, and this is the wrong place
+ * to find out.
+ */
+export function apAuthorityBase(): string {
+  const configured = process.env.AP_LICENSE_AUTHORITY_URL?.trim();
+  if (!configured) return DEFAULT_AP_AUTHORITY_URL;
+
+  try {
+    new URL(configured);
+  } catch {
+    logger.warn(
+      "[AP authority] AP_LICENSE_AUTHORITY_URL is not a valid URL - using the default authority",
+      { default: DEFAULT_AP_AUTHORITY_URL },
+    );
+    return DEFAULT_AP_AUTHORITY_URL;
+  }
+
+  return configured.replace(/\/$/, "");
+}

--- a/apps/backend/src/services/ap-license.service.ts
+++ b/apps/backend/src/services/ap-license.service.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import logger from "src/utils/logger";
+import { apAuthorityBase } from "src/services/ap-authority";
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -38,15 +39,6 @@ interface Cache<T> {
 let jwkCache: Cache<JWK[]> | null = null;
 let revokedCache: Cache<string[]> | null = null;
 
-function authorityBase(): string {
-  // The licence authority is SuperAdmin, not this API. Defaulting to the API's
-  // own host meant every deployment had to override this or fetch the signing
-  // key and revocation list from somewhere that does not serve them.
-  return (
-    process.env.AP_LICENSE_AUTHORITY_URL ?? "https://admin.yosemitecrew.com"
-  ).replace(/\/$/, "");
-}
-
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url, {
     headers: { Accept: "application/json" },
@@ -61,7 +53,7 @@ async function getJwks(): Promise<JWK[]> {
     return jwkCache.value;
   }
   const data = await fetchJson<{ keys: JWK[] }>(
-    `${authorityBase()}/api/ap/signing-key.json`,
+    `${apAuthorityBase()}/api/ap/signing-key.json`,
   );
   jwkCache = { value: data.keys, fetchedAt: Date.now() };
   return data.keys;
@@ -81,7 +73,7 @@ async function getRevokedJtis(): Promise<string[]> {
   // no instance could ever be verified. The object form is still accepted in
   // case the authority is changed later.
   const data = await fetchJson<string[] | { revokedJtis?: string[] }>(
-    `${authorityBase()}/api/ap/revoked.json`,
+    `${apAuthorityBase()}/api/ap/revoked.json`,
   );
   const jtis = Array.isArray(data) ? data : (data.revokedJtis ?? []);
   revokedCache = { value: jtis, fetchedAt: Date.now() };

--- a/apps/backend/test/services/activitypub.service.test.ts
+++ b/apps/backend/test/services/activitypub.service.test.ts
@@ -1441,7 +1441,15 @@ describe("setDirectoryListing", () => {
     );
   });
 
-  it("falls back to the default authority base when the env var is unset", async () => {
+  // This test used to expect `https://api.yosemitecrew.com`, which pinned the
+  // defect rather than the behaviour: the directory reader carried the API's own
+  // host as its default long after `ap-license.service` had been corrected away
+  // from it, and that host serves neither `/api/directory` nor
+  // `/api/ap/signing-key.json` (both 404 while `/health` answers 200). So with
+  // the variable unset, licence verification and the directory pointed at two
+  // different hosts and the directory fetched a 404 - and this assertion said
+  // that was correct.
+  it("falls back to the SuperAdmin authority when the env var is unset", async () => {
     delete process.env.AP_LICENSE_AUTHORITY_URL;
     prisma.organization.findUnique.mockResolvedValue({
       isVerified: true,
@@ -1454,7 +1462,27 @@ describe("setDirectoryListing", () => {
     await svc.setDirectoryListing("org-1", true);
 
     expect(mockFetch().mock.calls[0][0]).toBe(
-      "https://api.yosemitecrew.com/api/directory/listing",
+      "https://admin.yosemitecrew.com/api/directory/listing",
+    );
+  });
+
+  it("uses the same base the licence endpoints use, with the var unset", async () => {
+    // The regression this file could not catch on its own: two readers agreeing
+    // is the property, and each one asserted in isolation is what let them drift.
+    delete process.env.AP_LICENSE_AUTHORITY_URL;
+    prisma.organization.findUnique.mockResolvedValue({
+      isVerified: true,
+      name: "Example Vets",
+    });
+    prisma.aPActor.findUnique.mockResolvedValue(makeActor());
+    prisma.aPActor.update.mockResolvedValue({});
+    mockFetch().mockResolvedValue({ ok: true });
+
+    await svc.setDirectoryListing("org-1", true);
+
+    const { apAuthorityBase } = await import("src/services/ap-authority");
+    expect(mockFetch().mock.calls[0][0]).toBe(
+      `${apAuthorityBase()}/api/directory/listing`,
     );
   });
 });

--- a/apps/backend/test/services/ap-authority.test.ts
+++ b/apps/backend/test/services/ap-authority.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const warn = jest.fn();
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: (...args: unknown[]) => warn(...args),
+    error: jest.fn(),
+  },
+}));
+
+import {
+  DEFAULT_AP_AUTHORITY_URL,
+  apAuthorityBase,
+} from "src/services/ap-authority";
+
+const VAR = "AP_LICENSE_AUTHORITY_URL";
+
+function withValue<T>(value: string | undefined, run: () => T): T {
+  const previous = process.env[VAR];
+  if (value === undefined) delete process.env[VAR];
+  else process.env[VAR] = value;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) delete process.env[VAR];
+    else process.env[VAR] = previous;
+  }
+}
+
+beforeEach(() => {
+  warn.mockClear();
+});
+
+describe("apAuthorityBase", () => {
+  it.each([
+    ["unset", undefined],
+    // What .env.example ships. `??` would pass this straight through, and the
+    // result is not a wrong host - it is fetch("/api/ap/signing-key.json"),
+    // which throws `TypeError: Failed to parse URL` inside the fetch.
+    ["the empty string", ""],
+    ["whitespace only", "   "],
+    ["a tab", "\t"],
+  ])("falls back to the authority when the variable is %s", (_label, value) => {
+    expect(withValue(value, apAuthorityBase)).toBe(DEFAULT_AP_AUTHORITY_URL);
+    // Silently. Blank is "not configured", not "misconfigured" - a deployment
+    // that copied .env.example must not log a warning on every call. Asserting
+    // only the return value cannot tell the two apart, because an empty string
+    // also reaches the default by failing `new URL("")` and warning on the way.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["https://authority.example", "https://authority.example"],
+    ["https://authority.example/", "https://authority.example"],
+    ["  https://authority.example/  ", "https://authority.example"],
+    ["http://localhost:3001", "http://localhost:3001"],
+  ])("uses %s as the base", (value, expected) => {
+    expect(withValue(value, apAuthorityBase)).toBe(expected);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["not-a-url", "not-a-url"],
+    ["admin.yosemitecrew.com", "admin.yosemitecrew.com"],
+    ["://missing-scheme", "://missing-scheme"],
+  ])("falls back and warns once for %s", (_label, value) => {
+    expect(withValue(value, apAuthorityBase)).toBe(DEFAULT_AP_AUTHORITY_URL);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("never puts the configured value in the log line", () => {
+    // An authority URL is not a secret, but a mistyped one can carry
+    // `user:password@host`, and a warning is the wrong place to find that out.
+    // Deliberately an input that FAILS to parse: `http://user:pass@host` is a
+    // perfectly valid URL and never reaches the warning at all.
+    withValue("://user:hunter2@authority.example", apAuthorityBase);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(warn.mock.calls[0])).not.toContain("hunter2");
+  });
+});
+
+describe("the variable has exactly one reader", () => {
+  // The defect this module exists to fix was two readers with two different
+  // defaults, only one of which was corrected when the default changed. A second
+  // reader is the recurrence, and it is invisible to every other test here.
+  const SRC = join(__dirname, "..", "..", "src");
+
+  function sourceFiles(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) return sourceFiles(full);
+      return /\.tsx?$/.test(entry) ? [full] : [];
+    });
+  }
+
+  it("is read only by ap-authority.ts", () => {
+    const files = sourceFiles(SRC);
+    // A walk that found nothing would make the assertion below vacuous.
+    expect(files.length).toBeGreaterThan(100);
+
+    const readers = files.filter((file) =>
+      readFileSync(file, "utf8").includes(`process.env.${VAR}`),
+    );
+    expect(readers.map((file) => file.slice(SRC.length + 1))).toEqual([
+      join("services", "ap-authority.ts"),
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #2791

## The defect

`AP_LICENSE_AUTHORITY_URL` had three readers and two different defaults:

```
ap-license.service.ts:46     ?? "https://admin.yosemitecrew.com"
activitypub.service.ts:990   ?? "https://api.yosemitecrew.com"
.env.example:131             AP_LICENSE_AUTHORITY_URL=""
```

The comment above the first explains why *its* default was corrected — "the API's own host … does not
serve them". The directory reader was left on that old value. Measured unauthenticated, with the
control that makes it a measurement:

```
https://api.yosemitecrew.com/api/directory              404
https://api.yosemitecrew.com/api/ap/signing-key.json    404
https://api.yosemitecrew.com/health                     200   <- the host is up, it just does not serve these
```

So with the variable unset, licence verification and the federation directory pointed at **two
different hosts** and the directory fetched a 404. `setDirectoryListing` also sent the
organisation's licence token as a `Bearer` to that host.

**`??` does not close it either.** It falls back only on `null`/`undefined`, and `.env.example`
ships the empty string. Run rather than reasoned:

```
("" ?? "https://admin.yosemitecrew.com")  ->  ""
fetch(`${""}/api/ap/signing-key.json`)
  THREW  TypeError: Failed to parse URL from /api/ap/signing-key.json
```

Not a wrong host — **no HTTP request at all**. `isLicenseTokenValid` catches everything and returns
`false`, so every licence reads invalid and the only trace is `[AP license] token invalid` naming a
URL parse error rather than a configuration problem.

## The change

`apAuthorityBase()` is the single reader. Blank and whitespace mean *absent*; a value that does not
parse as a URL falls back and says so **once**, at the decision rather than three layers down; the
trailing slash is stripped. The configured value is never logged — an authority URL is not a secret,
but a mistyped one can carry `user:password@host`, and a warning is the wrong place to find that out.

## An existing test pinned the defect rather than the behaviour

```
- it("falls back to the default authority base when the env var is unset")
-   expect(...).toBe("https://api.yosemitecrew.com/api/directory/listing")
+ it("falls back to the SuperAdmin authority when the env var is unset")
+   expect(...).toBe("https://admin.yosemitecrew.com/api/directory/listing")
```

That assertion is why the divergence survived a correction to the other reader. Its replacement
carries the reason in a comment so the next reader meets the explanation before the behaviour.

Two guards added for the actual defect, which was **two readers**:

- both readers agree, asserted against `apAuthorityBase()` rather than a literal
- **the variable has exactly one reader in `src/`**, asserted by walking the tree — a second reader
  is the recurrence and it is invisible to every other test here. The walk asserts it found >100
  files first, so it cannot pass vacuously.

## Verification at `3aa57f7`

```
ap-authority + activitypub.service + ap-license.service   3 suites / 127 tests   rc 0
```

`type-check` and `lint` are **red at baseline** in this workspace, so both were run with the change
stashed as a control on the same commit and the same `node_modules`:

```
                base        branch
type-check      476 errs    476 errs      set difference: EMPTY
lint            13690       13690         identical
```

Neither total moves and no finding is present on the branch and absent from the base, so this change
introduces nothing. `apps/backend/src/services/activitypub.service.ts` does appear in both, at
pre-existing lines far from the edit.

**Nine mutations, each asserted to land exactly once, all nine killed**, including a false-positive
control (7 red) and a mutation in a *different* file that plants a second reader of the variable
(1 red, the single-reader guard).

**One survived the first pass**, and it is the reason a test changed. Making only `undefined` count
as absent left the suite green: an empty string still reaches the default, by failing `new URL("")`
and warning on the way. The returned value is identical either way, so asserting the return value
cannot separate them — only asserting that a blank value is **silent** does, and it should be, since
a deployment that copied `.env.example` must not log a warning on every call.

## Not in this PR

A boot-time assertion that the resolved authority actually serves the JWKS. `startup-controls.ts`
has the right mechanism, but adding a name to `EXPECTED_CONTROLS` changes what a deploy gate expects
and deserves its own change rather than riding along with a config fix.