### PR TITLE
fix(repo): treat a fully-deleted test file as unrunnable, not a pass

### DIFF
--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -151,7 +151,7 @@ export const verdict = ({
   // Distinct from "the tests failed against the base". Nothing ran, so nothing
   // was proved - and `false` here would be read as proof, which is the exact
   // false green this gate exists to remove. It was written that way first.
-  if (nothingRunnable) {
+  if (nothingRunnable === 'e2e-only') {
     return {
       ok: false,
       reason:
@@ -159,6 +159,17 @@ export const verdict = ({
         'It therefore cannot tell whether they verify this source change.\n' +
         'Add a unit test for the changed behaviour, or label the PR no-behaviour-change\n' +
         'if the source change genuinely alters nothing observable.',
+    };
+  }
+  if (nothingRunnable === 'all-tests-deleted') {
+    return {
+      ok: false,
+      reason:
+        'Every changed test file is one the branch DELETED, so none of them exist to run -\n' +
+        '`jest` against a path that is gone reports zero tests, which is not evidence either\n' +
+        'way. This is expected for a component removed alongside its own test; verify there\n' +
+        'is truly no other reference (a clean `tsc` build is real evidence of that) and label\n' +
+        'the PR no-behaviour-change, or add a test if any of the deleted source still runs.',
     };
   }
   if (testsPassedAgainstBase === false) {
@@ -263,11 +274,27 @@ const main = () => {
     if (modified.length || deleted.length) git('checkout', base, '--', ...modified, ...deleted);
     for (const file of added) rmSync(file, { force: true });
 
-    const byWorkspace = groupTestsByWorkspace(tests);
+    // A test file the branch DELETES does not exist at HEAD either - there is
+    // no content left to run it. Asking jest to run it anyway does not error;
+    // `--passWithNoTests` makes a path matching nothing exit 0, which this
+    // gate would otherwise misread as "the test survived its own revert",
+    // when nothing actually ran. Excluded here, the same way a deleted
+    // SOURCE file is excluded from the restore-from-HEAD step above.
+    const runnableTests = tests.filter(existsAtHead);
+    if (runnableTests.length < tests.length) {
+      console.log(
+        `${tests.length - runnableTests.length} changed test file(s) were deleted by this branch - excluded, nothing to run`
+      );
+    }
+
+    const byWorkspace = groupTestsByWorkspace(runnableTests);
     try {
-      if (byWorkspace.size === 0) {
+      if (runnableTests.length === 0) {
+        console.log('every changed test file was deleted by this branch; nothing left to run');
+        nothingRunnable = 'all-tests-deleted';
+      } else if (byWorkspace.size === 0) {
         console.log('no runnable unit tests changed (e2e only, or outside a known workspace)');
-        nothingRunnable = true;
+        nothingRunnable = 'e2e-only';
       } else {
         testsPassedAgainstBase = runChangedTests(byWorkspace);
       }

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -128,10 +128,25 @@ test('nothing runnable is NOT read as proof', () => {
     source: ['a.ts'],
     tests: ['apps/frontend/e2e/x.spec.ts'],
     testsPassedAgainstBase: null,
-    nothingRunnable: true,
+    nothingRunnable: 'e2e-only',
   });
   assert.equal(r.ok, false);
   assert.match(r.reason, /does not run/);
+});
+
+test('every changed test deleted is NOT read as proof either', () => {
+  // PR #2889 deleted 3 dead components and their only tests. Asking jest to
+  // run a path it deleted doesn't error - `--passWithNoTests` exits 0 with
+  // zero tests executed, which this gate would otherwise misread as "the
+  // tests survived their own revert" (a real pass), when nothing ran at all.
+  const r = verdict({
+    source: ['a.ts'],
+    tests: ['a.test.ts'],
+    testsPassedAgainstBase: null,
+    nothingRunnable: 'all-tests-deleted',
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /DELETED/);
 });
 
 test('a genuine failure against the base is still a pass', () => {
@@ -150,7 +165,7 @@ test('the refactor label still excuses an unrunnable change', () => {
   const r = verdict({
     source: ['a.ts'],
     tests: ['apps/frontend/e2e/x.spec.ts'],
-    nothingRunnable: true,
+    nothingRunnable: 'e2e-only',
     allowUnchangedBehaviour: true,
   });
   assert.equal(r.ok, false, 'the label excuses a PASSING base run, not an unverifiable one');


### PR DESCRIPTION
## Summary
Follow-up to #2893. Once the checkout crash on PR #2889 was fixed, the gate ran clean but gave the wrong verdict: `jest` invoked on a test file the branch deleted doesn't error - `--passWithNoTests` means a path matching nothing exits 0 with zero tests executed, which `runChangedTests` read as `testsPassedAgainstBase: true` and reported as **"the changed tests PASS against the unmodified base code"** - a real-finding's wording for a case where nothing ran at all.

## Change
Filters `tests` down to files that still exist at HEAD before grouping by workspace (a deleted test file cannot be "kept and run" - mirrors how a deleted source file is already excluded from the restore step in #2893). When every changed test was deleted, reports it as a distinct, honestly-worded unrunnable case - `nothingRunnable` is now `'e2e-only' | 'all-tests-deleted' | false` instead of a bare boolean, reusing the existing unrunnable path rather than inventing a new one, since both mean the same thing: nothing this gate can execute proves anything, and a human has to say so via the `no-behaviour-change` label.

## Verified
- Reproduced against PR #2889's actual branch: the gate now correctly reports FAIL with the new message (deletion has nothing left to prove either way) instead of a false PASS.
- `node --test scripts/ci/tests-must-be-able-to-fail.test.mjs`: 18/18 pass.
- `npm run test:scripts` (full suite): 463/463 pass.
- That PR needs the `no-behaviour-change` label, not a further code change - applying it separately once this merges.

## Test plan
- [x] `node --test scripts/ci/tests-must-be-able-to-fail.test.mjs`
- [x] `npm run test:scripts`
- [x] Reproduced against PR #2889's real branch