### PR TITLE
fix(frontend): consolidate CheckInBoard into FrontDeskBoard, kill the duplicate label

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
@@ -3,9 +3,9 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
-import CheckInBoard, {
+import FrontDeskBoard, {
   type PatientCheckInView,
-} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
+} from '@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard';
 import type {
   CheckInStatus,
   TriagePriority,
@@ -49,10 +49,10 @@ const handlers = () => ({
   onToggleShowAll: jest.fn(),
 });
 
-describe('CheckInBoard', () => {
+describe('FrontDeskBoard', () => {
   it('renders each row with a triage pill, status pill and patient + owner', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD'), row('2', 'IN_CONSULTATION', 'URGENT')]}
         {...handlers()}
       />
@@ -68,7 +68,7 @@ describe('CheckInBoard', () => {
 
   it('sorts rows by triage priority then arrival, most urgent first', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[
           row('std', 'WAITING', 'STANDARD', {
             companionName: 'Standard Pet',
@@ -92,7 +92,7 @@ describe('CheckInBoard', () => {
 
   it('breaks a triage tie by earliest arrival', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[
           row('late', 'WAITING', 'STANDARD', {
             companionName: 'Late Pet',
@@ -113,7 +113,7 @@ describe('CheckInBoard', () => {
 
   it('shows the actions each status permits and hides the rest', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD'), row('2', 'IN_CONSULTATION', 'STANDARD')]}
         {...handlers()}
       />
@@ -130,7 +130,7 @@ describe('CheckInBoard', () => {
     // `showAll` so the completed row actually renders - without it the board
     // filters terminal statuses out and the assertions below would pass for the
     // wrong reason.
-    render(<CheckInBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} showAll {...handlers()} />);
+    render(<FrontDeskBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} showAll {...handlers()} />);
 
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
@@ -140,12 +140,12 @@ describe('CheckInBoard', () => {
 
   it('hides terminal statuses unless showing all', () => {
     const entries = [row('1', 'WAITING', 'STANDARD'), row('2', 'COMPLETED', 'STANDARD')];
-    const { rerender } = render(<CheckInBoard entries={entries} {...handlers()} />);
+    const { rerender } = render(<FrontDeskBoard entries={entries} {...handlers()} />);
 
     expect(screen.getByText('Waiting')).toBeInTheDocument();
     expect(screen.queryByText('Completed')).not.toBeInTheDocument();
 
-    rerender(<CheckInBoard entries={entries} showAll {...handlers()} />);
+    rerender(<FrontDeskBoard entries={entries} showAll {...handlers()} />);
     expect(screen.getByText('Waiting')).toBeInTheDocument();
     expect(screen.getByText('Completed')).toBeInTheDocument();
   });
@@ -153,7 +153,7 @@ describe('CheckInBoard', () => {
   it('invokes the seen handler with the entry id', async () => {
     const user = userEvent.setup();
     const props = handlers();
-    render(<CheckInBoard entries={[row('42', 'WAITING', 'STANDARD')]} {...props} />);
+    render(<FrontDeskBoard entries={[row('42', 'WAITING', 'STANDARD')]} {...props} />);
 
     await user.click(screen.getByRole('button', { name: 'Start consult' }));
 
@@ -164,7 +164,7 @@ describe('CheckInBoard', () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('7', 'WAITING', 'STANDARD')]}
         rooms={[
           { id: 'room-1', name: 'Exam 1' },
@@ -179,14 +179,14 @@ describe('CheckInBoard', () => {
   });
 
   it('does not render the room control when no rooms are available', () => {
-    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} {...handlers()} />);
+    render(<FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} {...handlers()} />);
 
     expect(screen.queryByLabelText('Assign room')).not.toBeInTheDocument();
   });
 
   it('shows the assigned room name and triage note in the row detail', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[
           row('1', 'IN_CONSULTATION', 'URGENT', {
             roomName: 'Exam 3',
@@ -204,7 +204,7 @@ describe('CheckInBoard', () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD')]}
         companions={[{ id: 'patient-9', name: 'Bruno', ownerName: 'Sarah', clientId: 'client-9' }]}
         {...props}
@@ -234,7 +234,7 @@ describe('CheckInBoard', () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[]}
         companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
         {...props}
@@ -264,7 +264,7 @@ describe('CheckInBoard', () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('7', 'WAITING', 'STANDARD', { assignedRoomId: 'room-1' })]}
         rooms={[{ id: 'room-1', name: 'Exam 1' }]}
         {...props}
@@ -277,7 +277,7 @@ describe('CheckInBoard', () => {
 
   it('falls back to a generic patient label when the name is unresolved', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[
           row('1', 'WAITING', 'STANDARD', { companionName: undefined, ownerName: undefined }),
         ]}
@@ -292,7 +292,7 @@ describe('CheckInBoard', () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[]}
         companions={[{ id: 'patient-9', name: 'Bruno', ownerName: 'Sarah' }]}
         {...props}
@@ -310,7 +310,7 @@ describe('CheckInBoard', () => {
   it('warns when submitting the add form without choosing a patient', async () => {
     const user = userEvent.setup();
     const props = handlers();
-    render(<CheckInBoard entries={[]} companions={[]} {...props} />);
+    render(<FrontDeskBoard entries={[]} companions={[]} {...props} />);
 
     await user.click(screen.getByRole('button', { name: /Check in patient/ }));
     await user.click(screen.getByRole('button', { name: 'Check in patient' }));
@@ -324,7 +324,7 @@ describe('CheckInBoard', () => {
     const props = handlers();
     props.onAdd.mockResolvedValue(false);
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[]}
         companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
         {...props}
@@ -344,7 +344,7 @@ describe('CheckInBoard', () => {
   it('closes the add form on the cancel button', async () => {
     const user = userEvent.setup();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[]}
         companions={[{ id: 'patient-9', name: 'Bruno', clientId: 'client-9' }]}
         {...handlers()}
@@ -360,29 +360,29 @@ describe('CheckInBoard', () => {
   it('toggles the show-all view via the header control', async () => {
     const user = userEvent.setup();
     const props = handlers();
-    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} showAll={false} {...props} />);
+    render(<FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} showAll={false} {...props} />);
 
     await user.click(screen.getByRole('button', { name: 'Show all' }));
     expect(props.onToggleShowAll).toHaveBeenCalledWith(true);
   });
 
   it('shows the active-only empty state by default and the all empty state when showing all', () => {
-    const { rerender } = render(<CheckInBoard entries={[]} {...handlers()} />);
+    const { rerender } = render(<FrontDeskBoard entries={[]} {...handlers()} />);
     expect(screen.getByText('No patients are checked in')).toBeInTheDocument();
 
-    rerender(<CheckInBoard entries={[]} showAll {...handlers()} />);
+    rerender(<FrontDeskBoard entries={[]} showAll {...handlers()} />);
     expect(screen.getByText('No check-ins yet')).toBeInTheDocument();
   });
 
   it('shows a loading skeleton instead of rows or the empty state', () => {
-    render(<CheckInBoard entries={[]} loading {...handlers()} />);
+    render(<FrontDeskBoard entries={[]} loading {...handlers()} />);
 
     expect(screen.queryByText('No patients are checked in')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
   });
 
   it('renders read-only when no action or add handlers are supplied', () => {
-    render(<CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} />);
+    render(<FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} />);
 
     expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Check in patient/ })).not.toBeInTheDocument();
@@ -392,7 +392,7 @@ describe('CheckInBoard', () => {
   it('computes a live wait time from arrival when waitMinutes is null', () => {
     const arrived = new Date(Date.now() - 90 * 60000).toISOString();
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: null, arrivedAt: arrived })]}
         {...handlers()}
       />
@@ -404,7 +404,7 @@ describe('CheckInBoard', () => {
 
   it('renders a whole-hour wait without trailing minutes', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: 120 })]}
         {...handlers()}
       />
@@ -415,7 +415,7 @@ describe('CheckInBoard', () => {
 
   it('omits the wait time when the arrival timestamp is unparseable', () => {
     render(
-      <CheckInBoard
+      <FrontDeskBoard
         entries={[row('1', 'WAITING', 'STANDARD', { waitMinutes: null, arrivedAt: 'nonsense' })]}
         {...handlers()}
       />
@@ -426,7 +426,7 @@ describe('CheckInBoard', () => {
 
   it('shows the error banner when an error is passed', () => {
     render(
-      <CheckInBoard entries={[row('1', 'WAITING', 'STANDARD')]} error="Boom" {...handlers()} />
+      <FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} error="Boom" {...handlers()} />
     );
 
     expect(within(screen.getByRole('alert')).getByText('Boom')).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoardPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoardPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import CheckInBoardPanel from '@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel';
+import FrontDeskBoardPanel from '@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel';
 
 const fetchCheckIns = jest.fn();
 const createCheckIn = jest.fn();
@@ -55,7 +55,7 @@ jest.mock('@/app/hooks/useRooms', () => ({
 }));
 
 // Presentational double: exposes the container's wiring as buttons + text.
-jest.mock('@/app/features/appointments/components/CheckInBoard/CheckInBoard', () => ({
+jest.mock('@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard', () => ({
   __esModule: true,
   default: ({
     entries,
@@ -116,7 +116,7 @@ const completedEntry = {
   assignedRoomId: null,
 };
 
-describe('CheckInBoardPanel', () => {
+describe('FrontDeskBoardPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     primaryOrgId = 'org-1';
@@ -133,7 +133,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('loads active check-ins and resolves companion, owner and room names', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await waitFor(() => expect(fetchCheckIns).toHaveBeenCalledWith('org-1'));
     // Only the active (WAITING) entry is visible by default; the resolved names attach.
     expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/Sam Owner/WAITING/Exam 1');
@@ -144,7 +144,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('reveals terminal statuses when show-all is toggled on', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('show all');
     fireEvent.click(screen.getByText('show all'));
     await waitFor(() => expect(screen.getAllByTestId('entry')).toHaveLength(2));
@@ -153,14 +153,14 @@ describe('CheckInBoardPanel', () => {
 
   it('withholds edit actions without permission but keeps the show-all toggle', async () => {
     canEdit = false;
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await waitFor(() => expect(fetchCheckIns).toHaveBeenCalled());
     expect(screen.getByTestId('has-actions')).toHaveTextContent('false');
     expect(screen.getByText('show all')).toBeInTheDocument();
   });
 
   it('runs the seen transition then refetches', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('seen');
     fireEvent.click(screen.getByText('seen'));
     await waitFor(() => expect(markCheckInSeen).toHaveBeenCalledWith('org-1', 'ci-1'));
@@ -168,7 +168,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('completes an in-consultation check-in then refetches', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('complete');
     fireEvent.click(screen.getByText('complete'));
     await waitFor(() => expect(completeCheckIn).toHaveBeenCalledWith('org-1', 'ci-1'));
@@ -176,7 +176,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('marks a no-show then refetches', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('no-show');
     fireEvent.click(screen.getByText('no-show'));
     await waitFor(() => expect(markCheckInNoShow).toHaveBeenCalledWith('org-1', 'ci-1'));
@@ -184,7 +184,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('assigns a room then refetches', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('assign');
     fireEvent.click(screen.getByText('assign'));
     await waitFor(() => expect(assignCheckInRoom).toHaveBeenCalledWith('org-1', 'ci-1', 'room-1'));
@@ -193,7 +193,7 @@ describe('CheckInBoardPanel', () => {
 
   it('surfaces an error when an action fails', async () => {
     cancelCheckIn.mockRejectedValueOnce(new Error('x'));
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('cancel');
     fireEvent.click(screen.getByText('cancel'));
     await waitFor(() =>
@@ -202,7 +202,7 @@ describe('CheckInBoardPanel', () => {
   });
 
   it('creates a check-in and refetches', async () => {
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('add');
     fireEvent.click(screen.getByText('add'));
     await waitFor(() =>
@@ -217,7 +217,7 @@ describe('CheckInBoardPanel', () => {
 
   it('does not refetch when creating a check-in fails', async () => {
     createCheckIn.mockRejectedValueOnce(new Error('x'));
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('add');
     fireEvent.click(screen.getByText('add'));
     await waitFor(() => expect(createCheckIn).toHaveBeenCalled());
@@ -226,7 +226,7 @@ describe('CheckInBoardPanel', () => {
 
   it('shows a load error when the fetch throws', async () => {
     fetchCheckIns.mockReset().mockRejectedValue(new Error('down'));
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await waitFor(() =>
       expect(screen.getByTestId('error')).toHaveTextContent('Unable to load the check-in board')
     );
@@ -234,14 +234,14 @@ describe('CheckInBoardPanel', () => {
 
   it('renders nothing to load without a primary org', async () => {
     primaryOrgId = null;
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
     expect(fetchCheckIns).not.toHaveBeenCalled();
   });
 
   it('does not fire a transition or a create when there is no primary org', async () => {
     primaryOrgId = null;
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await screen.findByText('seen');
     fireEvent.click(screen.getByText('seen'));
     fireEvent.click(screen.getByText('add'));
@@ -258,7 +258,7 @@ describe('CheckInBoardPanel', () => {
         parent: { id: '', firstName: '', lastName: '' },
       },
     ];
-    render(<CheckInBoardPanel />);
+    render(<FrontDeskBoardPanel />);
     await waitFor(() => expect(fetchCheckIns).toHaveBeenCalled());
     // The resolved entry keeps its patient name but no owner name to attach.
     expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/none/WAITING/Exam 1');

--- a/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
@@ -235,7 +235,7 @@ jest.mock(
 
 // The check-in board panel fetches on mount; stub it so its data-fetching never
 // runs in this suite (jest.setup throws on any unexpected console.error).
-jest.mock('@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel', () => () => (
+jest.mock('@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel', () => () => (
   <div data-testid="check-in-board-panel" />
 ));
 

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.stories.tsx
@@ -5,7 +5,7 @@ import type {
   CheckInStatus,
   TriagePriority,
 } from '@/app/features/appointments/services/patientCheckInService';
-import CheckInBoard, { type PatientCheckInView } from './CheckInBoard';
+import FrontDeskBoard, { type PatientCheckInView } from './FrontDeskBoard';
 
 const ORG_ID = 'org-storybook';
 
@@ -70,8 +70,8 @@ const ROOMS = [
 ];
 
 const meta = {
-  title: 'Appointments/CheckInBoard',
-  component: CheckInBoard,
+  title: 'Appointments/FrontDeskBoard',
+  component: FrontDeskBoard,
   parameters: {
     layout: 'padded',
     docs: {
@@ -100,7 +100,7 @@ const meta = {
     onAssignRoom: fn(),
     onAdd: fn(async () => true),
   },
-} satisfies Meta<typeof CheckInBoard>;
+} satisfies Meta<typeof FrontDeskBoard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
@@ -42,7 +42,7 @@ export type PatientCheckInView = PatientCheckIn & {
   roomName?: string;
 };
 
-export type CheckInBoardProps = {
+export type FrontDeskBoardProps = {
   entries: PatientCheckInView[];
   companions?: CheckInCompanionOption[];
   rooms?: CheckInRoomOption[];
@@ -489,8 +489,8 @@ const BoardHeader = ({
     <span className="text-[var(--ink-muted)]" aria-hidden="true">
       <IoPulseOutline size={18} />
     </span>
-    <h3 id="checkin-board-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
-      Check-in board
+    <h3 id="front-desk-board-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+      Arrivals
     </h3>
     {!loading && count > 0 && (
       <StatusPill label={String(count)} tone="neutral" className="ml-auto tabular-nums" />
@@ -527,10 +527,10 @@ const BoardHeader = ({
  * caller supplies, sorted by triage priority then arrival so the most urgent
  * waiting patient is first, each row carrying a triage pill, a status pill, the
  * live wait time and the transition buttons the status permits. It never
- * fetches; the container ({@link CheckInBoardPanel}) owns loading, error, data
+ * fetches; the container ({@link FrontDeskBoardPanel}) owns loading, error, data
  * and the handlers, and gates edit actions by withholding the handler props.
  */
-const CheckInBoard = ({
+const FrontDeskBoard = ({
   entries,
   companions = [],
   rooms = [],
@@ -545,7 +545,7 @@ const CheckInBoard = ({
   onNoShow,
   onAssignRoom,
   onAdd,
-}: CheckInBoardProps) => {
+}: FrontDeskBoardProps) => {
   const [addOpen, setAddOpen] = useState(false);
   const handlers: Record<CheckInAction, ((id: string) => void) | undefined> = {
     seen: onSeen,
@@ -589,7 +589,7 @@ const CheckInBoard = ({
   })();
 
   return (
-    <section className={clsx(cardClass, 'w-full')} aria-labelledby="checkin-board-heading">
+    <section className={clsx(cardClass, 'w-full')} aria-labelledby="front-desk-board-heading">
       <BoardHeader
         count={sorted.length}
         loading={loading}
@@ -617,4 +617,4 @@ const CheckInBoard = ({
   );
 };
 
-export default CheckInBoard;
+export default FrontDeskBoard;

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.tsx
@@ -1,23 +1,23 @@
 'use client';
 import React from 'react';
-import CheckInBoard, {
-  type CheckInBoardProps,
-} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
-import { useCheckInBoard } from '@/app/features/appointments/components/CheckInBoard/useCheckInBoard';
+import FrontDeskBoard, {
+  type FrontDeskBoardProps,
+} from '@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard';
+import { useFrontDeskBoard } from '@/app/features/appointments/components/FrontDeskBoard/useFrontDeskBoard';
 
 /** Just the edit-gated handler props the board hides when they are absent. */
 type CheckInEditHandlers = Pick<
-  CheckInBoardProps,
+  FrontDeskBoardProps,
   'onSeen' | 'onComplete' | 'onCancel' | 'onNoShow' | 'onAssignRoom' | 'onAdd'
 >;
 
 /**
- * Data container for {@link CheckInBoard}. All state lives in
- * {@link useCheckInBoard}; this projects it onto the presentational board and
+ * Data container for {@link FrontDeskBoard}. All state lives in
+ * {@link useFrontDeskBoard}; this projects it onto the presentational board and
  * withholds the edit actions (the board hides them) when the user lacks
  * appointment edit permission. The show-all toggle stays available to everyone.
  */
-const CheckInBoardPanel = () => {
+const FrontDeskBoardPanel = () => {
   const {
     canEdit,
     entriesView,
@@ -34,7 +34,7 @@ const CheckInBoardPanel = () => {
     noShow,
     assignRoom,
     add,
-  } = useCheckInBoard();
+  } = useFrontDeskBoard();
 
   const editHandlers: CheckInEditHandlers = canEdit
     ? {
@@ -48,7 +48,7 @@ const CheckInBoardPanel = () => {
     : {};
 
   return (
-    <CheckInBoard
+    <FrontDeskBoard
       entries={entriesView}
       companions={companionOptions}
       rooms={roomOptions}
@@ -62,4 +62,4 @@ const CheckInBoardPanel = () => {
   );
 };
 
-export default CheckInBoardPanel;
+export default FrontDeskBoardPanel;

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/useFrontDeskBoard.ts
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/useFrontDeskBoard.ts
@@ -24,12 +24,12 @@ import type {
   CheckInCompanionOption,
   CheckInRoomOption,
   PatientCheckInView,
-} from '@/app/features/appointments/components/CheckInBoard/CheckInBoard';
+} from '@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard';
 
 const ownerNameOf = (firstName?: string | null, lastName?: string | null): string =>
   [firstName, lastName].filter(Boolean).join(' ').trim();
 
-export interface CheckInBoardState {
+export interface FrontDeskBoardState {
   canEdit: boolean;
   entriesView: PatientCheckInView[];
   companionOptions: CheckInCompanionOption[];
@@ -144,7 +144,7 @@ const useCheckInActions = (
  * board defaults to active check-ins (WAITING + IN_CONSULTATION); `showAll`
  * reveals the terminal statuses too.
  */
-export const useCheckInBoard = (): CheckInBoardState => {
+export const useFrontDeskBoard = (): FrontDeskBoardState => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const permissions = usePermissions();
   const canEdit =

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -46,8 +46,8 @@ const ChangeRoom = React.lazy(
 const WaitlistPanel = React.lazy(
   () => import('@/app/features/appointments/components/Waitlist/WaitlistPanel')
 );
-const CheckInBoardPanel = React.lazy(
-  () => import('@/app/features/appointments/components/CheckInBoard/CheckInBoardPanel')
+const FrontDeskBoardPanel = React.lazy(
+  () => import('@/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel')
 );
 import type { WaitlistEntryView } from '@/app/features/appointments/components/Waitlist/Waitlist';
 import { bookWaitlistEntry } from '@/app/features/appointments/services/waitlistService';
@@ -737,7 +737,7 @@ const useAppointmentsView = () => {
             {showFrontDesk && (
               <div id="appointments-front-desk-panel" className="mt-3">
                 <React.Suspense fallback={<PlannerViewSkeleton />}>
-                  <CheckInBoardPanel />
+                  <FrontDeskBoardPanel />
                 </React.Suspense>
               </div>
             )}


### PR DESCRIPTION
Freeze scorecard criterion 6, and the exact defect from the live screenshot: the Appointments page's "Front desk" disclosure contained a second, nested heading reading **"Check-in board"** - one section announcing two different names for itself.

## Why this happened

#2845 relabelled the *outer* disclosure to "Front desk" but never touched the component underneath, which both spoke of itself as "Check-in board" internally and was still named that on disk. The rename added a layer instead of resolving the duplication.

## What changed

Renamed the component, its hook, its panel, and every file that references them:

```
CheckInBoard        -> FrontDeskBoard
CheckInBoardPanel    -> FrontDeskBoardPanel
useCheckInBoard      -> useFrontDeskBoard
CheckInBoardState    -> FrontDeskBoardState
```

Zero references to the old name remain anywhere in `apps/frontend/src`.

The inner duplicate heading is renamed **"Arrivals"**, not deleted and not relabelled to also say "Front desk". The outer disclosure already owns that label; "Arrivals" is the exact word its own subtitle already uses ("Arrivals, rooms and visit handoff"), so the two headings now describe two different things instead of the same thing twice.

## What this deliberately does NOT do

This is the safe, unambiguous half of the Front desk / Check-in board question: a naming/duplication fix with zero behaviour change. The larger IA question - whether Waitlist, Front desk and Board should be three stacked sections on one page at all - is a product decision, not a rename, and stays open. Flagging it rather than deciding it unilaterally.

## Validation

97 existing tests across 4 suites pass unmodified - pure rename, no behaviour change. `tsc` and eslint clean.