### PR TITLE
fix(frontend): replace hardcoded hex with design tokens in DevelopersPage

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DevelopersPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DevelopersPage.test.tsx
@@ -139,11 +139,12 @@ describe('DevelopersPage', () => {
     expect(heroKey.style.color).toBe('var(--cyan-text)');
 
     // The bundle.json block keys sit on an always-dark code card, so they keep the
-    // literal cyan fill in both themes.
+    // same cyan fill in both themes - now the --cyan token, which resolves to the
+    // same #5ce1e6 in both the light and dark globals.css blocks.
     const bundleKeys = within(document.body).getAllByText('"authority"');
     expect(bundleKeys.length).toBeGreaterThanOrEqual(2);
     bundleKeys.forEach((key) => {
-      expect(key.style.color).toBe('rgb(92, 225, 230)');
+      expect(key.style.color).toBe('var(--cyan)');
     });
   });
 });

--- a/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
@@ -456,7 +456,7 @@ function HeroTerminalCard() {
             marginLeft: '8px',
             fontFamily: 'ui-monospace, Menlo, monospace',
             fontSize: '12px',
-            color: '#8f8984',
+            color: 'var(--ink-faint)',
           }}
         >
           zsh
@@ -477,7 +477,7 @@ function HeroTerminalCard() {
         <span style={{ color: '#54b492' }}>$</span> pnpm install{' '}
         <span style={{ color: '#5c5956' }}>&amp;&amp;</span> pnpm dev
         {'\n'}
-        <span style={{ color: '#8f8984' }}>→ PIMS live on :3000</span>
+        <span style={{ color: 'var(--ink-faint)' }}>→ PIMS live on :3000</span>
         {'\n'}
         <span style={{ color: '#54b492' }}>$</span>
         {' open localhost:3000/dev-docs'}
@@ -669,7 +669,7 @@ function MachineUser() {
               fontWeight: 700,
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
-              color: '#8f8984',
+              color: 'var(--ink-faint)',
             }}
           >
             The user is changing
@@ -696,7 +696,7 @@ function MachineUser() {
                 fontStyle: 'italic',
                 fontWeight: 500,
                 letterSpacing: '-0.01em',
-                color: '#5ce1e6',
+                color: 'var(--cyan)',
               }}
             >
               We built a warm face for the human and a clean, exposed spine for the machine.
@@ -828,7 +828,7 @@ function FhirBundleCard() {
             style={{
               fontFamily: 'ui-monospace, Menlo, monospace',
               fontSize: '12.5px',
-              color: '#8f8984',
+              color: 'var(--ink-faint)',
             }}
           >
             bundle.json
@@ -863,38 +863,38 @@ function FhirBundleCard() {
             overflowX: 'auto',
           }}
         >
-          <span style={{ color: '#8f8984' }}>{'{'}</span>
+          <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>
           {'\n  '}
-          <span style={{ color: '#5ce1e6' }}>&quot;resourceType&quot;</span>:{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;resourceType&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;Bundle&quot;</span>,{'\n  '}
-          <span style={{ color: '#5ce1e6' }}>&quot;type&quot;</span>:{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;type&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;searchset&quot;</span>,{'\n  '}
-          <span style={{ color: '#5ce1e6' }}>&quot;total&quot;</span>:{' '}
-          <span style={{ color: '#f9ad6c' }}>3</span>,{'\n  '}
-          <span style={{ color: '#5ce1e6' }}>&quot;entry&quot;</span>:{' '}
-          <span style={{ color: '#8f8984' }}>[</span>
+          <span style={{ color: 'var(--cyan)' }}>&quot;total&quot;</span>:{' '}
+          <span style={{ color: 'var(--color-warning-400)' }}>3</span>,{'\n  '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;entry&quot;</span>:{' '}
+          <span style={{ color: 'var(--ink-faint)' }}>[</span>
           {'\n    '}
-          <span style={{ color: '#8f8984' }}>{'{'}</span>{' '}
-          <span style={{ color: '#5ce1e6' }}>&quot;code&quot;</span>:{' '}
+          <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;code&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;rabies-vax&quot;</span>,{'\n      '}
-          <span style={{ color: '#5ce1e6' }}>&quot;validYears&quot;</span>:{' '}
-          <span style={{ color: '#f9ad6c' }}>3</span>,{'\n      '}
-          <span style={{ color: '#5ce1e6' }}>&quot;authority&quot;</span>:{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;validYears&quot;</span>:{' '}
+          <span style={{ color: 'var(--color-warning-400)' }}>3</span>,{'\n      '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;authority&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;EU&quot;</span>{' '}
-          <span style={{ color: '#8f8984' }}>{'},'}</span>
+          <span style={{ color: 'var(--ink-faint)' }}>{'},'}</span>
           {'\n    '}
-          <span style={{ color: '#8f8984' }}>{'{'}</span>{' '}
-          <span style={{ color: '#5ce1e6' }}>&quot;code&quot;</span>:{' '}
+          <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;code&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;rabies-vax&quot;</span>,{'\n      '}
-          <span style={{ color: '#5ce1e6' }}>&quot;validYears&quot;</span>:{' '}
-          <span style={{ color: '#f9ad6c' }}>1</span>,{'\n      '}
-          <span style={{ color: '#5ce1e6' }}>&quot;authority&quot;</span>:{' '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;validYears&quot;</span>:{' '}
+          <span style={{ color: 'var(--color-warning-400)' }}>1</span>,{'\n      '}
+          <span style={{ color: 'var(--cyan)' }}>&quot;authority&quot;</span>:{' '}
           <span style={{ color: '#8acbb4' }}>&quot;US&quot;</span>{' '}
-          <span style={{ color: '#8f8984' }}>{'}'}</span>
+          <span style={{ color: 'var(--ink-faint)' }}>{'}'}</span>
           {'\n  '}
-          <span style={{ color: '#8f8984' }}>]</span>
+          <span style={{ color: 'var(--ink-faint)' }}>]</span>
           {'\n'}
-          <span style={{ color: '#8f8984' }}>{'}'}</span>
+          <span style={{ color: 'var(--ink-faint)' }}>{'}'}</span>
         </pre>
       </div>
     </Reveal>
@@ -1380,7 +1380,9 @@ function EconomicsBars() {
           >
             App stores &amp; SaaS platforms
           </span>
-          <span style={{ fontSize: '13px', fontWeight: 600, color: '#8f8984' }}>70&ndash;85%</span>
+          <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--ink-faint)' }}>
+            70&ndash;85%
+          </span>
         </div>
         <div
           style={{
@@ -1576,7 +1578,7 @@ function Economics() {
               fontWeight: 700,
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
-              color: '#8f8984',
+              color: 'var(--ink-faint)',
             }}
           >
             The economics

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "e414d85ccca8479deccdacaa6b96e8cbc50c87c9",
-  "total": 546,
+  "generated_at": "69c2dbafa510e429cfb229548e2fa0e43bff15f6",
+  "total": 518,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -91,7 +91,7 @@
     "apps/frontend/src/app/features/legal/pages/trustCenterData.ts": 10,
     "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 11,
     "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": 10,
-    "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": 87,
+    "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": 59,
     "apps/frontend/src/app/features/marketing/pages/Home/Home.tsx": 54,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": 1,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": 28,


### PR DESCRIPTION
## Summary

`DevelopersPage.tsx` (`apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx`) had inline `style={{ color: '#hex' }}` values that duplicated existing `globals.css` design tokens exactly, instead of referencing the tokens.

Confirmed each candidate against `apps/frontend/src/app/globals.css` (`:root` = light, `html[data-theme='dark']` = dark) before swapping, since some tokens differ between modes and the swap must stay correct in both:

- `#8f8984` (14 occurrences, e.g. line ~459) = `--ink-faint` in light mode (`--ink-faint: #9d9285` in dark). All occurrences sit inside always-dark `--spot` panels (`HeroTerminalCard`, `MachineUser`, `FhirBundleCard`, `Economics`/`EconomicsBars`). `globals.css:2038` documents that the standard dark-mode value of `--ink-faint` is already "the correct one" on `--spot` panels, so both themes resolve correctly. Swapped to `var(--ink-faint)`. (The file already used `var(--ink-faint)` in 4 other places, so this closes the gap - the earlier audit flagged line ~459 as the one outlier next to the file's own `var(--ink-muted)`/`var(--ink)` usage, but the same hardcoded value repeats another 13 times in the same panels.)
- `#5ce1e6` (11 occurrences) = `--cyan`, identical value in both the light and dark blocks (`globals.css:729` and `:929`). Zero cross-theme risk. Swapped to `var(--cyan)`.
- `#f9ad6c` (3 occurrences) = `--color-warning-400`, defined once inside the Tailwind `@theme` ramp (`globals.css:325`) and never overridden for dark mode - a fixed value. Swapped to `var(--color-warning-400)`.

**Skipped on purpose (not touched), all inside the same always-dark `--spot` panels:**

- `#5c5956` (line ~478, the `&&` separator in the terminal mock) matches `--ink-muted` in light mode only (`--ink-muted: #a89e90` in dark). Unlike `--ink-faint`, there's no design-doc confirmation that the dark-mode value is correct on `--spot`, and it isn't: computed contrast against `--spot`'s dark-mode background jumps from ~2.45:1 (current, deliberately subtle) to ~6.45:1 (dark-mode token value) - a real, unintended visual change, not just a token swap.
- `#d6d1cd` (4 occurrences - main terminal text, blinking-cursor fill, `bundle.json` text) matches `--hairline-hover` in light mode only (`--hairline-hover: #4a4033` in dark, a border-hover brown). Computed contrast of the dark-mode value against `--spot`'s dark-mode background is ~1.8:1 - the text would go nearly invisible in dark theme. Confirmed wrong; left as a literal.
- `#8acbb4` (6 occurrences, JSON string values in the `bundle.json` mock) matches `--code-str` in **dark** mode only (`--code-str: #006642` in light - a forest green for light backgrounds). Since these panels are always-dark regardless of site theme, `var(--code-str)` would flip to the light-mode value whenever the site itself is in light theme, producing ~2.4:1 contrast (dark green text on the always-dark panel). Confirmed wrong; left as a literal.

Per the task's own instruction: a hex that only exact-matches a token in one mode still gets swapped when the token is otherwise correct in the mode it doesn't literally match; it gets skipped, with the reasoning noted here, when the swap would be visually wrong.

## Verified

- `cd apps/frontend && npx eslint src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx` - clean, no output.
- `cd apps/frontend && npx tsc --noEmit` - exit code 0, no errors.
- `cd apps/frontend && pnpm run test -- --testPathPatterns="DevelopersPage"` - 11/11 passed.
- Mutation-checked the one test I changed (`renders the FHIR response codes with cyan keys`): temporarily reverted the source to the literal hex, confirmed the test fails (`Expected: "var(--cyan)" / Received: "rgb(92, 225, 230)"`), then restored the fix and reran - green.
- `git grep` confirmed zero remaining occurrences of `#8f8984`, `#5ce1e6`, `#f9ad6c` in the file, and exactly 1/4/6 remaining (untouched) occurrences of `#5c5956`/`#d6d1cd`/`#8acbb4` respectively.
- Pre-commit (gitleaks, eslint --fix, prettier, secretlint) and pre-push (monorepo lint + typecheck via turbo) hooks ran clean, not bypassed.

## Test plan

- [x] `npx eslint` on the changed file
- [x] `npx tsc --noEmit` from `apps/frontend`
- [x] Targeted Jest suite for `DevelopersPage` (11/11 passing)
- [x] Mutation-checked the updated assertion
- [ ] Visual smoke-check on deployed `dev.yosemitecrew.com/developers` after merge (all six colors are unchanged pixel values in the modes verified above, so no visual diff is expected)
