### PR TITLE
fix(frontend): reserve the consent card's strip in the phone shell too

### DIFF
--- a/apps/frontend/src/app/ui/layout/PhoneShell/MainContentInset.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/MainContentInset.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
+import './PhoneShell.css';
+
+/**
+ * The `[data-yc-app] #main-content` reservation, on its own.
+ *
+ * Every rule in `PhoneShell.css` sits behind `max-width: 767px`, so the viewport
+ * is pinned; and the selector needs a `data-yc-app` ancestor, which the preview
+ * decorator supplies on non-marketing stories.
+ */
+const MainContentFixture = () => (
+  <div id="main-content" style={{ background: 'var(--inset)' }}>
+    <p style={{ margin: 0 }}>Route content sits inside this element.</p>
+  </div>
+);
+
+const meta = {
+  title: 'ui/layout/PhoneShell/MainContentInset',
+  component: MainContentFixture,
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+} satisfies Meta<typeof MainContentFixture>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const bottomPx = () =>
+  Number.parseFloat(
+    globalThis.getComputedStyle(document.querySelector('#main-content') as Element).paddingBottom
+  );
+
+export const ReservesTheConsentStrip: Story = {
+  name: 'Reserves the consent strip as well as the tab bar',
+  play: async () => {
+    const root = document.documentElement;
+    const main = document.querySelector('#main-content');
+    await expect(main).not.toBeNull();
+
+    // With no card, the reserve is the tab bar. env(safe-area-inset-bottom) is 0
+    // in a headless browser, so this is 72 there and larger on a device - read it
+    // rather than asserting the literal.
+    const barOnly = bottomPx();
+    await expect(barOnly).toBeGreaterThanOrEqual(72);
+
+    try {
+      // Taller than the bar, so `max` must pick it.
+      root.style.setProperty('--yc-consent-inset', '252px');
+      await expect(bottomPx()).toBe(252);
+
+      // Shorter than the bar: the bar still wins, which is the half a sum gets
+      // wrong by adding the two together.
+      root.style.setProperty('--yc-consent-inset', '20px');
+      await expect(bottomPx()).toBe(barOnly);
+
+      root.style.setProperty('--yc-consent-inset', '0px');
+      await expect(bottomPx()).toBe(barOnly);
+    } finally {
+      root.style.removeProperty('--yc-consent-inset');
+    }
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -9,10 +9,24 @@
     display: none !important;
   }
 
-  /* Make room for the fixed header and tab bar so content is never covered. */
+  /* Make room for the fixed header and tab bar so content is never covered.
+     There is a THIRD fixed element on a phone and this sum did not know about
+     it: until a choice is stored, the consent card sits above the tab bar and
+     denies its own height as well. It publishes that strip as
+     `--yc-consent-inset` (0 when it is absent), and the card is docked above
+     the tab bar, so the card's strip already contains the bar's reserve -
+     `max` rather than a sum, which would double-count the 72px.
+
+     This is the same reservation `AuthShell` makes for the same card. There it
+     was a blocker because the shell is pinned to `100svh` and could not scroll;
+     here the page can grow, so the cost was quieter - content simply ends
+     underneath an opaque card with no indication anything is below it. */
   [data-yc-app] #main-content {
     padding-top: 54px;
-    padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: max(
+      calc(72px + env(safe-area-inset-bottom, 0px)),
+      var(--yc-consent-inset, 0px)
+    );
   }
 
   /* ---------------------------------------------------------------- header */


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The rule that makes room for the fixed phone chrome knows about two fixed elements and there are three:

```css
/* Make room for the fixed header and tab bar so content is never covered. */
[data-yc-app] #main-content {
  padding-top: 54px;
  padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
}
```

The consent card is the third. Until a choice is stored it denies 336px of an 844px viewport on every signed-in route, and nothing reserved it. #2788 fixed the same card against the auth shell, where it was a blocker because that shell is pinned to `100svh` and cannot scroll. Here the page can grow, so the cost is quieter: a list simply ends underneath an opaque card with nothing to indicate anything is below it.

## What is the new behavior?

```css
padding-bottom: max(
  calc(72px + env(safe-area-inset-bottom, 0px)),
  var(--yc-consent-inset, 0px)
);
```

`max` and not a sum: the card docks above the tab bar, so the strip it publishes already contains the bar's 72px and adding them double-counts.

Measured on one production build with the auth-guard bypass on, A/B by forcing the padding back to its old value in the page so nothing else differs. The state that matters - a list running past the fold whose last row is what the card covers - cannot be reached without a dev account, so the rows are synthetic and appended inside `#main-content`; the shell, the card, the CSS and the scroll behaviour are the real ones.

| route | variant | scrollHeight | last row at bottom | best over every scroll position |
| --- | --- | --- | --- | --- |
| /tasks | before | 1518 | 0% | 33%, covered by the card |
| /tasks | after | 1782 | 100% | 100% |
| /dashboard | before | 2268 | 0% | 33%, covered by the card |
| /dashboard | after | 2532 | 100% | 100% |

`/finance` is inconclusive rather than passing: the last row reads 0% in both arms and the probe records the covering element as an `svg`, not the card, so something unrelated to this change is over it on a data-less render. Reported rather than dropped.

The probe records what is on top of a control, not just whether it is reachable - a dev-mode overlay and a product defect are indistinguishable from a boolean, and it refuses to report at all if `data-authgrid` or an email input is present, because `/dashboard` serves the sign-in page at HTTP 200 with the path unchanged when the guard bypass is off.

### Interaction with #2797

Checked rather than assumed, since that PR reserves the same strip inside two components that opt out of this shell with their own fixed height. A synthetic element carrying each shell's height calc, dropped into the real `#main-content` at 390x844:

| this PR | shell calc | shell height | shell bottom | card top | overlaps card | extra scroll |
| --- | --- | --- | --- | --- | --- | --- |
| old | old | 718 | 772 | 508 | yes | 0 |
| new | old | 718 | 772 | 508 | yes | 264 |
| old | new | 454 | 508 | 508 | no | 0 |
| new | new | 454 | 508 | 508 | no | 0 |

No double reservation. The shell's height is computed from `100dvh` rather than from `#main-content`'s content box, so this padding cannot shrink it again, and the shell's bottom lands exactly on the card's top so the padding below it starts where the viewport ends.

The third row is the transient if this merges first: 264px of empty scroll below a shell that still overlaps the card. Not broken, and it disappears when #2797 lands.

## Tests

`MainContentInset.stories.tsx` - a fixture rendering `#main-content` under the preview's `data-yc-app` ancestor, viewport pinned to `mobile` because every rule in this file sits behind `max-width: 767px`.

That rule previously had no coverage at all: `PhoneShell.tsx` imports the CSS but no story rendered `#main-content` inside a `data-yc-app` ancestor, so nothing exercised the declaration this PR edits. The original version of this section said a jest assertion could only assert the text of the rule and left it there - true of jest, and false of Storybook now that #2793 makes a phone-pinned story actually render at phone width.

Written by the reviewer and re-run here rather than trusted:

| Variant | Result |
| --- | --- |
| as-is | 1 passed, 1 total, rc 0 |
| `max(...)` -> `calc(72px + env(...))` | `expected 72 to be 252` - the inset ignored |
| `max(...)` -> `calc(72px + env(...) + var(...))` | `expected 324 to be 252` - 72 + 252 double-counted |
| restored | 1 passed, 1 total, rc 0 |

The second mutation is the one worth having. A test that only catches "the inset was ignored" passes a sum happily, and a sum is exactly what the next person writes after reading that there are three fixed elements on a phone. The middle assertion - a 20px inset where the 72px bar must still win - is what puts the `max` semantics under test rather than only its magnitude.

`barOnly` is measured rather than written as `72`, so the assertion is correct on a device where `env(safe-area-inset-bottom)` is not 0 - the same trap #2797's helper closed by deriving its expected height from `innerHeight`.

`jest.config` excludes `**/*.stories.tsx` from `collectCoverageFrom`, so this adds no uncovered executable lines to the diff-coverage gate.

## Verification

- `next build` - exit 0; every number above was measured on the bundle this PR ships
- pre-push monorepo lint and type-check - passed
- Aikido not run locally: no MCP server on this machine and no local frontend scan script, so the PR scan is the first pass

Related: #2787, #2788
