### PR TITLE
fix(backend): make waitlist Book actually create and link an appointment

### DIFF
--- a/apps/backend/src/controllers/web/waitlist.controller.ts
+++ b/apps/backend/src/controllers/web/waitlist.controller.ts
@@ -32,6 +32,13 @@ const ListQuerySchema = z.object({
 
 const EntryParamsSchema = orgParams.extend({ entryId: uuid() });
 
+/**
+ * `book()` links to an appointment staff already created through the
+ * ordinary New Appointment form (pre-filled from this entry) - it does not
+ * take a slot itself.
+ */
+const BookBodySchema = z.object({ appointmentId: uuid() });
+
 const { handler } = createClinicalHandlers(WaitlistError);
 
 export const WaitlistController = {
@@ -80,9 +87,15 @@ export const WaitlistController = {
 
   book: handler({
     params: EntryParamsSchema,
+    body: BookBodySchema,
     fallback: "Failed to book waitlist entry",
-    run: ({ params, userId }) =>
-      WaitlistService.book(params.entryId, params.organisationId, userId),
+    run: ({ params, input, userId }) =>
+      WaitlistService.book(
+        params.entryId,
+        params.organisationId,
+        input.appointmentId,
+        userId,
+      ),
   }),
 
   cancel: handler({

--- a/apps/backend/src/services/waitlist.service.ts
+++ b/apps/backend/src/services/waitlist.service.ts
@@ -4,6 +4,11 @@ import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
 import { NotificationTemplates } from "src/utils/notificationTemplates";
 import { notifyPatientOwner } from "src/services/shared/owner-notification";
+import {
+  AppointmentPrismaService,
+  AppointmentPrismaServiceError,
+} from "./appointment.prisma.service";
+import { fromAppointmentRequestDTO } from "@yosemite-crew/types";
 
 export class WaitlistError extends Error {
   constructor(
@@ -47,6 +52,7 @@ const entrySelect = {
   status: true,
   offeredAt: true,
   bookedAt: true,
+  appointmentId: true,
   expiresAt: true,
   createdAt: true,
   updatedAt: true,
@@ -172,7 +178,31 @@ export const WaitlistService = {
     return updated;
   },
 
-  async book(id: string, organisationId: string, bookedBy?: string) {
+  /**
+   * Closes a waitlist entry out against the Appointment staff actually booked
+   * it into.
+   *
+   * Before this, `book()` only flipped the entry's own status - no Appointment
+   * was ever linked, so nothing connected the two rows. A waitlist entry has
+   * no time slot by design (only an earliest/latest date range), so this does
+   * not create one: the PIMS "Book" action opens the ordinary New Appointment
+   * form (pre-filled from this entry's patient and date range) and lets staff
+   * pick the slot through the normal create flow, then calls this with the
+   * appointment that flow just created. Re-creating the appointment here
+   * instead would either duplicate it or fight that already-working form.
+   *
+   * `appointmentId` is resolved through `AppointmentPrismaService.getById`
+   * scoped to `organisationId`, so a caller cannot link an entry to another
+   * tenant's appointment - the lookup itself 404s across the boundary. The
+   * patient match below additionally guards against linking the right
+   * tenant's appointment but the wrong patient's.
+   */
+  async book(
+    id: string,
+    organisationId: string,
+    appointmentId: string,
+    bookedBy?: string,
+  ) {
     const entry = await assertEntry(id, organisationId);
     if (entry.status !== "OFFERED" && entry.status !== "WAITING") {
       throw new WaitlistError(
@@ -181,9 +211,28 @@ export const WaitlistService = {
       );
     }
 
+    let appointment;
+    try {
+      appointment = await AppointmentPrismaService.getById(appointmentId, {
+        organisationId,
+      });
+    } catch (err) {
+      if (err instanceof AppointmentPrismaServiceError) {
+        throw new WaitlistError(err.message, err.statusCode);
+      }
+      throw err;
+    }
+
+    if (fromAppointmentRequestDTO(appointment).patient.id !== entry.patientId) {
+      throw new WaitlistError(
+        "The appointment does not belong to this waitlist entry's patient.",
+        400,
+      );
+    }
+
     const updated = await prisma.waitlistEntry.update({
       where: { id },
-      data: { status: "BOOKED", bookedAt: new Date() },
+      data: { status: "BOOKED", bookedAt: new Date(), appointmentId },
       select: entrySelect,
     });
 
@@ -195,7 +244,7 @@ export const WaitlistService = {
       actorId: bookedBy ?? null,
       entityType: "APPOINTMENT",
       entityId: id,
-      metadata: {},
+      metadata: { appointmentId },
     });
 
     return updated;

--- a/apps/backend/test/controllers/web/clinical/waitlist.controller.test.ts
+++ b/apps/backend/test/controllers/web/clinical/waitlist.controller.test.ts
@@ -121,9 +121,11 @@ runClinicalControllerSuite({
     {
       handler: "book",
       params: { organisationId: ORG_ID, entryId: RECORD_ID },
+      body: { appointmentId: SECOND_ID },
       serviceMethod: "book",
-      expectArgs: [RECORD_ID, ORG_ID, USER_ID],
+      expectArgs: [RECORD_ID, ORG_ID, SECOND_ID, USER_ID],
       fallback: "Failed to book waitlist entry",
+      invalidPayload: { appointmentId: "" },
     },
     {
       handler: "cancel",

--- a/apps/backend/test/services/waitlist.service.test.ts
+++ b/apps/backend/test/services/waitlist.service.test.ts
@@ -4,6 +4,36 @@ import { AuditTrailService } from "src/services/audit-trail.service";
 import { NotificationService } from "src/services/notification.service";
 import { sendEmail } from "src/utils/email";
 import logger from "src/utils/logger";
+import {
+  AppointmentPrismaService,
+  AppointmentPrismaServiceError,
+} from "src/services/appointment.prisma.service";
+import { fromAppointmentRequestDTO } from "@yosemite-crew/types";
+
+jest.mock("@yosemite-crew/types", () => ({
+  ...(jest.requireActual("@yosemite-crew/types") as unknown as Record<
+    string,
+    unknown
+  >),
+  fromAppointmentRequestDTO: jest.fn(),
+  toAppointmentResponseDTO: jest.fn((appointment) => appointment),
+}));
+
+jest.mock("src/services/appointment.prisma.service", () => {
+  class AppointmentPrismaServiceError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "AppointmentPrismaServiceError";
+    }
+  }
+  return {
+    AppointmentPrismaService: { getById: jest.fn() },
+    AppointmentPrismaServiceError,
+  };
+});
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -90,6 +120,12 @@ beforeEach(() => {
   pm.parent.findUnique.mockResolvedValue(null);
   pm.patient.findUnique.mockResolvedValue({ name: "Buddy" });
   pm.appointment.findUnique.mockResolvedValue(null);
+  (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+    patient: { id: "pat-1" },
+  });
+  (AppointmentPrismaService.getById as jest.Mock).mockResolvedValue({
+    id: "appt-1",
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,23 +305,39 @@ describe("WaitlistService.offer", () => {
 // ---------------------------------------------------------------------------
 
 describe("WaitlistService.book", () => {
-  it("transitions WAITING to BOOKED", async () => {
-    await WaitlistService.book("entry-1", "org-1", "vet-1");
+  it("transitions WAITING to BOOKED and links the appointment", async () => {
+    const result = await WaitlistService.book(
+      "entry-1",
+      "org-1",
+      "appt-1",
+      "vet-1",
+    );
+
+    expect(AppointmentPrismaService.getById).toHaveBeenCalledWith("appt-1", {
+      organisationId: "org-1",
+    });
     expect(pm.waitlistEntry.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ status: "BOOKED" }),
+        data: expect.objectContaining({
+          status: "BOOKED",
+          appointmentId: "appt-1",
+        }),
       }),
     );
     expect(AuditTrailService.recordSafely).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: "WAITLIST_ENTRY_BOOKED" }),
+      expect.objectContaining({
+        eventType: "WAITLIST_ENTRY_BOOKED",
+        metadata: { appointmentId: "appt-1" },
+      }),
     );
+    expect(result.appointmentId).toBe("appt-1");
   });
 
   it("transitions OFFERED to BOOKED", async () => {
     pm.waitlistEntry.findFirst.mockResolvedValue(
       makeEntry({ status: "OFFERED" }),
     );
-    await WaitlistService.book("entry-1", "org-1");
+    await WaitlistService.book("entry-1", "org-1", "appt-1");
     expect(pm.waitlistEntry.update).toHaveBeenCalled();
   });
 
@@ -294,10 +346,46 @@ describe("WaitlistService.book", () => {
       makeEntry({ status: "CANCELLED" }),
     );
     await expect(
-      WaitlistService.book("entry-1", "org-1"),
+      WaitlistService.book("entry-1", "org-1", "appt-1"),
     ).rejects.toMatchObject({
       statusCode: 409,
     });
+    expect(AppointmentPrismaService.getById).not.toHaveBeenCalled();
+  });
+
+  it("rejects an appointment that does not belong to this entry's patient", async () => {
+    (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+      patient: { id: "some-other-patient" },
+    });
+
+    await expect(
+      WaitlistService.book("entry-1", "org-1", "appt-1"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(pm.waitlistEntry.update).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an AppointmentPrismaServiceError as a WaitlistError with the same status (e.g. appointment not found in this org)", async () => {
+    (AppointmentPrismaService.getById as jest.Mock).mockRejectedValue(
+      new AppointmentPrismaServiceError("Appointment not found", 404),
+    );
+
+    await expect(
+      WaitlistService.book("entry-1", "org-1", "appt-1"),
+    ).rejects.toMatchObject({
+      statusCode: 404,
+      message: "Appointment not found",
+    });
+    expect(pm.waitlistEntry.update).not.toHaveBeenCalled();
+  });
+
+  it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+    (AppointmentPrismaService.getById as jest.Mock).mockRejectedValue(
+      new Error("db down"),
+    );
+
+    await expect(
+      WaitlistService.book("entry-1", "org-1", "appt-1"),
+    ).rejects.toThrow("db down");
   });
 });
 

--- a/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/WaitlistPanel.test.tsx
@@ -73,7 +73,7 @@ describe('WaitlistPanel', () => {
   });
 
   it('loads the waitlist and resolves companion + owner names', async () => {
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await waitFor(() => expect(fetchWaitlist).toHaveBeenCalledWith('org-1'));
     expect(await screen.findByTestId('entry')).toHaveTextContent('Buddy/Sam Owner/WAITING');
     expect(screen.getByTestId('has-actions')).toHaveTextContent('true');
@@ -81,30 +81,37 @@ describe('WaitlistPanel', () => {
 
   it('withholds edit actions without permission', async () => {
     canEdit = false;
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await waitFor(() => expect(fetchWaitlist).toHaveBeenCalled());
     expect(screen.getByTestId('has-actions')).toHaveTextContent('false');
   });
 
-  it('runs an action then refetches', async () => {
+  it('hides the Book action when no onBookAppointment handler is given', async () => {
     render(<WaitlistPanel />);
+    await screen.findByTestId('entry');
+    expect(screen.queryByText('book')).not.toBeInTheDocument();
+  });
+
+  it('runs an action then refetches', async () => {
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await screen.findByText('offer');
     fireEvent.click(screen.getByText('offer'));
     await waitFor(() => expect(offerWaitlistEntry).toHaveBeenCalledWith('org-1', 'w-1'));
     expect(fetchWaitlist).toHaveBeenCalledTimes(2);
   });
 
-  it('books an offered entry then refetches', async () => {
-    render(<WaitlistPanel />);
+  it('hands the entry to onBookAppointment instead of booking directly', async () => {
+    const onBookAppointment = jest.fn();
+    render(<WaitlistPanel onBookAppointment={onBookAppointment} />);
     await screen.findByText('book');
     fireEvent.click(screen.getByText('book'));
-    await waitFor(() => expect(bookWaitlistEntry).toHaveBeenCalledWith('org-1', 'w-1'));
-    expect(fetchWaitlist).toHaveBeenCalledTimes(2);
+    expect(onBookAppointment).toHaveBeenCalledWith(expect.objectContaining(entry));
+    expect(bookWaitlistEntry).not.toHaveBeenCalled();
   });
 
   it('surfaces an error when an action fails', async () => {
     cancelWaitlistEntry.mockRejectedValueOnce(new Error('x'));
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await screen.findByText('cancel');
     fireEvent.click(screen.getByText('cancel'));
     await waitFor(() =>
@@ -113,7 +120,7 @@ describe('WaitlistPanel', () => {
   });
 
   it('adds an entry and refetches', async () => {
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await screen.findByText('add');
     fireEvent.click(screen.getByText('add'));
     await waitFor(() => expect(addToWaitlist).toHaveBeenCalledWith('org-1', { patientId: 'p-1' }));
@@ -121,7 +128,7 @@ describe('WaitlistPanel', () => {
 
   it('does not refetch when adding an entry fails', async () => {
     addToWaitlist.mockRejectedValueOnce(new Error('x'));
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await screen.findByText('add');
     fireEvent.click(screen.getByText('add'));
     await waitFor(() => expect(addToWaitlist).toHaveBeenCalled());
@@ -130,7 +137,7 @@ describe('WaitlistPanel', () => {
 
   it('shows a load error when the fetch throws', async () => {
     fetchWaitlist.mockReset().mockRejectedValue(new Error('down'));
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await waitFor(() =>
       expect(screen.getByTestId('error')).toHaveTextContent('Unable to load the waitlist')
     );
@@ -138,7 +145,7 @@ describe('WaitlistPanel', () => {
 
   it('renders nothing to load without a primary org', async () => {
     primaryOrgId = null;
-    render(<WaitlistPanel />);
+    render(<WaitlistPanel onBookAppointment={jest.fn()} />);
     await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
     expect(fetchWaitlist).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/services/waitlistService.test.ts
@@ -115,12 +115,17 @@ describe('waitlistService', () => {
 
   it.each([
     ['offer', offerWaitlistEntry],
-    ['book', bookWaitlistEntry],
     ['cancel', cancelWaitlistEntry],
   ] as const)('posts the %s transition', async (action, fn) => {
     postDataMock.mockResolvedValue({ data: { ...entry, status: 'OFFERED' } });
     await fn('org-1', 'w-1');
-    expect(postDataMock).toHaveBeenCalledWith(`${BASE}/w-1/${action}`);
+    expect(postDataMock).toHaveBeenCalledWith(`${BASE}/w-1/${action}`, undefined);
+  });
+
+  it('books an entry against the appointment already created for it', async () => {
+    postDataMock.mockResolvedValue({ data: { ...entry, status: 'BOOKED' } });
+    await bookWaitlistEntry('org-1', 'w-1', 'appt-1');
+    expect(postDataMock).toHaveBeenCalledWith(`${BASE}/w-1/book`, { appointmentId: 'appt-1' });
   });
 
   it.each(['', '../admin', 'entry/other', 'https://attacker.test'])(

--- a/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
@@ -348,9 +348,9 @@ describe('Appointments page', () => {
     await act(async () => {
       await addAppointmentSpy.mock.calls
         .at(-1)?.[0]
-        .onAppointmentCreated({ patient: { id: 'c1' } });
+        .onAppointmentCreated({ id: 'appt-created-1', patient: { id: 'c1' } });
     });
-    expect(bookWaitlistEntryMock).toHaveBeenCalledWith('org-1', 'wait-1');
+    expect(bookWaitlistEntryMock).toHaveBeenCalledWith('org-1', 'wait-1', 'appt-created-1');
   });
 
   it('clamps an elapsed waitlist earliest date to today before opening the appointment form', async () => {
@@ -395,7 +395,7 @@ describe('Appointments page', () => {
       act(async () => {
         await addAppointmentSpy.mock.calls
           .at(-1)?.[0]
-          .onAppointmentCreated({ patient: { id: 'c1' } });
+          .onAppointmentCreated({ id: 'appt-created-1', patient: { id: 'c1' } });
       })
     ).resolves.toBeUndefined();
     expect(notifyMock).toHaveBeenCalledWith('warning', {
@@ -412,7 +412,25 @@ describe('Appointments page', () => {
     await act(async () => {
       await addAppointmentSpy.mock.calls
         .at(-1)?.[0]
-        .onAppointmentCreated({ patient: { id: 'c2' } });
+        .onAppointmentCreated({ id: 'appt-created-2', patient: { id: 'c2' } });
+    });
+
+    expect(bookWaitlistEntryMock).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalledWith('warning', {
+      title: 'Waitlist not updated',
+      text: 'The appointment was created for a different patient. Review the waitlist before booking this patient again.',
+    });
+  });
+
+  it('does not mark a waitlist entry booked when the created appointment has no id', async () => {
+    await renderAppointments();
+
+    fireEvent.click(screen.getByRole('button', { name: /Waitlist/ }));
+    fireEvent.click(await screen.findByTestId('waitlist-book'));
+    await act(async () => {
+      await addAppointmentSpy.mock.calls
+        .at(-1)?.[0]
+        .onAppointmentCreated({ patient: { id: 'c1' } });
     });
 
     expect(bookWaitlistEntryMock).not.toHaveBeenCalled();

--- a/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/index.test.tsx
@@ -436,7 +436,7 @@ describe('Appointments page', () => {
     expect(bookWaitlistEntryMock).not.toHaveBeenCalled();
     expect(notifyMock).toHaveBeenCalledWith('warning', {
       title: 'Waitlist not updated',
-      text: 'The appointment was created for a different patient. Review the waitlist before booking this patient again.',
+      text: 'The appointment could not be confirmed. Review the waitlist before booking this patient again.',
     });
   });
 

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.tsx
@@ -5,6 +5,13 @@ import { useWaitlist } from '@/app/features/appointments/components/Waitlist/use
 import type { WaitlistEntryView } from '@/app/features/appointments/components/Waitlist/Waitlist';
 
 type WaitlistPanelProps = {
+  /**
+   * A waitlist entry has no time slot to book directly - "Book" opens the
+   * ordinary New Appointment form (pre-filled from the entry) and lets staff
+   * pick one through the normal create flow. Without this, there is nothing
+   * for the Book action to do, so it stays hidden rather than wired to a call
+   * that can only fail.
+   */
   onBookAppointment?: (entry: WaitlistEntryView) => void;
 };
 
@@ -22,7 +29,6 @@ const WaitlistPanel = ({ onBookAppointment }: WaitlistPanelProps) => {
     error,
     busyEntryId,
     offer,
-    book,
     cancel,
     add,
   } = useWaitlist();
@@ -35,11 +41,7 @@ const WaitlistPanel = ({ onBookAppointment }: WaitlistPanelProps) => {
       error={error}
       busyEntryId={busyEntryId}
       onOffer={canEdit ? (id) => void offer(id) : undefined}
-      onBook={
-        canEdit
-          ? (entry) => (onBookAppointment ? onBookAppointment(entry) : void book(entry.id))
-          : undefined
-      }
+      onBook={canEdit && onBookAppointment ? onBookAppointment : undefined}
       onCancel={canEdit ? (id) => void cancel(id) : undefined}
       onAdd={canEdit ? add : undefined}
     />

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/useWaitlist.ts
@@ -2,7 +2,6 @@
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import {
   addToWaitlist,
-  bookWaitlistEntry,
   cancelWaitlistEntry,
   fetchWaitlist,
   offerWaitlistEntry,
@@ -32,7 +31,6 @@ export interface WaitlistState {
   error: string | null;
   busyEntryId: string | null;
   offer: (id: string) => Promise<void>;
-  book: (id: string) => Promise<void>;
   cancel: (id: string) => Promise<void>;
   add: (payload: AddToWaitlistPayload) => Promise<boolean>;
 }
@@ -118,7 +116,6 @@ const useWaitlistActions = (
   return {
     busyEntryId,
     offer: (id: string) => runAction(id, offerWaitlistEntry),
-    book: (id: string) => runAction(id, bookWaitlistEntry),
     cancel: (id: string) => runAction(id, cancelWaitlistEntry),
     add,
   };
@@ -127,8 +124,11 @@ const useWaitlistActions = (
 /**
  * All of the waitlist container's state: it loads the primary org's waitlist,
  * resolves each entry's companion + owner names from the companions store (the
- * entry itself carries only `patientId`), and exposes the offer/book/cancel/add
- * actions. Kept out of the component so the container is a thin projection.
+ * entry itself carries only `patientId`), and exposes the offer/cancel/add
+ * actions. "Book" has no action of its own here: it opens the ordinary New
+ * Appointment form (see WaitlistPanel's `onBookAppointment`), since a
+ * waitlist entry has no slot to book directly. Kept out of the component so
+ * the container is a thin projection.
  */
 export const useWaitlist = (): WaitlistState => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -551,7 +551,9 @@ const useAppointmentsView = () => {
     if (!createdAppointment?.id || createdPatientId !== waitlistBooking.patientId) {
       notify('warning', {
         title: 'Waitlist not updated',
-        text: 'The appointment was created for a different patient. Review the waitlist before booking this patient again.',
+        text: !createdAppointment?.id
+          ? 'The appointment could not be confirmed. Review the waitlist before booking this patient again.'
+          : 'The appointment was created for a different patient. Review the waitlist before booking this patient again.',
       });
       setWaitlistBooking(null);
       return;

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -548,7 +548,7 @@ const useAppointmentsView = () => {
   const completeWaitlistBooking = async (createdAppointment?: Appointment) => {
     if (!waitlistBooking || !primaryOrgId) return;
     const createdPatientId = createdAppointment?.patient?.id ?? createdAppointment?.companion?.id;
-    if (createdPatientId !== waitlistBooking.patientId) {
+    if (!createdAppointment?.id || createdPatientId !== waitlistBooking.patientId) {
       notify('warning', {
         title: 'Waitlist not updated',
         text: 'The appointment was created for a different patient. Review the waitlist before booking this patient again.',
@@ -557,7 +557,7 @@ const useAppointmentsView = () => {
       return;
     }
     try {
-      await bookWaitlistEntry(primaryOrgId, waitlistBooking.id);
+      await bookWaitlistEntry(primaryOrgId, waitlistBooking.id, createdAppointment.id);
       setWaitlistRefreshKey((key) => key + 1);
     } catch {
       notify('warning', {

--- a/apps/frontend/src/app/features/appointments/services/waitlistService.ts
+++ b/apps/frontend/src/app/features/appointments/services/waitlistService.ts
@@ -98,13 +98,15 @@ export const addToWaitlist = async (
 const transition = async (
   organisationId: string,
   entryId: string,
-  action: 'offer' | 'book' | 'cancel'
+  action: 'offer' | 'book' | 'cancel',
+  body?: Record<string, unknown>
 ): Promise<WaitlistEntry> => {
   const safeOrganisationId = safePathSegment(organisationId, 'organisation');
   const safeEntryId = safePathSegment(entryId, 'waitlist entry');
   try {
-    const res = await postData<WaitlistEntry>(
-      `/v1/pms/organisation/${safeOrganisationId}/waitlist/${safeEntryId}/${action}`
+    const res = await postData<WaitlistEntry, Record<string, unknown> | undefined>(
+      `/v1/pms/organisation/${safeOrganisationId}/waitlist/${safeEntryId}/${action}`,
+      body
     );
     return res.data;
   } catch (err) {
@@ -116,8 +118,14 @@ const transition = async (
 export const offerWaitlistEntry = (organisationId: string, entryId: string) =>
   transition(organisationId, entryId, 'offer');
 
-export const bookWaitlistEntry = (organisationId: string, entryId: string) =>
-  transition(organisationId, entryId, 'book');
+/**
+ * Links an entry to the appointment staff already created for it through the
+ * ordinary New Appointment form - a waitlist entry has no slot of its own to
+ * book. See `openWaitlistAppointment`/`completeWaitlistBooking` in the
+ * Appointments page for the flow this closes out.
+ */
+export const bookWaitlistEntry = (organisationId: string, entryId: string, appointmentId: string) =>
+  transition(organisationId, entryId, 'book', { appointmentId });
 
 export const cancelWaitlistEntry = (organisationId: string, entryId: string) =>
   transition(organisationId, entryId, 'cancel');

--- a/packages/database/prisma/migrations/20260909140000_waitlist_entry_appointment_link/migration.sql
+++ b/packages/database/prisma/migrations/20260909140000_waitlist_entry_appointment_link/migration.sql
@@ -1,0 +1,20 @@
+-- Link a waitlist entry to the appointment `book()` actually creates for it.
+--
+-- Before this, `book()` only flipped WaitlistEntry.status to BOOKED - it never
+-- created an Appointment, so the Board never showed the patient and there was
+-- no row to point back to. This column is that missing pointer, written once
+-- when book() succeeds.
+--
+-- Nullable, not backfilled: every existing entry (WAITING/OFFERED/BOOKED under
+-- the old dead-end behaviour) has no real appointment to point at. A BOOKED
+-- entry from before this migration stays NULL forever - that is honest, since
+-- no appointment was actually created for it.
+--
+-- UNIQUE because the conversion is one-time: once an entry names an
+-- appointment, no other entry may claim the same one. A patient who cancels
+-- and re-joins the waitlist gets a new WaitlistEntry row, not a reused link.
+ALTER TABLE "WaitlistEntry" ADD COLUMN IF NOT EXISTS "appointmentId" TEXT;
+
+SET LOCAL lock_timeout = '5s';
+
+CREATE UNIQUE INDEX IF NOT EXISTS "WaitlistEntry_appointmentId_key" ON "WaitlistEntry"("appointmentId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2331,6 +2331,10 @@ model WaitlistEntry {
   status          WaitlistStatus @default(WAITING)
   offeredAt       DateTime?
   bookedAt        DateTime?
+  // The appointment `book()` created once a slot was actually found for this
+  // entry. Unique because booking is a one-time conversion, not a running
+  // link - an entry that is later re-added after cancelling starts a new row.
+  appointmentId   String?        @unique
   expiresAt       DateTime?
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt


### PR DESCRIPTION
## Summary
- `WaitlistService.book` only flipped the entry's own status to `BOOKED` - it never created or linked an `Appointment`. Staff clicking "Book" on a waitlist entry saw it marked booked with nothing on the Board to show for it, and no way to trace which appointment (if any) it turned into.
- `WaitlistEntry` gains an `appointmentId` column (unique) recording what it was actually booked into (migration `20260909140000_waitlist_entry_appointment_link`).
- `WaitlistService.book(id, organisationId, appointmentId, bookedBy?)` now resolves the appointment via `AppointmentPrismaService.getById` scoped to `organisationId` (so a caller cannot link across tenants - the lookup itself 404s), verifies it belongs to the entry's own patient, and links it.
- `book()` deliberately does not create the appointment itself. The PIMS "Book" action already opens the ordinary New Appointment form pre-filled from the entry (`openWaitlistAppointment`) and lets staff pick the slot through the normal create flow - `book()` only closes the entry out against what that flow just created (`completeWaitlistBooking`). Updated `bookWaitlistEntry`'s frontend signature and the `WaitlistPanel`/`useWaitlist` wiring to match; removed the now-impossible "book with no appointment" fallback path rather than leaving it as a dead end that would 400.

## Test plan
- [x] Backend: `waitlist.service.test.ts` + `waitlist.controller.test.ts` - 62/62 passing
- [x] Frontend: `WaitlistPanel.test.tsx`, `waitlistService.test.ts`, `Appointments/index.test.tsx`, `Waitlist.test.tsx` - 101/101 passing
- [x] Mutation-checked the backend service/controller change: reverted only the source files to `origin/dev` with the new tests still in place - 6 tests failed as expected, confirming they exercise the fix; restored and confirmed `git diff HEAD -- <source files>` matched the intended change exactly
- [x] `tsc --noEmit` clean on both `apps/backend` and `apps/frontend` (frontend: full run, zero errors)