### PR TITLE
fix(frontend): announce current route after navigation

### DIFF
--- a/apps/frontend/src/app/__tests__/ui/layout/RouteAnnouncer.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/RouteAnnouncer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -28,6 +29,12 @@ describe('RouteAnnouncer', () => {
     expect(screen.getByText('Pricing loaded')).toBeInTheDocument();
   });
 
+  it('renders an empty live region on the server', () => {
+    expect(renderToString(<RouteAnnouncer />)).toBe(
+      '<div class="sr-only" aria-live="polite" aria-atomic="true"></div>'
+    );
+  });
+
   it('announces "Page updated" when document title is empty', () => {
     document.title = '';
     render(<RouteAnnouncer />);
@@ -35,17 +42,26 @@ describe('RouteAnnouncer', () => {
     expect(screen.getByText('Page updated')).toBeInTheDocument();
   });
 
-  it('re-announces on pathname change', () => {
-    const { rerender } = render(<RouteAnnouncer />);
+  it('announces the new title when metadata updates after client navigation', async () => {
+    const { rerender, unmount } = render(<RouteAnnouncer />);
     expect(screen.getByText('Pricing loaded')).toBeInTheDocument();
 
     act(() => {
-      document.title = 'Dashboard';
       mockUsePathname.mockReturnValue('/appointments');
     });
-
     rerender(<RouteAnnouncer />);
-    expect(screen.getByText('Dashboard loaded')).toBeInTheDocument();
+
+    act(() => {
+      document.title = 'Dashboard';
+    });
+
+    expect(await screen.findByText('Dashboard loaded')).toBeInTheDocument();
+
+    unmount();
+    act(() => {
+      document.title = 'Appointments';
+    });
+    expect(screen.queryByText('Appointments loaded')).not.toBeInTheDocument();
   });
 
   it('live region is aria-live="polite" and aria-atomic="true"', () => {

--- a/apps/frontend/src/app/ui/layout/RouteAnnouncer.tsx
+++ b/apps/frontend/src/app/ui/layout/RouteAnnouncer.tsx
@@ -8,7 +8,11 @@ const getAnnouncementText = () => {
   return title ? `${title} loaded` : 'Page updated';
 };
 
-const subscribeToRouteAnnouncement = () => () => undefined;
+const subscribeToRouteAnnouncement = (onStoreChange: () => void) => {
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.head, { childList: true, subtree: true, characterData: true });
+  return () => observer.disconnect();
+};
 
 const getServerAnnouncementSnapshot = () => '';
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The screen-reader route announcement can retain the previous page title after client navigation because it reads `document.title` before Next.js metadata updates it.

## What is the new behavior?

The route announcer observes title mutations in `document.head` and refreshes the polite live region when metadata settles. The regression test covers client navigation followed by a delayed title update, server rendering, and cleanup on unmount.

Validation:

- Targeted RouteAnnouncer Jest suite: 6 tests passed with 100% statements, branches, functions, and lines for the component.
- Mutation check: restoring the previous no-op subscription fails the delayed-title regression test.
- Frontend TypeScript: passed.
- Frontend lint: passed with one pre-existing warning in `useLazyAuthStore.ts`.
- Production build: passed.
- React Doctor changed-file scan: 100/100 with no findings.
- Aikido scan of both changed files: no issues.
- Local production browser navigation from `/pricing` to `/about`: live region updated to `About · Yosemite Crew loaded` with zero console errors.

## Related Issue(s)

Fixes #2744
