### PR TITLE
ci(repo): stop asserting required-ness in the file that cannot notice it change

### DIFF
--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -306,7 +306,13 @@ jobs:
       # comparison and is never looked at again - but a `main` pull request's
       # merge base is the previous promotion, so the whole of `dev` since then
       # is in scope. That is why this workflow RUNS on BOTH branches - which is
-      # this file's `on:` block, not a ruleset. It is required on neither.
+      # this file's `on:` block, not a ruleset.
+      #
+      # Whether it is REQUIRED is not asserted here. It was required on neither
+      # ruleset when this was written, 2026-09-06 - but the identical sentence
+      # in the sibling repository went false that afternoon without anyone
+      # touching the file, because a ruleset changed. Nothing here can notice
+      # that. Read the rulesets.
       - name: Collect the surfaces
         if: ${{ github.event_name == 'pull_request' }}
         env:


### PR DESCRIPTION
The last present-tense ruleset assertion in this workflow.

```
before   "...not a ruleset. It is required on neither."
after    a dated observation, with the reason it must be read as one
```

It was **true when written** and I am not correcting it for being wrong. The identical sentence in the sibling repository went false on the afternoon of 2026-09-06, when `No named external product` was added to that repo's `dev` ruleset and nobody touched the file. Measured today: required on neither ruleset here, and on exactly one in the estate.

The argument for deleting the required-context enumerations from this same file was that **nothing in it can notice drift**. This line was the last place still betting nothing would, and it is the line the sibling proved wrong about itself.

The load-bearing half is untouched and structural: the workflow **RUNS** on both branches, which is this file's own `on:` block and depends on no ruleset.

Comment only. Suite 60 pass / 0 fail. Raised in review of the PR that fixed the false half of the same sentence.