### PR TITLE
test(frontend): bind the signalment guard by testid, not by its own text

### DIFF
--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -272,7 +272,15 @@ export const WithAllergy: Story = {
        changing `args.allergy` killed the lookup and the three assertions that are
        NOT about the allergy text - the ellipsis, the ink difference and the weight -
        stopped running rather than failing. The tail is bound by a prefix instead,
-       which survives a change to the allergy itself. */
+       which survives a change to the allergy itself.
+
+       If you mutate `args.allergy` to check that this still holds, the mutation
+       must NOT be a superstring of the shipped value. `toContain` below is
+       satisfied by one, so `Penicillinxx` - the string in the margin table two
+       stories down, which is the one to hand - leaves this story green whether
+       the assertions ran or never ran at all. `Amoxicillin` fails on the
+       comparison instead of the lookup, which is the answer the mutation was
+       asked for. */
     const signalment = canvas.getByTestId('patient-signalment');
     const allergy = within(signalment).getByText(/^Allergy: /);
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -323,16 +323,23 @@ export const NameKeepsItsRoom: Story = {
 
      Four strings, one identical scrollWidth pair, four different margins.
 
-     So the fixture sits 6.4px - two characters - from the edge. Deliberate for a
-     guard, but it means lengthening this allergy string turns the story red for a
-     copy change rather than a layout regression. Lengthen the NAME instead. */
+     So the fixture sits 6.4px - two characters - from the edge, which is close
+     enough that the margin is worth guarding rather than assuming.
+
+     `signalment` is bound by `data-testid` and deliberately NOT by its own text.
+     It was previously bound with `getByText('Allergy: Penicillin').parentElement`,
+     which made the string its own selector: lengthening the allergy killed the
+     lookup one statement before any width was read, so the clip assertion below
+     reported `Unable to find an element` and could never fire on a content
+     change. Bound by the testid, `Penicillinxx` fails on `expected 188 <= 184` -
+     the measurement rather than the lookup. */
   args: { allergy: 'Penicillin' },
   render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const name = canvas.getByText('Poppy Hartmann');
     const pill = canvas.getByRole('button', { name: /in progress/i });
-    const signalment = canvas.getByText('Allergy: Penicillin').parentElement as HTMLElement;
+    const signalment = canvas.getByTestId('patient-signalment');
 
     /* The control, and the reason this story is not a tautology. `truncate` makes
        a clipped element report scrollWidth > clientWidth, so the assertions below

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -267,8 +267,14 @@ export const WithAllergy: Story = {
   render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const allergy = canvas.getByText('Allergy: Penicillin');
-    const signalment = allergy.parentElement as HTMLElement;
+    /* Neither binding may be the string this story asserts about. `WithAllergy`
+       previously took the paragraph from `getByText('Allergy: Penicillin')`, so
+       changing `args.allergy` killed the lookup and the three assertions that are
+       NOT about the allergy text - the ellipsis, the ink difference and the weight -
+       stopped running rather than failing. The tail is bound by a prefix instead,
+       which survives a change to the allergy itself. */
+    const signalment = canvas.getByTestId('patient-signalment');
+    const allergy = within(signalment).getByText(/^Allergy: /);
 
     /* The tail is a span inside the same truncating paragraph as the signalment, so
        it is the FIRST thing lost when the name is long - and the only thing marking

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.tsx
@@ -99,7 +99,10 @@ const PhonePatientBar = ({
             widens the row to hold both, and the signalment keeps its full width
             because the timer takes the space the column gains. */}
         <div className="flex items-center gap-2">
-          <p className="min-w-0 flex-1 truncate text-[10.5px] leading-tight text-(--ink-faint)">
+          <p
+            data-testid="patient-signalment"
+            className="min-w-0 flex-1 truncate text-[10.5px] leading-tight text-(--ink-faint)"
+          >
             {signalment}
             {allergyText && (
               <>


### PR DESCRIPTION
## The defect

`NameKeepsItsRoom` in `PhonePatientBar.stories.tsx` measured whether the signalment
line clips, and located that line with:

```ts
const signalment = canvas.getByText('Allergy: Penicillin').parentElement as HTMLElement;
```

The asserted string was the selector for the subject of the assertion. Lengthening
the allergy — the exact content change the guard exists to catch — kills the lookup
one statement before any width is read, so the clip assertion reported
`Unable to find an element` and could not fail on the thing it guards.

## The change

`data-testid="patient-signalment"` on the paragraph, `getByTestId` in the story.
Two lines of production change, one line of test change, no behaviour change.

## Evidence

Three arms, each a fresh `pnpm run storybook:build` served locally and driven with
`test-storybook`. The served bundle was checked for the mutation before each run, so
a stale build could not produce a green.

| arm | fixture | selector | result |
|---|---|---|---|
| 1 | `Penicillin` (shipped) | testid | **6 passed** |
| 2 | `Penicillinxx` | testid | **1 failed** — `expected 188 to be less than or equal to 184` |
| 3 | `Penicillinxx` | old `getByText` | **1 failed** — `Unable to find an element with the text: Allergy: Penicillin` |

Arm 2 is the assertion firing on the measurement. Arm 3 is the same mutation under the
old binding, dying in the query — that is the control, and it is why the binding had to
change rather than the fixture.

`188 / 184` is the pair already recorded in that story's margin table for `Penicillinxx`.
It is now produced by the assertion rather than only asserted about.

Arm 1 was re-run after rebasing onto `dev`: 6 passed, on a bundle confirmed to carry
`patient-signalment` and to carry no `allergy: 'Penicillinxx'` arg.

Also run in this worktree at this head: `tsc --noEmit` (rc 0) and `eslint` over the
changed directory with `--max-warnings=0` (rc 0). `pnpm run lint` and `pnpm run type-check`
ran as the pre-push hook and passed.

## What this does not change

The story's fixture is still fixed at `Penicillin`, so an allergy longer than that
shipping in production is still not exercised — the file says so and that limit is
untouched. What is restored is that editing the fixture is now a test of the layout
instead of a test of the query.
