### PR TITLE
fix(backend): import firebase-admin through its modular subpath API

### DIFF
--- a/apps/backend/src/services/notification.service.ts
+++ b/apps/backend/src/services/notification.service.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import admin from "firebase-admin";
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { getMessaging, type Message } from "firebase-admin/messaging";
 import { NotificationType } from "@prisma/client";
 import logger from "src/utils/logger";
 import { NotificationPayload } from "src/utils/notificationTemplates";
@@ -8,7 +9,9 @@ import { prisma } from "src/config/prisma";
 
 // firebase-admin is used here ONLY for FCM push delivery (device messaging),
 // not for authentication. Initialized lazily so environments without push
-// credentials (CI, local API-only work) never require them.
+// credentials (CI, local API-only work) never require them. Imported through
+// the modular subpath entry points because firebase-admin v14 removes the
+// default-export namespace a `import admin from "firebase-admin"` relies on.
 const getFirebaseCredentialsPath = () => {
   const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (!credentialsPath || !existsSync(credentialsPath)) {
@@ -20,9 +23,9 @@ const getFirebaseCredentialsPath = () => {
 
 const credentialsPath = getFirebaseCredentialsPath();
 
-if (!admin.apps?.length && credentialsPath) {
-  admin.initializeApp({
-    credential: admin.credential.cert(credentialsPath),
+if (!getApps().length && credentialsPath) {
+  initializeApp({
+    credential: cert(credentialsPath),
   });
 }
 
@@ -75,8 +78,8 @@ const buildFcmMessage = (
   token: string,
   payload: NotificationPayload,
   options?: SendOptions,
-): admin.messaging.Message => {
-  const msg: admin.messaging.Message = {
+): Message => {
+  const msg: Message = {
     token,
     notification: {
       title: payload.title,
@@ -135,7 +138,7 @@ export const NotificationService = {
     const message = buildFcmMessage(token, payload, options);
 
     try {
-      const response = await admin.messaging().send(message, options?.dryRun);
+      const response = await getMessaging().send(message, options?.dryRun);
       logger.info(
         `Notification sent to token ${tokenPrefix(token)}…: ${response}`,
       );

--- a/apps/backend/test/services/notification.init.test.ts
+++ b/apps/backend/test/services/notification.init.test.ts
@@ -23,14 +23,15 @@ const importFreshWithAdmin = (
     jest.doMock("node:fs", () => ({
       existsSync,
     }));
-    jest.doMock("firebase-admin", () => ({
+    jest.doMock("firebase-admin/app", () => ({
       __esModule: true,
-      default: {
-        apps,
-        initializeApp,
-        credential: { cert },
-        messaging: jest.fn(),
-      },
+      getApps: jest.fn(() => apps),
+      initializeApp,
+      cert,
+    }));
+    jest.doMock("firebase-admin/messaging", () => ({
+      __esModule: true,
+      getMessaging: jest.fn(),
     }));
     require("../../src/services/notification.service");
   });

--- a/apps/backend/test/services/notification.service.test.ts
+++ b/apps/backend/test/services/notification.service.test.ts
@@ -6,13 +6,17 @@ import { prisma } from "src/config/prisma";
 
 // 1. Mock External Dependencies
 const mockSend = jest.fn();
-jest.mock("firebase-admin", () => ({
+jest.mock("firebase-admin/messaging", () => ({
   __esModule: true,
-  default: {
-    messaging: jest.fn(() => ({
-      send: mockSend,
-    })),
-  },
+  getMessaging: jest.fn(() => ({
+    send: mockSend,
+  })),
+}));
+jest.mock("firebase-admin/app", () => ({
+  __esModule: true,
+  getApps: jest.fn(() => []),
+  initializeApp: jest.fn(),
+  cert: jest.fn(),
 }));
 
 jest.mock("../../src/utils/logger", () => ({


### PR DESCRIPTION
## Why

`apps/backend/src/services/notification.service.ts` imported the FCM SDK as
`import admin from "firebase-admin"`. firebase-admin **v14 removes that default-export
namespace** — its `lib/index.d.ts` exports only the modular symbols, so the `admin` binding
resolves to an error type and every member access on it becomes an
`@typescript-eslint/no-unsafe-*` error.

That is the sole cause of `core / Static (backend)` — and therefore `CI Required` — being red on
the pending firebase-admin bump (#2839). It is not a lint-config problem and it is not fixable by
a rebase.

## What

Move the one consumer to the modular subpath entry points, which **v13 already exports**, so this
lands on `dev` under the current version and #2839 goes green on a rebase:

- `firebase-admin/app` → `getApps`, `initializeApp`, `cert`
- `firebase-admin/messaging` → `getMessaging`, `Message`

The two test suites mocked `"firebase-admin"`, so their `jest.mock` targets move to the same two
subpaths. No behaviour change: the lazy init guard, the credential path check and the FCM send
call are the same operations.

## Evidence

All arms below ran in one worktree per row, with shared packages built
(`pnpm exec turbo run build --filter='./packages/*'`, rc=0) and the Prisma client generated, which
is what `core / Static (backend)` does before it lints.

**Decisive arm — a worktree at #2839's head (`acc1b1ab0`, firebase-admin 14.3.0 installed and
confirmed via `require(...).version`). Same install, same commands, the patch as the only
difference:**

```
before   pnpm --filter backend run lint   rc=1   34 problems (9 errors, 25 warnings)
                                                 all 9 in notification.service.ts, lines and rule
                                                 ids identical to the CI log on #2839
after    pnpm --filter backend run lint   rc=0   25 problems (0 errors, 25 warnings)
after    pnpm --filter backend run type-check    rc=0
after    jest (the 2 notification suites)  rc=0  2 passed, 32 passed, 0 skipped
```

The first row is what makes the second a cure rather than an unrelated green.

**This branch, on `dev` (firebase-admin 13.6.0):**

```
pnpm --filter backend run lint         rc=0   25 problems (0 errors, 25 warnings)
pnpm --filter backend run type-check   rc=0
jest (the 2 notification suites)       rc=0   2 passed, 32 passed, 0 skipped
```

The 25 warnings are the pre-existing sonarjs set and are unchanged in every arm.

**Both changed test files were mutation-checked, and both arms fired:**

```
source reverted to HEAD, new mocks kept   2 suites failed, 12 of 32 tests failed
!getApps().length -> getApps().length     1 suite failed,  2 of 3 tests failed
```

The first is the arm `Tests Must Be Able To Fail` runs; the second shows the init test still binds
to the guard's logic and not merely to the import shape.

## After this merges

#2839 needs a rebase to pick it up. It is independent of #2865 (the `playwright-core` pin), which
covers the eight Dependabot PRs that are red on `core / Static (frontend)`.
