### PR TITLE
fix(frontend): accept legacy ObjectId organisation ids in check-in board

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/services/patientCheckInService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/services/patientCheckInService.test.ts
@@ -24,6 +24,11 @@ const ORG = '11111111-1111-4111-8111-111111111111';
 const CHECK_IN = '22222222-2222-4222-8222-222222222222';
 const BASE = `/v1/pms/organisation/${ORG}/check-in`;
 
+// Organisations created before the app's move to UUIDs still carry their
+// original 24-hex Mongo ObjectId, same as every other org-scoped endpoint.
+const LEGACY_ORG = '6970ca8262012cc3e1c93099';
+const LEGACY_BASE = `/v1/pms/organisation/${LEGACY_ORG}/check-in`;
+
 const checkIn: PatientCheckIn = {
   id: CHECK_IN,
   organisationId: ORG,
@@ -73,6 +78,19 @@ describe('patientCheckInService', () => {
 
     it.each(UNSAFE_IDS)('rejects an unsafe organisation id (%s)', async (organisationId) => {
       await expect(fetchCheckIns(organisationId)).rejects.toThrow('Invalid organisation ID');
+      expect(getDataMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legacy ObjectId organisation id', async () => {
+      getDataMock.mockResolvedValue({ data: [checkIn] });
+      await expect(fetchCheckIns(LEGACY_ORG)).resolves.toEqual([checkIn]);
+      expect(getDataMock).toHaveBeenCalledWith(LEGACY_BASE, {});
+    });
+
+    it('rejects a 24-char string that is not valid hex', async () => {
+      await expect(fetchCheckIns('zzzzzzzzzzzzzzzzzzzzzzzz')).rejects.toThrow(
+        'Invalid organisation ID'
+      );
       expect(getDataMock).not.toHaveBeenCalled();
     });
 
@@ -168,6 +186,12 @@ describe('patientCheckInService', () => {
         'Invalid organisation ID'
       );
       expect(postDataMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legacy ObjectId organisation id', async () => {
+      postDataMock.mockResolvedValue({ data: { ...checkIn, status: 'IN_CONSULTATION' } });
+      await markCheckInSeen(LEGACY_ORG, CHECK_IN);
+      expect(postDataMock).toHaveBeenCalledWith(`${LEGACY_BASE}/${CHECK_IN}/seen`);
     });
 
     it.each(UNSAFE_IDS)('rejects an unsafe check-in id (%s)', async (checkInId) => {

--- a/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
+++ b/apps/frontend/src/app/features/appointments/services/patientCheckInService.ts
@@ -68,8 +68,8 @@ export interface CheckInListFilter {
 
 /**
  * Path ids are interpolated straight into the request URL, so they are validated
- * against the canonical UUID shape and the matched value — not the raw input —
- * is what flows into the URL. A non-UUID id throws before any request is made,
+ * against a known id shape and the matched value — not the raw input — is what
+ * flows into the URL. An unrecognised id throws before any request is made,
  * which is the SSRF sanitiser the scanner recognises (`encodeURIComponent` does
  * not satisfy it, because the tainted value would still reach the URL).
  */
@@ -79,6 +79,23 @@ const assertUuid = (value: string, label: string): string => {
       value
     )?.[0];
   if (!safeValue) throw new Error(`Invalid ${label} ID`);
+  return safeValue;
+};
+
+/**
+ * Organisations predate this app's move to UUIDs, so `organisationId` still
+ * arrives as a legacy 24-hex Mongo ObjectId for every org created before the
+ * migration - `assertUuid` alone rejected all of them and took the whole
+ * check-in board down before a request ever left the browser. Mirrors the
+ * UUID-or-ObjectId check `patientFlagService`/`patientAllergyService` already
+ * use for the same field.
+ */
+const assertOrganisationId = (value: string): string => {
+  const safeValue =
+    /^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{24})$/.exec(
+      value
+    )?.[0];
+  if (!safeValue) throw new Error('Invalid organisation ID');
   return safeValue;
 };
 
@@ -94,7 +111,7 @@ export const fetchCheckIns = async (
   organisationId: string,
   filter: CheckInListFilter = {}
 ): Promise<PatientCheckIn[]> => {
-  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeOrganisationId = assertOrganisationId(organisationId);
   const params: Record<string, string> = {};
   if (filter.patientId) params.patientId = filter.patientId;
   if (filter.status) params.status = filter.status;
@@ -118,7 +135,7 @@ export const fetchCheckIn = async (
   organisationId: string,
   checkInId: string
 ): Promise<PatientCheckIn> => {
-  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeOrganisationId = assertOrganisationId(organisationId);
   const safeCheckInId = assertUuid(checkInId, 'check-in');
   try {
     const res = await getData<PatientCheckIn>(
@@ -135,7 +152,7 @@ export const createCheckIn = async (
   organisationId: string,
   payload: CreateCheckInPayload
 ): Promise<PatientCheckIn> => {
-  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeOrganisationId = assertOrganisationId(organisationId);
   try {
     const res = await postData<PatientCheckIn, CreateCheckInPayload>(
       `/v1/pms/organisation/${safeOrganisationId}/check-in`,
@@ -155,7 +172,7 @@ const transition = async (
   checkInId: string,
   action: CheckInTransition
 ): Promise<PatientCheckIn> => {
-  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeOrganisationId = assertOrganisationId(organisationId);
   const safeCheckInId = assertUuid(checkInId, 'check-in');
   try {
     const res = await postData<PatientCheckIn>(
@@ -185,7 +202,7 @@ export const assignCheckInRoom = async (
   checkInId: string,
   roomId: string
 ): Promise<PatientCheckIn> => {
-  const safeOrganisationId = assertUuid(organisationId, 'organisation');
+  const safeOrganisationId = assertOrganisationId(organisationId);
   const safeCheckInId = assertUuid(checkInId, 'check-in');
   try {
     const res = await postData<PatientCheckIn, { roomId: string }>(


### PR DESCRIPTION
## Summary
- Live on `dev.yosemitecrew.com`, the Appointments page's Front-desk / Arrivals panel showed "Unable to load the check-in board right now." for every organisation tested.
- Root cause: `patientCheckInService.ts`'s `assertUuid` sanitiser only accepted the canonical UUID shape. Organisations created before this app's move to UUIDs still carry their original 24-hex Mongo ObjectId (same as every other org-scoped endpoint - finance, availability, rooms, etc.), so the sanitiser threw synchronously before any request ever left the browser, and the catch block in `useFrontDeskBoard`'s `useCheckInData` swallowed it into the generic error string.
- Added `assertOrganisationId`, accepting both a UUID and a 24-hex ObjectId for `organisationId` specifically (mirroring the same UUID-or-ObjectId check `patientFlagService`/`patientAllergyService` already use for this field); `checkInId` stays UUID-only since it's this feature's own native id.

## Verified
- Reproduced live on `dev.yosemitecrew.com` (org id `6970ca8262012cc3e1c93099`, ObjectId-shaped) before the fix; confirmed the panel loads after applying it locally.
- Added tests for `fetchCheckIns` and `markCheckInSeen` accepting a legacy ObjectId org id, plus a rejection test for a 24-char non-hex string. Mutation-checked: reverting the ObjectId branch fails the new tests.
- Full `patientCheckInService`, `FrontDeskBoard`, and `FrontDeskBoardPanel` test suites pass (91 tests).
- `tsc --noEmit` clean from `apps/frontend`.

## Test plan
- [x] `npx jest patientCheckInService.test.ts FrontDeskBoardPanel.test.tsx FrontDeskBoard.test.tsx`
- [x] `tsc --noEmit`
- [x] Mutation-check: stripped the ObjectId branch, confirmed the new tests fail