### PR TITLE
fix(frontend): align companion alert chips to StatusPill's box

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/AddCompanionPresentational.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/AddCompanionPresentational.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  AlertChipView,
+  AlertChipEdit,
+} from '@/app/features/companions/components/AddCompanionCentralModal/AddCompanionPresentational';
+import type { CompanionAlert } from '@/app/features/companions/components/AddCompanion/type';
+
+// ─── AlertChipView / AlertChipEdit — StatusPill geometry parity ────────────────
+//
+// Both chips must render the same box the design system's `StatusPill` uses
+// (10px/700 uppercase, +0.08em tracking, 3px 10px padding, `leading: normal`) so
+// an alert badge doesn't visibly mismatch every other status pill in the app.
+// `AlertChipView` renders `StatusPill` directly; `AlertChipEdit` keeps its own
+// markup for the inline remove button but must match its geometry.
+
+const alert: CompanionAlert = { id: 'a1', label: 'Diabetic', priority: 'high' };
+
+describe('AlertChipView', () => {
+  it('renders through the shared StatusPill box', () => {
+    render(<AlertChipView alert={alert} />);
+    const chip = screen.getByText('Diabetic');
+    expect(chip).toHaveClass(
+      'yc-status-pill',
+      'px-2.5',
+      'leading-[normal]',
+      'uppercase',
+      'tracking-[0.08em]'
+    );
+  });
+
+  it('colours from the alert priority config', () => {
+    render(<AlertChipView alert={alert} />);
+    expect(screen.getByText('Diabetic')).toHaveStyle({ backgroundColor: 'var(--danger-bg)' });
+  });
+
+  it('falls back to the medium tone for an unrecognised priority', () => {
+    render(<AlertChipView alert={{ id: 'a2', label: 'Odd', priority: 'unknown' as never }} />);
+    expect(screen.getByText('Odd')).toHaveStyle({ backgroundColor: 'var(--warn-bg)' });
+  });
+});
+
+describe('AlertChipEdit', () => {
+  it('matches StatusPill geometry: 2.5 padding, normal leading, uppercase, +0.08em tracking', () => {
+    render(<AlertChipEdit alert={alert} onRemove={jest.fn()} />);
+    const chip = screen.getByText('Diabetic').closest('span');
+    expect(chip).toHaveClass('px-2.5', 'leading-[normal]', 'uppercase', 'tracking-[0.08em]');
+    // Not px-[9px] / leading-[1.4] — the pre-fix geometry that mismatched StatusPill.
+    expect(chip).not.toHaveClass('px-[9px]');
+    expect(chip).not.toHaveClass('leading-[1.4]');
+  });
+
+  it('removes the alert when its close button is clicked', () => {
+    const onRemove = jest.fn();
+    render(<AlertChipEdit alert={alert} onRemove={onRemove} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove alert Diabetic' }));
+    expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+});

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionPresentational.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionPresentational.tsx
@@ -2,6 +2,7 @@ import React, { useId } from 'react';
 import { IoArrowForward, IoCameraOutline, IoClose } from 'react-icons/io5';
 import { FiCheck } from 'react-icons/fi';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   CompanionAlert,
   ALERT_PRIORITY_CONFIG,
@@ -33,18 +34,20 @@ export const InfoRow = ({ label, value }: { label: string; value: React.ReactNod
   </div>
 );
 
+/** Read-only alert badge: the shared status-pill box, coloured by alert priority. */
 export const AlertChipView = ({ alert }: { alert: CompanionAlert }) => {
   const cfg = ALERT_PRIORITY_CONFIG[alert.priority] ?? ALERT_PRIORITY_CONFIG.medium;
   return (
-    <span
-      className="inline-flex items-center rounded-full px-[9px] py-[3px] text-[10px] font-bold border leading-[1.4]"
-      style={{ background: cfg.bg, color: cfg.text, borderColor: cfg.border }}
-    >
-      {alert.label}
-    </span>
+    <StatusPill label={alert.label} tokens={{ bg: cfg.bg, text: cfg.text, border: cfg.border }} />
   );
 };
 
+/**
+ * Editable/removable alert chip. Not a plain `StatusPill` render - it carries an
+ * inline remove button `StatusPill` has no affordance for - but the box geometry
+ * (padding, leading, case, tracking) is kept identical to it on purpose so an
+ * edit-mode chip doesn't visibly mismatch the read-only one it replaces in place.
+ */
 export const AlertChipEdit = ({
   alert,
   onRemove,
@@ -55,7 +58,7 @@ export const AlertChipEdit = ({
   const cfg = ALERT_PRIORITY_CONFIG[alert.priority];
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-[9px] py-[3px] text-[10px] font-bold border leading-[1.4]"
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-[3px] text-[10px] font-bold uppercase tracking-[0.08em] border leading-[normal]"
       style={{ background: cfg.bg, color: cfg.text, borderColor: cfg.border }}
     >
       {alert.label}


### PR DESCRIPTION
## Summary

A design-system audit found that `AlertChipView`/`AlertChipEdit` in `apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionPresentational.tsx` (lines 36-73) reimplemented `StatusPill`'s micro-badge box instead of reusing it, and did so slightly wrong:

- `px-[9px]` instead of `px-2.5` (1px narrower padding on each side)
- `leading-[1.4]` instead of `leading-[normal]` - `StatusPill.tsx` lines 94-98 document this exact leading value as a deliberate fix for a prior bug where two different line-heights made the same status badge render at two different heights (21px vs 18px) across the app
- Missing `uppercase` and `tracking-[0.08em]`, which every other status pill in the app has

Both components were read in full, including their call sites:

- `AlertChipView` (`AddCompanionViewMode.tsx:130,194`) is purely read-only display - a `<span>{label}</span>` with no interactivity. It's now replaced outright with `<StatusPill tokens={{bg, text, border}} label={alert.label} />`, so it gets the exact shared box (`yc-status-pill` class and all).
- `AlertChipEdit` (`AddCompanionFormMode.tsx:494,736`) additionally renders an inline remove (`x`) button that calls `onRemove(alert.id)`. `StatusPill` has no affordance for a trailing interactive child, so this component is kept as a deliberate variant rather than forced into `StatusPill` - but its box geometry (padding, leading, case, tracking) is now aligned to match exactly, so the chip doesn't visibly shift/mismatch when a companion's alerts flip between view mode (`AlertChipView`) and edit mode (`AlertChipEdit`).

**Which one was fully migrated vs. only aligned:** `AlertChipView` -> fully migrated to `StatusPill`. `AlertChipEdit` -> kept as its own component (for the remove button) but geometry-aligned to `StatusPill`.

## Verified

- `npx tsc --noEmit` (from `apps/frontend`) - clean, no errors.
- `npx eslint` on both changed files - clean, no warnings.
- Targeted Jest run: `pnpm --filter frontend run test -- --testPathPatterns="AddCompanionCentralModal" --coverage --collectCoverageFrom="src/app/features/companions/components/AddCompanionCentralModal/AddCompanionPresentational.tsx"` -> **2 suites, 115 tests, all passed**. Coverage on the touched file: 100% statements, 100% lines, 100% functions, 95.23% branches (unchanged from before this change - the two uncovered branches are pre-existing and outside the lines touched here).
- Full repo test suite (`--testPathPatterns="StatusPill"`, which the runner resolved against the whole matching set) also came back **1053/1053 suites, 13309/13309 tests passed** - no regressions anywhere else in the app.
- **Mutation check**: reverted only the source file to `origin/dev` (`git checkout origin/dev -- AddCompanionPresentational.tsx`), reran the new test file - 4 of 5 new tests failed against the pre-fix geometry/markup as expected (class-name assertions for `px-2.5`/`leading-[normal]`/`uppercase`/`tracking-[0.08em]` on both `AlertChipView` and `AlertChipEdit`, plus the `StatusPill`-render assertion). Restored the fix, reran clean (115/115 passing), and confirmed with `git diff HEAD -- AddCompanionPresentational.tsx` that the working tree/index show exactly the intended fix (no accidental revert baked into the commit).
- Pre-push hook (monorepo `lint` + `type-check` via turbo) passed on push.

## Test plan

- [x] `AlertChipView` renders via the shared `StatusPill` component (verified by class assertions + color/token passthrough + unknown-priority fallback)
- [x] `AlertChipEdit` keeps its remove-button behavior (`onRemove` called with the alert id) while matching `StatusPill`'s padding/leading/case/tracking
- [x] Existing `AddCompanionCentralModal` suite (110 pre-existing tests covering view mode, edit mode, alerts, etc.) still passes unmodified
- [x] Mutation-checked: new tests fail against the pre-fix code, pass against the fix