### PR TITLE
fix(frontend): align PackageBreakdownSearch to design tokens and add keyboard nav

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownSearch.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackageBreakdownSearch.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PackageBreakdownSearch from '@/app/features/organization/pages/Specialities/PackageBreakdownSearch';
+import type { CatalogEntry } from '@/app/features/organization/pages/Specialities/packageFormDraftHelpers';
+
+const entry = (id: string, name: string, unitPrice = 10): CatalogEntry => ({
+  id,
+  name,
+  type: 'CONSULTATION',
+  unitPrice,
+  defaultDiscount: 0,
+  maxDiscount: 20,
+  isBookable: true,
+  isInpatientPreferred: false,
+});
+
+const CATALOG: CatalogEntry[] = [
+  entry('cat-1', 'Dermatology consult', 85),
+  entry('cat-2', 'Dental scale and polish', 240),
+  entry('cat-3', 'Full blood panel', 62),
+];
+
+describe('PackageBreakdownSearch', () => {
+  const onQueryChange = jest.fn();
+  const onSelectItem = jest.fn();
+
+  const baseProps = {
+    searchQuery: 'de',
+    onQueryChange,
+    filteredSearch: CATALOG,
+    searchLoading: false,
+    orgCurrency: 'USD',
+    onSelectItem,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Real usage never mounts the panel already open - it opens via a
+   * `filteredSearch` prop transition from empty to populated as the parent
+   * recomputes results while the user types (see PackageBreakdownSearch.stories
+   * "Typing opens the results panel"). That transition is what seeds the
+   * highlighted index at 0, so keyboard-nav tests replay it instead of
+   * mounting pre-populated.
+   */
+  const openPanel = () => {
+    const utils = render(
+      <PackageBreakdownSearch {...baseProps} searchQuery="" filteredSearch={[]} />
+    );
+    utils.rerender(<PackageBreakdownSearch {...baseProps} />);
+    return utils;
+  };
+
+  it('renders the panel and options with the canonical floating-panel tokens', () => {
+    render(<PackageBreakdownSearch {...baseProps} />);
+
+    const panel = screen.getByRole('listbox', { name: 'Catalog search results' });
+    expect(panel.className).toContain('rounded-[13px]');
+    expect(panel.className).toContain('border-[var(--hairline)]');
+    expect(panel.className).toContain('shadow-[0_24px_60px_var(--sh28)]');
+    expect(panel.className).not.toContain('rounded-2xl');
+    expect(panel.className).not.toContain('border-card-border');
+    expect(panel.className).not.toContain('shadow-lg');
+
+    // The field container was hand-rolled with the same stale tokens.
+    const input = screen.getByRole('combobox', { name: 'Search catalog items' });
+    const container = input.parentElement as HTMLElement;
+    expect(container.className).toContain('rounded-[12px]');
+    expect(container.className).toContain('border-[var(--hairline)]');
+    expect(container.className).not.toContain('rounded-2xl');
+    expect(container.className).not.toContain('input-border-default');
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(3);
+  });
+
+  it('moves the highlighted option on ArrowDown', () => {
+    openPanel();
+    const input = screen.getByRole('combobox', { name: 'Search catalog items' });
+    const options = screen.getAllByRole('option');
+
+    // Opening seeds the highlight on the first option.
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+  });
+
+  it('selects the highlighted option on Enter', () => {
+    openPanel();
+    const input = screen.getByRole('combobox', { name: 'Search catalog items' });
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSelectItem).toHaveBeenCalledTimes(1);
+    expect(onSelectItem).toHaveBeenCalledWith(CATALOG[1]);
+  });
+
+  it('closes the panel on Escape without selecting', () => {
+    render(<PackageBreakdownSearch {...baseProps} />);
+    const input = screen.getByRole('combobox', { name: 'Search catalog items' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(onSelectItem).not.toHaveBeenCalled();
+  });
+
+  it('still supports click-to-select without changing the query/filter contract', () => {
+    render(<PackageBreakdownSearch {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('option', { name: /Full blood panel/ }));
+
+    expect(onSelectItem).toHaveBeenCalledWith(CATALOG[2]);
+  });
+});

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
@@ -61,9 +61,9 @@ const SearchHarness = (args: SearchProps) => {
   );
 };
 
-/** The panel carries no role or label, so it is reached through a row it contains. */
+/** The panel is a `role="listbox"`, so it is reached through an option it contains. */
 const panelFor = (canvasElement: HTMLElement, rowName: RegExp) =>
-  within(canvasElement).getByRole('button', { name: rowName }).parentElement as HTMLElement;
+  within(canvasElement).getByRole('option', { name: rowName }).parentElement as HTMLElement;
 
 const meta = {
   title: 'Organization/PackageBreakdownSearch',
@@ -79,9 +79,13 @@ const meta = {
           'There are **two** panels, not one, and they are separate elements with different ' +
           'padding: the results list (`overflow-hidden`, rows at `px-4 py-2`) and the "No items ' +
           'found." card (`px-4 py-3`). Both are `absolute top-full left-0 right-0 z-50 mt-1` over ' +
-          'a `--screen` fill with a `card-border` hairline, so they overlay whatever follows the ' +
-          'field rather than pushing it down - which means a regression to static positioning ' +
-          'shoves the entire breakdown table down the page instead of failing visibly.\n\n' +
+          'a `--screen` fill with a 13px-radius `--hairline` border and a `--sh28` shadow, matching ' +
+          'the floating-panel tokens the canonical `Dropdown` component uses, so they overlay ' +
+          'whatever follows the field rather than pushing it down - which means a regression to ' +
+          'static positioning shoves the entire breakdown table down the page instead of failing ' +
+          'visibly. The results list is a `role="listbox"` of `role="option"` rows, keyboard-' +
+          'navigable with Arrow keys / Home / End / Enter / Space / Escape via the shared ' +
+          '`useListboxKeyboardNav` hook.\n\n' +
           'The three conditions are mutually exclusive by arithmetic rather than by an explicit ' +
           'branch: results render when `filteredSearch.length > 0`, the empty card when there is a ' +
           'trimmed query, no results **and** `searchLoading` is false. Nothing renders while a ' +
@@ -134,7 +138,7 @@ export const TypingOpensResults: Story = {
     const panel = panelFor(canvasElement, /Dermatology consult/);
     // Assert the panel has its rows and that they carry both halves of their line -
     // an empty overlay would satisfy "the dropdown opened" on its own.
-    const rows = within(panel).getAllByRole('button');
+    const rows = within(panel).getAllByRole('option');
     await expect(rows).toHaveLength(2);
     await expect(rows[0]).toHaveTextContent('Dermatology consult');
     await expect(rows[0]).toHaveTextContent('Consultation · $85');
@@ -159,7 +163,7 @@ export const ResultsOpen: Story = {
   args: { searchQuery: 'a', filteredSearch: CATALOG },
   play: async ({ canvasElement }) => {
     const panel = panelFor(canvasElement, /Dermatology consult/);
-    const rows = within(panel).getAllByRole('button');
+    const rows = within(panel).getAllByRole('option');
     await expect(rows).toHaveLength(6);
     // One row per CatalogItemType, so every label in TYPE_LABELS is on screen at once.
     await expect(panel).toHaveTextContent('Diagnostics · $62');
@@ -211,7 +215,7 @@ export const Selecting: Story = {
   args: { searchQuery: 'dental', filteredSearch: [CATALOG[1]] },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: /Dental scale and polish/ }));
+    await userEvent.click(canvas.getByRole('option', { name: /Dental scale and polish/ }));
     // The whole entry goes back to the form - price, discounts and nested breakdown
     // included - not just an id.
     await expect(args.onSelectItem).toHaveBeenCalledWith(CATALOG[1]);

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.tsx
@@ -1,5 +1,7 @@
+import { useId, useState } from 'react';
 import { IoIosSearch } from 'react-icons/io';
 import { formatMoney } from '@/app/lib/money';
+import { useListboxKeyboardNav } from '@/app/ui/inputs/Dropdown/useDropdownKeyboardNav';
 import { CatalogEntry, TYPE_LABELS } from './packageFormDraftHelpers';
 
 type PackageBreakdownSearchProps = {
@@ -18,48 +20,107 @@ const PackageBreakdownSearch = ({
   searchLoading,
   orgCurrency,
   onSelectItem,
-}: PackageBreakdownSearchProps) => (
-  <div className="relative">
-    <div className="flex items-center gap-2 w-full border border-input-border-default rounded-2xl px-3.5 h-10.5 focus-within:border-input-border-active transition-colors bg-[var(--field-bg)]">
-      <input
-        type="text"
-        placeholder="Search services, inventory, lab tests, packages..."
-        value={searchQuery}
-        onChange={(e) => onQueryChange(e.target.value)}
-        className="flex-1 min-w-0 bg-transparent font-satoshi text-[13px] font-medium text-text-primary focus-visible:outline-none placeholder:text-text-secondary"
-        aria-label="Search catalog items"
-      />
-      <IoIosSearch
-        size={20}
-        color="var(--color-neutral-900)"
-        aria-hidden="true"
-        className="shrink-0"
-      />
+}: PackageBreakdownSearchProps) => {
+  const listboxId = useId();
+
+  // Neither panel owns an open flag - visibility derives entirely from the
+  // search props above. Escape has nothing to flip, so it hides the panel
+  // locally instead; typing again (a new searchQuery) clears the dismissal.
+  // Adjusted during render rather than in an effect (React's "you might not
+  // need an effect" guidance), matching useDropdownKeyboardNav's own pattern.
+  const [dismissed, setDismissed] = useState(false);
+  const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery);
+  if (searchQuery !== prevSearchQuery) {
+    setPrevSearchQuery(searchQuery);
+    setDismissed(false);
+  }
+
+  const showResults = !dismissed && filteredSearch.length > 0;
+  const showEmpty =
+    !dismissed && searchQuery.trim().length > 0 && filteredSearch.length === 0 && !searchLoading;
+
+  const selectItem = (item: CatalogEntry) => {
+    onSelectItem(item);
+    setDismissed(true);
+  };
+
+  const { activeOptionId, setActiveIndex, handleKeyDown } = useListboxKeyboardNav({
+    open: showResults,
+    openDropdown: () => setDismissed(false),
+    closeDropdown: () => setDismissed(true),
+    options: filteredSearch,
+    listboxId,
+    selectionKey: undefined,
+    getOptionValue: (option) => option.id,
+    isOptionSelected: () => false,
+    selectOption: selectItem,
+    spaceSkipsInput: true,
+  });
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2 w-full border border-[var(--hairline)] rounded-[12px] px-3.5 h-10.5 focus-within:border-input-border-active transition-colors bg-[var(--field-bg)]">
+        <input
+          type="text"
+          placeholder="Search services, inventory, lab tests, packages..."
+          value={searchQuery}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="flex-1 min-w-0 bg-transparent font-satoshi text-[13px] font-medium text-text-primary focus-visible:outline-none placeholder:text-text-secondary"
+          aria-label="Search catalog items"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={showResults}
+          aria-controls={listboxId}
+          aria-activedescendant={activeOptionId}
+        />
+        <IoIosSearch
+          size={20}
+          color="var(--color-neutral-900)"
+          aria-hidden="true"
+          className="shrink-0"
+        />
+      </div>
+      {showResults && (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="Catalog search results"
+          className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-[var(--hairline)] rounded-[13px] shadow-[0_24px_60px_var(--sh28)] overflow-hidden"
+        >
+          {filteredSearch.map((item, index) => {
+            const optionId = `${listboxId}-option-${item.id}`;
+            const isActive = activeOptionId === optionId;
+            return (
+              <button
+                key={item.id}
+                id={optionId}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => selectItem(item)}
+                className={`w-full flex items-center justify-between px-4 py-2 text-left hover:bg-card-hover text-[13px] text-text-primary ${
+                  isActive ? 'bg-card-hover' : ''
+                }`}
+              >
+                <span>{item.name}</span>
+                <span className="text-[12px] text-text-secondary">
+                  {TYPE_LABELS[item.type] ?? item.type} ·{' '}
+                  {formatMoney(item.unitPrice, item.currency ?? orgCurrency)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {showEmpty && (
+        <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-[var(--hairline)] rounded-[13px] shadow-[0_24px_60px_var(--sh28)] px-4 py-3 text-[13px] text-text-secondary">
+          No items found.
+        </div>
+      )}
     </div>
-    {filteredSearch.length > 0 && (
-      <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-card-border rounded-2xl shadow-lg overflow-hidden">
-        {filteredSearch.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => onSelectItem(item)}
-            className="w-full flex items-center justify-between px-4 py-2 text-left hover:bg-card-hover text-[13px] text-text-primary"
-          >
-            <span>{item.name}</span>
-            <span className="text-[12px] text-text-secondary">
-              {TYPE_LABELS[item.type] ?? item.type} ·{' '}
-              {formatMoney(item.unitPrice, item.currency ?? orgCurrency)}
-            </span>
-          </button>
-        ))}
-      </div>
-    )}
-    {searchQuery.trim() && filteredSearch.length === 0 && !searchLoading && (
-      <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-card-border rounded-2xl shadow-lg px-4 py-3 text-[13px] text-text-secondary">
-        No items found.
-      </div>
-    )}
-  </div>
-);
+  );
+};
 
 export default PackageBreakdownSearch;


### PR DESCRIPTION
## Summary
- `PackageBreakdownSearch` (the catalog item search used when building a service package) hand-rolled its floating search-results panel with stale tokens: `border-input-border-default`/`border-card-border` instead of `var(--hairline)`, `rounded-2xl` (16px) instead of the canonical radius, and `shadow-lg` instead of `var(--sh28)`.
- It also had zero keyboard navigation and no listbox semantics, so a keyboard-only user could not select a catalog item.
- Swapped the field container to the canonical `Dropdown.css` trigger tokens (`var(--hairline)`, 12px radius) and the results/empty panels to the canonical floating-panel tokens (`var(--hairline)`, 13px radius, `var(--sh28)` shadow) - matching `Dropdown.tsx`/`Dropdown.css` and the already-established `rounded-[13px] border-[var(--hairline)] ... shadow-[0_24px_60px_var(--sh28)]` pattern used by `Dropdown/index.tsx` and `LabelDropdown.tsx`.
- Wired in the shared `useListboxKeyboardNav` hook (same hook the canonical `Dropdown` uses): ArrowUp/Down moves a highlighted index, Home/End jump to the ends, Enter/Space selects the highlighted item, Escape closes the panel without selecting. Added `role="combobox"` on the input and `role="listbox"`/`role="option"`/`aria-selected`/`aria-expanded`/`aria-controls`/`aria-activedescendant` to match the accessible search+listbox pattern already used by `DocsSearch.tsx`.
- The panel has no `open` state of its own (visibility is derived from `filteredSearch`/`searchQuery` props), so Escape hides it via a small local `dismissed` flag that clears itself the next time `searchQuery` changes (adjusted during render, not in a `useEffect`, to match `useDropdownKeyboardNav`'s own "you might not need an effect" pattern and satisfy `react-hooks/set-state-in-effect`).
- All existing behavior preserved: the catalog search/filter logic, click-to-select, and the add-to-package flow are unchanged. Updated `PackageBreakdownSearch.stories.tsx` play functions to query rows by `role="option"` instead of `role="button"`, since the row buttons now carry an explicit `option` role.

## Verified
- `npx tsc --noEmit` (apps/frontend) - clean.
- `pnpm --filter frontend run lint` (targeted eslint run on changed files, then full pre-commit lint-staged pass) - clean.
- Mutation-checked the new test file: reverted only `PackageBreakdownSearch.tsx` to `origin/dev` (via `git checkout origin/dev -- <path>`) and confirmed all 5 new tests fail; restored the fix and confirmed all 5 pass.
- Pre-push hook (full monorepo lint + type-check via Turborepo) passed.

## Test plan
- [x] New Jest suite `PackageBreakdownSearch.test.tsx` covers: panel/options render with the corrected token classes (and not the old ones), ArrowDown moves the highlighted option, Enter selects the highlighted option, Escape closes the panel without selecting, and click-to-select still works unchanged.
- [x] `pnpm --filter frontend run test -- --testPathPatterns="PackageBreakdownSearch"` - 5/5 passing.