### PR TITLE
fix(frontend): replace Guides category tabs with shared FilterChip

### DIFF
--- a/apps/frontend/src/app/__tests__/features/guides/pages/Guides.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/guides/pages/Guides.test.tsx
@@ -167,6 +167,23 @@ describe('Guides page', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders category tabs as the shared FilterChip, not a hand-rolled pill', () => {
+    /* A hand-rolled button carries no aria-pressed at all, so
+       toHaveAttribute('aria-pressed', ...) fails outright on it - this pins the
+       category row to FilterChip rather than merely re-checking the filtering
+       behaviour above, which a hand-rolled lookalike would also pass. */
+    render(<ProtectedGuides />);
+    const allChip = screen.getByRole('button', { name: 'All' });
+    const visitChip = screen.getByRole('button', { name: 'The visit' });
+    expect(allChip).toHaveAttribute('aria-pressed', 'true');
+    expect(visitChip).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(visitChip);
+
+    expect(visitChip).toHaveAttribute('aria-pressed', 'true');
+    expect(allChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
   it('narrows the shelf to one role, and keeps what everyone needs', () => {
     render(<ProtectedGuides />);
 

--- a/apps/frontend/src/app/features/guides/pages/Guides.tsx
+++ b/apps/frontend/src/app/features/guides/pages/Guides.tsx
@@ -194,33 +194,14 @@ export const Guides = () => {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          {categories.map((category) => {
-            const isActive = category === activeCategory;
-            return (
-              <button
-                type="button"
-                key={category}
-                onClick={() => setActiveCategory(category)}
-                className="rounded-full border px-[15px] py-[7px] text-[12.5px] transition-colors"
-                style={
-                  isActive
-                    ? {
-                        backgroundColor: 'var(--inset)',
-                        borderColor: 'var(--divider)',
-                        color: 'var(--ink)',
-                        fontWeight: 700,
-                      }
-                    : {
-                        borderColor: 'var(--hairline)',
-                        color: 'var(--ink-muted)',
-                        fontWeight: 600,
-                      }
-                }
-              >
-                {category}
-              </button>
-            );
-          })}
+          {categories.map((category) => (
+            <FilterChip
+              key={category}
+              label={category}
+              active={category === activeCategory}
+              onClick={() => setActiveCategory(category)}
+            />
+          ))}
         </div>
         <Search
           value={search}


### PR DESCRIPTION
## Summary
- `apps/frontend/src/app/features/guides/pages/Guides.tsx` (~line 197-223) hand-rolled its category tabs with a plain `<button>` at `px-[15px] py-[7px] text-[12.5px]` and no fixed height — a near-miss of `FilterChip`'s canonical `h-8 shrink-0 ... px-[13px] text-[12.5px]` pill (`apps/frontend/src/app/ui/filters/FilterChip.tsx:73`), matching text size but not padding/height, so the row visually mismatched every other chip row on the page.
- The persona ("For") row three lines above it in the same file already renders `FilterChip` (`Guides.tsx:184-191`), and `TaskFilterBar.tsx:101-107` documents the identical migration ("Was a hand-rolled ... chip ... The task board's filters are the same control as Finance's and Guides'"), confirming Guides' category row was the one sibling left un-migrated.
- Fix: replaced the hand-rolled `<button>` loop with `<FilterChip label active onClick>`, same pattern as the persona row directly above it.

## Verified
- `npx eslint src/app/features/guides/pages/Guides.tsx src/app/__tests__/features/guides/pages/Guides.test.tsx` — clean.
- `npx tsc --noEmit` (apps/frontend) — clean, no errors.
- `npx jest --testPathPatterns='__tests__/features/guides/pages/Guides|__tests__/components/Filters/FilterChip|__tests__/components/tasks/TaskFilterBar'` — 3 suites, 32 tests passed (correctly scoped; a bare `--testPathPatterns=FilterChip` over-matches this worktree's own directory name and silently runs the full 1052-suite repo, so the pattern was anchored under `__tests__/...`).
- Mutation-check: added a new test asserting the category chips carry `aria-pressed` (a hand-rolled `<button>` has none). Reverted only `Guides.tsx` to the pre-fix `origin/dev` version, confirmed the new test fails (`Expected the element to have attribute: aria-pressed="true" / Received: null`), then restored the fix and confirmed the full scoped suite passes again. `git diff` on the source file showed exactly the intended change before committing.
- Visual QA (Storybook `Guides — Full library` story, since the page route requires auth the story bypasses): category row now renders as the same solid-pill/hairline-outline chip as the persona row above it, in both light and dark tokens (`--chip-selected-bg/ink` vs `--hairline`/`--ink-muted`), and click interaction correctly toggles `aria-pressed` and the active pill.
- Pre-push hook (full monorepo lint + typecheck via turbo) passed: `Tasks: 17 successful, 17 total`.

## Test plan
- [x] Existing Guides page tests (14) still pass unmodified — behavior (filtering, empty states, player) is unchanged.
- [x] New test pins the FilterChip migration and mutation-checked (fails without the fix, passes with it).
- [x] Typecheck and lint clean on both changed files.
- [x] Visual check in Storybook, light + dark tokens, active/rest + click interaction.