### PR TITLE
ci(desktop): verify desktop signatures instead of assuming them

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -174,6 +174,41 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Nothing downstream of the build re-reads the signature, so without this a
+      # green job means only that signing did not throw. Runs before the upload so
+      # an unsigned installer cannot become an artifact other jobs consume.
+      - name: Verify the Windows Authenticode signatures
+        working-directory: apps/desktop
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Read the expected publisher from the electron-builder config rather
+          # than repeating it, so the check cannot drift from what is signed.
+          $expected = (Get-Content package.json -Raw | ConvertFrom-Json).build.win.signtoolOptions.publisherName
+          if ([string]::IsNullOrWhiteSpace($expected)) {
+            throw 'build.win.signtoolOptions.publisherName is not set in package.json; cannot verify.'
+          }
+          $files = @(Get-ChildItem -Path dist -Filter *.exe -File -ErrorAction SilentlyContinue)
+          # An empty artifact set must fail. "Nothing to check" and "everything
+          # checked out" are not allowed to look the same from outside.
+          if ($files.Count -eq 0) { throw 'No .exe found in apps/desktop/dist; nothing was verified.' }
+          $failures = @()
+          foreach ($file in $files) {
+            $sig = Get-AuthenticodeSignature -FilePath $file.FullName
+            $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { '<unsigned>' }
+            Write-Host "$($file.Name): status=$($sig.Status) subject=$subject"
+            if ($sig.Status -ne 'Valid') {
+              $failures += "$($file.Name): Authenticode status is $($sig.Status), expected Valid."
+            } elseif ($subject -notlike "*$expected*") {
+              $failures += "$($file.Name): signed by $subject, expected $expected."
+            }
+          }
+          if ($failures.Count -gt 0) {
+            foreach ($failure in $failures) { Write-Host "::error::$failure" }
+            exit 1
+          }
+          Write-Host "All $($files.Count) Windows artifacts carry a valid $expected signature."
+
       - name: Upload signed Windows artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -218,6 +253,32 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # scripts/notarize.js falls back to `codesign --sign -` when APPLE_ID,
+      # APPLE_APP_SPECIFIC_PASSWORD or APPLE_TEAM_ID is absent or rejected, and an
+      # ad-hoc signed bundle passes `codesign --verify --deep --strict` with exit
+      # 0 - measured, macOS 15. So the obvious check is blind to the one failure
+      # this build can actually produce, and the script asserts the Developer ID
+      # authority, the team identifier, Gatekeeper acceptance and the stapled
+      # ticket instead. See apps/desktop/scripts/verify-macos-signature.js.
+      #
+      # The .app is the target rather than the .dmg: @electron/notarize staples
+      # the ticket to the bundle (lib/index.js calls stapleApp after notarizing),
+      # and the disk image is built from the already-stapled app.
+      - name: Verify the macOS signature and notarization
+        working-directory: apps/desktop
+        run: |
+          set -euo pipefail
+          # `-print -quit` rather than `| head -1`: under `pipefail` a closed pipe
+          # makes find exit 141 and fails the step for the wrong reason.
+          APP=$(find dist -maxdepth 2 -type d -name '*.app' -print -quit)
+          # An empty artifact set must fail. "Nothing to check" and "everything
+          # checked out" are not allowed to look the same from outside.
+          if [ -z "$APP" ]; then
+            echo "::error::No .app bundle under apps/desktop/dist; nothing was verified."
+            exit 1
+          fi
+          node scripts/verify-macos-signature.js "$APP"
 
       - name: Upload signed macOS artifacts
         if: always()

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -175,8 +175,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Nothing downstream of the build re-reads the signature, so without this a
-      # green job means only that signing did not throw. Runs before the upload so
-      # an unsigned installer cannot become an artifact other jobs consume.
+      # green job means only that signing did not throw.
+      #
+      # Step position does NOT contain a bad installer, and it must not be read
+      # that way: the upload step below is `if: always()` so it runs even when
+      # this fails, and on a tag the build step itself already passed
+      # `--publish always`, attaching the installers to the draft release before
+      # this step runs. What actually holds the line is job-level: `publish`
+      # needs verify + windows + macos and `release` needs windows + macos, so a
+      # failure here means the draft is never made public and no manual release
+      # is created. The artifact and the draft asset are deliberately still
+      # produced, because a rejected installer is the thing you need to inspect.
       - name: Verify the Windows Authenticode signatures
         working-directory: apps/desktop
         shell: pwsh
@@ -195,12 +204,31 @@ jobs:
           $failures = @()
           foreach ($file in $files) {
             $sig = Get-AuthenticodeSignature -FilePath $file.FullName
-            $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { '<unsigned>' }
-            Write-Host "$($file.Name): status=$($sig.Status) subject=$subject"
+            Write-Host "$($file.Name): status=$($sig.Status)"
             if ($sig.Status -ne 'Valid') {
               $failures += "$($file.Name): Authenticode status is $($sig.Status), expected Valid."
-            } elseif ($subject -notlike "*$expected*") {
-              $failures += "$($file.Name): signed by $subject, expected $expected."
+              continue
+            }
+            # Read the CN through GetNameInfo rather than pattern-matching the
+            # Subject DN: the publisher name contains a non-ASCII character
+            # (U+00E4) and parentheses, so substring and regex forms over the DN
+            # are both a bet on encoding and quoting. This returns the CN value.
+            $cn = $sig.SignerCertificate.GetNameInfo(
+              [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+            # Exact, ordinal. A `-like "*$expected*"` here would accept any
+            # publisher whose name merely CONTAINS ours.
+            if ($cn -cne $expected) {
+              $failures += "$($file.Name): signed by CN '$cn' (len $($cn.Length)), expected '$expected' (len $($expected.Length))."
+            }
+            # `Status -eq 'Valid'` is true for a signature that was never
+            # timestamped, and an untimestamped Authenticode signature stops
+            # validating when the signing certificate expires. This chain
+            # configures an RFC3161 timestamp explicitly
+            # (scripts/windows-trusted-sign.js sets TimestampRfc3161), and
+            # verification runs minutes after signing, when a timestamped and an
+            # untimestamped signature are otherwise indistinguishable.
+            if (-not $sig.TimeStamperCertificate) {
+              $failures += "$($file.Name): no RFC3161 countersignature; this signature expires with the certificate."
             }
           }
           if ($failures.Count -gt 0) {
@@ -265,20 +293,30 @@ jobs:
       # The .app is the target rather than the .dmg: @electron/notarize staples
       # the ticket to the bundle (lib/index.js calls stapleApp after notarizing),
       # and the disk image is built from the already-stapled app.
+      #
+      # As on the windows job, step position is not what contains a bad build -
+      # the upload below is `if: always()` and on a tag the build step has
+      # already run `--publish always`. The guarantee is job-level: `publish`
+      # needs verify + windows + macos, `release` needs windows + macos.
       - name: Verify the macOS signature and notarization
         working-directory: apps/desktop
         run: |
           set -euo pipefail
-          # `-print -quit` rather than `| head -1`: under `pipefail` a closed pipe
-          # makes find exit 141 and fails the step for the wrong reason.
-          APP=$(find dist -maxdepth 2 -type d -name '*.app' -print -quit)
+          # Every bundle, not the first one found. `build.mac.target` is dmg+zip
+          # with no `arch` list today, so macos-14 yields exactly one - but if an
+          # arch list is ever added this would otherwise silently verify half the
+          # output and pass.
+          COUNT=$(find dist -maxdepth 2 -type d -name '*.app' | wc -l | tr -d ' ')
           # An empty artifact set must fail. "Nothing to check" and "everything
           # checked out" are not allowed to look the same from outside.
-          if [ -z "$APP" ]; then
+          if [ "$COUNT" -eq 0 ]; then
             echo "::error::No .app bundle under apps/desktop/dist; nothing was verified."
             exit 1
           fi
-          node scripts/verify-macos-signature.js "$APP"
+          echo "Verifying ${COUNT} app bundle(s)."
+          # -print0/-0 because the bundle name contains spaces.
+          find dist -maxdepth 2 -type d -name '*.app' -print0 \
+            | xargs -0 node scripts/verify-macos-signature.js
 
       - name: Upload signed macOS artifacts
         if: always()

--- a/apps/desktop/scripts/verify-macos-signature.js
+++ b/apps/desktop/scripts/verify-macos-signature.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const childProcess = require('node:child_process');
+
+// Verifies that a built macOS artifact carries a real Developer ID signature and
+// a stapled notarization ticket, and fails the release build when it does not.
+//
+// Why this exists at all: nothing in desktop-release.yml verified a signature.
+// A green macOS job proved only that signing did not throw, which is a weaker
+// claim than it reads as, because the build has a path that produces an
+// unsigned-but-plausible artifact. scripts/notarize.js ad-hoc signs the bundle
+// (`codesign --sign -`) whenever APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD /
+// APPLE_TEAM_ID are absent, so a release run with a revoked or missing Apple
+// secret produces an .app that looks signed to the most obvious check.
+//
+// Measured on macOS 15 (arm64), Developer ID + notarized app vs the ad-hoc
+// bundle that path produces:
+//
+//   check                                  Developer ID   ad-hoc   unsigned
+//   codesign --verify --deep --strict      rc=0           rc=0     rc=1
+//   spctl -a -t exec                       rc=0           rc=3     rc=3
+//   stapler validate                       rc=0           rc=65    rc=65
+//   Authority=Developer ID Application     present        absent   absent
+//   CodeDirectory flags                    runtime        adhoc,runtime
+//   TeamIdentifier                         set            "not set"
+//
+// `codesign --verify` is rc=0 on the ad-hoc bundle. It is the check most
+// reached for and it is blind to the one failure this repo can actually
+// produce, so the verdict below is a conjunction and never that call alone.
+
+const ADHOC_FLAG = 'adhoc';
+const DEVELOPER_ID_AUTHORITY_PREFIX = 'Developer ID Application';
+const UNSET_TEAM_IDENTIFIER = 'not set';
+
+// `codesign -dv --verbose=4` writes to stderr. Only the fields asserted on are
+// read; unknown lines are ignored so a macOS release cannot fail the build by
+// adding one.
+const parseCodesignInfo = (output) => {
+  const info = { authorities: [], teamIdentifier: null, identifier: null, flags: null };
+
+  for (const rawLine of String(output == null ? '' : output).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith('Authority=')) {
+      info.authorities.push(line.slice('Authority='.length).trim());
+    } else if (line.startsWith('TeamIdentifier=')) {
+      info.teamIdentifier = line.slice('TeamIdentifier='.length).trim();
+    } else if (line.startsWith('Identifier=')) {
+      info.identifier = line.slice('Identifier='.length).trim();
+    } else if (line.startsWith('CodeDirectory ')) {
+      // e.g. `CodeDirectory v=20500 size=306 flags=0x10002(adhoc,runtime) ...`
+      const match = /flags=(0x[0-9a-fA-F]+)\(([^)]*)\)/.exec(line);
+      if (match) {
+        info.flags = {
+          hex: match[1],
+          names: match[2]
+            .split(',')
+            .map((name) => name.trim())
+            .filter(Boolean),
+        };
+      }
+    }
+  }
+
+  return info;
+};
+
+const isAdHoc = (info) => Boolean(info && info.flags && info.flags.names.includes(ADHOC_FLAG));
+
+const hasDeveloperIdAuthority = (info) =>
+  Boolean(
+    info &&
+    info.authorities.some((authority) => authority.startsWith(DEVELOPER_ID_AUTHORITY_PREFIX))
+  );
+
+const hasTeamIdentifier = (info) =>
+  Boolean(info && info.teamIdentifier && info.teamIdentifier !== UNSET_TEAM_IDENTIFIER);
+
+// Every condition is reported, not just the first, so one run names every reason
+// the artifact is unacceptable rather than making the release chase them singly.
+const assessMacSignature = ({
+  info,
+  verifyExitCode,
+  gatekeeperExitCode,
+  staplerExitCode,
+  requireNotarization = true,
+} = {}) => {
+  const parsed = info || parseCodesignInfo('');
+  const failures = [];
+
+  if (verifyExitCode !== 0) {
+    failures.push(`codesign --verify --deep --strict failed (exit ${verifyExitCode}).`);
+  }
+  if (isAdHoc(parsed)) {
+    failures.push(
+      'The bundle is ad-hoc signed. scripts/notarize.js does this when the Apple secrets are ' +
+        'absent, so treat this as a missing or rejected Developer ID credential.'
+    );
+  }
+  if (!hasDeveloperIdAuthority(parsed)) {
+    failures.push(`No "${DEVELOPER_ID_AUTHORITY_PREFIX}" authority in the certificate chain.`);
+  }
+  if (!hasTeamIdentifier(parsed)) {
+    failures.push('TeamIdentifier is not set on the signature.');
+  }
+  if (gatekeeperExitCode !== 0) {
+    failures.push(`spctl assessment rejected the artifact (exit ${gatekeeperExitCode}).`);
+  }
+  if (requireNotarization && staplerExitCode !== 0) {
+    failures.push(
+      `stapler validate found no stapled notarization ticket (exit ${staplerExitCode}).`
+    );
+  }
+
+  return { ok: failures.length === 0, failures };
+};
+
+const formatReport = (target, assessment) => {
+  if (assessment.ok) {
+    return `[verify-macos-signature] ${target}: Developer ID signed, accepted by Gatekeeper, notarization stapled.`;
+  }
+  const lines = assessment.failures.map((failure) => `  - ${failure}`);
+  return [`[verify-macos-signature] ${target}: FAILED`, ...lines].join('\n');
+};
+
+// The three tools are run unconditionally rather than short-circuiting on the
+// first failure, so the report names every problem the artifact has.
+const inspectArtifact = (target, deps = {}) => {
+  const spawnSync = deps.spawnSync || childProcess.spawnSync;
+  const run =
+    deps.run ||
+    ((command, args) => {
+      const result = spawnSync(command, args, { encoding: 'utf8' });
+      // A tool that could not be launched at all must not be reported as a
+      // passing check. `spawnSync` signals that through `error`, and a null
+      // status (killed by a signal) is not a zero exit either.
+      if (result.error) {
+        throw new Error(`Could not run ${command}: ${result.error.message}`);
+      }
+      if (result.status === null) {
+        throw new Error(`${command} was terminated before it produced an exit code.`);
+      }
+      // codesign and spctl write their detail to stderr, not stdout.
+      return { status: result.status, output: `${result.stdout || ''}${result.stderr || ''}` };
+    });
+
+  const describe = run('codesign', ['-dv', '--verbose=4', target]);
+  const verify = run('codesign', ['--verify', '--deep', '--strict', '--verbose=2', target]);
+  const gatekeeper = run('spctl', ['-a', '-t', 'exec', '-vv', target]);
+  const stapler = run('xcrun', ['stapler', 'validate', target]);
+
+  return {
+    info: parseCodesignInfo(describe.output),
+    verifyExitCode: verify.status,
+    gatekeeperExitCode: gatekeeper.status,
+    staplerExitCode: stapler.status,
+  };
+};
+
+const verifyTargets = (targets, deps = {}) => {
+  const log = deps.log || console.log;
+  const requireNotarization = deps.requireNotarization !== false;
+  const results = targets.map((target) => {
+    const assessment = assessMacSignature({
+      ...inspectArtifact(target, deps),
+      requireNotarization,
+    });
+    log(formatReport(target, assessment));
+    return { target, assessment };
+  });
+
+  return { ok: results.every((result) => result.assessment.ok), results };
+};
+
+// Returns a process exit code. A missing tool, an unreadable artifact and an
+// empty argument list all have to be failures: an unverified artifact and a
+// verified one must never leave the same exit code behind.
+const main = (argv, deps = {}) => {
+  const error = deps.error || console.error;
+  const targets = argv.slice(2);
+
+  if (targets.length === 0) {
+    error('Usage: node scripts/verify-macos-signature.js <artifact> [artifact...]');
+    return 1;
+  }
+
+  try {
+    return verifyTargets(targets, deps).ok ? 0 : 1;
+  } catch (thrown) {
+    error(`[verify-macos-signature] ${thrown.message || thrown}`);
+    return 1;
+  }
+};
+
+module.exports = {
+  ADHOC_FLAG,
+  DEVELOPER_ID_AUTHORITY_PREFIX,
+  UNSET_TEAM_IDENTIFIER,
+  assessMacSignature,
+  formatReport,
+  hasDeveloperIdAuthority,
+  hasTeamIdentifier,
+  inspectArtifact,
+  isAdHoc,
+  main,
+  parseCodesignInfo,
+  verifyTargets,
+};
+
+if (require.main === module) {
+  process.exitCode = main(process.argv);
+}

--- a/apps/desktop/tests/verify-macos-signature.test.ts
+++ b/apps/desktop/tests/verify-macos-signature.test.ts
@@ -137,6 +137,75 @@ describe('signature predicates', () => {
     expect(hasDeveloperIdAuthority(installer)).toBe(false);
   });
 
+  // The substring class: output that CONTAINS the accepted text without being
+  // the accepted thing. A check that searched the raw output rather than reading
+  // the Authority field would pass all three of these.
+  it('does not accept "Developer ID Application" appearing outside an Authority line', () => {
+    const { parseCodesignInfo, hasDeveloperIdAuthority } = loadModule();
+    const decoy = parseCodesignInfo(
+      [
+        'Executable=/Applications/Developer ID Application.app/Contents/MacOS/App',
+        'Identifier=Developer ID Application',
+        'CodeDirectory v=20500 size=306 flags=0x10002(adhoc,runtime) hashes=3+3 location=embedded',
+        'TeamIdentifier=not set',
+      ].join('\n')
+    );
+
+    expect(decoy.authorities).toEqual([]);
+    expect(hasDeveloperIdAuthority(decoy)).toBe(false);
+  });
+
+  // Kills the `startsWith` -> `includes` weakening: an authority that CONTAINS
+  // the accepted prefix without being it must not be accepted.
+  it('requires the authority to start with the prefix, not merely contain it', () => {
+    const { parseCodesignInfo, hasDeveloperIdAuthority } = loadModule();
+
+    for (const authority of [
+      'Authority=Not a Developer ID Application: Example Org (ABCDE12345)',
+      'Authority=Untrusted Developer ID Application clone',
+      'Authority=X-Developer ID Application: Example Org (ABCDE12345)',
+    ]) {
+      expect(hasDeveloperIdAuthority(parseCodesignInfo(authority))).toBe(false);
+    }
+  });
+
+  // Kills the `Authority=` -> `Authority` weakening in the parser: only the
+  // Authority field contributes, not any line that happens to say the word.
+  it('collects authorities only from Authority= lines', () => {
+    const { parseCodesignInfo } = loadModule();
+    const info = parseCodesignInfo(
+      [
+        'Executable=/Applications/Certificate Authority Tool.app/Contents/MacOS/Tool',
+        'Identifier=com.example.Authority',
+        'Authority=Developer ID Application: Example Org (ABCDE12345)',
+        'Sealed Resources Authority=decoy',
+      ].join('\n')
+    );
+
+    expect(info.authorities).toEqual(['Developer ID Application: Example Org (ABCDE12345)']);
+  });
+
+  it('does not read "adhoc" from anywhere but the CodeDirectory flags', () => {
+    const { parseCodesignInfo, isAdHoc } = loadModule();
+    const decoy = parseCodesignInfo(
+      [
+        'Executable=/Applications/adhoc/Contents/MacOS/App',
+        'CodeDirectory v=20500 size=308094 flags=0x10000(runtime) hashes=9617+7 location=embedded',
+        'Authority=Developer ID Application: Example Org (ABCDE12345)',
+        'TeamIdentifier=ABCDE12345',
+      ].join('\n')
+    );
+
+    expect(isAdHoc(decoy)).toBe(false);
+  });
+
+  it('does not accept a team identifier that merely contains "not set"', () => {
+    const { parseCodesignInfo, hasTeamIdentifier } = loadModule();
+
+    expect(hasTeamIdentifier(parseCodesignInfo('TeamIdentifier=not settled'))).toBe(true);
+    expect(hasTeamIdentifier(parseCodesignInfo('TeamIdentifier=not set'))).toBe(false);
+  });
+
   it('is safe on a null info object', () => {
     const { isAdHoc, hasDeveloperIdAuthority, hasTeamIdentifier } = loadModule();
 

--- a/apps/desktop/tests/verify-macos-signature.test.ts
+++ b/apps/desktop/tests/verify-macos-signature.test.ts
@@ -1,0 +1,451 @@
+import { createRequire } from 'node:module';
+
+type CodesignFlags = { hex: string; names: string[] };
+type CodesignInfo = {
+  authorities: string[];
+  teamIdentifier: string | null;
+  identifier: string | null;
+  flags: CodesignFlags | null;
+};
+type Assessment = { ok: boolean; failures: string[] };
+type RunResult = { status: number; output: string };
+type VerifyModule = {
+  ADHOC_FLAG: string;
+  DEVELOPER_ID_AUTHORITY_PREFIX: string;
+  UNSET_TEAM_IDENTIFIER: string;
+  assessMacSignature: (input: Record<string, unknown>) => Assessment;
+  formatReport: (target: string, assessment: Assessment) => string;
+  hasDeveloperIdAuthority: (info: CodesignInfo) => boolean;
+  hasTeamIdentifier: (info: CodesignInfo) => boolean;
+  inspectArtifact: (target: string, deps?: Record<string, unknown>) => Record<string, unknown>;
+  isAdHoc: (info: CodesignInfo) => boolean;
+  parseCodesignInfo: (output: unknown) => CodesignInfo;
+  verifyTargets: (
+    targets: string[],
+    deps?: Record<string, unknown>
+  ) => { ok: boolean; results: { target: string; assessment: Assessment }[] };
+};
+
+const loadModule = (): VerifyModule => {
+  const requireFromHere = createRequire(__filename);
+  return requireFromHere('../scripts/verify-macos-signature.js') as VerifyModule;
+};
+
+// Structurally identical to real `codesign -dv --verbose=4` output on macOS 15
+// (field order, the `flags=0x...(names)` shape, Authority repeated per chain
+// element). Identity values are placeholders; the parser only reads structure.
+const DEVELOPER_ID_OUTPUT = [
+  'Executable=/Applications/Example.app/Contents/MacOS/Example',
+  'Identifier=com.yosemitecrew.pims',
+  'Format=app bundle with Mach-O universal (x86_64 arm64)',
+  'CodeDirectory v=20500 size=308094 flags=0x10000(runtime) hashes=9617+7 location=embedded',
+  'Signature size=9075',
+  'Authority=Developer ID Application: Example Org (ABCDE12345)',
+  'Authority=Developer ID Certification Authority',
+  'Authority=Apple Root CA',
+  'Timestamp=1 Jan 2026 at 00:00:00',
+  'Notarization Ticket=stapled',
+  'TeamIdentifier=ABCDE12345',
+  'Sealed Resources version=2 rules=13 files=42',
+].join('\n');
+
+// What scripts/notarize.js produces when the Apple secrets are absent: it falls
+// back to `codesign --sign -`, which yields the adhoc flag and no authority.
+const AD_HOC_OUTPUT = [
+  'Executable=/tmp/Probe.app/Contents/MacOS/Probe',
+  'Identifier=com.yosemitecrew.pims',
+  'Format=app bundle with Mach-O universal (x86_64 arm64e)',
+  'CodeDirectory v=20500 size=306 flags=0x10002(adhoc,runtime) hashes=3+3 location=embedded',
+  'Signature=adhoc',
+  'TeamIdentifier=not set',
+].join('\n');
+
+const PASSING_EXIT_CODES = { verifyExitCode: 0, gatekeeperExitCode: 0, staplerExitCode: 0 };
+
+describe('parseCodesignInfo', () => {
+  it('reads every authority, the team identifier and the flag names', () => {
+    const { parseCodesignInfo } = loadModule();
+    const info = parseCodesignInfo(DEVELOPER_ID_OUTPUT);
+
+    expect(info.authorities).toEqual([
+      'Developer ID Application: Example Org (ABCDE12345)',
+      'Developer ID Certification Authority',
+      'Apple Root CA',
+    ]);
+    expect(info.teamIdentifier).toBe('ABCDE12345');
+    expect(info.identifier).toBe('com.yosemitecrew.pims');
+    expect(info.flags).toEqual({ hex: '0x10000', names: ['runtime'] });
+  });
+
+  it('splits multi-valued flags so adhoc is visible alongside runtime', () => {
+    const { parseCodesignInfo } = loadModule();
+
+    expect(parseCodesignInfo(AD_HOC_OUTPUT).flags).toEqual({
+      hex: '0x10002',
+      names: ['adhoc', 'runtime'],
+    });
+  });
+
+  it('returns empty fields rather than throwing on absent or unparsable output', () => {
+    const { parseCodesignInfo } = loadModule();
+
+    for (const input of [undefined, null, '', 'code object is not signed at all']) {
+      const info = parseCodesignInfo(input);
+      expect(info.authorities).toEqual([]);
+      expect(info.teamIdentifier).toBeNull();
+      expect(info.flags).toBeNull();
+    }
+  });
+
+  it('ignores a CodeDirectory line that carries no flags group', () => {
+    const { parseCodesignInfo } = loadModule();
+
+    expect(parseCodesignInfo('CodeDirectory v=20500 size=306').flags).toBeNull();
+  });
+});
+
+describe('signature predicates', () => {
+  it('separates a Developer ID chain from an ad-hoc signature', () => {
+    const { parseCodesignInfo, isAdHoc, hasDeveloperIdAuthority, hasTeamIdentifier } = loadModule();
+    const good = parseCodesignInfo(DEVELOPER_ID_OUTPUT);
+    const adHoc = parseCodesignInfo(AD_HOC_OUTPUT);
+
+    expect(isAdHoc(good)).toBe(false);
+    expect(hasDeveloperIdAuthority(good)).toBe(true);
+    expect(hasTeamIdentifier(good)).toBe(true);
+
+    expect(isAdHoc(adHoc)).toBe(true);
+    expect(hasDeveloperIdAuthority(adHoc)).toBe(false);
+    expect(hasTeamIdentifier(adHoc)).toBe(false);
+  });
+
+  it('treats the literal "not set" team identifier as absent', () => {
+    const { parseCodesignInfo, hasTeamIdentifier } = loadModule();
+
+    expect(hasTeamIdentifier(parseCodesignInfo('TeamIdentifier=not set'))).toBe(false);
+    expect(hasTeamIdentifier(parseCodesignInfo('TeamIdentifier=ABCDE12345'))).toBe(true);
+  });
+
+  it('does not accept a development or third-party authority as Developer ID', () => {
+    const { parseCodesignInfo, hasDeveloperIdAuthority } = loadModule();
+    const development = parseCodesignInfo('Authority=Apple Development: someone (ABCDE12345)');
+    const installer = parseCodesignInfo(
+      'Authority=Developer ID Installer: Example Org (ABCDE12345)'
+    );
+
+    expect(hasDeveloperIdAuthority(development)).toBe(false);
+    expect(hasDeveloperIdAuthority(installer)).toBe(false);
+  });
+
+  it('is safe on a null info object', () => {
+    const { isAdHoc, hasDeveloperIdAuthority, hasTeamIdentifier } = loadModule();
+
+    expect(isAdHoc(null as unknown as CodesignInfo)).toBe(false);
+    expect(hasDeveloperIdAuthority(null as unknown as CodesignInfo)).toBe(false);
+    expect(hasTeamIdentifier(null as unknown as CodesignInfo)).toBe(false);
+  });
+});
+
+describe('assessMacSignature', () => {
+  it('accepts a Developer ID signed, Gatekeeper accepted, stapled artifact', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const assessment = assessMacSignature({
+      info: parseCodesignInfo(DEVELOPER_ID_OUTPUT),
+      ...PASSING_EXIT_CODES,
+    });
+
+    expect(assessment).toEqual({ ok: true, failures: [] });
+  });
+
+  // The regression this whole script exists for: `codesign --verify` exits 0 on
+  // the ad-hoc bundle. Measured on macOS 15, not assumed. If the verdict were
+  // ever reduced to that one call, this case would start passing.
+  it('rejects the ad-hoc bundle even though codesign --verify exits 0', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const assessment = assessMacSignature({
+      info: parseCodesignInfo(AD_HOC_OUTPUT),
+      verifyExitCode: 0,
+      gatekeeperExitCode: 3,
+      staplerExitCode: 65,
+    });
+
+    expect(assessment.ok).toBe(false);
+    expect(assessment.failures).toHaveLength(5);
+    expect(assessment.failures.join('\n')).toContain('ad-hoc signed');
+  });
+
+  it('reports every failing condition rather than only the first', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const assessment = assessMacSignature({
+      info: parseCodesignInfo(''),
+      verifyExitCode: 1,
+      gatekeeperExitCode: 3,
+      staplerExitCode: 65,
+    });
+
+    expect(assessment.failures).toHaveLength(5);
+  });
+
+  it('fails each condition independently while the others pass', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const good = parseCodesignInfo(DEVELOPER_ID_OUTPUT);
+
+    expect(
+      assessMacSignature({ info: good, ...PASSING_EXIT_CODES, verifyExitCode: 1 }).failures
+    ).toEqual([expect.stringContaining('codesign --verify')]);
+    expect(
+      assessMacSignature({ info: good, ...PASSING_EXIT_CODES, gatekeeperExitCode: 3 }).failures
+    ).toEqual([expect.stringContaining('spctl')]);
+    expect(
+      assessMacSignature({ info: good, ...PASSING_EXIT_CODES, staplerExitCode: 65 }).failures
+    ).toEqual([expect.stringContaining('stapler validate')]);
+  });
+
+  it('skips only the stapling condition when notarization is not required', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const assessment = assessMacSignature({
+      info: parseCodesignInfo(DEVELOPER_ID_OUTPUT),
+      ...PASSING_EXIT_CODES,
+      staplerExitCode: 65,
+      requireNotarization: false,
+    });
+
+    expect(assessment).toEqual({ ok: true, failures: [] });
+  });
+
+  it('still requires a Developer ID chain when notarization is not required', () => {
+    const { assessMacSignature, parseCodesignInfo } = loadModule();
+    const assessment = assessMacSignature({
+      info: parseCodesignInfo(AD_HOC_OUTPUT),
+      ...PASSING_EXIT_CODES,
+      requireNotarization: false,
+    });
+
+    expect(assessment.ok).toBe(false);
+  });
+
+  // An unverified artifact and a verified one must not produce the same verdict.
+  it('fails closed when called with no arguments at all', () => {
+    const { assessMacSignature } = loadModule();
+
+    expect(assessMacSignature().ok).toBe(false);
+    expect(assessMacSignature({}).ok).toBe(false);
+  });
+});
+
+describe('formatReport', () => {
+  it('states the three properties that were established on success', () => {
+    const { formatReport } = loadModule();
+    const report = formatReport('Example.app', { ok: true, failures: [] });
+
+    expect(report).toContain('Developer ID signed');
+    expect(report).toContain('Gatekeeper');
+    expect(report).toContain('notarization stapled');
+  });
+
+  it('lists each failure under a FAILED heading', () => {
+    const { formatReport } = loadModule();
+    const report = formatReport('Example.app', { ok: false, failures: ['first', 'second'] });
+
+    expect(report).toContain('Example.app: FAILED');
+    expect(report.split('\n')).toEqual([
+      '[verify-macos-signature] Example.app: FAILED',
+      '  - first',
+      '  - second',
+    ]);
+  });
+});
+
+describe('inspectArtifact', () => {
+  const stubRun = (byCommand: Record<string, RunResult>) => {
+    const calls: { command: string; args: string[] }[] = [];
+    const run = (command: string, args: string[]): RunResult => {
+      calls.push({ command, args });
+      const key = command === 'xcrun' ? `xcrun ${args[0]}` : command;
+      const match = command === 'codesign' && args.includes('--verify') ? 'codesign --verify' : key;
+      return byCommand[match] ?? { status: 0, output: '' };
+    };
+    return { run, calls };
+  };
+
+  it('runs all four checks and returns their exit codes', () => {
+    const { inspectArtifact } = loadModule();
+    const { run, calls } = stubRun({
+      codesign: { status: 0, output: DEVELOPER_ID_OUTPUT },
+      'codesign --verify': { status: 0, output: 'valid on disk' },
+      spctl: { status: 0, output: 'accepted' },
+      'xcrun stapler': { status: 0, output: 'The validate action worked!' },
+    });
+
+    const result = inspectArtifact('Example.app', { run });
+
+    expect(calls.map((call) => call.command)).toEqual(['codesign', 'codesign', 'spctl', 'xcrun']);
+    expect(result.verifyExitCode).toBe(0);
+    expect(result.gatekeeperExitCode).toBe(0);
+    expect(result.staplerExitCode).toBe(0);
+    expect((result.info as CodesignInfo).teamIdentifier).toBe('ABCDE12345');
+  });
+
+  // Every tool must see the artifact; a check that silently inspected something
+  // else would report a verdict about the wrong file.
+  it('passes the target through to every tool', () => {
+    const { inspectArtifact } = loadModule();
+    const { run, calls } = stubRun({});
+
+    inspectArtifact('Some Artifact.dmg', { run });
+
+    expect(calls).toHaveLength(4);
+    for (const call of calls) {
+      expect(call.args).toContain('Some Artifact.dmg');
+    }
+  });
+
+  it('does not short-circuit when an early check fails', () => {
+    const { inspectArtifact } = loadModule();
+    const { run, calls } = stubRun({ 'codesign --verify': { status: 1, output: 'not signed' } });
+
+    const result = inspectArtifact('Example.app', { run });
+
+    expect(calls).toHaveLength(4);
+    expect(result.verifyExitCode).toBe(1);
+  });
+});
+
+describe('the default runner (fail-closed)', () => {
+  it('concatenates stdout and stderr, because codesign reports on stderr', () => {
+    const { inspectArtifact } = loadModule();
+    const spawnSync = jest.fn().mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: DEVELOPER_ID_OUTPUT,
+    });
+
+    const result = inspectArtifact('Example.app', { spawnSync });
+
+    expect((result.info as CodesignInfo).teamIdentifier).toBe('ABCDE12345');
+  });
+
+  it('throws rather than reporting a pass when the tool cannot be launched', () => {
+    const { inspectArtifact } = loadModule();
+    const spawnSync = jest.fn().mockReturnValue({ error: new Error('spawn ENOENT') });
+
+    expect(() => inspectArtifact('Example.app', { spawnSync })).toThrow(/Could not run codesign/);
+  });
+
+  it('throws when a tool is killed by a signal and leaves a null status', () => {
+    const { inspectArtifact } = loadModule();
+    const spawnSync = jest.fn().mockReturnValue({ status: null, stdout: '', stderr: '' });
+
+    expect(() => inspectArtifact('Example.app', { spawnSync })).toThrow(/terminated before/);
+  });
+
+  it('tolerates a tool that produces neither stdout nor stderr', () => {
+    const { inspectArtifact } = loadModule();
+    const spawnSync = jest.fn().mockReturnValue({ status: 1 });
+
+    const result = inspectArtifact('Example.app', { spawnSync });
+
+    expect(result.verifyExitCode).toBe(1);
+    expect((result.info as CodesignInfo).authorities).toEqual([]);
+  });
+});
+
+describe('main', () => {
+  it('returns 0 only when every artifact verifies', () => {
+    const { main } = loadModule();
+    const log = jest.fn();
+    const run = () => ({ status: 0, output: DEVELOPER_ID_OUTPUT });
+
+    expect(main(['node', 'script', 'a.app'], { run, log })).toBe(0);
+  });
+
+  it('returns 1 when no artifact was named, rather than reporting success', () => {
+    const { main } = loadModule();
+    const error = jest.fn();
+
+    expect(main(['node', 'script'], { error })).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+  });
+
+  it('returns 1 and reports when a tool throws, rather than propagating', () => {
+    const { main } = loadModule();
+    const error = jest.fn();
+    const run = () => {
+      throw new Error('spctl is missing');
+    };
+
+    expect(main(['node', 'script', 'a.app'], { run, error })).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('spctl is missing'));
+  });
+
+  it('returns 1 for an ad-hoc signed artifact', () => {
+    const { main } = loadModule();
+    const log = jest.fn();
+    const run = (command: string, args: string[]): RunResult => {
+      if (command === 'codesign' && !args.includes('--verify')) {
+        return { status: 0, output: AD_HOC_OUTPUT };
+      }
+      if (command === 'codesign') return { status: 0, output: '' };
+      return { status: 3, output: '' };
+    };
+
+    expect(main(['node', 'script', 'a.app'], { run, log })).toBe(1);
+  });
+});
+
+describe('verifyTargets', () => {
+  const runFor =
+    (output: string, statuses: Record<string, number>) =>
+    (command: string, args: string[]): RunResult => {
+      if (command === 'codesign' && !args.includes('--verify')) return { status: 0, output };
+      if (command === 'codesign') return { status: statuses.verify ?? 0, output: '' };
+      if (command === 'spctl') return { status: statuses.spctl ?? 0, output: '' };
+      return { status: statuses.stapler ?? 0, output: '' };
+    };
+
+  it('is ok only when every target passes', () => {
+    const { verifyTargets } = loadModule();
+    const log = jest.fn();
+
+    const passing = verifyTargets(['a.app', 'b.dmg'], {
+      run: runFor(DEVELOPER_ID_OUTPUT, {}),
+      log,
+    });
+
+    expect(passing.ok).toBe(true);
+    expect(passing.results).toHaveLength(2);
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails the whole run when a single target is ad-hoc signed', () => {
+    const { verifyTargets } = loadModule();
+    const log = jest.fn();
+    let call = 0;
+    const run = (command: string, args: string[]): RunResult => {
+      // First target good, second ad-hoc.
+      const output = call < 4 ? DEVELOPER_ID_OUTPUT : AD_HOC_OUTPUT;
+      const statuses = call < 4 ? {} : { spctl: 3, stapler: 65 };
+      call += 1;
+      return runFor(output, statuses)(command, args);
+    };
+
+    const result = verifyTargets(['good.app', 'adhoc.app'], { run, log });
+
+    expect(result.ok).toBe(false);
+    expect(result.results[0].assessment.ok).toBe(true);
+    expect(result.results[1].assessment.ok).toBe(false);
+  });
+
+  it('honours requireNotarization: false end to end', () => {
+    const { verifyTargets } = loadModule();
+    const log = jest.fn();
+
+    const result = verifyTargets(['a.app'], {
+      run: runFor(DEVELOPER_ID_OUTPUT, { stapler: 65 }),
+      log,
+      requireNotarization: false,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`desktop-release.yml` never verifies a signature. Grep for the tools across both release workflows returns two hits, and both are certificate import rather than verification:

```
$ grep -nE 'codesign|spctl|signtool|stapler' .github/workflows/desktop-release.yml .github/workflows/mobile-release.yml
mobile-release.yml:307:  security import ... -T /usr/bin/codesign
mobile-release.yml:329:  IDENTITY=$(security find-identity -v -p codesigning ...)
```

Zero hits in `desktop-release.yml`. So a green Windows or macOS job has only ever proved that signing did not throw.

That matters on macOS because the build has a path that produces an unsigned-but-plausible artifact. `apps/desktop/scripts/notarize.js` falls back to `codesign --sign -` whenever `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD` or `APPLE_TEAM_ID` is absent or rejected. A release run with a revoked Apple credential produces an ad-hoc signed `.app` and a green job.

## What is the new behavior?

Both jobs verify their output before the upload step.

**The check is a conjunction, not `codesign --verify`.** Measured on macOS 15 (arm64) against a real Developer ID signed and notarized app, against the ad-hoc bundle that `notarize.js` produces, and against an unsigned one:

| check | Developer ID | ad-hoc | unsigned |
|---|---|---|---|
| `codesign --verify --deep --strict` | rc=0 | **rc=0** | rc=1 |
| `spctl -a -t exec` | rc=0 | rc=3 | rc=3 |
| `stapler validate` | rc=0 | rc=65 | rc=65 |
| `Authority=Developer ID Application` | present | absent | absent |
| `CodeDirectory` flags | `runtime` | `adhoc,runtime` | n/a |
| `TeamIdentifier` | set | `not set` | n/a |

`codesign --verify` exits 0 on the ad-hoc bundle. It is the check most reached for and it is blind to the only signing failure this build can actually produce. `@electron/notarize` already runs that same call (`lib/check-signature.js` runs `codesign -vvv --deep --strict`) before notarizing, which is why nothing has ever caught this - and it only runs on the path where the credentials are present.

So the verdict asserts all of: Developer ID authority in the chain, team identifier set, not ad-hoc, Gatekeeper accepts, notarization ticket stapled.

The `.app` is the target rather than the `.dmg`: `@electron/notarize` staples the ticket to the bundle (`lib/index.js` calls `stapleApp` after `notarizeAndWaitForNotaryTool`), and the disk image is built from the already-stapled app. Asserting a stapled ticket on the `.dmg` would false-fail a good build.

Windows asserts Authenticode `Status -eq 'Valid'` and a signer subject matching `build.win.signtoolOptions.publisherName`, read out of `package.json` so the check cannot drift from what is actually signed.

Both steps fail on an empty artifact set. "Nothing to check" and "everything checked out" must not produce the same exit code.

## Verification

Full desktop suite at `142521474`:

```
Test Suites: 71 passed, 71 total
Tests:       1093 passed, 1093 total
Statements   : 98.37%   Branches : 90.87%   Functions : 97.68%   Lines : 98.37%
```

Above the desktop floors in `_test.yaml` (statements 95, branches 88, functions 95, lines 95). `lint` and `type-check` both exit 0.

New module measured alone: 36 tests, statements 99.05%, functions 100%.

**End to end against real artifacts on macOS 15**, one Developer ID signed and notarized app and the ad-hoc bundle:

```
GOOD  (Developer ID + notarized)   exit 0
ADHOC (what notarize.js produces)  exit 1
  - The bundle is ad-hoc signed. ...
  - No "Developer ID Application" authority in the certificate chain.
  - TeamIdentifier is not set on the signature.
  - spctl assessment rejected the artifact (exit 3).
  - stapler validate found no stapled notarization ticket (exit 65).
```

Note the positive control: the check is not simply always-failing.

**Mutation table.** A verification step that cannot fail is worse than none, because it converts "we never checked" into "we checked and it was fine". Every mutation below was applied to the shipped tree and reverted:

```
M1  drop ad-hoc rejection                     1 failed, 35 passed
M2  drop Developer ID authority check         2 failed, 34 passed
M3  drop stapler check                        3 failed, 33 passed
M4  drop spctl check                          3 failed, 33 passed
M5  main returns 0 on failure                 2 failed, 34 passed
M6  runner ignores spawn error                1 failed, 35 passed
M7  adhoc flag name typo                      2 failed, 34 passed
M8  authority startsWith -> includes          1 failed, 35 passed
M9  team check uses includes                  1 failed, 35 passed
M10 parse Authority by substring              1 failed, 35 passed
M11 adhoc read from wrong field               2 failed, 34 passed
M12 drop null-status guard                    1 failed, 35 passed
BASELINE                                     36 passed
```

M8 and M10 survived the first pass and are the reason for the second commit. Both are the substring class - a check that accepts anything CONTAINING the accepted text - which is the same defect a scanner flagged on the sibling mobile-guards PR. The added cases are an authority that contains the Developer ID prefix without starting with it, and a bundle whose executable path and identifier carry the word `Authority`.

## What this PR does not establish

- **The Windows step has not been executed.** It cannot be: every signing job sits behind the `release` environment, whose deployment branch policy is three tag patterns and zero branch patterns, so no branch dispatch reaches it. The macOS logic was exercised against real artifacts locally; the PowerShell step is reasoned from the `Get-AuthenticodeSignature` contract and reviewed, not run. Worth a reviewer's eye on that specifically.
- It does not make an unsigned build fail earlier. `forceCodeSigning` is deliberately not set, because local unsigned builds are a documented workflow in `apps/desktop/docs/RELEASE-TESTING.md`. The CI step is the gate, and CI is where it matters.
- It changes no credential, environment, or branch-protection setting.

## Related Issue(s)

No tracking issue. Came out of a release dry-run readiness review that established the release path had three signing chains and no verification on any of them.