### PR TITLE
fix(frontend): default controlled drug register to 30 days

### DIFF
--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstancesPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstancesPage.test.tsx
@@ -57,6 +57,7 @@ jest.mock('@/app/features/compliance/components/ControlledSubstanceRegister', ()
     canRecord: boolean;
     creating: boolean;
     createError: string | null;
+    dateRange: { fromDate?: string; toDate?: string };
     onCreate: (input: typeof SAMPLE_INPUT) => void;
     entries: Array<{ id: string }>;
   }) => (
@@ -64,6 +65,8 @@ jest.mock('@/app/features/compliance/components/ControlledSubstanceRegister', ()
       <span data-testid="entry-count">{props.entries.length}</span>
       <span data-testid="can-record">{String(props.canRecord)}</span>
       <span data-testid="create-error">{props.createError ?? ''}</span>
+      <span data-testid="from-date">{props.dateRange.fromDate}</span>
+      <span data-testid="to-date">{props.dateRange.toDate}</span>
       <button type="button" onClick={() => props.onCreate(SAMPLE_INPUT)}>
         fire-create
       </button>
@@ -92,12 +95,24 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('ProtectedControlledSubstances', () => {
-  it('wires the register with the primary org logs and record permission', () => {
+  it('loads the most recent 30 days by default', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-09-08T10:30:00.000Z'));
+
     render(<ProtectedControlledSubstances />);
+
     expect(screen.getByTestId('entry-count')).toHaveTextContent('1');
     expect(screen.getByTestId('can-record')).toHaveTextContent('true');
-    expect(mockUseLogs).toHaveBeenCalledWith('org-1', {});
+    expect(screen.getByTestId('from-date')).toHaveTextContent('2026-08-10T00:00:00.000Z');
+    expect(screen.getByTestId('to-date')).toHaveTextContent('2026-09-08T23:59:59.999Z');
+    expect(mockUseLogs).toHaveBeenCalledWith('org-1', {
+      fromDate: '2026-08-10T00:00:00.000Z',
+      toDate: '2026-09-08T23:59:59.999Z',
+    });
     expect(can).toHaveBeenCalledWith({ anyOf: [PERMISSIONS.CONTROLLED_DRUG_REGISTER_RECORD] });
   });
 

--- a/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
+++ b/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.tsx
@@ -19,6 +19,18 @@ import {
 import type { CreateControlledSubstanceLogInput } from '@/app/features/compliance/types/controlledSubstance';
 
 const PAGE_SKELETON = <PageSkeleton variant="list" />;
+const DEFAULT_RANGE_DAYS = 30;
+
+const createDefaultDateRange = (): ControlledSubstanceDateRange => {
+  const toDate = new Date();
+  toDate.setUTCHours(23, 59, 59, 999);
+
+  const fromDate = new Date(toDate);
+  fromDate.setUTCDate(fromDate.getUTCDate() - (DEFAULT_RANGE_DAYS - 1));
+  fromDate.setUTCHours(0, 0, 0, 0);
+
+  return { fromDate: fromDate.toISOString(), toDate: toDate.toISOString() };
+};
 
 const ControlledSubstancesContent = () => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
@@ -26,7 +38,7 @@ const ControlledSubstancesContent = () => {
   const { can } = usePermissions();
   const canRecord = can({ anyOf: [PERMISSIONS.CONTROLLED_DRUG_REGISTER_RECORD] });
 
-  const [dateRange, setDateRange] = useState<ControlledSubstanceDateRange>({});
+  const [dateRange, setDateRange] = useState<ControlledSubstanceDateRange>(createDefaultDateRange);
   const { logs, loading, error, reload } = useControlledSubstanceLogs(
     primaryOrgId ?? undefined,
     dateRange


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The controlled drug register opens without a useful historical window, which can leave the compliance view limited to the current day.

## What is the new behavior?

The register opens on a rolling 30-day range, inclusive of today. UTC day boundaries keep the visible date inputs and API query bounds aligned, and a focused component test pins the initial range.

## Related Issue(s)

Reported directly; no GitHub issue.
