### PR TITLE
fix(frontend): separate filter and navigation controls in finance headers

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -570,6 +570,21 @@ describe('Finance > Estimates page', () => {
       '/finance'
     );
   });
+
+  it('stacks page actions above the status filter, not beside it', async () => {
+    mockEstimateService.listEstimates.mockResolvedValue([]);
+
+    render(<ProtectedEstimates />);
+
+    const backLink = await screen.findByRole('link', { name: 'Back to invoices' });
+    const statusFilter = screen.getByRole('group', { name: 'Filter estimates by status' });
+
+    // Document order, not just presence: the nav row must come before the
+    // filter row, otherwise they render as one mixed row again.
+    expect(
+      backLink.compareDocumentPosition(statusFilter) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });
 
 describe('Finance > Estimates status filters', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/InsuranceClaims/InsuranceClaimsHeader.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/InsuranceClaims/InsuranceClaimsHeader.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import InsuranceClaimsHeader from '@/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  PermissionGate: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, ariaLabel, onClick, isDisabled }: any) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ href, text, ariaLabel }: any) => (
+    <a href={href} aria-label={ariaLabel}>
+      {text}
+    </a>
+  ),
+}));
+
+const baseProps = {
+  claims: [] as InsuranceClaim[],
+  currency: 'USD',
+  activeStatus: 'all',
+  onStatusChange: jest.fn(),
+  companions: [{ id: 'c1', name: 'Bruno' }] as any,
+  onCreate: jest.fn(),
+};
+
+describe('InsuranceClaimsHeader', () => {
+  it('shows the claim count and back-to-invoices link', () => {
+    render(<InsuranceClaimsHeader {...baseProps} claims={[{ id: '1' } as InsuranceClaim]} />);
+
+    expect(screen.getByText('(1)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to invoices' })).toHaveAttribute(
+      'href',
+      '/finance'
+    );
+  });
+
+  it('stacks page actions above the status filter, not beside it', () => {
+    render(<InsuranceClaimsHeader {...baseProps} />);
+
+    const backLink = screen.getByRole('link', { name: 'Back to invoices' });
+    const statusFilter = screen.getByRole('group', { name: 'Filter claims by status' });
+
+    // Document order, not just presence: the nav row must come before the
+    // filter row, otherwise they render as one mixed row again.
+    expect(
+      backLink.compareDocumentPosition(statusFilter) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Finance/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/index.test.tsx
@@ -346,4 +346,18 @@ describe('Finance page', () => {
       '/finance/discounts'
     );
   });
+
+  it('stacks page actions above the status filter, not beside it', () => {
+    useSearchStoreMock.mockImplementation((selector: any) => selector({ query: '' }));
+    render(<ProtectedFinance />);
+
+    const discountsLink = screen.getByRole('link', { name: 'Manage discounts' });
+    const statusPills = screen.getByTestId('status-pills');
+
+    // Document order, not just presence: the nav/Stripe row must come before
+    // the filter row, otherwise they render as one mixed row again.
+    expect(
+      discountsLink.compareDocumentPosition(statusPills) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });

--- a/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/index.tsx
@@ -275,10 +275,10 @@ const EstimatesContent = () => {
     <div className="flex flex-col gap-6 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-5! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-5!">
       {/*
         Deliberately the same header as Finance: title with a live count, an
-        info affordance, a metrics sub-line, then the status filter and the
-        page actions on the right of that same row. Estimates is reached from
-        Finance and reads as the same surface, so a second layout here made the
-        two pages look unrelated.
+        info affordance, a metrics sub-line, then page actions and the status
+        filter stacked on the right of that same row. Estimates is reached
+        from Finance and reads as the same surface, so a second layout here
+        made the two pages look unrelated.
       */}
       <div className="flex items-center justify-between w-full flex-wrap gap-2">
         <div className="flex flex-col gap-0.5">
@@ -307,7 +307,21 @@ const EstimatesContent = () => {
             )} approved`}
           </p>
         </div>
-        <div className="flex items-center gap-2 flex-wrap justify-end">
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex items-center gap-2 flex-wrap justify-end">
+            <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
+            <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+              <Primary
+                text="New estimate"
+                isDisabled={companions.length === 0}
+                onClick={() => {
+                  setCreateError(null);
+                  setCreateOpen(true);
+                }}
+                ariaLabel="Create a new estimate"
+              />
+            </PermissionGate>
+          </div>
           {/*
             Seven non-shrinking pills exceed a phone's width, so the group wraps
             here rather than pushing the page into a sideways scroll.
@@ -322,18 +336,6 @@ const EstimatesContent = () => {
             ariaLabel="Filter estimates by status"
             className="flex-wrap justify-end"
           />
-          <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
-          <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-            <Primary
-              text="New estimate"
-              isDisabled={companions.length === 0}
-              onClick={() => {
-                setCreateError(null);
-                setCreateOpen(true);
-              }}
-              ariaLabel="Create a new estimate"
-            />
-          </PermissionGate>
         </div>
       </div>
 

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -203,25 +203,38 @@ const Finance = () => {
                   )} outstanding`}
                 </p>
               </div>
-              <div className="flex items-center gap-2 flex-wrap justify-end">
+              {/*
+                Two rows, not one: the status filter is a different control
+                (a mutually-exclusive toggle over the visible rows) than the
+                page-level navigation and the Stripe indicator next to it, and
+                stacking them keeps a filter chip from sitting shoulder to
+                shoulder with a full-height nav button and a status pill.
+              */}
+              <div className="flex flex-col items-end gap-2">
+                <div className="flex items-center gap-2 flex-wrap justify-end">
+                  <Secondary
+                    href="/finance/estimates"
+                    text="Estimates"
+                    ariaLabel="View estimates"
+                  />
+                  <Secondary
+                    href="/finance/discounts"
+                    text="Discounts"
+                    ariaLabel="Manage discounts"
+                  />
+                  <Secondary
+                    href="/finance/insurance-claims"
+                    text="Insurance"
+                    ariaLabel="View insurance claims"
+                  />
+                  <StripeStatusPill />
+                </div>
                 <InvoiceStatusFilterPills
                   options={InvoiceStatusFilters}
                   activeStatus={activeStatus}
                   setActiveStatus={setActiveStatus}
                   className="flex-wrap justify-end"
                 />
-                <Secondary href="/finance/estimates" text="Estimates" ariaLabel="View estimates" />
-                <Secondary
-                  href="/finance/discounts"
-                  text="Discounts"
-                  ariaLabel="Manage discounts"
-                />
-                <Secondary
-                  href="/finance/insurance-claims"
-                  text="Insurance"
-                  ariaLabel="View insurance claims"
-                />
-                <StripeStatusPill />
               </div>
             </div>
             <div ref={plannerSectionRef} className={plannerSectionClassName}>

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.tsx
@@ -47,8 +47,8 @@ const summariseClaims = (claims: InsuranceClaim[]) =>
 
 /**
  * The Insurance claims header: the same anatomy as Finance and Estimates - a
- * title with a live count, an info affordance, a metrics sub-line, then the
- * status filter and page actions on the right of that row.
+ * title with a live count, an info affordance, a metrics sub-line, then page
+ * actions and the status filter stacked on the right of that row.
  */
 const InsuranceClaimsHeader = ({
   claims,
@@ -89,7 +89,18 @@ const InsuranceClaimsHeader = ({
           )} paid back`}
         </p>
       </div>
-      <div className="flex items-center gap-2 flex-wrap justify-end">
+      <div className="flex flex-col items-end gap-2">
+        <div className="flex items-center gap-2 flex-wrap justify-end">
+          <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
+          <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
+            <Primary
+              text="New insurance claim"
+              isDisabled={companions.length === 0}
+              onClick={onCreate}
+              ariaLabel="Create a new insurance claim"
+            />
+          </PermissionGate>
+        </div>
         <InvoiceStatusFilterPills
           options={InsuranceClaimStatusFilters}
           activeStatus={activeStatus}
@@ -97,15 +108,6 @@ const InsuranceClaimsHeader = ({
           ariaLabel="Filter claims by status"
           className="flex-wrap justify-end"
         />
-        <Secondary href="/finance" text="Invoices" ariaLabel="Back to invoices" />
-        <PermissionGate allOf={[PERMISSIONS.BILLING_EDIT_ANY]}>
-          <Primary
-            text="New insurance claim"
-            isDisabled={companions.length === 0}
-            onClick={onCreate}
-            ariaLabel="Create a new insurance claim"
-          />
-        </PermissionGate>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Finance, Estimates and Insurance claims headers each mixed page-navigation buttons (and, on Finance, the Stripe status pill) into the same row as the status filter chips, so three unrelated control types read as one inconsistent row of pill sizes.
- Stack page actions above the status filter in each header, matching the existing phone layout, which already keeps them apart.

## Test plan
- [x] `npx tsc --noEmit` (apps/frontend) - clean
- [x] `pnpm --filter frontend run lint` - 0 errors
- [x] `pnpm --filter frontend run test -- --testPathPatterns="Finance/Estimates|Finance/index|InsuranceClaims"` - 4 suites / 72 tests pass