### PR TITLE
ci(repo): handle added files and non-frontend workspaces in the test gate

### DIFF
--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -83,7 +83,9 @@ export const groupTestsByWorkspace = (tests) => {
     if (/(^|\/)e2e\//.test(t)) continue; // this gate does not drive browsers
     const ws = workspaceOf(t);
     if (!ws) continue;
-    out.set(ws, [...(out.get(ws) ?? []), t]);
+    const paths = out.get(ws);
+    if (paths) paths.push(t);
+    else out.set(ws, [t]);
   }
   return out;
 };
@@ -101,6 +103,7 @@ export const verdict = ({
   source,
   tests,
   testsPassedAgainstBase,
+  nothingRunnable = false,
   allowUnchangedBehaviour = false,
 }) => {
   if (source.length === 0) {
@@ -112,6 +115,19 @@ export const verdict = ({
       reason:
         `This pull request changes ${source.length} source file(s) and no test.\n` +
         'A change nothing can fail on is a change nothing verified.',
+    };
+  }
+  // Distinct from "the tests failed against the base". Nothing ran, so nothing
+  // was proved - and `false` here would be read as proof, which is the exact
+  // false green this gate exists to remove. It was written that way first.
+  if (nothingRunnable) {
+    return {
+      ok: false,
+      reason:
+        'The changed tests are all end-to-end specs, which this gate does not run.\n' +
+        'It therefore cannot tell whether they verify this source change.\n' +
+        'Add a unit test for the changed behaviour, or label the PR no-behaviour-change\n' +
+        'if the source change genuinely alters nothing observable.',
     };
   }
   if (testsPassedAgainstBase === false) {
@@ -136,6 +152,27 @@ export const verdict = ({
 };
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+/**
+ * Runs each workspace's changed tests against the reverted source.
+ *
+ * Every workspace must pass for the branch to be judged "the tests survive their
+ * own revert". One failing workspace proves the tests depend on the change.
+ */
+const runChangedTests = (byWorkspace) => {
+  let allPassed = true;
+  for (const [ws, paths] of byWorkspace) {
+    console.log(`running ${paths.length} changed test file(s) in ${ws} against the base`);
+    try {
+      execFileSync('pnpm', ['--filter', ws, 'exec', 'jest', '--ci', '--passWithNoTests', ...paths], {
+        stdio: 'inherit',
+      });
+    } catch {
+      allPassed = false;
+    }
+  }
+  return allPassed;
+};
 
 const main = () => {
   const args = process.argv.slice(2);
@@ -167,6 +204,7 @@ const main = () => {
   console.log(`test files changed:   ${tests.length}`);
 
   let testsPassedAgainstBase = null;
+  let nothingRunnable = false;
 
   if (source.length > 0 && tests.length > 0) {
     // A file the branch ADDS does not exist at the base, and `git checkout base --`
@@ -190,25 +228,9 @@ const main = () => {
     try {
       if (byWorkspace.size === 0) {
         console.log('no runnable unit tests changed (e2e only, or outside a known workspace)');
-        testsPassedAgainstBase = false; // absence of evidence is not a pass
+        nothingRunnable = true;
       } else {
-        // Every workspace must pass for the branch to be judged as "tests
-        // survive their own revert". One failing workspace proves the tests
-        // depend on the change.
-        let allPassed = true;
-        for (const [ws, paths] of byWorkspace) {
-          console.log(`running ${paths.length} changed test file(s) in ${ws} against the base`);
-          try {
-            execFileSync(
-              'pnpm',
-              ['--filter', ws, 'exec', 'jest', '--ci', '--passWithNoTests', ...paths],
-              { stdio: 'inherit' }
-            );
-          } catch {
-            allPassed = false;
-          }
-        }
-        testsPassedAgainstBase = allPassed;
+        testsPassedAgainstBase = runChangedTests(byWorkspace);
       }
     } finally {
       // Always put the branch back, including when the run threw. `checkout HEAD`
@@ -217,7 +239,13 @@ const main = () => {
     }
   }
 
-  const result = verdict({ source, tests, testsPassedAgainstBase, allowUnchangedBehaviour });
+  const result = verdict({
+    source,
+    tests,
+    testsPassedAgainstBase,
+    nothingRunnable,
+    allowUnchangedBehaviour,
+  });
   console.log(`\n${result.ok ? 'PASS' : 'FAIL'}: ${result.reason}`);
   process.exit(result.ok ? 0 : 1);
 };

--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -38,7 +38,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { realpathSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /** A test file, by this repository's own conventions. */
@@ -61,6 +61,31 @@ export const isCheckableSource = (file) => {
   if (/\.(stories|d)\.[mc]?[jt]sx?$/.test(file)) return false;
   if (/(^|\/)(dist|build|generated|__generated__)\//.test(file)) return false;
   return /\.[mc]?[jt]sx?$/.test(file);
+};
+
+/**
+ * The workspace a changed test belongs to.
+ *
+ * The first version ran `pnpm --filter frontend` unconditionally, so a PR whose
+ * only test change was in apps/backend ran nothing and the gate reported a pass
+ * it had not earned.
+ */
+export const workspaceOf = (file) => {
+  const match = /^apps\/([^/]+)\//.exec(file);
+  if (!match) return undefined;
+  return { frontend: 'frontend', backend: 'backend' }[match[1]];
+};
+
+/** Groups test paths by the workspace whose runner can execute them. */
+export const groupTestsByWorkspace = (tests) => {
+  const out = new Map();
+  for (const t of tests) {
+    if (/(^|\/)e2e\//.test(t)) continue; // this gate does not drive browsers
+    const ws = workspaceOf(t);
+    if (!ws) continue;
+    out.set(ws, [...(out.get(ws) ?? []), t]);
+  }
+  return out;
 };
 
 export const classify = (files) => ({
@@ -144,28 +169,50 @@ const main = () => {
   let testsPassedAgainstBase = null;
 
   if (source.length > 0 && tests.length > 0) {
-    // Restore ONLY the source files to their base content. The branch's test
-    // changes stay exactly as written - that is the whole experiment.
-    git('checkout', base, '--', ...source);
+    // A file the branch ADDS does not exist at the base, and `git checkout base --`
+    // fails outright on it - which crashed this gate on the first real pull
+    // request that added one. Reverting such a file means removing it.
+    const existsAtBase = (file) => {
+      try {
+        execFileSync('git', ['cat-file', '-e', `${base}:${file}`], { stdio: 'ignore' });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const modified = source.filter(existsAtBase);
+    const added = source.filter((f) => !existsAtBase(f));
+
+    if (modified.length) git('checkout', base, '--', ...modified);
+    for (const file of added) rmSync(file, { force: true });
+
+    const byWorkspace = groupTestsByWorkspace(tests);
     try {
-      const patterns = tests.filter((t) => !/(^|\/)e2e\//.test(t));
-      if (patterns.length === 0) {
-        console.log('only e2e specs changed; this gate does not run them');
-        testsPassedAgainstBase = false; // not evidence of a passing test
+      if (byWorkspace.size === 0) {
+        console.log('no runnable unit tests changed (e2e only, or outside a known workspace)');
+        testsPassedAgainstBase = false; // absence of evidence is not a pass
       } else {
-        try {
-          execFileSync(
-            'pnpm',
-            ['--filter', 'frontend', 'run', 'test', '--', '--testPathPatterns', patterns.join('|')],
-            { stdio: 'inherit' }
-          );
-          testsPassedAgainstBase = true;
-        } catch {
-          testsPassedAgainstBase = false;
+        // Every workspace must pass for the branch to be judged as "tests
+        // survive their own revert". One failing workspace proves the tests
+        // depend on the change.
+        let allPassed = true;
+        for (const [ws, paths] of byWorkspace) {
+          console.log(`running ${paths.length} changed test file(s) in ${ws} against the base`);
+          try {
+            execFileSync(
+              'pnpm',
+              ['--filter', ws, 'exec', 'jest', '--ci', '--passWithNoTests', ...paths],
+              { stdio: 'inherit' }
+            );
+          } catch {
+            allPassed = false;
+          }
         }
+        testsPassedAgainstBase = allPassed;
       }
     } finally {
-      // Always put the branch back, including when the run threw.
+      // Always put the branch back, including when the run threw. `checkout HEAD`
+      // restores a deleted file too, so added and modified are handled alike.
       git('checkout', 'HEAD', '--', ...source);
     }
   }

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -115,3 +115,39 @@ test('a PR with only e2e test changes is not treated as proven', () => {
   const grouped = groupTestsByWorkspace(['apps/frontend/e2e/route-sweep.spec.ts']);
   assert.equal(grouped.size, 0, 'nothing runnable means no evidence, not a pass');
 });
+
+test('nothing runnable is NOT read as proof', () => {
+  // This was the bug: `false` meant "the tests failed against the base", which
+  // verdict reads as success. A PR whose only test change was an e2e spec
+  // therefore PASSED the gate having proved nothing at all.
+  const r = verdict({
+    source: ['a.ts'],
+    tests: ['apps/frontend/e2e/x.spec.ts'],
+    testsPassedAgainstBase: null,
+    nothingRunnable: true,
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /does not run/);
+});
+
+test('a genuine failure against the base is still a pass', () => {
+  // The distinction that matters: tests ran and failed (proof) versus tests
+  // never ran (no proof).
+  const r = verdict({
+    source: ['a.ts'],
+    tests: ['apps/frontend/x.test.ts'],
+    testsPassedAgainstBase: false,
+    nothingRunnable: false,
+  });
+  assert.equal(r.ok, true);
+});
+
+test('the refactor label still excuses an unrunnable change', () => {
+  const r = verdict({
+    source: ['a.ts'],
+    tests: ['apps/frontend/e2e/x.spec.ts'],
+    nothingRunnable: true,
+    allowUnchangedBehaviour: true,
+  });
+  assert.equal(r.ok, false, 'the label excuses a PASSING base run, not an unverifiable one');
+});

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   classify,
+  groupTestsByWorkspace,
+  workspaceOf,
   isCheckableSource,
   isTestFile,
   verdict,
@@ -84,4 +86,32 @@ test('the label does NOT excuse shipping source with no test', () => {
     allowUnchangedBehaviour: true,
   });
   assert.equal(r.ok, false, 'the label must not become a way to skip writing tests');
+});
+
+test('routes a changed test to the workspace that can run it', () => {
+  // The first version ran `pnpm --filter frontend` unconditionally, so a PR
+  // whose only test change was in apps/backend ran nothing and reported a pass
+  // it had not earned.
+  assert.equal(workspaceOf('apps/backend/test/rate-limit-config.test.ts'), 'backend');
+  assert.equal(workspaceOf('apps/frontend/src/app/__tests__/x.test.ts'), 'frontend');
+  assert.equal(workspaceOf('scripts/ci/foo.test.mjs'), undefined);
+  assert.equal(workspaceOf('apps/mobileAppYC/__tests__/x.test.ts'), undefined);
+});
+
+test('groups tests per workspace and drops what this gate cannot run', () => {
+  const grouped = groupTestsByWorkspace([
+    'apps/backend/test/a.test.ts',
+    'apps/frontend/src/app/__tests__/b.test.ts',
+    'apps/frontend/src/app/__tests__/c.test.ts',
+    'apps/frontend/e2e/d.spec.ts',
+    'scripts/ci/e.test.mjs',
+  ]);
+  assert.deepEqual([...grouped.keys()].sort(), ['backend', 'frontend']);
+  assert.equal(grouped.get('frontend').length, 2, 'e2e specs must not be run by this gate');
+  assert.equal(grouped.get('backend').length, 1);
+});
+
+test('a PR with only e2e test changes is not treated as proven', () => {
+  const grouped = groupTestsByWorkspace(['apps/frontend/e2e/route-sweep.spec.ts']);
+  assert.equal(grouped.size, 0, 'nothing runnable means no evidence, not a pass');
 });


### PR DESCRIPTION
Follow-up to #2861, which the gate itself exposed on the first pull request it judged.

## Two defects

**It crashed on any PR that adds a source file.** `git checkout <base> -- <file>` fails outright for a path that does not exist at the base:

```
error: pathspec 'apps/backend/src/utils/rate-limit-config.ts' did not match any file(s) known to git
```

Reverting an added file means removing it. Added and modified source are now separated: modified is checked out from the base, added is deleted, and `checkout HEAD` restores both.

**It ran `pnpm --filter frontend` unconditionally.** A PR whose only test change was in `apps/backend` ran nothing, and the gate read that as "the tests passed against the base" - exactly the false green it exists to remove. Tests are grouped by the workspace that can run them, every group must pass for the branch to be judged proven, and a change with nothing runnable is recorded as absence of evidence rather than a pass.

## Validation

12 tests. Mutation-checked: routing every workspace back through the frontend filter fails two of them. `selftest` still passes, and still runs in CI before the gate is trusted to pass anything.