### PR TITLE
fix(frontend): drop the ledger story assertions for a removed receipt line

### DIFF
--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.stories.tsx
@@ -5,9 +5,10 @@ import type { Invoice } from '@yosemite-crew/types';
 import InvoicePaymentLedger from './InvoicePaymentLedger';
 
 /**
- * `formatMoney` runs at `maximumFractionDigits: 0`, so the total is a whole
- * number on purpose - a 113.60 total would print as "$114" and make the
- * assertion read as though the arithmetic were wrong.
+ * The block renders through `formatMoneyPrecise`, which pins no fraction digits
+ * and lets `Intl` use each currency's minor unit - so USD prints two decimals
+ * and this total renders as "$114.00", not "$114". The fixture stays a whole
+ * number so the rendered string is unambiguous rather than rounded.
  */
 const invoice = (overrides: Partial<Invoice> = {}): Invoice => ({
   id: 'a1b2c3d4e5f60718293a4b5c',
@@ -37,7 +38,7 @@ const legacyMethod = (value: string) => value as Invoice['paymentCollectionMetho
 
 const LONG_PAYER = 'Alexandra Constance Fotheringay-Whitmore';
 
-/** The bordered card: `region.children` is `[heading, card, receipt-sent?]`. */
+/** The bordered card: `region.children` is `[heading, card]`. */
 const cardOf = (region: HTMLElement): HTMLElement => region.children[1] as HTMLElement;
 
 const meta = {
@@ -97,10 +98,11 @@ export const PaidInApp: Story = {
     const region = within(canvasElement).getByRole('region', { name: 'Payments' });
     const card = cardOf(region);
 
-    // Heading, card, receipt-sent banner. The banner only exists here.
-    await expect(region.children).toHaveLength(3);
+    // Heading and card. There is no third child: the "Receipt sent to ..." line
+    // was removed deliberately, because nothing in the product emails a receipt.
+    await expect(region.children).toHaveLength(2);
     await expect(within(card).getByText('Paid in the pet-parent app')).toBeInTheDocument();
-    await expect(within(card).getByText('$114')).toBeInTheDocument();
+    await expect(within(card).getByText('$114.00')).toBeInTheDocument();
 
     /* The channel glyph carries the meaning only in the eyes of a sighted
        reader; the title beside it is what a screen reader gets. If the svg ever
@@ -136,12 +138,6 @@ export const PaidInApp: Story = {
     await expect(receipt.getBoundingClientRect().right).toBeLessThanOrEqual(
       card.getBoundingClientRect().right
     );
-
-    // The confirmation trims the address before printing it, so a padded value
-    // out of the record does not render as "Receipt sent to  sky@... ".
-    await expect(
-      within(region).getByText('Receipt sent to sky.doe@example.com')
-    ).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -177,11 +173,13 @@ export const PaidAtClinic: Story = {
     // No Stripe receipt for a desk payment, so the link is absent, not disabled.
     await expect(card.querySelectorAll('a')).toHaveLength(0);
     // Still closes with the amount - only the receipt went.
-    await expect(within(card).getByText('$114')).toBeInTheDocument();
+    await expect(within(card).getByText('$114.00')).toBeInTheDocument();
 
-    /* Two children, not three: with no payer email there is no confirmation
-       banner. Claiming a receipt was sent when no address was recorded is the
-       one failure here that a practice would repeat back to a client. */
+    /* Two children, as everywhere else now. This story used to be the contrast
+       - no payer email, so no confirmation banner - but the banner is gone for
+       every case, so what it pins is that nothing reintroduces a claim that a
+       receipt was sent. That is the one failure here a practice would repeat
+       back to a client. */
     await expect(region.children).toHaveLength(2);
     await expect(region.textContent).not.toContain('Receipt sent to');
   },
@@ -251,7 +249,7 @@ export const UntrustedReceiptUrl: Story = {
 
     // REFUNDED is settled, so the ledger is here - the URL is the only casualty.
     await expect(within(card).getByText('Paid in the pet-parent app')).toBeInTheDocument();
-    await expect(within(card).getByText('$114')).toBeInTheDocument();
+    await expect(within(card).getByText('$114.00')).toBeInTheDocument();
 
     /* No link at all, and the rejected host reaches no attribute either. Asserted
        against the markup rather than against the visible text, because the danger


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`InvoicePaymentLedger`'s five play functions fail on pristine `origin/dev`. They run in the advisory Storybook job, so nothing blocks on them and the red has been invisible.

```
Finance/InvoicePaymentLedger > PaidInApp        > play-test
Finance/InvoicePaymentLedger > PaidAtClinic     > play-test
Finance/InvoicePaymentLedger > SettledByPaidAt  > play-test
Finance/InvoicePaymentLedger > UntrustedReceiptUrl > play-test
Finance/InvoicePaymentLedger > Unsettled        > play-test
```

Three separate stale claims, each pointing at a deliberate change made elsewhere. None of them is a product defect.

1. One story asserts the `Receipt sent to ...` confirmation renders, while two other stories in the same file assert it is absent. #2609 removed it on purpose, and the component carries the reasoning: nothing in the product emails an invoice receipt, `receipt_email` is never set, and it also showed for cash and pay-at-clinic settlements - so staff could stop chasing a receipt a client never got.
2. Two `region.children` counts and the `cardOf` docblock still describe that third child.
3. Three matchers look for `$114`. The block renders through `formatMoneyPrecise`, which deliberately pins no fraction digits so `Intl` uses each currency's minor unit; USD therefore prints `$114.00`. The fixture docblock still cites `maximumFractionDigits: 0`, which is not what that helper does.

## What is the new behavior?

The assertion for the removed line is gone, both child counts are 2, and the money matchers expect `$114.00`. The comments that explained the old behaviour now explain the current behaviour, including why the second story's count is no longer the contrasting case it was written to be.

**No production change** - this is a stories file only.

Verified against a running Storybook rather than by reading:

```
with the fix        5 passed, 5 total
file reverted       5 failed, 5 total
restored            5 passed, 5 total
```

Not claimed: a wider `Finance` run on the same server reported failures across other suites, but 14 of them were `StoryStoreAccessedBeforeInitializationError` - a runner startup race, not assertions - and the server died partway through a serial re-run. `InvoicePaymentLedger` was not among the failures in either pass. Those other suites are neither verified nor blamed here.

## Related Issue(s)

Refs #2609
