### PR TITLE
fix(backend): sync appointment status when the front desk checks a patient in

### DIFF
--- a/apps/backend/src/services/patient-check-in.service.ts
+++ b/apps/backend/src/services/patient-check-in.service.ts
@@ -1,5 +1,9 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
+import {
+  AppointmentPrismaService,
+  AppointmentPrismaServiceError,
+} from "./appointment.prisma.service";
 import type { Prisma } from "@prisma/client";
 
 export class PatientCheckInError extends Error {
@@ -65,6 +69,38 @@ const assertCheckIn = async (id: string, organisationId: string) => {
   return record;
 };
 
+/**
+ * The front desk's arrival and the schedule's own CHECKED_IN status are two
+ * independent state machines (PatientCheckIn.status vs Appointment.status)
+ * that happened to grow the same vocabulary without ever being wired
+ * together: checking a patient in here never touched the linked appointment,
+ * so the Board kept showing "Upcoming" for a patient the front desk already
+ * had as arrived. This is the one write that closes that gap - reusing
+ * `checkInAppointment` (not a raw status write) so the encounter it creates
+ * on arrival still gets created.
+ *
+ * Deliberately best-effort: an appointment already CHECKED_IN or further
+ * along (IN_PROGRESS, COMPLETED, ...) throws on the transition, and a
+ * walk-in's appointmentId can point at a REQUESTED or CANCELLED appointment
+ * that was never confirmed - none of those should block the front desk from
+ * recording that someone physically arrived.
+ */
+const syncAppointmentOnArrival = async (
+  appointmentId: string | undefined,
+  organisationId: string,
+): Promise<void> => {
+  if (!appointmentId) return;
+  try {
+    await AppointmentPrismaService.checkInAppointment(
+      appointmentId,
+      organisationId,
+    );
+  } catch (err) {
+    if (err instanceof AppointmentPrismaServiceError) return;
+    throw err;
+  }
+};
+
 export const PatientCheckInService = {
   async create(params: CreateCheckInParams) {
     const record = await prisma.patientCheckIn.create({
@@ -83,6 +119,8 @@ export const PatientCheckInService = {
       },
       select: checkInSelect,
     });
+
+    await syncAppointmentOnArrival(params.appointmentId, params.organisationId);
 
     await AuditTrailService.recordSafely({
       organisationId: params.organisationId,

--- a/apps/backend/test/services/patient-check-in.service.test.ts
+++ b/apps/backend/test/services/patient-check-in.service.test.ts
@@ -11,14 +11,35 @@ jest.mock("src/config/prisma", () => ({
 jest.mock("../../src/services/audit-trail.service", () => ({
   AuditTrailService: { recordSafely: jest.fn() },
 }));
+jest.mock("../../src/services/appointment.prisma.service", () => {
+  class AppointmentPrismaServiceError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "AppointmentPrismaServiceError";
+    }
+  }
+  return {
+    AppointmentPrismaService: { checkInAppointment: jest.fn() },
+    AppointmentPrismaServiceError,
+  };
+});
 
 import { prisma } from "src/config/prisma";
 import {
   PatientCheckInService,
   PatientCheckInError,
 } from "../../src/services/patient-check-in.service";
+import {
+  AppointmentPrismaService,
+  AppointmentPrismaServiceError,
+} from "../../src/services/appointment.prisma.service";
 
 const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockedCheckInAppointment =
+  AppointmentPrismaService.checkInAppointment as jest.Mock;
 
 const arrivedAt = new Date("2026-06-30T09:00:00Z");
 const baseCheckIn = {
@@ -76,6 +97,73 @@ describe("PatientCheckInService", () => {
       const callData = (mockedPrisma.patientCheckIn.create as jest.Mock).mock
         .calls[0][0].data;
       expect(callData.triagePriority).toBe("NON_URGENT");
+    });
+
+    it("checks the linked appointment in so the Board reflects the arrival", async () => {
+      (mockedPrisma.patientCheckIn.create as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      mockedCheckInAppointment.mockResolvedValue(undefined);
+      await PatientCheckInService.create({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        clientId: "client-1",
+        appointmentId: "appt-1",
+        arrivedAt,
+      });
+      expect(mockedCheckInAppointment).toHaveBeenCalledWith("appt-1", "org-1");
+    });
+
+    it("does not touch the appointment when the check-in is not linked to one", async () => {
+      (mockedPrisma.patientCheckIn.create as jest.Mock).mockResolvedValue(
+        baseCheckIn,
+      );
+      await PatientCheckInService.create({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        clientId: "client-1",
+        arrivedAt,
+      });
+      expect(mockedCheckInAppointment).not.toHaveBeenCalled();
+    });
+
+    it("still creates the check-in when the appointment cannot be transitioned (e.g. already CHECKED_IN)", async () => {
+      (mockedPrisma.patientCheckIn.create as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      mockedCheckInAppointment.mockRejectedValue(
+        new AppointmentPrismaServiceError(
+          "Appointment cannot transition from COMPLETED to CHECKED_IN in checkInAppointment.",
+          409,
+        ),
+      );
+      const result = await PatientCheckInService.create({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        clientId: "client-1",
+        appointmentId: "appt-1",
+        arrivedAt,
+      });
+      expect(result.status).toBe("WAITING");
+    });
+
+    it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+      (mockedPrisma.patientCheckIn.create as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      mockedCheckInAppointment.mockRejectedValue(new Error("db down"));
+      await expect(
+        PatientCheckInService.create({
+          organisationId: "org-1",
+          patientId: "patient-1",
+          clientId: "client-1",
+          appointmentId: "appt-1",
+          arrivedAt,
+        }),
+      ).rejects.toThrow("db down");
     });
   });
 


### PR DESCRIPTION
## Summary
Following up on #2884 (which fixed the check-in board failing to load at all): once it loads, checking a patient in there still didn't move the needle anywhere else. Root cause is deeper than a UI bug.

- `PatientCheckIn.status` (front desk: WAITING/IN_CONSULTATION/COMPLETED/NO_SHOW/CANCELLED) and `Appointment.status` (the Board: REQUESTED/UPCOMING/CHECKED_IN/IN_PROGRESS/COMPLETED/CANCELLED/NO_SHOW) are two **independent state machines** that grew near-identical vocabulary without ever being wired together. `PatientCheckInService` never touched the linked `Appointment` row, even when `appointmentId` was set - confirmed by reading every method in `patient-check-in.service.ts`.
- Practical effect, verified live on `dev.yosemitecrew.com`: check a patient in at the front desk, and the Board still shows that appointment as "Upcoming." Two panels on the same page disagreeing about whether a patient has arrived.
- `checkInAppointment` in `appointment.prisma.service.ts` already exists as the correct UPCOMING → CHECKED_IN transition for this exact case, including creating the visit's clinical encounter. The next step, CHECKED_IN → IN_PROGRESS, is deliberately gated elsewhere (`clinical-artifact.service.ts`'s `advanceCheckedInAppointment`) behind a real clinical encounter specifically so a reception-only role can't force an appointment into a clinical state - so this PR only drives the arrival step, not the clinical ones.

## Change
`PatientCheckInService.create` now calls `AppointmentPrismaService.checkInAppointment` when the check-in carries an `appointmentId`, reusing the existing transition rather than a raw status write. Deliberately best-effort: an appointment already past CHECKED_IN, or a walk-in's `appointmentId` pointing at a REQUESTED/CANCELLED appointment, throws on the transition and is swallowed - none of those should block the front desk from recording that someone physically arrived.

## Verified
- Added tests: the appointment gets checked in when linked, is left untouched when there's no `appointmentId`, check-in creation still succeeds when the transition is rejected, and a genuinely unexpected error still propagates rather than being swallowed.
- Mutation-checked: removing the sync call fails the new tests.
- Full `patient-check-in.service.test.ts` + `patient-check-in.controller.test.ts` suites pass (43 tests).
- `tsc --noEmit` clean from `apps/backend`.

## Test plan
- [x] `npx jest patient-check-in.service.test.ts patient-check-in.controller.test.ts`
- [x] `tsc --noEmit`
- [x] Mutation-check: stripped the sync call, confirmed the new tests fail