### PR TITLE
fix(frontend): pin playwright-core so a lockfile refresh cannot split it

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -108,6 +108,7 @@
     "jest": "^30.4.2",
     "jest-axe": "^11.0.0",
     "jest-environment-jsdom": "^30.4.1",
+    "playwright-core": "1.62.1",
     "postcss": "^8.5.26",
     "storybook": "^10.5.10",
     "tailwindcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.4.1
         version: 30.4.1
+      playwright-core:
+        specifier: 1.62.1
+        version: 1.62.1
       postcss:
         specifier: 8.5.26
         version: 8.5.26


### PR DESCRIPTION
## What

`@axe-core/playwright` declares `playwright-core: '>= 1.0.0'` as a peer dependency and nothing in the workspace declared it, so pnpm auto-installs the peer and is free to pick the newest published version whenever the lockfile is fully re-resolved. `@playwright/test` brings its own `playwright-core@1.62.1`, so after such a refresh `apps/frontend/e2e/a11y.spec.ts` sees two different `Page` types:

```
e2e/a11y.spec.ts(30,20): error TS2741: Property 'ariaSnapshotJSON' is missing in type
  '...playwright-core@1.62.1...Page' but required in type '...playwright-core@1.63.0...Page'
e2e/a11y.spec.ts(46,61): error TS2741: (same)
```

That is why `core / Static (frontend)` — and with it the required `CI Required` — is red on **ten of the eleven open dependency-update pull requests** (#2833 #2834 #2835 #2836 #2837 #2838 #2839 #2840 #2841 #2842) while `dev` itself is green. `dev`'s lockfile still carries the resolution from before `playwright-core@1.63.0` was published; only a full re-resolution moves it, and a dependency-update branch is exactly where that happens.

This is not a lint of one bump. It is one shared cause behind the whole stalled dependency backlog, including the security-relevant ones (`bcrypt`, `firebase-admin`, `stripe`, `body-parser`).

## The change

One line in `apps/frontend/package.json` — declare `playwright-core` as a direct devDependency at the exact version `@playwright/test` already resolves to — plus the three lockfile lines that follow from it, all inside the `apps/frontend` importer. No version of anything else moves.

`apps/desktop` (`@playwright/test: 1.62.1`) and `apps/backend` (`playwright: 1.62.1`) already pin their playwright packages exactly; this matches them.

## Evidence

Measured on the head of #2833 (`b08f1c32a`), same worktree, same commands, the pin as the only difference between the two rows:

```
as-is                pnpm --filter frontend run type-check   rc=2   2x TS2741
with the pin         pnpm --filter frontend run type-check   rc=0
lockfile refresh     playwright-core@1.63.0 entries in lock  3 -> 0
```

The first row is the negative control: it reproduces CI's failure locally, byte for byte on the error text, so the second row is a cure and not an unrelated green.

On this branch, off `dev` at `2cdf25396`:

```
pnpm --filter frontend run lint          rc=0   0 errors, 1 warning (pre-existing, sonarjs/no-nested-functions in useLazyAuthStore.ts)
pnpm --filter frontend run type-check    rc=0
```

## After this merges

The ten red dependency PRs need a rebase to pick the pin up; their lockfiles then re-resolve the peer to `1.62.1`, which is what the third row above verified against a real one of their lockfiles.
