### PR TITLE
fix(backend): sync Appointment.room when front desk reassigns a check-in's room

### DIFF
--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1862,6 +1862,34 @@ export const AppointmentPrismaService = {
     return toResponse(updated);
   },
 
+  async updateAppointmentRoom(
+    appointmentId: string,
+    organisationId: string,
+    room: { id: string; name: string },
+  ) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
+
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
+    });
+    assertExists(current as AppointmentRow | null, "Appointment not found");
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { room: toJsonValue(room), updatedAt: new Date() },
+    });
+
+    return toResponse(updated);
+  },
+
   async admitAppointmentToInpatient(
     appointmentId: string,
     organisationId: string,

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1882,12 +1882,12 @@ export const AppointmentPrismaService = {
     });
     assertExists(current as AppointmentRow | null, "Appointment not found");
 
-    const updated = await prisma.appointment.update({
+    // No caller uses the return value - this only exists to persist the
+    // room, so it skips the DTO conversion's extra payment-state queries.
+    await prisma.appointment.update({
       where: { id: appointmentId },
       data: { room: toJsonValue(room), updatedAt: new Date() },
     });
-
-    return toResponse(updated);
   },
 
   async admitAppointmentToInpatient(

--- a/apps/backend/src/services/patient-check-in.service.ts
+++ b/apps/backend/src/services/patient-check-in.service.ts
@@ -101,6 +101,38 @@ const syncAppointmentOnArrival = async (
   }
 };
 
+/**
+ * Front desk's "current room" and the schedule's own Appointment.room are
+ * the same fact tracked in two places: reassigning a room at check-in never
+ * touched the appointment, so the Board kept showing whatever room the
+ * appointment was booked into even after the patient moved. Best-effort for
+ * the same reason as syncAppointmentOnArrival - a check-in isn't always
+ * linked to an appointment, and a stale/terminal appointment shouldn't block
+ * the front desk from recording a room move.
+ */
+const syncAppointmentRoom = async (
+  appointmentId: string | undefined,
+  organisationId: string,
+  roomId: string,
+): Promise<void> => {
+  if (!appointmentId) return;
+  const room = await prisma.organisationRoom.findFirst({
+    where: { id: roomId, organisationId },
+    select: { id: true, name: true },
+  });
+  if (!room) return;
+  try {
+    await AppointmentPrismaService.updateAppointmentRoom(
+      appointmentId,
+      organisationId,
+      room,
+    );
+  } catch (err) {
+    if (err instanceof AppointmentPrismaServiceError) return;
+    throw err;
+  }
+};
+
 export const PatientCheckInService = {
   async create(params: CreateCheckInParams) {
     const record = await prisma.patientCheckIn.create({
@@ -259,11 +291,19 @@ export const PatientCheckInService = {
   },
 
   async assignRoom(id: string, organisationId: string, roomId: string) {
-    await assertCheckIn(id, organisationId);
-    return prisma.patientCheckIn.update({
+    const existing = await assertCheckIn(id, organisationId);
+    const record = await prisma.patientCheckIn.update({
       where: { id },
       data: { assignedRoomId: roomId },
       select: checkInSelect,
     });
+
+    await syncAppointmentRoom(
+      existing.appointmentId ?? undefined,
+      organisationId,
+      roomId,
+    );
+
+    return record;
   },
 };

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -4695,18 +4695,16 @@ describe("AppointmentPrismaService", () => {
       expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
     });
 
-    it("updates the appointment's room and returns the refreshed response", async () => {
+    it("updates the appointment's room", async () => {
       mockedPrisma.appointment.findFirst.mockResolvedValue(makeRow());
       mockedPrisma.appointment.update.mockResolvedValue(
         makeRow({ room: { id: "room_2", name: "Room 2" } }),
       );
-      mockedPrisma.invoice.findMany.mockResolvedValue([]);
 
-      const result = await AppointmentPrismaService.updateAppointmentRoom(
-        "appt_1",
-        "org_1",
-        { id: "room_2", name: "Room 2" },
-      );
+      await AppointmentPrismaService.updateAppointmentRoom("appt_1", "org_1", {
+        id: "room_2",
+        name: "Room 2",
+      });
 
       expect(mockedPrisma.appointment.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -4716,7 +4714,9 @@ describe("AppointmentPrismaService", () => {
           }),
         }),
       );
-      expect((result as any).room).toEqual({ id: "room_2", name: "Room 2" });
+      // The DTO conversion (toResponse) queries payment state, which this
+      // discarded-return method has no caller that needs - it must not run.
+      expect(mockedPrisma.invoice.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -4650,4 +4650,73 @@ describe("AppointmentPrismaService", () => {
       );
     });
   });
+
+  describe("updateAppointmentRoom", () => {
+    it("requires an appointmentId", async () => {
+      await expect(
+        AppointmentPrismaService.updateAppointmentRoom("", "org_1", {
+          id: "room_1",
+          name: "Room 1",
+        }),
+      ).rejects.toMatchObject({
+        message: "appointmentId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.updateAppointmentRoom("appt_1", "", {
+          id: "room_1",
+          name: "Room 1",
+        }),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("throws 404 when the appointment is not found in this organisation", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.updateAppointmentRoom("appt_1", "org_1", {
+          id: "room_1",
+          name: "Room 1",
+        }),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_1", organisationId: "org_1" },
+      });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+    });
+
+    it("updates the appointment's room and returns the refreshed response", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(makeRow());
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ room: { id: "room_2", name: "Room 2" } }),
+      );
+      mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+      const result = await AppointmentPrismaService.updateAppointmentRoom(
+        "appt_1",
+        "org_1",
+        { id: "room_2", name: "Room 2" },
+      );
+
+      expect(mockedPrisma.appointment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "appt_1" },
+          data: expect.objectContaining({
+            room: { id: "room_2", name: "Room 2" },
+          }),
+        }),
+      );
+      expect((result as any).room).toEqual({ id: "room_2", name: "Room 2" });
+    });
+  });
 });

--- a/apps/backend/test/services/patient-check-in.service.test.ts
+++ b/apps/backend/test/services/patient-check-in.service.test.ts
@@ -6,6 +6,9 @@ jest.mock("src/config/prisma", () => ({
       findMany: jest.fn(),
       update: jest.fn(),
     },
+    organisationRoom: {
+      findFirst: jest.fn(),
+    },
   },
 }));
 jest.mock("../../src/services/audit-trail.service", () => ({
@@ -22,7 +25,10 @@ jest.mock("../../src/services/appointment.prisma.service", () => {
     }
   }
   return {
-    AppointmentPrismaService: { checkInAppointment: jest.fn() },
+    AppointmentPrismaService: {
+      checkInAppointment: jest.fn(),
+      updateAppointmentRoom: jest.fn(),
+    },
     AppointmentPrismaServiceError,
   };
 });
@@ -40,6 +46,8 @@ import {
 const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockedCheckInAppointment =
   AppointmentPrismaService.checkInAppointment as jest.Mock;
+const mockedUpdateAppointmentRoom =
+  AppointmentPrismaService.updateAppointmentRoom as jest.Mock;
 
 const arrivedAt = new Date("2026-06-30T09:00:00Z");
 const baseCheckIn = {
@@ -329,6 +337,118 @@ describe("PatientCheckInService", () => {
         "room-3",
       );
       expect(result.assignedRoomId).toBe("room-3");
+    });
+
+    it("does not touch the appointment when the check-in is not linked to one", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue(
+        baseCheckIn,
+      );
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        assignedRoomId: "room-3",
+      });
+      await PatientCheckInService.assignRoom("checkin-1", "org-1", "room-3");
+      expect(mockedPrisma.organisationRoom.findFirst).not.toHaveBeenCalled();
+      expect(mockedUpdateAppointmentRoom).not.toHaveBeenCalled();
+    });
+
+    it("syncs the linked appointment's room so the Board reflects the move", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        assignedRoomId: "room-3",
+      });
+      (mockedPrisma.organisationRoom.findFirst as jest.Mock).mockResolvedValue({
+        id: "room-3",
+        name: "Room 3",
+      });
+      mockedUpdateAppointmentRoom.mockResolvedValue(undefined);
+
+      await PatientCheckInService.assignRoom("checkin-1", "org-1", "room-3");
+
+      expect(mockedPrisma.organisationRoom.findFirst).toHaveBeenCalledWith({
+        where: { id: "room-3", organisationId: "org-1" },
+        select: { id: true, name: true },
+      });
+      expect(mockedUpdateAppointmentRoom).toHaveBeenCalledWith(
+        "appt-1",
+        "org-1",
+        { id: "room-3", name: "Room 3" },
+      );
+    });
+
+    it("skips the sync when the room cannot be found in this organisation", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        assignedRoomId: "room-3",
+      });
+      (mockedPrisma.organisationRoom.findFirst as jest.Mock).mockResolvedValue(
+        null,
+      );
+
+      await PatientCheckInService.assignRoom("checkin-1", "org-1", "room-3");
+
+      expect(mockedUpdateAppointmentRoom).not.toHaveBeenCalled();
+    });
+
+    it("still assigns the room when the appointment cannot be updated (e.g. cancelled)", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      const updated = {
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        assignedRoomId: "room-3",
+      };
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue(
+        updated,
+      );
+      (mockedPrisma.organisationRoom.findFirst as jest.Mock).mockResolvedValue({
+        id: "room-3",
+        name: "Room 3",
+      });
+      mockedUpdateAppointmentRoom.mockRejectedValue(
+        new AppointmentPrismaServiceError("Appointment not found", 404),
+      );
+
+      const result = await PatientCheckInService.assignRoom(
+        "checkin-1",
+        "org-1",
+        "room-3",
+      );
+
+      expect(result.assignedRoomId).toBe("room-3");
+    });
+
+    it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        assignedRoomId: "room-3",
+      });
+      (mockedPrisma.organisationRoom.findFirst as jest.Mock).mockResolvedValue({
+        id: "room-3",
+        name: "Room 3",
+      });
+      mockedUpdateAppointmentRoom.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        PatientCheckInService.assignRoom("checkin-1", "org-1", "room-3"),
+      ).rejects.toThrow("db down");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Front desk's `PatientCheckIn.assignedRoomId` and the schedule's `Appointment.room` were two independent writes tracking the same fact: which room the patient is currently in.
- Reassigning a room from the front desk never touched the linked appointment, so the Board kept showing whatever room the appointment was originally booked into even after the patient moved.
- `PatientCheckInService.assignRoom` now also syncs `Appointment.room` (best-effort, mirroring the existing `syncAppointmentOnArrival` pattern from #2885) when the check-in is linked to an appointment.
- Added `AppointmentPrismaService.updateAppointmentRoom`, a small targeted write (not the general-purpose `updateAppointmentPMS`, which requires a full `AppointmentRequestDTO` and handles unrelated concerns).

## Test plan
- [x] `patient-check-in.service.test.ts`: 24/24 passing, including 5 new cases covering the sync (linked appointment, unlinked check-in, unknown room, appointment update failure is swallowed, unexpected error still propagates)
- [x] Mutation-checked: reverted the source to HEAD with the new tests still in place — 2 tests failed as expected, confirming they actually exercise the fix
- [x] `tsc --noEmit`: zero new errors introduced (confirmed against the same pre-existing baseline on unmodified HEAD)
- Pre-existing typed-lint noise in this file (`no-unsafe-member-access` on `prisma.*`) is a worktree-local stale type-resolution artifact, confirmed present on unmodified HEAD before this change