### PR TITLE
fix(frontend): make clinical panel states exclusive

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoardPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoardPanel.test.tsx
@@ -10,6 +10,11 @@ const completeCheckIn = jest.fn();
 const cancelCheckIn = jest.fn();
 const markCheckInNoShow = jest.fn();
 const assignCheckInRoom = jest.fn();
+const isAuthRedirectError = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  isAuthRedirectError: (error: unknown) => isAuthRedirectError(error),
+}));
 
 jest.mock('@/app/features/appointments/services/patientCheckInService', () => ({
   __esModule: true,
@@ -230,6 +235,15 @@ describe('FrontDeskBoardPanel', () => {
     await waitFor(() =>
       expect(screen.getByTestId('error')).toHaveTextContent('Unable to load the check-in board')
     );
+  });
+
+  it('does not replace an auth redirect with a load error', async () => {
+    isAuthRedirectError.mockReturnValueOnce(true);
+    fetchCheckIns.mockReset().mockRejectedValue(new Error('redirecting'));
+    render(<FrontDeskBoardPanel />);
+
+    await waitFor(() => expect(fetchCheckIns).toHaveBeenCalled());
+    expect(screen.getByTestId('error')).toBeEmptyDOMElement();
   });
 
   it('renders nothing to load without a primary org', async () => {

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
@@ -119,6 +119,7 @@ describe('FlagList', () => {
 
     rerender(<FlagList flags={[]} error="Could not load patient flags." />);
     expect(screen.getByRole('alert')).toHaveTextContent('Could not load patient flags.');
+    expect(screen.queryByText('No active flags for this patient.')).not.toBeInTheDocument();
   });
 
   it('hides edit controls when the member cannot edit', () => {

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
@@ -140,6 +140,7 @@ describe('ProblemList', () => {
       <ProblemList problems={[]} error="Could not load the problem list. Please try again." />
     );
     expect(screen.getByRole('alert')).toHaveTextContent('Could not load the problem list');
+    expect(screen.queryByText(/No problems recorded/)).not.toBeInTheDocument();
   });
 
   it('hides the add and resolve controls when the member cannot edit', () => {

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/useFrontDeskBoard.ts
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/useFrontDeskBoard.ts
@@ -20,6 +20,7 @@ import { useLoadRoomsForPrimaryOrg, useRoomsForPrimaryOrg } from '@/app/hooks/us
 import { useOrgStore } from '@/app/stores/orgStore';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
+import { isAuthRedirectError } from '@/app/services/axios';
 import type {
   CheckInCompanionOption,
   CheckInRoomOption,
@@ -74,8 +75,8 @@ const useCheckInData = (organisationId: string | null): CheckInData => {
       try {
         const data = await fetchCheckIns(organisationId);
         if (active) setCheckIns(data);
-      } catch {
-        if (active) {
+      } catch (error) {
+        if (active && !isAuthRedirectError(error)) {
           setCheckIns([]);
           setError('Unable to load the check-in board right now.');
         }

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
@@ -317,7 +317,7 @@ const AllergyList = ({
 
   const body = (() => {
     if (loading) return <ClinicalListLoadingRows />;
-    if (error) return null;
+    if (error) return <ClinicalListError error={error} />;
     if (allergies.length === 0)
       return <ClinicalListEmpty message="No allergies recorded for this patient yet." />;
     return (
@@ -349,8 +349,6 @@ const AllergyList = ({
         onToggle={() => setShowForm((s) => !s)}
         addLabel="Add allergy"
       />
-
-      <ClinicalListError error={error} />
 
       {showForm && canEdit ? (
         <CreateAllergyForm

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -355,7 +355,7 @@ const GrantConsentForm = ({
   );
 };
 
-/** The list body: loading skeleton, error's null slot, empty state, or the rows. */
+/** The list body: loading skeleton, error, empty state, or the rows. */
 const ConsentListBody = ({
   loading,
   error,
@@ -372,7 +372,7 @@ const ConsentListBody = ({
   revokingId: string | null;
 }) => {
   if (loading) return <ClinicalListLoadingRows />;
-  if (error) return null;
+  if (error) return <ClinicalListError error={error} />;
   if (consents.length === 0)
     return <ClinicalListEmpty message="No consents recorded for this patient yet." />;
   return (
@@ -425,8 +425,6 @@ const ConsentList = ({
         onToggle={() => setShowForm((s) => !s)}
         addLabel="Record consent"
       />
-
-      <ClinicalListError error={error} />
 
       {showForm && canEdit ? (
         <GrantConsentForm

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
@@ -278,6 +278,15 @@ const FlagList = ({
 
   const body = (() => {
     if (loading) return <LoadingRows />;
+    if (error)
+      return (
+        <div
+          role="alert"
+          className="mx-4 mt-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      );
     if (flags.length === 0) return <EmptyState />;
     return (
       <ul className="divide-y divide-[var(--divider)]">
@@ -322,15 +331,6 @@ const FlagList = ({
           </button>
         ) : null}
       </header>
-
-      {error ? (
-        <div
-          role="alert"
-          className="mx-4 mt-3 rounded-xl border border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
-        >
-          {error}
-        </div>
-      ) : null}
 
       {showForm && canEdit ? (
         <CreateFlagForm

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -244,6 +244,7 @@ const ProblemList = ({
 
   const body = (() => {
     if (loading) return <ClinicalListLoadingRows />;
+    if (error) return <ClinicalListError error={error} />;
     if (problems.length === 0)
       return <ClinicalListEmpty message="No problems recorded for this patient yet." />;
     return (
@@ -274,8 +275,6 @@ const ProblemList = ({
         onToggle={() => setShowForm((s) => !s)}
         addLabel="Add problem"
       />
-
-      <ClinicalListError error={error} />
 
       {showForm && canEdit ? (
         <CreateProblemForm


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Companion-history panels can render an error banner together with empty-state copy. The check-in board also replaces an authentication redirect with a generic load error.

## What is the new behavior?

Problem, allergy, consent, and patient-flag panels choose exactly one body state in priority order: loading, error, empty, or content. The check-in board preserves authentication redirects while still showing its normal message for other fetch failures.

Validation:

- Frontend type-check
- Frontend lint
- Five targeted Jest suites: 53 tests and one snapshot
- Targeted coverage: 100% statements and lines, 97.42% branches, 98.5% functions

## Related Issue(s)

Reported directly in the Yosemite Crew delivery channel; no GitHub issue was created.

Fixes #
