### PR TITLE
fix(frontend): reuse FilterChip in the calendar filter row

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -30,8 +30,10 @@ describe('Header Component', () => {
     jest.clearAllMocks();
   });
 
+  // The presence badge now sits beside the FilterChip button (inside the
+  // wrapping div), not inside the button itself, so search from the parent.
   const getEmergencyDot = (button: HTMLElement) =>
-    Array.from(button.querySelectorAll('span')).find((span) =>
+    Array.from((button.parentElement ?? button).querySelectorAll('span')).find((span) =>
       span.className.includes('size-2.5')
     ) as HTMLElement;
 
@@ -176,13 +178,17 @@ describe('Header Component', () => {
     );
 
     // Design recipe: rounded-full pill, no icon glyph, danger tokens, transparent when inactive.
+    // FilterChip's own primitive geometry/tone (design: Filters card) delivers these
+    // via classes rather than an inline style at rest.
     const inactivePill = screen.getByRole('button', { name: 'Emergencies' });
     expect(inactivePill).toHaveClass('rounded-full!');
     expect(inactivePill).not.toHaveClass('h-12');
     expect(inactivePill.querySelector('svg')).toBeNull();
-    expect(inactivePill.getAttribute('style')).toContain('background-color: transparent');
-    expect(inactivePill.getAttribute('style')).toContain('border-color: var(--danger-border)');
-    expect(inactivePill.getAttribute('style')).toContain('color: var(--danger-text)');
+    expect(inactivePill).toHaveClass(
+      'bg-transparent',
+      'border-[var(--danger-border)]!',
+      'text-[var(--danger-text)]!'
+    );
     // Top-right presence dot uses --danger with a --screen outline.
     const inactiveDot = getEmergencyDot(inactivePill);
     expect(inactiveDot.getAttribute('style')).toContain('background-color: var(--danger)');
@@ -270,13 +276,14 @@ describe('Header Component', () => {
     );
 
     // Active non-emergency pill takes the shared --chip-selected-* ink fill at
-    // 700. The neutral surface tokens it used before sat within 1.1:1 of the
-    // page, so weight was the only thing marking the selection.
+    // 700, via FilterChip's neutral tone. The neutral surface tokens it used
+    // before sat within 1.1:1 of the page, so weight was the only thing
+    // marking the selection.
     const allPillActive = screen.getByRole('button', { name: 'All' });
     expect(allPillActive).toHaveClass(
       'bg-[var(--chip-selected-bg)]',
       'font-bold',
-      'text-[var(--chip-selected-ink)]'
+      'text-[var(--chip-selected-ink)]!'
     );
     expect(allPillActive).not.toHaveClass('bg-[var(--inset)]');
 
@@ -296,11 +303,14 @@ describe('Header Component', () => {
       />
     );
 
-    // Inactive non-emergency pill falls back to a bare --hairline outline with
-    // --ink-muted 600 type.
+    // Inactive non-emergency pill falls back to FilterChip's bare --hairline
+    // outline with --ink-muted 600 type.
     const allPillInactive = screen.getByRole('button', { name: 'All' });
-    expect(allPillInactive).toHaveClass('text-[var(--ink-muted)]', 'font-semibold');
-    expect(allPillInactive).toHaveStyle({ borderColor: 'var(--hairline)' });
+    expect(allPillInactive).toHaveClass(
+      'text-[var(--ink-muted)]',
+      'font-semibold',
+      'border-[var(--hairline)]!'
+    );
 
     // Active emergency pill draws its label colour from the inline style (white on
     // danger-800), so it no longer carries the AA-failing `text-danger-500!` class.

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -1,7 +1,6 @@
 import React, { startTransition, useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScroll';
 import { getMonthYear } from '@/app/features/appointments/components/Calendar/helpers';
-import { getEmergencyPillStyle } from '@/app/features/appointments/components/appointmentBoardHelpers';
 import { CalendarZoomMode } from '@/app/features/appointments/components/Calendar/calendarLayout';
 import Datepicker from '@/app/ui/inputs/Datepicker';
 import {
@@ -23,6 +22,7 @@ import { useCalendarNavigation } from '@/app/hooks/useCalendarNavigation';
 import { useCalendarWeekNavigation } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import { getStartOfWeek } from '@/app/features/appointments/components/Calendar/weekHelpers';
 import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+import FilterChip from '@/app/ui/filters/FilterChip';
 import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
 type FilterOption = { key: string; name: string; dotColor?: string };
@@ -43,25 +43,15 @@ const getStatusPillTokens = (status: StatusOption): StatusPillTokens => ({
   border: status.border ?? status.bg ?? 'var(--color-pill-neutral-border)',
 });
 
-// Scope pills follow the planner's filter-row recipe: inactive is a bare
-// --hairline outline with --ink-muted 600 type; the selected pill takes the
-// shared --chip-selected-* ink fill and steps the label to 700.
-const getFilterClassName = (filterKey: string, activeFilter: string): string => {
-  if (filterKey !== activeFilter)
-    return 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover!';
-  // The active emergency pill draws its fill/label from getEmergencyPillStyle's
-  // inline style (--danger-strong with its paired ink); return no colour class so
-  // an `!important` text colour can't override it (the old `text-danger-500!`
-  // failed WCAG AA in dark mode).
-  if (filterKey === 'emergencies') return 'font-bold';
-  return 'bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]';
-};
-
-const getFilterBorderColor = (filterKey: string, activeFilter: string): string => {
-  if (filterKey !== activeFilter) return 'var(--hairline)';
-  /* v8 ignore next -- unreachable: only called for non-emergency pills (emergency pills use getEmergencyPillStyle) */
-  if (filterKey === 'emergencies') return 'var(--color-danger-500)';
-  return 'var(--chip-selected-border)';
+// Scope pills are FilterChip (design: Filters card) — the emergencies chip
+// keeps FilterChip's danger tone for its rest state, but overrides the active
+// fill via `tokens` with the WCAG-AA-safe --danger-strong pairing rather than
+// FilterChip's translucent --danger-bg tone: the old --danger-bg tint +
+// `text-danger-500!` label failed contrast in dark mode (#1885).
+const EMERGENCY_ACTIVE_TOKENS = {
+  bg: 'var(--danger-strong)',
+  border: 'var(--danger-strong)',
+  text: 'var(--danger-strong-ink)',
 };
 
 const CALENDAR_VIEW_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
@@ -202,51 +192,37 @@ const FilterPills = ({
       {filterOptions.map((filter) => {
         const isEmergencyFilter = filter.key === 'emergencies';
         const isActiveFilter = filter.key === activeFilter;
-        const pillStyle = isEmergencyFilter
-          ? getEmergencyPillStyle(isActiveFilter)
-          : {
-              borderWidth: '1px',
-              borderStyle: 'solid',
-              borderColor: getFilterBorderColor(filter.key, activeFilter ?? ''),
-            };
-
-        return (
-          <button
-            key={filter.key}
-            type="button"
+        const chip = (
+          <FilterChip
+            active={isActiveFilter}
             onClick={() => onToggle(filter.key)}
-            className={clsx(
-              'relative flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap px-[13px] py-1.5 rounded-full! text-[12px] transition-colors',
-              getFilterClassName(filter.key, activeFilter ?? '')
-            )}
-            style={pillStyle}
-          >
-            {isEmergencyFilter && (
+            label={filter.name}
+            tone={isEmergencyFilter ? 'danger' : 'neutral'}
+            dotColor={isEmergencyFilter ? 'var(--danger)' : filter.dotColor}
+            tokens={isEmergencyFilter ? EMERGENCY_ACTIVE_TOKENS : undefined}
+            // `tokens` on an active chip drops FilterChip's own tone class (it
+            // carries the fill/border/ink instead), so restore the weight step
+            // that class would have set.
+            className={isEmergencyFilter && isActiveFilter ? 'font-bold' : undefined}
+          />
+        );
+
+        if (!isEmergencyFilter) return <React.Fragment key={filter.key}>{chip}</React.Fragment>;
+
+        // Presence badge lives outside the chip: FilterChip owns the pill
+        // itself, not an overlay slot, so the "emergencies exist" corner dot
+        // wraps it instead of reaching inside.
+        return (
+          <div key={filter.key} className="relative inline-flex shrink-0">
+            {chip}
+            {hasEmergency && (
               <span
                 aria-hidden="true"
-                className="size-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: 'var(--danger)' }}
+                className="pointer-events-none absolute -top-0.5 -right-0.5 size-2.5 rounded-full"
+                style={{ backgroundColor: 'var(--danger)', outline: '2px solid var(--screen)' }}
               />
             )}
-            {!isEmergencyFilter && filter.dotColor && (
-              <span
-                aria-hidden="true"
-                className="size-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: filter.dotColor }}
-              />
-            )}
-            <span>{filter.name}</span>
-            {isEmergencyFilter && hasEmergency && (
-              <span
-                aria-hidden="true"
-                className="absolute -top-0.5 -right-0.5 size-2.5 rounded-full"
-                style={{
-                  backgroundColor: 'var(--danger)',
-                  outline: '2px solid var(--screen)',
-                }}
-              />
-            )}
-          </button>
+          </div>
         );
       })}
     </>


### PR DESCRIPTION
## Summary

`apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx` hand-rolled its own filter-pill geometry and colour logic (`getFilterClassName` / `getFilterBorderColor`, `Header.tsx:49-65` on `origin/dev`) instead of using the canonical `FilterChip` primitive (`apps/frontend/src/app/ui/filters/FilterChip.tsx`) that every other filter row in the app already uses (`Filters/index.tsx`, `FormsFilters/index.tsx`, `TaskFilterBar.tsx`, `Guides.tsx`, `InvoiceStatusFilterPills.tsx`). The row's own code even called itself "the planner's filter-row recipe" (`Header.tsx:46`) while re-implementing the same `h-8`/`rounded-full`/`px-[13px]`/`text-[12.5px]` geometry and the same `--chip-selected-*` tokens by hand, in a shape that had drifted from `FilterChip`'s hover behaviour (`hover:bg-card-hover!` vs. `FilterChip`'s `hover:text-[var(--ink)]`).

Replaced the two hand-rolled filter buttons in `FilterPills` with `<FilterChip>`:
- Non-emergency filters: `tone="neutral"`, `dotColor={filter.dotColor}` (unused today but preserved from the old `FilterOption.dotColor` field).
- The emergencies filter: `tone="danger"` for its rest state (matches `FilterChip`'s built-in danger rest exactly: transparent bg, `--danger-border`, `--danger-text`), and the `tokens` prop to override the *active* fill with `--danger-strong` / `--danger-strong-ink` instead of `FilterChip`'s own translucent `--danger-bg` danger-active tone — `FilterChip`'s plain danger-active class would have regressed the WCAG-AA contrast fix from #1885 (a translucent `--danger-bg` tint under `--danger-text` fails AA in dark mode; `--danger-strong` is a solid, paired-contrast fill built specifically to fix that).
- The emergencies "an emergency is waiting" corner presence badge (`-top-0.5 -right-0.5 size-2.5`, absolutely positioned) has no `FilterChip` slot to render into (`FilterChip` renders a single `<button>` with no children slot), so it now wraps the chip in a `relative` container from the outside instead of being a child of the pill's own button. Not dropped — just repositioned one level out.

`getFilterClassName`, `getFilterBorderColor`, and the `getEmergencyPillStyle` import are removed; they had no other callers.

## Verified

- `npx eslint <changed files>` — clean.
- `npx tsc --noEmit` (apps/frontend) — clean.
- `pnpm --filter frontend run test -- --testPathPatterns="Calendar/common/Header"` — 21/21 passed.
- `pnpm --filter frontend run test -- --testPathPatterns="Filters/FilterChip"` — 6/6 passed (untouched, confirms no regression to the shared primitive).
- Coverage on the touched file: Statements 100%, Branches 97.22% (unchanged — the two uncovered branches are in the pre-existing, untouched `useAnchoredDropdown` width calc, not in the code this PR touches), Functions 100%, Lines 100%.
- Aikido SAST/secrets scan on both changed files — 0 issues.
- Mutation-check: reverted only `Header.tsx` to `origin/dev` and reran the updated test file against the old implementation — 2 of 21 tests failed as expected (the two assertions pinned to `FilterChip`'s classes), proving the tests actually exercise this change. Then restored the fix, reran clean (21/21), and confirmed `git diff origin/dev HEAD -- Header.tsx` shows exactly the intended change with no reverted content left staged.

Two existing test assertions were updated because the *mechanism* that delivers the same design tokens changed (inline `style` on a hand-rolled `<button>` → `FilterChip`'s Tailwind classes / `tokens`-prop inline style), not because the visual result changed:
- The inactive-emergency-pill assertions moved from checking an inline `style` attribute to checking `FilterChip`'s equivalent classes (`bg-transparent`, `border-[var(--danger-border)]!`, `text-[var(--danger-text)]!`).
- The active "All" pill assertion picked up the trailing `!` that `FilterChip`'s neutral-active class carries on its border/text tokens (`text-[var(--chip-selected-ink)]!`).
- `getEmergencyDot` now looks at the button's parent element, since the presence badge is a sibling of the button (inside the wrapping div) rather than a child of it.

The `Header.stories.tsx` `EmergencyFilterActive` play function asserts `toHaveClass('font-bold')` on the active emergency pill — `FilterChip` drops its own weight class when an active chip carries `tokens` (the inline style carries `fontWeight: 700` instead), so the migration passes `className="font-bold"` through explicitly to keep that class present, satisfying the story's assertion without changing font weight.

## Test plan

- [x] `npx eslint apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx`
- [x] `npx tsc --noEmit` (apps/frontend)
- [x] `pnpm --filter frontend run test -- --testPathPatterns="Calendar/common/Header"` (21/21)
- [x] `pnpm --filter frontend run test -- --testPathPatterns="Filters/FilterChip"` (6/6, unchanged file)
- [x] Aikido scan on changed files (0 issues)
- [x] Mutation-check on the updated test assertions (see Verified)
