### PR TITLE
fix(frontend): recover dead Storybook runner pages

### DIFF
--- a/apps/frontend/.storybook/test-runner.test.ts
+++ b/apps/frontend/.storybook/test-runner.test.ts
@@ -1,0 +1,82 @@
+import { getStoryContext } from '@storybook/test-runner';
+import config from './test-runner';
+
+declare global {
+  var context: unknown;
+  var page: unknown;
+  var __sbSetupPage: jest.Mock;
+}
+
+jest.mock('@storybook/test-runner', () => ({
+  getStoryContext: jest.fn().mockResolvedValue({ storyGlobals: {} }),
+}));
+
+const mockedGetStoryContext = jest.mocked(getStoryContext);
+
+describe('Storybook runner page recovery', () => {
+  const page = {
+    close: jest.fn(),
+    evaluate: jest.fn(),
+    setViewportSize: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    page.setViewportSize.mockResolvedValue(undefined);
+    mockedGetStoryContext.mockResolvedValue({ storyGlobals: {} } as never);
+    globalThis.__sbSetupPage = jest.fn();
+    globalThis.context = undefined;
+    globalThis.page = undefined;
+  });
+
+  it('does not reset a healthy page', async () => {
+    // Must-NOT-fire arm: a healthy page must be left alone; resetting it would
+    // make every passing story pay for a replacement page it does not need.
+    page.evaluate.mockResolvedValue(true);
+    await config.preVisit?.(page as never, { id: 'healthy' } as never);
+
+    expect(globalThis.__sbSetupPage).not.toHaveBeenCalled();
+    expect(mockedGetStoryContext).toHaveBeenCalledWith(page, expect.anything());
+  });
+
+  it('resets and re-injects before reading context on a dead page', async () => {
+    // The absence of a hang here is load-bearing: this fixture models the no-timeout
+    // cascade class. If recovery becomes hang-gated, do not add a hang to make it pass.
+    page.evaluate.mockResolvedValue(false);
+    const setupPage = jest.fn(async (candidate) => {
+      expect(globalThis.page).not.toBe(candidate);
+    });
+    const replacement = {
+      close: jest.fn().mockResolvedValue(undefined),
+      setViewportSize: jest.fn().mockResolvedValue(undefined),
+    };
+    globalThis.page = page as never;
+    const context = { newPage: jest.fn().mockResolvedValue(replacement) };
+    globalThis.context = context;
+    globalThis.__sbSetupPage = setupPage as never;
+
+    await config.preVisit?.(page as never, { id: 'recovered' } as never);
+
+    expect(context.newPage).toHaveBeenCalledTimes(1);
+    expect(setupPage).toHaveBeenCalledWith(replacement, context);
+    expect(page.close).toHaveBeenCalledTimes(1);
+    expect(mockedGetStoryContext).toHaveBeenCalled();
+  });
+
+  it('recovers when checking a closed page throws', async () => {
+    page.evaluate.mockRejectedValue(new Error('page closed'));
+    const replacement = {
+      close: jest.fn().mockResolvedValue(undefined),
+      setViewportSize: jest.fn().mockResolvedValue(undefined),
+    };
+    const context = { newPage: jest.fn().mockResolvedValue(replacement) };
+    globalThis.page = page as never;
+    globalThis.context = context;
+
+    await config.preVisit?.(page as never, { id: 'closed' } as never);
+
+    expect(context.newPage).toHaveBeenCalledTimes(1);
+    expect(globalThis.__sbSetupPage).toHaveBeenCalledWith(replacement, context);
+    expect(page.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/.storybook/test-runner.ts
+++ b/apps/frontend/.storybook/test-runner.ts
@@ -1,6 +1,29 @@
 import type { TestRunnerConfig } from '@storybook/test-runner';
 import { getStoryContext } from '@storybook/test-runner';
 
+type StorybookJestGlobals = typeof globalThis & {
+  context: Parameters<NonNullable<typeof globalThis.__sbSetupPage>>[1];
+  jestPlaywright: { resetPage: () => Promise<void> };
+  page: Parameters<NonNullable<typeof globalThis.__sbSetupPage>>[0];
+};
+
+async function restoreStorybookPage(
+  page: Parameters<NonNullable<TestRunnerConfig['preVisit']>>[0]
+) {
+  const hasContext = await page
+    .evaluate(() => typeof (globalThis as { __getContext?: unknown }).__getContext === 'function')
+    .catch(() => false);
+  if (hasContext) return page;
+
+  const globals = globalThis as StorybookJestGlobals;
+  const replacement = await globals.context.newPage();
+  await globals.__sbSetupPage(replacement, globals.context);
+  const previous = globals.page;
+  globals.page = replacement;
+  await previous?.close();
+  return replacement;
+}
+
 /**
  * The viewport sizes declared in preview.ts, restated here as numbers.
  *
@@ -39,7 +62,8 @@ const DEFAULT_VIEWPORT = 'laptop';
  */
 const config: TestRunnerConfig = {
   async preVisit(page, context) {
-    const storyContext = await getStoryContext(page, context);
+    const activePage = await restoreStorybookPage(page);
+    const storyContext = await getStoryContext(activePage, context);
     /* `storyGlobals`, not `globals`. Storybook 10's story context carries a
        story's own `globals` annotation under `storyGlobals`; `globals` is not a
        key on it at all, so this read was `undefined` for EVERY story and every
@@ -99,7 +123,7 @@ const config: TestRunnerConfig = {
       );
     }
 
-    await page.setViewportSize(size);
+    await activePage.setViewportSize(size);
   },
 };
 


### PR DESCRIPTION
## Summary

- detect when the Storybook preview page has lost its injected context helper
- create and initialize a replacement page before reading story context
- cover healthy, dead, and closed-page paths with Jest tests

Issue: #2281