### PR TITLE
ci(frontend): let the E2E suite target a deployed environment

### DIFF
--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const LOCAL_URL = 'http://127.0.0.1:3001';
+const baseURL = process.env.E2E_BASE_URL?.trim() || LOCAL_URL;
+
+/** Loopback only. Anything else is a deployed environment we must not try to serve. */
+const isLocalTarget = /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/.test(baseURL);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,17 +14,26 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
-    baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:3001',
+    baseURL,
     trace: 'on-first-retry',
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     ...(process.env.CI ? [{ name: 'firefox', use: { ...devices['Desktop Firefox'] } }] : []),
   ],
-  webServer: {
-    command: process.env.E2E_WEB_SERVER_COMMAND ?? 'pnpm exec next dev -p 3001 -H 127.0.0.1',
-    port: 3001,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  // Only build and serve locally when the target IS local. Pointed at a deployed
+  // environment, starting a dev server is worse than pointless: Playwright would
+  // wait for a server nothing under test talks to, and a spec that silently ran
+  // against localhost while reporting a remote run is exactly the false green
+  // this file exists to prevent.
+  ...(isLocalTarget
+    ? {
+        webServer: {
+          command: process.env.E2E_WEB_SERVER_COMMAND ?? 'pnpm exec next dev -p 3001 -H 127.0.0.1',
+          port: 3001,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
+      }
+    : {}),
 });


### PR DESCRIPTION
## What changed

`apps/frontend/playwright.config.ts` declared `webServer` unconditionally. Pointing `E2E_BASE_URL` at a deployed environment did not merely start a dev server nothing under test talked to - the run died before the first test:

```
Error: Process from config.webServer was not able to start. Exit code: 1
```

`webServer` is now declared only when the target is loopback. A deployed target runs the specs against that origin and starts nothing.

## Why

Verifying a change against `dev.yosemitecrew.com` was impossible, regardless of whether the runner held credentials. That is a large part of why the deployed app has drifted from what the suite asserts.

## Impact area

Test configuration only. A local run is unchanged: with `E2E_BASE_URL` unset, `baseURL` is still `http://127.0.0.1:3001` and the dev server still starts.

## Validation

Both directions exercised against the same specs, with only the config swapped:

| config | `E2E_BASE_URL` | result |
| --- | --- | --- |
| before | `https://dev.yosemitecrew.com` | `Process from config.webServer was not able to start` |
| after | `https://dev.yosemitecrew.com` | runs, no server started, 1s |

The before case is the mutation check: the old config fails where the new one works, so the change is doing the thing it claims.
