### PR TITLE
fix(frontend): move the inline status pills off the badge-blue pair

### DIFF
--- a/apps/frontend/src/app/__tests__/components/DataTable/tableUtils.orgStatus.test.ts
+++ b/apps/frontend/src/app/__tests__/components/DataTable/tableUtils.orgStatus.test.ts
@@ -25,8 +25,8 @@ describe('getOrganizationStatusStyle', () => {
 
   it('returns the default style for an unknown status', () => {
     expect(getOrganizationStatusStyle('Unknown')).toEqual({
-      color: 'var(--color-neutral-0)',
-      backgroundColor: 'var(--color-badge-blue-bg)',
+      color: 'var(--color-pill-neutral-text)',
+      backgroundColor: 'var(--color-pill-neutral-bg)',
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
@@ -227,12 +227,14 @@ describe('Inventory Utils', () => {
       });
       // default
       expect(getStatusBadgeStyle('Unknown')).toEqual({
-        color: 'var(--color-badge-blue-text)',
-        backgroundColor: 'var(--color-badge-blue-bg)',
+        color: 'var(--color-pill-neutral-text)',
+        backgroundColor: 'var(--color-pill-neutral-bg)',
+        borderColor: 'var(--color-pill-neutral-border)',
       });
       expect(getStatusBadgeStyle()).toEqual({
-        color: 'var(--color-badge-blue-text)',
-        backgroundColor: 'var(--color-badge-blue-bg)',
+        color: 'var(--color-pill-neutral-text)',
+        backgroundColor: 'var(--color-pill-neutral-bg)',
+        borderColor: 'var(--color-pill-neutral-border)',
       });
     });
   });

--- a/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getMerckSubtopicPillStyle } from '@/app/features/integrations/constants/merck';
+import { getStatusBadgeStyle } from '@/app/features/inventory/pages/Inventory/utils';
+import { measureContrast } from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
+import { getOrganizationStatusStyle } from '@/app/ui/tables/tableUtils';
+
+/**
+ * These three switches paint with inline `style`, so their colours are invisible
+ * to a className audit and to Storybook's theme decorator alike - the element
+ * carries a plausible `text-[var(--ink-muted)]` class that the style object
+ * overrides. They shipped `--color-badge-blue-text` on `--color-badge-blue-bg`,
+ * which is 3.61:1 against a 4.5:1 bar at every size they render.
+ *
+ * Asserting the token NAMES would pass forever, so this resolves them out of
+ * `globals.css` and measures. A regression in either the switch or the token
+ * values fails it.
+ */
+
+const CSS = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+
+/**
+ * Custom properties per theme.
+ *
+ * `@theme` is Tailwind 4's base layer and is theme-independent - the pill
+ * tokens live there and alias `--status-*`, which is what actually flips. So
+ * the base map must include it or every pill token resolves to nothing, and a
+ * missing value would otherwise compare "" against "" and read as a pass.
+ * `globals.css` also has more than one dark block, meant to merge with the
+ * later winning, so this accumulates in file order rather than stopping first.
+ */
+const collect = (): { light: Map<string, string>; dark: Map<string, string> } => {
+  const light = new Map<string, string>();
+  const dark = new Map<string, string>();
+  let depth = 0;
+  let selector = '';
+  let buffer = '';
+
+  for (const raw of CSS.split('\n')) {
+    const line = raw.replace(/\/\*.*?\*\//g, '');
+    const decl = /^\s*(--[\w-]+)\s*:\s*([^;]+);/.exec(line);
+    if (depth === 1 && decl) {
+      const isDark = /data-theme\s*=\s*['"]?dark/.test(selector);
+      const isBase =
+        selector.split(',').some((part) => part.trim() === ':root') ||
+        selector.trim().startsWith('@theme');
+      if (isDark) dark.set(decl[1], decl[2].trim());
+      else if (isBase) light.set(decl[1], decl[2].trim());
+    }
+    for (const ch of line) {
+      if (ch === '{') {
+        if (depth === 0) selector = buffer.trim();
+        depth += 1;
+        buffer = '';
+      } else if (ch === '}') {
+        depth -= 1;
+        buffer = '';
+      } else {
+        buffer += ch;
+      }
+    }
+    if (depth === 0) buffer = '';
+  }
+  return { light, dark };
+};
+
+const TOKENS = collect();
+
+const LIGHT = TOKENS.light;
+const DARK = TOKENS.dark;
+
+/** Resolves a `var(--a, fallback)` chain down to a literal colour. */
+const resolve = (value: string, dark: boolean): string => {
+  let current = value;
+  for (let i = 0; i < 12; i += 1) {
+    const m = /^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/.exec(current.trim());
+    if (!m) return current.trim();
+    const next = (dark ? DARK.get(m[1]) : undefined) ?? LIGHT.get(m[1]) ?? m[2];
+    if (next === undefined) return current.trim();
+    current = next;
+  }
+  return current.trim();
+};
+
+const resolveToken = (token: string, dark: boolean): string => {
+  const literal = resolve(token, dark);
+  // A silent miss would compare "" against "" and read as a perfect pass.
+  expect(literal).toMatch(/^(#|rgb)/);
+  return literal;
+};
+
+const mount = (color: string, background: string, surface: string, px: string, weight: string) => {
+  const outer = document.createElement('div');
+  outer.style.backgroundColor = surface;
+  const el = document.createElement('span');
+  el.style.color = color;
+  el.style.backgroundColor = background;
+  el.style.fontSize = px;
+  el.style.fontWeight = weight;
+  outer.appendChild(el);
+  document.body.appendChild(outer);
+  return el;
+};
+
+/** The surface each pill actually sits on, needed because the dark fills are translucent. */
+const SURFACE = { light: '--screen', dark: '--screen' };
+
+type Site = {
+  name: string;
+  style: { color?: string; backgroundColor?: string };
+  px: string;
+  weight: string;
+};
+
+const SITES: Site[] = [
+  {
+    // InventoryPhoneCatalog -> StatusPill, `text-[10px] ... font-bold`.
+    name: 'inventory status pill, unrecognised status',
+    style: getStatusBadgeStyle('a status the API invented'),
+    px: '10px',
+    weight: '700',
+  },
+  {
+    // AppointmentMerckSearch, `text-[10.5px] font-semibold`.
+    name: 'merck Full Summary pill',
+    style: getMerckSubtopicPillStyle('Full Summary'),
+    px: '10.5px',
+    weight: '600',
+  },
+  {
+    // No production caller today; fixed so the pairing is not waiting to be used.
+    name: 'organisation status, unknown',
+    style: getOrganizationStatusStyle('something unmapped'),
+    px: '10px',
+    weight: '700',
+  },
+];
+
+describe('the token reader itself', () => {
+  /* Every assertion below is only as good as this. A scanner that silently
+     resolves nothing would hand `measureContrast` two empty strings, which it
+     reads as black on white - a comfortable pass on a broken instrument. */
+  it('reads a token that flips between themes', () => {
+    expect(resolve('var(--screen)', false)).toBe('#f7f3ec');
+    expect(resolve('var(--screen)', true)).toBe('#2f271e');
+  });
+
+  it('resolves the aliased pill tokens through @theme into the dark values', () => {
+    expect(resolve('var(--color-pill-neutral-text)', false)).toBe('#5c5956');
+    expect(resolve('var(--color-pill-neutral-text)', true)).toBe('#b9b0a4');
+  });
+
+  it('shows the badge pair not flipping, which is why no ink rescued it', () => {
+    expect(resolve('var(--color-badge-blue-bg)', false)).toBe('#007cf5');
+    expect(resolve('var(--color-badge-blue-bg)', true)).toBe('#007cf5');
+  });
+});
+
+describe.each(['light', 'dark'] as const)('inline status pill contrast (%s)', (theme) => {
+  const dark = theme === 'dark';
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it.each(SITES.map((s) => [s.name, s] as const))('%s clears its bar', (_name, site) => {
+    expect(site.style.color).toBeDefined();
+    expect(site.style.backgroundColor).toBeDefined();
+
+    const el = mount(
+      resolveToken(site.style.color as string, dark),
+      resolveToken(site.style.backgroundColor as string, dark),
+      resolveToken(`var(${dark ? SURFACE.dark : SURFACE.light})`, dark),
+      site.px,
+      site.weight
+    );
+
+    const reading = measureContrast(el);
+    // None of these is large text, so the bar must be the strict one.
+    expect(reading.required).toBe(4.5);
+    expect(reading.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('the token pair these replaced', () => {
+  it('is still the failing pair, so the fix is not a no-op', () => {
+    /* If someone "fixes" --color-badge-blue-* itself, the switches above could
+       be reverted harmlessly and this test would stop meaning anything. Pin the
+       reason the change was needed. */
+    const el = mount(
+      resolveToken('var(--color-badge-blue-text)', false),
+      resolveToken('var(--color-badge-blue-bg)', false),
+      resolveToken('var(--screen)', false),
+      '10px',
+      '700'
+    );
+    const reading = measureContrast(el);
+    expect(reading.ratio).toBeLessThan(4.5);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
@@ -188,13 +188,16 @@ describe('the token pair these replaced', () => {
     /* If someone "fixes" --color-badge-blue-* itself, the switches above could
        be reverted harmlessly and this test would stop meaning anything. Pin the
        reason the change was needed. */
-    const el = mount(
-      resolveToken('var(--color-badge-blue-text)', false),
-      resolveToken('var(--color-badge-blue-bg)', false),
-      resolveToken('var(--screen)', false),
-      '10px',
-      '700'
-    );
+    const ink = resolveToken('var(--color-badge-blue-text)', false);
+    const fill = resolveToken('var(--color-badge-blue-bg)', false);
+    /* This is the only assertion here that a broken token reader would SURVIVE:
+       two empty strings measure as a low ratio and read as "still failing".
+       Naming the literals makes it fail loudly instead - the shared guard in
+       `resolveToken` is the other half, and removing it is what made this the
+       one test in the file that stayed green with the reader disabled. */
+    expect([ink, fill]).toEqual(['#eaf3ff', '#007cf5']);
+
+    const el = mount(ink, fill, resolveToken('var(--screen)', false), '10px', '700');
     const reading = measureContrast(el);
     expect(reading.ratio).toBeLessThan(4.5);
   });

--- a/apps/frontend/src/app/features/integrations/constants/merck.ts
+++ b/apps/frontend/src/app/features/integrations/constants/merck.ts
@@ -73,10 +73,15 @@ export const MERCK_COPYRIGHT_NOTICE =
   'Copyright \u00a9 2021 Merck & Co., Inc., known as MSD outside of the US, Kenilworth, New Jersey, USA. All rights reserved.';
 
 const MERCK_SUBTOPIC_STYLES = {
+  /* The accent pill, not the brand badge. `--color-badge-blue-text` on
+     `--color-badge-blue-bg` measures 3.61:1, and these render at 10.5px/600
+     and 11px/600 - far below the 18.66px-bold large-text threshold, so the bar
+     is 4.5:1. `--color-pill-accent-*` keeps Full Summary distinct from the
+     four category pills below and is a triple like all of them. */
   fullSummary: {
-    backgroundColor: 'var(--color-badge-blue-bg)',
-    color: 'var(--color-badge-blue-text)',
-    borderColor: 'var(--color-badge-blue-bg)',
+    backgroundColor: 'var(--color-pill-accent-bg)',
+    color: 'var(--color-pill-accent-text)',
+    borderColor: 'var(--color-pill-accent-border)',
   },
   etiology: {
     backgroundColor: 'var(--color-pill-neutral-bg)',

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -206,13 +206,6 @@ export const getStatusBadgeStyle = (statusLabel?: string) => {
         backgroundColor: 'var(--color-pill-danger-bg)',
         borderColor: 'var(--color-pill-danger-border)',
       };
-    case 'out of stock':
-    case 'hidden':
-      return {
-        color: 'var(--color-pill-neutral-text)',
-        backgroundColor: 'var(--color-pill-neutral-bg)',
-        borderColor: 'var(--color-pill-neutral-border)',
-      };
     case 'healthy':
     case 'active':
     case 'in stock':
@@ -221,10 +214,20 @@ export const getStatusBadgeStyle = (statusLabel?: string) => {
         backgroundColor: 'var(--color-pill-success-bg)',
         borderColor: 'var(--color-pill-success-border)',
       };
+    case 'out of stock':
+    case 'hidden':
     default:
+      /* The neutral pill, not the brand badge. `--color-badge-blue-text` on
+         `--color-badge-blue-bg` measures 3.61:1, and this renders through
+         `StatusPill` at 10px/700 - well under the 18.66px-bold large-text
+         threshold, so the bar is 4.5:1 and no ink rescues a fill identical in
+         both themes. `--color-pill-neutral-*` already carries the
+         "unclassified" meaning, which is why the two explicitly unstocked
+         states share this branch rather than duplicating it. */
       return {
-        color: 'var(--color-badge-blue-text)',
-        backgroundColor: 'var(--color-badge-blue-bg)',
+        color: 'var(--color-pill-neutral-text)',
+        backgroundColor: 'var(--color-pill-neutral-bg)',
+        borderColor: 'var(--color-pill-neutral-border)',
       };
   }
 };

--- a/apps/frontend/src/app/ui/tables/tableUtils.ts
+++ b/apps/frontend/src/app/ui/tables/tableUtils.ts
@@ -358,7 +358,14 @@ export const getOrganizationStatusStyle = (status: string) => {
     case 'pending':
       return { color: 'var(--color-warning-900)', backgroundColor: 'var(--color-warning-100)' };
     default:
-      return { color: 'var(--color-neutral-0)', backgroundColor: 'var(--color-badge-blue-bg)' };
+      /* White on `--color-badge-blue-bg` is 4.04:1 - the figure `globals.css`
+         already writes down as failing where it picks `--blue-strong` for the
+         selected day. The neutral pill matches this switch's "unknown status"
+         meaning and clears 4.5:1 in both themes. */
+      return {
+        color: 'var(--color-pill-neutral-text)',
+        backgroundColor: 'var(--color-pill-neutral-bg)',
+      };
   }
 };
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Three switches paint status pills with an inline `style` object rather than classes. All three shipped `--color-badge-blue-text` on `--color-badge-blue-bg`, which measures **3.61:1** against a **4.5:1** bar at every size they render, in both themes. The fill is identical light and dark, so no ink override rescued it.

These are hard to find, and #2799 originally reported one site when there are four. A `bg-badge-blue-bg` grep matches only the Tailwind spelling, and reading the className correctly still gets the wrong answer here: every one of these elements carries a plausible `text-[var(--ink-muted)]` class that the style object then overrides.

| site | renders at | ratio | bar |
| --- | --- | --- | --- |
| inventory status pill, default case, via `InventoryPhoneCatalog` -> `StatusPill` | 10px / 700 | 3.61:1 | 4.5 |
| Merck Full Summary pill, two call sites | 10.5px / 600 and 11px / 600 | 3.61:1 | 4.5 |
| organisation status, default case | 10px / 700 | 4.04:1 | 4.5 |

Nothing here is large text (that needs >= 24px, or >= 18.66px *and* bold), so 4.5:1 applies at every site and there is no large-text escape.

The third one is white on the same fill at 4.04:1 - the figure `globals.css` already writes down as failing where it picks `--blue-strong` for the selected day. It has **no production caller** today, so that change is preventative rather than a user-visible fix.

## What is the new behavior?

- The inventory default returns the **neutral** pill. The two explicitly unstocked states now share that branch rather than duplicating it.
- Full Summary returns the **accent** pill, which keeps it distinct from the four category pills below it and is a triple like all of them.
- The organisation default returns the neutral pill.

Measured with the repo's own `measureContrast`, which picks the bar from the rendered size and composites translucent fills over the real surface:

```
inventory   neutral   light 6.29:1   dark 5.54:1
merck       accent    light 8.88:1   dark 6.92:1
was         badge     light 3.61:1   dark 3.61:1
```

The test resolves the tokens out of `globals.css` and measures them, because asserting token *names* would pass forever. Reverting any of the three fixes fails it in both themes at 3.61:1:

```
as-is                          10 passed, 10 total
revert all three               6 failed  (3 sites x 2 themes), each naming 3.61:1
restored                       10 passed, 10 total
```

It also carries a control for the token reader itself, because a reader that silently resolved nothing would hand the probe two empty strings and measure black on white - a comfortable pass on a broken instrument. Mutating the guard rather than the guarded value found a real hole: with the reader disabled and its assertion removed, nine of ten tests failed and the negative control passed, because two empty strings measure as a low ratio and read as "still failing". Naming the literals fixed it, and the file now goes **ten of ten red** under that mutation.

Coverage on the three changed sources is 97.19% statements / 93.04% branches.

Not verified: the repo's terms gate needs a secret this machine does not have, so it is left to CI rather than reported as passing here.

## Related Issue(s)

Refs #2799
