### PR TITLE
fix(frontend): unify Settings card title size via PreferenceGroup

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/Personal.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/Personal.test.tsx
@@ -109,6 +109,18 @@ describe('Settings Personal identity card', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  /**
+   * Pins the shared PreferenceGroup primitive rather than a hand-rolled
+   * `.yc-card-surface` div with its own plain `<div>` title - the card used to
+   * declare its own 14.5px title independently of Settings' other cards, which
+   * is what let it and SecuritySection drift to two different sizes. A plain
+   * `<div>` title (not a heading) would fail this.
+   */
+  it('renders the "Personal" title through the shared PreferenceGroup primitive', () => {
+    render(<Personal />);
+    expect(screen.getByRole('heading', { name: 'Personal', level: 3 })).toBeInTheDocument();
+  });
+
   it('renders the name, meta line, initials avatar and availability summary', () => {
     render(<Personal />);
 

--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/PreferenceGroup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/PreferenceGroup.test.tsx
@@ -77,6 +77,31 @@ describe('PreferenceGroup', () => {
     // The trailing space from the template literal is trimmed away.
     expect(container.querySelector('section')?.className.endsWith(' ')).toBe(false);
   });
+
+  it('renders an action next to the title when provided, alongside a scope chip', () => {
+    render(
+      <PreferenceGroup
+        title="Your organizations"
+        scope="personal"
+        action={<a href="/create-org">New organization</a>}
+      >
+        <span>x</span>
+      </PreferenceGroup>
+    );
+
+    expect(screen.getByRole('link', { name: 'New organization' })).toBeInTheDocument();
+    expect(screen.getByText('Only you')).toBeInTheDocument();
+  });
+
+  it('omits the title-row action slot when none is provided', () => {
+    render(
+      <PreferenceGroup title="Group">
+        <span>x</span>
+      </PreferenceGroup>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
 });
 
 describe('PreferenceRow', () => {

--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/YourOrganizations.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/YourOrganizations.test.tsx
@@ -52,7 +52,13 @@ describe('YourOrganizations', () => {
 
     render(<YourOrganizations />);
 
-    expect(screen.getByRole('heading', { name: 'Your organizations' })).toBeInTheDocument();
+    // Pins the shared PreferenceGroup primitive (its title is an <h3>, and "New
+    // organization" is rendered through PreferenceGroup's `action` slot in the
+    // title row) rather than a hand-rolled `.yc-card-surface` section that
+    // reimplemented the same header layout independently.
+    expect(
+      screen.getByRole('heading', { name: 'Your organizations', level: 3 })
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'New organization' })).toHaveAttribute(
       'href',
       '/create-org'

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/Personal.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/Personal.tsx
@@ -8,6 +8,7 @@ import { usePrimaryOrgWithMembership } from '@/app/hooks/useOrgSelectors';
 import { usePrimaryOrgProfile } from '@/app/hooks/useProfiles';
 import { usePrimaryAvailability } from '@/app/hooks/useAvailabiities';
 
+import { PreferenceGroup } from './PreferenceGroup';
 import { summarizeAvailability } from './personal.utils';
 import '@/app/features/settings/styles/Settings.css';
 
@@ -62,8 +63,7 @@ const Personal = ({ onEditProfile, onEditHours }: PersonalProps) => {
   );
 
   return (
-    <div className="yc-card-surface px-5! py-[18px]! flex flex-col gap-[14px]">
-      <div className="text-[14.5px] font-bold text-[var(--ink)]">Personal</div>
+    <PreferenceGroup title="Personal">
       <div className="flex items-center gap-[14px]">
         {isHttpsAvatar(avatarUrl) ? (
           <AvatarImage
@@ -108,7 +108,7 @@ const Personal = ({ onEditProfile, onEditHours }: PersonalProps) => {
           Edit hours
         </button>
       </div>
-    </div>
+    </PreferenceGroup>
   );
 };
 

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/PreferenceGroup.tsx
@@ -41,6 +41,8 @@ type PreferenceGroupProps = {
    * for exactly that role.
    */
   readOnly?: boolean;
+  /** An action rendered in the title row, next to the scope chip (e.g. a "New organization" link). */
+  action?: React.ReactNode;
 };
 
 /**
@@ -57,6 +59,7 @@ export const PreferenceGroup = ({
   className,
   scope,
   readOnly = false,
+  action,
 }: PreferenceGroupProps) => {
   const copy = scope ? SCOPE_COPY[scope] : null;
 
@@ -68,8 +71,13 @@ export const PreferenceGroup = ({
     >
       <div className="flex flex-col gap-[3px]">
         <div className="flex items-center justify-between gap-3">
-          <h3 className="text-[14.5px] font-bold text-[var(--ink)]">{title}</h3>
-          {copy && <ScopeChip scope={scope!} label={copy.label} />}
+          <h3 className="min-w-0 text-[14.5px] font-bold text-[var(--ink)]">{title}</h3>
+          {(copy || action) && (
+            <div className="flex flex-none items-center gap-2">
+              {copy && <ScopeChip scope={scope!} label={copy.label} />}
+              {action}
+            </div>
+          )}
         </div>
         {copy && (
           <p className="m-0! text-[11.5px] text-[var(--ink-faint)]">

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
@@ -7,6 +7,8 @@ import { useOrgStore } from '@/app/stores/orgStore';
 import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 import '@/app/features/settings/styles/Settings.css';
 
+import { PreferenceGroup } from './PreferenceGroup';
+
 const PRIMARY_PILL_TOKENS: StatusPillTokens = {
   bg: 'var(--status-completed-bg)',
   text: 'var(--status-completed-text)',
@@ -40,14 +42,16 @@ const YourOrganizations = () => {
   if (orgs.length === 0) return null;
 
   return (
-    <section className="flex flex-col gap-3 yc-card-surface px-5! py-[18px]!">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="min-w-0 text-[14.5px] font-bold text-[var(--ink)]">Your organizations</h3>
+    <PreferenceGroup
+      title="Your organizations"
+      className="gap-3!"
+      action={
         <Link href="/create-org" className="yc-settings-card-action">
           <IoAdd size={13} aria-hidden="true" />
           New organization
         </Link>
-      </div>
+      }
+    >
       {orgs.map(({ org, membership }, index) => {
         const orgId = String(org._id ?? org.name);
         const isPrimary = primaryOrgId != null && orgId === primaryOrgId;
@@ -85,7 +89,7 @@ const YourOrganizations = () => {
           </div>
         );
       })}
-    </section>
+    </PreferenceGroup>
   );
 };
 


### PR DESCRIPTION
## Summary

- Settings page renders `Personal`, `PreferenceGroup` (x2), `YourOrganizations`, and `DeleteProfile` as grid siblings meant to look like one titled-card family (`apps/frontend/src/app/features/settings/pages/Settings/index.tsx:145-163`).
- `Personal.tsx` and `YourOrganizations.tsx` each hand-rolled their own `.yc-card-surface` wrapper and title element instead of using the shared `PreferenceGroup` primitive (`apps/frontend/src/app/features/settings/pages/Settings/Sections/Personal.tsx:65-66`, `apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx:43,45`). They matched `PreferenceGroup`'s `text-[14.5px] font-bold` title only by coincidence - hand-copied, not shared code.
- That drift is already visible elsewhere: `SecuritySection.tsx:148,150` (reached from Personal's "Edit profile" modal) hand-rolled the same pattern and has since drifted to `text-[16px]`. Out of scope for this PR (different modal context, not a Settings-grid sibling) - left as a known follow-up.
- Fix: `Personal.tsx` and `YourOrganizations.tsx` now render through `<PreferenceGroup title="...">`, the same primitive already used twice in `Settings/index.tsx`, so the title size can no longer drift independently.
- `PreferenceGroup` gained an optional `action` slot in the title row (next to the scope chip) so `YourOrganizations`' "New organization" link keeps its place. `Personal`'s "Edit profile" button needed no slot - it lives in the avatar row below the title, not the title row itself.

## Verified

- `npx eslint` on the three changed files - clean.
- `npx tsc --noEmit` (apps/frontend) - passes, exit code 0.
- Targeted Jest: `pnpm run test -- --testPathPatterns="Sections/(Personal|YourOrganizations|PreferenceGroup)\.test" --coverage` - 3 suites / 26 tests passed, 100% statement/line coverage on all three changed files (98% branch on `PreferenceGroup.tsx`, the one gap is a pre-existing `readOnly` ternary unrelated to this change).
- `pnpm run test -- --testPathPatterns="pages/Settings/index\.test"` - 11 tests passed (no regression in the page composing all four cards).
- Mutation check: temporarily changed the new `(copy || action)` guard to `(copy && action)` - 3 tests failed as expected (`YourOrganizations` lost its "New organization" link), then reverted. Confirms the new branch is exercised, not just executed.
- Visual QA via Storybook (`pnpm --filter frontend run storybook`): screenshotted `settings-personal--full-profile`, `settings-yourorganizations--palette-rotation`, and `settings-preferencegroup--organisation` side by side - all three titles now render at the same size/weight, and all existing behavior (avatar, Edit profile, Edit hours, New organization link, PRIMARY badge, Switch) is intact.

## Test plan

- [x] Lint clean on changed files
- [x] `tsc --noEmit` passes
- [x] Targeted Jest suites pass with coverage
- [x] `Settings/index.test.tsx` still passes (no regression to the composed page)
- [x] Mutation-checked the new conditional logic
- [x] Visual QA screenshots confirm consistent title sizing and preserved behavior
