### PR TITLE
fix(frontend): replace Companions sort toggle with shared FilterChip

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Companions/Companions.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Companions/Companions.test.tsx
@@ -325,8 +325,8 @@ describe('Companions page', () => {
     render(<ProtectedCompanions />);
     const sortPill = screen.getByRole('button', { name: /Last visit/ });
 
-    // Inactive: outline only, muted ink.
-    expect(sortPill).toHaveClass('border-[var(--hairline)]', 'text-[var(--ink-muted)]');
+    // Inactive: outline only, muted ink - the shared FilterChip's rest tone.
+    expect(sortPill).toHaveClass('border-[var(--hairline)]!', 'text-[var(--ink-muted)]');
     expect(sortPill).not.toHaveClass('bg-[var(--chip-selected-bg)]');
 
     fireEvent.click(sortPill);
@@ -334,9 +334,9 @@ describe('Companions page', () => {
     // Selected: the shared ink fill. `--inset` sat within 1.06:1 of the page, so
     // weight alone used to carry the selection and a revert would look "fine".
     expect(sortPill).toHaveClass(
-      'border-[var(--chip-selected-border)]',
+      'border-[var(--chip-selected-border)]!',
       'bg-[var(--chip-selected-bg)]',
-      'text-[var(--chip-selected-ink)]'
+      'text-[var(--chip-selected-ink)]!'
     );
     expect(sortPill).not.toHaveClass('bg-[var(--inset)]');
   });

--- a/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
@@ -7,6 +7,7 @@ import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 
 const COMPANIONS_PAGE_SKELETON = <PageSkeleton variant="list" />;
 import Filters from '@/app/ui/filters/Filters';
+import FilterChip from '@/app/ui/filters/FilterChip';
 import CompanionsTable, { type CompanionsViewMode } from '@/app/ui/tables/CompanionsTable';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import { useCompanionsParentsForPrimaryOrg } from '@/app/hooks/useCompanion';
@@ -27,7 +28,6 @@ import {
   IoGridOutline,
   IoInformationCircleOutline,
   IoReorderThreeOutline,
-  IoSwapVerticalOutline,
 } from 'react-icons/io5';
 import clsx from 'clsx';
 import { formatCompanionNameWithOwnerLastName } from '@/app/lib/companionName';
@@ -271,20 +271,11 @@ const Companions = () => {
                 setActiveStatus={setActiveStatus}
                 showAddButton={false}
               />
-              <button
-                type="button"
-                aria-pressed={sortByRecentVisit}
+              <FilterChip
+                label={terminologyText('Last visit')}
+                active={sortByRecentVisit}
                 onClick={() => setSortByRecentVisit((value) => !value)}
-                className={clsx(
-                  'inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-[12px] font-semibold transition-colors',
-                  sortByRecentVisit
-                    ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] text-[var(--chip-selected-ink)]'
-                    : 'border-[var(--hairline)] text-[var(--ink-muted)] hover:text-[var(--ink)]'
-                )}
-              >
-                <IoSwapVerticalOutline size={12} aria-hidden="true" />
-                {terminologyText('Last visit')}
-              </button>
+              />
             </div>
           </div>
           <div ref={plannerSectionRef} className={plannerSectionClassName}>


### PR DESCRIPTION
## Summary
- A design-system audit flagged the last-visit sort toggle in `Companions.tsx` (`apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx:274-287` on `dev`) as hand-rolling the same pill geometry FilterChip already owns: `rounded-full border px-3 py-1 text-[12px]` with the `--chip-selected-*` tokens for the active state, duplicated instead of reusing `apps/frontend/src/app/ui/filters/FilterChip.tsx`.
- The control is a simple two-state toggle (`sortByRecentVisit` boolean, flipped by `setSortByRecentVisit((v) => !v)`) that re-sorts the companions list by last visit via `sortByLastVisit` when active - a direct match for `FilterChip`'s `active`/`onClick` contract, same as how Finance (`InvoiceStatusFilterPills`), Guides, and the task board's `TaskFilterBar` already consume it.
- Replaced the hand-rolled `<button>` with `<FilterChip label={terminologyText('Last visit')} active={sortByRecentVisit} onClick={...} />`. Dropped the leading `IoSwapVerticalOutline` icon along with it - `FilterChip` has no icon slot, and every other consumer of the shared component (Finance, Guides, TaskFilterBar) drops hand-rolled icons/dots in favor of `FilterChip`'s own `dotColor`/`count` affordances rather than passing arbitrary icons, so this keeps the sort chip consistent with that established pattern instead of adding a new prop for one caller.
- Removed the now-unused `IoSwapVerticalOutline` import (still imported and used elsewhere in the app, in unrelated files, so left alone there).

## Verified
- `npx jest --testPathPatterns="pages/Companions/Companions.test"` - 20/20 passed, including the two tests that exercise this control (`toggles the last-visit sort control`, `marks the selected sort with the shared chip tokens, not the old inset fill`).
- Updated the second test's class assertions to match `FilterChip`'s actual output classes (it renders `border-[var(--hairline)]!` / `text-[var(--chip-selected-ink)]!` with Tailwind's `!important` marker, where the old hand-rolled markup did not) - **mutation-checked**: reverted only `Companions.tsx` to `origin/dev` via `git checkout origin/dev -- <path>`, reran the suite, confirmed `marks the selected sort with the shared chip tokens...` fails against the pre-fix source (`expect(element).toHaveClass(...)` mismatch), then restored the fix and confirmed `git diff HEAD~1 HEAD -- <path>` shows exactly the intended change with nothing reverted, and the suite is clean again (20/20).
- `npx eslint` on both changed files - clean, no output.
- `npx tsc --noEmit` from `apps/frontend` - clean, no errors (exit 0).
- Pre-push hook (`turbo run lint` + `turbo run type-check` across the whole monorepo) - 17/17 tasks successful.
- Visual: started the app locally (`NEXT_PUBLIC_DISABLE_AUTH_GUARD=true`) and reached `/companions`, but per this repo's known limitation the env var only bypasses the sidebar org-data gate, not full auth/session - the companions list and its filter/sort toolbar don't populate without a real session, so the chip itself wasn't visible in that local render. `FilterChip` is an already-shipped, already-visually-verified shared component (has its own Storybook story, consumed by Finance/Guides/TaskFilterBar in production), and the RTL tests above assert its exact rendered geometry and active/rest classes for this specific usage, which is the practical verification available here.

## Test plan
- [x] `pnpm --filter frontend run test -- --testPathPatterns="pages/Companions/Companions.test"` passes (20/20)
- [x] `npx eslint` on changed files passes
- [x] `npx tsc --noEmit` (apps/frontend) passes
- [x] Pre-push `turbo run lint` + `turbo run type-check` passes (17/17)
- [x] Mutation-check: test fails against pre-fix source, passes against the fix