### PR TITLE
fix(frontend): reuse EmergencyBadge in the appointment board card

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
@@ -738,7 +738,9 @@ describe('AppointmentBoard', () => {
       />
     );
 
-    expect(screen.getByLabelText('Emergency appointment')).toBeInTheDocument();
+    // The board card renders the shared EmergencyBadge (icon + "Emergency" text, no
+    // aria-label of its own — see EmergencyBadge.tsx), not a bespoke labelled pill.
+    expect(screen.getByText('Emergency')).toBeInTheDocument();
     expect(screen.getByLabelText('Draggable appointment Buddy').className).toContain(
       'border-l-[var(--danger)]'
     );

--- a/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
@@ -740,7 +740,13 @@ describe('AppointmentBoard', () => {
 
     // The board card renders the shared EmergencyBadge (icon + "Emergency" text, no
     // aria-label of its own — see EmergencyBadge.tsx), not a bespoke labelled pill.
+    // "Emergency" text alone doesn't distinguish it from the old hand-rolled span,
+    // which rendered the same word - pin the two things that actually changed:
+    // the old aria-label is gone, and EmergencyBadge's size-override classes for
+    // this card's density are present.
     expect(screen.getByText('Emergency')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Emergency appointment')).not.toBeInTheDocument();
+    expect(screen.getByText('Emergency').className).toContain('h-[15px]!');
     expect(screen.getByLabelText('Draggable appointment Buddy').className).toContain(
       'border-l-[var(--danger)]'
     );

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
@@ -19,7 +19,6 @@ import {
   IoEyeOutline,
   IoLocationOutline,
   IoTimeOutline,
-  IoWarning,
 } from 'react-icons/io5';
 import { RiHistoryLine } from 'react-icons/ri';
 import { MdMeetingRoom, MdOutlineAutorenew, MdScience } from 'react-icons/md';
@@ -36,6 +35,7 @@ import {
 } from '@/app/lib/appointments';
 import { canEnterAppointmentWorkspace } from '@/app/lib/appointmentWorkspace';
 import AppointmentPaymentBadge from '@/app/features/appointments/components/AppointmentPaymentBadge';
+import EmergencyBadge from '@/app/features/appointments/components/EmergencyBadge';
 import {
   getBoardOrgType,
   isMutedBoardStatus,
@@ -180,13 +180,12 @@ const BoardCardHeader = ({
       </div>
     </div>
     {isEmergency && (
-      <span
-        className="shrink-0 inline-flex items-center gap-[3px] rounded-full border border-[var(--danger-border)] bg-[var(--danger-bg)] px-[7px] py-[2px] text-[8.5px] font-bold uppercase leading-none text-[var(--danger-text)]"
-        aria-label="Emergency appointment"
-      >
-        <IoWarning size={8} aria-hidden="true" />
-        Emergency
-      </span>
+      // EmergencyBadge's default 22px/12px size is fixed by design for the workspace
+      // header and popover (see EmergencyBadge.stories.tsx). The board card's row is
+      // built around an 8.5px/13px type scale, so every size property is overridden
+      // (`!important`, since EmergencyBadge sets them via inline `style`) to match
+      // this card's density while keeping the shared icon, copy and colour tokens.
+      <EmergencyBadge className="h-[15px]! shrink-0 gap-[3px]! rounded-full! px-[7px]! py-0! text-[8.5px]! font-bold! uppercase leading-none! [&>svg]:h-2! [&>svg]:w-2!" />
     )}
   </div>
 );


### PR DESCRIPTION
## Summary

`AppointmentBoardCard` hand-rolled its own bespoke "Emergency" pill inline (`apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx:182-189` on `dev`) instead of using the shared `EmergencyBadge` component that the calendar popover and workspace header already use for the exact same flag (`Calendar/common/PopoverHeader.tsx:113`, `pages/AppointmentWorkspace/WorkspaceHeader.tsx:158`). That gave the app a third distinct "Emergency" badge shape/markup for one concept.

`EmergencyBadge` (`apps/frontend/src/app/features/appointments/components/EmergencyBadge.tsx`) already accepts a `className` prop, confirmed by reading its props interface and its `Positioned` story ("With a caller className"). Its default size (22px height, 12px font) is deliberately fixed for the workspace header/popover context - the component's own Storybook file documents and asserts this ("22px is not arbitrary... a drift to h-5 or h-6 shows up as a badge floating half a pixel proud of the pill", height locked at 22 even when squeezed).

Rather than assume that rigidity blocks reuse, I measured it directly instead of guessing from the code: I temporarily rendered `<EmergencyBadge className="...">` inside `AppointmentBoardCard`'s own Storybook story and read the computed styles/bounding boxes in a live browser (light + dark theme). Every size-affecting property `EmergencyBadge` sets (height, padding, gap, border-radius, font-size) turned out to be overridable with `!important` Tailwind utilities even though they're declared via an inline `style` object - because a `!important` class beats a non-important inline style. The one property with no override handle from the outside was the icon size (fixed `size={11}` on the internal `<IoWarning>`), which I closed with an `[&>svg]:h-2! [&>svg]:w-2!` descendant selector.

With that className, the rendered badge measured **78.25 x 15px** (8.5px font, 8x8 icon, bold, uppercase) against the original hand-rolled span's **77.4 x 14.5px** (8.5px font, 8x8 icon, bold, uppercase) - effectively pixel-identical, in both light and dark theme. So this is not a "genuinely can't fit" case: the fix replaces the bespoke `<span>` with `<EmergencyBadge className="...">`, keeping the shared icon, copy, and (now canonical, not card-specific) color tokens, while matching the board card's dense 8.5px/13px type scale via the override. Also dropped the now-unused `IoWarning` import from `AppointmentBoardCard.tsx` (the icon now lives inside `EmergencyBadge`).

## Verified

- `cd apps/frontend && pnpm run test -- --testPathPatterns="AppointmentBoard" --coverage=false` -> `Test Suites: 1 passed, 1 total / Tests: 33 passed, 33 total`
- Mutation-checked the updated assertion: temporarily replaced the `<EmergencyBadge>` render with `false` and re-ran the same suite - `expect(screen.getByText('Emergency')).toBeInTheDocument()` failed as expected (1 failed, 32 passed), confirming the assertion actually exercises the badge's presence. Reverted before committing.
- `npx eslint src/app/features/appointments/components/AppointmentBoardCard.tsx src/app/__tests__/components/AppointmentBoard.test.tsx` -> clean, no output.
- `npx tsc --noEmit` (from `apps/frontend`) -> clean, no output.
- Aikido SAST/secrets scan on both changed files -> `{"issues":[]}`.
- Visual QA in a live Storybook instance (`AppointmentBoardCard` -> `Emergency` story), zoomed 3x, in both light and dark theme: badge renders correctly, aligned, legible, no overflow, matches the prior hand-rolled pill's footprint almost exactly.
- `git push` ran the full monorepo pre-push hook (turbo lint + type-check across all 17 workspace tasks) -> all 17 successful.

One existing test asserted the old markup's `aria-label="Emergency appointment"` (`apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx`), which `EmergencyBadge` doesn't set (it has no `aria-label` of its own - both existing call sites render it bare). Updated that one assertion to `screen.getByText('Emergency')`, which still verifies the badge renders, without weakening what's being checked (see mutation-check above).

## Test plan

- [x] Targeted Jest suite passes (`AppointmentBoard.test.tsx`, 33/33)
- [x] Mutation-checked the updated assertion so it isn't a no-op
- [x] ESLint clean on changed files
- [x] `tsc --noEmit` clean
- [x] Aikido scan clean on changed files
- [x] Visual QA of the Emergency board-card story in light and dark theme
- [x] Full monorepo pre-push lint + type-check green