### PR TITLE
fix(frontend): use StatusPill for chat GroupModal owner badge

### DIFF
--- a/apps/frontend/src/app/__tests__/components/chat/GroupModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/GroupModal.test.tsx
@@ -199,6 +199,18 @@ describe('GroupModal', () => {
       expect(screen.getByText('Delete Group')).toBeInTheDocument();
     });
 
+    it('renders the owner badge on shared StatusPill geometry, not a hand-rolled near-miss', () => {
+      setup(editProps());
+      const badge = screen.getByText('Owner');
+      // StatusPill's canonical micro-badge type: 10px/700, +0.08em, tagged with its
+      // own marker class - the near-miss this replaced used 9.5px/+0.06em instead.
+      expect(badge.className).toContain('yc-status-pill');
+      expect(badge.className).toContain('text-[10px]');
+      expect(badge.className).toContain('tracking-[0.08em]');
+      expect(badge.className).not.toContain('text-[9.5px]');
+      expect(badge.className).not.toContain('tracking-[0.06em]');
+    });
+
     it('falls back to a generic header when the group has no title yet', () => {
       setup(editProps({ placeholder: '   ' }));
       expect(screen.getByText('Group chat · group')).toBeInTheDocument();

--- a/apps/frontend/src/app/features/chat/components/GroupModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/GroupModal.stories.tsx
@@ -316,10 +316,11 @@ export const EditAsCreator: Story = {
     docs: {
       description: {
         story:
-          'The full creator tree, and the only place the Owner pill exists: a soft-blue 9.5px ' +
-          'uppercase chip on a hairline border, deliberately not the solid brand badge. The owner ' +
-          'row has no Remove link at all rather than a disabled one, so a group can never be left ' +
-          'without its creator.',
+          'The full creator tree, and the only place the Owner pill exists: a StatusPill on a ' +
+          'soft-blue token set (a hairline border, deliberately not the solid brand badge), so it ' +
+          'shares the app-wide pill geometry instead of hand-rolling its own. The owner row has no ' +
+          'Remove link at all rather than a disabled one, so a group can never be left without its ' +
+          'creator.',
       },
     },
   },

--- a/apps/frontend/src/app/features/chat/components/GroupModal.tsx
+++ b/apps/frontend/src/app/features/chat/components/GroupModal.tsx
@@ -17,6 +17,7 @@ import Modal from '@/app/ui/overlays/Modal';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
 import ModalFooter from '@/app/ui/overlays/Modal/ModalFooter';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { ChatAvatar } from './ChatAvatar';
 
 export type OrgUserOption = {
@@ -225,11 +226,17 @@ export const GroupModal: FC<GroupModalProps> = ({
                       </div>
                       <div className="flex items-center gap-2">
                         {/* Design (group chat modal): the owner marker is a soft-blue
-                            pill, not the solid brand badge. */}
+                            pill, not the solid brand badge - colour only, geometry comes
+                            from StatusPill's `tokens` override. */}
                         {mode === 'edit' && m.id === ownerId && (
-                          <span className="inline-flex items-center rounded-full border border-[var(--hairline)] bg-[var(--blue-soft)] px-2.5 py-[3px] text-[9.5px] font-bold uppercase tracking-[0.06em] text-[var(--blue-text)]">
-                            Owner
-                          </span>
+                          <StatusPill
+                            label="Owner"
+                            tokens={{
+                              bg: 'var(--blue-soft)',
+                              text: 'var(--blue-text)',
+                              border: 'var(--hairline)',
+                            }}
+                          />
                         )}
                         {/* Design: an inline "Remove" text link, not a trash icon. */}
                         {isCreator && m.id !== ownerId && (


### PR DESCRIPTION
## What is the current behavior?

`GroupModal.tsx` (the chat group create/edit drawer) hand-rolls its own "Owner" badge for the group creator (`apps/frontend/src/app/features/chat/components/GroupModal.tsx:230` before this change):

```tsx
<span className="inline-flex items-center rounded-full border border-[var(--hairline)] bg-[var(--blue-soft)] px-2.5 py-[3px] text-[9.5px] font-bold uppercase tracking-[0.06em] text-[var(--blue-text)]">
  Owner
</span>
```

This is a near-exact copy of the app's shared `StatusPill` micro-badge (`apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx`), but 0.5px and 0.02em off its canonical geometry: `text-[9.5px]`/`tracking-[0.06em]` instead of StatusPill's `text-[10px]`/`tracking-[0.08em]`. It reads as an oversight, not an intentional variant - a real, measurable near-miss a design-system audit flagged.

## What is the new behavior?

Replaced the hand-rolled `<span>` with `<StatusPill label="Owner" tokens={{...}} />`, passing the badge's existing soft-blue colours (`--blue-soft` / `--blue-text` / `--hairline`) through StatusPill's `tokens` prop - which exists for exactly this case: callers that already resolve their own status colour adopting the shared geometry without rewriting their colour logic. Colour is unchanged; only the geometry now matches every other pill in the app.

Also updated the stale Storybook description on `EditAsCreator` (`GroupModal.stories.tsx`) that cited the old "9.5px" figure, so the docs don't contradict the component.

## Related Issue(s)

Fixes #

## Verified

- `pnpm --filter frontend run test -- --testPathPatterns="GroupModal"` - 30/30 passed (added a new assertion pinning `StatusPill`'s `yc-status-pill`/`text-[10px]`/`tracking-[0.08em]` classes on the Owner badge, and asserting the old `text-[9.5px]`/`tracking-[0.06em]` classes are gone).
- **Mutation-check**: reverted `GroupModal.tsx` to `origin/dev` and reran the same test - the new assertion failed as expected (`Expected substring: "yc-status-pill" / Received: "...text-[9.5px]...tracking-[0.06em]..."`), confirming the test actually pins the fix. Restored the fix and reran clean (30/30). Confirmed via `git diff HEAD~1 HEAD -- .../GroupModal.tsx` that the committed source matches the intended fix, not the reverted content.
- `npx eslint` on the three changed files - clean, no output.
- `npx tsc --noEmit` from `apps/frontend` - exit code 0, no errors.
- `git push` - pre-push hook (`turbo run lint` + `turbo run type-check` across the whole monorepo) passed: 17/17 tasks successful.

## Test plan

- [x] Existing `GroupModal.test.tsx` suite passes (30/30)
- [x] New test pins the StatusPill geometry on the Owner badge and was mutation-checked (fails on the old hand-rolled span, passes on the fix)
- [x] `eslint` clean on changed files
- [x] `tsc --noEmit` clean
- [x] Full monorepo lint + type-check clean (pre-push hook)