### PR TITLE
fix(frontend): keep the invoice number on screen in the phone detail header

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceDetailHeader.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceDetailHeader.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import InvoiceDetailHeader from '@/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader';
 import { Appointment, Invoice } from '@yosemite-crew/types';
+import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 
 expect.extend(toHaveNoViolations);
 
@@ -40,6 +41,13 @@ jest.mock('@/app/lib/urls', () => ({
 jest.mock('@/app/lib/appointments', () => ({
   getAppointmentCompanion: () => ({ name: 'Poppy', species: 'dog', parent: { name: 'Lena' } }),
   getAppointmentCompanionPhotoUrl: () => '',
+}));
+
+/* Defaults to false so every existing test keeps measuring the desktop tree.
+   The phone tests below flip it explicitly. */
+jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
 }));
 
 jest.mock('@/app/lib/companionName', () => ({
@@ -206,5 +214,79 @@ describe('InvoiceDetailHeader', () => {
     );
 
     expect(screen.queryByRole('link', { name: /PDF/ })).not.toBeInTheDocument();
+  });
+
+  describe('on a phone', () => {
+    const asPhone = () => (useIsPhone as jest.Mock).mockReturnValue(true);
+    afterEach(() => (useIsPhone as jest.Mock).mockReturnValue(false));
+
+    /* At 390px the header row is 342px and the desktop actions ask for 334 of it,
+       so the invoice number rendered at width 0 - present, 26px tall, showing
+       nothing. The row keeps the identity and the close button; the status moves
+       under the title and the navigation controls take a row of their own.
+       Asserted structurally rather than by class name: a class assertion passes
+       forever, which is the whole reason the defect survived. */
+    it('moves the status under the title, beside the subtitle', () => {
+      asPhone();
+      render(
+        <InvoiceDetailHeader
+          titleId="title"
+          invoice={makeInvoice({ pdfUrl: 'https://cdn.test/inv.pdf' })}
+          appointment={appointment}
+          statusLabel="Paid"
+          statusStyle={statusStyle}
+          onClose={jest.fn()}
+        />
+      );
+
+      const status = screen.getByText('Paid');
+      // The subtitle and the status share a parent, which is what "under the
+      // title" means structurally - on desktop the status sits in `actions` and
+      // has no subtitle beside it.
+      expect(status.parentElement?.textContent).toContain('rabies booster');
+    });
+
+    it('gives the navigation controls a row of their own, away from the status', () => {
+      asPhone();
+      render(
+        <InvoiceDetailHeader
+          titleId="title"
+          invoice={makeInvoice({ pdfUrl: 'https://cdn.test/inv.pdf' })}
+          appointment={appointment}
+          statusLabel="Paid"
+          statusStyle={statusStyle}
+          onClose={jest.fn()}
+          onOpenAppointment={jest.fn()}
+        />
+      );
+
+      const link = screen.getByRole('link', { name: /Download invoice/ });
+      const open = screen.getByRole('button', { name: 'Open appointment' });
+      const heading = screen.getByRole('heading', { name: '#2038' });
+
+      // Both controls, in one container, and that container is not the header.
+      expect(link.parentElement).toBe(open.parentElement);
+      expect(link.parentElement?.contains(heading)).toBe(false);
+      expect(link.parentElement?.contains(screen.getByText('Paid'))).toBe(false);
+    });
+
+    it('renders no extra row when there is nothing to put in it', () => {
+      asPhone();
+      const { container } = render(
+        <InvoiceDetailHeader
+          titleId="title"
+          invoice={makeInvoice({})}
+          appointment={undefined}
+          statusLabel="Paid"
+          statusStyle={statusStyle}
+          onClose={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByRole('link', { name: /Download invoice/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Open appointment' })).not.toBeInTheDocument();
+      // The header is returned bare rather than wrapped in an empty column.
+      expect(container.firstElementChild?.contains(screen.getByRole('heading'))).toBe(true);
+    });
   });
 });

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.stories.tsx
@@ -294,6 +294,43 @@ export const ClosesAndOpens: Story = {
   },
 };
 
+export const Phone: Story = {
+  name: 'Phone (390): the number survives the row',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* At 390px the header row is 342px and the desktop actions ask for 334 of it -
+       status pill, PDF link, Open appointment, close. `ModalHeader` gives the title
+       column `min-w-0` and the actions `shrink-0`, so the whole deficit came out of
+       the invoice number, which rendered at width 0: present, 26px tall, showing
+       nothing. `getByRole` could not see that - the text node is complete when the
+       paint is gone - so this measures the box instead. */
+    const heading = canvas.getByRole('heading', { name: '#INV-2026-0142' });
+    await expect(heading.scrollWidth).toBeLessThanOrEqual(heading.clientWidth + 1);
+    // Not vacuous: a heading that never rendered would also report 0 <= 1.
+    await expect(heading.clientWidth).toBeGreaterThan(100);
+
+    // Both controls survive the move out of the row - reachable, not merely present.
+    await expect(canvas.getByRole('link', { name: /Download invoice/ })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Open appointment' })).toBeEnabled();
+
+    // And the status is still on screen, under the title rather than beside it.
+    await expect(canvas.getByText('Paid')).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same header at a phone width. The row keeps the identity and the close button; the ' +
+          'status moves under the title and the two navigation controls take a row of their own. ' +
+          'This is a budget rather than a ranking - the actions alone exceeded the row by 74px, so ' +
+          'giving the title priority would only have chosen a different control to destroy.',
+      },
+    },
+  },
+};
+
 export const LongSubtitle: Story = {
   name: 'A long subtitle wraps, the actions do not move',
   args: {

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.tsx
@@ -4,6 +4,7 @@ import CompanionAvatar from '@/app/ui/avatars/CompanionAvatar';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
+import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getInvoiceNumberLabel } from '@/app/lib/invoice';
 import { formatDateLabel } from '@/app/lib/forms';
@@ -56,12 +57,76 @@ const InvoiceDetailHeader = ({
   // preview overlay uses accepts only https (and localhost over http in dev)
   // and returns '' for anything else.
   const pdfUrl = getSafePdfPreviewUrl(invoice.pdfUrl);
+  const isPhone = useIsPhone();
 
-  return (
+  const statusPill = statusLabel ? (
+    <StatusPill className="shrink-0" label={statusLabel} tone={statusTone} style={statusStyle} />
+  ) : null;
+
+  const pdfLink = pdfUrl ? (
+    <a
+      href={pdfUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-1.5 h-9 px-[15px] rounded-full border border-[var(--divider)] text-[12.5px] font-semibold text-[var(--ink-body)] hover:bg-[var(--inset)] transition-colors"
+      aria-label={`Download invoice ${numberLabel} PDF`}
+    >
+      <IoDownloadOutline size={14} aria-hidden="true" />
+      PDF
+    </a>
+  ) : null;
+
+  const openAppointmentButton =
+    appointment && onOpenAppointment ? (
+      <button
+        type="button"
+        onClick={onOpenAppointment}
+        className="flex items-center gap-1.5 h-9 px-[15px] rounded-full border border-[var(--divider)] text-[12.5px] font-semibold text-[var(--ink-body)] hover:bg-[var(--inset)] transition-colors"
+      >
+        <IoOpenOutline size={14} aria-hidden="true" />
+        Open appointment
+      </button>
+    ) : null;
+
+  /* At 390px the header row is 342px wide and the actions ask for more than it
+     has - 334px with a PDF link and an Open appointment button beside the status
+     pill. `ModalHeader` gives the title column `min-w-0` and the actions
+     `shrink-0`, so the deficit is taken entirely out of the invoice number,
+     which renders at 0px: present, 26px tall, and showing nothing.
+
+     Measured at 390x844, per story:
+
+       actions   row   invoice number gets / needs
+         257     342          25 / 139     status pill 134 + PDF 75 + close 32
+         251     342          31 / 132     status pill  48 + open 155 + close 32
+         334     342           0 / 132     all four
+
+     So this is a budget, not a ranking: giving the title priority would only
+     move which control is destroyed. On a phone the row keeps the identity and
+     the close button, the status moves under the title, and the two navigation
+     controls take a row of their own where they stay reachable and legible. */
+  const phoneActionRow =
+    isPhone && (pdfLink || openAppointmentButton) ? (
+      <div className="flex flex-wrap items-center gap-2">
+        {pdfLink}
+        {openAppointmentButton}
+      </div>
+    ) : null;
+
+  const header = (
     <ModalHeader
       titleId={titleId}
       title={numberLabel}
-      meta={subtitle || undefined}
+      meta={
+        isPhone && statusPill ? (
+          <span className="flex flex-wrap items-center gap-2">
+            {statusPill}
+            {subtitle}
+          </span>
+        ) : (
+          subtitle || undefined
+        )
+      }
       onClose={onClose}
       icon={
         <span className="flex size-10 shrink-0 overflow-hidden rounded-full bg-card-hover">
@@ -82,40 +147,24 @@ const InvoiceDetailHeader = ({
         </span>
       }
       actions={
-        <>
-          {statusLabel && (
-            <StatusPill
-              className="shrink-0"
-              label={statusLabel}
-              tone={statusTone}
-              style={statusStyle}
-            />
-          )}
-          {pdfUrl && (
-            <a
-              href={pdfUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 h-9 px-[15px] rounded-full border border-[var(--divider)] text-[12.5px] font-semibold text-[var(--ink-body)] hover:bg-[var(--inset)] transition-colors"
-              aria-label={`Download invoice ${numberLabel} PDF`}
-            >
-              <IoDownloadOutline size={14} aria-hidden="true" />
-              PDF
-            </a>
-          )}
-          {appointment && onOpenAppointment && (
-            <button
-              type="button"
-              onClick={onOpenAppointment}
-              className="flex items-center gap-1.5 h-9 px-[15px] rounded-full border border-[var(--divider)] text-[12.5px] font-semibold text-[var(--ink-body)] hover:bg-[var(--inset)] transition-colors"
-            >
-              <IoOpenOutline size={14} aria-hidden="true" />
-              Open appointment
-            </button>
-          )}
-        </>
+        isPhone ? undefined : (
+          <>
+            {statusPill}
+            {pdfLink}
+            {openAppointmentButton}
+          </>
+        )
       }
     />
+  );
+
+  if (!phoneActionRow) return header;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {header}
+      {phoneActionRow}
+    </div>
   );
 };
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for. — see "Related" below
- [x] All existing tests and lints pass.

**Head `a54408457`.** Naming it here deliberately: a rebase rewrites a review's `commit_id` to
follow the new head, so the metadata cannot tell a later reader which tree was approved.

## What is the current behavior?

At 390px the invoice detail header renders **its own invoice number at width 0**. The element is
there — `display: block`, 26px tall, `#INV-2026-0142` complete in the DOM — and it paints nothing.
An operator opening an invoice on a phone cannot see which invoice they have open.

Measured at 390x844, `document.fonts.ready` awaited before every read:

```
story           status pill          PDF  Open appt  Close  actions  row   number client/scroll
unlinked-sale   "Awaiting payment"   134   75    -     32     257    342      25 / 139
without-pdf     "Paid"                48    -  155     32     251    342      31 / 132
with-pdf        "Paid"                48   75  155     32     334    342       0 / 132
```

**This is a budget, not a ranking.** `ModalHeader` gives the title column `min-w-0` and the actions
`shrink-0`, so the whole deficit comes out of the identity — but the actions alone exceed the row by
74px *before the title is considered at all*. Giving the title priority would only choose a
different control to destroy. Even the status pill plus the close button is ~178px on the longest
status, against the ~143px the row can spare once the number has the 139px it needs.

## What is the new behavior?

On a phone the row keeps the identity and the close button. The status moves under the title into
`ModalHeader`'s `meta`, and the two navigation controls take a row of their own.

```
unlinked-sale  139 / 139      without-pdf  132 / 132      with-pdf  132 / 132
```

`clientWidth == scrollWidth` on all three: **not clipped**, rather than less clipped. Both controls
survive the move — asserted `toBeVisible` and `toBeEnabled`, not merely present — and the status is
still on screen.

### `ModalHeader` is deliberately untouched

Seven of its nine `actions`-passing consumers measure clean at 390px, and 48 of its 58 consumers
pass no `actions` at all, so their right-hand side is a close button that cannot compete. A change
there would have altered 58 modals to fix two call sites.

## Why nothing caught this

The component's five existing stories **pin no viewport**, so they render at the project default of
1280px where the row has room. The new story pins `mobile`. And `getByRole` cannot catch it either —
the text node is complete when the paint is gone — so the assertion measures the box rather than
querying the text.

## Testing

```
tsc --noEmit                                        0
eslint (both changed files)                         0
jest --ci (whole frontend package)                  1039 suites / 13147 tests passed
test-storybook InvoiceDetailHeader                  6 passed, 6 total
forbidden-terms scan, six surfaces, real exit code  0
```

**Mutation** — put the actions back in the row, which is the shipped behaviour:

```
Finance/InvoiceDetailHeader > Phone > play-test
  expected 132 to be less than or equal to 1
1 failed, 5 passed, 6 total
```

Only the new story fails. The assertion is also guarded against its own vacuity with
`clientWidth > 100`, because a heading that never rendered would satisfy `0 <= 1` and report a pass.

Verified visually at 390x844 at `deviceScaleFactor: 1` — deliberately, because a screenshot from a
2x context is a measurement in device pixels, which is how three of my earlier estimates in this
area came out at exactly twice their real values.

## Related

Found by a clipped-text sweep of 650 story renders across finance, inventory, tasks, dashboard and
billing. Sibling finding, not in this PR: `forms/AddForm`'s header title takes 20px of a 270px
string by the same mechanism, and belongs to the forms desk.


---

## Head `8769a1939` — coverage for the phone branch

`test / Merge coverage (frontend)` failed at `a54408457`, and it was right to:

```
InvoiceDetailHeader.tsx   89.47% stmts   76.92% branch
uncovered  110-114, 122-126, 162-169   = phoneActionRow, the phone `meta`, the wrapping return
```

The phone branch was exercised only by the Storybook play function above.
`collectCoverageFrom` excludes `*.stories.tsx`, so the story is a fixture that contributes
nothing to the denominator while the component lines it drives are counted — a green story suite
and an uncovered branch at the same time. Same shape as the helper caught at 0/55 on #2797.

Three jest tests, `useIsPhone` mocked and defaulting to `false` so every existing test still
measures the desktop tree:

```
moves the status under the title          the status and the subtitle share a parent
a row of its own, away from the status    both controls in one container, and that container
                                          holds neither the heading nor the status
no extra row when there is nothing        the header is returned bare, not wrapped in an
                                          empty column
```

Asserted structurally rather than by class name: a class assertion passes forever, which is how
the original defect survived five stories.

```
InvoiceDetailHeader.tsx        100% stmts / 100% branch / 100% funcs / 100% lines
mutation, action row disabled  1 failed  - "a row of their own"
mutation, status left in row   2 failed
restored                      12 passed, 12 total
tsc --noEmit                   0
```
