### PR TITLE
ci(repo): fail a PR whose tests pass against the code it claims to change

### DIFF
--- a/.github/workflows/tests-must-be-able-to-fail.yml
+++ b/.github/workflows/tests-must-be-able-to-fail.yml
@@ -1,0 +1,56 @@
+name: Tests Must Be Able To Fail
+
+# Every pull request, with no paths filter. Once this is required on the branch
+# ruleset, a filter here would mean GitHub never creates the context for a PR
+# outside it, leaving that PR waiting on a check that will never appear.
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+concurrency:
+  group: tests-can-fail-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  prove:
+    name: Tests Must Be Able To Fail
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The gate diffs the branch against its base and checks out base
+          # versions of individual files, so the full history is required.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prove the gate can fail before trusting it to pass
+        run: node scripts/ci/tests-must-be-able-to-fail.mjs selftest
+
+      - name: Unit-test the gate itself
+        run: node --test scripts/ci/tests-must-be-able-to-fail.test.mjs
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4.2.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Keep the branch's tests, revert its source, and run them
+        env:
+          # Claimed per pull request rather than configured in the repo, so it
+          # appears in the review and expires with the branch.
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          ALLOW=""
+          if echo "$LABELS" | grep -q '"no-behaviour-change"'; then
+            echo "::notice::no-behaviour-change label present: a passing base run will be allowed"
+            ALLOW="--allow-unchanged-behaviour"
+          fi
+          node scripts/ci/tests-must-be-able-to-fail.mjs --base "${BASE_SHA}" $ALLOW

--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Fails a pull request whose tests pass against the code it claims to change.
+ *
+ * WHY THIS EXISTS
+ *
+ * A PIMS release shipped an Inventory page reading "0 items below reorder point"
+ * directly above a panel headed "Low stock 21", with 546 tests passing and an
+ * audit document reporting mutation checks. Both numbers were tested. Neither
+ * test could see the other, because each asserted against a fixture its own
+ * author wrote, and a fixture cannot contradict itself.
+ *
+ * Counting tests cannot detect that. Coverage cannot detect it either: both
+ * lines were covered. The only mechanical question that separates a test which
+ * verifies a change from one that merely runs beside it is:
+ *
+ *     if the source change were removed, would this test fail?
+ *
+ * So that is what this does. Keep the branch's test changes, restore its source
+ * changes to the base, run the tests the branch added or modified. If they all
+ * still pass, they never tested the change.
+ *
+ * WHAT A FAILURE TO COMPILE MEANS
+ *
+ * Reverting source can leave a test importing something that no longer exists.
+ * That is treated as the test failing, and reported distinctly. It is weaker
+ * evidence than an assertion failure - it proves the test depends on the change
+ * without proving it checks the behaviour - but it is not a pass, and calling it
+ * one would be the exact false green this gate exists to remove.
+ *
+ * THE ESCAPE HATCH, AND WHY IT IS NARROW
+ *
+ * A pure refactor legitimately has tests that pass both ways. That is the only
+ * honest exemption, and it is claimed per pull request with a label rather than
+ * configured in the repository, so it appears in the review and expires with the
+ * branch. It is not a way to skip writing a test: a source change with no test
+ * change fails regardless of the label.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** A test file, by this repository's own conventions. */
+export const isTestFile = (file) =>
+  /(^|\/)__tests__\//.test(file) ||
+  /\.(test|spec)\.[mc]?[jt]sx?$/.test(file) ||
+  /(^|\/)e2e\//.test(file);
+
+/**
+ * A source file whose change should be provable by a test.
+ *
+ * Excludes what a test cannot meaningfully assert against: documentation,
+ * lockfiles, CI definitions, and generated output. A PR touching only these is
+ * not evading the gate, it has nothing for the gate to check.
+ */
+export const isCheckableSource = (file) => {
+  if (isTestFile(file)) return false;
+  if (/^docs\//.test(file) || /\.(md|mdx|txt|json|ya?ml|lock)$/.test(file)) return false;
+  if (/^\.github\//.test(file) || /^scripts\/ci\//.test(file)) return false;
+  if (/\.(stories|d)\.[mc]?[jt]sx?$/.test(file)) return false;
+  if (/(^|\/)(dist|build|generated|__generated__)\//.test(file)) return false;
+  return /\.[mc]?[jt]sx?$/.test(file);
+};
+
+export const classify = (files) => ({
+  source: files.filter(isCheckableSource),
+  tests: files.filter(isTestFile),
+});
+
+/**
+ * The whole judgement, as a pure function, so it is tested directly rather than
+ * inferred from a CI run.
+ */
+export const verdict = ({
+  source,
+  tests,
+  testsPassedAgainstBase,
+  allowUnchangedBehaviour = false,
+}) => {
+  if (source.length === 0) {
+    return { ok: true, reason: 'no checkable source changed; nothing for this gate to prove' };
+  }
+  if (tests.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `This pull request changes ${source.length} source file(s) and no test.\n` +
+        'A change nothing can fail on is a change nothing verified.',
+    };
+  }
+  if (testsPassedAgainstBase === false) {
+    return { ok: true, reason: 'the changed tests fail without the source change, as they must' };
+  }
+  if (allowUnchangedBehaviour) {
+    return {
+      ok: true,
+      reason:
+        'the changed tests pass against the base, allowed by the no-behaviour-change label.\n' +
+        'That claim is now on the record in this pull request.',
+    };
+  }
+  return {
+    ok: false,
+    reason:
+      'The changed tests PASS against the unmodified base code.\n' +
+      'They therefore do not verify this change: removing it entirely would not fail them.\n' +
+      'Assert the behaviour that is different, or label the PR no-behaviour-change if it is a\n' +
+      'pure refactor.',
+  };
+};
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+const main = () => {
+  const args = process.argv.slice(2);
+  const get = (flag, fallback) => {
+    const i = args.indexOf(flag);
+    return i === -1 ? fallback : args[i + 1];
+  };
+
+  if (args[0] === 'selftest') {
+    // Proves the gate can fail before it is trusted to pass anything.
+    const bad = verdict({ source: ['a.ts'], tests: ['a.test.ts'], testsPassedAgainstBase: true });
+    const good = verdict({ source: ['a.ts'], tests: ['a.test.ts'], testsPassedAgainstBase: false });
+    const noTest = verdict({ source: ['a.ts'], tests: [], testsPassedAgainstBase: false });
+    if (bad.ok || !good.ok || noTest.ok) {
+      console.error('selftest FAILED: the gate does not distinguish its own cases');
+      process.exit(1);
+    }
+    console.log('selftest passed: a test that survives its own revert is rejected');
+    return;
+  }
+
+  const base = get('--base', 'origin/dev');
+  const allowUnchangedBehaviour = args.includes('--allow-unchanged-behaviour');
+
+  const files = git('diff', '--name-only', `${base}...HEAD`).split('\n').filter(Boolean);
+  const { source, tests } = classify(files);
+
+  console.log(`source files changed: ${source.length}`);
+  console.log(`test files changed:   ${tests.length}`);
+
+  let testsPassedAgainstBase = null;
+
+  if (source.length > 0 && tests.length > 0) {
+    // Restore ONLY the source files to their base content. The branch's test
+    // changes stay exactly as written - that is the whole experiment.
+    git('checkout', base, '--', ...source);
+    try {
+      const patterns = tests.filter((t) => !/(^|\/)e2e\//.test(t));
+      if (patterns.length === 0) {
+        console.log('only e2e specs changed; this gate does not run them');
+        testsPassedAgainstBase = false; // not evidence of a passing test
+      } else {
+        try {
+          execFileSync(
+            'pnpm',
+            ['--filter', 'frontend', 'run', 'test', '--', '--testPathPatterns', patterns.join('|')],
+            { stdio: 'inherit' }
+          );
+          testsPassedAgainstBase = true;
+        } catch {
+          testsPassedAgainstBase = false;
+        }
+      }
+    } finally {
+      // Always put the branch back, including when the run threw.
+      git('checkout', 'HEAD', '--', ...source);
+    }
+  }
+
+  const result = verdict({ source, tests, testsPassedAgainstBase, allowUnchangedBehaviour });
+  console.log(`\n${result.ok ? 'PASS' : 'FAIL'}: ${result.reason}`);
+  process.exit(result.ok ? 0 : 1);
+};
+
+/**
+ * Compare REAL paths. import.meta.url resolves symlinks and process.argv[1]
+ * does not, so on a macOS temp dir (/var -> /private/var) the naive comparison
+ * is false, main() never runs, and the gate exits 0 having checked nothing -
+ * a no-op that reads as a pass, which is the failure mode this file exists to
+ * eliminate.
+ */
+const invokedDirectly = (() => {
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classify,
+  isCheckableSource,
+  isTestFile,
+  verdict,
+} from './tests-must-be-able-to-fail.mjs';
+
+test('recognises this repository\'s test conventions', () => {
+  for (const f of [
+    'apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx',
+    'apps/frontend/e2e/route-sweep.spec.ts',
+    'scripts/ci/diff-coverage.test.mjs',
+  ]) {
+    assert.equal(isTestFile(f), true, f);
+  }
+  assert.equal(isTestFile('apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx'), false);
+});
+
+test('an e2e helper is a test file even without a .spec suffix', () => {
+  // Without this, e2e/support/auth.ts counts as checkable source and a PR that
+  // only touches e2e plumbing is told to write a unit test for it.
+  assert.equal(isTestFile('apps/frontend/e2e/support/auth.ts'), true);
+  assert.equal(isTestFile('apps/desktop/tests/e2e/menu.ts'), true);
+  assert.equal(isCheckableSource('apps/frontend/e2e/support/pageInvariants.ts'), false);
+});
+
+test('only counts source a test could meaningfully assert against', () => {
+  assert.equal(isCheckableSource('apps/frontend/src/app/features/inventory/utils.ts'), true);
+  // A test cannot fail on any of these, so demanding one would only teach
+  // people to bypass the gate.
+  for (const f of [
+    'docs/ci/coverage.md',
+    'pnpm-lock.yaml',
+    '.github/workflows/frontend-e2e.yml',
+    'scripts/ci/forbidden-terms.mjs',
+    'apps/frontend/src/app/ui/Button.stories.tsx',
+    'packages/types/dist/index.js',
+  ]) {
+    assert.equal(isCheckableSource(f), false, f);
+  }
+});
+
+test('a source change with no test at all is rejected', () => {
+  const r = verdict({ source: ['a.ts'], tests: [], testsPassedAgainstBase: null });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /no test/);
+});
+
+test('THE CASE THIS GATE EXISTS FOR: tests that pass against the base are rejected', () => {
+  const r = verdict({ source: ['a.ts'], tests: ['a.test.ts'], testsPassedAgainstBase: true });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /do not verify this change/);
+});
+
+test('tests that fail without the change are accepted', () => {
+  const r = verdict({ source: ['a.ts'], tests: ['a.test.ts'], testsPassedAgainstBase: false });
+  assert.equal(r.ok, true);
+});
+
+test('a docs-only or CI-only pull request passes untouched', () => {
+  const { source, tests } = classify(['docs/x.md', '.github/workflows/y.yml']);
+  assert.deepEqual(source, []);
+  assert.equal(verdict({ source, tests, testsPassedAgainstBase: null }).ok, true);
+});
+
+test('the refactor label excuses a passing base run, and says so on the record', () => {
+  const r = verdict({
+    source: ['a.ts'],
+    tests: ['a.test.ts'],
+    testsPassedAgainstBase: true,
+    allowUnchangedBehaviour: true,
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.reason, /on the record/);
+});
+
+test('the label does NOT excuse shipping source with no test', () => {
+  const r = verdict({
+    source: ['a.ts'],
+    tests: [],
+    testsPassedAgainstBase: null,
+    allowUnchangedBehaviour: true,
+  });
+  assert.equal(r.ok, false, 'the label must not become a way to skip writing tests');
+});


### PR DESCRIPTION
## What changed

A gate that fails a pull request whose tests pass against the code it claims to change.

## Why

A release shipped an Inventory page reading "0 items below reorder point" directly above a panel headed "Low stock 21", with 546 tests passing and an audit document reporting mutation checks. Both numbers were tested. Neither test could see the other, because each asserted against a fixture its own author wrote, and a fixture cannot contradict itself.

Counting tests does not detect that. Coverage does not either - both lines were covered. One mechanical question separates a test that verifies a change from one that merely runs beside it:

> If the source change were removed, would this test fail?

So that is what runs. Keep the branch's test changes, restore its source changes to the base, run the tests the branch added or modified. If they all still pass, they never tested the change.

## Behaviour

| situation | verdict |
| --- | --- |
| source changed, no test changed | fail |
| changed tests fail without the source change | pass |
| changed tests pass without the source change | **fail** |
| docs / CI / lockfile only | pass |
| pure refactor with the `no-behaviour-change` label | pass, and the claim is on the record |

The label does **not** excuse changing source with no test. A revert that stops the tests compiling counts as failing, reported distinctly: weaker evidence than an assertion failure, but not a pass.

## Validation

The judgement is a pure function with 9 tests. Five mutations applied to the gate, all five fail it:

| mutation | result |
| --- | --- |
| accept tests that pass against the base | 0 pass, 1 fail |
| treat a no-test PR as fine | 6 pass, 2 fail |
| let the label excuse a missing test | 7 pass, 1 fail |
| count `.stories.tsx` as checkable source | 7 pass, 1 fail |
| stop recognising e2e helpers as test files | 8 pass, 1 fail |
| *(baseline)* | **9 pass, 0 fail** |

Two defects this process caught in the gate itself, both of which would have made it useless:

- **It was a silent no-op on first run.** `import.meta.url` resolves symlinks and `process.argv[1]` does not, so on a path under `/var` (symlink to `/private/var`) the entrypoint guard was false, `main()` never ran, and it exited 0 having checked nothing. It now compares real paths, and runs `selftest` in CI before it is trusted to pass anything.
- **The e2e branch was untested.** The mutation removing it initially passed 8/8. Without it, `e2e/support/auth.ts` counts as checkable source and a PR touching only e2e plumbing would be told to write a unit test for it. Now covered.

## Rollout

Triggers on every PR with no paths filter, so it cannot leave an unrelated PR waiting on a context GitHub never creates. Not yet added to the branch ruleset - land it, watch it on real PRs, then make it required.
