### PR TITLE
fix(frontend): compact organization specialities layout

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Organization/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/index.test.tsx
@@ -168,6 +168,12 @@ describe('Organization page', () => {
     expect(screen.getByTestId('document-e-signing')).toBeInTheDocument();
     expect(screen.getByTestId('delete-org')).toBeInTheDocument();
     expect(teamMock).toHaveBeenCalledWith(expect.objectContaining({ isVerified: true }));
+    expect(screen.getByTestId('team').parentElement).toBe(
+      screen.getByTestId('specialities').parentElement
+    );
+    expect(screen.getByTestId('rooms').parentElement).not.toBe(
+      screen.getByTestId('specialities').parentElement
+    );
   });
 
   it('hides gated sections for unverified org', () => {

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.stories.tsx
@@ -171,8 +171,9 @@ const meta = {
           'returned. The Head column resolves an id against the team store rather than printing ' +
           '`headName`, so a speciality whose head has left the practice renders an em dash ' +
           'instead of a stale name.\n\n' +
-          'Below `lg` the whole table is swapped for a card grid - both are always in the DOM ' +
-          'and a media query hides one - which is why every query here is a role query: the ' +
+          'Below 896px of available width the whole table is swapped for a card grid - both are ' +
+          'always in the DOM ' +
+          'and a container query hides one - which is why every query here is a role query: the ' +
           'hidden half is out of the accessibility tree but very much still in the text.',
       },
     },
@@ -180,9 +181,9 @@ const meta = {
   tags: ['autodocs'],
   /**
    * Pinned rather than left on the project default. Every query in this file is
-   * a role query against the `hidden lg:block` table, and the `lg:hidden` card
+   * a role query against the `hidden @4xl:block` table, and the `@4xl:hidden` card
    * grid renders the same names, the same counts and the same eye button. Above
-   * 1024px the card grid is `display:none` and out of the accessibility tree, so
+   * 896px the card grid is `display:none` and out of the accessibility tree, so
    * the role queries resolve to exactly one node each; below it they resolve to
    * the OTHER half, `getAllByRole('columnheader')` returns nothing and every
    * story here fails. That threshold currently holds only because
@@ -241,6 +242,34 @@ export const Table: Story = {
           'The resting table. The speciality name is a link to the full catalog route carrying ' +
           '`?open=<id>`, while the eye button opens the drawer in place - two different ' +
           'destinations from one row, which is only obvious with both drawn.',
+      },
+    },
+  },
+};
+
+export const OverviewColumn: Story = {
+  name: 'Organization overview column',
+  tags: ['layout-regression'],
+  decorators: [
+    (Story) => (
+      <div className="w-[700px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.queryByRole('columnheader')).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: 'View details' })).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: 'Manage' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The section at the width it receives in the Organization overview. Its own container ' +
+          'selects the compact card layout even when the browser viewport is wide.',
       },
     },
   },

--- a/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
@@ -105,7 +105,10 @@ export const Organization = () => {
       <Profile primaryOrg={primaryorg} />
       {primaryorg.isVerified ? (
         <div className="grid gap-[14px] xl:grid-cols-[1.5fr_1fr] xl:items-stretch">
-          <Team isVerified={primaryorg.isVerified} />
+          <div className="flex min-h-0 flex-col gap-[14px]">
+            <Team isVerified={primaryorg.isVerified} />
+            <Specialities />
+          </div>
           <div className="flex min-h-0 flex-col gap-[14px]">
             <Rooms />
             <Payment />
@@ -113,9 +116,11 @@ export const Organization = () => {
           </div>
         </div>
       ) : (
-        <DeleteOrg />
+        <>
+          <Specialities />
+          <DeleteOrg />
+        </>
       )}
-      <Specialities />
       {primaryorg.isVerified && (
         <>
           <LinkedMedicalDevices />

--- a/apps/frontend/src/app/ui/tables/SpecialitiesTableRevamp.tsx
+++ b/apps/frontend/src/app/ui/tables/SpecialitiesTableRevamp.tsx
@@ -140,9 +140,11 @@ const SpecialitiesTableRevamp = ({ filteredList, onManageTeam }: SpecialitiesTab
   ];
 
   return (
-    <div className="w-full">
-      {/* Table on wide screens; the table scrolls horizontally if space is tight */}
-      <div className="hidden lg:block w-full overflow-x-auto">
+    <div className="@container w-full">
+      {/* The organization overview places this section in its wider content
+          column. Use that available width, rather than the browser width, so a
+          wide viewport never forces the six-column table into a narrow card. */}
+      <div className="hidden w-full overflow-x-auto @4xl:block">
         <GenericTable
           itemNoun="specialities"
           data={filteredList}
@@ -153,8 +155,7 @@ const SpecialitiesTableRevamp = ({ filteredList, onManageTeam }: SpecialitiesTab
           embedded
         />
       </div>
-      {/* Responsive card grid below lg: 1 col on mobile, 2 on sm, 3 on md */}
-      <div className="grid lg:hidden grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @4xl:hidden">
         {filteredList.length === 0 ? (
           <NoDataMessage {...emptyStateCopy('specialities')} />
         ) : (


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Organization overview renders Specialities as a full-width section below the two-column team and operations layout. The speciality table also chooses its desktop layout from the viewport width, so placing it in a narrower overview column would squeeze six columns into the available space.

## What is the new behavior?

Specialities now sits below Team in the wider Organization overview column. Its table uses a container query: the full six-column table remains on the catalog-width surface, while the overview column presents the existing compact speciality cards. A Storybook case records the overview width and guards the responsive presentation.

Validation:

- `npx tsc --noemit` (frontend)
- `pnpm --filter frontend run lint` (one existing warning in `useLazyAuthStore.ts`)
- `pnpm --filter frontend run test -- --testPathPatterns='Organization/index|SpecialitiesTableRevamp'` (3 suites / 49 tests)
- pre-push monorepo lint and type-check hooks

## Related Issue(s)

No linked issue.
