### PR TITLE
fix(frontend): clear stale PIMS review scopes

### DIFF
--- a/apps/frontend/src/app/__tests__/hooks/useAppointmentForm.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useAppointmentForm.test.ts
@@ -69,6 +69,7 @@ jest.mock('@/app/lib/timezone', () => ({
     d.setHours(Math.floor(minuteOfDay / 60), minuteOfDay % 60, 0, 0);
     return d;
   }),
+  getDateKeyInPreferredTimeZone: jest.fn((date: Date) => date.toISOString().slice(0, 10)),
   isOnPreferredTimeZoneCalendarDay: jest.fn(() => false),
   utcClockTimeToPreferredTimeZoneClock: jest.fn((_time: string) => ({
     minutes: 540,
@@ -145,8 +146,11 @@ const { normalizeSlotsForSelectedDay } = jest.requireMock(
 const { resolveSlotDateTimesForSelectedDay } = jest.requireMock(
   '@/app/features/appointments/utils/slotNormalization'
 );
-const { isOnPreferredTimeZoneCalendarDay, utcClockTimeToPreferredTimeZoneClock } =
-  jest.requireMock('@/app/lib/timezone');
+const {
+  getDateKeyInPreferredTimeZone,
+  isOnPreferredTimeZoneCalendarDay,
+  utcClockTimeToPreferredTimeZoneClock,
+} = jest.requireMock('@/app/lib/timezone');
 const { loadInvoicesForOrgPrimaryOrg } = jest.requireMock(
   '@/app/features/billing/services/invoiceService'
 );
@@ -224,6 +228,10 @@ describe('useAppointmentForm', () => {
     (getCalendarPrefillMatchesForPrimaryOrg as jest.Mock).mockResolvedValue(null);
     (getSlotsForServiceAndDateForPrimaryOrg as jest.Mock).mockResolvedValue([]);
     mockUpsertAppointment.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('initializes with default state', () => {
@@ -1472,6 +1480,18 @@ describe('useAppointmentForm', () => {
 
     const errors = result.current.validateForm(false);
     expect(errors.slot).toBe('Appointments cannot be booked for past dates.');
+  });
+
+  it('validates the selected day in the preferred timezone', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-09-09T00:30:00.000Z'));
+    (getDateKeyInPreferredTimeZone as jest.Mock).mockReturnValue('2026-09-08');
+
+    const { result } = renderHook(() => useAppointmentForm());
+    act(() => result.current.setSelectedDate(new Date('2026-09-08T12:00:00.000Z')));
+
+    expect(result.current.validateForm(false).slot).toBe('Please select a slot');
+    jest.useRealTimers();
   });
 
   it('validateForm flags a selected service that is no longer bookable', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
@@ -1234,6 +1234,23 @@ describe('Inventory Page', () => {
     expect(screen.getByTestId('item-2')).toBeInTheDocument();
   });
 
+  it('clears an alert handoff when the catalog search changes', async () => {
+    render(<ProtectedInventory />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View low-stock catalog' }));
+    expect(screen.queryByTestId('item-1')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search inventory'), { target: { value: 'Item A' } });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('item-1')).toBeInTheDocument();
+    });
+  });
+
   it('keeps 30-day expiring alerts in the catalog handoff', () => {
     mockExpiringAlertItemIds = ['expiring-in-30-days'];
     (useInventoryModule as jest.Mock).mockReturnValue({

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -778,6 +778,10 @@ const useInventoryContent = () => {
   const [alertedItemIds, setAlertedItemIds] = useState<string[] | null>(null);
   const [dispensaryRecords, setDispensaryRecords] = useState<DispensaryRecord[]>([]);
 
+  useOnValueChange(primaryOrgId, () => {
+    setAlertedItemIds(null);
+  });
+
   // Pure fetch (null = leave current state alone) so the refresh effect can apply
   // the result in a subscription-style callback.
   const resolveDispensaryRecords = useCallback(async (): Promise<DispensaryRecord[] | null> => {
@@ -1092,9 +1096,17 @@ const useInventoryContent = () => {
     });
   }, []);
 
+  const updateFilters = useCallback<React.Dispatch<React.SetStateAction<InventoryFiltersState>>>(
+    (next) => {
+      setAlertedItemIds(null);
+      setFilters(next);
+    },
+    []
+  );
+
   const toggleCategoryFilter = useCallback(
     (category: string) => {
-      setFilters((prev) => {
+      updateFilters((prev) => {
         const categories = toggleArrayValue(prev.categories ?? [], category);
         const categorySubcategories = categorySubcategoryOptions[category] ?? [];
         const selectedCategories = new Set(categories);
@@ -1110,17 +1122,17 @@ const useInventoryContent = () => {
         };
       });
     },
-    [categorySubcategoryOptions]
+    [categorySubcategoryOptions, updateFilters]
   );
 
   const toggleListFilter = useCallback(
     (key: 'subCategories' | 'locations' | 'abcClasses' | 'suppliers', value: string) => {
-      setFilters((prev) => ({
+      updateFilters((prev) => ({
         ...prev,
         [key]: toggleArrayValue(prev[key] ?? [], value),
       }));
     },
-    []
+    [updateFilters]
   );
 
   const selectedFilterChips = useMemo(() => {
@@ -1129,7 +1141,7 @@ const useInventoryContent = () => {
       chips.push({
         id: `status-${filters.status}`,
         label: filters.status.replaceAll('_', ' ').toLowerCase(),
-        onRemove: () => setFilters((prev) => ({ ...prev, status: 'ALL' })),
+        onRemove: () => updateFilters((prev) => ({ ...prev, status: 'ALL' })),
       });
     }
     (filters.categories ?? []).forEach((category) =>
@@ -1172,11 +1184,11 @@ const useInventoryContent = () => {
       chips.push({
         id: `categorySingle-${filters.category}`,
         label: filters.category,
-        onRemove: () => setFilters((prev) => ({ ...prev, category: 'all' })),
+        onRemove: () => updateFilters((prev) => ({ ...prev, category: 'all' })),
       });
     }
     return chips;
-  }, [filters, toggleCategoryFilter, toggleListFilter]);
+  }, [filters, toggleCategoryFilter, toggleListFilter, updateFilters]);
 
   const pageTitle = getInventoryPageTitle(activeView);
   const filteredDispensaryRecords = useMemo(
@@ -1286,7 +1298,7 @@ const useInventoryContent = () => {
             <InventoryPhoneCatalog
               filteredInventory={filteredInventory}
               filters={filters}
-              setFilters={setFilters}
+              setFilters={updateFilters}
               categoryOptions={categoryOptions}
               toggleCategoryFilter={toggleCategoryFilter}
               lowStockCount={lowStockCount}
@@ -1305,7 +1317,7 @@ const useInventoryContent = () => {
                 selectedFilterChips={selectedFilterChips}
                 sortMode={sortMode}
                 setFilterOpen={setFilterOpen}
-                setFilters={setFilters}
+                setFilters={updateFilters}
                 setSortMode={setSortMode}
                 dispensarySearch={dispensarySearch}
                 dispensaryStatusFilter={dispensaryStatusFilter}
@@ -1375,7 +1387,7 @@ const useInventoryContent = () => {
           filterOpen={filterOpen}
           selectedFilterChips={selectedFilterChips}
           setFilterOpen={setFilterOpen}
-          setFilters={setFilters}
+          setFilters={updateFilters}
           filterOpenSections={filterOpenSections}
           toggleFilterSection={toggleFilterSection}
           filters={filters}

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -17,6 +17,7 @@ import {
 import { buildUtcDateFromDateAndTime, getDurationMinutes } from '@/app/lib/date';
 import {
   buildDateInPreferredTimeZone,
+  getDateKeyInPreferredTimeZone,
   isOnPreferredTimeZoneCalendarDay,
   utcClockTimeToPreferredTimeZoneClock,
 } from '@/app/lib/timezone';
@@ -1226,9 +1227,7 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
             ? "You've reached your free appointment limit. Please upgrade to book more."
             : "We couldn't verify your booking limit right now. Please try again.";
       }
-      const todayStart = new Date();
-      todayStart.setHours(0, 0, 0, 0);
-      if (selectedDate < todayStart) {
+      if (getDateKeyInPreferredTimeZone(selectedDate) < getDateKeyInPreferredTimeZone(new Date())) {
         errors.slot = 'Appointments cannot be booked for past dates.';
       }
       if (requireCompanion && !formData.companion.id) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. This follows review feedback on #2845.
- [x] All existing tests and lints pass.

## What is the current behavior?

Inventory alert handoffs could keep their hidden item scope after normal catalog filtering, and appointment validation compared the selected clinic day against the browser-local day.

## What is the new behavior?

Normal inventory filters and organization changes clear the alert handoff scope. Appointment validation now compares calendar-day keys in the preferred timezone. Targeted Jest coverage, type-check, lint, and Aikido scan pass.

## Related Issue(s)

Review follow-up for #2845.

Fixes #
