### PR TITLE
fix(repo): stop publishing a stale clone count, and fail repo-stats on a 403

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -12,6 +12,40 @@ jobs:
     permissions:
       contents: write
     steps:
+      # The action retries an authorization failure fifteen times at sixty-second
+      # intervals and then runs into `timeout-minutes`, and GitHub reports a
+      # timed-out job as `cancelled`. Twelve consecutive runs failed that way in
+      # August and September 2026 and every one of them read like somebody had
+      # pressed stop, so the frozen clone count on the marketing site was found by
+      # eye rather than by CI.
+      #
+      # A 403 here is permanent - the token authenticates and is refused - so
+      # retrying it cannot help. Check once, fail immediately, and put the required
+      # permission in the message so the fix does not need an investigation.
+      - name: Check the traffic API is readable before scanning
+        env:
+          GHRS_TOKEN: ${{ secrets.GHRS_GITHUB_API_TOKEN }}
+        run: |
+          set -u
+          # -o /dev/null keeps the response body out of a public log; only the
+          # status code is read. On a transport error curl exits non-zero, and the
+          # `|| status=000` overwrites whatever it printed - so a DNS or TLS failure
+          # lands on a value that is not 200 and fails, rather than passing as a
+          # response nobody checked.
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GHRS_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/traffic/clones") || status="000"
+
+          if [ "$status" = "200" ]; then
+            echo "Traffic API readable (HTTP 200)."
+            exit 0
+          fi
+
+          echo "::error title=repo-stats cannot read the traffic API::GHRS_GITHUB_API_TOKEN got HTTP ${status} from /traffic/clones. The traffic endpoints need Administration (read) on this repository - a fine-grained token also needs Contents (read and write) for the data branch, and a classic token needs the repo scope plus push access. A 401 means the token is invalid or expired; a 403 means it authenticates but is not permitted."
+          exit 1
+
       - name: Generate repo stats report
         uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa # v1.4.2
         with:

--- a/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
@@ -44,7 +44,45 @@ const call = async (url?: string) => (await GET(request(url))) as unknown as Moc
 
 const originalFetch = globalThis.fetch;
 
+/**
+ * The EXACT string the repo-stats workflow writes into `summary.json`. It is not
+ * ISO 8601, and the route parses it with its own pattern precisely because
+ * `Date.parse` accepting this shape is an engine choice rather than a guarantee.
+ * Fixtures use this literal rather than a tidy ISO stamp on purpose: a fixture in
+ * a format the production data never uses cannot fail on the production data.
+ */
+const FRESH_STAMP = '2026-08-24 23:06 UTC';
+/** 54 minutes after FRESH_STAMP, so that report is comfortably inside 72h. */
+const NOW = new Date('2026-08-25T00:00:00Z');
+/** The real incident: the report that sat unchanged for thirteen days. */
+const STALE_STAMP = '2026-08-11 23:06 UTC';
+
+const fresh = (payload: Record<string, unknown>) => ({
+  generated_at_utc: FRESH_STAMP,
+  ...payload,
+});
+
+const summaryOnly = (payload: unknown) =>
+  jest.fn((input: RequestInfo | URL) =>
+    String(input).includes('summary.json')
+      ? Promise.resolve(makeRes(payload))
+      : Promise.resolve(notOk())
+  ) as unknown as FetchLike;
+
 describe('github-stats route handler', () => {
+  // Per-test, NOT beforeAll: jest.setup.ts installs a global
+  // `afterEach(() => jest.clearAllTimers())`, which drops the faked system time
+  // after the first test. Installing it once leaves every later test silently
+  // reading the REAL clock, so a freshness fixture stamped days ago is judged
+  // stale for the wrong reason and the assertion it was written for never runs.
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   afterEach(() => {
     globalThis.fetch = originalFetch;
   });
@@ -53,7 +91,7 @@ describe('github-stats route handler', () => {
     globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('summary.json'))
-        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
+        return Promise.resolve(makeRes(fresh({ clones: { total: 67134 } })));
       if (url.includes('contributors'))
         // 58 people plus 2 bots. The bots must not reach the response.
         return Promise.resolve(
@@ -99,11 +137,15 @@ describe('github-stats route handler', () => {
     globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
       String(input).includes('summary.json')
         ? Promise.resolve(
-            makeRes({
-              charts: {
-                '#clones_total': { datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] } },
-              },
-            })
+            makeRes(
+              fresh({
+                charts: {
+                  '#clones_total': {
+                    datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] },
+                  },
+                },
+              })
+            )
           )
         : Promise.resolve(notOk())
     ) as unknown as FetchLike;
@@ -115,7 +157,9 @@ describe('github-stats route handler', () => {
     globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
       String(input).includes('summary.json')
         ? Promise.resolve(
-            makeRes({ charts: { '#clones_total': { datasets: { a: [{}, { clones_total: 5 }] } } } })
+            makeRes(
+              fresh({ charts: { '#clones_total': { datasets: { a: [{}, { clones_total: 5 }] } } } })
+            )
           )
         : Promise.resolve(notOk())
     ) as unknown as FetchLike;
@@ -124,10 +168,16 @@ describe('github-stats route handler', () => {
   });
 
   it.each([
-    ['a summary with neither supported clone shape', { something: 'else' }],
+    [
+      'a summary with neither supported clone shape',
+      { generated_at_utc: FRESH_STAMP, something: 'else' },
+    ],
     [
       'a summary whose chart dataset is not a list',
-      { charts: { '#clones_total': { datasets: { a: 'nope' } } } },
+      {
+        generated_at_utc: FRESH_STAMP,
+        charts: { '#clones_total': { datasets: { a: 'nope' } } },
+      },
     ],
     ['a summary that is not an object', 'not-json-object'],
     ['a null summary', null],
@@ -273,4 +323,102 @@ describe('github-stats route handler', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     }
   );
+
+  // The clone count is the only metric here whose feed can go stale while still
+  // answering 200, so it is the only one that can be wrong rather than absent.
+  // Every rejection below must land on null - the same degraded state a failed
+  // lookup produces - and never on a published number.
+  describe('clone-count freshness', () => {
+    it("publishes the count for a report stamped in the workflow's own format", async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: FRESH_STAMP,
+        clones: { total: 67134 },
+      });
+
+      expect((await call()).body.repositoryClones).toBe('67,134');
+    });
+
+    it('drops the count for the thirteen-day-old report from the real incident', async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: STALE_STAMP,
+        clones: { total: 183516 },
+      });
+
+      // The value is present, parseable and wrong. Publishing it is the bug.
+      expect((await call()).body.repositoryClones).toBeNull();
+    });
+
+    it.each([
+      ['no stamp at all', {}],
+      ['a stamp that is not a string', { generated_at_utc: 1756076760000 }],
+      ['a stamp that is not a date', { generated_at_utc: 'not-a-date' }],
+      ['an empty stamp', { generated_at_utc: '' }],
+      // Date.UTC rolls month 13 forward into the next year, which would make this
+      // malformed stamp read as a FUTURE date and therefore fresh. The bounds live
+      // in the pattern to stop exactly that.
+      ['a month outside 1-12', { generated_at_utc: '2026-13-01 00:00 UTC' }],
+      ['a day outside 1-31', { generated_at_utc: '2026-08-32 00:00 UTC' }],
+      ['an hour outside 0-23', { generated_at_utc: '2026-08-24 24:00 UTC' }],
+      ['a stamp with no zone', { generated_at_utc: '2026-08-24 23:06' }],
+    ])('fails closed on %s', async (_label, stamp) => {
+      globalThis.fetch = summaryOnly({ ...stamp, clones: { total: 67134 } });
+
+      expect((await call()).body.repositoryClones).toBeNull();
+    });
+
+    it.each([
+      ['the workflow format', '2026-08-24 23:06 UTC'],
+      ['the same instant with seconds', '2026-08-24 23:06:45 UTC'],
+      ['an ISO-shaped stamp, should the generator ever switch', '2026-08-24T23:06:00Z'],
+    ])('accepts %s', async (_label, generated_at_utc) => {
+      globalThis.fetch = summaryOnly({ generated_at_utc, clones: { total: 5 } });
+
+      expect((await call()).body.repositoryClones).toBe('5');
+    });
+
+    // The window is 72h because the workflow is daily and two missed runs should
+    // not blank the number. These pin both sides of that edge.
+    it('publishes a report just inside the 72 hour window', async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: '2026-08-22 00:01 UTC',
+        clones: { total: 9 },
+      });
+
+      expect((await call()).body.repositoryClones).toBe('9');
+    });
+
+    it('drops a report just outside the 72 hour window', async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: '2026-08-21 23:59 UTC',
+        clones: { total: 9 },
+      });
+
+      expect((await call()).body.repositoryClones).toBeNull();
+    });
+
+    it('leaves the other metrics alone when the report is stale', async () => {
+      globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('summary.json'))
+          return Promise.resolve(
+            makeRes({ generated_at_utc: STALE_STAMP, clones: { total: 183516 } })
+          );
+        if (url.includes('contributors'))
+          return Promise.resolve(makeRes([{ type: 'User' }, { type: 'User' }]));
+        if (url.endsWith('/Yosemite-Crew'))
+          return Promise.resolve(makeRes({ stargazers_count: 2020 }));
+        return Promise.resolve(notOk());
+      }) as unknown as FetchLike;
+
+      const res = await call();
+
+      // Stars and contributors come from the public API and were never affected by
+      // the workflow breaking - dropping the clone count must not take them with it.
+      expect(res.body.repositoryClones).toBeNull();
+      expect(res.body.starsFull).toBe('2,020');
+      expect(res.body.contributors).toBe('2');
+      // Something resolved, so the response is still cacheable.
+      expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
+    });
+  });
 });

--- a/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
@@ -360,6 +360,12 @@ describe('github-stats route handler', () => {
       ['a day outside 1-31', { generated_at_utc: '2026-08-32 00:00 UTC' }],
       ['an hour outside 0-23', { generated_at_utc: '2026-08-24 24:00 UTC' }],
       ['a stamp with no zone', { generated_at_utc: '2026-08-24 23:06' }],
+      // Every case above is a PATTERN rejection, so none of them reaches the
+      // freshness comparison. These do: each parses to a real instant and is
+      // refused by the window itself.
+      ['a stamp one day in the future', { generated_at_utc: '2026-08-26 00:00 UTC' }],
+      ['a stamp four months in the future', { generated_at_utc: '2027-01-01 00:00 UTC' }],
+      ['a stamp that would be fresh forever', { generated_at_utc: '9999-12-31 00:00 UTC' }],
     ])('fails closed on %s', async (_label, stamp) => {
       globalThis.fetch = summaryOnly({ ...stamp, clones: { total: 67134 } });
 
@@ -387,6 +393,28 @@ describe('github-stats route handler', () => {
       expect((await call()).body.repositoryClones).toBe('9');
     });
 
+    // The stamp is written by a GitHub runner and read by this server; the two
+    // clocks are not synchronised, so a report generated seconds ago can carry a
+    // timestamp slightly ahead. That must not blank a good number - but the
+    // allowance is minutes, not enough to rescue anything actually stale.
+    it('publishes a report stamped a little ahead of this server', async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: '2026-08-25 00:02 UTC',
+        clones: { total: 11 },
+      });
+
+      expect((await call()).body.repositoryClones).toBe('11');
+    });
+
+    it('drops a report stamped beyond the skew allowance', async () => {
+      globalThis.fetch = summaryOnly({
+        generated_at_utc: '2026-08-25 00:06 UTC',
+        clones: { total: 11 },
+      });
+
+      expect((await call()).body.repositoryClones).toBeNull();
+    });
+
     it('drops a report just outside the 72 hour window', async () => {
       globalThis.fetch = summaryOnly({
         generated_at_utc: '2026-08-21 23:59 UTC',
@@ -394,6 +422,44 @@ describe('github-stats route handler', () => {
       });
 
       expect((await call()).body.repositoryClones).toBeNull();
+    });
+
+    // An impossible day rolls FORWARD through Date.UTC, and against the clock
+    // above every such roll lands in the past and is refused by the window - so
+    // those cases prove nothing about the round-trip. These set the clock so the
+    // rolled date would be comfortably FRESH, which leaves the component
+    // round-trip as the only thing that can reject them. Each pair carries a
+    // valid neighbouring date as its control: if the control did not publish,
+    // the rejection would be the window talking, not the round-trip.
+    describe.each([
+      [
+        'a 31st in a 30-day month',
+        '2026-05-01T12:00:00Z',
+        '2026-04-31 00:00 UTC',
+        '2026-04-30 00:00 UTC',
+      ],
+      [
+        'a 29th of February in a non-leap year',
+        '2026-03-01T12:00:00Z',
+        '2026-02-29 00:00 UTC',
+        '2026-02-28 00:00 UTC',
+      ],
+    ])('%s', (_label, clock, impossible, control) => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date(clock));
+      });
+
+      it('publishes the valid neighbouring date, so the window is not what rejects', async () => {
+        globalThis.fetch = summaryOnly({ generated_at_utc: control, clones: { total: 7 } });
+
+        expect((await call()).body.repositoryClones).toBe('7');
+      });
+
+      it('drops the impossible date even though the rolled value would be fresh', async () => {
+        globalThis.fetch = summaryOnly({ generated_at_utc: impossible, clones: { total: 7 } });
+
+        expect((await call()).body.repositoryClones).toBeNull();
+      });
     });
 
     it('leaves the other metrics alone when the report is stale', async () => {

--- a/apps/frontend/src/app/api/community/github-stats/route.ts
+++ b/apps/frontend/src/app/api/community/github-stats/route.ts
@@ -70,6 +70,63 @@ const githubFetch = (url: string) =>
     cache: 'no-store',
   });
 
+/**
+ * The stats branch is refreshed by the daily `repo-stats` workflow, and when that
+ * workflow stops running `summary.json` does not start failing - it keeps being
+ * served with a 200 and a valid integer. That makes the clone count the one metric
+ * on this route that can fail without looking like a failure: stars, contributors
+ * and releases all go null and render as a placeholder, while a frozen clone total
+ * renders exactly like a live one. In August 2026 the workflow's token lost the
+ * traffic-API permission and the number sat unchanged for thirteen days, cached at
+ * the CDN as healthy the whole time.
+ *
+ * The report already stamps itself, so the check needs no credential, no extra
+ * request and no new workflow. Past the threshold the count is dropped to null,
+ * which is the same degraded state a failed lookup already produces and which the
+ * marketing surfaces already render as a loading placeholder.
+ *
+ * Three days rather than one: the workflow runs daily, so this tolerates two missed
+ * runs before calling the number stale.
+ */
+const SUMMARY_MAX_AGE_MS = 72 * 60 * 60 * 1000;
+
+/**
+ * `generated_at_utc` is written as `2026-08-24 23:06 UTC`, which is NOT ISO 8601 -
+ * so `Date.parse` accepting it is a V8 choice, not a language guarantee. Parsing it
+ * explicitly avoids depending on that, and every rejected form counts as STALE.
+ *
+ * Failing closed is the whole point. If an unreadable stamp produced NaN and were
+ * compared numerically, `NaN < threshold` is false, the count would be published as
+ * fresh forever, and the check would certify a frozen number as live - which is the
+ * exact defect it exists to catch. The bounds are in the pattern rather than left to
+ * `Date.UTC` because that function rolls a month of `13` forward into the next year,
+ * turning a malformed stamp into a future date that reads as fresh.
+ */
+const SUMMARY_STAMP =
+  /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])[ T]([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?\s*(?:UTC|Z)$/;
+
+const summaryGeneratedAt = (summary: unknown): number | null => {
+  if (!summary || typeof summary !== 'object') return null;
+  const stamp = (summary as { generated_at_utc?: unknown }).generated_at_utc;
+  if (typeof stamp !== 'string') return null;
+  const parts = SUMMARY_STAMP.exec(stamp.trim());
+  if (!parts) return null;
+  return Date.UTC(
+    Number(parts[1]),
+    Number(parts[2]) - 1,
+    Number(parts[3]),
+    Number(parts[4]),
+    Number(parts[5]),
+    parts[6] ? Number(parts[6]) : 0
+  );
+};
+
+/** True only for a report that stamps itself and is inside the freshness window. */
+const isSummaryFresh = (summary: unknown, now: number): boolean => {
+  const generatedAt = summaryGeneratedAt(summary);
+  return generatedAt !== null && now - generatedAt < SUMMARY_MAX_AGE_MS;
+};
+
 const readRepositoryClonesTotal = (summary: unknown): number | null => {
   if (!summary || typeof summary !== 'object') return null;
   const data = summary as {
@@ -102,11 +159,15 @@ const fetchStars = async (): Promise<Pick<GithubStatsResponse, 'stars' | 'starsF
   }
 };
 
-const fetchRepositoryClones = async (): Promise<string | null> => {
+const fetchRepositoryClones = async (now: number): Promise<string | null> => {
   try {
     const res = await githubFetch(REPO_STATS_SUMMARY);
     if (!res.ok) return null;
-    const total = readRepositoryClonesTotal(await res.json());
+    const summary = await res.json();
+    // A stale report is dropped rather than published: the surfaces that render
+    // this advertise a live number, and a wrong live number is worse than none.
+    if (!isSummaryFresh(summary, now)) return null;
+    const total = readRepositoryClonesTotal(summary);
     return total === null ? null : total.toLocaleString('en-US');
   } catch {
     return null;
@@ -134,9 +195,12 @@ export async function GET(request: Request): Promise<NextResponse> {
   const rejected = rejectUnexpectedParams(request, {});
   if (rejected) return rejected;
 
+  // One instant for the whole response, so the freshness verdict cannot straddle
+  // the threshold mid-request.
+  const now = Date.now();
   const [starCounts, repositoryClones, contributors] = await Promise.all([
     fetchStars(),
-    fetchRepositoryClones(),
+    fetchRepositoryClones(now),
     fetchContributors(),
   ]);
 

--- a/apps/frontend/src/app/api/community/github-stats/route.ts
+++ b/apps/frontend/src/app/api/community/github-stats/route.ts
@@ -91,6 +91,14 @@ const githubFetch = (url: string) =>
 const SUMMARY_MAX_AGE_MS = 72 * 60 * 60 * 1000;
 
 /**
+ * How far ahead of this server a report may be stamped and still count as fresh.
+ * The stamp is written by a GitHub runner and read here, and the two clocks are
+ * not synchronised, so a report generated seconds ago can carry a timestamp a
+ * little in the future. Small enough that it cannot rescue a stale report.
+ */
+const SUMMARY_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+/**
  * `generated_at_utc` is written as `2026-08-24 23:06 UTC`, which is NOT ISO 8601 -
  * so `Date.parse` accepting it is a V8 choice, not a language guarantee. Parsing it
  * explicitly avoids depending on that, and every rejected form counts as STALE.
@@ -98,9 +106,13 @@ const SUMMARY_MAX_AGE_MS = 72 * 60 * 60 * 1000;
  * Failing closed is the whole point. If an unreadable stamp produced NaN and were
  * compared numerically, `NaN < threshold` is false, the count would be published as
  * fresh forever, and the check would certify a frozen number as live - which is the
- * exact defect it exists to catch. The bounds are in the pattern rather than left to
- * `Date.UTC` because that function rolls a month of `13` forward into the next year,
- * turning a malformed stamp into a future date that reads as fresh.
+ * exact defect it exists to catch.
+ *
+ * The month, hour and minute bounds are here rather than left to `Date.UTC`, which
+ * rolls a month of `13` forward into the next year. The pattern cannot bound the DAY,
+ * though - 31 is legal in some months and not others - so `summaryGeneratedAt` reads
+ * the components back afterwards. Both roads lead to a date later than the one
+ * written, which is the direction that reads as fresh, so neither is left open.
  */
 const SUMMARY_STAMP =
   /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])[ T]([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?\s*(?:UTC|Z)$/;
@@ -111,20 +123,43 @@ const summaryGeneratedAt = (summary: unknown): number | null => {
   if (typeof stamp !== 'string') return null;
   const parts = SUMMARY_STAMP.exec(stamp.trim());
   if (!parts) return null;
-  return Date.UTC(
-    Number(parts[1]),
-    Number(parts[2]) - 1,
-    Number(parts[3]),
+  const year = Number(parts[1]);
+  const month = Number(parts[2]);
+  const day = Number(parts[3]);
+  const at = Date.UTC(
+    year,
+    month - 1,
+    day,
     Number(parts[4]),
     Number(parts[5]),
     parts[6] ? Number(parts[6]) : 0
   );
+  // The pattern bounds the day to 1-31 for every month, which it cannot do per
+  // month, so `2026-04-31` and `2026-02-30` still reach `Date.UTC` - and it
+  // rolls them FORWARD, towards fresh. Read the components back and reject
+  // anything that moved, which is the only check that knows how long a month is.
+  const roundTrip = new Date(at);
+  if (
+    roundTrip.getUTCFullYear() !== year ||
+    roundTrip.getUTCMonth() !== month - 1 ||
+    roundTrip.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return at;
 };
 
 /** True only for a report that stamps itself and is inside the freshness window. */
 const isSummaryFresh = (summary: unknown, now: number): boolean => {
   const generatedAt = summaryGeneratedAt(summary);
-  return generatedAt !== null && now - generatedAt < SUMMARY_MAX_AGE_MS;
+  if (generatedAt === null) return false;
+  const age = now - generatedAt;
+  // Two-sided, and the lower bound is the load-bearing half. A stamp dated in
+  // the future makes `age` negative, so a one-sided `age < MAX_AGE` calls it
+  // fresh - permanently, and for any value the report carries. That is reachable
+  // without malformed input at all: a year typo in the generator, or this
+  // server's clock running behind the runner that wrote the stamp.
+  return age >= -SUMMARY_CLOCK_SKEW_MS && age < SUMMARY_MAX_AGE_MS;
 };
 
 const readRepositoryClonesTotal = (summary: unknown): number | null => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The cumulative clone figure on the marketing surfaces froze on 2026-08-24 and was served as a live
number for thirteen days, found by eye rather than by any check. See #2802 for the full measurement.

Two of the three defects there are code, and this PR is those two. **The credential half is not
fixed here** - it needs repository-settings access.

**The route cannot see staleness.** `summary.json` on the `github-repo-stats` branch does not start
failing when the workflow stops updating it; it keeps answering `200` with a valid integer. Stars,
contributors, releases and Discord all degrade to `null` and render a loading placeholder, so the
clone count is the only metric here that can be *wrong* rather than absent - and it was CDN-cached
as healthy the whole time. The report already carries `generated_at_utc` and the route discarded it.

**CI could not see it either.** The action retries an authorization failure fifteen times at sixty
seconds and then hits `timeout-minutes: 15`; GitHub reports a timed-out job as `cancelled`. Twelve
consecutive dead runs therefore read as somebody pressing stop.

## What is the new behavior?

**Route.** `generated_at_utc` is read and the count is dropped past 72 hours - the same degraded
state a failed lookup already produces, which the marketing surfaces already render as a placeholder.
No credential and no extra request: the freshness signal is already in the payload being parsed.
Three days rather than one tolerates two missed runs of a daily job.

That stamp is `2026-08-24 23:06 UTC`, which is **not ISO 8601**, so `Date.parse` accepting it is an
engine choice rather than a language guarantee. It is parsed with an explicit bounded pattern
instead, and every form the pattern rejects counts as **stale**. Failing closed is the whole point:
an unreadable stamp compared as `NaN` evaluates `NaN < threshold` as false, would publish forever,
and would certify a frozen number as live - the exact defect the check exists to catch. The bounds
live in the pattern rather than being left to `Date.UTC`, which rolls a month of `13` forward into
the next year and would turn a malformed stamp into a future date that reads as fresh.

**Workflow.** One unauthenticated-cost check of the traffic API before the action runs, failing
immediately with the required permission in the message. A `403` is permanent, so retrying it cannot
help. On a transport error `curl` yields `000` and the step also fails - it cannot pass as a response
nobody checked.

## Verification

Preflight exercised against the live API, all three outcomes, not by inspection:

```
permitted token        HTTP 200   rc=0
invalid token          HTTP 401   rc=1   message names the required permission
unresolvable host      HTTP 000   rc=1   transport error does not pass
shellcheck -s bash                clean
```

Route tests **40/40**. Coverage on the touched file: statements/lines/functions 100%, branches
**92.3% -> 98.3%**. The single remaining uncovered branch is the `!summary` guard in
`readRepositoryClonesTotal`, which this change makes unreachable because the freshness check runs
first and rejects a non-object; it is kept as defence in depth rather than removed.

Mutation-checked, because a test that cannot fail is not coverage:

```
remove the freshness gate entirely        11 tests fail
fail OPEN on an unparseable stamp          8 tests fail
drop the pattern's month/day/hour bounds   4 tests fail
move the window 72h -> 24h                 1 test fails   (the boundary test, and only it)
restored                                  40/40 pass
```

The fixtures use the exact string the workflow writes rather than a tidy ISO stamp - a fixture in a
format the production data never uses cannot fail on the production data.

`npx tsc --noEmit` clean. `pnpm --filter frontend run lint`: 0 errors, 2 pre-existing warnings in
files this PR does not touch.

One test-harness note worth carrying: `jest.setup.ts` installs a global
`afterEach(() => jest.clearAllTimers())`, which drops a faked system time installed in `beforeAll`
after the first test. Every later time-dependent test then silently reads the real clock. That bit
this PR during development and there is a comment on the `beforeEach` explaining it.

## Not covered here

- The token permission itself, which needs repository settings.
- `summary.json`'s `clones.total` has been `null` in every archived version that could be decoded, so
  the published figure has always come from the undocumented `charts['#clones_total']` fallback. That
  is a separate defect, it survives the credential fix untouched, and it is recorded in #2802 rather
  than changed here.
- A local Aikido scan: no Aikido MCP or scan skill was available in this session, so the PR-level
  Aikido check is the gate for this change.

Note on rollout: `repo-stats` is a scheduled workflow, and scheduled workflows run from the default
branch, so the preflight only takes effect once this reaches `main`.

## Related Issue(s)

Fixes #2802
