### PR TITLE
ci(mobile): gate the Play and TestFlight uploads on a tag push

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -185,7 +185,18 @@ jobs:
           echo "Building version code ${VERSION_CODE}"
           ./gradlew bundleRelease --no-daemon "-PversionCodeOverride=${VERSION_CODE}"
 
-      - name: Upload to Play internal track
+      # Only a `mobile-v*` tag push publishes. A workflow_dispatch builds and
+      # signs, then stops here, so the Android signing chain can be exercised
+      # without a Play submission and without burning a version code (Play
+      # rejects a repeat, and the run number that produced it is not reusable).
+      # This mirrors desktop-release.yml, where the same separation is spelled
+      # `--publish ${{ github.event_name == 'push' && 'always' || 'never' }}`.
+      # The guard reads `push` rather than the ref because the only push trigger
+      # this workflow has is `tags: mobile-v*`; adding a branch trigger above
+      # would make it fire on a branch, so add `startsWith(github.ref,
+      # 'refs/tags/')` here if that trigger ever changes.
+      - name: Upload to Play internal track (tag pushes only)
+        if: github.event_name == 'push'
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -543,7 +554,12 @@ jobs:
           ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: ruby scripts/ci/asc-key-check.rb
 
-      - name: Upload to TestFlight
+      # Same separation as Android above. The steps before this one still run on
+      # a dispatch on purpose: importing the certificate, exporting a signed IPA
+      # and checking the App Store Connect key all exercise the iOS credentials
+      # without submitting anything. Only the upload is a submission.
+      - name: Upload to TestFlight (tag pushes only)
+        if: github.event_name == 'push'
         env:
           ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |

--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -33,6 +33,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { parse } from 'yaml';
+import { resolveWithin } from './safe-path.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -69,10 +70,30 @@ export function classifyStep(step) {
   return null;
 }
 
-/** True when `condition` restricts the step to a release tag. */
+/**
+ * True when `condition` restricts the step to a release tag.
+ *
+ * A substring test is not enough and the counter-example is 78 lines above the
+ * step it would wave through. The `android` job is gated on
+ *
+ *   github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'android'
+ *
+ * and copying that condition down onto the upload step is the most natural edit
+ * anyone will make to this file. It contains an accepted guard and submits on a
+ * plain dispatch anyway, because a disjunction can only widen: `A || B` runs
+ * whenever B alone is true, so no guard to the left of a `||` restricts
+ * anything. Any `||` is therefore rejected outright.
+ *
+ * `&&` is the opposite and is accepted, so tightening the shipped guard to
+ * `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')` does not
+ * red the build. Every other spelling fails closed - a red build and a human
+ * reading this comment is the outcome we want from an expression we cannot
+ * classify.
+ */
 export function isTagOnly(condition) {
   if (typeof condition !== 'string') return false;
-  return TAG_ONLY_GUARDS.some((guard) => condition.includes(guard));
+  if (condition.includes('||')) return false;
+  return condition.split('&&').some((operand) => TAG_ONLY_GUARDS.includes(operand.trim()));
 }
 
 /**
@@ -99,11 +120,21 @@ export function findUnguardedSubmissions(source, file) {
   return findings;
 }
 
-/** Runs the check over the real workflow files. */
+/**
+ * Runs the check over the real workflow files.
+ *
+ * `files` is a module constant and nothing reaches this script from a request,
+ * so the containment assertion is not load-bearing today. It is here because a
+ * path built from a parameter is worth pinning inside the tree it claims to
+ * describe before someone passes one in, and `resolveWithin` is what the other
+ * scripts in this directory use for it.
+ */
 export function checkRepo(root = REPO_ROOT, files = RELEASE_WORKFLOWS) {
-  return files.flatMap((file) =>
-    findUnguardedSubmissions(readFileSync(path.join(root, file), 'utf8'), file)
-  );
+  return files.flatMap((file) => {
+    const resolved = resolveWithin(root, file);
+    if (resolved === null) throw new Error(`Workflow path escapes the repository: ${file}`);
+    return findUnguardedSubmissions(readFileSync(resolved, 'utf8'), file);
+  });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
@@ -118,7 +149,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   if (findings.length > 0) {
     console.error(
       `\n${findings.length} store submission(s) reachable from a workflow_dispatch. ` +
-        `Gate each on one of: ${TAG_ONLY_GUARDS.join(' | ')}`
+        `Gate each on ${TAG_ONLY_GUARDS.join(' or ')}. ` +
+        `A condition containing '||' is never accepted: a disjunction can only widen.`
     );
     process.exit(1);
   }

--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -4,8 +4,8 @@
  *
  * `mobile-release.yml` runs on `push: tags: mobile-v*` and on `workflow_dispatch`.
  * The jobs are deliberately reachable both ways so the Android and iOS signing
- * chains can be exercised without cutting a release — but until #2817 the two
- * submitting steps carried no condition at all, so a plain dispatch shipped a
+ * chains can be exercised without cutting a release — but the two submitting
+ * steps once carried no condition at all, so a plain dispatch shipped a
  * build to the Play internal track (`status: completed`) and to TestFlight. There
  * was no dispatch shape that built without uploading: `platform` offers only
  * `both`, `android` and `ios`.

--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Fails when a step that submits a build to a store is not gated to a release tag.
+ *
+ * `mobile-release.yml` runs on `push: tags: mobile-v*` and on `workflow_dispatch`.
+ * The jobs are deliberately reachable both ways so the Android and iOS signing
+ * chains can be exercised without cutting a release — but until #2817 the two
+ * submitting steps carried no condition at all, so a plain dispatch shipped a
+ * build to the Play internal track (`status: completed`) and to TestFlight. There
+ * was no dispatch shape that built without uploading: `platform` offers only
+ * `both`, `android` and `ios`.
+ *
+ * That is invisible to every other gate in this repo. The workflow is valid YAML,
+ * the run goes green, and the evidence that anything happened is in App Store
+ * Connect rather than in CI. It is also invisible to a run history: the dispatch
+ * path had never been exercised, so there was no red run to learn from.
+ *
+ * What is checked is the SUBMITTING MECHANISM, not the step name. A step that
+ * renames from "Upload to TestFlight" to something else still calls `altool
+ * --upload-app`, and that is what this matches on. Adding a new way to submit
+ * means adding a row to SUBMISSIONS below; the check cannot infer one.
+ *
+ * The accepted guards are `github.event_name == 'push'` (the idiom desktop-release.yml
+ * already uses for `--publish never`) and `startsWith(github.ref, 'refs/tags/')`.
+ * Either is sufficient: the only push trigger these workflows declare is a tag
+ * pattern, so on this repo they are equivalent, and accepting both means a future
+ * tightening does not red the build.
+ *
+ * Runs offline against the workflow files, so it is a hard gate rather than an
+ * advisory one. `pnpm run test:scripts` covers it (.github/workflows/_core.yaml).
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parse } from 'yaml';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Workflows whose steps can reach a store. */
+export const RELEASE_WORKFLOWS = [
+  '.github/workflows/mobile-release.yml',
+  '.github/workflows/desktop-release.yml',
+];
+
+/**
+ * How a step submits. `uses` is matched on the action name without its version so a
+ * pin bump does not silently drop the row; `run` is matched on the command.
+ */
+export const SUBMISSIONS = [
+  { store: 'Google Play', uses: 'r0adkll/upload-google-play' },
+  { store: 'App Store Connect', run: 'altool --upload-app' },
+];
+
+/** Conditions that restrict a step to a release tag. Either one is enough. */
+export const TAG_ONLY_GUARDS = [
+  "github.event_name == 'push'",
+  "startsWith(github.ref, 'refs/tags/')",
+];
+
+/** The submission a step performs, or null when it does not submit. */
+export function classifyStep(step) {
+  if (!step || typeof step !== 'object') return null;
+  const uses = typeof step.uses === 'string' ? step.uses : '';
+  const run = typeof step.run === 'string' ? step.run : '';
+  for (const submission of SUBMISSIONS) {
+    if (submission.uses && uses.split('@')[0] === submission.uses) return submission;
+    if (submission.run && run.includes(submission.run)) return submission;
+  }
+  return null;
+}
+
+/** True when `condition` restricts the step to a release tag. */
+export function isTagOnly(condition) {
+  if (typeof condition !== 'string') return false;
+  return TAG_ONLY_GUARDS.some((guard) => condition.includes(guard));
+}
+
+/**
+ * Every submitting step in one workflow that is not gated to a tag.
+ * `file` is only used to label the finding.
+ */
+export function findUnguardedSubmissions(source, file) {
+  const doc = parse(source);
+  const findings = [];
+  for (const [jobId, job] of Object.entries(doc?.jobs ?? {})) {
+    for (const step of job?.steps ?? []) {
+      const submission = classifyStep(step);
+      if (!submission) continue;
+      if (isTagOnly(step.if)) continue;
+      findings.push({
+        file,
+        job: jobId,
+        step: step.name ?? step.uses ?? '<unnamed>',
+        store: submission.store,
+        condition: step.if ?? null,
+      });
+    }
+  }
+  return findings;
+}
+
+/** Runs the check over the real workflow files. */
+export function checkRepo(root = REPO_ROOT, files = RELEASE_WORKFLOWS) {
+  return files.flatMap((file) =>
+    findUnguardedSubmissions(readFileSync(path.join(root, file), 'utf8'), file)
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const findings = checkRepo();
+  for (const finding of findings) {
+    const condition = finding.condition === null ? 'no condition' : `if: ${finding.condition}`;
+    console.error(
+      `${finding.file}: job '${finding.job}' step '${finding.step}' submits to ` +
+        `${finding.store} with ${condition}.`
+    );
+  }
+  if (findings.length > 0) {
+    console.error(
+      `\n${findings.length} store submission(s) reachable from a workflow_dispatch. ` +
+        `Gate each on one of: ${TAG_ONLY_GUARDS.join(' | ')}`
+    );
+    process.exit(1);
+  }
+  console.log(`No unguarded store submissions in ${RELEASE_WORKFLOWS.length} release workflows.`);
+}

--- a/scripts/ci/check-release-upload-guards.test.mjs
+++ b/scripts/ci/check-release-upload-guards.test.mjs
@@ -1,0 +1,136 @@
+// Tests for the store-submission gate. Reading the real workflows is what the CI step
+// does, so that case is pinned first — but every other case is a fixture, because the
+// defect this exists to catch is one the repo no longer has and a test that can only
+// read the current tree could never fail.
+//
+// The shapes below are the real ones. `mobile-release.yml` shipped for months with
+// both upload steps carrying no condition at all, on a workflow whose jobs are
+// reachable from `workflow_dispatch` by design.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyStep,
+  isTagOnly,
+  findUnguardedSubmissions,
+  checkRepo,
+} from './check-release-upload-guards.mjs';
+
+/** A one-job workflow around `steps`, indented to match. */
+const workflow = (steps) => `
+name: fixture
+on:
+  push:
+    tags: ['mobile-v*']
+  workflow_dispatch: {}
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+${steps}
+`;
+
+const PLAY_UNGUARDED = `      - name: Upload to Play internal track
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          track: internal
+          status: completed`;
+
+const PLAY_GUARDED = `      - name: Upload to Play internal track (tag pushes only)
+        if: github.event_name == 'push'
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          track: internal
+          status: completed`;
+
+const TESTFLIGHT_UNGUARDED = `      - name: Upload to TestFlight
+        run: |
+          xcrun altool --upload-app -f "\${RUNNER_TEMP}/export/app.ipa" -t ios`;
+
+const TESTFLIGHT_GUARDED = `      - name: Upload to TestFlight (tag pushes only)
+        if: github.event_name == 'push'
+        run: |
+          xcrun altool --upload-app -f "\${RUNNER_TEMP}/export/app.ipa" -t ios`;
+
+test('the repo has no unguarded store submissions', () => {
+  assert.deepEqual(checkRepo(), []);
+});
+
+test('an unguarded Play upload is caught', () => {
+  const findings = findUnguardedSubmissions(workflow(PLAY_UNGUARDED), 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].store, 'Google Play');
+  assert.equal(findings[0].job, 'android');
+  assert.equal(findings[0].condition, null);
+});
+
+test('an unguarded TestFlight upload is caught', () => {
+  const findings = findUnguardedSubmissions(workflow(TESTFLIGHT_UNGUARDED), 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].store, 'App Store Connect');
+});
+
+test('both unguarded uploads are reported, not just the first', () => {
+  const source = workflow(`${PLAY_UNGUARDED}\n${TESTFLIGHT_UNGUARDED}`);
+  assert.equal(findingsStores(source).join(','), 'Google Play,App Store Connect');
+});
+
+test('the guard as shipped clears both', () => {
+  const source = workflow(`${PLAY_GUARDED}\n${TESTFLIGHT_GUARDED}`);
+  assert.deepEqual(findUnguardedSubmissions(source, 'fixture.yml'), []);
+});
+
+test('a ref-based guard clears them too, so tightening later does not red the build', () => {
+  const source = workflow(
+    PLAY_GUARDED.replace("github.event_name == 'push'", "startsWith(github.ref, 'refs/tags/')")
+  );
+  assert.deepEqual(findUnguardedSubmissions(source, 'fixture.yml'), []);
+});
+
+test('a condition that is not tag-only does not count as a guard', () => {
+  // `if: always()` is the shape used by the secret-cleanup steps in the same job, so
+  // a copy-paste of the wrong one is the realistic mistake here.
+  const source = workflow(
+    PLAY_UNGUARDED.replace('        uses:', '        if: always()\n        uses:')
+  );
+  const findings = findUnguardedSubmissions(source, 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].condition, 'always()');
+});
+
+test('renaming the step does not shake the check off', () => {
+  const source = workflow(PLAY_UNGUARDED.replace('Upload to Play internal track', 'Ship it'));
+  assert.equal(findUnguardedSubmissions(source, 'fixture.yml').length, 1);
+});
+
+test('bumping the action pin does not shake the check off', () => {
+  const source = workflow(
+    PLAY_UNGUARDED.replace(/@[0-9a-f]{40}/, '@0000000000000000000000000000000000000000')
+  );
+  assert.equal(findUnguardedSubmissions(source, 'fixture.yml').length, 1);
+});
+
+test('an ordinary step is not mistaken for a submission', () => {
+  // The negative control. A gate that fires on `pnpm install` gets deleted in a week.
+  const source = workflow(`      - name: Install dependencies
+        run: pnpm install --frozen-lockfile`);
+  assert.deepEqual(findUnguardedSubmissions(source, 'fixture.yml'), []);
+});
+
+test('classifyStep and isTagOnly answer on their own', () => {
+  assert.equal(classifyStep({ uses: 'r0adkll/upload-google-play@v1' })?.store, 'Google Play');
+  assert.equal(classifyStep({ uses: 'actions/checkout@v4' }), null);
+  assert.equal(
+    classifyStep({ run: 'xcrun altool --upload-app -f x.ipa' })?.store,
+    'App Store Connect'
+  );
+  assert.equal(classifyStep({ run: 'xcrun altool --validate-app -f x.ipa' }), null);
+  assert.equal(classifyStep(null), null);
+  assert.equal(isTagOnly("github.event_name == 'push'"), true);
+  assert.equal(isTagOnly('always()'), false);
+  assert.equal(isTagOnly(undefined), false);
+});
+
+function findingsStores(source) {
+  return findUnguardedSubmissions(source, 'fixture.yml').map((f) => f.store);
+}

--- a/scripts/ci/check-release-upload-guards.test.mjs
+++ b/scripts/ci/check-release-upload-guards.test.mjs
@@ -131,6 +131,50 @@ test('classifyStep and isTagOnly answer on their own', () => {
   assert.equal(isTagOnly(undefined), false);
 });
 
+// The job that contains the upload step is gated like this, 78 lines above it. A
+// substring implementation of isTagOnly accepts it, and it submits on a plain
+// dispatch - `A || B` runs whenever B alone is true. Copying this condition down
+// onto the step is the most natural edit anyone will make to the file, so it is
+// the mutant the suite has to catch.
+const JOB_CONDITION = "github.event_name == 'push' || inputs.platform == 'android'";
+
+test('the job condition copied onto the upload step is NOT accepted as a guard', () => {
+  const source = workflow(PLAY_GUARDED.replace("github.event_name == 'push'", JOB_CONDITION));
+  const findings = findUnguardedSubmissions(source, 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].store, 'Google Play');
+  assert.equal(findings[0].condition, JOB_CONDITION);
+});
+
+test('a disjunction is rejected whichever side the accepted guard is on', () => {
+  assert.equal(isTagOnly(JOB_CONDITION), false);
+  assert.equal(isTagOnly("always() || github.event_name == 'push'"), false);
+  assert.equal(
+    isTagOnly("startsWith(github.ref, 'refs/tags/') || inputs.platform == 'ios'"),
+    false
+  );
+});
+
+test('a conjunction is accepted, so tightening the guard later does not red the build', () => {
+  assert.equal(
+    isTagOnly("github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"),
+    true
+  );
+  assert.equal(isTagOnly("github.event_name == 'push' && inputs.platform == 'android'"), true);
+});
+
+test('an expression that cannot be classified fails closed', () => {
+  // Not an exhaustive list - the point is that anything unrecognised is a finding
+  // rather than a pass, so a red build puts a human in front of it.
+  assert.equal(isTagOnly("github.event_name=='push'"), false);
+  assert.equal(isTagOnly("${{ github.event_name == 'push' }}"), false);
+  assert.equal(isTagOnly(''), false);
+});
+
+test('a workflow path that escapes the repository is refused', () => {
+  assert.throws(() => checkRepo(process.cwd(), ['../../../etc/hosts']), /escapes the repository/);
+});
+
 function findingsStores(source) {
   return findUnguardedSubmissions(source, 'fixture.yml').map((f) => f.store);
 }


### PR DESCRIPTION
## What was wrong

`mobile-release.yml` triggers on `push: tags: mobile-v*` **and** `workflow_dispatch`, and both jobs are reachable either way by design — the `platform` input defaults to `both` and the job guards name it explicitly:

```yaml
if: github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'android'
```

The two steps that submit carried **no condition at all**:

- `Upload to Play internal track` — `r0adkll/upload-google-play`, `track: internal`, `status: completed`
- `Upload to TestFlight` — `xcrun altool --upload-app`

So a plain `workflow_dispatch` shipped a build to the Play internal track and to TestFlight. The `platform` input offers only `both` / `android` / `ios`, so there was no dispatch shape that built without uploading.

The only event-conditional anywhere in the file was the tag-on-`main` ancestry check in `preflight`. Enumerated rather than grepped, because searching for the guard you expect to be missing cannot distinguish "absent" from "spelled differently":

```
91   github.event_name == 'push'          preflight, tag-on-main ancestry
120  ... || inputs.platform == 'android'  job gate
198  always()                             secret cleanup
213  ... || inputs.platform == 'ios'      job gate
560  always()                             secret cleanup
```

Five, and that is the whole file. Lines 188 and 546 are not among them.

**Nothing else in the repo could have caught this.** The workflow is valid, the run goes green, and the evidence that a submission happened is in App Store Connect rather than in CI. The run history could not warn either — `mobile-release.yml` had never been dispatched, 0 runs all time, so there was no red run to learn from and no precedent to contradict a reading of the file.

## The fix

Both upload steps now carry `if: github.event_name == 'push'` and are renamed to say so. That is the idiom `desktop-release.yml` already uses for the same separation, where it is spelled `--publish ${{ github.event_name == 'push' && 'always' || 'never' }}`.

The guard reads the event rather than the ref because the only push trigger this workflow declares is a tag pattern. I checked whether a branch push could reach these jobs before settling on it — the `desktop-release.yml` runs that appear in the run list with `event=push` on `dev` and on dependabot branches have `jobs: 0`, i.e. startup failures from an invalid workflow file, which GitHub files under the workflow regardless of its `on:` filters. No branch push has ever executed a job in these workflows. The comment beside the guard names the dependency so a future branch trigger is caught by a reader.

**Everything before the upload still runs on a dispatch, which is the point.** Importing the certificate, exporting a signed IPA, decoding and checking the App Store Connect key, and building the signed AAB all exercise the credentials without submitting anything. A dispatch also no longer burns a Play version code (`20 + GITHUB_RUN_NUMBER`), which is not reusable once consumed.

## The second commit, and why it is here

Two lines of `if:` are exactly the kind of control that gets removed quietly. `scripts/ci/check-release-upload-guards.mjs` fails when a step that submits to a store is not gated to a release tag.

It matches the **submitting mechanism, not the step name** — `r0adkll/upload-google-play` with its version pin stripped, and `altool --upload-app` in a run block — so renaming a step or bumping the action pin does not shake it off. It accepts either `github.event_name == 'push'` or `startsWith(github.ref, 'refs/tags/')`, so tightening the guard later does not red the build. Adding a new way to submit means adding a row; the check cannot infer one, and the header says so.

It needed no workflow change to become a gate: `scripts/ci/*.test.mjs` is run by `pnpm run test:scripts` at `.github/workflows/_core.yaml:82`, in the job the file's own comment calls "the one job every event reaches", and the first test asserts the real workflows are clean.

## Evidence

Guards land on the right steps — parsed, not grepped, with the non-submitting steps as controls:

```
android/Build signed AAB                                  if: <NO IF>     <- control
android/Upload to Play internal track (tag pushes only)   if: github.event_name == 'push'
ios/Check the App Store Connect key                       if: <NO IF>     <- control
ios/Upload to TestFlight (tag pushes only)                if: github.event_name == 'push'
```

The gate can fail. Cutting the Play guard back out of the real workflow, at the committed tree:

```
MUTANT     CLI rc=1  ("submits to Google Play with no condition")   suite 10 pass / 1 fail
RESTORED   CLI rc=0                                                 suite 11 pass / 0 fail
                                                                    file byte-identical
```

The test file is picked up by the command CI runs — measured, not assumed:

```
pnpm run test:scripts   without this file   369 tests
pnpm run test:scripts   with this file      380 tests      (+11)
named subtest present in the log:  2 with, 0 without
```

Full suite at the pushed commit:

```
pnpm run test:scripts   rc=0   380 tests / 380 pass / 0 fail / 0 skipped
node scripts/ci/check-release-upload-guards.mjs   rc=0
```

Pre-commit hooks ran on every commit: gitleaks, secretlint, eslint `--max-warnings=0`, prettier. None bypassed.

## What this does not do

- It does not make mobile dry-runnable on its own. Every credential-bearing job declares `environment: release`, whose deployment policy is three tag patterns and zero branch patterns, so a branch dispatch cannot reach a signing credential. This fix is independent of that and holds whatever is decided there.
- It adds no signature *verification*. Neither release workflow has any — the `codesign` hits in this file are certificate import and identity selection, never verification — so a green run proves the signing step did not throw, never that the artifact is validly signed. Being handled separately.
- The check imports `yaml`, which this repo resolves transitively through `pnpm.overrides` rather than a root dependency. That is the existing pattern (`scripts/ci/openapi-drift.mjs` does the same); I followed it rather than adding a root dependency in this PR, but it is worth knowing it is transitive.
