### PR TITLE
fix(frontend): remove the 4 remaining shadowed StatusPill declarations

### DIFF
--- a/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
+++ b/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
@@ -8,9 +8,13 @@
 // "transparent card" defect and three hand-rolled status pills were all this
 // one pattern.
 //
-// Reads the primitive directory names from disk once at rule creation, so a
-// new primitive is covered automatically - nobody has to remember to add its
-// name to a list here.
+// Indexes the ACTUAL exported value names under ui/primitives/ (default
+// exports, named const/function/class exports, and `export { x as Y }`
+// re-exports), not directory basenames. A directory's basename is frequently
+// not a name anything exports - e.g. PanelStates/ exports PanelEmptyState and
+// PanelLoadingRows, never a component called PanelStates - so basename
+// matching both missed the real shadow risk and flagged unrelated
+// declarations that happened to share a folder's name.
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -18,17 +22,67 @@ import { fileURLToPath } from 'node:url';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PRIMITIVES_DIR = path.join(HERE, '../src/app/ui/primitives');
 
-const primitiveNames = (() => {
+const SOURCE_FILE = /\.(ts|tsx)$/;
+const SKIP_FILE = /\.(stories|test|spec)\.[tj]sx?$/;
+
+const DEFAULT_EXPORT = /^export\s+default\s+([A-Z][A-Za-z0-9_$]*)\s*;/gm;
+const NAMED_VALUE_EXPORT = /^export\s+(?:const|function|class)\s+([A-Z][A-Za-z0-9_$]*)/gm;
+// `export { default as Primary } from '...'` / `export { Foo, Bar as Baz }` -
+// deliberately excludes `export type { ... }`, which has "type" between
+// "export" and "{" and so never matches this pattern.
+const NAMED_LIST_EXPORT = /^export\s*\{([^}]+)\}\s*(?:from\s+['"][^'"]+['"])?\s*;?\s*$/gm;
+
+const namesFromExportList = (list) =>
+  list
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const asMatch = entry.match(/\bas\s+([A-Za-z0-9_$]+)\s*$/);
+      return asMatch ? asMatch[1] : entry.split(/\s+/)[0];
+    })
+    .filter((name) => /^[A-Z]/.test(name));
+
+const collectSourceFiles = (dir) => {
+  let entries;
   try {
-    return new Set(
-      fs.readdirSync(PRIMITIVES_DIR, { withFileTypes: true })
-        .filter((e) => e.isDirectory())
-        .map((e) => e.name)
-    );
+    entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch {
-    return new Set();
+    return [];
   }
-})();
+  return entries.flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(full);
+    if (SOURCE_FILE.test(entry.name) && !SKIP_FILE.test(entry.name)) return [full];
+    return [];
+  });
+};
+
+// name -> path of the primitive file it's actually exported from, relative
+// to ui/primitives/, for the report message.
+const buildPrimitiveIndex = () => {
+  const index = new Map();
+  for (const file of collectSourceFiles(PRIMITIVES_DIR)) {
+    let text;
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const relPath = path.relative(PRIMITIVES_DIR, file);
+    const add = (name) => {
+      if (!index.has(name)) index.set(name, relPath);
+    };
+    for (const m of text.matchAll(DEFAULT_EXPORT)) add(m[1]);
+    for (const m of text.matchAll(NAMED_VALUE_EXPORT)) add(m[1]);
+    for (const m of text.matchAll(NAMED_LIST_EXPORT)) {
+      namesFromExportList(m[1]).forEach(add);
+    }
+  }
+  return index;
+};
+
+const primitiveIndex = buildPrimitiveIndex();
 
 const rule = {
   meta: {
@@ -40,14 +94,14 @@ const rule = {
     schema: [],
     messages: {
       shadowed:
-        "'{{name}}' shadows the shared primitive at ui/primitives/{{name}}. " +
+        "'{{name}}' shadows the shared primitive exported from ui/primitives/{{path}}. " +
         'Import the primitive (aliased if you need a differently-named local ' +
         'wrapper) instead of redeclaring it - a local copy silently diverges ' +
         'from the design system and stops receiving its fixes.',
     },
   },
   create(context) {
-    if (primitiveNames.size === 0) return {};
+    if (primitiveIndex.size === 0) return {};
     const filename = context.filename ?? context.getFilename();
     // Only feature code is in scope. The primitives themselves, of course,
     // declare their own name; stories and tests may deliberately construct a
@@ -57,8 +111,14 @@ const rule = {
     if (filename.includes(`__tests__${path.sep}`)) return {};
 
     const checkId = (idNode) => {
-      if (idNode?.type === 'Identifier' && primitiveNames.has(idNode.name)) {
-        context.report({ node: idNode, messageId: 'shadowed', data: { name: idNode.name } });
+      const primitivePath =
+        idNode?.type === 'Identifier' ? primitiveIndex.get(idNode.name) : undefined;
+      if (primitivePath) {
+        context.report({
+          node: idNode,
+          messageId: 'shadowed',
+          data: { name: idNode.name, path: primitivePath },
+        });
       }
     };
 
@@ -75,4 +135,5 @@ const rule = {
   },
 };
 
-export default { rules: { 'no-shadowed-primitive': rule } };
+const noShadowedPrimitivePlugin = { rules: { 'no-shadowed-primitive': rule } };
+export default noShadowedPrimitivePlugin;

--- a/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
+++ b/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
@@ -43,7 +43,14 @@ const namesFromExportList = (list) =>
     })
     .filter((name) => /^[A-Z]/.test(name));
 
-const collectSourceFiles = (dir) => {
+// Bounds two things Aikido flagged on the recursive walk below: unbounded
+// recursion depth on a pathological directory tree, and `entry.name` (though
+// it only ever comes from readdirSync's own listing, never external input)
+// resolving outside `dir` - entries are rejected unless they stay under it.
+const MAX_DEPTH = 12;
+
+const collectSourceFiles = (dir, depth = 0) => {
+  if (depth > MAX_DEPTH) return [];
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -51,8 +58,11 @@ const collectSourceFiles = (dir) => {
     return [];
   }
   return entries.flatMap((entry) => {
+    if (entry.isSymbolicLink()) return [];
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return collectSourceFiles(full);
+    const relative = path.relative(dir, full);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return [];
+    if (entry.isDirectory()) return collectSourceFiles(full, depth + 1);
     if (SOURCE_FILE.test(entry.name) && !SKIP_FILE.test(entry.name)) return [full];
     return [];
   });

--- a/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
+++ b/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
@@ -1,0 +1,78 @@
+// Forbids declaring a top-level component in features/ whose name collides
+// with a shared primitive under ui/primitives/.
+//
+// This is the exact bug the freeze audit found four times over: a feature file
+// declares its own `const StatusPill` or `const SectionCard`, and the local
+// version silently diverges from the design system - different geometry,
+// missing tokens, no shared fix when the primitive is patched. The federation
+// "transparent card" defect and three hand-rolled status pills were all this
+// one pattern.
+//
+// Reads the primitive directory names from disk once at rule creation, so a
+// new primitive is covered automatically - nobody has to remember to add its
+// name to a list here.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PRIMITIVES_DIR = path.join(HERE, '../src/app/ui/primitives');
+
+const primitiveNames = (() => {
+  try {
+    return new Set(
+      fs.readdirSync(PRIMITIVES_DIR, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+    );
+  } catch {
+    return new Set();
+  }
+})();
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a features/ component whose name shadows a shared ui/primitives/ export.',
+    },
+    schema: [],
+    messages: {
+      shadowed:
+        "'{{name}}' shadows the shared primitive at ui/primitives/{{name}}. " +
+        'Import the primitive (aliased if you need a differently-named local ' +
+        'wrapper) instead of redeclaring it - a local copy silently diverges ' +
+        'from the design system and stops receiving its fixes.',
+    },
+  },
+  create(context) {
+    if (primitiveNames.size === 0) return {};
+    const filename = context.filename ?? context.getFilename();
+    // Only feature code is in scope. The primitives themselves, of course,
+    // declare their own name; stories and tests may deliberately construct a
+    // conflicting fixture.
+    if (!filename.includes(`${path.sep}features${path.sep}`)) return {};
+    if (/\.(stories|test|spec)\.[tj]sx?$/.test(filename)) return {};
+    if (filename.includes(`__tests__${path.sep}`)) return {};
+
+    const checkId = (idNode) => {
+      if (idNode?.type === 'Identifier' && primitiveNames.has(idNode.name)) {
+        context.report({ node: idNode, messageId: 'shadowed', data: { name: idNode.name } });
+      }
+    };
+
+    return {
+      // const StatusPill = (...) => ...
+      VariableDeclarator(node) {
+        checkId(node.id);
+      },
+      // function StatusPill(...) {...}
+      FunctionDeclaration(node) {
+        checkId(node.id);
+      },
+    };
+  },
+};
+
+export default { rules: { 'no-shadowed-primitive': rule } };

--- a/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
+++ b/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
@@ -113,10 +113,18 @@ const rule = {
   create(context) {
     if (primitiveIndex.size === 0) return {};
     const filename = context.filename ?? context.getFilename();
-    // Only feature code is in scope. The primitives themselves, of course,
-    // declare their own name; stories and tests may deliberately construct a
-    // conflicting fixture.
-    if (!filename.includes(`${path.sep}features${path.sep}`)) return {};
+    // In scope: features/ (the freeze audit's original finding) and the rest
+    // of ui/ (InventoryTable.tsx, under ui/tables/, had this exact bug too -
+    // a local StatusPill wrapper around SharedStatusPill). Out of scope: the
+    // primitives themselves declare their own name; ui/primitives/ is excluded
+    // outright rather than just skipped-on-collision, so a primitive's own
+    // internal helpers are never second-guessed by this rule. Stories and
+    // tests may deliberately construct a conflicting fixture.
+    const inFeatures = filename.includes(`${path.sep}features${path.sep}`);
+    const inUiOutsidePrimitives =
+      filename.includes(`${path.sep}ui${path.sep}`) &&
+      !filename.includes(`${path.sep}ui${path.sep}primitives${path.sep}`);
+    if (!inFeatures && !inUiOutsidePrimitives) return {};
     if (/\.(stories|test|spec)\.[tj]sx?$/.test(filename)) return {};
     if (filename.includes(`__tests__${path.sep}`)) return {};
 
@@ -139,6 +147,12 @@ const rule = {
       },
       // function StatusPill(...) {...}
       FunctionDeclaration(node) {
+        checkId(node.id);
+      },
+      // class StatusPill extends React.Component {...} - the primitive index
+      // already recognizes exported classes, so this closes the matching gap
+      // on the report side; a class component can shadow just as easily.
+      ClassDeclaration(node) {
         checkId(node.id);
       },
     };

--- a/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
+++ b/apps/frontend/eslint-rules/no-shadowed-primitive.mjs
@@ -25,7 +25,13 @@ const PRIMITIVES_DIR = path.join(HERE, '../src/app/ui/primitives');
 const SOURCE_FILE = /\.(ts|tsx)$/;
 const SKIP_FILE = /\.(stories|test|spec)\.[tj]sx?$/;
 
+// `export default Foo;` - a bare reference to a name declared earlier in the file.
 const DEFAULT_EXPORT = /^export\s+default\s+([A-Z][A-Za-z0-9_$]*)\s*;/gm;
+// `export default function Foo(...)` / `export default class Foo ...` - the
+// declaration and the export happen in one statement, so there's no bare
+// `export default Foo;` line for DEFAULT_EXPORT to match.
+const DEFAULT_INLINE_DECLARATION_EXPORT =
+  /^export\s+default\s+(?:function\s*\*?|class)\s+([A-Z][A-Za-z0-9_$]*)/gm;
 const NAMED_VALUE_EXPORT = /^export\s+(?:const|function|class)\s+([A-Z][A-Za-z0-9_$]*)/gm;
 // `export { default as Primary } from '...'` / `export { Foo, Bar as Baz }` -
 // deliberately excludes `export type { ... }`, which has "type" between
@@ -84,6 +90,7 @@ const buildPrimitiveIndex = () => {
       if (!index.has(name)) index.set(name, relPath);
     };
     for (const m of text.matchAll(DEFAULT_EXPORT)) add(m[1]);
+    for (const m of text.matchAll(DEFAULT_INLINE_DECLARATION_EXPORT)) add(m[1]);
     for (const m of text.matchAll(NAMED_VALUE_EXPORT)) add(m[1]);
     for (const m of text.matchAll(NAMED_LIST_EXPORT)) {
       namesFromExportList(m[1]).forEach(add);

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -5,6 +5,7 @@
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 import nextTypescript from 'eslint-config-next/typescript';
 import sonarjs from 'eslint-plugin-sonarjs';
+import noShadowedPrimitive from './eslint-rules/no-shadowed-primitive.mjs';
 
 const eslintConfig = [
   {
@@ -99,6 +100,16 @@ const eslintConfig = [
       'sonarjs/cognitive-complexity': 'off',
       'sonarjs/regex-complexity': 'off',
       'sonarjs/no-unused-vars': 'off',
+    },
+  },
+  {
+    // Freeze audit finding: a features/ file redeclaring a shared primitive's
+    // name (StatusPill, SectionCard, ...) silently diverges from the design
+    // system instead of importing it. See eslint-rules/no-shadowed-primitive.mjs.
+    files: ['src/app/features/**/*.{ts,tsx}'],
+    plugins: { local: noShadowedPrimitive },
+    rules: {
+      'local/no-shadowed-primitive': 'error',
     },
   },
   {

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -103,10 +103,13 @@ const eslintConfig = [
     },
   },
   {
-    // Freeze audit finding: a features/ file redeclaring a shared primitive's
-    // name (StatusPill, SectionCard, ...) silently diverges from the design
-    // system instead of importing it. See eslint-rules/no-shadowed-primitive.mjs.
-    files: ['src/app/features/**/*.{ts,tsx}'],
+    // Freeze audit finding: a features/ or ui/ file redeclaring a shared
+    // primitive's name (StatusPill, SectionCard, ...) silently diverges from
+    // the design system instead of importing it. ui/primitives/ itself is
+    // excluded inside the rule, not by narrowing this glob, so the check
+    // stays a single source of truth for scope.
+    // See eslint-rules/no-shadowed-primitive.mjs.
+    files: ['src/app/features/**/*.{ts,tsx}', 'src/app/ui/**/*.{ts,tsx}'],
     plugins: { local: noShadowedPrimitive },
     rules: {
       'local/no-shadowed-primitive': 'error',
@@ -159,7 +162,10 @@ const eslintConfig = [
         'error',
         {
           forbid: [
-            { element: 'textarea', message: 'Use Textarea from ui/primitives; it owns the shared field contract.' },
+            {
+              element: 'textarea',
+              message: 'Use Textarea from ui/primitives; it owns the shared field contract.',
+            },
           ],
         },
       ],

--- a/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
+++ b/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
@@ -39,7 +39,7 @@ const lintTsx = (code: string, filename: string) =>
 describe('no-shadowed-primitive', () => {
   it('flags a features/ component whose name shadows a real primitive', () => {
     const messages = lintTsx(
-      "const StatusPill = () => null;\nexport default StatusPill;\n",
+      'const StatusPill = () => null;\nexport default StatusPill;\n',
       'src/app/features/widgets/Bad.tsx'
     );
     expect(messages).toHaveLength(1);
@@ -58,7 +58,7 @@ describe('no-shadowed-primitive', () => {
 
   it('does not fire on an unrelated component name', () => {
     const messages = lintTsx(
-      "const WidgetSummary = () => null;\nexport default WidgetSummary;\n",
+      'const WidgetSummary = () => null;\nexport default WidgetSummary;\n',
       'src/app/features/widgets/Fine.tsx'
     );
     expect(messages).toHaveLength(0);
@@ -66,7 +66,7 @@ describe('no-shadowed-primitive', () => {
 
   it('does not fire outside features/ - primitives declare their own name', () => {
     const messages = lintTsx(
-      "const StatusPill = () => null;\nexport default StatusPill;\n",
+      'const StatusPill = () => null;\nexport default StatusPill;\n',
       'src/app/ui/primitives/StatusPill/StatusPill.tsx'
     );
     expect(messages).toHaveLength(0);
@@ -74,10 +74,10 @@ describe('no-shadowed-primitive', () => {
 
   it('does not fire in a story or test fixture', () => {
     expect(
-      lintTsx("const StatusPill = () => null;\n", 'src/app/features/widgets/Bad.stories.tsx')
+      lintTsx('const StatusPill = () => null;\n', 'src/app/features/widgets/Bad.stories.tsx')
     ).toHaveLength(0);
     expect(
-      lintTsx("const StatusPill = () => null;\n", 'src/app/features/widgets/__tests__/Bad.test.tsx')
+      lintTsx('const StatusPill = () => null;\n', 'src/app/features/widgets/__tests__/Bad.test.tsx')
     ).toHaveLength(0);
   });
 
@@ -85,9 +85,98 @@ describe('no-shadowed-primitive', () => {
     // The actual fix applied in this PR: a local wrapper that delegates to the
     // real primitive is fine once it no longer shares its name.
     const messages = lintTsx(
-      "const VisitStatusPill = () => null;\nexport default VisitStatusPill;\n",
+      'const VisitStatusPill = () => null;\nexport default VisitStatusPill;\n',
       'src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx'
     );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('derives protected names from actual exports, not directory basenames', () => {
+    // PanelStates/ is a real primitive directory, but the file inside it never
+    // declares anything called PanelStates - it exports PanelEmptyState and
+    // PanelLoadingRows. Basename matching used to flag the harmless name below
+    // and miss the two that actually matter; export-based matching is the
+    // inverse of that on both counts.
+    const shadowsUnexportedDirName = lintTsx(
+      'const PanelStates = () => null;\nexport default PanelStates;\n',
+      'src/app/features/widgets/Fine2.tsx'
+    );
+    expect(shadowsUnexportedDirName).toHaveLength(0);
+
+    const shadowsRealExport = lintTsx(
+      'const PanelEmptyState = () => null;\nexport default PanelEmptyState;\n',
+      'src/app/features/widgets/Bad3.tsx'
+    );
+    expect(shadowsRealExport).toHaveLength(1);
+    expect(shadowsRealExport[0].message).toContain('PanelStates/PanelStates.tsx');
+  });
+
+  it('does not protect a bare index.ts namespace re-export (`export * as Buttons`)', () => {
+    // primitives/index.ts re-exports the Buttons directory as a namespace;
+    // that binding is not a component and declaring a local one named
+    // Buttons is not the shadow bug this rule exists to catch.
+    const messages = lintTsx(
+      'const Buttons = () => null;\nexport default Buttons;\n',
+      'src/app/features/widgets/Fine3.tsx'
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('protects a named re-export reached only through an index barrel', () => {
+    // Buttons/index.tsx re-exports Primary via `export { default as Primary }
+    // from './Primary'` - the name never appears as `export default Primary`
+    // or `export const Primary` in any single file, only in this list form.
+    const messages = lintTsx(
+      'const Primary = () => null;\nexport default Primary;\n',
+      'src/app/features/widgets/Bad4.tsx'
+    );
+    expect(messages).toHaveLength(1);
+  });
+});
+
+describe('no-shadowed-primitive - primitive index resilience', () => {
+  afterEach(() => {
+    jest.dontMock('node:fs');
+    jest.resetModules();
+  });
+
+  it('never reports (fails safe) if ui/primitives cannot be read', () => {
+    jest.resetModules();
+    jest.doMock('node:fs', () => ({
+      ...jest.requireActual('node:fs'),
+      readdirSync: () => {
+        throw new Error('ENOENT: no such file or directory');
+      },
+    }));
+
+    let freshModule: { default?: typeof ruleModule } & typeof ruleModule;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- re-require a mocked node:fs synchronously inside isolateModules
+      freshModule = require('../../../../eslint-rules/no-shadowed-primitive.mjs');
+    });
+    const freshPlugin = freshModule!.default ?? freshModule!;
+
+    const freshLinter = new Linter();
+    const messages = freshLinter.verify(
+      'const StatusPill = () => null;\nexport default StatusPill;\n',
+      [
+        {
+          files: ['**/*.tsx'],
+          languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            parserOptions: { ecmaFeatures: { jsx: true } },
+          },
+          plugins: { local: freshPlugin },
+          rules: { 'local/no-shadowed-primitive': 'error' },
+        },
+      ] as never,
+      'src/app/features/widgets/Bad.tsx'
+    );
+
+    // A directory read failure must never crash the lint run and must never
+    // silently allow the OPPOSITE - reporting spurious findings from an
+    // empty/garbage index. The safe failure mode is "no findings at all".
     expect(messages).toHaveLength(0);
   });
 });

--- a/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
+++ b/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
@@ -56,6 +56,34 @@ describe('no-shadowed-primitive', () => {
     expect(messages).toHaveLength(1);
   });
 
+  it('also flags a shadowed class declaration - class components still exist', () => {
+    const messages = lintTsx(
+      'class SectionCard extends React.Component { render() { return null; } }\n',
+      'src/app/features/widgets/Bad2b.tsx'
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('SectionCard');
+  });
+
+  it('applies outside features/ too - ui/tables/InventoryTable.tsx had this exact bug', () => {
+    const messages = lintTsx(
+      'const StatusPill = () => null;\nexport default StatusPill;\n',
+      'src/app/ui/tables/InventoryTable.tsx'
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("still does not fire inside ui/primitives/ itself, even for another primitive's name", () => {
+    // A primitive file may legitimately reference a sibling primitive's name
+    // (e.g. composing SectionCard inside StatusPill's own directory); only
+    // features/ and the rest of ui/ are shadow-risk territory.
+    const messages = lintTsx(
+      'const SectionCard = () => null;\nexport default SectionCard;\n',
+      'src/app/ui/primitives/StatusPill/StatusPill.tsx'
+    );
+    expect(messages).toHaveLength(0);
+  });
+
   it('does not fire on an unrelated component name', () => {
     const messages = lintTsx(
       'const WidgetSummary = () => null;\nexport default WidgetSummary;\n',
@@ -140,7 +168,7 @@ describe('no-shadowed-primitive - primitive index resilience', () => {
     jest.resetModules();
   });
 
-  it('never reports (fails safe) if ui/primitives cannot be read', () => {
+  it('never reports (fails safe) if ui/primitives cannot be read', async () => {
     jest.resetModules();
     jest.doMock('node:fs', () => ({
       ...jest.requireActual('node:fs'),
@@ -149,12 +177,11 @@ describe('no-shadowed-primitive - primitive index resilience', () => {
       },
     }));
 
-    let freshModule: { default?: typeof ruleModule } & typeof ruleModule;
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports -- re-require a mocked node:fs synchronously inside isolateModules
-      freshModule = require('../../../../eslint-rules/no-shadowed-primitive.mjs');
+    let freshModule: { default: typeof ruleModule };
+    await jest.isolateModulesAsync(async () => {
+      freshModule = await import('../../../../eslint-rules/no-shadowed-primitive.mjs');
     });
-    const freshPlugin = freshModule!.default ?? freshModule!;
+    const freshPlugin = freshModule!.default;
 
     const freshLinter = new Linter();
     const messages = freshLinter.verify(

--- a/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
+++ b/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
@@ -1,0 +1,93 @@
+import v8 from 'node:v8';
+import { Linter } from 'eslint';
+import ruleModule from '../../../../eslint-rules/no-shadowed-primitive.mjs';
+
+// jest.setup.ts's jsdom sandbox does not forward Node's global structuredClone,
+// which ESLint's flat-config internals use to clone rule schemas. Node's own
+// v8 module gives a faithful (non-lossy, for plain config data) equivalent.
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = <T>(value: T): T => v8.deserialize(v8.serialize(value));
+}
+
+/**
+ * Drives the rule through ESLint's own Linter rather than asserting on the
+ * rule object's shape, so this fails if the rule stops firing - the same
+ * property every other check in this freeze effort was held to. A manual
+ * one-off check (which is how this rule was first verified) proves nothing
+ * once the person who ran it moves on; this is the version that survives.
+ */
+const linter = new Linter();
+
+const lintTsx = (code: string, filename: string) =>
+  linter.verify(
+    code,
+    [
+      {
+        files: ['**/*.ts', '**/*.tsx'],
+        languageOptions: {
+          ecmaVersion: 2022,
+          sourceType: 'module',
+          parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        plugins: { local: ruleModule },
+        rules: { 'local/no-shadowed-primitive': 'error' },
+      },
+    ] as never,
+    filename
+  );
+
+describe('no-shadowed-primitive', () => {
+  it('flags a features/ component whose name shadows a real primitive', () => {
+    const messages = lintTsx(
+      "const StatusPill = () => null;\nexport default StatusPill;\n",
+      'src/app/features/widgets/Bad.tsx'
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe('local/no-shadowed-primitive');
+    expect(messages[0].message).toContain('StatusPill');
+    expect(messages[0].message).toContain('shadows the shared primitive');
+  });
+
+  it('also flags a shadowed function declaration, not only const', () => {
+    const messages = lintTsx(
+      'function SectionCard() { return null; }\n',
+      'src/app/features/widgets/Bad2.tsx'
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it('does not fire on an unrelated component name', () => {
+    const messages = lintTsx(
+      "const WidgetSummary = () => null;\nexport default WidgetSummary;\n",
+      'src/app/features/widgets/Fine.tsx'
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not fire outside features/ - primitives declare their own name', () => {
+    const messages = lintTsx(
+      "const StatusPill = () => null;\nexport default StatusPill;\n",
+      'src/app/ui/primitives/StatusPill/StatusPill.tsx'
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not fire in a story or test fixture', () => {
+    expect(
+      lintTsx("const StatusPill = () => null;\n", 'src/app/features/widgets/Bad.stories.tsx')
+    ).toHaveLength(0);
+    expect(
+      lintTsx("const StatusPill = () => null;\n", 'src/app/features/widgets/__tests__/Bad.test.tsx')
+    ).toHaveLength(0);
+  });
+
+  it('a delegate wrapper renamed away from the collision is clean', () => {
+    // The actual fix applied in this PR: a local wrapper that delegates to the
+    // real primitive is fine once it no longer shares its name.
+    const messages = lintTsx(
+      "const VisitStatusPill = () => null;\nexport default VisitStatusPill;\n",
+      'src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx'
+    );
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
+++ b/apps/frontend/src/app/__tests__/eslint-rules/no-shadowed-primitive.test.ts
@@ -162,6 +162,24 @@ describe('no-shadowed-primitive', () => {
   });
 });
 
+const lintTsxWithPlugin = (plugin: unknown, code: string, filename: string) =>
+  new Linter().verify(
+    code,
+    [
+      {
+        files: ['**/*.tsx'],
+        languageOptions: {
+          ecmaVersion: 2022,
+          sourceType: 'module',
+          parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        plugins: { local: plugin },
+        rules: { 'local/no-shadowed-primitive': 'error' },
+      },
+    ] as never,
+    filename
+  );
+
 describe('no-shadowed-primitive - primitive index resilience', () => {
   afterEach(() => {
     jest.dontMock('node:fs');
@@ -181,23 +199,10 @@ describe('no-shadowed-primitive - primitive index resilience', () => {
     await jest.isolateModulesAsync(async () => {
       freshModule = await import('../../../../eslint-rules/no-shadowed-primitive.mjs');
     });
-    const freshPlugin = freshModule!.default;
 
-    const freshLinter = new Linter();
-    const messages = freshLinter.verify(
+    const messages = lintTsxWithPlugin(
+      freshModule!.default,
       'const StatusPill = () => null;\nexport default StatusPill;\n',
-      [
-        {
-          files: ['**/*.tsx'],
-          languageOptions: {
-            ecmaVersion: 2022,
-            sourceType: 'module',
-            parserOptions: { ecmaFeatures: { jsx: true } },
-          },
-          plugins: { local: freshPlugin },
-          rules: { 'local/no-shadowed-primitive': 'error' },
-        },
-      ] as never,
       'src/app/features/widgets/Bad.tsx'
     );
 
@@ -205,5 +210,44 @@ describe('no-shadowed-primitive - primitive index resilience', () => {
     // silently allow the OPPOSITE - reporting spurious findings from an
     // empty/garbage index. The safe failure mode is "no findings at all".
     expect(messages).toHaveLength(0);
+  });
+
+  it('indexes `export default function Foo()` and `export default class Bar`, not just `export default Name;`', async () => {
+    jest.resetModules();
+    const actualFs = jest.requireActual('node:fs');
+    // Real directory listing, but StatusPill.tsx's content is swapped for a
+    // fixture using the inline declaration forms - the two this rule's
+    // DEFAULT_EXPORT regex could not see before this fix.
+    jest.doMock('node:fs', () => ({
+      ...actualFs,
+      readFileSync: (filePath: string, ...rest: unknown[]) => {
+        if (typeof filePath === 'string' && filePath.endsWith('StatusPill.tsx')) {
+          return (
+            'export default function InlineFuncPrimitive() { return null; }\n' +
+            'export default class InlineClassPrimitive {}\n'
+          );
+        }
+        return actualFs.readFileSync(filePath, ...rest);
+      },
+    }));
+
+    let freshModule: { default: typeof ruleModule };
+    await jest.isolateModulesAsync(async () => {
+      freshModule = await import('../../../../eslint-rules/no-shadowed-primitive.mjs');
+    });
+
+    const funcMessages = lintTsxWithPlugin(
+      freshModule!.default,
+      'const InlineFuncPrimitive = () => null;\nexport default InlineFuncPrimitive;\n',
+      'src/app/features/widgets/Bad5.tsx'
+    );
+    expect(funcMessages).toHaveLength(1);
+
+    const classMessages = lintTsxWithPlugin(
+      freshModule!.default,
+      'const InlineClassPrimitive = () => null;\nexport default InlineClassPrimitive;\n',
+      'src/app/features/widgets/Bad6.tsx'
+    );
+    expect(classMessages).toHaveLength(1);
   });
 });

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
@@ -48,7 +48,7 @@ const dayMarker = (iso: string): { weekday: string; day: string } => {
   return { weekday: WEEKDAYS[date.getDay()], day: String(date.getDate()) };
 };
 
-const StatusPill = ({ status }: { status: OutpatientVisitStatus }) => (
+const VisitStatusPill = ({ status }: { status: OutpatientVisitStatus }) => (
   <SharedStatusPill
     tone={getAppointmentStatusTone(STATUS_STYLE_KEY[status])}
     label={STATUS_LABEL[status]}
@@ -102,7 +102,7 @@ const VisitRow = ({ visit, isNext = false }: { visit: OutpatientVisit; isNext?: 
         </span>
         <span className="block truncate text-caption-1 text-text-tertiary">{subline}</span>
       </span>
-      <StatusPill status={visit.status} />
+      <VisitStatusPill status={visit.status} />
       <IoEllipsisHorizontal size={15} aria-hidden="true" className="shrink-0 text-text-tertiary" />
     </li>
   );

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
@@ -8,8 +8,7 @@ import {
   IoPencilOutline,
 } from 'react-icons/io5';
 import TabToggle from '@/app/ui/primitives/TabToggle/TabToggle';
-import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
-import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import SharedStatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
@@ -8,6 +8,8 @@ import {
   IoPencilOutline,
 } from 'react-icons/io5';
 import TabToggle from '@/app/ui/primitives/TabToggle/TabToggle';
+import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
@@ -58,12 +60,6 @@ const TABS = [
   { key: 'PARENT', label: 'Parent task' },
 ];
 
-const STATUS_CLASSES: Record<ScheduleTaskStatus, string> = {
-  COMPLETED: 'border-pill-success-border bg-pill-success-bg text-pill-success-text',
-  UPCOMING: 'border-pill-info-border bg-pill-info-bg text-pill-info-text',
-  CANCELLED: 'border-pill-warning-border bg-pill-warning-bg text-pill-warning-text',
-  PENDING: 'border-pill-neutral-border bg-pill-neutral-bg text-pill-neutral-text',
-};
 
 const STATUS_OPTIONS: { label: string; value: ScheduleTaskStatus }[] = [
   { label: 'Upcoming', value: 'UPCOMING' },
@@ -127,16 +123,23 @@ const scheduleTaskFromTask = (task: Task): ScheduleTask => ({
   sourceRefId: task.templateId || task.libraryTaskId,
 });
 
-const StatusPill = ({ status }: { status: ScheduleTaskStatus }) => {
+/**
+ * ScheduleTaskStatus -> the shared pill's tone. STATUS_CLASSES referenced the
+ * same --color-pill-* tokens by hand as Tailwind utility classes, so this
+ * mapping changes nothing about colour - only geometry, by routing through
+ * the one shared StatusPill instead of a locally reimplemented span.
+ */
+const STATUS_TONE: Record<ScheduleTaskStatus, StatusTone> = {
+  COMPLETED: 'success',
+  UPCOMING: 'info',
+  CANCELLED: 'warning',
+  PENDING: 'neutral',
+};
+
+const TaskStatusPill = ({ status }: { status: ScheduleTaskStatus }) => {
   /* v8 ignore next -- status is always one of the four STATUS_OPTIONS, so the ?. miss and ?? fallback are unreachable */
   const label = STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status;
-  return (
-    <span
-      className={`inline-flex rounded-2xl border px-3 py-1 text-caption-1 ${STATUS_CLASSES[status]}`}
-    >
-      {label}
-    </span>
-  );
+  return <SharedStatusPill label={label} tone={STATUS_TONE[status]} />;
 };
 
 /** One "Task details" row inside the expandable breakdown. */
@@ -214,7 +217,7 @@ const TaskRow = ({
       </div>
       <div className="flex items-center gap-2">
         {actionsDisabled ? (
-          <StatusPill status={task.status} />
+          <TaskStatusPill status={task.status} />
         ) : (
           <button
             type="button"
@@ -225,7 +228,7 @@ const TaskRow = ({
               onStatus(next);
             }}
           >
-            <StatusPill status={task.status} />
+            <TaskStatusPill status={task.status} />
           </button>
         )}
       </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -10,8 +10,7 @@ import {
   IoShareOutline,
 } from 'react-icons/io5';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
-import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
-import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import SharedStatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Textarea } from '@/app/ui/Input';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
 import TotalBillContainer from '@/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer';

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -10,6 +10,8 @@ import {
   IoShareOutline,
 } from 'react-icons/io5';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Textarea } from '@/app/ui/Input';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
 import TotalBillContainer from '@/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer';
@@ -88,11 +90,6 @@ const STATUS_LABELS: Record<InvoiceStatus, string> = {
   PARTIAL: 'Partial',
 };
 
-const STATUS_CLASSES: Record<InvoiceStatus, string> = {
-  PAID_FULL: 'border-pill-success-border bg-pill-success-bg text-pill-success-text',
-  UNPAID: 'border-pill-warning-border bg-pill-warning-bg text-pill-warning-text',
-  PARTIAL: 'border-pill-info-border bg-pill-info-bg text-pill-info-text',
-};
 
 const PAYMENT_LABELS: Record<PaymentMethod, string> = {
   ONLINE: 'Paid Online',
@@ -394,12 +391,18 @@ const getDepositModalActionLabel = (saving: boolean, method: PaymentMethod): str
   return method === 'ONLINE' ? 'Generate link' : 'Collect deposit';
 };
 
-export const StatusPill = ({ status }: { status: InvoiceStatus }) => (
-  <span
-    className={`inline-flex rounded-2xl border px-3 py-1 text-caption-1 ${STATUS_CLASSES[status]}`}
-  >
-    {STATUS_LABELS[status]}
-  </span>
+/**
+ * InvoiceStatus -> the shared pill's tone. STATUS_CLASSES referenced the same
+ * --color-pill-* tokens by hand, so this changes only geometry.
+ */
+const INVOICE_STATUS_TONE: Record<InvoiceStatus, StatusTone> = {
+  PAID_FULL: 'success',
+  UNPAID: 'warning',
+  PARTIAL: 'info',
+};
+
+export const InvoiceStatusPill = ({ status }: { status: InvoiceStatus }) => (
+  <SharedStatusPill label={STATUS_LABELS[status]} tone={INVOICE_STATUS_TONE[status]} />
 );
 
 const getPaymentProgressDescription = (status: PaymentProgressState['status']): string => {
@@ -642,7 +645,7 @@ export const InvoiceRow = ({
           {formatCents(invoice.outstandingCents, currency)}
         </span>
         <div className="flex">
-          <StatusPill status={invoice.status} />
+          <InvoiceStatusPill status={invoice.status} />
         </div>
         <div className="flex justify-end gap-2">
           <CircleIconButton

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -212,7 +212,7 @@ const DeviceCard = ({ device }: { device: IvlsDevice }) => {
             {device.deviceSerialNumber}
           </div>
         </div>
-        <StatusPill label={statusLabel} tokens={dt} showDot={statusKey === 'active'} />
+        <IntegrationStatusPill label={statusLabel} tokens={dt} showDot={statusKey === 'active'} />
       </div>
       <div className="mt-2 grid grid-cols-2 gap-2 text-caption-1">
         <div className="text-text-secondary">Last cloud poll</div>
@@ -235,7 +235,7 @@ const NEUTRAL_FALLBACK_TOKENS: StatusTokens = {
   border: 'var(--color-card-border)',
 };
 
-const StatusPill = ({
+const IntegrationStatusPill = ({
   status,
   label,
   tokens: tokensOverride,
@@ -334,7 +334,7 @@ const RecentOrdersList = ({ orders }: { orders: LabOrder[] }) => {
             <span className="min-w-0 truncate font-semibold text-text-primary">
               {formatOrderLabel(order)}
             </span>
-            <StatusPill label={formatOrderStatusLabel(order.status)} tokens={tokens} />
+            <IntegrationStatusPill label={formatOrderStatusLabel(order.status)} tokens={tokens} />
           </div>
         );
       })}
@@ -824,7 +824,7 @@ export const IdexxSettingsModal = ({
               <div className="grid grid-cols-2 gap-2 text-caption-1">
                 <div className="text-text-secondary">Credentials status</div>
                 <div className="text-right">
-                  <StatusPill
+                  <IntegrationStatusPill
                     label={credentialsStatusLabel}
                     tokens={credentialsStatusTokens[credentialsStatusKey]}
                   />
@@ -839,7 +839,7 @@ export const IdexxSettingsModal = ({
             <div className="flex flex-col gap-3 py-2">
               <div className="flex items-center justify-between gap-2">
                 <div className="text-body-4 text-text-primary">Current status</div>
-                <StatusPill status={idexxIntegration?.status} />
+                <IntegrationStatusPill status={idexxIntegration?.status} />
               </div>
               <div className="flex items-center justify-between gap-2">
                 <div className="text-caption-1 text-text-secondary">Connected since</div>
@@ -999,7 +999,7 @@ const IdexxIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           IDEXX VetConnect PLUS
         </div>
-        <StatusPill
+        <IntegrationStatusPill
           status={s.idexxIntegration?.status}
           label={s.idexxEnabled ? 'Connected' : undefined}
         />
@@ -1072,7 +1072,7 @@ const MerckIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           MSD Veterinary Manual
         </div>
-        <StatusPill status={s.merckIntegration?.status} />
+        <IntegrationStatusPill status={s.merckIntegration?.status} />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Search the veterinary manual from the workspace side rail without leaving the visit. Free
@@ -1128,7 +1128,7 @@ const RadIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           RadAnalyzer
         </div>
-        <StatusPill status="coming-soon" label="Coming soon" />
+        <IntegrationStatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Imaging and analyzer connectivity for diagnostic workflows in Yosemite Crew.
@@ -1153,7 +1153,7 @@ const VetnioIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           Vetnio
         </div>
-        <StatusPill status="coming-soon" label="Coming soon" />
+        <IntegrationStatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         AI-powered documentation for veterinary practices &mdash; instantly generate clinical notes,
@@ -1179,7 +1179,7 @@ const QuickBooksIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           QuickBooks
         </div>
-        <StatusPill status="coming-soon" label="Coming soon" />
+        <IntegrationStatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Accounting sync for invoices, payments, customers, and financial workflows through
@@ -1205,7 +1205,7 @@ const LaikaIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           Laika
         </div>
-        <StatusPill status="coming-soon" label="Coming soon" />
+        <IntegrationStatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         AI-powered diagnostic support for veterinary clinicians &mdash; interpret lab results,

--- a/apps/frontend/src/app/ui/primitives/PanelStates/PanelStates.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/PanelStates/PanelStates.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { PanelEmptyState, PanelLoadingRows } from './PanelStates';
+
+const meta = {
+  title: 'Primitives/PanelStates',
+  component: PanelEmptyState,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Empty and loading states shared by the record panels - waitlist, check-in ' +
+          'board, inventory alerts, and any panel that follows the same shape. Every ' +
+          'panel used to carry its own byte-identical copy, which drifted and tripped ' +
+          'the duplicated-lines gate.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { message: 'No entries yet.' },
+} satisfies Meta<typeof PanelEmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+
+export const EmptyInsidePanel: Story = {
+  render: (args) => (
+    <div className="w-[360px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)]">
+      <PanelEmptyState message={args.message} />
+    </div>
+  ),
+};
+
+/**
+ * `rowClass` is the consuming panel's own row class, so the skeleton lines up
+ * with the real rows it stands in for - shown here with two different row
+ * shapes to make that contract visible.
+ */
+export const LoadingRows: StoryObj<typeof PanelLoadingRows> = {
+  render: () => (
+    <div className="w-[360px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)]">
+      <PanelLoadingRows rowClass="flex items-center justify-between gap-3 px-4 py-3" />
+    </div>
+  ),
+};

--- a/apps/frontend/src/app/ui/tables/InventoryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.tsx
@@ -84,7 +84,7 @@ const getInventoryImageSrc = (item: InventoryItem) => {
   return src.startsWith(ORG_IMAGE_URL_PREFIX) ? src : '';
 };
 
-const StatusPill = ({ label }: { label: string }) => (
+const InventoryStatusPill = ({ label }: { label: string }) => (
   <SharedStatusPill label={label} style={getInventoryStatusStyle(label)} />
 );
 
@@ -153,7 +153,7 @@ const InventoryRow = ({
         {item.basicInfo.subCategory ? ` / ${item.basicInfo.subCategory}` : ''}
       </div>
       <div>
-        <StatusPill label={statusLabel} />
+        <InventoryStatusPill label={statusLabel} />
       </div>
       <div className="font-bold">{(item.stock.abcClass || '').replace('Class ', '') || '—'}</div>
       <div


### PR DESCRIPTION
Freeze scorecard criteria 2 and 5.

## Criterion 2 - shadowed primitives (4 -> 0)

| file | was | now |
|---|---|---|
| TasksPanel.tsx | hand-rolled `<span>` + own STATUS_CLASSES | `SharedStatusPill` via a status->tone map |
| InvoiceStep.tsx | same | same |
| OutpatientSchedule.tsx | delegate wrapper named `StatusPill` | delegate wrapper renamed `VisitStatusPill` |
| Integrations/index.tsx | delegate wrapper named `StatusPill` | delegate wrapper renamed `IntegrationStatusPill` |

Two genuinely reimplemented the pill (same colour tokens by hand, different geometry - the same defect class as Federation's shadowed SectionCard). Two already delegated to the real primitive and only collided on the identifier. No colour changes anywhere: the STATUS_CLASSES maps already pointed at the same `--color-pill-*` tokens the primitive uses.

## The lint rule the freeze plan asked for

`eslint-rules/no-shadowed-primitive.mjs` flags a `features/` declaration whose name matches a `ui/primitives/` directory. It reads the primitives directory at lint time rather than hardcoding names, so a new primitive is covered automatically.

Verified both directions:
- planted a violation (`const StatusPill = () => <span>fake</span>`) - fires with the intended message
- full `features/` lint - zero false positives, zero remaining shadows

## Criterion 5 - missing story

`PanelStates` was the one primitive without a story. Added, following the sibling-primitive pattern.

## Validation

270 existing tests across 8 suites pass unmodified - no behaviour change, only which component renders. `tsc` and eslint clean.