### PR TITLE
fix(frontend): replace hand-rolled FilterPill with shared FilterChip

### DIFF
--- a/apps/frontend/src/app/__tests__/features/documents/components/CompanionDocumentsSection.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/documents/components/CompanionDocumentsSection.test.tsx
@@ -138,8 +138,10 @@ describe('CompanionDocumentsSection', () => {
     // Month bucket header, typed sub-category label, and both status pills.
     expect(screen.getByText('January 2026')).toBeInTheDocument();
     expect(screen.getByText(/Vaccination/)).toBeInTheDocument();
-    // "Synced" is both a filter tab (button) and this row's status pill (span).
-    expect(screen.getByText('Synced', { selector: 'span' })).toBeInTheDocument();
+    // "Synced" is both a filter tab (FilterChip, which also renders its label in
+    // a span) and this row's status pill - scope to the status pill's own class
+    // to disambiguate.
+    expect(screen.getByText('Synced', { selector: '.yc-status-pill' })).toBeInTheDocument();
     expect(screen.getByText('PMS visible')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Open vaccination card' }));
@@ -252,6 +254,30 @@ describe('CompanionDocumentsSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Synced' }));
     expect(screen.getByText('Synced Report')).toBeInTheDocument();
     expect(screen.queryByText('Manual Upload')).not.toBeInTheDocument();
+  });
+
+  it('renders the source tabs with the design system FilterChip geometry', async () => {
+    loadCompanionDocumentMock.mockResolvedValue([
+      {
+        id: 's1',
+        title: 'Synced Report',
+        category: 'HEALTH',
+        subcategory: 'LAB_TEST',
+        issueDate: '2026-02-01T10:00:00Z',
+        syncedFromPms: true,
+        attachments: [{ mimeType: 'application/pdf' }],
+      },
+    ]);
+
+    render(<CompanionDocumentsSection companionId="comp-1" />);
+    await waitFor(() => expect(screen.getByText('Synced Report')).toBeInTheDocument());
+
+    // The shared FilterChip control (apps/frontend/src/app/ui/filters/FilterChip.tsx),
+    // not a hand-rolled pill that happens to look similar - h-8/px-[13px]/text-[12.5px]
+    // is FilterChip's one geometry, pixels the old bespoke pill (px-3 py-1.5, text-[12px])
+    // did not use.
+    const allChip = screen.getByRole('button', { name: /^All/ });
+    expect(allChip).toHaveClass('h-8', 'px-[13px]', 'text-[12.5px]');
   });
 
   it('shows an inline message when a filter matches no records', async () => {

--- a/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.tsx
@@ -20,6 +20,7 @@ import CompanionDocumentUploadForm, {
   DocumentUploadFormErrors,
 } from '@/app/features/documents/components/CompanionDocumentUploadForm';
 import CompanionRecordRow from '@/app/features/documents/components/CompanionRecordRow';
+import FilterChip from '@/app/ui/filters/FilterChip';
 import CompanionRecordsEmptyState from '@/app/features/documents/components/CompanionRecordsEmptyState';
 import {
   RecordFilter,
@@ -58,27 +59,6 @@ const FILTER_TABS: { value: RecordFilter; label: string }[] = [
   { value: 'UPLOADED', label: 'Uploaded' },
   { value: 'SYNCED', label: 'Synced' },
 ];
-
-type FilterPillProps = {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-};
-
-const FilterPill = ({ active, onClick, children }: FilterPillProps) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-pressed={active}
-    className={`rounded-full border px-3 py-1.5 text-[12px] ${
-      active
-        ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]'
-        : 'border-[var(--hairline)] font-semibold text-[var(--ink-muted)]'
-    }`}
-  >
-    {children}
-  </button>
-);
 
 type CompanionDocumentsSectionProps = {
   companionId: string;
@@ -258,22 +238,20 @@ const CompanionDocumentsSection = ({ companionId }: CompanionDocumentsSectionPro
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex flex-wrap items-center gap-2">
                 {FILTER_TABS.map((tab) => (
-                  <FilterPill
+                  <FilterChip
                     key={tab.value}
+                    label={tab.value === 'ALL' ? `${tab.label} · ${records.length}` : tab.label}
                     active={effectiveFilter === tab.value}
                     onClick={() => setFilter(tab.value)}
-                  >
-                    {tab.value === 'ALL' ? `${tab.label} · ${records.length}` : tab.label}
-                  </FilterPill>
+                  />
                 ))}
                 {lifecycleTabs.map((lifecycle) => (
-                  <FilterPill
+                  <FilterChip
                     key={lifecycle}
+                    label={RECORD_LIFECYCLE_LABELS[lifecycle]}
                     active={effectiveFilter === RECORD_LIFECYCLE_FILTERS[lifecycle]}
                     onClick={() => setFilter(RECORD_LIFECYCLE_FILTERS[lifecycle])}
-                  >
-                    {RECORD_LIFECYCLE_LABELS[lifecycle]}
-                  </FilterPill>
+                  />
                 ))}
               </div>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

`CompanionDocumentsSection.tsx` (`apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.tsx`, previously lines 62-81) defined a local `FilterPill` button that hand-rolled the same pill geometry the design system's `FilterChip` (`apps/frontend/src/app/ui/filters/FilterChip.tsx`) already provides - `rounded-full border px-3 py-1.5 text-[12px]` versus `FilterChip`'s canonical `h-8 px-[13px] text-[12.5px] rounded-full!` control. It was used for both the source tabs (All / Uploaded / Synced, lines 261-267) and the lifecycle tabs (Requested / Generated / Signed, lines 270-276).

Fix: import the real `FilterChip` and replace both `<FilterPill>` usages with `<FilterChip label=... active=... onClick=... />`, then delete the now-dead `FilterPill`/`FilterPillProps` definitions. Confirmed via `grep -rn "FilterPill" apps/frontend/src` that the local component had no other consumers before deleting it.

## Verified

- `npx eslint src/app/features/documents/components/CompanionDocumentsSection.tsx src/app/__tests__/features/documents/components/CompanionDocumentsSection.test.tsx` - clean.
- `npx tsc --noEmit` (apps/frontend) - clean, no errors.
- `pnpm run test -- --testPathPatterns="CompanionDocumentsSection" --coverage --collectCoverageFrom="src/app/features/documents/components/CompanionDocumentsSection.tsx"` - 23/23 passing, 100% statements/lines, 98.52% branches, 100% functions.
- Updated one existing assertion: switching to `FilterChip` wraps its label in a `<span>`, so `getByText('Synced', { selector: 'span' })` became ambiguous against the row's own "Synced" status pill span. Scoped it to the status pill's `.yc-status-pill` class instead.
- Added a new test, `renders the source tabs with the design system FilterChip geometry`, asserting the All chip carries `h-8 px-[13px] text-[12.5px]` - the classes unique to `FilterChip`'s geometry, which the old hand-rolled pill never used.
- Mutation-check: reverted only the source file to `origin/dev` (`git checkout origin/dev -- <path>`), reran the suite - the new geometry test failed as expected (22/23 passing, only that test red) while the other 22 stayed green, confirming they were unaffected by the swap. Restored the fix, reran clean (23/23), then confirmed `git diff origin/dev -- <path>` matched the intended change exactly before committing (no reverted-content trap in the index).

## Test plan

- [x] `npx eslint` on both changed files
- [x] `npx tsc --noEmit` (apps/frontend)
- [x] Targeted Jest suite for `CompanionDocumentsSection`, with coverage
- [x] Mutation-check on the new pinning test
