### PR TITLE
fix(frontend): count out-of-stock items as below the reorder point

### DIFF
--- a/apps/frontend/src/app/__tests__/features/inventory/belowReorderPoint.test.ts
+++ b/apps/frontend/src/app/__tests__/features/inventory/belowReorderPoint.test.ts
@@ -1,0 +1,46 @@
+import {
+  effectiveStockHealthKey,
+  isBelowReorderPoint,
+} from '@/app/features/inventory/pages/Inventory/utils';
+
+/**
+ * The production defect: /inventory showed "0 items below reorder point"
+ * directly above a panel headed "Low stock 21". The header counted only
+ * LOW_STOCK; the panel used the server rule `onHand <= reorderLevel`, which
+ * includes zero. Two of the three rows on screen read "OUT OF STOCK".
+ */
+// Shape taken from what stockHealth actually reads: stock.available and
+// stock.reorderLevel, not a flat onHand.
+const item = (available: number, reorderLevel: number) =>
+  ({
+    stock: { available, current: available, reorderLevel },
+    basicInfo: { status: 'ACTIVE' },
+    status: 'ACTIVE',
+  }) as unknown as Parameters<typeof effectiveStockHealthKey>[0];
+
+describe('isBelowReorderPoint', () => {
+  it('counts an out-of-stock item, which is below reorder point by definition', () => {
+    const zero = item(0, 5);
+    // The precondition that made the bug invisible: zero is never LOW_STOCK,
+    // because stockHealth returns OUT_OF_STOCK first.
+    expect(effectiveStockHealthKey(zero)).toBe('OUT_OF_STOCK');
+    expect(isBelowReorderPoint(zero)).toBe(true);
+  });
+
+  it('counts a low-stock item', () => {
+    const low = item(7, 10);
+    expect(effectiveStockHealthKey(low)).toBe('LOW_STOCK');
+    expect(isBelowReorderPoint(low)).toBe(true);
+  });
+
+  it('does not count an item above its reorder point', () => {
+    expect(isBelowReorderPoint(item(50, 10))).toBe(false);
+  });
+
+  it('reconciles the header with the panel on the reported data', () => {
+    // 7/10 low, 0/5 out of stock, 0/100 out of stock: the panel said 3, the
+    // header said 1. They must now agree.
+    const rows = [item(7, 10), item(0, 5), item(0, 100), item(80, 10)];
+    expect(rows.filter(isBelowReorderPoint)).toHaveLength(3);
+  });
+});

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -27,6 +27,7 @@ import {
 import {
   defaultFilters,
   effectiveStockHealthKey,
+  isBelowReorderPoint,
 } from '@/app/features/inventory/pages/Inventory/utils';
 import { InventorySectionKey } from '@/app/features/inventory/components/AddInventory/InventoryConfig';
 import { BusinessType } from '@/app/features/organization/types/org';
@@ -1206,9 +1207,7 @@ const useInventoryContent = () => {
     );
   }, [inventory, filters.visibility]);
   const lowStockCount = useMemo(
-    () =>
-      visibilityScopedInventory.filter((item) => effectiveStockHealthKey(item) === 'LOW_STOCK')
-        .length,
+    () => visibilityScopedInventory.filter(isBelowReorderPoint).length,
     [visibilityScopedInventory]
   );
   const expiredCount = useMemo(

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -796,6 +796,23 @@ export const getDerivedStockHealth = (
 // The stock-health key used for header counts AND the status filter, so the two
 // always agree: the explicit stockHealth when the item carries one, otherwise the
 // derived state (batch expiry / reorder levels) the table already labels rows with.
+/**
+ * Whether an item is at or below its reorder point.
+ *
+ * OUT_OF_STOCK and LOW_STOCK are separate stock-health keys, and
+ * `stockHealth` returns OUT_OF_STOCK first, so an item at zero on hand is never
+ * LOW_STOCK. Counting only LOW_STOCK therefore reported ZERO items below
+ * reorder point directly above an alerts panel headed "Low stock 21", because
+ * that panel uses the server rule `onHand <= reorderLevel`, which includes zero.
+ *
+ * An item at zero is below its reorder point by definition. This is the single
+ * predicate both counts must agree on.
+ */
+export const isBelowReorderPoint = (item: Parameters<typeof effectiveStockHealthKey>[0]): boolean => {
+  const key = effectiveStockHealthKey(item);
+  return key === 'LOW_STOCK' || key === 'OUT_OF_STOCK';
+};
+
 export const effectiveStockHealthKey = (item: InventoryItem): string => {
   const explicit = (item.stockHealth || '').toString().toUpperCase().replaceAll(' ', '_');
   if (explicit) return explicit;


### PR DESCRIPTION
Fixes the first of the screenshot defects.

## What was wrong

`/inventory` showed **"0 items below reorder point"** directly above a panel headed **"Low stock 21"**, with two of the three visible rows reading OUT OF STOCK.

Two sources disagreed about one quantity:

| | rule | counts zero on hand? |
| --- | --- | --- |
| page header | `effectiveStockHealthKey(item) === 'LOW_STOCK'` | no |
| alerts panel | server: `onHand <= reorderLevel` | yes |

`OUT_OF_STOCK` and `LOW_STOCK` are separate keys and `stockHealth` returns `OUT_OF_STOCK` **first**, so an item at zero can never be `LOW_STOCK`. The header counted it in neither branch.

An item at zero is below its reorder point by definition. Both counts now agree on one predicate.

## Why no unit test caught it

Each side was covered against a fixture its own author wrote, in which the two agreed by construction. A fixture cannot contradict itself. The route sweep from #2860 reconciles the two numbers from the rendered page, which is the only place they can disagree.

## Validation

- 4 new tests, including that zero on hand is `OUT_OF_STOCK` (the precondition that made the bug invisible) and a reconciliation over the exact reported data.
- Mutation-checked: restoring `LOW_STOCK`-only fails 2 of 4.
- Existing Inventory suites unaffected: 231 tests across 11 suites, all passing. `tsc` clean, eslint clean on the changed files.