### PR TITLE
fix(repo): explain a rate-limited sign-in, and let an environment set its ceiling

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,5 +1,9 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
+import {
+  resolveRateLimitMax,
+  resolveRateLimitWindowMs,
+} from "src/utils/rate-limit-config";
 import fileUpload from "express-fileupload";
 import {
   getControlReports,
@@ -97,9 +101,13 @@ export function createApp() {
   app.use(helmet());
   app.disable("x-powered-by");
 
+  // Ceiling defaults to what production runs today; an environment that needs
+  // headroom sets RATE_LIMIT_MAX. Deliberately NOT an account allowlist - see
+  // utils/rate-limit-config for why that was rejected. The /auth limiter above
+  // is untouched: it guards the brute-force surface and stays at 100.
   const limiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 500,
+    windowMs: resolveRateLimitWindowMs(process.env.RATE_LIMIT_WINDOW_MS),
+    max: resolveRateLimitMax(process.env.RATE_LIMIT_MAX),
     standardHeaders: true,
     legacyHeaders: false,
   });

--- a/apps/backend/src/utils/rate-limit-config.ts
+++ b/apps/backend/src/utils/rate-limit-config.ts
@@ -1,0 +1,59 @@
+/**
+ * The global limiter's ceiling, read from the environment.
+ *
+ * WHY THIS IS CONFIGURABLE AND NOT AN ALLOWLIST
+ *
+ * The limit is 500 requests per 15 minutes keyed on client IP. That is shared by
+ * everyone behind one address: every member of staff at a practice on one NAT,
+ * and every automated check running against an environment. An authenticated
+ * page load issues roughly a dozen API calls, so a full end-to-end sweep of the
+ * app consumes most of a window on its own, and the symptom is a signed-in user
+ * bounced back to the sign-in form with no useful explanation.
+ *
+ * The obvious shortcut is to exempt the test account. It was considered and
+ * rejected twice over. The global limiter runs before any route-level auth
+ * middleware, so no verified identity exists at that point and the exemption
+ * would have to trust an unverified claim - the precise mistake buildRateLimitKey
+ * documents, where folding a caller-supplied header into the key let one session
+ * mint unlimited buckets. And an account exemption compiled into the codebase
+ * reaches production, turning a shared test credential into permanent unlimited
+ * request rights.
+ *
+ * A per-environment ceiling has neither property. Production keeps the value it
+ * has today because that is the default; an environment that needs headroom sets
+ * one variable; no credential grants anyone an exemption, because none exists.
+ */
+
+/** What production runs with, and what every environment gets unless it says otherwise. */
+export const DEFAULT_RATE_LIMIT_MAX = 500;
+export const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+const resolvePositiveInteger = (
+  raw: string | undefined,
+  fallback: number,
+): number => {
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return fallback;
+  const parsed = Number.parseInt(trimmed, 10);
+  return parsed > 0 ? parsed : fallback;
+};
+
+/**
+ * Anything that is not a positive integer - unset, empty, a typo, a negative,
+ * zero - falls back to the default.
+ *
+ * Zero deserves its own mention: express-rate-limit treats `max: 0` as "block
+ * everything", so a typo producing zero would take the API down rather than
+ * loosen it. Falling back is the safe direction for a misconfiguration; failing
+ * closed here would mean an unparseable value bricks the service.
+ */
+export const resolveRateLimitMax = (
+  raw: string | undefined,
+  fallback: number = DEFAULT_RATE_LIMIT_MAX,
+): number => resolvePositiveInteger(raw, fallback);
+
+export const resolveRateLimitWindowMs = (
+  raw: string | undefined,
+  fallback: number = DEFAULT_RATE_LIMIT_WINDOW_MS,
+): number => resolvePositiveInteger(raw, fallback);

--- a/apps/backend/test/rate-limit-config.test.ts
+++ b/apps/backend/test/rate-limit-config.test.ts
@@ -1,0 +1,38 @@
+import {
+  DEFAULT_RATE_LIMIT_MAX,
+  DEFAULT_RATE_LIMIT_WINDOW_MS,
+  resolveRateLimitMax,
+  resolveRateLimitWindowMs,
+} from "../src/utils/rate-limit-config";
+
+describe("rate limit configuration", () => {
+  it("keeps production's current ceiling when nothing is set", () => {
+    expect(resolveRateLimitMax(undefined)).toBe(500);
+    expect(DEFAULT_RATE_LIMIT_MAX).toBe(500);
+    expect(resolveRateLimitWindowMs(undefined)).toBe(15 * 60 * 1000);
+    expect(DEFAULT_RATE_LIMIT_WINDOW_MS).toBe(15 * 60 * 1000);
+  });
+
+  it("raises the ceiling only when an environment asks for it", () => {
+    expect(resolveRateLimitMax("5000")).toBe(5000);
+    expect(resolveRateLimitWindowMs("60000")).toBe(60_000);
+  });
+
+  it("falls back rather than accepting a value that would break the API", () => {
+    // express-rate-limit reads max: 0 as "block everything", so a typo that
+    // produced zero would take the API down instead of loosening it.
+    expect(resolveRateLimitMax("0")).toBe(500);
+    expect(resolveRateLimitMax("-1")).toBe(500);
+    expect(resolveRateLimitMax("")).toBe(500);
+    expect(resolveRateLimitMax("   ")).toBe(500);
+    expect(resolveRateLimitMax("lots")).toBe(500);
+    expect(resolveRateLimitMax("5e3")).toBe(500);
+    expect(resolveRateLimitMax("500.5")).toBe(500);
+    expect(resolveRateLimitWindowMs("0")).toBe(15 * 60 * 1000);
+    expect(resolveRateLimitWindowMs("nope")).toBe(15 * 60 * 1000);
+  });
+
+  it("tolerates surrounding whitespace, which an env var routinely carries", () => {
+    expect(resolveRateLimitMax(" 2000 ")).toBe(2000);
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/auth/lib/signInErrorMessage.test.ts
+++ b/apps/frontend/src/app/__tests__/features/auth/lib/signInErrorMessage.test.ts
@@ -1,0 +1,52 @@
+import {
+  DEFAULT_SIGN_IN_ERROR,
+  signInErrorMessage,
+  statusOf,
+} from '@/app/features/auth/lib/signInErrorMessage';
+
+describe('signInErrorMessage', () => {
+  it('explains a rate-limited bootstrap without blaming the credentials', () => {
+    // The observed failure: /auth/signin returned 200 and /v1/auth/me returned 429.
+    const message = signInErrorMessage({ response: { status: 429 } });
+    expect(message).toMatch(/too many requests/i);
+    expect(message).toMatch(/wait a minute/i);
+    // The credentials were accepted, so the copy must not suggest otherwise.
+    expect(message).not.toMatch(/password|incorrect|invalid/i);
+    expect(message).not.toMatch(/status code/i);
+  });
+
+  it('never shows a raw transport string, whatever the status', () => {
+    expect(signInErrorMessage({ message: 'Request failed with status code 500' })).toBe(
+      DEFAULT_SIGN_IN_ERROR
+    );
+    expect(signInErrorMessage({ message: 'Request failed with status code 429' })).toBe(
+      DEFAULT_SIGN_IN_ERROR
+    );
+  });
+
+  it('keeps a message the API wrote for a person', () => {
+    expect(signInErrorMessage({ message: 'Incorrect email or password.' })).toBe(
+      'Incorrect email or password.'
+    );
+  });
+
+  it('handles an upstream outage separately from throttling', () => {
+    for (const status of [502, 503, 504]) {
+      expect(signInErrorMessage({ response: { status } })).toMatch(/temporarily unavailable/i);
+    }
+  });
+
+  it('falls back rather than rendering nothing', () => {
+    expect(signInErrorMessage(undefined)).toBe(DEFAULT_SIGN_IN_ERROR);
+    expect(signInErrorMessage(null)).toBe(DEFAULT_SIGN_IN_ERROR);
+    expect(signInErrorMessage({})).toBe(DEFAULT_SIGN_IN_ERROR);
+    expect(signInErrorMessage({ message: '   ' })).toBe(DEFAULT_SIGN_IN_ERROR);
+  });
+
+  it('reads the status from either shape the transport throws', () => {
+    expect(statusOf({ response: { status: 429 } })).toBe(429);
+    expect(statusOf({ status: 503 })).toBe(503);
+    expect(statusOf({ status: '429' })).toBeUndefined();
+    expect(statusOf(undefined)).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignIn/SignIn.test.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/app/stores/authStore';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useErrorTost } from '@/app/ui/overlays/Toast/Toast';
 import { resolvePostAuthRedirect } from '@/app/lib/postAuthRedirect';
+import { DEFAULT_SIGN_IN_ERROR } from '@/app/features/auth/lib/signInErrorMessage';
 
 // --- Mocks ---
 
@@ -519,7 +520,7 @@ describe('SignIn Page', () => {
     });
 
     expect(mockShowErrorTost).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Sign in failed' })
+      expect.objectContaining({ message: DEFAULT_SIGN_IN_ERROR })
     );
   });
 

--- a/apps/frontend/src/app/features/auth/lib/signInErrorMessage.ts
+++ b/apps/frontend/src/app/features/auth/lib/signInErrorMessage.ts
@@ -1,0 +1,44 @@
+/**
+ * Turns a sign-in failure into something the person at the desk can act on.
+ *
+ * The catch in SignIn.tsx rendered `error.message` verbatim, so a rate-limited
+ * bootstrap put "Request failed with status code 429" on screen under a generic
+ * "Error" heading. That names a condition a veterinary receptionist has no way
+ * to interpret, gives no indication of whether they did anything wrong, and
+ * suggests no action - so the reasonable conclusion available to them is that
+ * their password is wrong. It is not: authentication had already succeeded, and
+ * only the profile call afterwards was throttled.
+ */
+
+/** Extracts an HTTP status from whatever shape the transport threw. */
+export const statusOf = (error: unknown): number | undefined => {
+  const candidate = error as
+    | { status?: unknown; response?: { status?: unknown } }
+    | null
+    | undefined;
+  const raw = candidate?.response?.status ?? candidate?.status;
+  return typeof raw === 'number' ? raw : undefined;
+};
+
+export const DEFAULT_SIGN_IN_ERROR = 'Sign in failed. Please try again.';
+
+export const signInErrorMessage = (error: unknown): string => {
+  switch (statusOf(error)) {
+    case 429:
+      // Says what happened, that it is temporary, and what to do. Deliberately
+      // does not blame the credentials, which were accepted.
+      return 'Too many requests right now. Your sign in was accepted - please wait a minute and try again.';
+    case 502:
+    case 503:
+    case 504:
+      return 'The service is temporarily unavailable. Please wait a moment and try again.';
+    default: {
+      const message = (error as { message?: unknown } | null | undefined)?.message;
+      // A transport string like "Request failed with status code 500" tells the
+      // reader nothing, so it is replaced rather than shown. Anything the API
+      // wrote for a human (a wrong-credentials message) is kept.
+      if (typeof message !== 'string' || !message.trim()) return DEFAULT_SIGN_IN_ERROR;
+      return /request failed with status code/i.test(message) ? DEFAULT_SIGN_IN_ERROR : message;
+    }
+  }
+};

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx
@@ -33,6 +33,7 @@ import {
   AuthSubmitButton,
   AuthAltNote,
 } from '@/app/features/auth/pages/authForm';
+import { signInErrorMessage } from '@/app/features/auth/lib/signInErrorMessage';
 
 type SignInProps = {
   redirectPath?: string;
@@ -240,7 +241,7 @@ const SignInForm = ({
         await handleCodeResendonError();
       } else {
         showErrorTost({
-          message: error.message || `Sign in failed`,
+          message: signInErrorMessage(error),
           errortext: 'Error',
           iconElement: (
             <Icon


### PR DESCRIPTION
Fixes #2862.

## What happened

Observed on `dev.yosemitecrew.com` with valid credentials:

```
200  /auth/signin        <- authentication SUCCEEDED, session established
200  /auth/mfa/info
429  /v1/auth/me         <- post-sign-in bootstrap rate-limited
landed: /signin
on screen: "Error" / "Request failed with status code 429"
```

The user is returned to the sign-in form holding a valid session, and the only explanation offered is a transport string. A veterinary receptionist has no way to read that, and the reasonable conclusion available to them is that their password is wrong. It was not.

## Two changes

**`signInErrorMessage`** maps the condition to something actionable - what happened, that it is temporary, what to do - and explicitly does not blame credentials the API had already accepted. A raw `Request failed with status code N` is never rendered again; a message the API wrote for a person is kept.

**The global limiter's ceiling and window** come from `RATE_LIMIT_MAX` / `RATE_LIMIT_WINDOW_MS`, defaulting to the 500 per 15 minutes production runs today. **Production behaviour is unchanged by this commit.** An environment that needs headroom sets one variable.

## Why not exempt the test account

It was asked for, considered, and rejected twice over:

- The global limiter runs at `app.use` before any route-level auth middleware, so `resolveVerifiedUserId` returns undefined there. An account exemption would have to trust an unverified claim - the exact mistake `buildRateLimitKey` documents, where folding a caller-supplied header into the key let one session mint unlimited buckets.
- An exemption compiled into the codebase reaches production, turning a shared test credential that lives in GitHub secrets and on three laptops into permanent unlimited request rights.

A per-environment ceiling has neither property, and needs no extra accounts.

The `/auth` limiter that guards the brute-force surface is untouched at 100.

## Validation

Frontend 6 tests, backend 4 tests. Eight mutations applied, eight caught:

| mutation | result |
| --- | --- |
| default becomes 5000 instead of 500 | 2 failed |
| accept `0` (express-rate-limit reads it as "block everything") | 1 failed |
| accept any numeric-looking string | 1 failed |
| stop trimming whitespace | 1 failed |
| 429 falls through to the default message | 1 failed |
| let the raw transport string through | 1 failed |
| drop 502/503/504 handling | 1 failed |
| accept a string status | 1 failed |

Frontend `tsc --noEmit` exit 0; frontend eslint clean on the changed files. The backend's 10 `no-unsafe-call` errors in `app.ts` lines 67-87 are **pre-existing** - an identical set appears on unmodified `dev` in the same worktree, caused by unbuilt workspace packages, which CI builds first.

## Deploying this

`deploy-api.yml` is deliberately `workflow_dispatch` only, so merging does not ship it. The API needs a manual deploy plus `RATE_LIMIT_MAX` set on the target environment before the headroom exists.
