### PR TITLE
test(ci): assert both out-of-shape hazards on the scan path

### DIFF
--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -865,6 +865,18 @@ test('scan refuses a pattern outside PATTERN_SHAPE, without needing selftest fir
   // an in-shape pattern.
   const dir = surfaceDir({ title: 'a harmless title' });
 
+  // Two out-of-shape hazards, not one. `.*` matches every line, so a scan that
+  // ran it would report every surface as a finding; `(a+)+b` backtracks
+  // exponentially and hangs the scanner on a crafted surface instead. The shape
+  // check refuses both, and asserting only one leaves the other resting on a
+  // predicate nothing here exercises.
+  const everything = run(['scan', '--dir', dir], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64('.*'),
+  });
+  assert.equal(everything.code, 2, 'a match-everything pattern must not reach the scan');
+  assert.match(everything.stderr, /plain alternation of literal words/);
+  assert.doesNotMatch(everything.stdout, /BLOCKED/);
+
   const refused = run(['scan', '--dir', dir], {
     FORBIDDEN_TERMS_PATTERN_B64: b64('(a+)+b'),
   });
@@ -881,7 +893,7 @@ test('scan refuses a pattern outside PATTERN_SHAPE, without needing selftest fir
 });
 
 test('a surface that is a SYMLINK exits 2 rather than being followed', () => {
-  // `readFileSync` follows links, so without the `lstat` check this run reads
+  // `readFileSync` follows links, so without `O_NOFOLLOW` on the open this run
   // the link's target, finds nothing in it, and exits 0 with
   // "clean - 6 surfaces read". The target here is deliberately clean and the
   // real surface deliberately is not: a guard that reports clean about a file


### PR DESCRIPTION
## What is the current behavior?

The scan-path shape check refuses two different failure modes and this repository asserts **one** of them.

- `(a+)+b` — nested quantifiers that backtrack exponentially, hanging the scanner on a crafted surface. **Asserted.**
- `.*` — matches every line, so a scan that ran it would report every surface as a finding. **Not asserted.**

Both are refused by one predicate, so asserting one leaves the other resting on a check nothing here exercises end to end.

## How this went unnoticed

The sibling repository asserts `.*` and **not** `(a+)+b`; this one asserts `(a+)+b` and **not** `.*` — under a test name identical on both sides. Neither was behind the other:

```
test count       41  vs  41
test NAME sets   zero differences
non-comment lines inside the bodies   16 differ
```

Every cheap comparison agreed. The name set is the first thing anyone checks and it was the last thing that would have shown this.

## How was it tested?

`node --test scripts/ci/forbidden-terms.test.mjs` — **60 pass, 0 fail** (60 before; this expands a test rather than adding one).

Mutation-checked with the anchor asserted as exactly one occurrence before each substitution, because `PATTERN_SHAPE.test(pattern.source)` appears at **two** sites — `selfTest` and the scan path — and only the second is the subject.

| mutation | fail | what it kills |
|---|---|---|
| `PATTERN_SHAPE` widened to admit `.` and `*` | 2 | `the shape refuses a wildcard` **and** this test — `.*` now reaches the scan while `(a+)+b` is still refused, so the new assertion is what fails |
| scan-path check **never** fires | 1 | this test alone, on a **refusal** assertion. The predicate's own unit tests stay green, so the new assertion is not redundant with them — it covers the scan path, which they do not |
| scan-path check **always** fires | 9 | and inside this test the failing assertion is the **control** |
| reverted | 0 | 60 pass |

**The last two rows are the argument for the control.** The two polarities of the same guard are caught by different halves of the test: `never fires` is caught by the refusals, `always fires` is caught only by the control. Neither half catches both.

That third row also shows why it is the weaker evidence taken alone — killing nine tests says the mutation is easy to catch, not that the control is load-bearing. The pair of polarities is what makes the case; a single over-broad mutation does not.

## Also in this change

The symlink test explained itself as *"without the `lstat` check"*. `lstat` was replaced by `O_NOFOLLOW` on the open, so the comment outlived its mechanism. The identical sentence was stale in the sibling and has been corrected there, so fixing it here converges the two rather than diverging them.

## Checklist

- [x] PR title follows conventional commit format
- [x] All existing tests pass
- [x] New code has test coverage — the change *is* a test, mutation-checked three ways
- [x] Lint and type-check pass — the pre-commit hooks ran (prettier, lint-staged, secretlint)
