### PR TITLE
fix(frontend): match Rooms section title to SectionCard's type ramp

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/Rooms.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/Rooms.test.tsx
@@ -36,6 +36,22 @@ describe('Rooms section', () => {
     usePermissionsMock.mockReturnValue({ can: jest.fn(() => true) });
   });
 
+  /**
+   * Pins the shared SectionCard primitive rather than the old hand-rolled
+   * `.yc-card-surface` section with its own `text-[15.5px]` title - that
+   * hand-rolled size was one type ramp below the `text-heading-3` (20px/500)
+   * SectionCard already gives Specialities, Documents and Online booking on
+   * the same page, which is what made Rooms' title visibly smaller/bolder
+   * than its siblings when scrolling the Organization page.
+   */
+  it('renders the "Rooms" title through the shared SectionCard primitive', () => {
+    render(<Rooms />);
+
+    const heading = screen.getByRole('heading', { name: /Rooms/ });
+    expect(heading.className).toContain('text-heading-3');
+    expect(heading.className).not.toContain('text-[15.5px]');
+  });
+
   it('renders the rooms list, count, type suffix and add trigger when permitted', () => {
     render(<Rooms />);
 

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
@@ -15,6 +15,7 @@ import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { humanize } from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
+import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
 
 type ManagedRoom = OrganisationRoom & {
   availability?: {
@@ -126,12 +127,13 @@ const Rooms = () => {
 
   return (
     <PermissionGate allOf={[PERMISSIONS.ROOM_VIEW_ANY]} fallback={<Fallback resource="rooms" />}>
-      <section className="overflow-hidden yc-card-surface">
-        <div className="flex items-center justify-between gap-3 px-5! pt-4! pb-3!">
-          <h2 className="text-[15.5px] font-bold tracking-[-0.01em] text-[var(--ink)]">
-            Rooms <span className="font-medium text-[var(--ink-faint)]">({rooms.length})</span>
-          </h2>
-          {canEditRoom && (
+      <SectionCard
+        title={`Rooms (${rooms.length})`}
+        actions={
+          canEditRoom && (
+            // Design keeps this a plain text link, not the filled `--cta` pill
+            // SectionCard's own buttonTitle prop renders - that treatment is
+            // reserved for Team, the section that spends money on a seat.
             <button
               type="button"
               onClick={() => setAddPopup(true)}
@@ -139,8 +141,9 @@ const Rooms = () => {
             >
               + Add room
             </button>
-          )}
-        </div>
+          )
+        }
+      >
         {rooms.length === 0 ? (
           <div className="border-t border-[var(--hairline)] px-5! py-[18px]! text-[12.5px] text-[var(--ink-faint)]">
             No rooms added yet.
@@ -152,7 +155,7 @@ const Rooms = () => {
             ))}
           </ul>
         )}
-      </section>
+      </SectionCard>
       <AddRoom showModal={addPopup} setShowModal={setAddPopup} />
       {activeRoom && (
         <RoomInfo


### PR DESCRIPTION
## Summary

The Organization page renders Team, Specialities, Rooms, Payment and DeleteOrg as
sibling cards that are meant to look like the same kind of titled section, but
`Rooms.tsx` hand-rolled its own heading instead of using the shared `SectionCard`
primitive:

- `SectionCard` (`apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.tsx:85`)
  renders every section title as `text-heading-3` (20px / 500 weight).
- `Rooms.tsx` rendered its title as
  `<h2 className="text-[15.5px] font-bold tracking-[-0.01em] ...">` (old line ~131),
  a completely different ramp.

So scrolling the Organization page swung the section title between two type ramps:
Team/Specialties/Documents/Online booking/Booking requests at 20px/500, Rooms at
15.5px/700.

## Fix

`Rooms.tsx` now renders inside `<SectionCard title={`Rooms (${rooms.length})`}>`,
matching how `Specialities.tsx` already consumes the primitive. The existing
"+ Add room" trigger moves into SectionCard's `actions` slot rather than its
`buttonTitle` prop, because `buttonTitle` renders a filled `--cta` pill and the
design deliberately keeps this section's action as a plain text link (see
`Rooms.stories.tsx`'s own docs: the filled pill is reserved for Team, the section
that spends money on a seat). All other behavior - permission gates, the add/view
drawers, the empty state, the schedule/capability summary line - is untouched.

### Investigated, not changed

- **Team.tsx**: its own code comment (line ~134) claims the title already matches
  SectionCard's ramp. Verified independently: it renders
  `<h2 className="text-heading-3 text-text-primary">`, which is exactly
  SectionCard's title class. No change needed.
- **Payment.tsx**: does not have a hand-rolled duplicate of SectionCard's title at
  all - it has no heading element. It's a compact single-row banner (icon + status
  line + link), the same pattern as `DeleteOrg.tsx`, and was shaped by
  commit `6e2000359` ("feature-level exact-value fidelity to match the design") to
  match measured design values. Wrapping it in `SectionCard` would add a title bar
  with no basis in the shipped design and roughly double its height - a different,
  unrequested change rather than a fix for the title-ramp bug. Left as-is.

## Verified

- `npx tsc --noEmit` (apps/frontend) - clean.
- `npx eslint` on the changed file and its story - clean.
- `pnpm run test -- --testPathPatterns="Rooms.test|SectionCard.test|Team.test|Payment.test|Specialities.test"` -
  14 suites / 108 tests passed.
- `pnpm run test -- --testPathPatterns="pages/Organization/index.test"` - 6 tests passed.
- Visual QA in Storybook (`organization-rooms--room-list`,
  `organization-specialities--table`, `organization-team--roster`,
  `organization-payment--charges-and-payouts`): Rooms' title now renders at the
  same size/weight as Specialities' and Team's SectionCard titles; the "+ Add room"
  link is unchanged; Payment's compact row is unchanged.

## Test plan

- [x] `apps/frontend`: `npx tsc --noEmit`
- [x] `apps/frontend`: `npx eslint` on changed files
- [x] `apps/frontend`: targeted Jest suites for Rooms/SectionCard/Team/Payment/Specialities/Organization index
- [x] Storybook visual check of Rooms vs Specialities/Team title size
