### PR TITLE
fix(frontend): withhold the active count pill when a clinical panel is in error state

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyList.test.tsx
@@ -152,6 +152,18 @@ describe('AllergyList', () => {
     expect(screen.queryByText(/No allergies recorded/)).not.toBeInTheDocument();
   });
 
+  it('withholds the active count while the error hides the retained records', () => {
+    render(
+      <AllergyList
+        allergies={ALLERGIES}
+        error="Could not load the allergy list. Please try again."
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load the allergy list');
+    expect(screen.queryByText('Penicillin')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
   it('shows full reaction text and disables every resolve action during a mutation', () => {
     render(<AllergyList allergies={ALLERGIES} canEdit resolvingId="a-1" />);
     expect(screen.getByText(/Reaction: Anaphylaxis/)).not.toHaveClass('line-clamp-2');

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ClinicalListChrome.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ClinicalListChrome.test.tsx
@@ -64,10 +64,12 @@ describe('ClinicalListHeader', () => {
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
-  it('withholds the active pill while loading or at zero', () => {
+  it('withholds the active pill while loading, on error, or at zero', () => {
     const { rerender } = render(<ClinicalListHeader {...headerProps} activeCount={0} />);
     expect(screen.queryByText(/active/)).not.toBeInTheDocument();
     rerender(<ClinicalListHeader {...headerProps} activeCount={3} loading />);
+    expect(screen.queryByText(/active/)).not.toBeInTheDocument();
+    rerender(<ClinicalListHeader {...headerProps} activeCount={3} error="Could not load." />);
     expect(screen.queryByText(/active/)).not.toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
@@ -206,6 +206,14 @@ describe('ConsentList', () => {
     expect(screen.queryByText(/No consents recorded/)).not.toBeInTheDocument();
   });
 
+  it('withholds the active count while the error hides the retained records', () => {
+    render(
+      <ConsentList consents={CONSENTS} error="Could not load the consent list. Please try again." />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load the consent list');
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
   it('disables every revoke trigger while a revoke is in flight', () => {
     render(<ConsentList consents={CONSENTS} canEdit revokingId="c-1" />);
     expect(screen.getByRole('button', { name: 'Revoke Surgical consent' })).toBeDisabled();

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
@@ -122,6 +122,13 @@ describe('FlagList', () => {
     expect(screen.queryByText('No active flags for this patient.')).not.toBeInTheDocument();
   });
 
+  it('withholds the active count while the error hides the retained records', () => {
+    render(<FlagList flags={FLAGS} error="Could not load patient flags." />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load patient flags.');
+    expect(screen.queryByText('Use a muzzle')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
   it('hides edit controls when the member cannot edit', () => {
     render(<FlagList flags={FLAGS} canEdit={false} />);
 

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
@@ -143,6 +143,15 @@ describe('ProblemList', () => {
     expect(screen.queryByText(/No problems recorded/)).not.toBeInTheDocument();
   });
 
+  it('withholds the active count while the error hides the retained records', () => {
+    render(
+      <ProblemList problems={PROBLEMS} error="Could not load the problem list. Please try again." />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load the problem list');
+    expect(screen.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 active')).not.toBeInTheDocument();
+  });
+
   it('hides the add and resolve controls when the member cannot edit', () => {
     render(<ProblemList problems={PROBLEMS} canEdit={false} />);
     expect(screen.queryByRole('button', { name: /Add problem/ })).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
@@ -344,6 +344,7 @@ const AllergyList = ({
         title="Allergies"
         activeCount={activeCount}
         loading={loading}
+        error={error}
         canEdit={canEdit}
         showForm={showForm}
         onToggle={() => setShowForm((s) => !s)}

--- a/apps/frontend/src/app/features/companionHistory/components/ClinicalListChrome.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ClinicalListChrome.tsx
@@ -66,9 +66,11 @@ export type ClinicalListHeaderProps = {
   /** Must match the section's `aria-labelledby`. */
   headingId: string;
   title: string;
-  /** Count of active records; the pill is withheld while loading or at zero. */
+  /** Count of active records; the pill is withheld while loading, on error, or at zero. */
   activeCount: number;
   loading: boolean;
+  /** When set, the body shows only the error and the count pill is withheld. */
+  error?: string | null;
   canEdit: boolean;
   showForm: boolean;
   onToggle: () => void;
@@ -82,6 +84,7 @@ export const ClinicalListHeader = ({
   title,
   activeCount,
   loading,
+  error,
   canEdit,
   showForm,
   onToggle,
@@ -94,7 +97,7 @@ export const ClinicalListHeader = ({
     <h3 id={headingId} className="text-[13.5px] font-bold text-[var(--ink)]">
       {title}
     </h3>
-    {!loading && activeCount > 0 ? (
+    {!loading && !error && activeCount > 0 ? (
       <StatusPill label={`${activeCount} active`} tone="warning" className="ml-2 tabular-nums" />
     ) : null}
     {canEdit ? (

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -420,6 +420,7 @@ const ConsentList = ({
         title="Consents"
         activeCount={activeCount}
         loading={loading}
+        error={error}
         canEdit={canEdit}
         showForm={showForm}
         onToggle={() => setShowForm((s) => !s)}

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
@@ -312,7 +312,7 @@ const FlagList = ({
         <h3 id="patient-flag-list-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
           Patient flags
         </h3>
-        {!loading && activeCount > 0 ? (
+        {!loading && !error && activeCount > 0 ? (
           <StatusPill
             label={`${activeCount} active`}
             tone="warning"

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -270,6 +270,7 @@ const ProblemList = ({
         title="Problem list"
         activeCount={activeCount}
         loading={loading}
+        error={error}
         canEdit={canEdit}
         showForm={showForm}
         onToggle={() => setShowForm((s) => !s)}


### PR DESCRIPTION
PR #2873 made the clinical panel body show only the error state when a load fails, but left the header active-count pill independent of the error. The header could claim '2 active' while the body showed an error and no records.

This withholds the pill on error across all five clinical panels (allergies, consents, flags, problems, plus the shared chrome). Added a test to each list suite pinning the count is withheld while the error hides the retained records, and a red/green case in ClinicalListChrome. Full companionHistory suite: 24 suites / 403 tests pass.