### PR TITLE
fix(frontend): route PhoneMyDayRail Signed badge through StatusPill

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneMyDayRail.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneMyDayRail.test.tsx
@@ -270,7 +270,11 @@ describe('PhoneMyDayRail', () => {
       expect(screen.getByTestId('icon-bed')).toBeInTheDocument();
       expect(screen.getByText('Poppy · Surolan 5 drops L ear')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
-      expect(screen.getByText('Signed')).toBeInTheDocument();
+      const signedBadge = screen.getByText('Signed');
+      expect(signedBadge).toBeInTheDocument();
+      // Pins the shared StatusPill success tone (not a hand-rolled --status-completed-* badge).
+      expect(signedBadge).toHaveClass('yc-status-pill');
+      expect(signedBadge).toHaveStyle({ backgroundColor: 'var(--color-pill-success-bg)' });
     });
 
     it('reports opening the ward and signing an item', async () => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import AvatarImage from '@/app/ui/avatars/AvatarImage';
 import CompanionAvatar from '@/app/ui/avatars/CompanionAvatar';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import clsx from 'clsx';
 import { IoBedOutline, IoCheckboxOutline, IoCheckmark } from 'react-icons/io5';
 import { getAppointmentCompanionPhotoUrl } from '@/app/lib/appointments';
@@ -314,9 +315,7 @@ const RoundRow = ({
             Sign
           </button>
         ) : (
-          <span className="rounded-full border border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-2.5 py-1 text-[9.5px] font-bold text-[var(--status-completed-text)]">
-            Signed
-          </span>
+          <StatusPill label="Signed" tone="success" />
         )}
       </div>
     ))}


### PR DESCRIPTION
## Summary

- `PhoneMyDayRail.tsx`'s round-item "Signed" badge (`RoundRow`, previously around line 307-309) hand-rolled its own pill markup off CSS custom properties in a wholly separate `--status-completed-*` namespace, instead of going through the shared `StatusPill` primitive and its `TONE_TOKENS` map (`apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx`).
- Confirmed in `apps/frontend/src/app/globals.css` that `--color-pill-success-bg/text/border` (lines 464-466, both light and dark theme blocks) are direct aliases of `--status-completed-bg/text/border` - so `StatusPill`'s `success` tone resolves to the exact same colors the hand-rolled badge used, not an approximation.
- Replaced the hand-rolled `<span>` with `<StatusPill label="Signed" tone="success" />`, matching how the rest of the app renders status badges.

## Verified

- `cd apps/frontend && npx tsc --noEmit` - clean, 0 output.
- `pnpm --filter frontend run lint` (targeted: `npx eslint` on both changed files) - 0 errors/warnings.
- `pnpm --filter frontend run test -- --testPathPatterns="__tests__/components/Calendar/responsive/PhoneMyDayRail\.test\.tsx$"` - 1 suite, 28 tests, all passing.
  - Note: the naive unanchored pattern `--testPathPatterns="PhoneMyDayRail"` ran the FULL 1052-suite frontend test run (worktree dir name `wt-phonemydayrail-signed` matched the pattern too) - one unrelated pre-existing flake surfaced in `Companion.test.tsx` (breed-code resolution), nothing to do with this change. Re-ran with an anchored pattern to get the correct targeted 1-suite run.
- **Mutation check**: added a new assertion pinning the fix (`PhoneMyDayRail.test.tsx`, "renders the round heading, items and sign affordances" test) - checks the Signed badge has class `yc-status-pill` and inline `backgroundColor: var(--color-pill-success-bg)`. Reverted only the source file to pre-fix content, reran the targeted test, confirmed it FAILED with `Expected the element to have class: yc-status-pill / Received: rounded-full border border-[var(--status-completed-border)]...`. Restored the fix, reran clean (28/28 passing). Confirmed `git diff HEAD~1 HEAD -- <source file>` shows exactly the intended change (no stale reverted index content).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Targeted eslint clean
- [x] Targeted jest suite passing (28/28)
- [x] New assertion mutation-checked (fails on pre-fix source, passes on fixed source)
- [x] No other hand-rolled `--status-*` badges introduced or touched in this file (existing `CompletedAppointmentCard`/`UpcomingAppointmentCard`/task-status usages of `--status-completed-*`/`--status-upcoming-*`/`--status-cancelled-*` were left untouched - out of scope for this fix, which targets only the StatusPill-namespace mismatch called out in the task)
