### PR TITLE
ci(repo): read job-level guards, and cover desktop's own publish steps

### DIFF
--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -50,6 +50,15 @@ export const RELEASE_WORKFLOWS = [
 export const SUBMISSIONS = [
   { store: 'Google Play', uses: 'r0adkll/upload-google-play' },
   { store: 'App Store Connect', run: 'altool --upload-app' },
+  // Desktop does not reach a store, it reaches the public. `gh release edit
+  // --draft=false` is the step that takes a draft release public, and a public
+  // release is what electron-updater's clients poll.
+  { store: 'a public GitHub Release', run: '--draft=false' },
+  // action-gh-release publishes unless the release is explicitly a draft. The
+  // dispatch-only `release` job sets `draft: true`, which is why it is not a
+  // finding today - but flipping that one word publishes from a branch, and
+  // that is the edit this entry exists to catch.
+  { store: 'a GitHub Release', uses: 'softprops/action-gh-release', exemptWhenDraft: true },
 ];
 
 /** Conditions that restrict a step to a release tag. Either one is enough. */
@@ -63,7 +72,9 @@ export function classifyStep(step) {
   if (!step || typeof step !== 'object') return null;
   const uses = typeof step.uses === 'string' ? step.uses : '';
   const run = typeof step.run === 'string' ? step.run : '';
+  const isDraft = Boolean(step.with && step.with.draft === true);
   for (const submission of SUBMISSIONS) {
+    if (submission.exemptWhenDraft && isDraft) continue;
     if (submission.uses && uses.split('@')[0] === submission.uses) return submission;
     if (submission.run && run.includes(submission.run)) return submission;
   }
@@ -107,7 +118,12 @@ export function findUnguardedSubmissions(source, file) {
     for (const step of job?.steps ?? []) {
       const submission = classifyStep(step);
       if (!submission) continue;
-      if (isTagOnly(step.if)) continue;
+      // A step runs only when its job runs AND its own condition passes, so a
+      // tag-only condition at EITHER level restricts it. Desktop guards at the
+      // job (`publish` carries the condition, its step does not) and mobile at
+      // the step, and reading only one level misses one of them: reading only
+      // steps waves through a desktop `publish` job whose guard was deleted.
+      if (isTagOnly(step.if) || isTagOnly(job?.if)) continue;
       findings.push({
         file,
         job: jobId,
@@ -148,11 +164,11 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   }
   if (findings.length > 0) {
     console.error(
-      `\n${findings.length} store submission(s) reachable from a workflow_dispatch. ` +
+      `\n${findings.length} outward-facing publish step(s) reachable from a workflow_dispatch. ` +
         `Gate each on ${TAG_ONLY_GUARDS.join(' or ')}. ` +
         `A condition containing '||' is never accepted: a disjunction can only widen.`
     );
     process.exit(1);
   }
-  console.log(`No unguarded store submissions in ${RELEASE_WORKFLOWS.length} release workflows.`);
+  console.log(`No unguarded publish steps in ${RELEASE_WORKFLOWS.length} release workflows.`);
 }

--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -93,13 +93,33 @@ export function classifyStep(step) {
  * anyone will make to this file. It contains an accepted guard and submits on a
  * plain dispatch anyway, because a disjunction can only widen: `A || B` runs
  * whenever B alone is true, so no guard to the left of a `||` restricts
- * anything. Any `||` is therefore rejected outright.
+ * anything.
  *
  * `&&` is the opposite and is accepted, so tightening the shipped guard to
  * `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')` does not
- * red the build. Every other spelling fails closed - a red build and a human
- * reading this comment is the outcome we want from an expression we cannot
- * classify.
+ * red the build.
+ *
+ * THE `||` REJECTION IS WHAT MAKES THE `&&` SPLIT BELOW SOUND, and that is not
+ * the same claim as the paragraph above it. Splitting on `&&` ignores operator
+ * precedence: `&&` binds tighter than `||`, so
+ *
+ *   inputs.force || inputs.x && github.event_name == 'push'
+ *
+ * means `inputs.force || (inputs.x && push)` - it runs on a dispatch whenever
+ * `inputs.force` is set - yet splitting it on `&&` yields an operand that is
+ * EXACTLY an accepted guard. Without the early return this is accepted, measured.
+ * Note it is order-dependent: move the guard to the left of the `&&` and the
+ * naive split happens to reject it, so the hole opens on one spelling and not
+ * the other. Both are pinned in the tests.
+ *
+ * A plain `A || B` is rejected either way, because the whole string becomes one
+ * operand and no operand equals a guard. So the early return looks redundant
+ * against the case this comment opens with, and is load-bearing against a case
+ * that comment never mentions. Do not delete it on the strength of the first
+ * paragraph.
+ *
+ * Every other spelling fails closed - a red build and a human reading this
+ * comment is the outcome we want from an expression we cannot classify.
  */
 export function isTagOnly(condition) {
   if (typeof condition !== 'string') return false;

--- a/scripts/ci/check-release-upload-guards.test.mjs
+++ b/scripts/ci/check-release-upload-guards.test.mjs
@@ -175,6 +175,67 @@ test('a workflow path that escapes the repository is refused', () => {
   assert.throws(() => checkRepo(process.cwd(), ['../../../etc/hosts']), /escapes the repository/);
 });
 
+// Desktop guards at the JOB and mobile guards at the STEP. Reading only steps
+// waved through a `publish` job whose own guard had been deleted - found by a
+// peer running the mutation this fixture now pins.
+const jobWorkflow = (jobIf, steps) => `
+name: fixture
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}
+jobs:
+  publish:
+${jobIf === null ? '' : `    if: ${jobIf}\n`}    runs-on: ubuntu-latest
+    steps:
+${steps}
+`;
+
+const PUBLISH_STEP = `      - name: Publish the release
+        run: |
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest=true`;
+
+test('a job-level tag guard covers a step that carries none', () => {
+  // The shipped desktop shape: `publish` holds the condition, its step does not.
+  const source = jobWorkflow("github.event_name == 'push'", PUBLISH_STEP);
+  assert.deepEqual(findUnguardedSubmissions(source, 'fixture.yml'), []);
+});
+
+test('deleting the job-level guard is caught', () => {
+  const findings = findUnguardedSubmissions(jobWorkflow(null, PUBLISH_STEP), 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].store, 'a public GitHub Release');
+  assert.equal(findings[0].job, 'publish');
+});
+
+test('a job-level guard widened with || does not rescue the step either', () => {
+  const source = jobWorkflow("github.event_name == 'push' || inputs.force == true", PUBLISH_STEP);
+  assert.equal(findUnguardedSubmissions(source, 'fixture.yml').length, 1);
+});
+
+test('a job-level || does not rescue a step whose own guard was deleted', () => {
+  // The mobile shape, and the regression this change could have caused: the
+  // `android` job's condition contains an accepted guard inside a disjunction,
+  // so reading the job level must not turn that into a pass.
+  const source = workflow(PLAY_UNGUARDED).replace(
+    '    environment: release',
+    "    environment: release\n    if: github.event_name == 'push' || inputs.platform == 'android'"
+  );
+  assert.equal(findUnguardedSubmissions(source, 'fixture.yml').length, 1);
+});
+
+test('action-gh-release is a submission unless the release is a draft', () => {
+  const step = (draft) => `      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
+        with:
+${draft === null ? '' : `          draft: ${draft}\n`}          tag_name: manual-v1`;
+  const count = (draft) =>
+    findUnguardedSubmissions(jobWorkflow(null, step(draft)), 'fixture.yml').length;
+  assert.equal(count(true), 0, 'draft: true is not outward-facing');
+  assert.equal(count(false), 1, 'draft: false publishes');
+  assert.equal(count(null), 1, 'no draft key publishes');
+});
+
 function findingsStores(source) {
   return findUnguardedSubmissions(source, 'fixture.yml').map((f) => f.store);
 }

--- a/scripts/ci/check-release-upload-guards.test.mjs
+++ b/scripts/ci/check-release-upload-guards.test.mjs
@@ -155,6 +155,28 @@ test('a disjunction is rejected whichever side the accepted guard is on', () => 
   );
 });
 
+test('operator precedence: a guard on the right of an && inside a disjunction is rejected', () => {
+  // `&&` binds tighter than `||`, so this is `inputs.force || (inputs.x && push)`
+  // and runs on a dispatch whenever inputs.force is set. Splitting on `&&` yields
+  // an operand that is EXACTLY an accepted guard, so without the `||` early
+  // return in isTagOnly this is ACCEPTED - measured, not argued. This test is the
+  // only thing standing between that line and a reader who deletes it as
+  // redundant against the plain-disjunction case, which it genuinely is.
+  assert.equal(isTagOnly("inputs.force || inputs.x && github.event_name == 'push'"), false);
+  // Order-dependent: with the guard on the left of the `&&` the naive split
+  // happens to reject it anyway. Pinned so a future change to the splitter
+  // cannot open one spelling while the other keeps passing.
+  assert.equal(isTagOnly("inputs.force || github.event_name == 'push' && inputs.x"), false);
+});
+
+test('a conjunction containing a parenthesised disjunction is refused, conservatively', () => {
+  // `push && (x || y)` is genuinely restricted by the `&&`, so rejecting it is
+  // stricter than necessary. Recorded as the deliberate cost of the `||` rule
+  // rather than left as an undocumented surprise: it fails closed, and the fix
+  // if it ever bites is to spell the condition without an inner disjunction.
+  assert.equal(isTagOnly("github.event_name == 'push' && (inputs.x || inputs.y)"), false);
+});
+
 test('a conjunction is accepted, so tightening the guard later does not red the build', () => {
   assert.equal(
     isTagOnly("github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"),


### PR DESCRIPTION
## The finding

Review of the gate merged in #2818 found that stripping `if: github.event_name == 'push'` off `desktop-release.yml`'s `publish` job — **the job that flips a draft release public** — left the check green. Reproduced here before fixing anything:

```
mutation: remove the publish job's if:      gate rc=0   MISSED
control:  plant an upload-google-play step
          into that same desktop job        gate rc=1   fires
```

The control and the mutation are in the same file and the same job, so it is not file scope — the gate reads `desktop-release.yml` correctly.

## Two independent causes, and fixing either alone is wrong

**1. `SUBMISSIONS` listed only mobile mechanisms.** Desktop does not reach a store, it reaches the public: `gh release edit --draft=false` in `publish`, and `softprops/action-gh-release` in the dispatch-only `release` job.

**2. The check read `step.if` and nothing else.** Desktop guards at the **job** (`publish` carries the condition, its step carries none); mobile guards at the **step**. So adding the mechanism on its own reds the *correct* tree — measured, not predicted:

```
mechanism added, no job-level reading, shipped tree:
  "job 'publish' step 'Publish the release' submits to a public GitHub Release
   with no condition."                      rc=1   <- false positive on correct code
```

A step runs only when its job runs **and** its own condition passes, so a tag-only condition at either level restricts it. Both are now consulted.

**This cannot weaken the mobile side, and that is the regression this change could have caused.** `isTagOnly` rejects any `||`, and the `android`/`ios` job conditions are disjunctions (`... || inputs.platform == 'android'`), so a mobile step whose own guard is deleted is still a finding. Pinned by its own test.

**`action-gh-release` is a submission unless `draft: true`.** The dispatch-only `release` job sets it, which is why it is not a finding today — but flipping that one word publishes from a branch, and nothing else would notice.

## Evidence

Every arm applied to the real workflow files and reverted, at the pushed commit `fb7c84b33` after the hooks reformatted:

```
M0  baseline                                   rc=0
M1  publish job guard deleted                  rc=1    was rc=0
M2  publish job guard widened with ||          rc=1
M3  action-gh-release draft: true -> false     rc=1
M4  mobile step guard deleted, job if has ||   rc=1    regression guard
M5  restored                                   rc=0    files byte-identical
```

The tests discriminate rather than decorate. Run against the implementation currently on `dev`:

```
new tests vs dev's implementation    18 pass / 3 fail
new tests vs this implementation     21 pass / 0 fail

pnpm run test:scripts   rc=0   390 tests / 390 pass / 0 fail / 0 skipped
```

**Two of the five new tests pass under both implementations, deliberately, and neither is evidence for this change:** the mobile regression guard *must* pass under both — that is its job — and the desktop false-positive guard has nothing to false-positive on until the mechanism exists. Saying which tests carry the argument and which are guards seemed better than a bare 21/21.

## Severity — latent, not reachable

`publish` needs `verify`, `windows` and `macos`, and those sit behind the `release` environment, whose deployment policy is three tag patterns and zero branch patterns. The job cannot run from a branch whatever its own `if:` says.

It becomes load-bearing the moment that policy changes, or if the pattern is copied into a new environment. **That is the same reasoning that made the unguarded Play upload look safe this morning: safe because of a different control, with nothing pinning its own.**

## Credit

The mutation that found this was run by a reviewer on my file after I had planted a *mobile* mechanism into a desktop workflow and concluded the gate covered desktop. It read the file; it did not know desktop's own way of publishing. **A planted hit proves the scanner reaches the file, not that it recognises what lives there.**
