### PR TITLE
fix(backend): guard allocated stock from exceeding on-hand inventory

### DIFF
--- a/apps/backend/src/services/inventory.service.ts
+++ b/apps/backend/src/services/inventory.service.ts
@@ -864,6 +864,18 @@ const ensureNonNegativeNumbers = (
   }
 };
 
+// `allocated` is client-writable (create + edit forms) with no other write path
+// checking it against on-hand stock, so a raw save can put an item above 100%
+// reserved. Available stock (onHand - allocated) must never go negative.
+const ensureAllocatedWithinOnHand = (onHand: number, allocated: number) => {
+  if (allocated > onHand) {
+    throw new InventoryServiceError(
+      "allocated cannot exceed on-hand stock",
+      400,
+    );
+  }
+};
+
 const ensureCreateBatchExpiryRules = (input: CreateInventoryItemInput) => {
   if (!input.expiryTrackingRequired) return;
   if ((input.batches?.length ?? 0) === 0) {
@@ -949,6 +961,12 @@ const validateCreateInventoryItemInput = async (
 
   ensureCreateBatchExpiryRules(input);
   await ensureCreateSkuUnique(organisationId, input.sku);
+
+  const effectiveOnHand = input.batches?.length
+    ? input.batches.reduce((sum, batch) => sum + (batch.quantity ?? 0), 0)
+    : (input.initialOnHand ?? 0);
+  const effectiveAllocated = input.allocated ?? input.initialAllocated ?? 0;
+  ensureAllocatedWithinOnHand(effectiveOnHand, effectiveAllocated);
 
   return {
     organisationId,
@@ -1547,6 +1565,10 @@ export const InventoryService = {
       ],
       ["allocated", input.allocated],
     ]);
+    ensureAllocatedWithinOnHand(
+      existing.onHand ?? 0,
+      input.allocated ?? existing.allocated ?? 0,
+    );
 
     const nextSku = await resolveUniqueSkuForUpdate(
       itemId,

--- a/apps/backend/test/services/inventory.service.test.ts
+++ b/apps/backend/test/services/inventory.service.test.ts
@@ -127,7 +127,7 @@ describe("Inventory service", () => {
       category: "Consumables",
       businessType: "HOSPITAL",
       initialOnHand: 2,
-      allocated: 6,
+      allocated: 3,
       initialAllocated: 2,
       stockUnitType: "bottle",
       unitOfMeasure: "mg",
@@ -302,6 +302,7 @@ describe("Inventory service", () => {
       category: "Consumables",
       businessType: "HOSPITAL",
       itemType: "NON_MEDICAL",
+      onHand: 7,
       allocated: 2,
     });
     (prisma.inventoryItem.update as jest.Mock).mockResolvedValueOnce({
@@ -954,6 +955,58 @@ describe("Inventory service", () => {
         organisationId: "org-1",
       }),
     ).rejects.toThrow("Not enough unallocated stock");
+  });
+
+  // Regression for a live dev bug: an item showed On Hand 7 / Available -8
+  // because `allocated` is a plain writable field on create and edit with no
+  // check against on-hand stock, unlike the allocateStock/releaseAllocatedStock
+  // pair above. Available (onHand - allocated) must never go negative.
+  it("rejects creating an item whose allocated stock exceeds on-hand stock", async () => {
+    await expect(
+      InventoryService.createItem({
+        organisationId: "org-1",
+        name: "Itraconazole 100 mg",
+        category: "Medicine",
+        businessType: "HOSPITAL",
+        initialOnHand: 7,
+        allocated: 15,
+      }),
+    ).rejects.toThrow("allocated cannot exceed on-hand stock");
+    expect(prisma.inventoryItem.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating an item whose batch quantities can't cover the requested allocation", async () => {
+    await expect(
+      InventoryService.createItem({
+        organisationId: "org-1",
+        name: "Itraconazole 100 mg",
+        category: "Medicine",
+        businessType: "HOSPITAL",
+        allocated: 15,
+        batches: [{ quantity: 7 }],
+      }),
+    ).rejects.toThrow("allocated cannot exceed on-hand stock");
+  });
+
+  it("rejects updating an item's allocated stock above its current on-hand stock", async () => {
+    (prisma.inventoryItem.findFirst as jest.Mock).mockResolvedValueOnce({
+      id: "item-1",
+      organisationId: "org-1",
+      category: "Medicine",
+      businessType: "HOSPITAL",
+      itemType: "MEDICAL",
+      genericName: "Itraconazole",
+      strength: "100 mg",
+      dosageForm: "Capsule",
+      routeOfAdministration: "Oral",
+      onHand: 7,
+      allocated: 0,
+    });
+
+    await expect(
+      InventoryService.updateItem("item-1", { allocated: 15 }, "org-1"),
+    ).rejects.toThrow("allocated cannot exceed on-hand stock");
+    expect(prisma.inventoryItem.update).not.toHaveBeenCalled();
   });
 
   it("rejects invalid vendor and meta-field inputs", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

On dev.yosemitecrew.com, org "Avenger Park, Avondale FC", Inventory > Catalog shows the "Itraconazole 100 mg" row (SKU MED-ITRA-100) with On Hand: 7 but Available: -8. Available is computed on the frontend as `onHand - allocated`, so this means the item's `allocated` field is 15 while only 7 units physically exist.

Root cause: `InventoryService.createItem` and `InventoryService.updateItem` in `apps/backend/src/services/inventory.service.ts` accept a client-supplied `allocated` value (the "Allocated stock" field on the Add/Edit Inventory form) and only validated that it is non-negative - never that it does not exceed on-hand stock. `InventoryAllocationService.allocateStock` (the reservation endpoint used for appointments/boarding/grooming) already guards this correctly (`onHand - allocated < quantity` throws "Not enough unallocated stock"), but that guard only applies to that one endpoint, not to a direct create/edit of the item.

Checked against the historical dispense-quantity bug (#1880, `resolveDispenseTotalUnits`, fixed in bd343ffc7): the dispense/consumption paths in `inventory-consumption.service.ts` correctly keep `onHand` and `allocated` in lockstep (`finalizeInventoryAdjustment`), so this is a separate, new gap in create/update, not a recurrence of that bug.

I confirmed against the dev database (Supabase project `yosemitecrew-dev`) that this item's only batch has `quantity: 7, allocated: 0` - the item-level `allocated: 15` was never derived from batch data or any logged `InventoryStockMovement` / `InventoryConsumptionEvent` (both are empty for this item), which is consistent with the value having been typed directly into the Allocated field on create/edit rather than produced by a reservation or dispense.

## What is the new behavior?

Added `ensureAllocatedWithinOnHand(onHand, allocated)`, called from both `createItem` and `updateItem`, throwing a 400 (`"allocated cannot exceed on-hand stock"`) if the resulting allocation would exceed on-hand stock - mirroring the guard `allocateStock` already has. Available stock (onHand - allocated) can now reach 0 but never go negative through these paths.

Added regression tests covering: create with `allocated` above `initialOnHand`, create with `allocated` above the sum of provided batch quantities, and update raising `allocated` above the item's current `onHand`. Verified each new test fails on the pre-fix code (mutation check) and passes with the fix. Two pre-existing tests used fixture data that itself violated the new invariant (unrelated to what they were testing); adjusted those fixtures to realistic values.

Note: this fix prevents new over-allocation going forward. It does not retroactively correct the already-bad `allocated` value on existing dev-database rows (this item, and several others in the same org found via the same query) - that would need a separate, explicit data correction.

## Related Issue(s)

Fixes #