### PR TITLE
fix(frontend): take the inventory count badge off the badge-blue pair

### DIFF
--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
@@ -3,6 +3,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { InventoryFilterBar } from './index';
+/* Cross-feature import rather than a second copy, matching #2796: a duplicated
+   contrast helper is how two of them drift apart on the thing they both exist to
+   measure. It belongs in `@/app/lib`; moving it is a separate change. */
+import {
+  describeContrast,
+  measureContrast,
+} from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
 import { defaultFilters } from './utils';
 import type { InventoryFiltersState } from './types';
 
@@ -219,6 +226,21 @@ export const WithSelectedFilters: Story = {
     await expect(filter.querySelectorAll('svg')).toHaveLength(1);
     await expect(filter).toHaveTextContent('3');
 
+    /* The count has to be readable on its own fill. This badge used the
+       `badge-blue` pair, whose ink and fill measure 3.61:1 together at 14px/500 -
+       under AA in BOTH themes, since neither token has a dark override. Measured
+       on composited pixels rather than asserted from a class list, so a future
+       token change is caught rather than a future rename. */
+    const badge = [...filter.querySelectorAll('span')].find(
+      (node) => node.textContent?.trim() === '3'
+    );
+    await expect(badge).toBeDefined();
+    const reading = measureContrast(badge as Element);
+    await expect(
+      reading.ratio,
+      describeContrast('filter count badge', reading)
+    ).toBeGreaterThanOrEqual(reading.required);
+
     await userEvent.click(filter);
     await expect(args.setFilterOpen).toHaveBeenCalledWith(true);
   },
@@ -229,6 +251,43 @@ export const WithSelectedFilters: Story = {
           "Three filters applied. The badge takes the chevron's place, so the trigger keeps its " +
           'width and the row does not reflow when a filter is added - which is the only reason to ' +
           'swap rather than append.',
+      },
+    },
+  },
+};
+
+/* The badge is asserted in BOTH themes deliberately. `--inset`/`--ink` are
+   theme-aware, so a light-only assertion measures one of the two composites and
+   goes vacuous the day the toolbar default changes - the gap #2803 had to close
+   in a follow-up. The pair this replaces failed identically in both themes
+   because neither of its tokens has a dark override, so the light story alone
+   would still have caught the original defect; that is luck, not coverage. */
+export const WithSelectedFiltersDark: Story = {
+  name: 'Filter trigger with a count badge (dark)',
+  args: { selectedFilterChips: CHIPS },
+  globals: { theme: 'dark' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Otherwise this is the light assertion run twice under a dark name.
+    await expect(document.documentElement.dataset.theme).toBe('dark');
+
+    const filter = canvas.getByRole('button', { name: /^Filter 3$/ });
+    const badge = [...filter.querySelectorAll('span')].find(
+      (node) => node.textContent?.trim() === '3'
+    );
+    await expect(badge).toBeDefined();
+    const reading = measureContrast(badge as Element);
+    await expect(
+      reading.ratio,
+      describeContrast('filter count badge, dark', reading)
+    ).toBeGreaterThanOrEqual(reading.required);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same badge on the dark composite. `--inset` and `--ink` both flip per theme, so ' +
+          'this measures a different pair of colours rather than repeating the light story.',
       },
     },
   },

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
@@ -219,8 +219,17 @@ export const SortPanelClosesOnOutsideClick: Story = {
 export const WithSelectedFilters: Story = {
   name: 'Filter trigger with a count badge',
   args: { selectedFilterChips: CHIPS },
+  /* Pinned, and the failure mode it prevents is a PASS rather than a vacuity.
+     Unpinned, this story inherits `preview.ts`'s default; if that default ever
+     flips to dark it measures the dark composite, reads 12.64, clears 4.5 and
+     reports green - while the light composite goes unmeasured and nothing
+     fails. The dark story below asserts its theme before measuring, so pinning
+     only one of the two leaves them protected by different mechanisms and only
+     one of those is a mechanism. */
+  globals: { theme: 'light' },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
+    await expect(document.documentElement.dataset.theme).toBe('light');
     const filter = canvas.getByRole('button', { name: /^Filter 3$/ });
     // The chevron is replaced by the badge rather than sitting beside it.
     await expect(filter.querySelectorAll('svg')).toHaveLength(1);

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -380,7 +380,16 @@ export const InventoryFilterBar = ({
             <IoOptionsOutline size={16} aria-hidden="true" />
             <span>Filter</span>
             {selectedFilterChips.length > 0 ? (
-              <span className="rounded-full bg-badge-blue-bg px-2 text-caption-1 text-badge-blue-text">
+              /* `--inset`/`--ink`, not the badge-blue pair. `--color-badge-blue-text`
+                 (#eaf3ff) on `--color-badge-blue-bg` (#007cf5) measures 3.61:1 at
+                 this size - text-caption-1 is 14px/500, so AA wants 4.5 and there is
+                 no large-text escape. Neither token has a dark override, so it fails
+                 identically in both themes. Moving only the fill does not fix it
+                 either: this ink on `--blue-strong` is 5.79 light but 4.06 dark.
+                 `0e5e9de36` already moved three inventory badges to this pair for
+                 the same reason; 13.24 light, 12.64 dark, and both tokens are
+                 theme-aware. See #2799. */
+              <span className="rounded-full bg-[var(--inset)] px-2 text-caption-1 text-[var(--ink)]">
                 {selectedFilterChips.length}
               </span>
             ) : (

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -473,6 +473,13 @@ input[type='radio']:focus-visible {
   --color-upload-success: #10b981;
   --color-upload-text: var(--ink-body);
 
+  /* These two are declared together and MUST NOT be used together at body sizes:
+     #eaf3ff on #007cf5 is 3.61:1, and neither has a dark override so it fails
+     identically in both themes. No ink in this palette clears 4.5 on that fill -
+     white is 4.04 and --ink is 4.21 - so the fill has to change, not the ink.
+     `0e5e9de36` and #2799 moved the badges that paired them to --inset/--ink.
+     The fill alone remains in use for chart series and filter definitions, where
+     nothing is written on top of it. */
   --color-badge-blue-bg: var(--color-primary-500);
   --color-badge-blue-text: #eaf3ff;
   --color-pill-neutral-bg: var(--status-requested-bg);


### PR DESCRIPTION
Head at review time: `c24637ce7`.

## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`globals.css` declares an ink and a fill meant to be used together, and they fail AA together:

```css
--color-badge-blue-bg: var(--color-primary-500);   /* #007cf5 */
--color-badge-blue-text: #eaf3ff;
```

`#eaf3ff` on `#007cf5` is **3.61:1**. The inventory Filter trigger renders the count badge with that pair at `text-caption-1`, which is 14px at weight 500 - not WCAG large text, so the requirement is 4.5:1 and there is no escape. Neither token has a dark override, so it fails identically in both themes.

## What is the new behavior?

`bg-[var(--inset)]` / `text-[var(--ink)]` - 13.24:1 light, 12.64:1 dark, and both tokens are theme-aware, which is the property whose absence caused this.

This follows an existing decision rather than making a new one: `0e5e9de36` already moved three inventory badges off this pair to exactly these tokens.

**Moving only the fill does not work**, which is the fix most people reach for first - it is what #2785 did for the phone calendar:

| | light | dark |
| --- | --- | --- |
| `#eaf3ff` on `--blue-strong` | 5.79 PASS | **4.06 FAIL** |
| `#ffffff` on `--blue-strong` | 6.48 PASS | 4.54 PASS |

That fix carried white ink; this token does not. Both halves have to move, or the fill has to change - and no ink in this palette rescues the original fill: white is 4.04:1 and `--ink` is 4.21:1, both short.

## Tests

Measured on composited pixels rather than asserted from a class list, using the probe #2785 introduced. **No new story was needed for the light case** - `InventoryFilterBar / Filter trigger with a count badge` already renders this badge and already asserts the chevron swap; it only lacked an assertion about the colour.

A dark-pinned story is added rather than left as a follow-up:

| Variant | Result |
| --- | --- |
| as-is | 7 passed, 7 total |
| restore the badge-blue pair | **2 failed** - light AND dark, each reporting `3.61:1 (needs 4.5:1) - rgb(234,243,255) on rgb(0,124,245) at 14px/500` |
| restored | 7 passed, 7 total |

The dark story asserts `document.documentElement.dataset.theme === 'dark'` before measuring, because without it a decorator that stops applying leaves the light assertion running twice under a dark name.

Its docblock states the honest limit: the light story alone would still have caught this defect, because neither *old* token has a dark override. That is luck rather than coverage, and it stops being true once this lands, since `--inset` and `--ink` do flip.

## The token definitions now carry the warning

An ink and a fill declared as a pair that cannot legally be used together is a trap regardless of how many components are standing on it today. The comment carries the ratio, the size that decides the bar, and the reason changing the ink cannot fix it. The fill alone remains in use for chart series and filter definitions, where nothing is written on top of it.

## Verification

- `npx tsc --noemit` - exit 0
- `pnpm run lint` - 10 tasks successful
- `pnpm run type-check` - 18 tasks successful
- `test-storybook InventoryFilterBar` - 7 passed, and the mutation table above
- forbidden-terms `scan` run locally over all six surfaces before pushing, exit code captured directly rather than through a pipe: exit 0, `clean - 6 surfaces read`

## Scope

Refs #2799. That issue originally said one site; it is four. My grep matched the Tailwind class form and missed three inline-style sites, two of which pair the same tokens and one of which is white on the same fill at 4.04:1. Those three are Claude L2's - `merck.ts`, `tableUtils.ts`, and `utils.ts`'s default case, which is a token choice between `--inset`/`--ink` and `--color-pill-neutral-*` that belongs with the desk holding the render measurements.