### PR TITLE
ci(repo): cover gh release create, the third way desktop reaches the public

### DIFF
--- a/scripts/ci/check-release-upload-guards.mjs
+++ b/scripts/ci/check-release-upload-guards.mjs
@@ -54,6 +54,24 @@ export const SUBMISSIONS = [
   // --draft=false` is the step that takes a draft release public, and a public
   // release is what electron-updater's clients poll.
   { store: 'a public GitHub Release', run: '--draft=false' },
+  // `gh release create` opens a release, and the only shipped one is guarded at
+  // the step (`verify`'s `Open a draft release for the build jobs` carries
+  // `if: github.event_name == 'push'`), so there is NO draft exemption here and
+  // nothing reads the command text for flags. Two consequences, both deliberate:
+  //
+  //   * Deleting `--draft` while KEEPING the tag guard is not a finding. That is
+  //     a real defect - the tag path would open a published, asset-less release,
+  //     which the comment above the `publish` job explains is visible to beta
+  //     updaters immediately - but it is a different property. This check asks
+  //     whether something outward-facing is reachable from a dispatch, not
+  //     whether the release it opens starts as a draft. That wants its own check.
+  //
+  //   * A DRAFTED `gh release create` on a deliberately dispatch-only path IS a
+  //     false positive here, and the finding will read `no condition`. Measured:
+  //     respelling the `release` job's step with the CLI reds it. The repair in
+  //     that case is an exemption like the one below, NOT a tag guard on a job
+  //     that is dispatch-only by design. Do not follow the message off a cliff.
+  { store: 'a GitHub Release', run: 'gh release create' },
   // action-gh-release publishes unless the release is explicitly a draft. The
   // dispatch-only `release` job sets `draft: true`, which is why it is not a
   // finding today - but flipping that one word publishes from a branch, and

--- a/scripts/ci/check-release-upload-guards.test.mjs
+++ b/scripts/ci/check-release-upload-guards.test.mjs
@@ -258,6 +258,77 @@ ${draft === null ? '' : `          draft: ${draft}\n`}          tag_name: manual
   assert.equal(count(null), 1, 'no draft key publishes');
 });
 
+// `verify` is the one job in desktop-release.yml with no `environment:` and no
+// job-level condition, so it runs on a branch dispatch today. Its release-opening
+// step is safe because of TWO things - a step-level tag guard and `--draft` - and
+// before this entry the checker pinned neither.
+const CREATE_STEP = `      - name: Open a draft release for the build jobs
+        run: |
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --generate-notes --draft`;
+
+const verifyJob = (stepIf) => `
+name: fixture
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch: {}
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+${stepIf === null ? CREATE_STEP : CREATE_STEP.replace('\n        run: |', `\n        if: ${stepIf}\n        run: |`)}
+`;
+
+test('the shipped verify shape is covered by its step-level tag guard', () => {
+  assert.deepEqual(
+    findUnguardedSubmissions(verifyJob("github.event_name == 'push'"), 'fixture.yml'),
+    []
+  );
+});
+
+test('deleting the tag guard on the release-opening step is caught', () => {
+  // The reachable one: `verify` has no environment, so this publishes from a
+  // branch dispatch. Silent before this entry existed.
+  const findings = findUnguardedSubmissions(verifyJob(null), 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].store, 'a GitHub Release');
+  assert.equal(findings[0].job, 'verify');
+});
+
+test('--draft is NOT read, so removing it alone is deliberately not a finding', () => {
+  // Recorded so the omission is a decision rather than a gap someone finds later.
+  // Nothing here parses the command text: no regex, no comment stripping, no
+  // quoting hazard. The cost is that this real defect belongs to another check.
+  const undrafted = verifyJob("github.event_name == 'push'").replace(' --draft', '');
+  assert.ok(!undrafted.includes('--draft'), 'the fixture must actually drop the flag');
+  assert.deepEqual(findUnguardedSubmissions(undrafted, 'fixture.yml'), []);
+});
+
+test('a drafted create on a dispatch-only path is a false positive, and is refused anyway', () => {
+  // The cost of having no exemption, measured rather than left to be discovered:
+  // respelling the dispatch-only `release` job's step with the CLI reds correct
+  // code. Fails closed. The repair is an exemption, NOT a tag guard on a job that
+  // is dispatch-only by design - the finding message will not say that, so the
+  // header does.
+  const source = `
+name: fixture
+on:
+  workflow_dispatch: {}
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Create draft GitHub Release
+        run: |
+          gh release create "$TAG" --generate-notes --draft
+`;
+  const findings = findUnguardedSubmissions(source, 'fixture.yml');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].condition, null);
+});
+
 function findingsStores(source) {
   return findUnguardedSubmissions(source, 'fixture.yml').map((f) => f.store);
 }


### PR DESCRIPTION
Follow-up to #2820, found in review of it.

## The gap

`desktop-release.yml` has **three** ways to reach the public, and the third is in the one job with no protection:

```
JOB verify   if: <none>   environment: <none>   permissions: contents: write   <- runs on a branch dispatch today
  step Open a draft release for the build jobs
       if: github.event_name == 'push'     <- safety 1, unpinned
       gh release create "$TAG" ... --draft <- safety 2, unpinned
```

`publish` was latent because it `needs` two environment-gated jobs. **`verify` has no such protection**, so this is a lower bar than the gap #2820 closed.

## The entry is bare, and that is the design decision

No draft exemption, and nothing reads the command text for flags. The shipped step already carries a step-level tag guard, so there is nothing to exempt.

Two proposals were tried and dropped before this one:

- **A `--draft` word-boundary regex.** `--draft=false` is a superstring of `--draft`, so the naive form disarms the mechanism #2820 added; and a *comment* naming the flag exempts a command that no longer passes it.
- **A command splitter** (drop comment lines, join continuations, split on `;`/`&&`/`||`). Better, and still defeated by a trailing inline comment — stripping those correctly means knowing whether a `#` is inside quotes, which is a shell, not a gate.

Both stop being necessary once the question is *"does this need expressing at all"* rather than *"how do I express `--draft` safely"*.

## Two costs, in the header rather than discovered later

**Deleting `--draft` while keeping the tag guard is not a finding.** That is a real defect — the tag path would open a published, asset-less release, which the comment above `publish` explains is visible to beta updaters immediately — but it is a different property. This check asks whether something outward-facing is reachable from a dispatch, not whether the release starts as a draft. That wants its own check.

**A drafted `gh release create` on a deliberately dispatch-only path is a false positive**, and the finding reads `no condition`. Measured on a fixture respelling the `release` job's step with the CLI. It fails closed, but the repair is an exemption like `action-gh-release`'s, **not** a tag guard on a job that is dispatch-only by design — and the message will not say that, so the header does.

## Evidence

Real workflow, every arm applied and reverted:

```
shipped                            rc=0
M-B  step tag guard deleted        rc=1   the reachable hole
M-A  --draft deleted, guard kept   rc=0   deliberate, documented
restored                           rc=0
```

```
entry removed:  suite 25 pass / 2 FAIL
as shipped:     suite 27 pass / 0 fail
pnpm run test:scripts   rc=0   396 tests / 396 pass / 0 fail / 0 skipped
```

Two of the four new tests are the documented costs — they assert current behaviour so the omission and the false positive are decisions rather than surprises. They are labelled as such and not counted as coverage; **the entry is defended by the other two.**
