### PR TITLE
fix(repo): let the tests-must-be-able-to-fail gate handle a deleted source file

### DIFF
--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -96,6 +96,37 @@ export const classify = (files) => ({
 });
 
 /**
+ * Splits changed source files by where they exist, so the checkout dance
+ * around them can be run in the right direction for each:
+ *
+ * - `added`    exists at HEAD only (the branch created it) - reverting it
+ *   means removing it, and restoring it means checking it out from HEAD.
+ * - `deleted`  exists at base only (the branch removed it) - reverting it
+ *   means checking it out from base, and restoring it means removing it
+ *   again. The mirror image of `added`, and just as real: a PR that deletes
+ *   a file is exactly as checkable as one that adds or edits one.
+ * - `modified` exists at both - checkout works in both directions.
+ *
+ * A pure function of two existence checks, not of git itself, so the
+ * decision is testable without a real repository.
+ */
+export const categorizeSourceFiles = (source, existsAtBase, existsAtHead) => {
+  const added = [];
+  const deleted = [];
+  const modified = [];
+  for (const file of source) {
+    const atBase = existsAtBase(file);
+    const atHead = existsAtHead(file);
+    if (atBase && atHead) modified.push(file);
+    else if (atHead) added.push(file);
+    else if (atBase) deleted.push(file);
+    // Present at neither is unreachable: `source` came from a diff against
+    // one of these two refs, so every entry exists at at least one of them.
+  }
+  return { added, deleted, modified };
+};
+
+/**
  * The whole judgement, as a pure function, so it is tested directly rather than
  * inferred from a CI run.
  */
@@ -164,9 +195,13 @@ const runChangedTests = (byWorkspace) => {
   for (const [ws, paths] of byWorkspace) {
     console.log(`running ${paths.length} changed test file(s) in ${ws} against the base`);
     try {
-      execFileSync('pnpm', ['--filter', ws, 'exec', 'jest', '--ci', '--passWithNoTests', ...paths], {
-        stdio: 'inherit',
-      });
+      execFileSync(
+        'pnpm',
+        ['--filter', ws, 'exec', 'jest', '--ci', '--passWithNoTests', ...paths],
+        {
+          stdio: 'inherit',
+        }
+      );
     } catch {
       allPassed = false;
     }
@@ -207,21 +242,25 @@ const main = () => {
   let nothingRunnable = false;
 
   if (source.length > 0 && tests.length > 0) {
-    // A file the branch ADDS does not exist at the base, and `git checkout base --`
-    // fails outright on it - which crashed this gate on the first real pull
-    // request that added one. Reverting such a file means removing it.
-    const existsAtBase = (file) => {
+    // A file the branch ADDS does not exist at the base, and one it DELETES
+    // does not exist at HEAD - `git checkout <ref> -- <path>` fails outright
+    // when <path> is not in <ref>'s tree, in either direction. Both crashed
+    // this gate the first time a real pull request did them.
+    const existsAt = (ref, file) => {
       try {
-        execFileSync('git', ['cat-file', '-e', `${base}:${file}`], { stdio: 'ignore' });
+        execFileSync('git', ['cat-file', '-e', `${ref}:${file}`], { stdio: 'ignore' });
         return true;
       } catch {
         return false;
       }
     };
-    const modified = source.filter(existsAtBase);
-    const added = source.filter((f) => !existsAtBase(f));
+    const existsAtBase = (file) => existsAt(base, file);
+    const existsAtHead = (file) => existsAt('HEAD', file);
+    const { added, deleted, modified } = categorizeSourceFiles(source, existsAtBase, existsAtHead);
 
-    if (modified.length) git('checkout', base, '--', ...modified);
+    // Revert: added files vanish, deleted files come back, modified files
+    // take the base version.
+    if (modified.length || deleted.length) git('checkout', base, '--', ...modified, ...deleted);
     for (const file of added) rmSync(file, { force: true });
 
     const byWorkspace = groupTestsByWorkspace(tests);
@@ -233,9 +272,15 @@ const main = () => {
         testsPassedAgainstBase = runChangedTests(byWorkspace);
       }
     } finally {
-      // Always put the branch back, including when the run threw. `checkout HEAD`
-      // restores a deleted file too, so added and modified are handled alike.
-      git('checkout', 'HEAD', '--', ...source);
+      // Always put the branch back, including when the run threw. Mirror the
+      // revert: added and modified files exist at HEAD and check out cleanly;
+      // deleted files do not exist at HEAD, so removing them again is the
+      // only way to restore that state - `checkout HEAD --` on a path HEAD's
+      // tree does not have just errors, which is the bug this fixes.
+      const restorable = [...added, ...modified];
+      if (restorable.length) git('checkout', 'HEAD', '--', ...restorable);
+      for (const file of deleted) rmSync(file, { force: true });
+      if (deleted.length) git('rm', '--cached', '-q', '--ignore-unmatch', '--', ...deleted);
     }
   }
 

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -7,9 +7,10 @@ import {
   isCheckableSource,
   isTestFile,
   verdict,
+  categorizeSourceFiles,
 } from './tests-must-be-able-to-fail.mjs';
 
-test('recognises this repository\'s test conventions', () => {
+test("recognises this repository's test conventions", () => {
   for (const f of [
     'apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx',
     'apps/frontend/e2e/route-sweep.spec.ts',
@@ -17,7 +18,10 @@ test('recognises this repository\'s test conventions', () => {
   ]) {
     assert.equal(isTestFile(f), true, f);
   }
-  assert.equal(isTestFile('apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx'), false);
+  assert.equal(
+    isTestFile('apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx'),
+    false
+  );
 });
 
 test('an e2e helper is a test file even without a .spec suffix', () => {
@@ -150,4 +154,35 @@ test('the refactor label still excuses an unrunnable change', () => {
     allowUnchangedBehaviour: true,
   });
   assert.equal(r.ok, false, 'the label excuses a PASSING base run, not an unverifiable one');
+});
+
+test('categorizeSourceFiles: a file the branch deletes is its own category, not silently dropped or mistaken for modified', () => {
+  // PR #2889 deleted 3 dead components. `existsAtBase` alone put them in
+  // "modified" (true, they exist at base) and the restore step later ran
+  // `git checkout HEAD -- <path>` on a path HEAD's tree does not have -
+  // `error: pathspec '...' did not match any file(s) known to git`, crashing
+  // the gate on a PR with nothing wrong with it.
+  const atBase = new Set(['deleted.ts', 'modified.ts']);
+  const atHead = new Set(['added.ts', 'modified.ts']);
+  const { added, deleted, modified } = categorizeSourceFiles(
+    ['added.ts', 'deleted.ts', 'modified.ts'],
+    (f) => atBase.has(f),
+    (f) => atHead.has(f)
+  );
+  assert.deepEqual(added, ['added.ts']);
+  assert.deepEqual(deleted, ['deleted.ts']);
+  assert.deepEqual(modified, ['modified.ts']);
+});
+
+test('categorizeSourceFiles: every file lands in exactly one category', () => {
+  const files = ['a.ts', 'b.ts', 'c.ts', 'd.ts'];
+  const atBase = new Set(['b.ts', 'c.ts']); // a=head-only, b=both, c=base-only, d=head-only
+  const atHead = new Set(['a.ts', 'b.ts', 'd.ts']);
+  const result = categorizeSourceFiles(
+    files,
+    (f) => atBase.has(f),
+    (f) => atHead.has(f)
+  );
+  const seen = [...result.added, ...result.deleted, ...result.modified].sort();
+  assert.deepEqual(seen, [...files].sort());
 });


### PR DESCRIPTION
## Summary
[PR #2889](https://github.com/YosemiteCrew/Yosemite-Crew/pull/2889) (pure dead-code deletion, independently verified zero remaining references) was blocked by a crash in this gate, not a real finding:

```
error: pathspec 'apps/frontend/src/app/ui/tables/DocumentsTable.tsx' did not match any file(s) known to git
```

The gate already special-cased a file the branch **adds** (missing at base, so `git checkout base -- file` fails outright). It never special-cased the mirror case: a file the branch **deletes** is missing at HEAD, so the restore step's blanket `git checkout HEAD -- source` fails the same way once the file has been un-deleted for the revert-and-test run.

## Change
Extracted `categorizeSourceFiles(source, existsAtBase, existsAtHead)` as a pure function (`added` / `deleted` / `modified`) so the split is unit-testable without a real repository, and fixed the restore step to mirror the revert step: added and modified files check out from HEAD; deleted files are removed again instead.

## Verified
- Reproduced the original crash locally against PR #2889's actual branch (not a synthetic fixture): confirmed the crash before the fix, confirmed a clean run and a clean `git status` after it, with the fix applied.
- Mutation-checked the new test: reintroduced the original bug in `categorizeSourceFiles`, confirmed the targeted test fails, restored the fix.
- `node --test scripts/ci/tests-must-be-able-to-fail.test.mjs`: 17/17 pass.
- `npm run test:scripts` (full suite): 462/462 pass.

## Test plan
- [x] `node --test scripts/ci/tests-must-be-able-to-fail.test.mjs`
- [x] `npm run test:scripts`
- [x] Reproduced the original crash and fix against PR #2889's real branch
- [x] Mutation-check on the new test