### PR TITLE
refactor(frontend): complete textarea adoption

### DIFF
--- a/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/book/[slug]/BookClient.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Card from '@/app/ui/Card';
+import { Textarea } from '@/app/ui/Input';
 import {
   PublicBookingRequestError,
   getPublicPractice,
@@ -103,6 +104,23 @@ const PracticeHeader = ({ practice }: { practice: PublicPractice }) => (
 
 type SlotsResult = { key: string; windows: PublicSlot[]; error: string | null };
 
+type SlotButtonProps = {
+  selected: boolean;
+  startTime: string;
+  onSelect: (startTime: string) => void;
+};
+
+const SlotButton = ({ selected, startTime, onSelect }: SlotButtonProps) => (
+  <button
+    type="button"
+    aria-pressed={selected}
+    onClick={() => onSelect(startTime)}
+    className={PILL}
+  >
+    {startTime}
+  </button>
+);
+
 /**
  * The time picker and its four states.
  *
@@ -186,15 +204,12 @@ const SlotPicker = ({
             // The button's entire text is the bare startTime. No end time, no
             // duration, no aria-label: getByRole('button', { name: '09:00' })
             // is an exact match in both the tests and the story.
-            <button
+            <SlotButton
               key={slot.startTime}
-              type="button"
-              aria-pressed={selectedTime === slot.startTime}
-              onClick={() => onSelect(slot.startTime)}
-              className={PILL}
-            >
-              {slot.startTime}
-            </button>
+              startTime={slot.startTime}
+              selected={selectedTime === slot.startTime}
+              onSelect={onSelect}
+            />
           ))}
         </div>
       </fieldset>
@@ -738,7 +753,7 @@ const DetailsFieldset = ({
         <label htmlFor="book-concern" className={FIELD_LABEL}>
           What is the visit for? (optional)
         </label>
-        <textarea
+        <Textarea
           id="book-concern"
           className={FIELD}
           rows={4}

--- a/apps/frontend/src/app/__tests__/components/Input.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Input.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import Input from '@/app/ui/Input';
+import Input, { Textarea } from '@/app/ui/Input';
 
 describe('Input', () => {
   test('forwards native input attributes and changes', () => {
@@ -30,5 +30,17 @@ describe('Input', () => {
     expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input).toBeDisabled();
     expect(input).toHaveClass('border-[var(--danger)]');
+  });
+
+  test('renders a multiline control without requiring placeholder copy', () => {
+    const handleChange = jest.fn();
+    render(<Textarea aria-label="Notes" onChange={handleChange} />);
+
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+    fireEvent.change(textarea, { target: { value: 'Follow-up needed' } });
+
+    expect(handleChange).toHaveBeenCalled();
+    expect(textarea).not.toHaveAttribute('placeholder');
+    expect(textarea).toHaveClass('min-h-22', 'rounded-xl', 'bg-[var(--field-bg)]');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
@@ -1429,9 +1429,10 @@ describe('<InvoiceStep /> component', () => {
       openSpy.mockRestore();
     });
 
-    it('falls back to a print window and escapes invoice HTML', async () => {
+    it('builds the fallback print document with text-only invoice values', async () => {
+      const printableDocument = document.implementation.createHTMLDocument();
       const printWindow = {
-        document: { head: { innerHTML: '' }, body: { innerHTML: '' } },
+        document: printableDocument,
         focus: jest.fn(),
         print: jest.fn(),
       };
@@ -1447,9 +1448,8 @@ describe('<InvoiceStep /> component', () => {
       );
 
       expect(printWindow.print).toHaveBeenCalled();
-      expect(printWindow.document.body.innerHTML).toContain(
-        'Rabies &lt;vaccine&gt; &amp; &quot;shot&quot;'
-      );
+      expect(printableDocument.body.textContent).toContain('Rabies <vaccine> & "shot"');
+      expect(printableDocument.body.querySelector('vaccine')).toBeNull();
       openSpy.mockRestore();
     });
 
@@ -1460,8 +1460,9 @@ describe('<InvoiceStep /> component', () => {
     // pins the preferred timezone (Europe/Berlin by default, hence 01:00 AM for
     // a midnight-UTC invoice).
     it('prints the same date string the invoice row shows', async () => {
+      const printableDocument = document.implementation.createHTMLDocument();
       const printWindow = {
-        document: { head: { innerHTML: '' }, body: { innerHTML: '' } },
+        document: printableDocument,
         focus: jest.fn(),
         print: jest.fn(),
       };
@@ -1474,7 +1475,7 @@ describe('<InvoiceStep /> component', () => {
         await screen.findByRole('button', { name: 'Download invoice inv-doc' })
       );
 
-      expect(printWindow.document.body.innerHTML).toContain('Date: Jan 1, 2026, 01:00 AM');
+      expect(printableDocument.body.textContent).toContain('Date: Jan 1, 2026, 01:00 AM');
       openSpy.mockRestore();
     });
 

--- a/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CheckInBoard/CheckInBoard.tsx
@@ -10,6 +10,7 @@ import {
 import { CompanionSelect } from '@/app/features/appointments/components/CompanionSelect';
 import { IoPulseOutline, IoAddOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import { Textarea } from '@/app/ui/Input';
 import type {
   PatientCheckIn,
   CheckInStatus,
@@ -413,7 +414,7 @@ const CheckInNotesFields = ({ form }: { form: AddCheckInFormState }) => (
     </label>
     <label className="flex flex-col gap-1" htmlFor="checkin-notes">
       <span className={fieldLabelClass}>Notes</span>
-      <textarea
+      <Textarea
         id="checkin-notes"
         className={clsx(inputClass, 'min-h-16 resize-y')}
         value={form.notes}

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/Waitlist.tsx
@@ -10,6 +10,7 @@ import {
 import { CompanionSelect } from '@/app/features/appointments/components/CompanionSelect';
 import { IoListOutline, IoAddOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import { Textarea } from '@/app/ui/Input';
 import type {
   WaitlistEntry,
   WaitlistStatus,
@@ -278,7 +279,7 @@ const AddWaitlistForm = ({
 
       <label className="flex flex-col gap-1">
         <span className={fieldLabelClass}>Reason / notes</span>
-        <textarea
+        <Textarea
           className={clsx(inputClass, 'min-h-16 resize-y')}
           value={notes}
           onChange={(e) => setNotes(e.target.value)}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -50,6 +50,7 @@ import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
 import Datepicker from '@/app/ui/inputs/Datepicker';
 import Timepicker from '@/app/ui/inputs/Timepicker';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import QuickActionsModal from '@/app/features/appointments/pages/AppointmentWorkspace/sidemodal/QuickActionsModal';
 import WorkspaceActionRail from '@/app/features/appointments/pages/AppointmentWorkspace/components/WorkspaceActionRail';
 import PhoneWorkspaceShell from '@/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell';
@@ -336,7 +337,7 @@ export const DischargeDateTimeModal = ({
             </p>
             <label className="flex flex-col gap-1 text-caption-2 text-text-secondary">
               {'Override reason (required)'}
-              <textarea
+              <Textarea
                 value={overrideReason}
                 onChange={(event) => setOverrideReason(event.target.value)}
                 rows={2}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
@@ -8,6 +8,7 @@ import {
   IoTrendingUpOutline,
 } from 'react-icons/io5';
 import Search from '@/app/ui/inputs/Search';
+import { Textarea } from '@/app/ui/Input';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
 import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
@@ -714,7 +715,7 @@ const VitalsForm = ({
       </div>
       <label className="flex flex-col gap-1">
         <span className="text-[12px] font-medium text-neutral-700">Notes (optional)</span>
-        <textarea
+        <Textarea
           value={notes}
           onChange={(e) => dispatchFormState({ type: 'SET_NOTES', value: e.target.value })}
           aria-label="Vitals notes"

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -10,6 +10,7 @@ import {
   IoShareOutline,
 } from 'react-icons/io5';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
 import TotalBillContainer from '@/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer';
 import PackageBreakdownTooltip from '@/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip';
@@ -286,12 +287,62 @@ const openDocumentUrl = (url: string): void => {
 const formatCents = (cents: number, currency: string = DEFAULT_CURRENCY): string =>
   formatMoney(cents / 100, currency);
 
-const escapeHtml = (value: string): string =>
-  value.replace(
-    /[&<>"']/g,
-    (char) =>
-      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char] ?? char
+const createInvoiceCell = (
+  document: Document,
+  tagName: 'td' | 'th',
+  text: string,
+  alignRight = false
+) => {
+  const cell = document.createElement(tagName);
+  cell.textContent = text;
+  if (alignRight) cell.style.textAlign = 'right';
+  return cell;
+};
+
+const buildPrintableInvoice = (document: Document, invoice: PastInvoice, currency: string) => {
+  document.title = `Invoice ${invoice.id}`;
+
+  const style = document.createElement('style');
+  style.textContent =
+    'body{font-family:Arial,Helvetica,sans-serif;padding:32px;color:#1a1a1a}' +
+    'h1{font-size:18px}table{width:100%;border-collapse:collapse;margin-top:16px}' +
+    'td,th{padding:8px 0;border-bottom:1px solid #e5e5e5;font-size:13px}' +
+    'tfoot td{font-weight:bold;border-bottom:none}';
+  document.head.replaceChildren(style);
+
+  const heading = document.createElement('h1');
+  heading.textContent = `Invoice ${invoice.id}`;
+  const date = document.createElement('div');
+  date.textContent = `Date: ${formatDateTimeLocal(invoice.createdAt)}`;
+  const table = document.createElement('table');
+  const header = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  headerRow.append(
+    createInvoiceCell(document, 'th', 'Item'),
+    createInvoiceCell(document, 'th', 'Amount', true)
   );
+  header.append(headerRow);
+
+  const body = document.createElement('tbody');
+  for (const item of invoice.items) {
+    const row = document.createElement('tr');
+    row.append(
+      createInvoiceCell(document, 'td', item.name),
+      createInvoiceCell(document, 'td', formatCents(item.amountCents, currency), true)
+    );
+    body.append(row);
+  }
+
+  const footer = document.createElement('tfoot');
+  const footerRow = document.createElement('tr');
+  footerRow.append(
+    createInvoiceCell(document, 'td', 'Total'),
+    createInvoiceCell(document, 'td', formatCents(invoice.totalCents, currency), true)
+  );
+  footer.append(footerRow);
+  table.append(header, body, footer);
+  document.body.replaceChildren(heading, date, table);
+};
 
 // Render an invoice as a standalone printable document and open the browser print
 // dialog (print-to-PDF). There is no backend invoice-PDF endpoint, so this is the
@@ -302,33 +353,7 @@ const printInvoice = (invoice: PastInvoice, currency: string): boolean => {
   // Popup blocked (or otherwise unavailable) — report failure so the caller can
   // surface it instead of the download silently doing nothing.
   if (!printWindow) return false;
-  const rows = invoice.items
-    .map(
-      (item) =>
-        `<tr><td>${escapeHtml(item.name)}</td><td style="text-align:right">${escapeHtml(
-          formatCents(item.amountCents, currency)
-        )}</td></tr>`
-    )
-    .join('');
-  // document.write is deprecated; populate the popup's head/body directly instead.
-  printWindow.document.head.innerHTML =
-    `<title>Invoice ${escapeHtml(invoice.id)}</title>` +
-    `<style>body{font-family:Arial,Helvetica,sans-serif;padding:32px;color:#1a1a1a}` +
-    `h1{font-size:18px}table{width:100%;border-collapse:collapse;margin-top:16px}` +
-    `td,th{padding:8px 0;border-bottom:1px solid #e5e5e5;font-size:13px}` +
-    `tfoot td{font-weight:bold;border-bottom:none}</style>`;
-  printWindow.document.body.innerHTML =
-    `<h1>Invoice ${escapeHtml(invoice.id)}</h1>` +
-    // The printed date has to read the same as the invoice row it was printed
-    // from. This was `new Date(...).toLocaleString()` - the device locale and
-    // zone, numeric and with seconds ("9/3/2026, 10:05:00 PM", or "03/09/2026"
-    // day-first on an en-GB machine) - against "Sep 3, 2026, 10:05 PM" on screen.
-    `<div>Date: ${escapeHtml(formatDateTimeLocal(invoice.createdAt))}</div>` +
-    `<table><thead><tr><th style="text-align:left">Item</th><th style="text-align:right">Amount</th></tr></thead>` +
-    `<tbody>${rows}</tbody>` +
-    `<tfoot><tr><td>Total</td><td style="text-align:right">${escapeHtml(
-      formatCents(invoice.totalCents, currency)
-    )}</td></tr></tfoot></table>`;
+  buildPrintableInvoice(printWindow.document, invoice, currency);
   printWindow.focus();
   printWindow.print();
   return true;
@@ -902,7 +927,7 @@ export const DepositModal = ({
         </label>
         <label className="flex flex-col gap-1 text-body-4 text-text-primary">
           <span>Notes</span>
-          <textarea
+          <Textarea
             value={notes}
             onChange={(event) => setNotes(event.target.value)}
             className="min-h-20 rounded-2xl border border-input-border-default px-4 py-3 focus-visible:border-input-border-active focus-visible:outline-none"

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
@@ -17,6 +17,7 @@ import {
   titleClass,
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import type {
   AllergySeverity,
   AllergyStatus,
@@ -272,7 +273,7 @@ const CreateAllergyForm = ({
         <label className={fieldLabelClass} htmlFor="allergy-notes">
           Notes
         </label>
-        <textarea
+        <Textarea
           id="allergy-notes"
           className={clsx(controlClass, 'min-h-16 resize-y')}
           value={values.notes}

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -147,7 +147,7 @@ const ConsentRow = ({
 }: {
   consent: PatientConsent;
   canEdit: boolean;
-  onRevoke?: ConsentListProps['onRevoke'];
+  onRevoke: ConsentListProps['onRevoke'];
   revoking: boolean;
   revokeDisabled: boolean;
 }) => {
@@ -368,7 +368,7 @@ const ConsentListBody = ({
   error: string | null;
   consents: PatientConsent[];
   canEdit: boolean;
-  onRevoke?: ConsentListProps['onRevoke'];
+  onRevoke: ConsentListProps['onRevoke'];
   revokingId: string | null;
 }) => {
   if (loading) return <ClinicalListLoadingRows />;

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -17,6 +17,7 @@ import {
   titleClass,
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import type {
   ConsentStatus,
   ConsentType,
@@ -116,7 +117,7 @@ const RevokeConsentForm = ({
         <label className={fieldLabelClass} htmlFor={reasonId}>
           Reason for revoking
         </label>
-        <textarea
+        <Textarea
           id={reasonId}
           className={clsx(controlClass, 'min-h-14 resize-y')}
           value={reason}
@@ -338,7 +339,7 @@ const GrantConsentForm = ({
         <label className={fieldLabelClass} htmlFor="consent-notes">
           Notes
         </label>
-        <textarea
+        <Textarea
           id="consent-notes"
           className={clsx(controlClass, 'min-h-16 resize-y')}
           value={values.notes}

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { IoAddOutline, IoCheckmarkOutline, IoFlagOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import type {
   FlagSeverity,
   PatientFlag,
@@ -240,7 +241,7 @@ const CreateFlagForm = ({ creating, onCreate, onCancel }: CreateFlagFormProps) =
         <label className={fieldLabelClass} htmlFor="patient-flag-description">
           Description
         </label>
-        <textarea
+        <Textarea
           id="patient-flag-description"
           className={clsx(controlClass, 'min-h-16 resize-y')}
           value={values.description}

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -17,6 +17,7 @@ import {
   titleClass,
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import type {
   PatientProblem,
   ProblemSeverity,
@@ -171,7 +172,7 @@ const CreateProblemForm = ({
       </label>
       <label className="flex flex-col gap-1">
         <span className={fieldLabelClass}>Description</span>
-        <textarea
+        <Textarea
           className={clsx(controlClass, 'min-h-16 resize-y')}
           value={values.notes}
           onChange={(e) => setValues((v) => ({ ...v, notes: e.target.value }))}

--- a/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
+++ b/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
+import { Textarea } from '@/app/ui/Input';
 import { formatDateTimeLocal } from '@/app/lib/date';
 import {
   DEA_SCHEDULES,
@@ -611,7 +612,7 @@ const AddEntryForm = ({ creating, createError, onSubmit, onCancel }: AddEntryFor
           Notes (optional)
         </label>
         <span className={fieldClass}>
-          <textarea
+          <Textarea
             id="cs-notes"
             rows={2}
             value={notes}

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import { Secondary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import { formatMoneyPrecise } from '@/app/lib/money';
 import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/EstimateLineRow';
 import {
@@ -130,7 +131,7 @@ export const EstimateNotesField = ({
       Notes (optional)
     </label>
     <span className={fieldClass}>
-      <textarea
+      <Textarea
         id="estimate-notes"
         value={notes}
         rows={2}

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
@@ -5,6 +5,7 @@ import { formatMoneyPrecise } from '@/app/lib/money';
 import { formatDisplayDate } from '@/app/lib/date';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import { Textarea } from '@/app/ui/Input';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import {
   fieldClass,
@@ -198,7 +199,7 @@ const StatusChangeForm = ({
             Rejection reason (optional)
           </label>
           <span className={fieldClass}>
-            <textarea
+            <Textarea
               id="claim-rejection-reason"
               rows={2}
               value={reason}

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import { currencySymbol } from '@/app/lib/money';
+import { Textarea } from '@/app/ui/Input';
 import {
   fieldClass,
   inputClass,
@@ -133,7 +134,7 @@ const InsuranceClaimFormFields = ({
         Notes (optional)
       </label>
       <span className={fieldClass}>
-        <textarea
+        <Textarea
           id="claim-notes"
           rows={2}
           value={draft.notes}

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/app/features/marketing/site';
 import { postData } from '@/app/services/axios';
 import { makeOptions } from '@/app/lib/options';
+import { Textarea } from '@/app/ui/Input';
 
 const NEWSREADER = 'var(--font-newsreader)';
 const EASE = 'cubic-bezier(0.16,1,0.3,1)';
@@ -446,7 +447,7 @@ function TextAreaField({
         {label}
         {required ? requiredMark : null}
       </label>
-      <textarea
+      <Textarea
         id={fieldId}
         className="yc-field"
         style={style}

--- a/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.tsx
@@ -1,4 +1,5 @@
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+import { Textarea } from '@/app/ui/Input';
 
 type NameDescriptionFieldsProps = {
   name: string;
@@ -38,7 +39,7 @@ const NameDescriptionFields = ({
       >
         Description
       </label>
-      <textarea
+      <Textarea
         id={descId}
         aria-label="Description"
         value={description}

--- a/apps/frontend/src/app/features/petPassport/components/attestation/AttestationRevokePanel.tsx
+++ b/apps/frontend/src/app/features/petPassport/components/attestation/AttestationRevokePanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useId } from 'react';
+import { Textarea } from '@/app/ui/Input';
 
 type AttestationRevokePanelProps = {
   reason: string;
@@ -33,7 +34,7 @@ const AttestationRevokePanel = ({
         <label htmlFor={reasonId} className="text-[12.5px] font-semibold text-[var(--ink-soft)]">
           Reason (optional, stored with the record)
         </label>
-        <textarea
+        <Textarea
           id={reasonId}
           value={reason}
           disabled={disabled}

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNotify } from '@/app/hooks/useNotify';
 import { Primary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import type {
   APActorSettings,
@@ -674,7 +675,7 @@ const ReferralFormFields = ({
       <label htmlFor="referral-clinical-context" className={FIELD_LABEL_CLS}>
         Clinical context
       </label>
-      <textarea
+      <Textarea
         id="referral-clinical-context"
         className={`${REFERRAL_INPUT_CLS} resize-none`}
         rows={3}
@@ -751,7 +752,7 @@ const EmergencyCard = () => {
       <div className={TEXT_MUTED}>
         Announces an emergency to all approved followers across the federation network.
       </div>
-      <textarea
+      <Textarea
         className="w-full text-body-4 border border-card-border rounded-lg px-3 py-2 bg-transparent text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary resize-none"
         rows={3}
         placeholder="Describe the emergency or critical notice..."

--- a/apps/frontend/src/app/ui/Input.tsx
+++ b/apps/frontend/src/app/ui/Input.tsx
@@ -9,8 +9,7 @@ export type InputProps = {
 
 export type TextareaProps = {
   error?: boolean;
-  placeholder: string;
-} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'placeholder'>;
+} & TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Input = forwardRef<HTMLInputElement, InputProps>(({ className, error, ...props }, ref) => (
   <input


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Eighteen production files bypass the canonical form-field contract by rendering native textareas directly. The shared `Textarea` also requires a placeholder even though native textareas do not.

## What is the new behavior?

- Routes every production textarea through the canonical `Textarea` primitive.
- Preserves existing labels, values, handlers, disabled states, and sizing overrides.
- Makes the shared placeholder prop optional to match native textarea behavior.
- Replaces the touched invoice print fallback's HTML-string construction with DOM nodes and `textContent`.
- Adds regression coverage for the shared textarea contract and safe invoice print output.

Validation at `d21932ca8`:
- Full frontend suite: 1,049 suites and 13,241 tests pass.
- Affected-surface suite: 24 suites and 564 tests pass.
- Focused changed-file coverage: 100% statements and lines, 94.54% branches, 95.83% functions.
- Production build, TypeScript, pre-commit, and full pre-push lint/type-check hooks pass.
- Aikido: 21 changed TypeScript files, zero findings.
- React Doctor: 92/100, no issues.
- Desktop and phone Storybook checks pass in light and dark themes.
- Both new regression tests were mutation-checked.

## Related Issue(s)

Fixes #2829
