### PR TITLE
fix(frontend): centralize developer guard bypass

### DIFF
--- a/apps/frontend/src/app/__tests__/lib/localGuardBypass.test.tsx
+++ b/apps/frontend/src/app/__tests__/lib/localGuardBypass.test.tsx
@@ -154,4 +154,21 @@ describe('the render-time form', () => {
     // answer. The plain function reads window.location and diverges.
     expect(offenders.map((f) => relative(root, f))).toEqual([]);
   });
+
+  it('keeps the public bypass flag behind the shared helper', () => {
+    const root = join(__dirname, '..', '..');
+    const walkSource = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) return entry.name === '__tests__' ? [] : walkSource(full);
+        return entry.isFile() && /\.tsx?$/.test(full) && !full.endsWith('.stories.tsx')
+          ? [full]
+          : [];
+      });
+    const readers = walkSource(root).filter((file) =>
+      /process\.env\.NEXT_PUBLIC_DISABLE_AUTH_GUARD/.test(readFileSync(file, 'utf8'))
+    );
+
+    expect(readers.map((file) => relative(root, file))).toEqual(['lib/localGuardBypass.ts']);
+  });
 });

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
@@ -2,17 +2,10 @@
 import React from 'react';
 import { redirect, usePathname } from 'next/navigation';
 import { getStorageItem } from '@/app/lib/browserStorage';
+import { useLocalGuardBypass } from '@/app/lib/localGuardBypass';
 import { useAuthStore } from '@/app/stores/authStore';
 import { hasDeveloperRole, resolveHeldRoles } from '@/app/lib/postAuthRedirect';
 import NotADeveloperState from './NotADeveloperState';
-
-const isLocalDeveloperFallbackEnabled = () => {
-  if (process.env.NEXT_PUBLIC_DISABLE_AUTH_GUARD !== 'true') return false;
-  const hostname = (
-    process.env.YC_TEST_HOSTNAME ?? globalThis.window?.location?.hostname
-  )?.toLowerCase();
-  return hostname === 'localhost' || hostname === '127.0.0.1';
-};
 
 /**
  * Blocks access to developer routes unless authenticated with developer role.
@@ -29,10 +22,10 @@ const DevRouteGuard = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
   const authStore = useAuthStore();
   const { status, role, roles } = authStore;
+  const isLocalGuardBypassed = useLocalGuardBypass();
   const isPending = status === 'idle' || status === 'checking';
   const isDevPath = pathname?.startsWith('/developers');
-  const devFlag =
-    isLocalDeveloperFallbackEnabled() && getStorageItem('session', 'devAuth') === 'true';
+  const devFlag = isLocalGuardBypassed && getStorageItem('session', 'devAuth') === 'true';
   /*
    * Asked of every role the account holds, not just the one `/v1/auth/me`
    * surfaces as `role`.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`DevRouteGuard` duplicates the local auth-guard bypass flag and hostname checks, so future changes to the shared guard helper can leave developer routes behind.

## What is the new behavior?

`DevRouteGuard` uses the render-safe shared bypass hook. A source-level regression test requires the public bypass flag to have exactly one production reader.

Validation:

- Frontend TypeScript check
- Strict ESLint on both changed files
- Targeted `localGuardBypass` and `DevRouteGuard` tests: 2 suites, 22 tests
- Pre-push monorepo lint and type-check hooks

## Related Issue(s)

Fixes #2805
