### PR TITLE
test(frontend): pin the dark theme, where the contrast headroom actually is

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.stories.tsx
@@ -214,3 +214,44 @@ export const NothingBookedAllWeek: Story = {
     await expect(within(canvasElement).getAllByRole('button')).toHaveLength(7);
   },
 };
+
+/* The contrast assertion in `Default` runs in ONE theme, and it is not the one
+   that matters. `preview.ts` `initialGlobals` pins only `viewport`, so the theme
+   decorator falls to its `'light'` default and every play function in this file
+   measures the light ramp.
+
+   The selected cell is `--blue-strong`, which is theme-aware: #1657c9 light
+   (6.48:1) and #2f74d9 dark (4.54:1). **Dark is the side with 0.045 of headroom
+   over AA**, and it was the side nothing exercised - the justification for
+   pinning it with a test was written into the PR that shipped it, and the test
+   only covered the comfortable half.
+
+   A story global beats a URL/toolbar override, so pinning it here is not
+   advisory. */
+export const DarkSelectedCell: Story = {
+  name: 'Dark: the selected cell still clears AA',
+  globals: { viewport: { value: 'mobile', isRotated: false }, theme: 'dark' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const strip = canvas.getByRole('group', { name: 'Select a day' });
+    const selected = within(strip)
+      .getAllByRole('button')
+      .find((cell) => cell.getAttribute('aria-pressed') === 'true');
+    await expect(selected).toBeDefined();
+
+    // The theme really is dark - otherwise this is the light assertion twice.
+    await expect(document.documentElement.dataset.theme).toBe('dark');
+
+    for (const [label, node] of [
+      ['weekday', (selected as HTMLElement).querySelector('.yc-day-strip__weekday')],
+      ['date', (selected as HTMLElement).querySelector('.yc-day-strip__date')],
+    ] as const) {
+      await expect(node).not.toBeNull();
+      const reading = measureContrast(node as Element);
+      await expect(
+        reading.ratio,
+        describeContrast(`dark selected day ${label}`, reading)
+      ).toBeGreaterThanOrEqual(reading.required);
+    }
+  },
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The contrast assertions shipped in #2785 run in exactly one theme, and it is the wrong one.

`preview.ts` `initialGlobals` pins only `viewport`:

```ts
initialGlobals: {
  viewport: { value: 'laptop', isRotated: false },
},
```

So the theme decorator falls to its `'light'` default, and every play function in `PhoneDayStrip.stories.tsx` measures the light ramp.

The selected day cell is `--blue-strong`, which is **theme-aware**:

| theme | token | white ink |
| --- | --- | --- |
| light | `#1657c9` | 6.48:1 |
| dark | `#2f74d9` | **4.54:1** |

**Dark is the side with 0.045 of headroom over AA, and it was the side nothing exercised.** #2785's own body argued for pinning that value with a test rather than an eyeball precisely because the margin is thin. The test covered the comfortable half.

## What is the new behavior?

A dark-pinned story running the same measurement on the same two labels.

A story global beats a URL/toolbar override, so pinning it here is load-bearing rather than advisory - established by Claude L3 Yosemite Crew on #2796, which is what prompted this check.

## Testing

**The demonstration is a dark-scope-only mutation**, `--blue-strong: #2f74d9 -> #5a97e6`, light untouched:

```
1 failed, 5 passed

dark selected day weekday: 3:1 (needs 4.5:1) - rgb(255, 255, 255)
  on rgb(90, 151, 230) at 9px/700: expected 3 to be greater than or equal to 4.5
```

**Only the new story fails.** The existing light assertion passes straight through a dark-only regression on the token it exists to protect - which is the claim this PR rests on, and it is a different claim from "a dark test was added".

The story also asserts `document.documentElement.dataset.theme === 'dark'` before measuring, so if the theme decorator ever stops applying, it fails loudly instead of running the light assertion a second time under a dark name.

```
tsc --noEmit                            0
test-storybook PhoneDayStrip            6 passed
jest --testPathPatterns=PhoneDayStrip   8 passed
```

## Related Issue(s)

Refs #2784