### PR TITLE
fix(frontend): route IDEXX ModalityPills through FilterChip

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
@@ -654,6 +654,23 @@ describe('IDEXX Hub page', () => {
     });
   });
 
+  it('renders modality and awaiting-review pills as shared FilterChips', async () => {
+    render(<ProtectedIdexxWorkspace />);
+    await findHeading();
+
+    // Shared FilterChip geometry/typography (12.5px), not a local 14px pill.
+    const allModalities = screen.getByRole('button', { name: 'All modalities' });
+    expect(allModalities).toHaveClass('h-8', 'text-[12.5px]');
+    expect(allModalities.className).not.toMatch(/text-caption-1/);
+    // ALL is selected by default, so it carries FilterChip's shared
+    // active-state token class rather than the old local inline style.
+    expect(allModalities).toHaveClass('bg-[var(--chip-selected-bg)]');
+
+    const awaitingReview = screen.getByRole('button', { name: 'Awaiting review' });
+    expect(awaitingReview).toHaveClass('h-8', 'text-[12.5px]');
+    expect(awaitingReview.className).not.toMatch(/text-caption-1/);
+  });
+
   it('filters results by the header search query', async () => {
     mockSearchQuery = 'buddy';
     listIdexxResultsMock.mockResolvedValue([

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -58,6 +58,7 @@ import {
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
 import TableHead from '@/app/ui/tables/TableHead';
+import FilterChip from '@/app/ui/filters/FilterChip';
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
 const MODALITY_FILTERS = [
@@ -1092,18 +1093,6 @@ type ModalityPillsProps = {
   onToggleAwaitingReview: () => void;
 };
 
-const MODALITY_PILL_ACTIVE_STYLE: React.CSSProperties = {
-  background: 'var(--inset)',
-  borderColor: 'var(--divider)',
-  color: 'var(--ink)',
-  fontWeight: 700,
-};
-const MODALITY_PILL_IDLE_STYLE: React.CSSProperties = {
-  borderColor: 'var(--hairline)',
-  color: 'var(--ink-muted)',
-  fontWeight: 600,
-};
-
 const ModalityPills = ({
   modalityFilter,
   awaitingReviewOnly,
@@ -1113,38 +1102,27 @@ const ModalityPills = ({
   return (
     // Phone: a single horizontally scrollable row. Tablet / desktop: wraps.
     <div className="scrollbar-x-float flex items-center gap-2 overflow-x-auto md:flex-wrap md:overflow-visible">
-      {MODALITY_FILTERS.map((filter) => {
-        const active = modalityFilter === filter.value;
-        return (
-          <button
-            key={filter.value}
-            type="button"
-            aria-pressed={active}
-            onClick={() => onSelectModality(filter.value as ModalityFilter)}
-            className="inline-flex shrink-0 items-center rounded-full border px-[13px] py-1.5 text-caption-1 whitespace-nowrap transition-colors"
-            style={active ? MODALITY_PILL_ACTIVE_STYLE : MODALITY_PILL_IDLE_STYLE}
-          >
-            {filter.label}
-          </button>
-        );
-      })}
+      {MODALITY_FILTERS.map((filter) => (
+        <FilterChip
+          key={filter.value}
+          label={filter.label}
+          active={modalityFilter === filter.value}
+          onClick={() => onSelectModality(filter.value as ModalityFilter)}
+        />
+      ))}
       <span
         className="mx-1 hidden h-4 w-px md:block"
         style={{ background: 'var(--hairline)' }}
         aria-hidden="true"
       />
-      <button
-        type="button"
-        aria-pressed={awaitingReviewOnly}
+      <FilterChip
+        label="Awaiting review"
+        active={awaitingReviewOnly}
         onClick={onToggleAwaitingReview}
-        className="inline-flex shrink-0 items-center rounded-full border px-[13px] py-1.5 text-caption-1 whitespace-nowrap transition-colors"
-        style={awaitingReviewOnly ? MODALITY_PILL_ACTIVE_STYLE : MODALITY_PILL_IDLE_STYLE}
-      >
-        Awaiting review
-      </button>
+      />
       <span
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-[13px] py-1.5 text-caption-1 whitespace-nowrap md:ml-auto"
-        style={MODALITY_PILL_IDLE_STYLE}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-[13px] py-1.5 text-[12.5px] whitespace-nowrap md:ml-auto"
+        style={{ borderColor: 'var(--hairline)', color: 'var(--ink-muted)', fontWeight: 600 }}
       >
         <IoCalendarClearOutline size={12} aria-hidden="true" />
         Last 7 days


### PR DESCRIPTION
## Summary

- `ModalityPills` in `apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx` (previously ~lines 1088-1150) rendered its own filter buttons using `text-caption-1` (14px) styled via local `MODALITY_PILL_ACTIVE_STYLE` / `MODALITY_PILL_IDLE_STYLE` inline style objects, instead of the shared `FilterChip` primitive (`apps/frontend/src/app/ui/filters/FilterChip.tsx`) that every other filter row in the app (Calendar, Integrations, Companions, Documents, Guides) already uses.
- `FilterChip` renders at `text-[12.5px]` with `h-8` geometry and `--chip-selected-*` active-state tokens (`FilterChip.tsx:73`, `:32-33`). The IDEXX modality row was visibly larger (14px vs 12.5px) and off-token compared to every sibling filter row, a real, visible design-system inconsistency.
- Replaced both the modality-filter buttons and the "Awaiting review" toggle button with `<FilterChip label active onClick />` (`index.tsx:1105-1122` after the change), removing the now-dead `MODALITY_PILL_ACTIVE_STYLE`/`MODALITY_PILL_IDLE_STYLE` objects.
- The trailing "Last 7 days" badge is **not** a filter toggle (no `onClick`, it's a static date-range indicator), so it can't be a `FilterChip` — left as a plain `<span>`, but its class was updated from `text-caption-1` to `text-[12.5px]` so the row still reads as one consistent size.

## Verified

- `pnpm run test -- --testPathPatterns="IdexxWorkspace"` (from `apps/frontend`): **62/62 passed**, including a new pinning test (`renders modality and awaiting-review pills as shared FilterChips`) that asserts the `h-8 text-[12.5px]` classes and `bg-[var(--chip-selected-bg)]` active token, and asserts the old `text-caption-1` class is gone.
- `npx eslint` on both changed files: clean, no output.
- `npx tsc --noEmit` (from `apps/frontend`): clean, no errors.
- **Mutation-check**: temporarily reverted only the source file to `origin/dev` (`git checkout origin/dev -- apps/frontend/.../IdexxWorkspace/index.tsx`), reran the suite — the new test failed as expected (`expect(element).toHaveClass("h-8 text-[12.5px]")` received the old `text-caption-1 ...` classes), the other 61 tests were unaffected. Restored the fix from the verified branch (not a blind `git checkout HEAD --`, since HEAD was still dev tip pre-commit — confirmed via `git diff HEAD --stat` / `git diff --cached --stat` that both working tree and index reflected the fix before committing), reran clean: 62/62 passed.
- Push's pre-push hook (turbo lint + type-check across the whole monorepo): **17/17 tasks successful**.
- Verified the pushed branch independently via `git ls-remote --heads origin fix/idexx-modality-filterchip`, matching the local commit SHA.

## Test plan

- [x] `pnpm run test -- --testPathPatterns="IdexxWorkspace"` — 62/62 passing
- [x] New test pinning the FilterChip geometry/tokens, mutation-checked (fails on reverted source, passes with fix)
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` (apps/frontend) — clean
- [x] Full monorepo turbo lint+type-check via pre-push hook — 17/17 successful