### PR TITLE
refactor(frontend): declare the card surface once and migrate the copies onto it

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Stats/StatCardShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Stats/StatCardShell.test.tsx
@@ -110,7 +110,7 @@ describe('StatCardShell', () => {
     );
 
     const surface = container.querySelector('.min-h-89') as HTMLElement;
-    expect(surface).toHaveClass('gap-3.5', 'overflow-hidden', 'rounded-[18px]');
+    expect(surface).toHaveClass('gap-3.5', 'overflow-hidden', 'yc-card-surface');
     expect(surface).not.toHaveClass('min-h-75');
     expect(surface).not.toHaveClass('gap-2.5');
   });
@@ -122,12 +122,12 @@ describe('StatCardShell', () => {
       </StatCardShell>
     );
 
-    expect(container.querySelector('.min-h-75')).toHaveClass(
-      'bg-[var(--screen)]',
-      'border',
-      'border-[var(--hairline)]',
-      'rounded-[18px]',
-      'min-h-75'
-    );
+    /* The frame is `.yc-card-surface` in globals.css - one declaration of the
+       --screen ground, hairline border, 18px radius and two-stop shadow that
+       this file used to spell out as four utilities, and that 39 other files
+       spelled out identically. Asserting the class is what makes a silent
+       divergence impossible; asserting the utilities only proved this one
+       component still agreed with itself. */
+    expect(container.querySelector('.min-h-75')).toHaveClass('yc-card-surface', 'min-h-75');
   });
 });

--- a/apps/frontend/src/app/__tests__/components/chat/SharedEntityCard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/SharedEntityCard.test.tsx
@@ -146,7 +146,7 @@ describe('SharedEntityCard', () => {
   it('renders the tokenized hairline card chrome when mine is true', () => {
     const { container } = render(<SharedEntityCard entity={makeEntity()} mine />);
     const card = container.firstChild as HTMLElement;
-    expect(card.className).toContain('border-[var(--hairline)]');
+    expect(card.className).toContain('yc-card-surface');
     // The legacy cool-slate accent border is gone (dark-mode safe).
     expect(container.querySelector('.border-primary-300')).not.toBeInTheDocument();
   });
@@ -154,8 +154,8 @@ describe('SharedEntityCard', () => {
   it('renders the same card chrome whether or not the message is mine', () => {
     const { container: a } = render(<SharedEntityCard entity={makeEntity()} mine />);
     const { container: b } = render(<SharedEntityCard entity={makeEntity()} mine={false} />);
-    expect((a.firstChild as HTMLElement).className).toContain('border-[var(--hairline)]');
-    expect((b.firstChild as HTMLElement).className).toContain('border-[var(--hairline)]');
+    expect((a.firstChild as HTMLElement).className).toContain('yc-card-surface');
+    expect((b.firstChild as HTMLElement).className).toContain('yc-card-surface');
   });
 
   it('renders an icon glyph for the entity', () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
     </div>
   </div>
   <div
-    class="rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-2.5 pb-2.5 pt-3 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]"
+    class="yc-card-surface yc-card-surface--tile px-2.5 pb-2.5 pt-3"
   >
     <div
       class="mb-1.5 grid grid-cols-7"

--- a/apps/frontend/src/app/__tests__/ui/tokens/cardSurface.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/cardSurface.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The card surface is declared once, and the migration onto it was a no-op.
+ *
+ * The warm-bone frame - `--screen` ground, hairline border, the two-stop depth
+ * shadow - existed as exactly one CSS class (`.TableShell`) and as a hand-typed
+ * Tailwind string in 39 more files and a hand-typed CSS block in 12. Nothing
+ * could enforce it, because a four-utility string spread across a `className`
+ * is not greppable and a reviewer cannot see that two cards agree.
+ *
+ * Two claims are worth a test rather than a sentence:
+ *
+ *   1. Replacing `bg-neutral-0` / `border-card-border` with a class that writes
+ *      `var(--screen)` / `var(--hairline)` changed no colour. That is only true
+ *      because those utilities alias those tokens, in BOTH themes - a fact
+ *      about globals.css that a future retint can break silently.
+ *   2. No copy came back. The gate is the point of the whole exercise; without
+ *      it the 39 files return over a month and we do this again.
+ *
+ * The CSS-literal check collapses whitespace before matching. Prettier
+ * hard-wraps a `box-shadow` past the print width, and 9 of the 12 CSS
+ * occurrences are wrapped - a line-oriented scan finds 3 of 12 and reports a
+ * confident near-zero.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import postcss from 'postcss';
+
+import { GLOBALS_CSS, resolveColour } from '@/app/__tests__/support/globalsTokens';
+
+const SRC = join(process.cwd(), 'src');
+
+const declarationsOf = (selector: string, css: string): Map<string, string> => {
+  const found = new Map<string, string>();
+  postcss.parse(css).walkRules((rule) => {
+    if (rule.selector !== selector) return;
+    rule.walkDecls((decl) => {
+      found.set(decl.prop, decl.value.replace(/\s+/g, ' ').trim());
+    });
+  });
+  return found;
+};
+
+/** Source with comments and whitespace runs flattened, so a hard-wrapped
+    declaration and a single-line one are the same string to a scan. */
+const flatten = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\s+/g, ' ');
+
+const TAILWIND_RECIPE = 'shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]';
+const CSS_RECIPE = '0 1px 2px var(--sh03), 0 8px 22px var(--sh05)';
+
+/**
+ * The CSS spelling still lives in these files and only these.
+ *
+ * They are NOT the same edit as the Tailwind ones: three of them
+ * (`.invite-picker-card`, `.org-picker-card`, `.videos-card-tile`) carry the
+ * shadow over a transparent ground with no background of their own, and two
+ * have `:hover` / `--current` rules that override the frame. Applying an
+ * unlayered class there is a visible change and a cascade question, not a
+ * rename, so they are a separate change with its own screenshots. Listing them
+ * by name means a NEW css copy fails this test rather than hiding among them.
+ */
+const CSS_COPIES_REMAINING = [
+  'app/features/appointments/components/Calendar/AppointmentCalendar.tsx',
+  'app/features/appointments/components/Calendar/TaskCalendar.tsx',
+  'app/features/appointments/components/Calendar/responsive/PhoneDayRail.css',
+  'app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css',
+  'app/features/developers/pages/DeveloperBilling/DeveloperBilling.css',
+  'app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css',
+  'app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css',
+  'app/features/integrations/pages/IdexxWorkspace/index.tsx',
+  'app/ui/cards/InviteCard/InviteCard.css',
+  'app/ui/cards/OrgCard/OrgCard.css',
+  'app/ui/cards/VideosCard/VideosCard.css',
+];
+
+describe('.yc-card-surface is the only declaration of the card frame', () => {
+  it('declares the four surface properties and nothing else', () => {
+    const decls = declarationsOf('.yc-card-surface', GLOBALS_CSS);
+    expect(Object.fromEntries(decls)).toEqual({
+      background: 'var(--screen)',
+      border: '1px solid var(--hairline)',
+      'border-radius': '18px',
+      'box-shadow': CSS_RECIPE,
+    });
+  });
+
+  it('leaves .TableShell holding behaviour only, so the frame is not declared twice', () => {
+    const sheet = readFileSync(join(SRC, 'app/ui/tables/GenericTable/Generictable.css'), 'utf8');
+    const decls = declarationsOf('.TableShell', sheet);
+    expect([...decls.keys()].sort()).toEqual(['isolation', 'min-height', 'overflow']);
+  });
+
+  it('keeps the three radius tiers the app already ships, each declared once', () => {
+    expect(Object.fromEntries(declarationsOf('.yc-card-surface--tile', GLOBALS_CSS))).toEqual({
+      'border-radius': '16px',
+    });
+    expect(Object.fromEntries(declarationsOf('.yc-card-surface--inset', GLOBALS_CSS))).toEqual({
+      'border-radius': '14px',
+    });
+    expect(Object.fromEntries(declarationsOf('.yc-card-surface--flat', GLOBALS_CSS))).toEqual({
+      'box-shadow': '0 1px 2px var(--sh03)',
+    });
+  });
+});
+
+describe('the migration changed no colour, because the spellings alias', () => {
+  /* Every background spelling the 39 files used, and every border spelling. If
+     any of these stops aliasing, cards that read identical today diverge and
+     this test names which spelling moved. */
+  it.each([false, true])('background spellings agree (dark=%s)', (dark) => {
+    const screen = resolveColour('var(--screen)', dark);
+    expect(resolveColour('var(--color-neutral-0)', dark)).toBe(screen);
+    expect(resolveColour('var(--color-surface-card)', dark)).toBe(screen);
+    expect(resolveColour('var(--color-screen)', dark)).toBe(screen);
+  });
+
+  it.each([false, true])('border spellings agree (dark=%s)', (dark) => {
+    const hairline = resolveColour('var(--hairline)', dark);
+    expect(resolveColour('var(--color-card-border)', dark)).toBe(hairline);
+    expect(resolveColour('var(--color-neutral-200)', dark)).toBe(hairline);
+    expect(resolveColour('var(--color-hairline)', dark)).toBe(hairline);
+  });
+
+  /* The comparator above is only worth its passes if it can fail. --band is the
+     neighbouring bone surface, one step darker; if this reads equal, the
+     resolver is returning a constant and the four assertions above mean
+     nothing. */
+  it('the spelling comparator can say two tokens differ', () => {
+    expect(resolveColour('var(--band)', false)).not.toBe(resolveColour('var(--screen)', false));
+  });
+});
+
+describe('no copy of the recipe survives outside globals.css', () => {
+  const files = readdirSync(join(SRC, 'app'), { recursive: true, encoding: 'utf8' })
+    .map((f) => join('app', f))
+    .filter((f) => /\.(ts|tsx|css)$/.test(f) && !/\.test\.tsx?$/.test(f))
+    .sort();
+  const sources = new Map(files.map((f) => [f, readFileSync(join(SRC, f), 'utf8')]));
+
+  it('reads a corpus that could contain the recipe', () => {
+    expect(files.length).toBeGreaterThan(500);
+    expect(flatten(GLOBALS_CSS)).toContain(CSS_RECIPE);
+  });
+
+  /**
+   * The one Tailwind call site that is not a rename.
+   *
+   * ExploreCard's stat tile steps its radius at the xl breakpoint
+   * (`rounded-[14px] xl:rounded-2xl`). `.yc-card-surface` is unlayered so that
+   * it beats Tailwind's layered bg/border/shadow utilities - which also means a
+   * layered `xl:rounded-2xl` can no longer override its radius, and the tile
+   * would silently freeze at 14px on desktop. The radius-ladder change (the
+   * design system's `--radius-card` is 20px, and the repo defines no radius
+   * tokens at all) removes the step, so this resolves there rather than by
+   * inventing a breakpoint variant for a hand-written class.
+   */
+  const TAILWIND_COPIES_REMAINING = ['app/ui/cards/ExploreCard/ExploreCard.tsx'];
+
+  it('has no hand-typed Tailwind copies beyond the one responsive tile', () => {
+    const offenders = [...sources]
+      .filter(([, text]) => text.includes(TAILWIND_RECIPE))
+      .map(([f]) => f)
+      .sort();
+    expect(offenders).toEqual(TAILWIND_COPIES_REMAINING);
+  });
+
+  it('confines the CSS-declared copies to the files still awaiting their own change', () => {
+    const offenders = [...sources]
+      .filter(([f, text]) => f !== 'app/globals.css' && flatten(text).includes(CSS_RECIPE))
+      .map(([f]) => f)
+      .sort();
+    expect(offenders).toEqual(CSS_COPIES_REMAINING);
+  });
+
+  /* Both scans above are negatives, and a negative is only as wide as the
+     matcher. A wrapped `box-shadow` is the exact shape that made a first pass
+     at this report 3 of 12: prove the flattened matcher sees one. */
+  it('the CSS matcher sees a hard-wrapped declaration', () => {
+    const wrapped =
+      '.x {\n  box-shadow:\n    0 1px 2px var(--sh03),\n    0 8px 22px var(--sh05);\n}';
+    expect(wrapped.includes(CSS_RECIPE)).toBe(false);
+    expect(flatten(wrapped)).toContain(CSS_RECIPE);
+  });
+
+  it('the Tailwind matcher fires on a planted copy', () => {
+    const planted = '<div className="rounded-2xl border bg-neutral-0 ' + TAILWIND_RECIPE + '" />';
+    expect(planted.includes(TAILWIND_RECIPE)).toBe(true);
+  });
+});

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
@@ -232,7 +232,7 @@ const PhoneMonthOverview = ({
         />
       </div>
 
-      <div className="rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-2.5 pb-2.5 pt-3 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <div className="yc-card-surface yc-card-surface--tile px-2.5 pb-2.5 pt-3">
         <div className="mb-1.5 grid grid-cols-7">
           {WEEKDAY_LABELS.map((label) => (
             <span

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
@@ -174,7 +174,7 @@ const OutpatientSchedule = ({
 
   return (
     <SectionContainer title="Task schedule" className="flex flex-col gap-4">
-      <div className="overflow-hidden rounded-[14px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <div className="overflow-hidden yc-card-surface yc-card-surface--inset">
         <div className="flex items-center justify-between border-b border-card-border px-4 py-2.5">
           <span className="text-body-4 font-bold text-text-primary">
             Scheduled outpatient tasks · {schedule.total}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceTreatmentSummary.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceTreatmentSummary.tsx
@@ -37,10 +37,7 @@ const WorkspaceTreatmentSummary = ({
 
   return (
     <div className="flex w-full flex-col gap-3">
-      <section
-        aria-label="Treatment summary"
-        className="rounded-[14px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]"
-      >
+      <section aria-label="Treatment summary" className="yc-card-surface yc-card-surface--inset">
         <div className="flex items-center justify-between border-b border-card-border px-4 py-3">
           <span className="text-body-4 text-text-secondary">Treatment items</span>
           <span className="text-body-4-emphasis tabular-nums text-text-primary">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceVitalsPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceVitalsPanel.tsx
@@ -74,10 +74,7 @@ const VitalsCard = ({
   canRecord: boolean;
   onRecordVitals: () => void;
 }) => (
-  <section
-    aria-label="Vitals"
-    className="overflow-hidden rounded-[14px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]"
-  >
+  <section aria-label="Vitals" className="overflow-hidden yc-card-surface yc-card-surface--inset">
     <div className="flex items-center justify-between px-4 pb-2.5 pt-3">
       <span
         className="text-[14px] font-bold leading-[130%] tracking-[-0.01em]"
@@ -147,7 +144,7 @@ const ObservationToolsCard = ({
 }) => (
   <section
     aria-label="Observation tools"
-    className="overflow-hidden rounded-[14px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]"
+    className="overflow-hidden yc-card-surface yc-card-surface--inset"
   >
     <div className="flex items-center justify-between px-4 pb-2.5 pt-3">
       <span

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -770,7 +770,7 @@ export const PaymentActions = ({
   return (
     <section
       aria-label="Payment method"
-      className="flex flex-col gap-3 rounded-[14px] border border-card-border bg-neutral-0 p-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]"
+      className="flex flex-col gap-3 yc-card-surface yc-card-surface--inset p-4"
     >
       <span
         className="text-[14px] font-bold leading-[130%] tracking-[-0.01em]"

--- a/apps/frontend/src/app/features/chat/components/SharedEntityCard.tsx
+++ b/apps/frontend/src/app/features/chat/components/SharedEntityCard.tsx
@@ -90,7 +90,7 @@ export function SharedEntityCard({
   const showValueRow = Boolean(amount || deepLink);
 
   return (
-    <div className="w-64 max-w-full overflow-hidden rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] xl:w-[340px]">
+    <div className="w-64 max-w-full overflow-hidden yc-card-surface yc-card-surface--tile xl:w-[340px]">
       <div
         className={
           showValueRow

--- a/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
@@ -1954,7 +1954,7 @@ const useCompanionHistoryTimelineView = ({
           className={
             isPhoneVariant
               ? 'flex flex-col gap-3'
-              : 'flex flex-col gap-3 overflow-hidden rounded-[18px] border border-hairline bg-[var(--screen)] px-[22px] py-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]'
+              : 'flex flex-col gap-3 overflow-hidden yc-card-surface px-[22px] py-[18px]'
           }
         >
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -242,7 +242,7 @@ const CompanionProfilePanel = ({
   return (
     <section
       aria-label="Companion profile"
-      className="flex min-h-36 flex-col gap-4 rounded-[18px] border border-card-border bg-neutral-0 px-5 py-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] md:flex-row md:items-start"
+      className="flex min-h-36 flex-col gap-4 yc-card-surface px-5 py-[18px] md:flex-row md:items-start"
     >
       <AvatarImage
         alt={record.companion.name}
@@ -318,7 +318,7 @@ const ParentProfilePanel = ({
   return (
     <section
       aria-label="Parent profile"
-      className="flex min-h-36 flex-col gap-4 rounded-[18px] border border-card-border bg-neutral-0 px-5 py-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] md:flex-row md:items-start"
+      className="flex min-h-36 flex-col gap-4 yc-card-surface px-5 py-[18px] md:flex-row md:items-start"
     >
       <div className="flex w-16 shrink-0 items-start">
         <AvatarImage

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -943,14 +943,12 @@ const IntegrationFilterTabs = ({
   </fieldset>
 );
 
-// Compact integration card — design: 16px/18px padding, 18px radius, a 10px
-// column gap and a 42px inline icon leading the title row.
-const INTEGRATION_CARD_CLASS =
-  'rounded-[18px] border px-[18px] py-4 w-full flex flex-col gap-2.5 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]';
-const INTEGRATION_CARD_STYLE: React.CSSProperties = {
-  background: 'var(--screen)',
-  borderColor: 'var(--hairline)',
-};
+// Compact integration card — design: 16px/18px padding, a 10px column gap and a
+// 42px inline icon leading the title row. The frame is `.yc-card-surface`; this
+// card used to write the same recipe half as utilities and half as an inline
+// style object, which is why the shared class could not be applied to it by the
+// obvious edit.
+const INTEGRATION_CARD_CLASS = 'yc-card-surface px-[18px] py-4 w-full flex flex-col gap-2.5';
 const INTEGRATION_CARD_HEADER_CLASS = 'flex items-center gap-3';
 const INTEGRATION_CARD_TITLE_CLASS =
   'min-w-0 flex-1 truncate text-[14.5px] font-bold tracking-[-0.01em]';
@@ -993,7 +991,7 @@ const IdexxIntegrationCard = ({
   if (!s.showIdexxCard) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.idexx}>
           IDX
@@ -1066,7 +1064,7 @@ const MerckIntegrationCard = ({
   if (!s.showMerckCard) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.merck}>
           <IoBookOutline size={19} aria-hidden="true" />
@@ -1122,7 +1120,7 @@ const RadIntegrationCard = ({
   if (!shouldShowComingSoonCards(activeFilter)) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.radAnalyzer}>
           RA
@@ -1159,7 +1157,7 @@ const VetnioIntegrationCard = ({
   if (!shouldShowComingSoonCards(activeFilter)) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.vetnio}>
           VN
@@ -1197,7 +1195,7 @@ const QuickBooksIntegrationCard = ({
   if (!shouldShowComingSoonCards(activeFilter)) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.quickBooks}>
           QB
@@ -1235,7 +1233,7 @@ const LaikaIntegrationCard = ({
   if (!shouldShowComingSoonCards(activeFilter)) return null;
 
   return (
-    <div className={INTEGRATION_CARD_CLASS} style={INTEGRATION_CARD_STYLE}>
+    <div className={INTEGRATION_CARD_CLASS}>
       <div className={INTEGRATION_CARD_HEADER_CLASS}>
         <span className={INTEGRATION_ICON_CLASS} style={INTEGRATION_ICON_STYLES.laika}>
           LK

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -55,8 +55,7 @@ const cardClass =
   'rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
 // The wide chart / detail cards sit on the ambient two-layer lift; the KPI
 // mini-cards keep the single tight layer.
-const largeCardClass =
-  'rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]';
+const largeCardClass = 'yc-card-surface yc-card-surface--tile';
 const kpiCardClass = `${cardClass} flex flex-col gap-[3px] px-4 py-3.5`;
 const kpiLabelClass = 'text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--ink-faint)]';
 const kpiValueClass = 'text-[22px] font-bold tracking-[-0.02em] tabular-nums text-[var(--ink)]';

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/OrgProfileBand.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/OrgProfileBand.tsx
@@ -69,7 +69,7 @@ const OrgProfileBand = ({ org, canEdit, onEdit }: OrgProfileBandProps) => {
   const secondaryMeta = buildSecondaryMeta(org);
 
   return (
-    <div className="flex flex-col gap-[14px] rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-[22px]! py-5! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] sm:flex-row sm:items-center sm:gap-[18px]">
+    <div className="flex flex-col gap-[14px] yc-card-surface px-[22px]! py-5! sm:flex-row sm:items-center sm:gap-[18px]">
       <OrgAvatar org={org} />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-[10px]">

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
@@ -49,7 +49,7 @@ const Payment = () => {
       allOf={[PERMISSIONS.SUBSCRIPTION_VIEW_ANY]}
       fallback={<Fallback resource="billing and subscription" />}
     >
-      <div className="flex items-center gap-3 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[15px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <div className="flex items-center gap-3 yc-card-surface px-5! py-[15px]!">
         <span className="flex size-9 flex-none items-center justify-center rounded-[11px] bg-[var(--blue-soft)] text-[var(--blue-text)]">
           <IoCardOutline size={16} aria-hidden="true" />
         </span>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
@@ -376,7 +376,7 @@ const ProfileCard = ({
   };
 
   return (
-    <div className="bg-[var(--screen)] border border-[var(--hairline)] rounded-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <div className="yc-card-surface">
       <div className="px-5! pt-4! pb-3! border-b border-[var(--hairline)] flex items-center justify-between gap-3">
         <div className="text-[16px] font-bold tracking-[-0.01em] text-[var(--ink)]">{title}</div>
         {isActuallyEditable && !isEditing && (

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
@@ -126,7 +126,7 @@ const Rooms = () => {
 
   return (
     <PermissionGate allOf={[PERMISSIONS.ROOM_VIEW_ANY]} fallback={<Fallback resource="rooms" />}>
-      <section className="overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <section className="overflow-hidden yc-card-surface">
         <div className="flex items-center justify-between gap-3 px-5! pt-4! pb-3!">
           <h2 className="text-[15.5px] font-bold tracking-[-0.01em] text-[var(--ink)]">
             Rooms <span className="font-medium text-[var(--ink-faint)]">({rooms.length})</span>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
@@ -129,7 +129,7 @@ const Team = ({ isVerified = false }: { isVerified?: boolean }) => {
       allOf={[PERMISSIONS.TEAMS_VIEW_ANY]}
       fallback={<Fallback resource="the team roster" />}
     >
-      <section className="flex flex-col overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <section className="flex flex-col overflow-hidden yc-card-surface">
         <div className="flex items-center justify-between gap-3 px-5! pt-4! pb-3!">
           {/* Section heading: `text-heading-3` (20px/500), the same ramp SectionCard
               gives Specialities, Documents, Online booking and Booking requests

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.tsx
@@ -430,13 +430,7 @@ const SpecialityAccordionRevamp = ({
   };
 
   return (
-    <div
-      className={`flex flex-col w-full rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] ${
-        open
-          ? 'shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]'
-          : 'shadow-[0_1px_2px_var(--sh03)]'
-      }`}
-    >
+    <div className={`flex flex-col w-full yc-card-surface ${open ? '' : 'yc-card-surface--flat'}`}>
       <SpecialityAccordionHeader
         speciality={speciality}
         activeTab={activeTab}

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/Personal.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/Personal.tsx
@@ -62,7 +62,7 @@ const Personal = ({ onEditProfile, onEditHours }: PersonalProps) => {
   );
 
   return (
-    <div className="bg-[var(--screen)] border border-[var(--hairline)] rounded-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] px-5! py-[18px]! flex flex-col gap-[14px]">
+    <div className="yc-card-surface px-5! py-[18px]! flex flex-col gap-[14px]">
       <div className="text-[14.5px] font-bold text-[var(--ink)]">Personal</div>
       <div className="flex items-center gap-[14px]">
         {isHttpsAvatar(avatarUrl) ? (

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
@@ -62,7 +62,7 @@ export const PreferenceGroup = ({
 
   return (
     <section
-      className={`flex flex-col gap-[14px] rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[18px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${
+      className={`flex flex-col gap-[14px] yc-card-surface px-5! py-[18px]! ${
         className ?? ''
       }`.trim()}
     >

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/SecuritySection.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/SecuritySection.tsx
@@ -145,7 +145,7 @@ const SecuritySection = () => {
   const totpActive = Boolean(mfaStatus?.totp.required && mfaStatus?.totp.setup);
 
   return (
-    <div className="bg-[var(--screen)] border border-[var(--hairline)] rounded-[18px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <div className="yc-card-surface">
       <div className="px-5! pt-4! pb-3! border-b border-[var(--hairline)] flex items-center justify-between">
         <div className="text-[16px] font-bold tracking-[-0.01em] text-[var(--ink)]">Security</div>
       </div>

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
@@ -40,7 +40,7 @@ const YourOrganizations = () => {
   if (orgs.length === 0) return null;
 
   return (
-    <section className="flex flex-col gap-3 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[18px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <section className="flex flex-col gap-3 yc-card-surface px-5! py-[18px]!">
       <div className="flex items-center justify-between gap-3">
         <h3 className="min-w-0 text-[14.5px] font-bold text-[var(--ink)]">Your organizations</h3>
         <Link href="/create-org" className="yc-settings-card-action">

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
@@ -164,7 +164,7 @@ const TaskWeekAgenda = ({
   const weekStartKey = weekStart.getTime();
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden yc-card-surface">
       <div className="grid grid-cols-7 border-b border-card-border bg-[var(--screen-2)]">
         {days.map((day, index) => {
           const isToday = isOnPreferredTimeZoneCalendarDay(today, day);

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1871,6 +1871,59 @@ html[data-theme='dark'] [data-yc-app] ::selection {
     0 10px 30px var(--sh08);
 }
 
+/* ------------------------------------------------------------------ *
+ * The warm-bone card surface — the one recipe for an in-flow card.
+ *
+ * `--screen` ground, hairline border and the two-stop depth shadow. This
+ * existed once as `.TableShell` (ui/tables/GenericTable/Generictable.css) and
+ * was hand-retyped as Tailwind utilities in 39 more files and as CSS in 12,
+ * which is why the same card is 18px in one place and 16px in another and why
+ * no gate could ever catch a new copy: a class can be grepped, a four-utility
+ * string spread across a `className` cannot.
+ *
+ * Unlayered on purpose, exactly like `.yc-glass-overlay` above, so it beats
+ * Tailwind's layered bg/border/shadow utilities on the same element. That is
+ * what lets `.TableShell` drop the `!important` it used to carry on all four
+ * properties without changing which declaration wins.
+ *
+ * RADIUS IS A LADDER, not a single value, and the modifiers below preserve the
+ * three sizes the app already ships rather than flattening them by fiat:
+ *   (default) 18px  page sections, tables, page-level containers
+ *   --tile     16px  entity tiles laid out in a grid
+ *   --inset    14px  a card nested inside a panel that already has a frame
+ * The design system owns which tier a surface belongs to; this file owns the
+ * fact that there are three of them and that changing one changes every call
+ * site. Pair with `.yc-card-elevated` only for the raised stat-tile treatment,
+ * which is a different shadow and not a second surface.
+ * ------------------------------------------------------------------ */
+.yc-card-surface {
+  background: var(--screen);
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  box-shadow:
+    0 1px 2px var(--sh03),
+    0 8px 22px var(--sh05);
+}
+
+.yc-card-surface--tile {
+  border-radius: 16px;
+}
+
+.yc-card-surface--inset {
+  border-radius: 14px;
+}
+
+/* The resting elevation, for a card that drops to it in one of its own states.
+   The speciality accordion is the only surface in the app that does this: open
+   it carries the full two-stop depth, collapsed it keeps the contact shadow
+   alone. Written as a modifier rather than left as a hand-rolled `shadow-[...]`
+   because an unlayered `.yc-card-surface` beats a layered Tailwind shadow
+   utility on the same element - the override has to live at the same level as
+   the thing it overrides, or it silently does nothing. */
+.yc-card-surface--flat {
+  box-shadow: 0 1px 2px var(--sh03);
+}
+
 /* App runtime toasts (react-toastify).
    One recipe for every toast `useNotify` raises: a 360px warm --screen card
    with a hairline and a level-3 float, 16px popover radius, Satoshi, and no

--- a/apps/frontend/src/app/ui/cards/AppointmentCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/AppointmentCard/index.tsx
@@ -54,7 +54,7 @@ const AppointmentCard = ({
   const appointmentCompanionName = getAppointmentCompanion(appointment).name || 'appointment';
 
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <AppointmentCardContent appointment={appointment} />
       <div className="flex gap-3 w-full justify-center">
         {isRequestedLikeStatus(appointment.status) ? (

--- a/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
@@ -22,7 +22,7 @@ type AvailabilityCardProps = {
 
 const AvailabilityCard = ({ team, handleViewTeam }: AvailabilityCardProps) => {
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-2 items-center">
         <div className="size-10">
           <AvatarImage

--- a/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.tsx
@@ -48,7 +48,7 @@ const CompanionCard = ({
 }: CompanionCardProps) => {
   const terminologyText = useCompanionTerminologyText();
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-2 items-center">
         <AvatarImage
           alt={''}

--- a/apps/frontend/src/app/ui/cards/DocumentsCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/DocumentsCard/index.tsx
@@ -10,7 +10,7 @@ type DocumentsCardProps = {
 
 const DocumentsCard = ({ document, handleViewDocument }: DocumentsCardProps) => {
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{document.title}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/FormCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/FormCard/index.tsx
@@ -14,7 +14,7 @@ type FormCardProps = {
 
 const FormCard = ({ form, handleViewForm, getUserName, orgType }: FormCardProps) => {
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{form.name}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/InventoryCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InventoryCard/index.tsx
@@ -42,7 +42,7 @@ const InventoryCard = ({ item, handleViewInventory }: any) => {
   };
 
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{item.basicInfo.name}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/InventoryTurnoverCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InventoryTurnoverCard/index.tsx
@@ -7,7 +7,7 @@ const InventoryTurnoverCard = ({ item }: any) => {
   const totalPurchased = item.totalPurchases ?? item.totalPurchased ?? 0;
 
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{item.name}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
@@ -33,7 +33,7 @@ const InvoiceCard = ({ invoice, handleViewInvoice }: InvoiceCardProps) => {
   );
 
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{companionName}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/RoomCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/RoomCard/index.tsx
@@ -13,7 +13,7 @@ type RoomCardProps = {
 
 const RoomCard = ({ room, handleViewRoom, staffNameById, specialityNameById }: RoomCardProps) => {
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{room.name}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/SpecialitiesCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/SpecialitiesCard/index.tsx
@@ -10,7 +10,7 @@ type SpecialitiesCardProps = {
 
 const SpecialitiesCard = ({ speciality, handleViewSpeciality }: SpecialitiesCardProps) => {
   return (
-    <div className="w-full h-full rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="w-full h-full yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex gap-1">
         <div className="text-body-3-emphasis text-text-primary">{speciality.name}</div>
       </div>

--- a/apps/frontend/src/app/ui/cards/TaskCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/index.tsx
@@ -34,7 +34,7 @@ const TaskCard = ({
   canEditTasks = false,
 }: TaskCardProps) => {
   return (
-    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] p-3 flex flex-col justify-between gap-2 cursor-pointer">
+    <div className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] yc-card-surface yc-card-surface--tile p-3 flex flex-col justify-between gap-2 cursor-pointer">
       <div className="flex items-start justify-between gap-2">
         <div className="text-body-3-emphasis text-text-primary">{item.name}</div>
         <StatusPill tone={getTaskStatusTone(item.status)} label={toTitleCase(item.status)} />

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
@@ -24,7 +24,7 @@ const withSession = (status: AuthStatus, role: string | null) => {
 
 /** Stand-in for whatever developer-portal page the guard is wrapped around. */
 const DeveloperPanel = () => (
-  <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+  <div className="yc-card-surface px-5 py-4">
     <p className="text-[15px] font-semibold text-[var(--ink-body)]">API keys</p>
     <p className="mt-1 text-[13px] text-[var(--ink-muted)]">
       Two live keys, one sandbox key. Visible because the session carries the developer role.

--- a/apps/frontend/src/app/ui/layout/guards/PermissionGate.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/PermissionGate.stories.tsx
@@ -49,7 +49,7 @@ const withMembership = (membership: UserOrganization | null, status: OrgStatus =
 
 /** Stand-in for whatever section the gate is wrapped around. */
 const GatedPanel = () => (
-  <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+  <div className="yc-card-surface px-5 py-4">
     <p className="text-[15px] font-semibold text-[var(--ink-body)]">Today&apos;s appointments</p>
     <p className="mt-1 text-[13px] text-[var(--ink-muted)]">
       12 booked, 3 awaiting confirmation. Visible because the role carries{' '}

--- a/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.tsx
+++ b/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.tsx
@@ -80,9 +80,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
     // ground and shadow this rendered as a bare frame, which is why four
     // consumers had each grown their OWN inner card to compensate - stacking two
     // visible borders. The surface belongs to the primitive, once.
-    <div
-      className={`flex flex-col gap-3 rounded-[18px] border border-card-border bg-[var(--screen)] px-6 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${paddingYClass}`}
-    >
+    <div className={`flex flex-col gap-3 yc-card-surface px-6 ${paddingYClass}`}>
       <div className="flex items-center gap-x-4 gap-y-2">
         <h2 className="min-w-0 flex-1 text-heading-3 text-text-primary">{title}</h2>
         <div className="flex shrink-0 items-center gap-3 flex-wrap">

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -503,7 +503,7 @@ const CompanionsTable = ({
   return (
     <div className="table-wrapper companions-scroll-x h-full min-h-0 overflow-hidden">
       <div className="companions-table-list flex h-full min-h-0 flex-1 overflow-hidden">
-        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden yc-card-surface">
           {viewMode === 'grid' ? (
             <div className="min-h-0 flex-1 overflow-y-auto scrollbar-hidden p-4">
               {pageItems.length === 0 ? (

--- a/apps/frontend/src/app/ui/tables/GenericTable/GenericTable.tsx
+++ b/apps/frontend/src/app/ui/tables/GenericTable/GenericTable.tsx
@@ -154,7 +154,7 @@ const GenericTable = <T extends object>({
       ref={containerRef}
       className={`flex min-h-0 w-full flex-col gap-3 overflow-hidden ${needsFill ? 'h-full' : 'h-auto'} ${showPagination ? 'pb-2' : ''}`}
     >
-      <div className={`TableShell min-h-0 ${needsFill ? 'flex-1' : ''}`}>
+      <div className={`yc-card-surface TableShell min-h-0 ${needsFill ? 'flex-1' : ''}`}>
         <div
           ref={bodyScrollRef}
           className={`TableBodyScroll min-h-0 overflow-y-auto scrollbar-custom ${needsFill ? 'h-full' : 'h-auto'}`}

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -1,10 +1,12 @@
+/* The table's BEHAVIOUR only. Its warm-bone frame — ground, hairline, 18px
+   radius and the two-stop shadow — is `.yc-card-surface` in globals.css, applied
+   beside this class at every call site. It used to be declared here as well —
+   the file that owned the recipe counting as one of the fifty-one copies of it.
+
+   The four surface properties carried `!important` so they would beat Tailwind's
+   layered utilities on the same element; `.yc-card-surface` is unlayered and wins
+   the same contest without it, the way `.yc-glass-overlay` already does. */
 .TableShell {
-  background: var(--screen) !important;
-  border: 1px solid var(--hairline) !important;
-  border-radius: 18px !important;
-  box-shadow:
-    0 1px 2px var(--sh03),
-    0 8px 22px var(--sh05) !important;
   overflow: hidden;
   min-height: 0;
   /* Own a compositing context so the 16px rounded overflow:hidden clip is

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
@@ -124,7 +124,7 @@ const PaginatedGridTable = <T,>({
             renders the sticky header on its own layer and its square top edge
             pokes out past the rounded corners on scroll repaint (same fix as
             .TableShell in Generictable.css). */}
-        <div className="isolate flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+        <div className="isolate flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden yc-card-surface">
           <div className="min-h-0 flex-1 overflow-auto">
             <div style={{ minWidth: `${minWidthPx}px` }}>
               <div

--- a/apps/frontend/src/app/ui/tables/RoomTable.tsx
+++ b/apps/frontend/src/app/ui/tables/RoomTable.tsx
@@ -156,7 +156,7 @@ const RoomTable = ({
           .TableBodyScroll: `.TableShell` sets `overflow: hidden` unlayered, which
           beats a layered `overflow-x-auto` utility on the same element and would
           clip the trailing columns with no way to reach them. */}
-      <div className="table-list TableShell">
+      <div className="table-list yc-card-surface TableShell">
         {filteredList.length === 0 ? (
           <NoDataMessage {...emptyStateCopy('rooms')} />
         ) : (

--- a/apps/frontend/src/app/ui/tables/TableHead.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/TableHead.stories.tsx
@@ -47,7 +47,7 @@ const Row = ({ track }: { track: string }) => (
 export const Default: Story = {
   args: { columns: COLUMNS, track: TRACK },
   render: (args) => (
-    <div className="TableShell">
+    <div className="yc-card-surface TableShell">
       <TableHead {...args} />
       <Row track={args.track} />
       <Row track={args.track} />
@@ -59,7 +59,7 @@ export const NotSticky: Story = {
   name: 'Inside a drawer (not sticky)',
   args: { columns: COLUMNS, track: TRACK, sticky: false },
   render: (args) => (
-    <div className="TableShell">
+    <div className="yc-card-surface TableShell">
       <TableHead {...args} />
       <Row track={args.track} />
     </div>
@@ -86,7 +86,7 @@ export const RightAligned: Story = {
     track: 'minmax(0,1.7fr) 72px 130px 120px',
   },
   render: (args) => (
-    <div className="TableShell">
+    <div className="yc-card-surface TableShell">
       <TableHead {...args} />
     </div>
   ),
@@ -123,7 +123,7 @@ export const Consistency: StoryObj = {
       </div>
       <div>
         <p className="mb-2 text-[12px] text-[var(--ink-faint)]">TableHead — grid shell</p>
-        <div className="TableShell">
+        <div className="yc-card-surface TableShell">
           <TableHead
             columns={[
               { key: 'name', label: 'Name' },

--- a/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
@@ -112,7 +112,7 @@ const DashboardSteps = () => {
             <div
               key={step.title}
               className={clsx(
-                'flex flex-col items-start justify-between gap-3 px-5 py-[18px] rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]'
+                'flex flex-col items-start justify-between gap-3 px-5 py-[18px] yc-card-surface'
               )}
             >
               <div className="flex w-full flex-col items-start gap-2">

--- a/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.tsx
@@ -126,7 +126,7 @@ const DynamicChartCard: FC<ChartProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-3 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <div className="flex flex-col gap-3 yc-card-surface px-5 py-4">
       {headerContent}
       {!hideKeys && !headerContent && <ChartLegend keys={keys} />}
       {isEmpty ? (

--- a/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.tsx
@@ -34,9 +34,7 @@ const StatCardShell = ({
       selected={selected ?? options[0]}
       onSelect={onSelect}
     />
-    <div
-      className={`flex w-full flex-col rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${cardClassName}`}
-    >
+    <div className={`flex w-full flex-col yc-card-surface px-5 py-4 ${cardClassName}`}>
       {isEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-2 text-[var(--ink-faint)]">
           <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">


### PR DESCRIPTION
**Stacked on #2823** (`fix/2822-dark-token-shadowing`), which adds the postcss-backed globals.css reader this PR's tests use. GitHub retargets this to `dev` when #2823 merges. Read the diff against that base — it is one commit.

Closes the "44 hand-copied surface recipes" line of the UI freeze (criterion 2, surfaces).

## What was wrong

The warm-bone card frame — `--screen` ground, hairline border, 18px radius, the two-stop depth shadow — existed as exactly one CSS class (`.TableShell`) and as a hand-retyped Tailwind string in 39 more files and a hand-written CSS block in 12. 51 files, one recipe, nothing able to enforce it: a four-utility string spread across a `className` is not greppable, and a reviewer cannot see that two cards agree.

`.yc-card-surface` in `globals.css` is now the only declaration, beside `.yc-card-elevated`. `.TableShell` keeps its behaviour (`overflow`, `min-height`, `isolation`) and drops the four surface properties it used to restate — the file that owned the recipe was itself one of the fifty-one copies of it.

## The no-op is the claim worth checking, because the copies were not written the same way

Only the shadow was byte-identical across all 51. Background was spelled three ways and the border three ways:

| spelled | resolves to | light | dark |
| --- | --- | --- | --- |
| `bg-[var(--screen)]` | `--screen` | ✓ | ✓ |
| `bg-neutral-0` | `--color-neutral-0` → `--screen` | ✓ | ✓ |
| `var(--color-surface-card)` | → `--color-neutral-0` → `--screen` | ✓ | ✓ |
| `border-[var(--hairline)]` | `--hairline` | ✓ | ✓ |
| `border-card-border` | → `--color-neutral-200` → `--hairline` | ✓ | ✓ |
| `border-hairline` | `--color-hairline` | ✓ | ✓ |

So the migration changed no colour. That is a fact about `globals.css` that a retint can break silently, so `cardSurface.test.ts` asserts it in both themes rather than assuming it — with a control that the comparator can still tell `--band` from `--screen`, so the six passes are not a resolver returning a constant.

## Radius is a ladder, and reconciling it is NOT this PR

~20 page-level containers and tables at 18px, ~14 entity tiles at 16px, 6 in-panel sub-cards at 14px. `--tile` and `--inset` preserve those exactly.

Three sources currently disagree about what a card radius is — the shipped app says 18px, the design system's `--radius-card` says 20px, and the now-deleted `packages/design-tokens` said 24px. Collapsing 51 cards onto one value is a visible change to every card in the product and needs its own before/after, so this PR deliberately changes no pixel.

## Two call sites are named in the test rather than hidden

- **`ExploreCard`** steps its radius at `xl` (`rounded-[14px] xl:rounded-2xl`). `.yc-card-surface` is unlayered so it beats Tailwind's layered bg/border/shadow utilities — which also means a layered `xl:rounded-2xl` can no longer override it, and the tile would silently freeze at 14px on desktop. It resolves in the radius change, which removes the step.
- **The 11 CSS-declared copies.** Three carry the shadow over a transparent ground with no background of their own, and two have `:hover` / `--current` rules that override the frame, so applying an unlayered class there is a cascade question with its own screenshots, not a rename.

Both are enumerated in the test, so a *new* copy fails rather than hiding among the known ones.

## The gate collapses whitespace before matching

Prettier hard-wraps a `box-shadow` past the print width and **9 of the 12 CSS occurrences are wrapped**. A line-oriented scan finds 3 of 12 and reports a confident near-zero. There is a test arm that proves the flattened matcher sees a wrapped declaration and the raw one does not.

## Why unlayered, and why `--flat` exists

`.yc-card-surface` sits outside `@layer`, exactly as `.yc-glass-overlay` already does, so it beats Tailwind's layered utilities. That is what lets `.TableShell` drop the `!important` it carried on all four properties without changing which declaration wins. It is also why the speciality accordion's collapsed state needed `.yc-card-surface--flat`: its reduced `shadow-[0_1px_2px_var(--sh03)]` was a layered utility and would now lose silently.

## Verification

Each mutation reds a **named** test:

| mutation | test that failed |
| --- | --- |
| `.yc-card-surface` radius 18px → 20px | declares the four surface properties and nothing else |
| a `background` put back on `.TableShell` | leaves .TableShell holding behaviour only |
| a Tailwind copy planted in `TaskCard` | no hand-typed Tailwind copies beyond the one responsive tile |
| a **hard-wrapped** CSS copy planted in `DataTable.css` | confines the CSS-declared copies to the named files |
| `--color-neutral-0` repointed at `--band` | background spellings agree (both themes) |

```
frontend suite   1046/1046 files   13230/13230 tests   rc=0
npx tsc --noemit                                       rc=0
pnpm --filter frontend run lint                        rc=0  (2 pre-existing warnings, neither in a touched file)
```

`tsc` and the suite were run in this worktree at this commit. The pre-push hook's type-check was a turbo **cache replay** from another worktree, so it is not the evidence above — it is a different run and it is not being quoted here.

## Visual evidence: 466 before/after pairs, 465 of them pixel-identical

Two static Storybook builds — a clean checkout of this PR's base (`81d91e6a3`) and this head — captured
with Playwright at 1280x800, `deviceScaleFactor: 1`, reduced motion, and an injected stylesheet zeroing
every transition. Corpus is **every story in every migrated component**: all 40 have a colocated
`.stories.tsx`, 236 stories, both themes, both arms.

```
pairs compared      466        222,078,400 pixels
                    465  IDENTICAL, zero channels differ
                      1  44 px differ by 1/255, perceptible(>8) = 0
```

The single non-identical pair is `CompanionHistoryTimeline / Record drawer` in light. Its 44 pixels sit
in a 939x35 band at the top of the frame — the rounded ends of the sort pill and the search field,
neither of which is a `.yc-card-surface`. Antialiasing, not a surface change.

### Controls, because "no visual change" is what a broken capture also reports

```
the two arms really are different builds   'yc-card-surface' in built assets: after 44 files, before 0
the server stayed up                       index.json probed 200 at the START and END of each arm
the comparator can see a difference        light-vs-dark, same arm, same code path -> 100.0% of pixels
the harness is silent when nothing changes a no-op stylesheet moves 0 pixels
```

### The class is doing the work — read off the DOM, not inferred from the pixels

Identical pixels cannot by themselves distinguish "the class applied and reproduces the old frame" from
"the class is inert". 223 of 236 stories render at least one `.yc-card-surface`, 626 elements in total,
and their computed frames collapse to exactly the declared ladder and nothing else:

| variant | radius | light ground / border | dark ground / border | count |
|---|---|---|---|---|
| `.yc-card-surface` | 18px | `rgb(247,243,236)` / `rgb(229,220,207)` | `rgb(47,39,30)` / `rgb(64,54,43)` | 341 |
| `--tile` | 16px | same | same | 206 |
| `--inset` | 14px | same | same | 74 |
| `--flat` | 18px | same, contact shadow only | same | 4 |

### Sensitivity, measured rather than assumed

| mutation of `.yc-card-surface` | pixels differing | max delta |
|---|---|---|
| none (no-op stylesheet) | 0 | 0 |
| `border-radius` 18 -> 17 | 255 | 18 |
| `border-radius` 18 -> 14 | 362 | 29 |
| shadow alpha `.05` -> `.049` | 105 | 1 |
| ground `247,243,236` -> `247,243,235` | 109,082 | 1 |

A one-unit ground change moves ~110k pixels; a no-op moves none. That is what makes 465 pairs at
exactly zero a statement rather than an absence.

## The `!important` removal, answered in a real browser on both arms

`.TableShell` used to mark all four surface properties `!important` so it would beat Tailwind's
layered utilities. It now declares none of them and the frame comes from the unlayered
`.yc-card-surface`. That is a **cascade** change, and neither a stylesheet-parsing test nor a pixel
diff can answer it — specificity and `@layer` order decide it at compute time. So it was measured:
`getComputedStyle` in Chromium, on both arms, against the same six competitor probes, on
`RoomTable/Default` and two `TableHead` stories in both themes (6 subjects).

**The computed frame is identical on every subject**: `18px`, `rgb(247,243,236)` / `rgb(47,39,30)`
ground, `1px solid rgb(229,220,207)` / `rgb(64,54,43)`, same two-stop shadow.

| competitor applied to the same element | before | after | subjects changed |
|---|---|---|---|
| inert sheet, class not applied | shell holds | shell holds | 0/6 |
| layered (`@layer utilities`) utility, normal | shell holds | shell holds | 0/6 |
| layered utility, `!important` | probe wins | probe wins | 0/6 |
| **unlayered author class, normal** | **shell holds** | **probe wins** | **6/6** |
| unlayered author class, `!important` | probe wins | probe wins | 0/6 |
| **inline `style`, normal** | **shell holds** | **probe wins** | **6/6** |
| inline `style`, `!important` (control) | probe wins | probe wins | 0/6 |

Two rows change, and they are the honest cost of dropping `!important`: a consumer's plain unlayered
class or a normal inline style now wins where it used to lose. Everything the class was carrying
`!important` *for* — beating layered Tailwind utilities — is unchanged, which is what
`.yc-glass-overlay` already relies on.

**Nothing in the tree exercises either row.** Every rule matching a rendered `.TableShell` that
declares any of `background`, `border`, `border-radius`, `box-shadow` was enumerated on both arms:

```
before   [base]        *, ::after, ::before, ::backdrop   border:0px solid   (Tailwind's reset)
         [(unlayered)] .TableShell                        all four, !important
after    [base]        *, ::after, ::before, ::backdrop   border:0px solid
         [(unlayered)] .yc-card-surface                   all four, no !important
control  2585 / 2526 / 2522 selector rules walked per subject, 5-7 matching the element
```

No third rule on either arm, and **no `.TableShell` element carries a `style` attribute at all**.
`.table-list`, the one other author class on a shell, declares only `display` inside a media query.

Pixel coverage for `.TableShell` specifically: `RoomTable`'s 10 stories x 2 themes are in the 466
above, and 3 of the 4 `TableHead` stories x 2 themes were captured separately — **6 more pairs, all
identical**, with a cross-theme control on the same arm at 100%.

### Not covered

`GenericTable`'s three stories time out before `#storybook-root` gains a child, in both themes and on
**both arms** — pre-existing, and the cause is in the story rather than the component: `tableUtils.ts:13`
does `itemNoun.charAt(0)` on an `itemNoun` those stories do not pass, so the story throws before mounting.
Identical console error on the base commit. `GenericTable.tsx` therefore has no pixel evidence, but it is
covered by the computed-frame table above through its sibling shells. `TableHead/Consistency` fails the
same way on both arms. 10 further stories mount no card at all (empty, loading and permission-denied).


