### PR TITLE
fix(frontend): route the integrations filter tabs through FilterChip

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
@@ -382,6 +382,17 @@ describe('Integrations settings', () => {
     expect(connectedTab).toHaveAttribute('aria-pressed', 'false');
   });
 
+  // Pins the tabs to the shared FilterChip primitive (h-8, text-[12.5px]) rather than a
+  // hand-rolled pill (the old markup was h-unset/py-1.5/text-[12px]) — a design-system audit
+  // flagged the duplicate geometry.
+  it('filter tabs render through the shared FilterChip primitive', async () => {
+    render(<ProtectedIntegrations />);
+    await screen.findByRole('heading', { name: /^Integrations/ });
+    const allTab = screen.getByRole('button', { name: 'All' });
+    expect(allTab).toHaveClass('h-8');
+    expect(allTab).toHaveClass('text-[12.5px]');
+  });
+
   it('shows "No connected integrations yet." when connected filter is active with no connections', async () => {
     const disabledIntegration = {
       _id: 'int-1',

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -44,10 +44,10 @@ import {
   IoSettingsOutline,
   IoTrashOutline,
 } from 'react-icons/io5';
-import clsx from 'clsx';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
+import FilterChip from '@/app/ui/filters/FilterChip';
 
 type StatusTokens = { bg: string; text: string; border: string };
 
@@ -919,28 +919,18 @@ const IntegrationFilterTabs = ({
   activeFilter: IntegrationsPageState['activeFilter'];
   setActiveFilter: IntegrationsPageState['setActiveFilter'];
 }) => (
-  <fieldset className="flex items-center gap-2 flex-wrap">
-    <legend className="sr-only">Filter integrations</legend>
-    {integrationFilters.map((tab) => {
-      const isActive = activeFilter === tab.key;
-      return (
-        <button
-          key={tab.key}
-          type="button"
-          onClick={() => setActiveFilter(tab.key)}
-          aria-pressed={isActive}
-          className={clsx(
-            'rounded-full! border px-[13px] py-1.5 text-[12px] whitespace-nowrap transition-colors',
-            isActive
-              ? 'bg-[var(--chip-selected-bg)] border-[var(--chip-selected-border)] text-[var(--chip-selected-ink)] font-bold'
-              : 'border-[var(--hairline)] text-[var(--ink-muted)] font-semibold hover:border-[var(--divider)]'
-          )}
-        >
-          {tab.label}
-        </button>
-      );
-    })}
-  </fieldset>
+  // NOSONAR: styled flex pill group; native <fieldset> defaults (block layout, border,
+  // required legend) break the pill design — same pattern as InvoiceStatusFilterPills.
+  <div role="group" aria-label="Filter integrations" className="flex items-center gap-2 flex-wrap">
+    {integrationFilters.map((tab) => (
+      <FilterChip
+        key={tab.key}
+        label={tab.label}
+        active={activeFilter === tab.key}
+        onClick={() => setActiveFilter(tab.key)}
+      />
+    ))}
+  </div>
 );
 
 // Compact integration card — design: 16px/18px padding, a 10px column gap and a

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -919,9 +919,11 @@ const IntegrationFilterTabs = ({
   activeFilter: IntegrationsPageState['activeFilter'];
   setActiveFilter: IntegrationsPageState['setActiveFilter'];
 }) => (
-  // NOSONAR: styled flex pill group; native <fieldset> defaults (block layout, border,
-  // required legend) break the pill design — same pattern as InvoiceStatusFilterPills.
-  <div role="group" aria-label="Filter integrations" className="flex items-center gap-2 flex-wrap">
+  <div /* NOSONAR: styled flex pill group; native <fieldset> defaults (block layout, border, required legend) break the pill design */
+    role="group"
+    aria-label="Filter integrations"
+    className="flex items-center gap-2 flex-wrap"
+  >
     {integrationFilters.map((tab) => (
       <FilterChip
         key={tab.key}


### PR DESCRIPTION
## Summary

A design-system audit found that `IntegrationFilterTabs` in `apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx` (previously lines 915-944) hand-rolled the same pill geometry `FilterChip` (`apps/frontend/src/app/ui/filters/FilterChip.tsx`) already implements independently:

- Old: `rounded-full! border px-[13px] py-1.5 text-[12px] whitespace-nowrap transition-colors`, with active state `bg-[var(--chip-selected-bg)] border-[var(--chip-selected-border)] text-[var(--chip-selected-ink)] font-bold` and inactive `border-[var(--hairline)] text-[var(--ink-muted)] font-semibold hover:border-[var(--divider)]` - a near-exact duplicate of `FilterChip`'s neutral tone recipe (`h-8 ... rounded-full! border px-[13px] text-[12.5px] ...`, `TONE_CLASSNAMES.neutral`).
- The tabs carry no counts, so `FilterChip`'s optional `count` prop is simply unused.

## Fix

Replaced the hand-rolled `<fieldset>`/`<button>` markup with `<FilterChip>`, mapped over the existing `integrationFilters` list:

- `active` = `activeFilter === tab.key` (same comparison as before)
- `onClick` = `() => setActiveFilter(tab.key)` (unchanged)
- `label` = `tab.label` (unchanged)

The `<fieldset>`/`<legend className="sr-only">` wrapper was replaced with `<div role="group" aria-label="Filter integrations">`, matching the existing pattern already used by `InvoiceStatusFilterPills` (`apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills.tsx:30`) with the same NOSONAR rationale (a native `<fieldset>`'s default block layout/border/required-legend breaks the pill row design). `role="group"` + `aria-label` preserves the same accessible name and grouping semantics a `<fieldset>`/`<legend>` gave (a `<fieldset>` has an implicit `role="group"` named by its `<legend>`), which is also what the existing tests already assert against (`getByRole('group', { name: 'Filter integrations' })`).

`aria-pressed` on each tab is preserved unchanged - `FilterChip` sets `aria-pressed={active}` itself.

The now-unused `clsx` import was removed (it had no other use in this file).

## Verified

Run from `apps/frontend` in a fresh worktree off `origin/dev` (packages/database and packages/auth built first):

- `npx eslint src/app/features/integrations/pages/Integrations/index.tsx src/app/__tests__/pages/Integrations/Integrations.test.tsx` - clean, no output.
- `npx tsc --noEmit` - clean, no output.
- `pnpm run test -- --testPathPatterns="Integrations"` - 11 suites, 284 tests passed (up from 283 - the added pinning test), including the existing `filter tabs expose aria-pressed state` and jest-axe "no violations" assertions.
- Pre-push hook (`turbo run lint type-check` across the whole monorepo): 17/17 tasks successful.

**Mutation-check on the new test:** temporarily reverted only the source file to `origin/dev`'s content (`git checkout origin/dev -- apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx`), reran the suite - the new test (`filter tabs render through the shared FilterChip primitive`) failed as expected (`expect(element).toHaveClass("h-8")` - received the old `py-1.5 text-[12px]` classes instead), everything else stayed green. Restored the fix and confirmed `git diff HEAD -- <source file>` matched the intended change exactly (guarding against the git-index revert trap), then reran - back to 284/284 passing.

## Test plan

- [x] `npx eslint` on both changed files - clean
- [x] `npx tsc --noEmit` from `apps/frontend` - clean
- [x] `pnpm run test -- --testPathPatterns="Integrations"` - 284/284 passing
- [x] New test added and mutation-checked (fails without the fix, passes with it)
- [x] Pre-push monorepo lint + type-check - 17/17 successful
- [x] Manually traced `activeFilter`/`setActiveFilter` state and click handling through `useIntegrationsPage` - unchanged