### PR TITLE
fix(backend): classify malformed Documenso webhook JSON as 400

### DIFF
--- a/apps/backend/src/controllers/web/documenso.controller.ts
+++ b/apps/backend/src/controllers/web/documenso.controller.ts
@@ -17,7 +17,7 @@ import { Prisma } from "@prisma/client";
 interface DocumensoWebhookBody {
   event?: string;
   payload?: {
-    id?: string | number;
+    id?: string | number | null;
   };
 }
 
@@ -42,11 +42,23 @@ function verifySignature(
   return crypto.timingSafeEqual(expectedBuf, providedBuf);
 }
 
-function parseWebhookBody(rawBody: Buffer) {
-  return JSON.parse(rawBody.toString("utf8")) as DocumensoWebhookBody;
+function isDocumensoWebhookBody(body: unknown): body is DocumensoWebhookBody {
+  return typeof body === "object" && body !== null && !Array.isArray(body);
 }
 
-function parseWebhookEvent(body: DocumensoWebhookBody) {
+function parseWebhookBody(rawBody: Buffer): DocumensoWebhookBody | null {
+  try {
+    const body = JSON.parse(rawBody.toString("utf8")) as unknown;
+    return isDocumensoWebhookBody(body) ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseWebhookEvent(body: DocumensoWebhookBody | null) {
+  if (!body) {
+    return null;
+  }
   const eventType = body.event;
   const documentId = body.payload?.id;
 

--- a/apps/backend/test/controllers/web/documenso.controller.test.ts
+++ b/apps/backend/test/controllers/web/documenso.controller.test.ts
@@ -130,28 +130,53 @@ describe("DocumensoWebhookController", () => {
     expect(jsonMock).toHaveBeenCalledWith({ message: "Invalid payload" });
   });
 
-  it("rejects payloads that carry an event but no document id", async () => {
-    req = {
-      ...req,
-      body: Buffer.from(
-        JSON.stringify({
-          event: "DOCUMENT_COMPLETED",
-          payload: {},
-        }),
-      ),
-    };
+  it.each(["not-json", "null", "[]", '"text"'])(
+    "returns 400 for invalid JSON body %s without logging the caller payload",
+    async (body) => {
+      req = {
+        ...req,
+        body: Buffer.from(body),
+      };
 
-    const mockedPrisma = prisma as any;
+      await DocumensoWebhookController.handle(req as Request, res as Response);
 
-    await DocumensoWebhookController.handle(req as Request, res as Response);
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "[DocumensoWebhook] Invalid payload",
+      );
+      expect(mockedLogger.error).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.anything(),
+      );
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ message: "Invalid payload" });
+    },
+  );
 
-    expect(mockedPrisma.formSubmission.findFirst).not.toHaveBeenCalled();
-    expect(mockedLogger.error).toHaveBeenCalledWith(
-      "[DocumensoWebhook] Invalid payload",
-    );
-    expect(statusMock).toHaveBeenCalledWith(400);
-    expect(jsonMock).toHaveBeenCalledWith({ message: "Invalid payload" });
-  });
+  it.each([{}, { id: null }])(
+    "rejects payloads that carry an event but no usable document id: %j",
+    async (payload) => {
+      req = {
+        ...req,
+        body: Buffer.from(
+          JSON.stringify({
+            event: "DOCUMENT_COMPLETED",
+            payload,
+          }),
+        ),
+      };
+
+      const mockedPrisma = prisma as any;
+
+      await DocumensoWebhookController.handle(req as Request, res as Response);
+
+      expect(mockedPrisma.formSubmission.findFirst).not.toHaveBeenCalled();
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        "[DocumensoWebhook] Invalid payload",
+      );
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ message: "Invalid payload" });
+    },
+  );
 
   /**
    * A passport attestation is only honoured from a cryptographically verified


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Malformed JSON sent to the Documenso webhook reaches the controller's broad error handler and returns HTTP 500 as an internal processing failure.

## What is the new behavior?

The webhook parser now treats malformed JSON and valid JSON values that are not objects as invalid caller payloads. These requests return HTTP 400 without logging caller-controlled payload content. Verified with the Documenso controller suite (28 tests) and the full pre-push lint and type-check gates.

## Related Issue(s)

Fixes #2745
