### PR TITLE
feat(backend): mirror web banner consent decisions to SuperAdmin consent ledger

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -124,6 +124,14 @@ PUBLIC_WALLET_HERO_URL=""
 # The key must match CONTACT_INTAKE_KEY configured on the SuperAdmin side.
 SUPERADMIN_CONTACT_INTAKE_URL=""
 SUPERADMIN_CONTACT_INTAKE_KEY=""
+# --- SuperAdmin panel consent mirror ----------------------------------------
+# SuperAdmin consent intake
+# URL is the full intake endpoint, e.g. "https://<superadmin-host>/api/consent".
+# The key must match CONSENT_INTAKE_KEY configured on the SuperAdmin side.
+# Leave both empty to disable mirroring; a live banner accept/reject simply
+# skips the forward and the ledger stays empty.
+SUPERADMIN_CONSENT_INTAKE_URL=""
+SUPERADMIN_CONSENT_INTAKE_KEY=""
 # ActivityPub federation
 AP_BASE_URL=""                  # Full public URL of this instance, e.g. https://api.yosemitecrew.com
 AP_ENABLED="true"               # Set to "false" to disable AP endpoints

--- a/apps/backend/src/controllers/app/consent.controller.ts
+++ b/apps/backend/src/controllers/app/consent.controller.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { SuperadminConsentService } from "src/services/superadmin-consent.service";
+import { resolveVerifiedUserId } from "src/utils/request";
+import type { AuthenticatedRequest } from "src/middlewares/auth";
+
+const consentWebBodySchema = z.object({
+  consentId: z.string().min(1).max(200),
+  granted: z.boolean(),
+});
+
+/**
+ * Public relay for the web cookie banner's consent decision. The banner fires
+ * on marketing and product pages alike, often before sign-in, so the route is
+ * anonymous; the shared consent key lives only server-side in the forward.
+ *
+ * The product app keeps no consent ledger of its own - the SuperAdmin panel's
+ * append-only ledger IS the durable record, so a rejected decision here must
+ * still have been recorded there. The panel being down or unconfigured must
+ * never fail the visitor, so the forward runs off the request path and the
+ * response is a 202 regardless: the confirmation the visitor earns is the
+ * banner dismissing, not our HTTP status.
+ *
+ * Identity is best-effort enrichment, never required: `attachSessionIfPresent`
+ * supplies the verified userId/email when a session happens to be present, and
+ * the panel links them fill-only-if-absent. A signed-out visitor's decision is
+ * recorded against the consentId the browser generated - anonymous but durable.
+ */
+export const ConsentController = {
+  reportWebDecision(this: void, req: Request, res: Response): void {
+    const parsed = consentWebBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        message: "A consentId and a boolean decision are required",
+      });
+      return;
+    }
+
+    const uid = resolveVerifiedUserId(req);
+    const email = (req as AuthenticatedRequest).email;
+
+    const payload = {
+      consentId: parsed.data.consentId,
+      source: "web" as const,
+      decisions: [
+        { category: "analytics" as const, granted: parsed.data.granted },
+      ],
+      userId: uid,
+      email,
+    };
+
+    const userAgent =
+      typeof req.headers["user-agent"] === "string"
+        ? req.headers["user-agent"]
+        : undefined;
+
+    // Fire-and-forget: a missing or failing forward must never surface to the
+    // visitor; the banner dismissal already happened.
+    void SuperadminConsentService.forwardConsentDecision(payload, userAgent);
+
+    res.status(202).json({ ok: true });
+  },
+};

--- a/apps/backend/src/routers/consent.router.ts
+++ b/apps/backend/src/routers/consent.router.ts
@@ -1,0 +1,32 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import { ConsentController } from "src/controllers/app/consent.controller";
+import { attachSessionIfPresent } from "src/middlewares/auth";
+
+const router = Router();
+
+// The consent relay is reachable without a session - the banner fires on
+// marketing pages before sign-in. Keep a per-IP budget so an anonymous caller
+// cannot use it to hammer the SuperAdmin panel's intake. A single visitor
+// decides at most a handful of times per day (banner accept/reject, plus any
+// future preference page), so 60 per 15 minutes is generous while bounded.
+const consentLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Public. The banner must work for a signed-out visitor, and the shared
+// consent key never leaves the server (it is applied in the service when
+// forwarding). `attachSessionIfPresent` binds the session when one is sent so
+// the panel can link the decision to the verified user without a 401, and is a
+// no-op in the anonymous case.
+router.post(
+  "/",
+  consentLimiter,
+  attachSessionIfPresent,
+  ConsentController.reportWebDecision,
+);
+
+export default router;

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -34,6 +34,7 @@ import chatRouter from "./chat.router";
 import notificationRouter from "./notification.router";
 import mobilePrescriptionRouter from "./mobile-prescription.router";
 import contactRouter from "./contact-us.router";
+import consentRouter from "./consent.router";
 import accountWithdrawalRouter from "./account-withdrawal.router";
 import { OrganizationDocumentController } from "src/controllers/web/organisation-document.controller";
 import organisationDocumentRouter from "./organisation-document.router";
@@ -185,6 +186,7 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/notification`, notificationRouter);
   app.use(`/v1/prescription`, mobilePrescriptionRouter);
   app.use(`/v1/contact-us`, contactRouter);
+  app.use(`/v1/consent`, consentRouter);
   app.use(`/v1/account-withdrawal`, accountWithdrawalRouter);
   app.get(
     `/v1/legal-document/:type`,

--- a/apps/backend/src/services/superadmin-consent.service.ts
+++ b/apps/backend/src/services/superadmin-consent.service.ts
@@ -1,0 +1,76 @@
+import logger from "src/utils/logger";
+
+// Give the panel a few seconds and no more: the forward runs off the request
+// path, but an unbounded hang would pin the event loop's socket pool for
+// nothing when the panel is unreachable.
+const FORWARD_TIMEOUT_MS = 5_000;
+
+export type ConsentCategory = "analytics" | "marketing";
+
+export interface ConsentDecision {
+  category: ConsentCategory;
+  granted: boolean;
+}
+
+export interface SuperadminConsentPayload {
+  consentId: string;
+  source: "web" | "mobile";
+  decisions: ConsentDecision[];
+  email?: string;
+  userId?: string;
+  policyVersion?: string;
+}
+
+/**
+ * Best-effort mirror of web consent decisions into the SuperAdmin panel's
+ * consent ledger (GDPR audit trail). The panel's /api/consent is an append-only
+ * record of banner/preference decisions, authenticated by a shared secret in
+ * the x-consent-key header.
+ *
+ * The product web app owns no consent ledger of its own - this forward IS the
+ * durable record, so it is wired from the cookie banner's accept/reject action
+ * through a public relay route (see consent.router.ts) that holds the shared
+ * key server-side. The panel being down or unconfigured must never fail the
+ * visitor's decision, so the forward is fire-and-forget: it returns immediately
+ * and a missing or rejected forward surfaces only in the log.
+ *
+ * Unconfigured (either env var absent) means mirroring is off, exactly as on
+ * the contact side.
+ */
+export const SuperadminConsentService = {
+  async forwardConsentDecision(
+    payload: SuperadminConsentPayload,
+    userAgent?: string,
+  ): Promise<void> {
+    const url = process.env.SUPERADMIN_CONSENT_INTAKE_URL;
+    const key = process.env.SUPERADMIN_CONSENT_INTAKE_KEY;
+    if (!url || !key) return;
+
+    try {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "x-consent-key": key,
+      };
+      // The browser's user-agent is what the panel's consent event wants; the
+      // server's undici default would otherwise be recorded.
+      if (userAgent) headers["user-agent"] = userAgent;
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        logger.warn("SuperAdmin consent intake rejected the forward", {
+          status: response.status,
+        });
+      }
+    } catch (error) {
+      logger.error("Failed to forward consent decision to SuperAdmin", {
+        error,
+      });
+    }
+  },
+};

--- a/apps/backend/test/controllers/consent.controller.test.ts
+++ b/apps/backend/test/controllers/consent.controller.test.ts
@@ -1,0 +1,121 @@
+import { ConsentController } from "../../src/controllers/app/consent.controller";
+import { SuperadminConsentService } from "../../src/services/superadmin-consent.service";
+
+jest.mock("../../src/services/superadmin-consent.service", () => ({
+  SuperadminConsentService: {
+    forwardConsentDecision: jest.fn(),
+  },
+}));
+
+const mockedForward =
+  SuperadminConsentService.forwardConsentDecision as jest.Mock;
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+};
+
+describe("ConsentController.reportWebDecision", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects a body without a consentId", async () => {
+    const res = createResponse();
+
+    await ConsentController.reportWebDecision(
+      { body: { granted: true } } as any,
+      res as any,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "A consentId and a boolean decision are required",
+    });
+    expect(mockedForward).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body with a non-boolean decision", async () => {
+    const res = createResponse();
+
+    await ConsentController.reportWebDecision(
+      { body: { consentId: "c-1", granted: "true" } } as any,
+      res as any,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockedForward).not.toHaveBeenCalled();
+  });
+
+  it("forwards a valid decision without identity enrichment", async () => {
+    const res = createResponse();
+
+    await ConsentController.reportWebDecision(
+      {
+        body: { consentId: "c-1", granted: false },
+        headers: {},
+      } as any,
+      res as any,
+    );
+
+    expect(mockedForward).toHaveBeenCalledWith(
+      {
+        consentId: "c-1",
+        source: "web",
+        decisions: [{ category: "analytics", granted: false }],
+        userId: undefined,
+        email: undefined,
+      },
+      undefined,
+    );
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("enriches from a verified session when one is present", async () => {
+    const res = createResponse();
+
+    await ConsentController.reportWebDecision(
+      {
+        body: { consentId: "c-2", granted: true },
+        headers: { "user-agent": "Mozilla/5.0" },
+        userId: "user-9",
+        email: "ada@example.com",
+      } as any,
+      res as any,
+    );
+
+    expect(mockedForward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consentId: "c-2",
+        userId: "user-9",
+        email: "ada@example.com",
+      }),
+      "Mozilla/5.0",
+    );
+  });
+
+  it("does not wait for the forward to settle before responding", async () => {
+    let resolveForward: (() => void) | undefined;
+    mockedForward.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveForward = resolve;
+        }),
+    );
+    const res = createResponse();
+
+    await ConsentController.reportWebDecision(
+      { body: { consentId: "c-3", granted: true }, headers: {} } as any,
+      res as any,
+    );
+
+    // The response has been sent although the forward is still pending.
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(mockedForward).toHaveBeenCalledTimes(1);
+    resolveForward?.();
+  });
+});

--- a/apps/backend/test/routers/consent.router.test.ts
+++ b/apps/backend/test/routers/consent.router.test.ts
@@ -1,0 +1,65 @@
+import type { Router } from "express";
+
+const attachSessionIfPresent = jest.fn((_req, _res, next) => next());
+const consentLimiter = jest.fn((_req, _res, next) => next());
+
+const ConsentController = {
+  reportWebDecision: jest.fn(),
+};
+
+jest.mock("../../src/middlewares/auth", () => ({
+  attachSessionIfPresent,
+}));
+
+jest.mock("express-rate-limit", () => jest.fn(() => consentLimiter));
+
+jest.mock("../../src/controllers/app/consent.controller", () => ({
+  ConsentController,
+}));
+
+const consentRouter = jest.requireActual("../../src/routers/consent.router")
+  .default as Router;
+
+type Layer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+};
+
+const findRoute = (path: string, method: string) => {
+  const layer = (
+    (consentRouter as unknown as { stack: Layer[] }).stack ?? []
+  ).find(
+    (entry) =>
+      entry.route?.path === path && Boolean(entry.route?.methods?.[method]),
+  );
+  return layer?.route;
+};
+
+describe("consent.router", () => {
+  it("mounts the public consent report route", () => {
+    const route = findRoute("/", "post");
+    expect(route).toBeDefined();
+    expect(route?.stack.map((layer) => layer.handle)).toContain(
+      ConsentController.reportWebDecision,
+    );
+  });
+
+  it("rate limits the anonymous route", () => {
+    const route = findRoute("/", "post");
+    expect(route?.stack.map((layer) => layer.handle)).toContain(consentLimiter);
+  });
+
+  it("attaches the session when present without rejecting anonymous callers", () => {
+    // attachSessionIfPresent is the optional-session middleware: it never
+    // rejects. Order before the controller so identity is bound for enrichment.
+    const route = findRoute("/", "post");
+    const handles = route?.stack.map((layer) => layer.handle) ?? [];
+    expect(handles).toContain(attachSessionIfPresent);
+    expect(handles.indexOf(attachSessionIfPresent)).toBeLessThan(
+      handles.indexOf(ConsentController.reportWebDecision),
+    );
+  });
+});

--- a/apps/backend/test/routers/index.test.ts
+++ b/apps/backend/test/routers/index.test.ts
@@ -44,6 +44,7 @@ const MARKER_ROUTER_MODULES = [
   "chat.router",
   "notification.router",
   "contact-us.router",
+  "consent.router",
   "account-withdrawal.router",
   "organisation-document.router",
   "adverse-event.router",

--- a/apps/backend/test/services/superadmin-consent.service.test.ts
+++ b/apps/backend/test/services/superadmin-consent.service.test.ts
@@ -1,0 +1,131 @@
+const warnMock = jest.fn();
+const errorMock = jest.fn();
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    error: errorMock,
+    info: jest.fn(),
+    warn: warnMock,
+    debug: jest.fn(),
+  },
+}));
+
+import {
+  SuperadminConsentService,
+  type SuperadminConsentPayload,
+} from "../../src/services/superadmin-consent.service";
+
+const makeResponse = (ok = true, status = 200) =>
+  ({ ok, status }) as unknown as Response;
+
+const PAYLOAD: SuperadminConsentPayload = {
+  consentId: "probe-consent-b6724",
+  source: "web",
+  decisions: [{ category: "analytics", granted: true }],
+};
+
+describe("SuperadminConsentService.forwardConsentDecision", () => {
+  const originalEnv = process.env;
+  const originalFetch = globalThis.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    globalThis.fetch = originalFetch;
+  });
+
+  const configure = () => {
+    process.env.SUPERADMIN_CONSENT_INTAKE_URL =
+      "https://panel.example.com/api/consent";
+    process.env.SUPERADMIN_CONSENT_INTAKE_KEY = "shared-secret";
+  };
+
+  it("does nothing when the URL is unset", async () => {
+    process.env.SUPERADMIN_CONSENT_INTAKE_KEY = "shared-secret";
+    delete process.env.SUPERADMIN_CONSENT_INTAKE_URL;
+    await SuperadminConsentService.forwardConsentDecision(PAYLOAD);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the key is unset", async () => {
+    process.env.SUPERADMIN_CONSENT_INTAKE_URL =
+      "https://panel.example.com/api/consent";
+    delete process.env.SUPERADMIN_CONSENT_INTAKE_KEY;
+    await SuperadminConsentService.forwardConsentDecision(PAYLOAD);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("posts the payload with the shared key and a timeout", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse());
+    await SuperadminConsentService.forwardConsentDecision(PAYLOAD);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://panel.example.com/api/consent");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      "content-type": "application/json",
+      "x-consent-key": "shared-secret",
+    });
+    expect(JSON.parse(init.body as string)).toEqual(PAYLOAD);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("carries the browser user-agent through to the panel", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse());
+    await SuperadminConsentService.forwardConsentDecision(
+      PAYLOAD,
+      "Mozilla/5.0 (test)",
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ "user-agent": "Mozilla/5.0 (test)" });
+  });
+
+  it("does not set a user-agent header when none was supplied", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse());
+    await SuperadminConsentService.forwardConsentDecision(PAYLOAD);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty("user-agent");
+  });
+
+  it("warns but resolves when the panel rejects the forward", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse(false, 401));
+    await expect(
+      SuperadminConsentService.forwardConsentDecision(PAYLOAD),
+    ).resolves.toBeUndefined();
+    expect(warnMock).toHaveBeenCalledWith(
+      "SuperAdmin consent intake rejected the forward",
+      { status: 401 },
+    );
+  });
+
+  it("logs but resolves when the request itself fails", async () => {
+    configure();
+    const error = new Error("ECONNREFUSED");
+    fetchMock.mockRejectedValue(error);
+    await expect(
+      SuperadminConsentService.forwardConsentDecision(PAYLOAD),
+    ).resolves.toBeUndefined();
+    expect(errorMock).toHaveBeenCalledWith(
+      "Failed to forward consent decision to SuperAdmin",
+      { error },
+    );
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Cookies.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Cookies.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Cookies from '@/app/ui/widgets/Cookies/Cookies';
+import { reportConsentDecision } from '@/app/lib/consentReporter';
+
+jest.mock('@/app/lib/consentReporter', () => ({
+  reportConsentDecision: jest.fn().mockResolvedValue(undefined),
+}));
 
 jest.mock('@/app/ui/primitives/Buttons', () => ({
   Primary: ({ text, onClick }: { text: string; onClick: () => void }) => (
@@ -73,6 +78,7 @@ describe('Cookies Component', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith('cookieConsentGiven', 'true');
     expect(localStorage.getItem('cookieConsentGiven')).toBe('true');
+    expect(reportConsentDecision).toHaveBeenCalledWith(true);
 
     setItemSpy.mockRestore();
   });
@@ -96,6 +102,7 @@ describe('Cookies Component', () => {
 
     expect(setItemSpy).toHaveBeenCalledWith('cookieConsentGiven', 'false');
     expect(localStorage.getItem('cookieConsentGiven')).toBe('false');
+    expect(reportConsentDecision).toHaveBeenCalledWith(false);
 
     setItemSpy.mockRestore();
   });
@@ -142,13 +149,11 @@ describe('Cookies Component', () => {
         configurable: true,
         value: innerHeight,
       });
-      return jest
-        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-        .mockReturnValue({
-          top: cardTop,
-          bottom: cardTop + cardHeight,
-          height: cardHeight,
-        } as DOMRect);
+      return jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        top: cardTop,
+        bottom: cardTop + cardHeight,
+        height: cardHeight,
+      } as DOMRect);
     };
 
     const inset = () => document.documentElement.style.getPropertyValue('--yc-consent-inset');

--- a/apps/frontend/src/app/__tests__/lib/consentReporter.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/consentReporter.test.ts
@@ -1,0 +1,61 @@
+import {
+  CONSENT_ID_KEY,
+  CONSENT_ENDPOINT,
+  getOrCreateConsentId,
+  reportConsentDecision,
+} from '@/app/lib/consentReporter';
+
+const postDataMock = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  postData: (...args: unknown[]) => postDataMock(...args),
+}));
+
+describe('consentReporter', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    postDataMock.mockReset();
+    postDataMock.mockResolvedValue({ data: { ok: true } });
+  });
+
+  describe('getOrCreateConsentId', () => {
+    it('generates and persists an id on first call', () => {
+      const id = getOrCreateConsentId();
+      expect(id).toBeTruthy();
+      expect(localStorage.getItem(CONSENT_ID_KEY)).toBe(id);
+    });
+
+    it('reuses the persisted id on later calls', () => {
+      localStorage.setItem(CONSENT_ID_KEY, 'stable-id');
+      expect(getOrCreateConsentId()).toBe('stable-id');
+      expect(getOrCreateConsentId()).toBe('stable-id');
+    });
+  });
+
+  describe('reportConsentDecision', () => {
+    it('posts the stable consentId with the decision', async () => {
+      localStorage.setItem(CONSENT_ID_KEY, 'subject-1');
+      await reportConsentDecision(true);
+
+      expect(postDataMock).toHaveBeenCalledWith(CONSENT_ENDPOINT, {
+        consentId: 'subject-1',
+        granted: true,
+      });
+    });
+
+    it('does not regenerate the consentId when reporting', async () => {
+      await reportConsentDecision(false);
+      const firstId = localStorage.getItem(CONSENT_ID_KEY);
+
+      await reportConsentDecision(true);
+      expect(localStorage.getItem(CONSENT_ID_KEY)).toBe(firstId);
+      expect(postDataMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('resolves without throwing when the relay is unreachable', async () => {
+      postDataMock.mockRejectedValueOnce(new Error('network down'));
+      await expect(reportConsentDecision(true)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/frontend/src/app/lib/consentReporter.ts
+++ b/apps/frontend/src/app/lib/consentReporter.ts
@@ -1,0 +1,38 @@
+import { getStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { postData } from '@/app/services/axios';
+
+/**
+ * Stable per-browser consent subject id, persisted so an accept today and a
+ * later re-decision land on the SAME ledger subject (the panel's store records
+ * identity fill-only-if-absent and keys everything on consentId). Generated
+ * once per browser; cleared when the user clears site storage, which is the
+ * same lifetime as the consent cookie itself.
+ */
+export const CONSENT_ID_KEY = 'ycConsentId';
+export const CONSENT_ENDPOINT = '/v1/consent';
+
+export const getOrCreateConsentId = (): string => {
+  const existing = getStorageItem('local', CONSENT_ID_KEY);
+  if (existing) return existing;
+  const id = globalThis.crypto?.randomUUID?.() ?? `anon-${Date.now()}`;
+  setStorageItem('local', CONSENT_ID_KEY, id);
+  return id;
+};
+
+/**
+ * Fire-and-forget report of one banner decision to the product backend, which
+ * relays it to the panel's consent ledger with the shared key held server-side.
+ * The visitor's action (banner dismissing) already happened; a failed report
+ * must never surface to them, so errors are swallowed here and the promise is
+ * never exposed to the caller.
+ */
+export const reportConsentDecision = async (granted: boolean): Promise<void> => {
+  try {
+    await postData(CONSENT_ENDPOINT, {
+      consentId: getOrCreateConsentId(),
+      granted,
+    });
+  } catch {
+    // Best-effort mirror only - the ledger is the panel's, not the visitor's.
+  }
+};

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { getStorageItem, setStorageItem } from '@/app/lib/browserStorage';
 import { PHONE_MEDIA_QUERY } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import { COOKIE_CONSENT_KEY } from '@/app/lib/posthog';
+import { reportConsentDecision } from '@/app/lib/consentReporter';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
 
@@ -37,10 +38,14 @@ const getServerConsentSnapshot = () => null;
 
 const handleConsent = () => {
   setConsent('true');
+  // Report the accept to the backend, which relays it to the panel's consent
+  // ledger. Fire-and-forget: the banner has already served its purpose.
+  void reportConsentDecision(true);
 };
 
 const handleRejection = () => {
   setConsent('false');
+  void reportConsentDecision(false);
 };
 
 const Cookies = () => {


### PR DESCRIPTION
## Summary

Resolves **YosemiteCrew/SuperAdmin#316** — *"Does anything call the consent intake? No caller for x-consent-key."*

The product web cookie banner now reports accept/reject decisions through a public relay to the panel's consent ledger, with the shared `x-consent-key` held **server-side**. The key never appears in browser code.

## What changed

**Backend** (new)
- `POST /v1/consent` — anonymous, rate-limited (60/15min/IP), session-enriched when one is present
- `consent.controller.ts` — validates `{ consentId, granted }`, builds the SuperAdmin payload, returns **202 before** the forward settles (mirrors `superadmin-contact.service.ts`)
- `superadmin-consent.service.ts` — fire-and-forget forward to `SUPERADMIN_CONSENT_INTAKE_URL` with `x-consent-key` header, 5s AbortSignal timeout, UA passthrough, no-op when unconfigured
- Env vars documented in `.env.example`

**Frontend** (new)
- `consentReporter.ts` — stable per-browser `consentId` (localStorage `ycConsentId`, `crypto.randomUUID` fallback) so re-decisions land on the same ledger subject; errors swallowed (never surfaces to visitor)
- `Cookies.tsx` accept/reject now call `reportConsentDecision(...)`

## Failure behavior

- Panel down/unconfigured: forward no-ops/errors are logged server-side; the visitor always gets `202` — the banner dismissal is the confirmation, not our HTTP status
- Invalid body: `400` with a clear message

## Test evidence

- Backend: `superadmin-consent.service.test.ts` (7), `consent.controller.test.ts` (5), `consent.router.test.ts` (3) — **15/15 pass**
- Frontend: `Cookies.test.tsx` + `consentReporter.test.ts` — **14/14 pass**
- Mutation-verified: inverting `granted` in the controller and reporter each failed the suite, then restored
- `tsc` clean (backend + frontend), eslint 0 errors, Prettier clean on touched files