### PR TITLE
docs(ci): say that CI Required is required, because it is

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,14 @@ name: CI
 #
 # This is the primary CI. It replaced the standalone ci-affected, frontend-a11y
 # and dev-docs-build workflows (all deleted) and slimmed frontend-quality to a
-# reusable bundle/Lighthouse stage called from here. It is not yet a required
-# status check; docs/ci/required-checks-migration.md covers making it required
-# and enabling the merge queue.
+# reusable bundle/Lighthouse stage called from here.
+#
+# Whether its aggregate check is REQUIRED is not stated here. It was, as "not
+# yet a required status check", and the same commit that corrected the identical
+# claim on the `ci-required` job below left this one standing - so the file said
+# pending at the top and done in the middle, and the top is what a reader meets
+# first. The job comment owns that fact and dates it; the remaining migration
+# steps are in docs/ci/required-checks-migration.md.
 
 on:
   pull_request: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,9 +130,18 @@ jobs:
 
   ci-required:
     name: CI Required
-    # Not yet a required status check on either ruleset. It is published now so
-    # its behaviour can be observed before it is made required; the runbook in
-    # docs/ci/required-checks-migration.md covers that switchover.
+    # REQUIRED on the `dev` ruleset since 2026-09-06, alongside
+    # `Supply Chain Required`. NOT required on `Main`, whose only required
+    # status check is the context literally named "Only dev may merge into
+    # main" - a check context worded as a sentence, which reads like a rule
+    # description in any listing that prints contexts in a column.
+    #
+    # That asymmetry decides how to read an ABSENT row: on a pull request into
+    # `dev` a missing `CI Required` blocks the merge and means this job has not
+    # reported yet, not that nothing enforces it. The wording here said "not yet
+    # required on either ruleset" for some time after the switchover, which
+    # points a reader at the opposite action. Runbook:
+    # docs/ci/required-checks-migration.md.
     if: always()
     needs: [core, test, migration, sonar, frontend-quality, mobile-version]
     runs-on: ubuntu-latest

--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -304,7 +304,9 @@ jobs:
       # through an earlier pull request sits in the BASE of every later `dev`
       # comparison and is never looked at again - but a `main` pull request's
       # merge base is the previous promotion, so the whole of `dev` since then
-      # is in scope. That is why this workflow is required on BOTH branches.
+      # is in scope. That is why this workflow RUNS on BOTH branches - which is
+      # this file's `on:` block, not a ruleset. It is required on neither; the
+      # header above says which contexts each ruleset actually requires.
       - name: Collect the surfaces
         if: ${{ github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -49,10 +49,11 @@ name: Forbidden Terms
 #
 # So the cost is real historically and near zero now, and the two halves point
 # opposite ways. What settles it is a third fact rather than a bigger number:
-# `No named external product` IS NOT A REQUIRED STATUS CHECK on either branch -
-# `dev` requires `CI Required` and `Supply Chain Required`, `main` requires
-# `Only dev may merge into main`. A fork therefore gets a visible red that
-# reports honestly and blocks nothing, and a maintainer who wants it green
+# `No named external product` IS NOT A REQUIRED STATUS CHECK on either branch.
+# Which contexts each ruleset does require is deliberately not listed here: it
+# drifts, this file cannot notice when it does, and the argument only needs the
+# negative. A fork therefore gets a visible red that reports honestly and
+# blocks nothing, and a maintainer who wants it green
 # pushes the branch to this repository and opens the pull request from there.
 #
 # THAT IS ALSO WHAT MAKES THIS PARAGRAPH EXPIRE. The moment this context is
@@ -305,8 +306,7 @@ jobs:
       # comparison and is never looked at again - but a `main` pull request's
       # merge base is the previous promotion, so the whole of `dev` since then
       # is in scope. That is why this workflow RUNS on BOTH branches - which is
-      # this file's `on:` block, not a ruleset. It is required on neither; the
-      # header above says which contexts each ruleset actually requires.
+      # this file's `on:` block, not a ruleset. It is required on neither.
       - name: Collect the surfaces
         if: ${{ github.event_name == 'pull_request' }}
         env:

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -43,15 +43,16 @@ the merge. Read off the rulesets, not off this file:
 
 The `required status checks` column is the `required_status_checks` rule's
 context list and nothing else. **Rulesets carry other rule types that gate
-merges too** - `code_quality`, `code_scanning`, `copilot_code_review`,
-`pull_request` - and none of those appear in that column. Do not read an empty
-cell as an ungated branch.
+merges too** - and none of them appear in that column. The `other gating rules`
+column lists every non-`required_status_checks` rule on each ruleset, so it can
+be read down as well as across. Do not take an empty first cell for an ungated
+branch.
 
-| ruleset    | name                                              | required status checks                 | other gating rules                                                        |
-| ---------- | ------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
-| `3468092`  | dev                                               | `CI Required`, `Supply Chain Required` | `code_quality` (severity `errors`), `copilot_code_review`, `pull_request` |
-| `3440858`  | Main                                              | `Only dev may merge into main`         | `code_scanning` (CodeQL), `copilot_code_review`, `pull_request`           |
-| `21048611` | Protect main and dev from deletion and force-push | none                                   | `deletion`, `non_fast_forward` only                                       |
+| ruleset    | name                                              | required status checks                 | other gating rules                                                                                        |
+| ---------- | ------------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `3468092`  | dev                                               | `CI Required`, `Supply Chain Required` | `deletion`, `non_fast_forward`, `copilot_code_review`, `code_quality` (severity `errors`), `pull_request` |
+| `3440858`  | Main                                              | `Only dev may merge into main`         | `deletion`, `non_fast_forward`, `copilot_code_review`, `code_scanning` (CodeQL), `pull_request`           |
+| `21048611` | Protect main and dev from deletion and force-push | none                                   | `deletion`, `non_fast_forward`                                                                            |
 
 **There are three rulesets, not two.** And `Only dev may merge into main` is a
 status check _context_ whose text reads exactly like a rule description, so any

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -35,31 +35,47 @@ Verified draft-day: rulesets `3440858` (Main) and `3468092` (dev) had **zero**
 required status checks, so nothing removed above was ever a required check and
 none of it blocked merges.
 
-**Re-measured 2026-09-06 and step 1 below is DONE.** `dev` now requires
-`CI Required` and `Supply Chain Required`. `Main` requires exactly one context,
-literally named `Only dev may merge into main` - it is a status check, not a
-rule description, and it prints identically to one in any listing of contexts.
-`CI Required` is not among Main's required checks. Leaving
-the paragraph above in the present tense outlived the change it described, and
-a reader using it to judge whether a missing `CI Required` row matters would
-have drawn the opposite conclusion - on `dev` an absent row blocks the merge.
+**Re-measured 2026-09-06. Step 1 is DONE and its instructions are removed
+below.** Leaving the paragraph above in the present tense outlived the change it
+described, and a reader using it to judge whether a missing `CI Required` row
+matters would have drawn the opposite conclusion - on `dev` an absent row blocks
+the merge. Read off the rulesets, not off this file:
 
-Two steps remain, both needing a green `merge_group` run first:
+| ruleset    | name                                              | required status checks                 |
+| ---------- | ------------------------------------------------- | -------------------------------------- |
+| `3468092`  | dev                                               | `CI Required`, `Supply Chain Required` |
+| `3440858`  | Main                                              | `Only dev may merge into main`         |
+| `21048611` | Protect main and dev from deletion and force-push | none                                   |
 
-1. **Make `CI Required` required.** Re-GET both rulesets, confirm nobody added a
-   required context referencing an old job name, then append the rule:
+**There are three rulesets, not two.** And `Only dev may merge into main` is a
+status check _context_ whose text reads exactly like a rule description, so any
+listing that prints contexts in a column gives a reader no way to tell which it
+is. `CI Required` is not among Main's required checks; `code_quality` is
+required on none of the three.
 
-   ```
-   gh api repos/YosemiteCrew/Yosemite-Crew/rulesets/<id> > r.json
-   jq '.rules += [{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"do_not_enforce_on_create":false,"required_status_checks":[{"context":"CI Required"}]}}]' r.json > r.new.json
-   gh api -X PUT repos/YosemiteCrew/Yosemite-Crew/rulesets/<id> --input r.new.json
-   ```
+~~1. Make `CI Required` required.~~ **Done.** The instructions that stood here
+appended a `required_status_checks` rule to a ruleset - re-GET, `jq '.rules +=
+[...]'`, `PUT`. Running them now would append a _second_ such rule to a ruleset
+that already has one. That is why they are deleted rather than struck: this
+section is imperative, and a stale imperative is worse than a stale description
+because a reader can execute it. The precondition it assumed is exactly what
+this document now records as false.
 
-2. **Enable the merge queue on `dev`,** only once step 1 is green. Check whether
+The one instruction worth keeping from it, because it is the check that would
+have caught this: **re-GET the rulesets and confirm nobody has added a required
+context referencing an old job name** before changing any of them.
+
+One step remains, and its gate is now satisfied - it was blocked on step 1 and
+is not any more:
+
+1. **Enable the merge queue on `dev`.** No ruleset carries a `merge_queue` rule
+   today. Check whether
    a `code_quality` status posts on a `merge_group` ref. It is not expected to -
    SonarCloud decorates pull requests, not merge groups. If it does not, remove
    `code_quality` from dev's required set before enabling the queue, keeping it
-   as PR decoration. The Sonar signal for queued changes is the PR run's sonar
+   as PR decoration. (Measured 2026-09-06: `code_quality` is not in dev's
+   required set, so that removal may already be moot - re-check rather than
+   assume either way.) The Sonar signal for queued changes is the PR run's sonar
    stage (which runs `-Dsonar.qualitygate.wait=true`, so a red gate reds the
    PR's `CI Required` before the PR can enter the queue): the `merge_group` run
    itself SKIPS sonar deliberately, because the SonarCloud plan only analyzes

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -41,17 +41,22 @@ described, and a reader using it to judge whether a missing `CI Required` row
 matters would have drawn the opposite conclusion - on `dev` an absent row blocks
 the merge. Read off the rulesets, not off this file:
 
-| ruleset    | name                                              | required status checks                 |
-| ---------- | ------------------------------------------------- | -------------------------------------- |
-| `3468092`  | dev                                               | `CI Required`, `Supply Chain Required` |
-| `3440858`  | Main                                              | `Only dev may merge into main`         |
-| `21048611` | Protect main and dev from deletion and force-push | none                                   |
+The `required status checks` column is the `required_status_checks` rule's
+context list and nothing else. **Rulesets carry other rule types that gate
+merges too** - `code_quality`, `code_scanning`, `copilot_code_review`,
+`pull_request` - and none of those appear in that column. Do not read an empty
+cell as an ungated branch.
+
+| ruleset    | name                                              | required status checks                 | other gating rules                                                        |
+| ---------- | ------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| `3468092`  | dev                                               | `CI Required`, `Supply Chain Required` | `code_quality` (severity `errors`), `copilot_code_review`, `pull_request` |
+| `3440858`  | Main                                              | `Only dev may merge into main`         | `code_scanning` (CodeQL), `copilot_code_review`, `pull_request`           |
+| `21048611` | Protect main and dev from deletion and force-push | none                                   | `deletion`, `non_fast_forward` only                                       |
 
 **There are three rulesets, not two.** And `Only dev may merge into main` is a
 status check _context_ whose text reads exactly like a rule description, so any
 listing that prints contexts in a column gives a reader no way to tell which it
-is. `CI Required` is not among Main's required checks; `code_quality` is
-required on none of the three.
+is. `CI Required` is not among Main's required checks.
 
 ~~1. Make `CI Required` required.~~ **Done.** The instructions that stood here
 appended a `required_status_checks` rule to a ruleset - re-GET, `jq '.rules +=
@@ -73,9 +78,11 @@ is not any more:
    a `code_quality` status posts on a `merge_group` ref. It is not expected to -
    SonarCloud decorates pull requests, not merge groups. If it does not, remove
    `code_quality` from dev's required set before enabling the queue, keeping it
-   as PR decoration. (Measured 2026-09-06: `code_quality` is not in dev's
-   required set, so that removal may already be moot - re-check rather than
-   assume either way.) The Sonar signal for queued changes is the PR run's sonar
+   as PR decoration. (Measured 2026-09-06: dev's ruleset carries `code_quality`
+   with `severity: errors`. It is a rule TYPE, not a status-check context, so it
+   does not appear in the required-contexts column above - an earlier draft of
+   this paragraph read that column, found nothing, and reported the removal as
+   moot. It is not: the rule is present and enforced, and this step applies.) The Sonar signal for queued changes is the PR run's sonar
    stage (which runs `-Dsonar.qualitygate.wait=true`, so a red gate reds the
    PR's `CI Required` before the PR can enter the queue): the `merge_group` run
    itself SKIPS sonar deliberately, because the SonarCloud plan only analyzes

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -17,7 +17,7 @@ directly:
 - `_sonar` - scan only, reading the coverage `_test` produced. No install, no
   Prisma, no jest. Kill switch: set the `DISABLE_SONAR` repo variable to `true`.
 - `frontend-quality` - bundle budgets and Lighthouse, consuming `next-build`.
-- `CI Required` - one aggregate check. **Not yet a required status check.**
+- `CI Required` - one aggregate check. **Required on `dev` since 2026-09-06.**
 
 ## What was removed, and where it went
 
@@ -31,10 +31,18 @@ directly:
 
 ## Outstanding (post-merge, require repo-admin and a human)
 
-Verified draft-day: rulesets `3440858` (Main) and `3468092` (dev) have **zero**
-required status checks. Main gates on CodeQL `code_scanning` + PR review +
-copilot; dev on Sonar `code_quality` + PR review + copilot. So nothing that was
-removed above was ever a required check, and none of this blocked merges.
+Verified draft-day: rulesets `3440858` (Main) and `3468092` (dev) had **zero**
+required status checks, so nothing removed above was ever a required check and
+none of it blocked merges.
+
+**Re-measured 2026-09-06 and step 1 below is DONE.** `dev` now requires
+`CI Required` and `Supply Chain Required`. `Main` requires exactly one context,
+literally named `Only dev may merge into main` - it is a status check, not a
+rule description, and it prints identically to one in any listing of contexts.
+`CI Required` is not among Main's required checks. Leaving
+the paragraph above in the present tense outlived the change it described, and
+a reader using it to judge whether a missing `CI Required` row matters would
+have drawn the opposite conclusion - on `dev` an absent row blocks the merge.
 
 Two steps remain, both needing a green `merge_group` run first:
 


### PR DESCRIPTION
## What is the current behavior?

Two documents describe `CI Required` as pending, and it is not.

```
.github/workflows/ci.yaml       "Not yet a required status check on either ruleset."
docs/ci/required-checks-migration.md
   "- `CI Required` - one aggregate check. **Not yet a required status check.**"
   "Verified draft-day: rulesets ... have **zero** required status checks."
```

Measured against the API rather than the documents:

```
dev  ruleset 3468092   CI Required · Supply Chain Required
Main ruleset 3440858   Only dev may merge into main
```

## Why the wording matters in this direction

It is not a tidy-up. On a pull request into `dev`, an **absent** `CI Required` row blocks the merge and means the aggregate job has not reported yet. The old sentence says nothing enforces it — which points a reader at the opposite action: ignore the missing row and merge past it.

That is not hypothetical. It happened on #2807 this afternoon: a missing `CI Required` was read as satisfied, from a query whose one-element result looked like a two-element one. The wrong comment and the wrong reading agree with each other, which is what makes the pair dangerous.

## What Main actually requires

Its single required context is **literally named** `Only dev may merge into main`. That is a status check worded as a sentence, so in any listing that prints contexts in a column it is indistinguishable from a rule description.

A first pass at this change said "Main requires none" for exactly that reason. It was caught by re-reading the raw ruleset instead of my own earlier column output — which is the only reason this PR does not ship a fresh wrong sentence in place of a stale one.

## How was it tested?

Comment and documentation only — no job, `needs`, condition, or step is changed:

```
2 files changed, 25 insertions(+), 8 deletions(-)
```

Every claim in the new text was taken from `gh api .../rulesets/<id>` at the time of writing, and both substitutions were applied under an anchor asserted at exactly one occurrence. The pre-commit hooks ran.

The sibling repository carries the same stale sentence and is fixing it separately, so this converges the two rather than diverging them.

## Checklist

- [x] PR title follows conventional commit format
- [x] All existing tests pass — nothing executable is touched
- [x] Lint and type-check pass — pre-commit hooks ran