### PR TITLE
ci(repo): copy the forbidden-terms secrets into the Dependabot scope

### DIFF
--- a/.github/workflows/copy-forbidden-terms-secrets.yml
+++ b/.github/workflows/copy-forbidden-terms-secrets.yml
@@ -1,0 +1,74 @@
+name: Copy forbidden-terms secrets to Dependabot
+
+# Dependabot has its own secret scope. FORBIDDEN_TERMS_PATTERN_B64 and
+# FORBIDDEN_TERMS_CORPUS_B64 exist under Actions, so every Dependabot pull
+# request fails the forbidden-terms gate with "No named external product" - a
+# failure no one can fix from the branch, on a dozen PRs at a time.
+#
+# The values cannot be copied by hand: GitHub never returns a secret, so the
+# only person who can retype them is whoever still holds the originals, and a
+# retyped list that differs from the Actions one leaves two gates enforcing two
+# different policies while both look green.
+#
+# A workflow can read the Actions scope and write the Dependabot scope, so the
+# value moves inside GitHub and is never printed, logged, or seen by anyone.
+#
+# DELIBERATELY NOT GENERAL. The two names are hardcoded and the direction is
+# fixed. A workflow that copied an arbitrary named secret would be an
+# exfiltration primitive available to anyone who can dispatch it; this one can
+# only ever move these two values, Actions to Dependabot, within this repo.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  copy:
+    name: Copy to the Dependabot scope
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to run without the source values
+        env:
+          PATTERN: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+          CORPUS: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
+        run: |
+          missing=""
+          [ -n "$PATTERN" ] || missing="$missing FORBIDDEN_TERMS_PATTERN_B64"
+          [ -n "$CORPUS" ]  || missing="$missing FORBIDDEN_TERMS_CORPUS_B64"
+          if [ -n "$missing" ]; then
+            echo "Not set under Actions in this repository:$missing"
+            echo "There is nothing to copy. Set them under Actions first."
+            exit 1
+          fi
+          # Lengths only. Enough to tell a truncated secret from a whole one,
+          # and nothing about the contents.
+          echo "pattern length: ${#PATTERN}"
+          echo "corpus length:  ${#CORPUS}"
+
+      - name: Write them to the Dependabot scope
+        env:
+          PATTERN: ${{ secrets.FORBIDDEN_TERMS_PATTERN_B64 }}
+          CORPUS: ${{ secrets.FORBIDDEN_TERMS_CORPUS_B64 }}
+          # Needs a token that can administer this repository's secrets. The
+          # default GITHUB_TOKEN cannot write them, by design.
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # gh performs the libsodium sealed-box encryption itself, so the
+          # plaintext never touches a file and is never echoed.
+          printf '%s' "$PATTERN" | gh secret set FORBIDDEN_TERMS_PATTERN_B64 \
+            --app dependabot --repo "$GITHUB_REPOSITORY"
+          printf '%s' "$CORPUS" | gh secret set FORBIDDEN_TERMS_CORPUS_B64 \
+            --app dependabot --repo "$GITHUB_REPOSITORY"
+          echo "copied"
+
+      - name: Confirm both exist in the Dependabot scope
+        env:
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Names and timestamps only; the API never returns a value.
+          gh api "repos/$GITHUB_REPOSITORY/dependabot/secrets" \
+            --jq '.secrets[] | select(.name | startswith("FORBIDDEN_TERMS")) | "\(.name) updated \(.updated_at)"'


### PR DESCRIPTION
Unblocks the Dependabot PRs failing `No named external product`.

## Why a workflow rather than pasting them in

GitHub never returns a secret value, so the Dependabot scope cannot be populated from the Actions one by hand. The only person who could retype them is whoever still holds the originals - and a retyped list that differs from the Actions one leaves two gates enforcing two different policies while both look green.

A workflow can read Actions and write Dependabot, so the value moves inside GitHub. It is never printed, never logged, and nobody sees it.

## Containment

Deliberately not general:

- both secret names are hardcoded, and there are no workflow inputs
- direction is fixed, Actions to Dependabot, within its own repository
- it fails when the source values are unset rather than writing empty secrets
- it reports lengths only, then lists names and timestamps from an API that never returns values

A workflow that copied an arbitrary named secret would be an exfiltration primitive for anyone who can dispatch it. This one cannot be pointed at anything else.

## After merging

Dispatch it once per repository. The Dependabot PRs then pass forbidden-terms on their next run.