### PR TITLE
fix(backend): exclude expired batches from expiring alerts

### DIFF
--- a/apps/backend/src/services/inventory.service.ts
+++ b/apps/backend/src/services/inventory.service.ts
@@ -2413,7 +2413,7 @@ export const InventoryAlertService = {
     return prisma.inventoryBatch.findMany({
       where: {
         organisationId: safeOrganisationId,
-        expiryDate: { lte: threshold },
+        expiryDate: { gte: now.toDate(), lte: threshold },
       },
       orderBy: { expiryDate: "asc" },
     });

--- a/apps/backend/test/services/inventory.service.test.ts
+++ b/apps/backend/test/services/inventory.service.test.ts
@@ -3208,6 +3208,16 @@ describe("Inventory service guards, helpers, and branch paths", () => {
       expect(days).toBeLessThan(7.5);
     });
 
+    it("starts the expiry window now so expired batches stay out", async () => {
+      const before = Date.now();
+      InventoryAlertService.getExpiringItems("org-1", 30);
+
+      const expiryRange = mockOf(prisma.inventoryBatch.findMany).mock
+        .calls[0][0].where.expiryDate as { gte: Date; lte: Date };
+      expect(expiryRange.gte.getTime()).toBeGreaterThanOrEqual(before);
+      expect(expiryRange.gte.getTime()).toBeLessThanOrEqual(Date.now());
+    });
+
     it("honours an explicit day count", async () => {
       InventoryAlertService.getExpiringItems("org-1", 30);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

The expiring-inventory query applies only an upper date bound, so batches that have already expired can appear in the Expiring soon list.

## What is the new behavior?

The shared inventory alert service now bounds the expiry window from the current time through the configured warning threshold. A regression test verifies the lower bound.

Backend lint and type-check pass. The focused inventory suite passes 177 tests with 99.95% statement and line coverage. The complete backend suite reported 486 suites and 11,543 tests passing, but did not terminate because existing Redis queue handles kept reconnecting after completion.

## Related Issue(s)

Not linked.
