### PR TITLE
fix(ci): the colour baseline records the commit it describes

### DIFF
--- a/apps/frontend/src/app/ui/README.md
+++ b/apps/frontend/src/app/ui/README.md
@@ -63,6 +63,21 @@ Those live in the baseline's `justified` map, each with a written `why`. The
 list is not an exemption:
 
 - an entry with no usable reason fails the gate with exit 2, not a pass
-- a justified file is pinned in **both** directions, so a *new* literal cannot
+- a justified file is pinned in **both** directions, so a _new_ literal cannot
   hide behind a reason written for a different one
 - `--update` never moves a file into `justified`; a reason is written by a person
+
+### If the gate reports colours you did not write, read the last line first
+
+The baseline is a per-file count of a specific commit, recorded as `generated_at`.
+Run it on a branch cut before that commit and every literal the baseline's commit
+_removed_ appears as a literal your branch _added_ — real file, real line, real
+colour, wrong conclusion. On any failure the gate now says which case it is:
+
+```
+READ THIS BEFORE ACTING ON THE ABOVE. The baseline describes commit 1007378ea,
+which is NOT in this tree's history.
+```
+
+Merge `origin/dev` and re-run before believing the findings. If git cannot answer,
+it says that too rather than assuming the baseline is current.

--- a/scripts/ci/check-hardcoded-colours.mjs
+++ b/scripts/ci/check-hardcoded-colours.mjs
@@ -48,6 +48,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from '
 import { join, dirname, relative, resolve, isAbsolute, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
+import { spawnSync } from 'node:child_process';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -284,6 +285,50 @@ export const compare = (counts, baseline, justified = {}) => {
 };
 
 /**
+ * Where the baseline was generated, and whether this tree can contain it.
+ *
+ * WHY THIS EXISTS. The baseline is a per-file count of a specific tree. Point it
+ * at a tree that PREDATES it and every literal the baseline's commit removed
+ * reads as a literal this branch just added - real file, real line, real colour,
+ * and a completely invented finding. It happened within minutes of the gate
+ * landing on dev: a reviewer paired dev's new baseline with a branch cut before
+ * it and got `ShareEntityModal.tsx: 0 -> 1  rgba(29,28,27,0.44)`, which is a
+ * literal the baseline's own commit DELETED. One keystroke from telling another
+ * desk their PR introduced new colours.
+ *
+ * The gate cannot tell those apart from the counts alone - both are "the tree
+ * has more than the baseline says". So it stops inferring and prints the state.
+ *
+ * Three outcomes, and the third is the one that must not be silent: `current`,
+ * `stale` (the baseline's commit is not in this history), and `unknown` (git
+ * would not answer). An unknown that quietly behaved like `current` would be a
+ * fifth thing draining to fine.
+ */
+const git = (...args) => {
+  const run = spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+  if (run.error || run.status === null) return { ok: false, out: '' };
+  return { ok: run.status === 0, status: run.status, out: (run.stdout || '').trim() };
+};
+
+/* `run` is injectable so the three states can be tested without depending on
+   the shape of this repository's history - a test that needs a real
+   non-ancestor commit would pass or fail on which commits the CI clone happens
+   to have fetched, which is the test grading the checkout rather than the code. */
+export const baselineFreshness = (generatedAt, run = git) => {
+  if (!generatedAt) return { state: 'unknown', why: 'the baseline records no commit' };
+  const known = run('cat-file', '-e', `${generatedAt}^{commit}`);
+  if (!known.ok) {
+    return { state: 'unknown', why: `commit ${generatedAt.slice(0, 9)} is not in this clone` };
+  }
+  const head = run('rev-parse', 'HEAD');
+  if (!head.ok) return { state: 'unknown', why: 'git could not resolve HEAD' };
+  const contains = run('merge-base', '--is-ancestor', generatedAt, 'HEAD');
+  if (contains.ok) return { state: 'current', at: generatedAt };
+  if (contains.status === 1) return { state: 'stale', at: generatedAt, head: head.out };
+  return { state: 'unknown', why: 'git merge-base could not answer' };
+};
+
+/**
  * `{ files, justified }`.
  *
  * `files` is debt: literals that should become tokens, counted per file so the
@@ -315,7 +360,7 @@ const readBaseline = () => {
       throw new GateError(`justified entry for ${file} has no positive "n"`);
     }
   }
-  return { files: parsed.files ?? {}, justified };
+  return { files: parsed.files ?? {}, justified, generatedAt: parsed.generated_at ?? null };
 };
 
 /**
@@ -336,9 +381,23 @@ const writeBaseline = (counts, scanned, justified = {}) => {
       .map(([file, entry]) => [file, { n: counts[file] ?? 0, why: entry.why }])
   );
   const total = Object.values(files).reduce((n, c) => n + c, 0);
+  const head = git('rev-parse', 'HEAD');
   writeFileSync(
     BASELINE_PATH,
-    `${JSON.stringify({ generated_by: 'scripts/ci/check-hardcoded-colours.mjs --update', total, justified: carried, files }, null, 2)}\n`
+    `${JSON.stringify(
+      {
+        generated_by: 'scripts/ci/check-hardcoded-colours.mjs --update',
+        // The commit this count describes. Read back on every failing run so a
+        // branch that predates it is told so instead of being handed the
+        // baseline's own deletions as its additions.
+        generated_at: head.ok ? head.out : null,
+        total,
+        justified: carried,
+        files,
+      },
+      null,
+      2
+    )}\n`
   );
   return { total, fileCount: Object.keys(files).length, scanned };
 };
@@ -425,7 +484,7 @@ const main = () => {
     for (const f of findings) console.log(`${f.file}:${f.line}  ${f.text}`);
   }
 
-  const { files: baseline, justified } = readBaseline();
+  const { files: baseline, justified, generatedAt } = readBaseline();
 
   if (args.includes('--update')) {
     const { total, fileCount } = writeBaseline(counts, scanned, justified);
@@ -468,7 +527,30 @@ const main = () => {
       console.error(`  ${file}: ${was} -> ${now}\n      reason on record: ${why}`);
     }
   }
-  if (increased.length || decreased.length || vanished.length || drifted.length) return 1;
+  if (increased.length || decreased.length || vanished.length || drifted.length) {
+    /* Printed only on a failure, and only ever as context: a branch that is
+       merely behind is not itself an error, and turning it into one would red
+       every open PR the moment the baseline moves. What it must not do is stay
+       quiet, because "your tree has more than the baseline says" is the same
+       sentence for a new literal and for one the baseline's commit removed. */
+    const freshness = baselineFreshness(generatedAt);
+    if (freshness.state === 'stale') {
+      console.error(
+        `\nREAD THIS BEFORE ACTING ON THE ABOVE. The baseline describes commit ` +
+          `${freshness.at.slice(0, 9)}, which is NOT in this tree's history.\n` +
+          'Literals that commit REMOVED will appear above as literals this branch ADDED - ' +
+          'real file, real line, real colour, wrong conclusion.\n' +
+          'Merge origin/dev into this branch and re-run before believing any of it.'
+      );
+    } else if (freshness.state === 'unknown') {
+      console.error(
+        `\nCould not check whether the baseline is current: ${freshness.why}. ` +
+          'If this branch predates the baseline, the findings above may be its deletions ' +
+          'rather than your additions.'
+      );
+    }
+    return 1;
+  }
 
   const debt = Object.entries(counts)
     .filter(([file]) => !(file in justified))

--- a/scripts/ci/check-hardcoded-colours.mjs
+++ b/scripts/ci/check-hardcoded-colours.mjs
@@ -532,7 +532,18 @@ const main = () => {
        merely behind is not itself an error, and turning it into one would red
        every open PR the moment the baseline moves. What it must not do is stay
        quiet, because "your tree has more than the baseline says" is the same
-       sentence for a new literal and for one the baseline's commit removed. */
+       sentence for a new literal and for one the baseline's commit removed.
+
+       LOAD-BEARING DEPENDENCY, and it is not local to this branch: living under
+       the failure arm is sufficient ONLY because the ratchet fails in BOTH
+       directions. A stale baseline shifts counts either way - the branch is
+       missing literals the baseline's commit added as well as carrying ones it
+       removed - and today a decrease fails just as loudly as an increase, so
+       every stale tree reaches this line. Make the gate a ceiling that ignores
+       decreases and a stale baseline becomes a SILENT FALSE PASS, at which
+       point this note has to print on success too. `compare` reporting the loss
+       direction is what holds it up; the test named for this dependency reds if
+       that stops being true. */
     const freshness = baselineFreshness(generatedAt);
     if (freshness.state === 'stale') {
       console.error(

--- a/scripts/ci/check-hardcoded-colours.test.mjs
+++ b/scripts/ci/check-hardcoded-colours.test.mjs
@@ -342,3 +342,22 @@ test('the shipped baseline records the commit it describes', () => {
     'a baseline with no generated_at cannot be checked for staleness at all'
   );
 });
+
+test('the staleness note may live under the failure arm only while a LOSS also fails', () => {
+  // A correctness dependency between two parts of this file with nothing else
+  // connecting them, so it is asserted rather than left as a comment.
+  //
+  // A stale baseline moves counts in BOTH directions: the tree carries literals
+  // the baseline's commit removed, AND lacks literals it added. The note is
+  // printed only when the run fails, which reaches every stale tree only
+  // because a decrease fails as loudly as an increase. Turn this gate into a
+  // ceiling that ignores decreases and a stale baseline becomes a silent false
+  // pass - the note would then have to print on success too.
+  //
+  // If this test goes red, the placement of baselineFreshness() is wrong, not
+  // this assertion.
+  const staleGain = compare({ 'package.json': 1 }, { 'package.json': 0 });
+  const staleLoss = compare({ 'package.json': 0 }, { 'package.json': 1 });
+  assert.equal(staleGain.increased.length, 1, 'the gain direction must fail');
+  assert.equal(staleLoss.decreased.length, 1, 'the LOSS direction must fail too');
+});

--- a/scripts/ci/check-hardcoded-colours.test.mjs
+++ b/scripts/ci/check-hardcoded-colours.test.mjs
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import {
   BASELINE_PATH,
   SELFTEST_CASES,
+  baselineFreshness,
   compare,
   findColours,
   scan,
@@ -254,4 +255,90 @@ test('every reason in the shipped baseline is long enough to be a reason', () =>
     assert.ok(entry.why.trim().length >= 20, `${file}: "${entry.why}" is not a reason`);
     assert.ok(Number.isInteger(entry.n) && entry.n > 0, `${file}: n must be a positive integer`);
   }
+});
+
+/* ---------------------------------------------------------------------------
+   Baseline provenance.
+
+   The baseline is a per-file count OF A SPECIFIC TREE. Point it at a tree that
+   predates it and every literal that commit removed reads as a literal this
+   branch just added. It is not a hypothetical: within minutes of the gate
+   landing on dev, a reviewer paired dev's baseline with a branch cut before it
+   and got `ShareEntityModal.tsx: 0 -> 1  rgba(29,28,27,0.44)` - a literal the
+   baseline's own commit DELETED - and was one keystroke from telling another
+   desk their PR introduced new colours.
+
+   The counts cannot distinguish the two cases. So the gate stops inferring and
+   prints the state, and `unknown` is a first-class answer rather than a quiet
+   pass-through.
+   --------------------------------------------------------------------------- */
+
+/** A git runner whose answers are stated, so the state under test is the code. */
+const fakeGit =
+  (answers) =>
+  (...args) =>
+    answers[args.join(' ')] ?? { ok: false, status: 128, out: '' };
+
+const KNOWN = 'a'.repeat(40);
+
+test('a baseline with no recorded commit is unknown, not assumed current', () => {
+  assert.equal(baselineFreshness(null, fakeGit({})).state, 'unknown');
+  assert.equal(baselineFreshness(undefined, fakeGit({})).state, 'unknown');
+});
+
+test('a commit this clone does not have is unknown, and says so', () => {
+  const got = baselineFreshness(KNOWN, fakeGit({}));
+  assert.equal(got.state, 'unknown');
+  assert.match(got.why, /not in this clone/);
+});
+
+test('the baseline commit being an ancestor of HEAD is current', () => {
+  const got = baselineFreshness(
+    KNOWN,
+    fakeGit({
+      [`cat-file -e ${KNOWN}^{commit}`]: { ok: true, status: 0, out: '' },
+      'rev-parse HEAD': { ok: true, status: 0, out: 'b'.repeat(40) },
+      [`merge-base --is-ancestor ${KNOWN} HEAD`]: { ok: true, status: 0, out: '' },
+    })
+  );
+  assert.equal(got.state, 'current');
+});
+
+test('a baseline commit NOT in this history is stale - the case that invents findings', () => {
+  const got = baselineFreshness(
+    KNOWN,
+    fakeGit({
+      [`cat-file -e ${KNOWN}^{commit}`]: { ok: true, status: 0, out: '' },
+      'rev-parse HEAD': { ok: true, status: 0, out: 'b'.repeat(40) },
+      // rc=1 is git's "no", distinct from rc=128 "could not answer".
+      [`merge-base --is-ancestor ${KNOWN} HEAD`]: { ok: false, status: 1, out: '' },
+    })
+  );
+  assert.equal(got.state, 'stale');
+  assert.equal(got.at, KNOWN);
+});
+
+test('merge-base failing for any OTHER reason is unknown, not stale', () => {
+  // The load-bearing distinction. Collapsing rc>1 into "stale" would print a
+  // confident "your branch is behind" every time git itself could not answer,
+  // and collapsing it into "current" would restore the silence this exists to
+  // remove. Only rc=1 is an answer.
+  const got = baselineFreshness(
+    KNOWN,
+    fakeGit({
+      [`cat-file -e ${KNOWN}^{commit}`]: { ok: true, status: 0, out: '' },
+      'rev-parse HEAD': { ok: true, status: 0, out: 'b'.repeat(40) },
+      [`merge-base --is-ancestor ${KNOWN} HEAD`]: { ok: false, status: 128, out: '' },
+    })
+  );
+  assert.equal(got.state, 'unknown');
+});
+
+test('the shipped baseline records the commit it describes', () => {
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  assert.match(
+    baseline.generated_at ?? '',
+    /^[0-9a-f]{40}$/,
+    'a baseline with no generated_at cannot be checked for staleness at all'
+  );
 });

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,5 +1,6 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
+  "generated_at": "1007378eabe50dcafd4723705184761db209eff8",
   "total": 575,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {


### PR DESCRIPTION
Follow-up to #2826, found by a reviewer within minutes of it merging.

## The bug

The baseline is a per-file count **of a specific tree**. Point it at a tree that predates it and every literal that commit *removed* reads as a literal this branch *added*. The counts cannot tell the two apart — both are "the tree has more than the baseline says".

Not hypothetical. Reproduced here in a detached worktree at `69ea5e339` (the PR base before #2826) carrying dev's new gate and baseline, which is exactly the pairing a reviewer hit:

```
New hardcoded colours. Use a token from globals.css instead:
  .../AddAppointmentCentralModal/index.tsx: 0 -> 2    208: #d32f2f   987: #d32f2f
  .../ForgotPassword.stories.tsx:           0 -> 2    237: #e7f4ec   238: #2f9e63
  .../NetworkDirectoryModal.tsx:            0 -> 1     92: rgba(29,28,27,0.44)
  .../ShareEntityModal.tsx:                 0 -> 1    149: rgba(29,28,27,0.44)
rc=1
```

Every one of those is a literal **#2826 deleted**. A real gate, a real red, real file names and line numbers, and a completely invented finding — one keystroke from telling another desk their PR introduced new colours.

## The fix: stop inferring, print the state

`--update` records `generated_at`. Any **failing** run then reports which of three cases it is:

| state | meaning | printed |
|---|---|---|
| `current` | the baseline's commit is in this history | nothing extra |
| `stale` | it is not | "the findings above may be its deletions — merge origin/dev and re-run" |
| `unknown` | git would not answer | said out loud, never treated as current |

Only `merge-base --is-ancestor` **rc=1** means "no". rc>1 is "could not answer" and maps to `unknown` — collapsing it into `stale` prints a confident "you are behind" every time git fails, and collapsing it into `current` restores the silence this exists to remove.

**Context only, never a new failure.** A branch merely being behind is not an error, and making it one would red every open PR the moment the baseline moves.

On the stale tree above, the same run now ends:

```
READ THIS BEFORE ACTING ON THE ABOVE. The baseline describes commit 1007378ea,
which is NOT in this tree's history.
Literals that commit REMOVED will appear above as literals this branch ADDED -
real file, real line, real colour, wrong conclusion.
Merge origin/dev into this branch and re-run before believing any of it.
```

## Evidence

The git runner is injectable so all four states are tested without depending on which commits a CI clone happens to have fetched — otherwise the test grades the checkout rather than the code.

```
gate                 575 to migrate / 115 files, 15 justified / 5, 2044 scanned   rc=0
selftest             15 cases pass                                                rc=0
scanner tests        30 pass, 0 fail   (24 -> 30)
pnpm test:scripts    422 pass, 0 fail
```

Three mutations, each reds a named test:

```
collapse rc>1 into stale        -> "merge-base failing for any OTHER reason is unknown, not stale"
treat an unknown commit as current -> "a commit this clone does not have is unknown, and says so"
stop recording generated_at     -> "the shipped baseline records the commit it describes"
```

And the three live states, run end to end: a genuine new literal on an up-to-date tree prints **no** staleness note; the pre-#2826 tree prints the stale note; a `generated_at` this clone does not have prints the "could not check" note.

Counts are untouched — 575 across 115 files, 15 justified across 5, before and after. The only diff to the baseline JSON is the one new field.