### PR TITLE
fix(backend): accept negative keyset timestamps

### DIFF
--- a/apps/backend/src/services/shared/pagination.ts
+++ b/apps/backend/src/services/shared/pagination.ts
@@ -89,7 +89,7 @@ export type KeysetCursor = {
 };
 
 const KEYSET_SEPARATOR = "|";
-const KEYSET_MILLIS = /^\d{1,15}$/;
+const KEYSET_MILLIS = /^-?\d{1,15}$/;
 
 /**
  * A cursor that carries the whole sort key, for `(createdAt, id)` lists.

--- a/apps/backend/test/services/shared/pagination.test.ts
+++ b/apps/backend/test/services/shared/pagination.test.ts
@@ -116,6 +116,13 @@ describe("keyset cursors", () => {
     ).toEqual({ createdAt: CREATED_AT, id: ID });
   });
 
+  it("round-trips a timestamp before the Unix epoch", () => {
+    const createdAt = new Date("1969-12-31T23:59:59.999Z");
+    expect(
+      parseKeysetCursor(encodeKeysetCursor({ createdAt, id: ID })),
+    ).toEqual({ createdAt, id: ID });
+  });
+
   /*
    * `createdAt` is TIMESTAMP(3) on every model paged this way, so the
    * millisecond is the whole precision of the column. A cursor that dropped it


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`encodeKeysetCursor` emits a negative millisecond timestamp for dates before the Unix epoch, but `parseKeysetCursor` rejects that cursor as malformed.

## What is the new behavior?

The keyset parser accepts an optional minus sign while keeping the existing 15-digit bound. A regression test covers a pre-1970 encode/parse round trip.

Validation performed:

- Focused backend suite: 33 tests passed; `pagination.ts` reached 100% statements, branches, functions, and lines.
- Mutation check: restoring the unsigned timestamp pattern made the new pre-epoch test fail; restoring the fix returned the suite to green.
- Backend lint: 0 errors (25 pre-existing warnings outside the changed files).
- Backend type-check: passed.
- Pre-push repository gates: 10/10 lint tasks and 17/17 type-check tasks passed.
- Aikido scan: 0 issues across the two changed files.
- Local Sonar Vortex analysis was unavailable for this connection; the required CI Sonar analysis remains unchanged.

## Related Issue(s)

Fixes #2723
