### PR TITLE
fix(frontend): declare each dark token once, and read the AA bar off the file

### DIFF
--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -341,6 +341,9 @@ const ESM_PACKAGES = [
   'direction',
   'bcp-47-match',
   'css-selector-parser',
+  // postcss reaches for nanoid at load; the reader-agreement guard parses
+  // globals.css with it. ESM-only, no CJS build.
+  'nanoid',
   '@ungap/.*',
   'entities',
   'highlight\\.js',

--- a/apps/frontend/src/app/__tests__/support/globalsTokens.ts
+++ b/apps/frontend/src/app/__tests__/support/globalsTokens.ts
@@ -1,0 +1,152 @@
+/**
+ * One reader for `globals.css`, shared by every guard that needs the artefact
+ * rather than a copy of it.
+ *
+ * The failure this exists to prevent is the one recorded on #2822: a contrast
+ * guard that restates a token's value as a literal keeps passing after the
+ * token moves, because its input is a transcript of the file rather than the
+ * file. Anything asserting on a token colour should resolve it through here.
+ *
+ * Kept in `__tests__/support/`, which `jest.config.ts` lists in
+ * `testPathIgnorePatterns` - a module of helpers under `__tests__` is otherwise
+ * collected as a suite and fails for having no tests.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type Declaration = { line: number; prop: string; value: string };
+
+export type Rule = {
+  selector: string;
+  /** 1-based line of the `{` that opens the rule. */
+  open: number;
+  /** 1-based line of the `}` that closes it. */
+  close: number;
+  /** Custom properties declared directly in this rule, in file order. */
+  declarations: Declaration[];
+};
+
+const DECLARATION = /^\s*(--[\w-]+)\s*:\s*([^;]+);/;
+const VAR_CHAIN = /^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/;
+
+/**
+ * Top-level rules and the custom properties declared directly inside them.
+ *
+ * Line comments are stripped before parsing so a token named inside prose is
+ * not read as a declaration, and brace depth is tracked so a declaration
+ * nested one level further down does not attach to the enclosing rule.
+ */
+export const parseRules = (css: string): Rule[] => {
+  const rules: Rule[] = [];
+  const lines = css.split('\n');
+  let depth = 0;
+  let buffer = '';
+  let current: Rule | null = null;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].replace(/\/\*.*?\*\//g, '');
+    const decl = DECLARATION.exec(line);
+    if (depth === 1 && decl && current) {
+      current.declarations.push({ line: i + 1, prop: decl[1], value: decl[2].trim() });
+    }
+    for (const ch of line) {
+      if (ch === '{') {
+        if (depth === 0)
+          current = { selector: buffer.trim(), open: i + 1, close: -1, declarations: [] };
+        depth += 1;
+        buffer = '';
+      } else if (ch === '}') {
+        depth -= 1;
+        if (depth === 0 && current) {
+          current.close = i + 1;
+          rules.push(current);
+          current = null;
+        }
+        buffer = '';
+      } else {
+        buffer += ch;
+      }
+    }
+    if (depth === 0) buffer = '';
+  }
+  return rules;
+};
+
+/**
+ * Properties this rule declares more than once, with every declaration.
+ *
+ * At equal specificity the last one wins, so every earlier copy is dead text
+ * that an editor will nonetheless read, edit, and watch do nothing.
+ */
+export const duplicatesWithin = (rule: Rule): { prop: string; declarations: Declaration[] }[] => {
+  const byProp = new Map<string, Declaration[]>();
+  for (const d of rule.declarations) {
+    const seen = byProp.get(d.prop);
+    if (seen) seen.push(d);
+    else byProp.set(d.prop, [d]);
+  }
+  return [...byProp.entries()]
+    .filter(([, declarations]) => declarations.length > 1)
+    .map(([prop, declarations]) => ({ prop, declarations }));
+};
+
+const isDarkRule = (selector: string) => /data-theme\s*=\s*['"]?dark/.test(selector);
+
+/**
+ * `@theme` is Tailwind 4's base layer and is theme-independent, so it belongs
+ * in the light map or tokens that only alias through it resolve to nothing -
+ * and a missing value would compare "" against "" and read as a pass.
+ * More than one rule matches the dark selector, so these accumulate in file
+ * order and let the later one win, exactly as the cascade does.
+ */
+export const themeMaps = (rules: Rule[]) => {
+  const light = new Map<string, string>();
+  const dark = new Map<string, string>();
+  for (const rule of rules) {
+    const isBase =
+      rule.selector.split(',').some((part) => part.trim() === ':root') ||
+      rule.selector.trim().startsWith('@theme');
+    if (!isDarkRule(rule.selector) && !isBase) continue;
+    for (const d of rule.declarations) {
+      if (isDarkRule(rule.selector)) dark.set(d.prop, d.value);
+      else light.set(d.prop, d.value);
+    }
+  }
+  return { light, dark };
+};
+
+export const GLOBALS_CSS_PATH = join(process.cwd(), 'src/app/globals.css');
+export const GLOBALS_CSS = readFileSync(GLOBALS_CSS_PATH, 'utf8');
+export const RULES = parseRules(GLOBALS_CSS);
+
+const { light: LIGHT, dark: DARK } = themeMaps(RULES);
+export { LIGHT, DARK };
+
+/** Follows a `var(--a, fallback)` chain down to a literal colour. */
+export const resolve = (value: string, dark: boolean): string => {
+  let current = value;
+  for (let i = 0; i < 12; i += 1) {
+    const m = VAR_CHAIN.exec(current.trim());
+    if (!m) return current.trim();
+    const next = (dark ? DARK.get(m[1]) : undefined) ?? LIGHT.get(m[1]) ?? m[2];
+    if (next === undefined) return current.trim();
+    current = next;
+  }
+  return current.trim();
+};
+
+/**
+ * `resolve`, with the silent miss made loud.
+ *
+ * A token that resolves to nothing hands a contrast probe an empty string,
+ * which it reads as black on white - a comfortable pass on a dead instrument.
+ */
+export const resolveColour = (token: string, dark: boolean): string => {
+  const literal = resolve(token, dark);
+  if (!/^(#|rgb)/.test(literal)) {
+    throw new Error(
+      `${token} did not resolve to a colour in ${dark ? 'dark' : 'light'}: "${literal}"`
+    );
+  }
+  return literal;
+};

--- a/apps/frontend/src/app/__tests__/support/globalsTokens.ts
+++ b/apps/frontend/src/app/__tests__/support/globalsTokens.ts
@@ -18,7 +18,7 @@ export type Declaration = { line: number; prop: string; value: string };
 
 export type Rule = {
   selector: string;
-  /** 1-based line of the `{` that opens the rule. */
+  /** 1-based line the rule starts on - where its selector begins, not its `{`. */
   open: number;
   /** 1-based line of the `}` that closes it. */
   close: number;
@@ -27,34 +27,76 @@ export type Rule = {
 };
 
 const DECLARATION = /^\s*(--[\w-]+)\s*:\s*([^;]+);/;
+const DECLARATION_START = /^\s*--[\w-]+\s*:/;
 const VAR_CHAIN = /^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/;
+
+/**
+ * Comment text replaced with spaces, newlines kept so every line number still
+ * refers to the real file.
+ *
+ * A comment can span lines, and a token name or a brace inside one reads as
+ * code to anything that strips comments a line at a time.
+ */
+const blankComments = (css: string) =>
+  css.replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, ' '));
+
+/**
+ * A declaration whose value the formatter wrapped, put back onto one line.
+ *
+ * `DECLARATION` needs the `;` on the line that names the property, and prettier
+ * does not leave it there for a value past the print width - `globals.css` has
+ * two such declarations today. Reading only the naming line made them invisible,
+ * so a duplicate of either was invisible too and the shadowing scan reported a
+ * zero about the file's single-line declarations rather than about the file.
+ */
+const joinToTerminator = (lines: string[], i: number): string => {
+  if (!DECLARATION_START.test(lines[i])) return lines[i];
+  let joined = lines[i];
+  for (let j = i + 1; j < lines.length && !/[;{}]/.test(joined); j += 1) {
+    joined += ` ${lines[j].trim()}`;
+  }
+  return joined;
+};
 
 /**
  * Top-level rules and the custom properties declared directly inside them.
  *
- * Line comments are stripped before parsing so a token named inside prose is
- * not read as a declaration, and brace depth is tracked so a declaration
- * nested one level further down does not attach to the enclosing rule.
+ * Comments are blanked before parsing so a token named inside prose is not read
+ * as a declaration, and brace depth is tracked so a declaration nested one level
+ * further down does not attach to the enclosing rule.
  */
 export const parseRules = (css: string): Rule[] => {
   const rules: Rule[] = [];
-  const lines = css.split('\n');
+  const lines = blankComments(css).split('\n');
   let depth = 0;
   let buffer = '';
+  /** 1-based line the current selector started on, so a wrapped one reports its
+      first line rather than the line that happens to carry the `{`. */
+  let selectorStart = 0;
   let current: Rule | null = null;
 
   for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i].replace(/\/\*.*?\*\//g, '');
-    const decl = DECLARATION.exec(line);
+    const line = lines[i];
+    const decl = DECLARATION.exec(joinToTerminator(lines, i));
     if (depth === 1 && decl && current) {
-      current.declarations.push({ line: i + 1, prop: decl[1], value: decl[2].trim() });
+      current.declarations.push({
+        line: i + 1,
+        prop: decl[1],
+        value: decl[2].replace(/\s+/g, ' ').trim(),
+      });
     }
     for (const ch of line) {
       if (ch === '{') {
         if (depth === 0)
-          current = { selector: buffer.trim(), open: i + 1, close: -1, declarations: [] };
+          current = {
+            selector: buffer.trim().replace(/\s+/g, ' '),
+            open: selectorStart || i + 1,
+            close: -1,
+            declarations: [],
+          };
         depth += 1;
         buffer = '';
+        selectorStart = 0;
       } else if (ch === '}') {
         depth -= 1;
         if (depth === 0 && current) {
@@ -63,11 +105,20 @@ export const parseRules = (css: string): Rule[] => {
           current = null;
         }
         buffer = '';
+        selectorStart = 0;
+      } else if (ch === ';' && depth === 0) {
+        /* A statement at-rule (`@import 'tailwindcss';`) ends here; it is not
+           the beginning of the next rule's selector. */
+        buffer = '';
+        selectorStart = 0;
       } else {
+        if (depth === 0 && !selectorStart && ch.trim()) selectorStart = i + 1;
         buffer += ch;
       }
     }
-    if (depth === 0) buffer = '';
+    /* A selector list may be wrapped across lines, so the buffer survives the
+       line end rather than being reset by it. */
+    if (depth === 0) buffer += ' ';
   }
   return rules;
 };

--- a/apps/frontend/src/app/__tests__/ui/contrast/blueStrongContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/blueStrongContrast.test.ts
@@ -60,9 +60,15 @@ describe('the reader behind these assertions', () => {
     expect(dark).not.toBe(light);
   });
 
-  it('resolves the ink through to an opaque literal', () => {
-    expect(resolveColour(INK, false)).toBe(resolveColour(INK, true));
-    expect(resolveColour(INK, true)).toMatch(/^#/);
+  it('resolves the ink to an opaque literal in both themes', () => {
+    /* A translucent ink would be composited against the fill before the ratio
+       is taken, so the number below would still be correct - but it would no
+       longer be the measurement this file claims to make, which is white on
+       the fill. Opacity is the precondition, not the cross-theme sameness:
+       a dark override for the ink is a legitimate change and the assertion
+       below would measure it correctly. */
+    expect(resolveColour(INK, false)).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(resolveColour(INK, true)).toMatch(/^#[0-9a-f]{6}$/i);
   });
 });
 

--- a/apps/frontend/src/app/__tests__/ui/contrast/blueStrongContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/blueStrongContrast.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `--blue-strong` is the shared fill under white text, and it is measured from
+ * `globals.css` rather than restated here.
+ *
+ * The token clears AA by 0.04 in dark (#2f74d9 is 4.54:1 against white), and it
+ * is not one component's margin: every site that puts text on this fill pairs
+ * it with white. At the time of writing that is 30 uses across 21 files -
+ * lines under `src/app` matching `var(--blue-strong)`, excluding tests,
+ * stories, markdown, `globals.css` itself and matches inside comments. The
+ * remainder are border, hover and checked-state uses with no text over the
+ * fill. So a nudge to this one value moves every consumer at once.
+ *
+ * The guard that existed before this one asserted
+ * `measureContrast(mount('rgb(255,255,255)', 'rgb(47,116,217)')).ratio === 4.54`
+ * against a literal the test carried. That pins the arithmetic of
+ * `measureContrast`, which is worth pinning and is still pinned there - but its
+ * input is a copy of the artefact, so moving the token to a failing value left
+ * the whole suite green (#2822). This one reads the file and asserts the bar,
+ * not the number, so it fails when the colour fails rather than when it changes.
+ */
+import {
+  describeContrast,
+  measureContrast,
+} from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
+import { resolveColour } from '@/app/__tests__/support/globalsTokens';
+
+const FILL = 'var(--blue-strong)';
+const INK = 'var(--white-text)';
+const SURFACE = 'var(--screen)';
+
+const mount = (color: string, background: string, surface: string) => {
+  const outer = document.createElement('div');
+  outer.style.backgroundColor = surface;
+  const el = document.createElement('span');
+  el.style.color = color;
+  el.style.backgroundColor = background;
+  /* The smallest and lightest text any consumer puts on this fill: the chat
+     unread badge and the day-rail now-marker are 8.5-10px. Nothing here is
+     WCAG-large, so the bar must be the strict 4.5 and never the 3.0 escape. */
+  el.style.fontSize = '10px';
+  el.style.fontWeight = '700';
+  outer.appendChild(el);
+  document.body.appendChild(outer);
+  return el;
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('the reader behind these assertions', () => {
+  it('resolves --blue-strong to a different literal in each theme', () => {
+    /* Without this, a reader that returned the light value for both themes
+       would make the dark assertion below a second copy of the light one -
+       and dark is the side with the headroom problem. */
+    const light = resolveColour(FILL, false);
+    const dark = resolveColour(FILL, true);
+    expect(light).toMatch(/^#/);
+    expect(dark).toMatch(/^#/);
+    expect(dark).not.toBe(light);
+  });
+
+  it('resolves the ink through to an opaque literal', () => {
+    expect(resolveColour(INK, false)).toBe(resolveColour(INK, true));
+    expect(resolveColour(INK, true)).toMatch(/^#/);
+  });
+});
+
+describe.each(['light', 'dark'] as const)('white on --blue-strong (%s)', (theme) => {
+  const dark = theme === 'dark';
+
+  it('clears AA at the smallest size any consumer renders it', () => {
+    const reading = measureContrast(
+      mount(resolveColour(INK, dark), resolveColour(FILL, dark), resolveColour(SURFACE, dark))
+    );
+    expect(reading.required).toBe(4.5);
+    expect(
+      reading.ratio >= reading.required ? true : describeContrast(`--blue-strong ${theme}`, reading)
+    ).toBe(true);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
@@ -1,10 +1,8 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
 import { getMerckSubtopicPillStyle } from '@/app/features/integrations/constants/merck';
 import { getStatusBadgeStyle } from '@/app/features/inventory/pages/Inventory/utils';
 import { measureContrast } from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
 import { getOrganizationStatusStyle } from '@/app/ui/tables/tableUtils';
+import { resolve, resolveColour } from '@/app/__tests__/support/globalsTokens';
 
 /**
  * These three switches paint with inline `style`, so their colours are invisible
@@ -16,79 +14,15 @@ import { getOrganizationStatusStyle } from '@/app/ui/tables/tableUtils';
  * Asserting the token NAMES would pass forever, so this resolves them out of
  * `globals.css` and measures. A regression in either the switch or the token
  * values fails it.
- */
-
-const CSS = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
-
-/**
- * Custom properties per theme.
  *
- * `@theme` is Tailwind 4's base layer and is theme-independent - the pill
- * tokens live there and alias `--status-*`, which is what actually flips. So
- * the base map must include it or every pill token resolves to nothing, and a
- * missing value would otherwise compare "" against "" and read as a pass.
- * `globals.css` also has more than one dark block, meant to merge with the
- * later winning, so this accumulates in file order rather than stopping first.
+ * The reader moved to `__tests__/support/globalsTokens` when #2822 added a
+ * second guard that needed it. It is the same parse: `@theme` and `:root` into
+ * the light map, every dark rule accumulating in file order so the later one
+ * wins, and `resolveColour` failing loudly rather than handing the probe an
+ * empty string it would read as black on white.
  */
-const collect = (): { light: Map<string, string>; dark: Map<string, string> } => {
-  const light = new Map<string, string>();
-  const dark = new Map<string, string>();
-  let depth = 0;
-  let selector = '';
-  let buffer = '';
 
-  for (const raw of CSS.split('\n')) {
-    const line = raw.replace(/\/\*.*?\*\//g, '');
-    const decl = /^\s*(--[\w-]+)\s*:\s*([^;]+);/.exec(line);
-    if (depth === 1 && decl) {
-      const isDark = /data-theme\s*=\s*['"]?dark/.test(selector);
-      const isBase =
-        selector.split(',').some((part) => part.trim() === ':root') ||
-        selector.trim().startsWith('@theme');
-      if (isDark) dark.set(decl[1], decl[2].trim());
-      else if (isBase) light.set(decl[1], decl[2].trim());
-    }
-    for (const ch of line) {
-      if (ch === '{') {
-        if (depth === 0) selector = buffer.trim();
-        depth += 1;
-        buffer = '';
-      } else if (ch === '}') {
-        depth -= 1;
-        buffer = '';
-      } else {
-        buffer += ch;
-      }
-    }
-    if (depth === 0) buffer = '';
-  }
-  return { light, dark };
-};
-
-const TOKENS = collect();
-
-const LIGHT = TOKENS.light;
-const DARK = TOKENS.dark;
-
-/** Resolves a `var(--a, fallback)` chain down to a literal colour. */
-const resolve = (value: string, dark: boolean): string => {
-  let current = value;
-  for (let i = 0; i < 12; i += 1) {
-    const m = /^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/.exec(current.trim());
-    if (!m) return current.trim();
-    const next = (dark ? DARK.get(m[1]) : undefined) ?? LIGHT.get(m[1]) ?? m[2];
-    if (next === undefined) return current.trim();
-    current = next;
-  }
-  return current.trim();
-};
-
-const resolveToken = (token: string, dark: boolean): string => {
-  const literal = resolve(token, dark);
-  // A silent miss would compare "" against "" and read as a perfect pass.
-  expect(literal).toMatch(/^(#|rgb)/);
-  return literal;
-};
+const resolveToken = resolveColour;
 
 const mount = (color: string, background: string, surface: string, px: string, weight: string) => {
   const outer = document.createElement('div');

--- a/apps/frontend/src/app/__tests__/ui/tokens/customPropertyShadowing.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/customPropertyShadowing.test.ts
@@ -1,0 +1,63 @@
+/**
+ * No custom property may be declared twice inside one rule in `globals.css`.
+ *
+ * The defect this pins is not a wrong colour - it is an edit that does nothing.
+ * At equal specificity the later declaration wins, so when a token appears
+ * twice in the same rule the first copy is dead text. It still reads like the
+ * declaration, it is still what a search for the token name lands on first, and
+ * changing it leaves the page exactly as it was.
+ *
+ * `html[data-theme='dark']` carried 80 such pairs (#2822). Every pair held the
+ * same value, so nothing rendered wrong and nothing could - which is why this
+ * survived: the only symptom was a developer's edit going missing.
+ *
+ * Duplication ACROSS rules is a different thing and is not flagged here. A
+ * token declared in `:root` and again under `html[data-theme='dark']` is how
+ * theming works, and again under a scoped block is how scoping works.
+ */
+import { RULES, duplicatesWithin, parseRules } from '@/app/__tests__/support/globalsTokens';
+
+describe('the duplicate detector itself', () => {
+  /* A zero from this scan is only worth reading if the scan can return
+     something else. Both halves are planted, because a parser that finds
+     nothing and a file that contains nothing produce the same clean pass. */
+  it('reports a property declared twice in the same rule', () => {
+    const found = parseRules(':root {\n  --a: 1px;\n  --b: 2px;\n  --a: 3px;\n}\n').flatMap(
+      duplicatesWithin
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].prop).toBe('--a');
+    expect(found[0].declarations.map((d) => d.line)).toEqual([2, 4]);
+  });
+
+  it('does not report the same property in two different rules', () => {
+    const css = ":root {\n  --a: 1px;\n}\nhtml[data-theme='dark'] {\n  --a: 2px;\n}\n";
+    expect(parseRules(css).flatMap(duplicatesWithin)).toEqual([]);
+  });
+
+  it('does not read a token named inside a comment as a declaration', () => {
+    const css = ':root {\n  /* --a: 1px; is what this used to be */\n  --a: 2px;\n}\n';
+    expect(parseRules(css).flatMap(duplicatesWithin)).toEqual([]);
+  });
+
+  it('has actually read globals.css', () => {
+    /* Without this, an empty parse of the real file passes the assertion
+       below by describing nothing at all. */
+    expect(RULES.length).toBeGreaterThan(5);
+    expect(RULES.reduce((n, r) => n + r.declarations.length, 0)).toBeGreaterThan(300);
+  });
+});
+
+describe('globals.css', () => {
+  it('declares every custom property at most once per rule', () => {
+    const offenders = RULES.flatMap((rule) =>
+      duplicatesWithin(rule).map(
+        ({ prop, declarations }) =>
+          `${rule.selector} [${rule.open}-${rule.close}]: ${prop} at ${declarations
+            .map((d) => `${d.line}=${d.value}`)
+            .join(' | ')} - all but the last are inert`
+      )
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/tokens/customPropertyShadowing.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/customPropertyShadowing.test.ts
@@ -35,6 +35,19 @@ describe('the duplicate detector itself', () => {
     expect(parseRules(css).flatMap(duplicatesWithin)).toEqual([]);
   });
 
+  it('reports a duplicate whose value the formatter wrapped', () => {
+    /* The reader needed the `;` on the line that names the property, so a
+       wrapped declaration was invisible to it - and a duplicate of one was
+       invisible too, while this scan reported a confident zero. Two of
+       `globals.css`'s own declarations are wrapped. */
+    const css =
+      ':root {\n  --a:\n    0 2px 4px rgba(0, 0, 0, 0.28),\n    0 12px 28px rgba(0, 0, 0, 0.44);\n  --b: 1px;\n  --a: 2px;\n}\n';
+    const found = parseRules(css).flatMap(duplicatesWithin);
+    expect(found).toHaveLength(1);
+    expect(found[0].prop).toBe('--a');
+    expect(found[0].declarations.map((d) => d.line)).toEqual([2, 6]);
+  });
+
   it('does not read a token named inside a comment as a declaration', () => {
     const css = ':root {\n  /* --a: 1px; is what this used to be */\n  --a: 2px;\n}\n';
     expect(parseRules(css).flatMap(duplicatesWithin)).toEqual([]);

--- a/apps/frontend/src/app/__tests__/ui/tokens/globalsReader.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/globalsReader.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `globals.css` as the reader sees it, checked against a parser with no stake
+ * in the answer.
+ *
+ * Every guard built on `globalsTokens` is worth exactly its negative - "no
+ * property is declared twice", "this token clears AA in both themes" - and a
+ * negative is only as wide as what the reader can see. The reader is a hand
+ * parser, so the question is not whether it works on a fixture; it is whether
+ * it agrees with a real one about the file that actually ships.
+ *
+ * It shipped disagreeing. Prettier wraps a value past the print width onto its
+ * own lines, which leaves the `;` three lines below the property name, and the
+ * reader needed it on the naming line: `postcss` found 635 custom-property
+ * declarations in `globals.css` and the reader found 633. A duplicate of either
+ * wrapped declaration was invisible while the shadowing scan reported zero.
+ * Sixteen selector lists are wrapped the same way and were read as their last
+ * line alone - `):focus-visible` for one of them - which is one re-wrap away
+ * from `html[data-theme='dark']` not being recognised as the dark rule at all.
+ *
+ * `postcss` is already a devDependency here; it is what Tailwind parses with.
+ */
+import postcss from 'postcss';
+
+import {
+  GLOBALS_CSS,
+  RULES,
+  parseRules,
+  themeMaps,
+  type Rule,
+} from '@/app/__tests__/support/globalsTokens';
+
+type Shape = { selector: string; open: number; close: number; declarations: string[] };
+
+/** The same shape, read by postcss: top-level rules and the custom properties
+    declared directly inside them, which is `parseRules`'s exact contract. */
+const byPostcss = (css: string): Shape[] => {
+  const shapes: Shape[] = [];
+  postcss.parse(css).each((node) => {
+    if (node.type !== 'rule' && node.type !== 'atrule') return;
+    if (node.nodes === undefined) return; // `@import 'tailwindcss';` has no block
+    const declarations: string[] = [];
+    node.each((child) => {
+      if (child.type === 'decl' && child.prop.startsWith('--'))
+        declarations.push(`${child.prop}@${child.source?.start?.line}`);
+    });
+    shapes.push({
+      selector: (node.type === 'rule' ? node.selector : `@${node.name} ${node.params}`)
+        .replace(/\s+/g, ' ')
+        .trim(),
+      open: node.source?.start?.line ?? -1,
+      close: node.source?.end?.line ?? -1,
+      declarations,
+    });
+  });
+  return shapes;
+};
+
+const byReader = (rules: Rule[]): Shape[] =>
+  rules.map((rule) => ({
+    selector: rule.selector,
+    open: rule.open,
+    close: rule.close,
+    declarations: rule.declarations.map((d) => `${d.prop}@${d.line}`),
+  }));
+
+describe('the globals.css reader', () => {
+  it('is comparing something', () => {
+    /* Two empty arrays are equal, so the agreement below means nothing until
+       the reference is shown to have read a real stylesheet. */
+    const reference = byPostcss(GLOBALS_CSS);
+    expect(reference.length).toBeGreaterThan(50);
+    expect(reference.flatMap((r) => r.declarations).length).toBeGreaterThan(600);
+  });
+
+  it('agrees with postcss about every rule, selector and declaration', () => {
+    expect(byReader(RULES)).toEqual(byPostcss(GLOBALS_CSS));
+  });
+
+  it('reads a declaration whose value the formatter wrapped', () => {
+    const css =
+      ':root {\n  --shadow:\n    0 2px 4px rgba(0, 0, 0, 0.28),\n    0 12px 28px rgba(0, 0, 0, 0.44);\n  --after: #ffffff;\n}\n';
+    expect(byReader(parseRules(css))).toEqual(byPostcss(css));
+    expect(parseRules(css)[0].declarations.map((d) => d.value)).toEqual([
+      '0 2px 4px rgba(0, 0, 0, 0.28), 0 12px 28px rgba(0, 0, 0, 0.44)',
+      '#ffffff',
+    ]);
+  });
+
+  it('reads a selector list the formatter wrapped', () => {
+    /* Read as its last line alone, this rule stops matching the dark selector
+       and every token in it silently falls back to the light literal. */
+    const css = "html[data-theme='dark'],\n.yc-scope-dark {\n  --a: #111111;\n}\n";
+    expect(parseRules(css)[0].selector).toBe("html[data-theme='dark'], .yc-scope-dark");
+    expect(themeMaps(parseRules(css)).dark.get('--a')).toBe('#111111');
+  });
+
+  it('does not read a token named inside a comment that spans lines', () => {
+    const css =
+      ':root {\n  /* this used to be\n     --a: 1px;\n     until it moved */\n  --a: 2px;\n}\n';
+    expect(parseRules(css).flatMap((r) => r.declarations.map((d) => d.line))).toEqual([5]);
+  });
+
+  it("does not take a statement at-rule for the next rule's selector", () => {
+    const css = "@import 'tailwindcss';\n\n:root {\n  --a: #111111;\n}\n";
+    expect(parseRules(css)[0].selector).toBe(':root');
+  });
+});

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -578,7 +578,6 @@ input[type='radio']:focus-visible {
   --pureblack: var(--color-black-pure);
   --black-grey: var(--color-grey-bg);
   --black-grey-Text: var(--color-grey-text);
-  --blue-text: var(--color-blue-text);
   --light-blue: var(--color-primary-100);
   --white-text: #ffffff;
   /* Its counterpart. Some surfaces are a FIXED colour in both themes -
@@ -818,12 +817,6 @@ input[type='radio']:focus-visible {
 }
 
 html[data-theme='dark'] {
-  --page: #201c18;
-  --band: #2a2216;
-  --inset: #302820;
-  --screen: #2f271e;
-  --screen-2: #221d17;
-  --hairline: #40362b;
   /* The warm-bone `--color-*` tokens are declared as light literals in @theme
      (Tailwind needs a parseable value there at build time) and so never flip on
      their own. Mirror them onto the semantic tokens here — otherwise anything
@@ -837,58 +830,14 @@ html[data-theme='dark'] {
   --color-ink: var(--ink);
   --color-ink-body: var(--ink-body);
   --color-cyan-text: var(--cyan-text);
-  --divider: #3a3128;
-  --hairline-hover: #4a4033;
-  --nav-active: #8fb6f5;
-  --nav-active-bg: rgba(143, 182, 245, 0.13);
-  --ink: #f4efe6;
-  --ink-body: #e6ddd0;
-  --ink-muted: #a89e90;
-  --ink-soft: #cabfb0;
-  --ink-faint: #9d9285;
-  /* #8b8173 passed only on --spot: it was 3.78:1 on --inset (the marketing
-     footer), 3.84 on --screen and 4.10 on --band. #998f82 clears 4.5 on every
-     dark surface (4.56-5.78) and is the value the app scope already used, so
-     the two agree now instead of the app being the only readable one. */
-  --ink-faint2: #998f82;
-  --ink-6b: #a1968a;
-  --cta: #f2ece1;
-  --cta-hover: #fbf8f1;
-  --cta-text: #201c18;
   --dl-btn: #f7f3ec;
   --dl-btn-text: #201c18;
   --dl-btn-sub: #6b6155;
   --dl-btn-hover: #ffffff;
-  --blue: #257bed;
-  /* The window is narrow: white needs the fill dark, the espresso page needs it
-     light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
-     against every dark surface. */
-  --blue-strong: #2f74d9;
-  /* Inverted here: see the light declaration. A dark fill on a dark surface has
-     no visible boundary (#a6271d is 2.05:1 on --screen), so dark mode uses the
-     light tone as the fill and a near-black as its label. 6.5-7.5 against every
-     dark surface, 7.5 for the label on top. */
-  --danger-strong: #f2938a;
-  --danger-strong-ink: var(--ink-fixed);
-  --success-strong: #2bbd86;
-  --success-strong-ink: var(--ink-fixed);
-  --blue-text: var(--color-blue-text);
-  --blue-soft: rgba(143, 182, 245, 0.16);
-  --pink: #ff90d4;
-  --cyan: #5ce1e6;
-  --cyan-text: #5ce1e6;
-  --success: #2bbd86;
-  --success-text: #2bbd86;
   --warn: #f5a83c;
   --spot: #17140f;
   --spot-ink: #f4efe6;
   --code-str: #8acbb4;
-  --avatar-violet-bg: rgba(167, 139, 250, 0.2);
-  --avatar-violet-ink: #cbb2f4;
-  --avatar-green-bg: rgba(74, 205, 155, 0.17);
-  --avatar-green-ink: #74d0a2;
-  --avatar-amber-bg: rgba(233, 170, 120, 0.17);
-  --avatar-amber-ink: #ecb488;
   --nav-hover: rgba(255, 255, 255, 0.06);
   --glass-btn: linear-gradient(180deg, rgba(54, 46, 37, 0.82), rgba(34, 29, 23, 0.72));
   --glass-btn-border: rgba(255, 255, 255, 0.1);
@@ -896,62 +845,22 @@ html[data-theme='dark'] {
     0 2px 4px rgba(0, 0, 0, 0.28), 0 12px 28px rgba(0, 0, 0, 0.44),
     inset 0 1px 0 rgba(255, 255, 255, 0.05), inset 0 -12px 22px rgba(0, 0, 0, 0.14);
   --glass-95: rgba(30, 26, 21, 0.9);
-  --glass-93: rgba(34, 29, 23, 0.92);
   --glass-92: rgba(34, 29, 23, 0.86);
-  --hairline-soft: rgba(255, 255, 255, 0.09);
   --hero-halo1: rgba(18, 15, 11, 0.92);
   --hero-halo2: rgba(18, 15, 11, 0.82);
   --nav-glass: rgba(28, 24, 20, 0.82);
   --nav-border: rgba(255, 255, 255, 0.08);
   --nav-shadow: 0 1px 0 rgba(255, 255, 255, 0.04), 0 10px 34px rgba(0, 0, 0, 0.4);
-  --glass-inset-hi: rgba(255, 255, 255, 0.06);
-  --sh03: rgba(0, 0, 0, 0.14);
-  --sh05: rgba(0, 0, 0, 0.2);
-  --sh06: rgba(0, 0, 0, 0.24);
-  --sh08: rgba(0, 0, 0, 0.3);
-  --sh09: rgba(0, 0, 0, 0.32);
-  --sh10: rgba(0, 0, 0, 0.34);
-  --sh12: rgba(0, 0, 0, 0.36);
-  --sh14: rgba(0, 0, 0, 0.4);
-  --sh16: rgba(0, 0, 0, 0.44);
-  --sh18: rgba(0, 0, 0, 0.48);
-  --sh20: rgba(0, 0, 0, 0.52);
-  --sh22: rgba(0, 0, 0, 0.55);
-  --sh28: rgba(0, 0, 0, 0.62);
-  --sh55: rgba(0, 0, 0, 0.8);
-  --glow-b07: rgba(37, 123, 237, 0.13);
   --glow-b08: rgba(37, 123, 237, 0.14);
   --glow-b09: rgba(37, 123, 237, 0.16);
-  --glow-b10: rgba(37, 123, 237, 0.18);
-  --glow-b12: rgba(37, 123, 237, 0.22);
   --glow-b13: rgba(37, 123, 237, 0.23);
-  --glow-b14: rgba(37, 123, 237, 0.25);
   --glow-b20: rgba(37, 123, 237, 0.34);
-  --glow-b26: rgba(37, 123, 237, 0.42);
   --glow-c09: rgba(92, 225, 230, 0.16);
-  --glow-c10: rgba(92, 225, 230, 0.18);
-  --glow-c14: rgba(92, 225, 230, 0.25);
   --glow-p07: rgba(244, 121, 190, 0.13);
   --glow-p08: rgba(244, 121, 190, 0.14);
-  --glow-p10: rgba(244, 121, 190, 0.18);
-  --glow-p12: rgba(244, 121, 190, 0.22);
   --glow-k10: rgba(255, 144, 212, 0.18);
-  --surface-soft: #2a2216;
-  --pill-raised: #383026;
-  --field-bg: #241f18;
-  /* PIMS design-system Badge — DS ships light-only; tint-on-dark equivalents */
-  --status-requested-bg: rgba(255, 255, 255, 0.07);
-  --status-requested-text: #b9b0a4;
-  --status-requested-border: rgba(255, 255, 255, 0.28);
-  --status-upcoming-bg: rgba(37, 123, 237, 0.18);
-  --status-upcoming-text: #9cc4f8;
-  --status-upcoming-border: rgba(103, 160, 239, 0.6);
-  --status-checked-in-bg: rgba(99, 102, 241, 0.18);
-  --status-checked-in-text: #bcbef9;
-  --status-checked-in-border: rgba(129, 132, 245, 0.6);
-  --status-in-progress-bg: rgba(139, 92, 246, 0.18);
-  --status-in-progress-text: #cdb8fa;
-  --status-in-progress-border: rgba(154, 113, 247, 0.6);
+  /* PIMS design-system status colours - DS ships light-only; tint-on-dark
+     equivalents. The Badge set itself is declared further down this rule. */
   --color-status-success-text: #74d0a2;
   --color-status-success-bg: rgba(74, 205, 155, 0.16);
 
@@ -959,8 +868,12 @@ html[data-theme='dark'] {
      Warm-bone token set, folded in from what used to be a second
      html[data-theme="dark"] block further down this file. The two blocks were
      kept apart while the surfaces landed on separate branches; they are one
-     rule now. Declarations below still come last, so where a token appears in
-     both halves this value is the effective one -- do not reorder.
+     rule now, and every token in it is declared exactly once.
+
+     Until #2822 the merge left 80 tokens declared twice. Every pair held the
+     same value, so nothing rendered wrong - but at equal specificity the later
+     declaration wins, which made an edit to the first copy silently inert.
+     `customPropertyShadowing.test.ts` fails if a second declaration comes back.
      --------------------------------------------------------------------- */
   --page: #201c18;
   --band: #2a2216;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two halves of #2822, both measured there.

`html[data-theme='dark']` in `apps/frontend/src/app/globals.css` declares 174 custom properties across 254 declarations - 80 tokens appear twice. Every pair holds the same value, so nothing renders wrong and nothing can. The symptom is that at equal specificity the later declaration wins, so **an edit to the first copy is silently inert**. `:root` had one more of the same shape, `--blue-text`, whose own surviving comment says the token is "aliased, never re-stated".

And no test could see the value move. `--blue-strong` is `#2f74d9` in dark, **4.54:1 against white - 0.04 above the bar** - and it is the fill under white text at 30 sites in 21 files, so one nudge moves every consumer at once. The nearest guard asserted a literal the test carried:

```js
// contrastProbe.test.ts:73
expect(measureContrast(mount('rgb(255, 255, 255)', 'rgb(47, 116, 217)')).ratio).toBe(4.54);
```

That pins the arithmetic of `measureContrast`, which is worth pinning and is untouched here. It cannot see the token move, because its input is a copy of the artefact rather than the artefact.

## What is the new behavior?

**Each token is declared once.** 81 shadowed declarations removed (80 in the dark rule, 1 in `:root`). Two comment blocks went with them because they were byte-duplicated at the surviving declaration; leaving them would have parked prose above tokens it does not describe. The merge banner in the dark rule now records the shape instead of warning against a reorder that no longer matters.

**This cannot change a rendered colour, and that is checked rather than asserted.** Every rule's winning value and every resolved literal in both themes, before and after:

```
8 rules, 370 resolved tokens per theme
diff before.json after.json   ->   rc=0, identical
```

Section A and section B were not a paste of one another - A has 36 properties B lacks, B has 58 A lacks, and the overlap is 80 with zero differing values. So neither section could simply be deleted; only the shadowed lines could go.

**Three test changes.**

- `__tests__/support/globalsTokens.ts` - one reader for the file: rules, per-theme maps (`@theme` and `:root` into light, every dark rule accumulating in file order so the later wins), `var()` chain resolution, and a resolver that **throws** on a token resolving to nothing rather than handing a probe an empty string it reads as black on white. `statusPillContrast.test.ts` now shares it instead of carrying a second copy - two copies of a reader is the same drift this issue is about.
- `blueStrongContrast.test.ts` - resolves `--blue-strong` and `--white-text` out of `globals.css` and asserts **the bar, not the number**, in both themes, at the smallest size any consumer renders (10px/700, so the strict 4.5 and never the 3.0 large-text escape). Includes a control that the two themes resolve to *different* literals, without which the dark arm would be a second copy of the light one.
- `customPropertyShadowing.test.ts` - fails on any custom property declared twice inside one rule. Duplication *across* rules is untouched: that is how theming and scoping work.

## Evidence

Full frontend suite at `6c1f9903f15ffecc9fc37a311cb795b7d38e1afb`:

```
npx jest --ci      rc=0    Test Suites: 1044 passed    Tests: 13210 passed
pnpm --filter frontend run type-check   rc=0
pnpm --filter frontend run lint         0 errors, 2 warnings (both pre-existing, in files this PR does not touch)
```

Baseline on `dev` was 1042 suites / 13201 tests. The delta is exactly the two new files and their 9 tests.

**Every new guard was mutation-checked. A guard that has never failed is not yet a guard.**

```
ARM A  --blue-strong -> #5b93e8 (white on it = 3.10:1)
       blueStrongContrast.test.ts    rc=1   1 failed, 3 passed   <- the dark arm
       contrastProbe.test.ts         rc=0   9 passed             <- the literal guard, still blind, as filed

ARM B  reintroduce one duplicate declaration in the dark rule
       customPropertyShadowing       rc=1   "--blue-strong at 914 | 915 - all but the last are inert"

ARM C  restore the pre-PR globals.css
       customPropertyShadowing       rc=1   81 offenders - it would have caught what shipped

ARM D  break the reader so resolve() returns ""
       blueStrong + statusPill       rc=1   14 failed, "did not resolve to a colour in light"
                                            - loudly, not as a comfortable pass on a dead instrument

ARM E  give --white-text a translucent dark override: rgba(255, 255, 255, 0.75)
       blueStrongContrast            rc=1   2 failed
                                            "--blue-strong dark: 3.27:1 (needs 4.5:1) -
                                             rgba(255,255,255,0.75) on rgb(47,116,217) at 10px/700"
```

Arm D is the one that matters most: an empty string measures as black on white, which is a very comfortable 21:1.

## What this does not cover

- The consumers are not driven individually. The pairing is asserted at the token level - white on `--blue-strong` - because that is what all 30 sites use; a per-site render assertion would be 30 copies of one measurement. The predicate for that count is in the test header.
- No Aikido scan ran locally (no MCP or scan skill available in this session); CI's scan is the check.

## Related Issue(s)

Fixes #2822
