### PR TITLE
fix(frontend): give the All filter option its own colour tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/constants/status.test.ts
+++ b/apps/frontend/src/app/__tests__/constants/status.test.ts
@@ -1,4 +1,5 @@
 import {
+  AllFilterOption,
   AppointmentLabels,
   TaskLabels,
   getAppointmentStatusTone,
@@ -17,13 +18,18 @@ describe('statusLabel', () => {
     });
   });
 
-  it('honours a border override', () => {
-    expect(statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)')).toEqual({
+  /* This slot used to assert `statusLabel('All', 'ALL', 'color-badge-blue',
+     'var(--color-primary-500)')`, which put the 3.61:1 badge-blue pair in the
+     expected value. A reader checking whether that pairing was intended found a
+     green test saying yes (#2814). The option now has its own prefix, and no
+     entry mixes tokens from two of them. */
+  it('gives the neutral All option its own prefix, with no borrowed tokens', () => {
+    expect(AllFilterOption).toEqual({
       name: 'All',
       key: 'ALL',
-      bg: 'var(--color-badge-blue-bg)',
-      text: 'var(--color-badge-blue-text)',
-      border: 'var(--color-primary-500)',
+      bg: 'var(--color-pill-all-bg)',
+      text: 'var(--color-pill-all-text)',
+      border: 'var(--color-pill-all-border)',
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
@@ -2,6 +2,7 @@ import { getMerckSubtopicPillStyle } from '@/app/features/integrations/constants
 import { getStatusBadgeStyle } from '@/app/features/inventory/pages/Inventory/utils';
 import { measureContrast } from '@/app/features/appointments/components/Calendar/responsive/contrastProbe';
 import { getOrganizationStatusStyle } from '@/app/ui/tables/tableUtils';
+import { AllFilterOption } from '@/app/constants/status';
 import { resolve, resolveColour } from '@/app/__tests__/support/globalsTokens';
 
 /**
@@ -114,6 +115,43 @@ describe.each(['light', 'dark'] as const)('inline status pill contrast (%s)', (t
     // None of these is large text, so the bar must be the strict one.
     expect(reading.required).toBe(4.5);
     expect(reading.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+/**
+ * The same defect one step earlier: colours that are not painted today but are
+ * one deleted `key === 'ALL'` guard away from it.
+ *
+ * `StatusOptionButtons`' non-ALL branch renders `option.bg` under `option.text`.
+ * The All row used to carry the badge-blue pair there and was kept off screen
+ * only because each of its four consumers substituted something else at the
+ * point of use (#2814). These two arms assert the data is safe to render, not
+ * that the consumers happen not to render it.
+ */
+describe('the neutral All filter option', () => {
+  it.each(['light', 'dark'] as const)('has no fill to write on (%s)', (theme) => {
+    /* Not `expect(...).not.toBe('#007cf5')`: any prefix whose `-bg` is a colour
+       reintroduces the pairing, so the assertion is the absence of a fill.
+       Pointing `AllFilterOption` at any filled prefix fails here. */
+    expect(resolve(AllFilterOption.bg, theme === 'dark')).toBe('transparent');
+  });
+
+  it.each(['light', 'dark'] as const)('reads on the panel it sits on (%s)', (theme) => {
+    const dark = theme === 'dark';
+    const el = mount(
+      resolveToken(AllFilterOption.text, dark),
+      resolveToken(`var(${dark ? SURFACE.dark : SURFACE.light})`, dark),
+      resolveToken(`var(${dark ? SURFACE.dark : SURFACE.light})`, dark),
+      '13px',
+      '400'
+    );
+    const reading = measureContrast(el);
+    expect(reading.required).toBe(4.5);
+    expect(reading.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 });
 

--- a/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/contrast/statusPillContrast.test.ts
@@ -122,11 +122,17 @@ describe.each(['light', 'dark'] as const)('inline status pill contrast (%s)', (t
  * The same defect one step earlier: colours that are not painted today but are
  * one deleted `key === 'ALL'` guard away from it.
  *
- * `StatusOptionButtons`' non-ALL branch renders `option.bg` under `option.text`.
- * The All row used to carry the badge-blue pair there and was kept off screen
- * only because each of its four consumers substituted something else at the
- * point of use (#2814). These two arms assert the data is safe to render, not
- * that the consumers happen not to render it.
+ * The site that pairs an option's fill under its ink is the trigger chip -
+ * `getStockHealthButtonStyle` and `getTurnoverStatusButtonStyle`, whose non-ALL
+ * branch returns `{ backgroundColor: option.bg, color: option.text }`. Their
+ * `key === 'ALL'` branch is the guard; delete it and the All option is rendered
+ * the ordinary way. (`StatusOptionButtons` is not that site and never was: its
+ * option type is `{ key, name, border? }`, so it cannot read `bg` at all.)
+ *
+ * The All row used to carry the badge-blue pair in that data and was kept off
+ * screen only because each of its four consumers substituted something else at
+ * the point of use (#2814). These two arms assert the data is safe to render,
+ * not that the consumers happen not to render it.
  */
 describe('the neutral All filter option', () => {
   it.each(['light', 'dark'] as const)('has no fill to write on (%s)', (theme) => {

--- a/apps/frontend/src/app/constants/status.ts
+++ b/apps/frontend/src/app/constants/status.ts
@@ -99,21 +99,29 @@ export const getAppointmentStatusTone = (status?: string | null): StatusTone => 
 
 /**
  * Builds a StatusLabel whose colour tokens all derive from one CSS variable
- * prefix (`--<prefix>-bg` / `--<prefix>-text` / `--<prefix>-border`). Entries
- * whose border token comes from elsewhere pass it as `borderOverride`.
+ * prefix (`--<prefix>-bg` / `--<prefix>-text` / `--<prefix>-border`).
+ *
+ * There is deliberately no per-token override. The one entry that used it - the
+ * "All" filter option - borrowed a prefix whose `bg`/`text` it never meant to
+ * use and replaced the odd one out at each point of use, which is how a 3.61:1
+ * pair stayed in the data with nothing rendering it (#2814). An entry that
+ * needs different colours gets its own prefix.
  */
-export const statusLabel = (
-  name: string,
-  key: string,
-  cssPrefix: string,
-  borderOverride?: string
-): StatusLabel => ({
+export const statusLabel = (name: string, key: string, cssPrefix: string): StatusLabel => ({
   name,
   key,
   bg: `var(--${cssPrefix}-bg)`,
   text: `var(--${cssPrefix}-text)`,
-  border: borderOverride ?? `var(--${cssPrefix}-border)`,
+  border: `var(--${cssPrefix}-border)`,
 });
+
+/**
+ * The neutral "All" row shared by the status-filter dropdown panels.
+ *
+ * One construction site rather than three copies of the same literal, so the
+ * contrast guard measures the object the panels actually render.
+ */
+export const AllFilterOption: StatusLabel = statusLabel('All', 'ALL', 'color-pill-all');
 
 export const AppointmentLabels: StatusLabel[] = [
   statusLabel('Requested', 'requested', 'status-requested'),

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -478,10 +478,21 @@ input[type='radio']:focus-visible {
      identically in both themes. No ink in this palette clears 4.5 on that fill -
      white is 4.04 and --ink is 4.21 - so the fill has to change, not the ink.
      `0e5e9de36` and #2799 moved the badges that paired them to --inset/--ink.
-     The fill alone remains in use for chart series and filter definitions, where
-     nothing is written on top of it. */
+     #2814 took the last non-painting user - the "All" filter option - to
+     --color-pill-all-*, so the fill's only remaining use is the chart series in
+     CommunityStats, where nothing is written on top of it. */
   --color-badge-blue-bg: var(--color-primary-500);
   --color-badge-blue-text: #eaf3ff;
+  /* The neutral "All" row in the status-filter dropdowns. It borrowed
+     badge-blue's prefix and stayed legible only because each consumer replaced
+     `text` at the point of use; one deleted `key === 'ALL'` guard away from
+     painting 3.61:1 (#2814). `bg` is `transparent` because the option is never
+     filled - the row is a dot and a label on the panel - so there is no pairing
+     left to fail. The dot keeps --color-primary-500, which is what the border
+     override used to supply. */
+  --color-pill-all-bg: transparent;
+  --color-pill-all-text: var(--color-text-primary);
+  --color-pill-all-border: var(--color-primary-500);
   --color-pill-neutral-bg: var(--status-requested-bg);
   --color-pill-neutral-text: var(--status-requested-text);
   --color-pill-neutral-border: var(--status-requested-border);

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
@@ -4,13 +4,13 @@ import { createPortal } from 'react-dom';
 import { IoCaretDown } from 'react-icons/io5';
 import clsx from 'clsx';
 import { InventoryFiltersState } from '@/app/features/inventory/pages/Inventory/types';
-import { statusLabel, type StatusLabel } from '@/app/constants/status';
+import { AllFilterOption, statusLabel, type StatusLabel } from '@/app/constants/status';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
 import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
 const StockHealthOptions: StatusLabel[] = [
-  statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)'),
+  AllFilterOption,
   statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
   statusLabel('Low stock', 'LOW_STOCK', 'color-pill-progress'),
   statusLabel('Expiring soon', 'EXPIRING_SOON', 'color-pill-info'),
@@ -29,8 +29,9 @@ const getVisibilityLabel = (key: 'ALL' | 'ACTIVE' | 'HIDDEN'): string => {
   return 'Hidden';
 };
 
-const getStockHealthDropdownTextColor = (option: StatusLabel): string =>
-  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+/* Every option now carries ink it is safe to render, ALL included, so this is
+   the identity the shared component needs rather than a guard (#2814). */
+const getStockHealthDropdownTextColor = (option: StatusLabel): string => option.text;
 
 const getStockHealthButtonStyle = (option: StatusLabel): React.CSSProperties => {
   if (option.key === 'ALL') {

--- a/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
@@ -3,13 +3,13 @@ import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from '
 import { createPortal } from 'react-dom';
 import { IoCaretDown } from 'react-icons/io5';
 import clsx from 'clsx';
-import { statusLabel, type StatusLabel } from '@/app/constants/status';
+import { AllFilterOption, statusLabel, type StatusLabel } from '@/app/constants/status';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
 import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
 const STATUS_OPTIONS: StatusLabel[] = [
-  statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)'),
+  AllFilterOption,
   statusLabel('Excellent', 'EXCELLENT', 'color-pill-success'),
   statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
   statusLabel('Moderate', 'MODERATE', 'color-pill-progress'),
@@ -19,8 +19,9 @@ const STATUS_OPTIONS: StatusLabel[] = [
 
 const DEFAULT_CATEGORIES: string[] = [];
 
-const getTurnoverDropdownTextColor = (option: StatusLabel): string =>
-  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+/* Every option now carries ink it is safe to render, ALL included, so this is
+   the identity the shared component needs rather than a guard (#2814). */
+const getTurnoverDropdownTextColor = (option: StatusLabel): string => option.text;
 
 const getTurnoverStatusButtonStyle = (option: StatusLabel): React.CSSProperties => {
   if (option.key === 'ALL') {

--- a/apps/frontend/src/app/ui/filters/StatusOptionButtons.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/StatusOptionButtons.stories.tsx
@@ -2,7 +2,7 @@ import { type ComponentProps, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 
-import { AppointmentLabels, statusLabel } from '../../constants/status';
+import { AllFilterOption, AppointmentLabels, statusLabel } from '../../constants/status';
 import StatusOptionButtons, { type StatusOptionButtonsOption } from './StatusOptionButtons';
 
 /**
@@ -12,18 +12,16 @@ import StatusOptionButtons, { type StatusOptionButtonsOption } from './StatusOpt
 type FilterOption = StatusOptionButtonsOption & { text: string };
 
 /**
- * The neutral "all" row takes plain primary ink; each real status keeps its own
- * `--status-*-text` token so the row reads as the status it filters to.
+ * Each row takes its own `text` token - the neutral "all" row resolves to plain
+ * primary ink through `--color-pill-all-text`, each real status to its own
+ * `--status-*-text`, so the row reads as the status it filters to.
  */
-const getTextColor = (option: FilterOption): string =>
-  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+const getTextColor = (option: FilterOption): string => option.text;
 
-const ALL_OPTION = statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)');
-
-const APPOINTMENT_OPTIONS: FilterOption[] = [ALL_OPTION, ...AppointmentLabels];
+const APPOINTMENT_OPTIONS: FilterOption[] = [AllFilterOption, ...AppointmentLabels];
 
 const STOCK_HEALTH_OPTIONS: FilterOption[] = [
-  ALL_OPTION,
+  AllFilterOption,
   statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
   statusLabel('Low stock', 'LOW_STOCK', 'color-pill-progress'),
   statusLabel('Expiring soon', 'EXPIRING_SOON', 'color-pill-info'),


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The neutral "All" row in the two inventory status-filter dropdowns is built from the `badge-blue` prefix:

```ts
statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)')
```

So its data carries `--color-badge-blue-text` (#eaf3ff) on `--color-badge-blue-bg` (#007cf5), which measures 3.61:1 against a 4.5:1 bar. No ink in this palette clears 4.5 on that fill.

Nothing paints it today, but only because four consumers each replace it at the point of use:

1. `StatusOptionButtons` never reads `option.bg` or `option.text` - its option type is `{ key, name, border? }`.
2. `InventoryFilters/index.tsx` returned `'var(--color-text-primary)'` for `option.key === 'ALL'`.
3. `InventoryTurnoverFilters/index.tsx` did the same.
4. Both trigger-style helpers return no `backgroundColor` at all for `ALL`, where the branch two lines below returns `backgroundColor: option.bg, color: option.text`.

Delete any one of those guards, or add a consumer that renders the option the ordinary way, and 3.61:1 paints.

`__tests__/constants/status.test.ts` asserted that pair as the expected return value of `statusLabel`, so a reader checking whether the pairing was intended found a green test saying it was.

## What is the new behavior?

`--color-pill-all-*` in `globals.css`: no fill, `--color-text-primary` ink, and the `--color-primary-500` dot the border override used to supply. The option is built once as `AllFilterOption` in `constants/status.ts` rather than copied into three files.

`statusLabel` loses its `borderOverride` parameter. It had no other caller, and it was the mechanism that let one entry mix tokens from two prefixes while only the odd one out got replaced downstream.

The two `key === 'ALL'` ink guards become `option.text`. The two trigger-style helpers keep their `ALL` branch on purpose - the trigger's unfiltered state is a placeholder (`--color-text-tertiary` on a `--color-card-border` outline), which is genuinely different from the row's own colours, not a substitution for them. What changes is that the branch is now a style choice rather than the only thing standing between the data and a 3.61:1 render.

**Rendered output is unchanged in both themes.** Read out of a running Storybook with transitions disabled, before (at `57e0db282`) and after, same server:

| | light | dark |
|---|---|---|
| All label ink | `rgb(48, 47, 46)` -> `rgb(48, 47, 46)` | `rgb(230, 221, 208)` -> `rgb(230, 221, 208)` |
| All dot | `rgb(0, 124, 245)` -> `rgb(0, 124, 245)` | `rgb(0, 124, 245)` -> `rgb(0, 124, 245)` |
| All row fill | `rgba(0, 0, 0, 0)` -> `rgba(0, 0, 0, 0)` | `rgba(0, 0, 0, 0)` -> `rgba(0, 0, 0, 0)` |

The four non-All rows read identically too. The before/after PNGs of `filters-statusoptionbuttons--stock-health` are byte-identical in each theme (`e707ca1c...` light, `29a47a4a...` dark). The control that the reverted tree was actually being served: `getComputedStyle(document.documentElement).getPropertyValue('--color-pill-all-text')` read empty on the before capture and non-empty on the after.

### The guard

`statusPillContrast.test.ts` gains two arms that measure the option itself rather than its consumers:

- `has no fill to write on` - `resolve(AllFilterOption.bg)` is `transparent` in both themes. Any prefix whose `-bg` is a colour reintroduces the pairing, so the assertion is the absence of a fill rather than the absence of one specific hex.
- `reads on the panel it sits on` - the ink clears 4.5:1 on `--screen` in both themes.

Both were mutation-checked:

- `AllFilterOption` pointed back at `color-badge-blue`: 4 failed / 27 passed - `status.test.ts`, both `has no fill` arms, and `reads on the panel (light)`. Dark passes there correctly, since `#eaf3ff` is legible on the dark screen; the fill arm is what catches it in both themes.
- `--color-pill-all-text` set to `#8a8378`: 2 failed / 29 passed - exactly the two `reads on the panel` arms, so that arm is live independently of the fill arm.

### Verification

- `pnpm --filter frontend run test -- --testPathPatterns="constants/status|contrast/statusPillContrast|ui/filters"` - 4 suites, 43 passed, 0 skipped, at `66aa9a468` with a clean tree.
- Wider sweep `--testPathPatterns="[Ii]nventory|filters|contrast|constants|globals|[Tt]oken|Overview|Calendar/common"` - 71 suites, 965 passed, 0 skipped, exit 0.
- `npx tsc --noemit` from `apps/frontend` - exit 0.
- `pnpm --filter frontend run lint` - exit 0, 1 pre-existing warning in `hooks/useLazyAuthStore.ts`, a file this PR does not touch.
- Aikido: no local scan - no Aikido MCP tool and no `aikido:scan` skill is present in this session. The PR's own `Aikido Security: check code` job passed in 24s (scan 187264337), so the change is covered; what is missing is the pre-push local run, not the gate. `GitGuardian Security Checks` and `Detect secrets (Gitleaks)` also passed.

## Related Issue(s)

Fixes #2814
