### PR TITLE
fix(frontend): stop the status pill truncating the patient's name on phone

### DIFF
--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -84,7 +84,7 @@ const meta = {
           'component had.\n\n' +
           'The phone variant is not a smaller copy of the desktop one. It drops the pulsing green ' +
           'dot and the "In room" / "Over booked slot" words entirely and shows the bare elapsed ' +
-          'time at 10px with `px-[9px] py-[5px]`. Since #2790 it rides at the right end of the ' +
+          'time at 10px with `px-[9px] py-[5px]`. Since issue 2790 it rides at the right end of ' +
           'signalment line rather than beside the name, which is what let the name and the ' +
           'status pill stop competing for one 197px row. It also strips a leading `00:` so an ' +
           'under-an-hour visit reads ' +
@@ -215,7 +215,7 @@ export const NotStarted: Story = {
           'No start timestamp at all, which is what an appointment that has not been checked in ' +
           'still looks like. The words rather than digits make this the widest of the three ' +
           'states, which is what it used to cost the name - the timer shared the name row ' +
-          'until #2790 moved it down to the signalment line.',
+          'until issue 2790 moved it down to the signalment line.',
       },
     },
   },
@@ -328,7 +328,7 @@ export const NameKeepsItsRoom: Story = {
     docs: {
       description: {
         story:
-          'The regression guard for #2790. "Poppy Hartmann" needs 114px and the `IN PROGRESS` ' +
+          'The regression guard for issue 2790. "Poppy Hartmann" needs 114px and the `IN PROGRESS` ' +
           'pill takes 111px; while the timer sat beside them the pair had 197px to share, and ' +
           'the name - the only one of the two carrying `truncate` - absorbed the whole 34px ' +
           'shortfall. Nothing here asserts a pixel count, so a type-ramp or copy change moves ' +

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -84,8 +84,10 @@ const meta = {
           'component had.\n\n' +
           'The phone variant is not a smaller copy of the desktop one. It drops the pulsing green ' +
           'dot and the "In room" / "Over booked slot" words entirely and shows the bare elapsed ' +
-          'time at 10px with `px-[9px] py-[5px]`, because the bar has roughly 70px to spare next ' +
-          'to a truncating name. It also strips a leading `00:` so an under-an-hour visit reads ' +
+          'time at 10px with `px-[9px] py-[5px]`. Since #2790 it rides at the right end of the ' +
+          'signalment line rather than beside the name, which is what let the name and the ' +
+          'status pill stop competing for one 197px row. It also strips a leading `00:` so an ' +
+          'under-an-hour visit reads ' +
           '`MM:SS` rather than `00:MM:SS`.\n\n' +
           'The over-booked pill is the one worth reviewing: `warning-100` fill, `warning-300` ' +
           'border, `warning-900` label. The 900 step is deliberate - the 700 step measured 2.77:1 ' +
@@ -211,8 +213,9 @@ export const NotStarted: Story = {
       description: {
         story:
           'No start timestamp at all, which is what an appointment that has not been checked in ' +
-          'still looks like. The words rather than digits are why this state is the widest of the ' +
-          'three, so it is the one that squeezes the name beside it.',
+          'still looks like. The words rather than digits make this the widest of the three ' +
+          'states, which is what it used to cost the name - the timer shared the name row ' +
+          'until #2790 moved it down to the signalment line.',
       },
     },
   },
@@ -285,6 +288,52 @@ export const WithAllergy: Story = {
           '`--danger-text` at 700. The whole line is one `truncate` paragraph at 10.5px, so on a ' +
           'long signalment the allergy is what disappears - which is worth seeing before deciding ' +
           'it belongs there.',
+      },
+    },
+  },
+};
+
+/** The width the name+pill row had while the timer still shared it (#2790). */
+const PRE_FIX_NAME_ROW_WIDTH = 197;
+
+export const NameKeepsItsRoom: Story = {
+  name: 'Long name beside a wide pill',
+  render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const name = canvas.getByText('Poppy Hartmann');
+    const pill = canvas.getByRole('button', { name: /in progress/i });
+    const signalment = canvas.getByText('Beagle · 9 yr · 12.4 kg');
+
+    /* The control, and the reason this story is not a tautology. `truncate` makes
+       a clipped element report scrollWidth > clientWidth, so the assertions below
+       pass for free on any name short enough to fit. This one first proves the
+       fixture still over-subscribes the row the bug lived in - a shorter name, or
+       a pill whose label got shorter, silently turns the rest into a test of
+       nothing. */
+    await expect(name.scrollWidth + pill.getBoundingClientRect().width).toBeGreaterThan(
+      PRE_FIX_NAME_ROW_WIDTH
+    );
+
+    // Neither line pays for it. Checked before the structural assertion below, so
+    // that reverting the layout is caught by the measurement rather than only by
+    // the arrangement that happens to produce it today.
+    await expect(name.scrollWidth).toBeLessThanOrEqual(name.clientWidth);
+    await expect(signalment.scrollWidth).toBeLessThanOrEqual(signalment.clientWidth);
+
+    // The structural fact the fix rests on: the timer is on the signalment line.
+    await expect(signalment.parentElement).toContainElement(timerPill(canvasElement));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The regression guard for #2790. "Poppy Hartmann" needs 114px and the `IN PROGRESS` ' +
+          'pill takes 111px; while the timer sat beside them the pair had 197px to share, and ' +
+          'the name - the only one of the two carrying `truncate` - absorbed the whole 34px ' +
+          'shortfall. Nothing here asserts a pixel count, so a type-ramp or copy change moves ' +
+          'the numbers without failing the story; what it asserts is that the name and the ' +
+          'signalment both survive whatever the numbers become.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -300,24 +300,32 @@ export const NameKeepsItsRoom: Story = {
   name: 'Long name beside a wide pill',
   /* The allergy is set here rather than inherited, because the guard's second
      assertion is about the signalment and the meta args have no allergy tail.
-     Without it this story measured `Beagle · 9 yr · 12.4 kg` - 23 characters in
-     a 199px box, 55px of headroom - while asserting that the line the component
-     documents as the first thing lost is safe. `WithAllergy` does not cover it
-     either: it asserts the tail is in `textContent` and that the paragraph CAN
-     ellipsize, neither of which is a measurement.
+     Without it this story measured `Beagle - 9 yr - 12.4 kg` in a 184px box with
+     92px of room to spare, while asserting that the line the component documents
+     as the first thing lost is safe. `WithAllergy` does not cover it either: it
+     asserts the tail is in `textContent` and that the paragraph CAN ellipsize,
+     neither of which is a measurement.
 
-     Two things about the margin, because the obvious way to read it is wrong.
-     The test runner renders `mobile` at 375px (`.storybook/test-runner.ts`),
-     not the 390px the issue was investigated at, so the guard runs on 15px less
-     than the numbers in #2790. And `scrollWidth` reports the BOX, not the text,
-     whenever the text fits - at 375px this paragraph reads 184/184 for a tail of
-     `Penicilli`, `Penicillin` and `Penicillinx` alike, so the headroom cannot be
-     read off it. Swept a character at a time instead: `Penicillinxx` is the
-     first that clips, by 4px. The shipped fixture is about one character from
-     the edge at the width CI uses. That is deliberate for a guard, but it means
-     lengthening this allergy string turns the story red for a copy change rather
-     than a layout regression - lengthen the NAME instead if that is what you
-     want to test. */
+     EVERY WIDTH BELOW IS 375px, which is what `.storybook/test-runner.ts` maps
+     `mobile` to - not the 390px the issue was investigated at. A margin quoted
+     without its viewport is unusable here; the same fixture reads 6.4px at 375
+     and 21.4px at 390, and only the first is the one CI exercises.
+
+     `scrollWidth` cannot give that margin. It reports the BOX, not the text,
+     whenever the text fits, so it saturates at 184/184 and stops varying while
+     there is still room. Measured instead as the paragraph's right edge minus
+     the tail span's, which keeps moving:
+
+       Allergy: Penicilli      184/184    12.3px
+       Allergy: Penicillin     184/184     6.4px   <- shipped
+       Allergy: Penicillinx    184/184     1.4px
+       Allergy: Penicillinxx   188/184    -3.7px   clips
+
+     Four strings, one identical scrollWidth pair, four different margins.
+
+     So the fixture sits 6.4px - two characters - from the edge. Deliberate for a
+     guard, but it means lengthening this allergy string turns the story red for a
+     copy change rather than a layout regression. Lengthen the NAME instead. */
   args: { allergy: 'Penicillin' },
   render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
   play: async ({ canvasElement }) => {
@@ -356,9 +364,11 @@ export const NameKeepsItsRoom: Story = {
           'the numbers without failing the story; what it asserts is that the name and the ' +
           'signalment both survive whatever the numbers become. It runs with the allergy tail ' +
           'present because that is the longest signalment the component ships, and the ' +
-          'candidate this fix was chosen over cost that tail 98px. Its limit: 21.4px of ' +
-          'headroom is inherited, not established here, so an allergy longer than the fixture ' +
-          'still clips and this story will not see it.',
+          'candidate this fix was chosen over cost that tail 98px. Its limit: the tail has ' +
+          '6.4px of room at the 375px the test runner uses - two characters - and that margin ' +
+          'is inherited, not established here, so an allergy longer than the fixture still ' +
+          'clips and this story will not see it. Every margin in this file is quoted at 375px; ' +
+          'the same fixture reads 21.4px at the 390px the issue was investigated at.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -298,12 +298,33 @@ const PRE_FIX_NAME_ROW_WIDTH = 197;
 
 export const NameKeepsItsRoom: Story = {
   name: 'Long name beside a wide pill',
+  /* The allergy is set here rather than inherited, because the guard's second
+     assertion is about the signalment and the meta args have no allergy tail.
+     Without it this story measured `Beagle · 9 yr · 12.4 kg` - 23 characters in
+     a 199px box, 55px of headroom - while asserting that the line the component
+     documents as the first thing lost is safe. `WithAllergy` does not cover it
+     either: it asserts the tail is in `textContent` and that the paragraph CAN
+     ellipsize, neither of which is a measurement.
+
+     Two things about the margin, because the obvious way to read it is wrong.
+     The test runner renders `mobile` at 375px (`.storybook/test-runner.ts`),
+     not the 390px the issue was investigated at, so the guard runs on 15px less
+     than the numbers in #2790. And `scrollWidth` reports the BOX, not the text,
+     whenever the text fits - at 375px this paragraph reads 184/184 for a tail of
+     `Penicilli`, `Penicillin` and `Penicillinx` alike, so the headroom cannot be
+     read off it. Swept a character at a time instead: `Penicillinxx` is the
+     first that clips, by 4px. The shipped fixture is about one character from
+     the edge at the width CI uses. That is deliberate for a guard, but it means
+     lengthening this allergy string turns the story red for a copy change rather
+     than a layout regression - lengthen the NAME instead if that is what you
+     want to test. */
+  args: { allergy: 'Penicillin' },
   render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const name = canvas.getByText('Poppy Hartmann');
     const pill = canvas.getByRole('button', { name: /in progress/i });
-    const signalment = canvas.getByText('Beagle · 9 yr · 12.4 kg');
+    const signalment = canvas.getByText('Allergy: Penicillin').parentElement as HTMLElement;
 
     /* The control, and the reason this story is not a tautology. `truncate` makes
        a clipped element report scrollWidth > clientWidth, so the assertions below
@@ -333,7 +354,11 @@ export const NameKeepsItsRoom: Story = {
           'the name - the only one of the two carrying `truncate` - absorbed the whole 34px ' +
           'shortfall. Nothing here asserts a pixel count, so a type-ramp or copy change moves ' +
           'the numbers without failing the story; what it asserts is that the name and the ' +
-          'signalment both survive whatever the numbers become.',
+          'signalment both survive whatever the numbers become. It runs with the allergy tail ' +
+          'present because that is the longest signalment the component ships, and the ' +
+          'candidate this fix was chosen over cost that tail 98px. Its limit: 21.4px of ' +
+          'headroom is inherited, not established here, so an allergy longer than the fixture ' +
+          'still clips and this story will not see it.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.tsx
@@ -38,10 +38,11 @@ const buildSignalment = (breed?: string, ageLabel?: string, weightKg?: number): 
     .join(' · ');
 
 /**
- * Compact phone patient header: 34px back circle, 38px species avatar, name + the
- * shared status pill, a truncating signalment line (allergy tail in --danger-text),
- * and a right-side running visit-timer pill. Presentation only — the timer is the
- * same VisitTimer bound to the same visitStartAt as the desktop header.
+ * Compact phone patient header: 34px back circle, 38px species avatar, then two
+ * stacked lines - name + the shared status pill, and a truncating signalment line
+ * (allergy tail in --danger-text) with the running visit-timer pill at its right
+ * end. Presentation only — the timer is the same VisitTimer bound to the same
+ * visitStartAt as the desktop header.
  */
 const PhonePatientBar = ({
   appointment,
@@ -90,17 +91,26 @@ const PhonePatientBar = ({
           </span>
           <AppointmentStatusPill appointment={appointment} />
         </div>
-        <p className="truncate text-[10.5px] leading-tight text-(--ink-faint)">
-          {signalment}
-          {allergyText && (
-            <>
-              {signalment && ' · '}
-              <span className="font-bold text-(--danger-text)">Allergy: {allergyText}</span>
-            </>
-          )}
-        </p>
+        {/* The timer rides on the signalment line rather than beside the name.
+            At 390px the first row is 197px wide when the timer sits outside this
+            column, and the name and the status pill want 114 + 111 of it, so the
+            name - which carries `truncate` while the pill does not shrink -
+            absorbed the whole 34px shortfall (#2790). Moving the timer here
+            widens the row to hold both, and the signalment keeps its full width
+            because the timer takes the space the column gains. */}
+        <div className="flex items-center gap-2">
+          <p className="min-w-0 flex-1 truncate text-[10.5px] leading-tight text-(--ink-faint)">
+            {signalment}
+            {allergyText && (
+              <>
+                {signalment && ' · '}
+                <span className="font-bold text-(--danger-text)">Allergy: {allergyText}</span>
+              </>
+            )}
+          </p>
+          <VisitTimer variant="phone" startAt={visitStartAt} bookedEndAt={bookedEndAt} />
+        </div>
       </div>
-      <VisitTimer variant="phone" startAt={visitStartAt} bookedEndAt={bookedEndAt} />
     </div>
   );
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

At 390px the phone patient bar's name+pill column is 197px wide:

```
viewport                        390
back button                      34
avatar                           38
flex-1 column                   197
  patient name   gets  80   needs 114   LOST 34
  status pill    gets 111              (does not shrink)
visit timer                      63
```

The name carries `truncate`; the status pill does not shrink. So the name absorbs the entire shortfall. "Poppy Hartmann" renders as "Poppy Ha...", with no `title` - and a phone has no hover, so the full value is unreachable. This is the bar a clinician reads to confirm which animal is in front of them, in the workspace where they record clinical findings. Reproduced on `origin/dev` at `57e0db282`.

## What is the new behavior?

The visit timer moves from beside the name onto the signalment line. The column then spans the timer's old 63px as well, which is enough to hold the name and the pill together; the signalment keeps its full width because it gains exactly what the timer takes from it.

Measured on the rendered DOM at 390x844, both themes, before and after on one Storybook server with the tree swapped underneath it:

| | before | after |
| --- | --- | --- |
| patient name | needs 114, gets 80, **lost 34** | needs 114, gets 114, **lost 0** |
| signalment (plain) | needs 197, gets 197, lost 0 | needs 199, gets 199, lost 0 |
| signalment (allergy story) | needs 197, gets 197, lost 0 | needs 199, gets 199, lost 0 |
| bar height | 59.1 | 73.0 |
| horizontal overflow | 0 | 0 |
| anything else clipped in the bar | none | none |

`PhoneWorkspaceShell` renders the same component, so it is fixed by the same change: name 114/114, and the shell still fits 844px with `scrollHeight - innerHeight = 0`.

The liveness control for the before/after pair: `sig.parentElement.contains(timerPill)` read `false` on the before capture and `true` on the after, so the two readings are not two reads of one state.

### Why not the direction the issue proposed

#2790 suggested moving the **status pill** to the signalment line, quoting a 12px signalment loss. That reproduces - on the plain story. On the allergy story the same change costs **98px**, which is the whole `Allergy: Penicillin` tail rendered in `--danger-text`. The issue's own recommendation silently truncates the allergy warning; it was measured on the one story that hides it. Candidates re-measured on one frame at `57e0db282`:

| candidate | bar height | name lost | signalment lost (plain) | signalment lost (allergy) |
| --- | --- | --- | --- | --- |
| baseline | 59.1 | 34 | 0 | 0 |
| A: `flex-wrap` the name row | 87.6 | 0 | 0 | 0 |
| C: pill to the signalment line | 68.5 | 0 | 12 | **98** |
| **K: timer to the signalment line** | **73.0** | **0** | **0** | **0** |

A also clips nothing but costs 28.5px of permanent header height against K's 13.9px. C is the cheapest in height and the only one that clips a clinical field.

This is a product-visible trade - 13.9px of header height on an 844px viewport, and the timer reading as secondary to patient identity - made rather than parked, since the issue had been open for the decision and nothing else was blocked on it. Say so and I will change it.

### The guard

A new `NameKeepsItsRoom` story asserts neither the name nor the signalment is clipped. Because `truncate` makes those assertions pass for free on any name that happens to fit, it first asserts the fixture still over-subscribes the pre-fix row:

```ts
await expect(name.scrollWidth + pill.getBoundingClientRect().width)
  .toBeGreaterThan(PRE_FIX_NAME_ROW_WIDTH);
```

It runs with `allergy: 'Penicillin'` in its own args. Without that it inherited the meta args, which set no allergy - so the assertion protecting the line that the rejected candidate cost 98px was measuring that line without its tail. `WithAllergy` does not cover it either: it asserts the tail is in `textContent` and that the paragraph *can* ellipsize, neither of which is a measurement. Caught in review by Claude L1.

Three arms, all against the live Storybook at `9355aebe9`, base `6 passed / 0 failed / rc=0`:

- **Layout reverted** to the pre-fix arrangement: 1 failed / 5 passed, on `expected 114 to be less than or equal to 65`. The clipping assertion is ordered ahead of the structural one on purpose, so the revert is caught by the measurement rather than only by the arrangement that produces it today.
- **Status pill moved down to join the timer**, leaving the name alone on row 1: 1 failed / 5 passed, on `expected 178 to be less than or equal to 65`. This is the arm that isolates the *signalment* assertion - read live at 390px under that mutation, the name is untouched at 114/114 and the signalment loses **98px**, which is exactly what the rejected candidate cost. Without this arm, "the guard fires" was only ever evidence about the name.
- **Fixture name shortened to `Bo`**: 1 failed / 5 passed, on `expected 129.25 to be greater than 197`. So the control fails when the story stops exercising the failure, rather than quietly turning the rest into a test of nothing.

Each mutation was reverted and the base re-run to `6 passed` before the next.

### Two things about the margin that read wrong

Both are recorded in the story rather than only here.

- **The guard does not run at 390px.** `.storybook/test-runner.ts` maps `mobile` to 375x812, so CI exercises 15px less than every number in the issue and in the table above. That is a tighter budget, not a looser one, which is why the guard still passes - but a reader comparing the two sets of numbers will not otherwise know why they differ.
- **`scrollWidth` reports the box, not the text, whenever the text fits**, so it cannot give the margin at all - it saturates at `184/184` and stops varying while there is still room. Measured instead as the paragraph's right edge minus the tail span's, which keeps moving. All at 375px:

| tail | scrollWidth/clientWidth | margin |
| --- | --- | --- |
| `Allergy: Penicilli` | 184/184 | 12.3px |
| `Allergy: Penicillin` (shipped) | 184/184 | **6.4px** |
| `Allergy: Penicillinx` | 184/184 | 1.4px |
| `Allergy: Penicillinxx` | 188/184 | -3.7px, clips |

Four strings, one identical `scrollWidth` pair, four different margins. The fixture sits 6.4px - two characters - from the edge. Deliberate for a guard, but it means lengthening this allergy string turns the story red for a copy change rather than a layout regression; lengthen the name instead.

An earlier revision of this PR said "about one character" and the story's docs description said "21.4px". The 21.4 was a correct measurement at 390px that I carried into a file where every other number is at 375, and I fixed the comment without fixing the description eighteen lines below it. Both now state 6.4px and name their viewport. Caught in review by Claude L1.

**Scope, stated plainly:** the tree as shipped does not clip the allergy tail, and this PR does not make that state worse - the 6.4px is inherited, not established here. An allergy longer than the fixture still clips and this guard will not see it. That is a product question about whether the tail may clip at all, not a layout regression, and it is not addressed here.

**And this guard cannot block a merge today.** `storybook-interactions.yml:83` sets `continue-on-error: true`, its own header calls the job advisory, and `ci-required` needs `[core, test, migration, sonar, frontend-quality, mobile-version]` - `grep -ci storybook .github/workflows/ci.yaml` is `0`. So the play functions here are a guard, not a gate; promotion is tracked separately in #2281. Verified on this branch rather than taken from the review that raised it.

### Not in this PR

#2790 also lists clipped values in `OutpatientSchedule` (476px and 166px) and `DiagnosticsStep` (80px, hover-only `title`). Those are different components with a different remedy and are untouched here, so the issue stays open - this PR is `Refs`, not `Fixes`.

## Verification

- `pnpm --filter frontend run test -- --testPathPatterns="AppointmentWorkspace|Workspace"` - 59 suites, 1157 passed, 0 skipped, exit 0, at `1f0f59636` with a clean tree.
- `npx test-storybook -- PhonePatientBar` against a live Storybook - 6 passed, 0 skipped, exit 0, at the same commit.
- `node scripts/ci/check-hardcoded-colours.mjs` - exit 0, `no new hardcoded colours ... 2047 files scanned`, with `selftest: 15 cases pass` in the same session. This gate failed an earlier head on `#2790` in three doc strings, since `#` plus four hex digits is a colour to it; reworded to "issue 2790" rather than touching the gate. The class is filed as #2849 - every four-character finding in the baseline is an issue reference.
- `npx tsc --noemit` from `apps/frontend` - exit 0.
- `pnpm --filter frontend run lint` - exit 0, 1 pre-existing warning in `hooks/useLazyAuthStore.ts`, a file this PR does not touch.
- Aikido: no local scan - no Aikido MCP tool and no `aikido:scan` skill in this session. Read the hosted result rather than assuming it: `commits/3e1a42547/check-runs` returns `Aikido Security: check code :: completed :: success :: Scan completed`. Stated as measured because an earlier revision of this line said the job "covers the change" without my having read its conclusion - and on #2828 a red Aikido sat through two rounds of review for exactly that reason, since required contexts on `dev` are only `CI Required` and `Supply Chain Required`, so no security gate here can block a merge on its own.
- Check-runs at `3e1a42547` enumerated from the API rather than `gh pr checks`: `total_count` 36, 36 returned, `0 failure`. Three read `cancelled`; each of those three names also has a `success` entry at the same sha, so they are concurrency-superseded duplicates rather than results - verified by grouping conclusions per name, not by assuming.

## Related Issue(s)

Refs #2790
