### PR TITLE
fix(frontend): add keyboard navigation to ServiceSearch and SpecialitySearch

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearchBase.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearchBase.test.tsx
@@ -24,7 +24,7 @@ describe('ServiceSearchBase', () => {
     fireEvent.change(screen.getByPlaceholderText('Search or create service'), {
       target: { value: 'Vaccination' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Vaccination & Booster Shots' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Vaccination & Booster Shots' }));
 
     await waitFor(() => {
       expect(onSelectService).toHaveBeenCalledWith('Vaccination & Booster Shots');
@@ -46,11 +46,85 @@ describe('ServiceSearchBase', () => {
     fireEvent.change(screen.getByPlaceholderText('Search or create service'), {
       target: { value: 'Home visit' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Add service “Home visit”' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Add service “Home visit”' }));
 
     await waitFor(() => {
       expect(onAddService).toHaveBeenCalledWith('Home visit');
     });
     expect(onSelectService).not.toHaveBeenCalled();
+  });
+
+  it('moves the highlight with ArrowDown and selects it with Enter', async () => {
+    const onSelectService = jest.fn().mockResolvedValue(undefined);
+    const onAddService = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <ServiceSearchBase
+        speciality={speciality}
+        onSelectService={onSelectService}
+        onAddService={onAddService}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search or create service');
+    fireEvent.focus(input);
+    // Catalogue order (General Consult excluded, already on the speciality):
+    // Vaccination & Booster Shots, Health Certificate, ... Opening seeds the
+    // highlight on the first row, so one ArrowDown reaches the second.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSelectService).toHaveBeenCalledWith('Health Certificate');
+    });
+    expect(onAddService).not.toHaveBeenCalled();
+  });
+
+  it('adds a custom service via ArrowDown + Enter when nothing matches', async () => {
+    const onSelectService = jest.fn().mockResolvedValue(undefined);
+    const onAddService = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <ServiceSearchBase
+        speciality={speciality}
+        onSelectService={onSelectService}
+        onAddService={onAddService}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search or create service'), {
+      target: { value: 'Zzz not in catalogue' },
+    });
+    const input = screen.getByPlaceholderText('Search or create service');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onAddService).toHaveBeenCalledWith('Zzz not in catalogue');
+    });
+    expect(onSelectService).not.toHaveBeenCalled();
+  });
+
+  it('closes the results listbox on Escape without selecting anything', () => {
+    const onSelectService = jest.fn().mockResolvedValue(undefined);
+    const onAddService = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <ServiceSearchBase
+        speciality={speciality}
+        onSelectService={onSelectService}
+        onAddService={onAddService}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search or create service');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(onSelectService).not.toHaveBeenCalled();
+    expect(onAddService).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Inputs/SpecialitySearchBase.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/SpecialitySearchBase.test.tsx
@@ -31,7 +31,7 @@ describe('SpecialitySearchBase', () => {
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'General Practice' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'General Practice' }));
+    fireEvent.click(screen.getByRole('option', { name: 'General Practice' }));
 
     expect(setSpecialities).toHaveBeenCalled();
     const updater = (setSpecialities as jest.Mock).mock.calls[0][0];
@@ -49,7 +49,7 @@ describe('SpecialitySearchBase', () => {
 
     const input = screen.getByPlaceholderText('Search or create specialty');
     fireEvent.change(input, { target: { value: 'new field' } });
-    fireEvent.click(screen.getByRole('button', { name: 'New speciality “new field”' }));
+    fireEvent.click(screen.getByRole('option', { name: 'New speciality “new field”' }));
 
     const updater = (setSpecialities as jest.Mock).mock.calls[0][0];
     expect(updater([])).toEqual([{ name: 'New field', organisationId: 'org-1' }]);
@@ -70,8 +70,66 @@ describe('SpecialitySearchBase', () => {
 
     const input = screen.getByPlaceholderText('Search or create specialty');
     fireEvent.change(input, { target: { value: 'General' } });
-    fireEvent.click(screen.getByRole('button', { name: 'General Practice' }));
+    fireEvent.click(screen.getByRole('option', { name: 'General Practice' }));
 
+    expect(setSpecialities).not.toHaveBeenCalled();
+  });
+
+  it('moves the highlight with ArrowDown and selects it with Enter', () => {
+    render(
+      <SpecialitySearchBase
+        specialities={[]}
+        currentSpecialities={[]}
+        setSpecialities={setSpecialities}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search or create specialty');
+    fireEvent.focus(input);
+    // Catalogue order: Observational tools, General Practice, ... Opening
+    // seeds the highlight on the first row, so one ArrowDown reaches the second.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(setSpecialities).toHaveBeenCalled();
+    const updater = (setSpecialities as jest.Mock).mock.calls[0][0];
+    expect(updater([])).toEqual([{ name: 'General Practice', organisationId: 'org-1' }]);
+  });
+
+  it('adds a custom speciality via ArrowDown + Enter when nothing matches', () => {
+    render(
+      <SpecialitySearchBase
+        specialities={[]}
+        currentSpecialities={[]}
+        setSpecialities={setSpecialities}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search or create specialty');
+    fireEvent.change(input, { target: { value: 'zzz not in catalogue' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    const updater = (setSpecialities as jest.Mock).mock.calls[0][0];
+    expect(updater([])).toEqual([{ name: 'Zzz not in catalogue', organisationId: 'org-1' }]);
+  });
+
+  it('closes the results listbox on Escape without selecting anything', () => {
+    render(
+      <SpecialitySearchBase
+        specialities={[]}
+        currentSpecialities={[]}
+        setSpecialities={setSpecialities}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search or create specialty');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     expect(setSpecialities).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.css
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.css
@@ -57,7 +57,8 @@
   cursor: pointer;
   transition: all 0.3s ease-in-out;
 }
-.service-search-speciality:hover {
+.service-search-speciality:hover,
+.service-search-speciality[aria-selected='true'] {
   background-color: var(--color-card-hover);
 }
 .service-search-add:focus-visible {
@@ -80,6 +81,9 @@
   font-weight: 400;
   line-height: 120%;
   letter-spacing: -0.2px;
+}
+.service-search-add[aria-selected='true'] {
+  background-color: var(--color-card-hover);
 }
 .service-search-speciality-title {
   color: var(--ink-body);

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.stories.tsx
@@ -163,9 +163,9 @@ export const DropdownOpen: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
-    await expect(results.getByRole('button', { name: 'General Consult' })).toBeInTheDocument();
+    await expect(results.getByRole('option', { name: 'General Consult' })).toBeInTheDocument();
     await expect(
-      results.getByRole('button', { name: 'Dental Cleaning & Scaling' })
+      results.getByRole('option', { name: 'Dental Cleaning & Scaling' })
     ).toBeInTheDocument();
   },
 };
@@ -176,7 +176,7 @@ export const PickFromCatalogue: Story = {
     const canvas = within(canvasElement);
     const field = canvas.getByRole('textbox', { name: FIELD });
     await userEvent.click(field);
-    await userEvent.click(canvas.getByRole('button', { name: 'Tooth Extraction' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Tooth Extraction' }));
 
     const chips = within(canvas.getByRole('list', { name: 'Dentistry services' }));
     await expect(chips.getByText('Tooth Extraction')).toBeInTheDocument();
@@ -206,7 +206,7 @@ export const CreateCustom: Story = {
     await userEvent.click(field);
     await userEvent.type(field, 'feline dental radiographs');
     await userEvent.click(
-      canvas.getByRole('button', { name: 'Add service “feline dental radiographs”' })
+      canvas.getByRole('option', { name: 'Add service “feline dental radiographs”' })
     );
 
     const chips = within(canvas.getByRole('list', { name: 'Dentistry services' }));
@@ -246,13 +246,13 @@ export const AlreadyAdded: Story = {
     await userEvent.click(field);
     const results = within(await canvas.findByLabelText(RESULTS));
     await expect(
-      results.queryByRole('button', { name: 'Tooth Extraction' })
+      results.queryByRole('option', { name: 'Tooth Extraction' })
     ).not.toBeInTheDocument();
 
     // Typing an existing name in a different case falls through to the create
     // row, and the wrapper still refuses it.
     await userEvent.type(field, 'tooth extraction');
-    await userEvent.click(canvas.getByRole('button', { name: 'Add service “tooth extraction”' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Add service “tooth extraction”' }));
     await expect(chips.getAllByRole('listitem')).toHaveLength(2);
     await expect(field).toHaveValue('');
   },

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.stories.tsx
@@ -81,13 +81,13 @@ export const DropdownOpen: Story = {
     const results = within(await canvas.findByLabelText(RESULTS));
     // "General Consult" is prepended for every consult-flagged speciality, then
     // the five dentistry services in catalogue order.
-    await expect(results.getAllByRole('button')).toHaveLength(6);
-    await expect(results.getByRole('button', { name: 'General Consult' })).toBeInTheDocument();
+    await expect(results.getAllByRole('option')).toHaveLength(6);
+    await expect(results.getByRole('option', { name: 'General Consult' })).toBeInTheDocument();
     await expect(
-      results.getByRole('button', { name: 'Dental Cleaning & Scaling' })
+      results.getByRole('option', { name: 'Dental Cleaning & Scaling' })
     ).toBeInTheDocument();
     await expect(
-      results.getByRole('button', { name: 'Bad Breath Evaluation' })
+      results.getByRole('option', { name: 'Bad Breath Evaluation' })
     ).toBeInTheDocument();
   },
   parameters: {
@@ -107,7 +107,7 @@ export const PickFromCatalogue: Story = {
     const canvas = within(canvasElement);
     const field = canvas.getByRole('textbox', { name: FIELD });
     await userEvent.click(field);
-    await userEvent.click(canvas.getByRole('button', { name: 'Oral X-Rays' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Oral X-Rays' }));
 
     await expect(args.onSelectService).toHaveBeenCalledWith('Oral X-Rays');
     await expect(args.onAddService).not.toHaveBeenCalled();
@@ -134,9 +134,9 @@ export const CreateCustom: Story = {
     await userEvent.type(field, '  feline dental radiographs ');
 
     const results = within(await canvas.findByLabelText(RESULTS));
-    await expect(results.getAllByRole('button')).toHaveLength(1);
+    await expect(results.getAllByRole('option')).toHaveLength(1);
     await userEvent.click(
-      results.getByRole('button', { name: 'Add service “feline dental radiographs”' })
+      results.getByRole('option', { name: 'Add service “feline dental radiographs”' })
     );
 
     // Trimmed, not capitalised: the wrapper's builder decides the stored casing.
@@ -168,15 +168,15 @@ export const ExistingFilteredOut: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
-    await expect(results.getAllByRole('button')).toHaveLength(4);
+    await expect(results.getAllByRole('option')).toHaveLength(4);
     await expect(
-      results.queryByRole('button', { name: 'Dental Cleaning & Scaling' })
+      results.queryByRole('option', { name: 'Dental Cleaning & Scaling' })
     ).not.toBeInTheDocument();
     await expect(
-      results.queryByRole('button', { name: 'Tooth Extraction' })
+      results.queryByRole('option', { name: 'Tooth Extraction' })
     ).not.toBeInTheDocument();
     await expect(
-      results.getByRole('button', { name: 'Gum Disease Treatment' })
+      results.getByRole('option', { name: 'Gum Disease Treatment' })
     ).toBeInTheDocument();
   },
   parameters: {
@@ -201,8 +201,8 @@ export const OffCatalogueSpeciality: Story = {
     const results = within(await canvas.findByLabelText(RESULTS));
     // No suggestions exist, so focus lands straight on the create row - which
     // quotes an empty name until something is typed.
-    await expect(results.getAllByRole('button')).toHaveLength(1);
-    await expect(results.getByRole('button', { name: 'Add service “”' })).toBeInTheDocument();
+    await expect(results.getAllByRole('option')).toHaveLength(1);
+    await expect(results.getByRole('option', { name: 'Add service “”' })).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.tsx
@@ -3,6 +3,7 @@ import { IoSearch } from 'react-icons/io5';
 import { specialtiesByKey } from '@/app/lib/specialities';
 import { Service } from '@yosemite-crew/types';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
+import { useListboxKeyboardNav } from '@/app/ui/inputs/Dropdown/useDropdownKeyboardNav';
 
 import './ServiceSearch.css';
 
@@ -11,6 +12,9 @@ type ServiceSearchBaseProps = {
   onSelectService: (serviceName: string) => void | Promise<void>;
   onAddService: (serviceName: string) => void | Promise<void>;
 };
+
+/** One row of the results listbox: a matching service, or the single "add new" row shown when nothing matches. */
+type ServiceOption = { id: string; kind: 'service'; name: string } | { id: 'add'; kind: 'add' };
 
 const ServiceSearchBase = ({
   speciality,
@@ -43,6 +47,18 @@ const ServiceSearchBase = ({
     });
   }, [query, selectedNames, services]);
 
+  const listOptions: ServiceOption[] = useMemo(
+    () =>
+      filtered.length > 0
+        ? filtered.map((name: string, index: number) => ({
+            id: String(index),
+            kind: 'service' as const,
+            name,
+          }))
+        : [{ id: 'add', kind: 'add' as const }],
+    [filtered]
+  );
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
@@ -69,6 +85,27 @@ const ServiceSearchBase = ({
     setOpen(false);
   };
 
+  const selectOption = (option: ServiceOption) => {
+    if (option.kind === 'add') {
+      void handleAdd();
+    } else {
+      void handleSelect(option.name);
+    }
+  };
+
+  const { activeOptionId, handleKeyDown } = useListboxKeyboardNav({
+    open,
+    openDropdown: () => setOpen(true),
+    closeDropdown: () => setOpen(false),
+    options: listOptions,
+    listboxId,
+    selectionKey: undefined,
+    getOptionValue: (option) => option.id,
+    isOptionSelected: () => false,
+    selectOption,
+    spaceSkipsInput: true,
+  });
+
   return (
     <div className="service-search" ref={wrapperRef}>
       <IoSearch size={15} className="service-search-icon" color="var(--color-text-tertiary)" />
@@ -85,25 +122,52 @@ const ServiceSearchBase = ({
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={activeOptionId}
       />
       {open && (
-        <div className="service-search-dropdown" id={listboxId} aria-label="Service results">
-          {filtered?.length > 0 ? (
-            filtered.map((service: any) => (
+        <div
+          className="service-search-dropdown"
+          id={listboxId}
+          role="listbox"
+          aria-label="Service results"
+        >
+          {listOptions.map((option) => {
+            const optionId = `${listboxId}-option-${option.id}`;
+            const isActive = activeOptionId === optionId;
+            if (option.kind === 'add') {
+              return (
+                <button
+                  key="add"
+                  type="button"
+                  id={optionId}
+                  role="option"
+                  aria-selected={isActive}
+                  className="service-search-add"
+                  onClick={handleAdd}
+                >
+                  Add service “{query.trim()}”
+                </button>
+              );
+            }
+            return (
               <button
-                key={service}
+                key={option.name}
                 type="button"
+                id={optionId}
+                role="option"
+                aria-selected={isActive}
                 className="service-search-speciality"
-                onClick={() => handleSelect(service)}
+                onClick={() => handleSelect(option.name)}
               >
-                <div className="service-search-speciality-title">{service}</div>
+                <div className="service-search-speciality-title">{option.name}</div>
               </button>
-            ))
-          ) : (
-            <button type="button" className="service-search-add" onClick={handleAdd}>
-              Add service “{query.trim()}”
-            </button>
-          )}
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearch.css
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearch.css
@@ -56,7 +56,8 @@
   cursor: pointer;
   transition: all 0.3s ease-in-out;
 }
-.step-search-speciality:hover {
+.step-search-speciality:hover,
+.step-search-speciality[aria-selected='true'] {
   background-color: var(--color-card-hover);
 }
 .step-search-add:focus-visible {
@@ -79,6 +80,9 @@
   font-weight: 400;
   line-height: 120%;
   letter-spacing: -0.2px;
+}
+.step-search-add[aria-selected='true'] {
+  background-color: var(--color-card-hover);
 }
 .step-search-speciality-title {
   color: var(--ink-body);

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.stories.tsx
@@ -150,9 +150,9 @@ export const DropdownOpen: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
-    await expect(results.getAllByRole('button')).toHaveLength(specialties.length);
-    await expect(results.getByRole('button', { name: 'Cardiology' })).toBeInTheDocument();
-    await expect(results.getByRole('button', { name: 'Dentistry' })).toBeInTheDocument();
+    await expect(results.getAllByRole('option')).toHaveLength(specialties.length);
+    await expect(results.getByRole('option', { name: 'Cardiology' })).toBeInTheDocument();
+    await expect(results.getByRole('option', { name: 'Dentistry' })).toBeInTheDocument();
   },
 };
 
@@ -162,7 +162,7 @@ export const PickAppends: Story = {
     const canvas = within(canvasElement);
     const field = canvas.getByRole('textbox', { name: FIELD });
     await userEvent.click(field);
-    await userEvent.click(canvas.getByRole('button', { name: 'Cardiology' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Cardiology' }));
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
     await expect(chips.getByText('Cardiology')).toBeInTheDocument();
@@ -192,7 +192,7 @@ export const CreateCapitalised: Story = {
     await userEvent.click(field);
     await userEvent.type(field, 'exotic reptile medicine');
     await userEvent.click(
-      canvas.getByRole('button', { name: 'New speciality “exotic reptile medicine”' })
+      canvas.getByRole('option', { name: 'New speciality “exotic reptile medicine”' })
     );
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
@@ -221,7 +221,7 @@ export const SingleSelect: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
-    await userEvent.click(canvas.getByRole('button', { name: 'Dermatology' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Dermatology' }));
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
     await expect(chips.getAllByRole('listitem')).toHaveLength(1);
@@ -248,10 +248,10 @@ export const CurrentHidden: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
-    await expect(results.getAllByRole('button')).toHaveLength(specialties.length - 2);
-    await expect(results.queryByRole('button', { name: 'Cardiology' })).not.toBeInTheDocument();
-    await expect(results.queryByRole('button', { name: 'Dermatology' })).not.toBeInTheDocument();
-    await expect(results.getByRole('button', { name: 'Dentistry' })).toBeInTheDocument();
+    await expect(results.getAllByRole('option')).toHaveLength(specialties.length - 2);
+    await expect(results.queryByRole('option', { name: 'Cardiology' })).not.toBeInTheDocument();
+    await expect(results.queryByRole('option', { name: 'Dermatology' })).not.toBeInTheDocument();
+    await expect(results.getByRole('option', { name: 'Dentistry' })).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -274,7 +274,7 @@ export const FallsBackToPrimaryOrg: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
-    await userEvent.click(canvas.getByRole('button', { name: 'Ophthalmology' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Ophthalmology' }));
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
     await expect(chips.getByText('Ophthalmology')).toBeInTheDocument();
@@ -299,7 +299,7 @@ export const NoOrganisation: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
-    await userEvent.click(canvas.getByRole('button', { name: 'Cardiology' }));
+    await userEvent.click(canvas.getByRole('option', { name: 'Cardiology' }));
 
     // Nothing to stamp the speciality with, so nothing is added - and the
     // dropdown stays open, because the early return skips the close as well.

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.tsx
@@ -2,10 +2,15 @@ import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import { specialties as SPECIALITIES } from '@/app/lib/specialities';
 import { useOrgStore } from '@/app/stores/orgStore';
+import { useListboxKeyboardNav } from '@/app/ui/inputs/Dropdown/useDropdownKeyboardNav';
 
 import './SpecialitySearch.css';
 
 const DEFAULT_CURRENT_SPECIALITIES: never[] = [];
+
+/** One row of the results listbox: a matching speciality, or the single "add new" row shown when nothing matches. */
+type SpecialityOption =
+  { id: string; kind: 'speciality'; name: string } | { id: 'add'; kind: 'add' };
 
 type SpecialitySearchBaseProps<T extends { name: string }> = {
   organisationId?: string | null;
@@ -50,6 +55,18 @@ const SpecialitySearchBase = <T extends { name: string }>({
       return name.includes(q);
     });
   }, [query, selectedNames, currentNames]);
+
+  const listOptions: SpecialityOption[] = useMemo(
+    () =>
+      filtered.length > 0
+        ? filtered.map((speciality: { name: string }, index: number) => ({
+            id: String(index),
+            kind: 'speciality' as const,
+            name: speciality.name,
+          }))
+        : [{ id: 'add', kind: 'add' as const }],
+    [filtered]
+  );
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -103,6 +120,27 @@ const SpecialitySearchBase = <T extends { name: string }>({
     setOpen(false);
   };
 
+  const selectOption = (option: SpecialityOption) => {
+    if (option.kind === 'add') {
+      handleAddSpeciality();
+    } else {
+      handleSelectSpeciality({ name: option.name });
+    }
+  };
+
+  const { activeOptionId, handleKeyDown } = useListboxKeyboardNav({
+    open,
+    openDropdown: () => setOpen(true),
+    closeDropdown: () => setOpen(false),
+    options: listOptions,
+    listboxId,
+    selectionKey: undefined,
+    getOptionValue: (option) => option.id,
+    isOptionSelected: () => false,
+    selectOption,
+    spaceSkipsInput: true,
+  });
+
   return (
     <div className="step-search" ref={wrapperRef}>
       <IoSearch size={15} className="step-search-icon" color="var(--color-text-tertiary)" />
@@ -119,25 +157,52 @@ const SpecialitySearchBase = <T extends { name: string }>({
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={activeOptionId}
       />
       {open && (
-        <div className="step-search-dropdown" id={listboxId} aria-label="Speciality results">
-          {filtered?.length > 0 ? (
-            filtered.map((speciality: any) => (
+        <div
+          className="step-search-dropdown"
+          id={listboxId}
+          role="listbox"
+          aria-label="Speciality results"
+        >
+          {listOptions.map((option) => {
+            const optionId = `${listboxId}-option-${option.id}`;
+            const isActive = activeOptionId === optionId;
+            if (option.kind === 'add') {
+              return (
+                <button
+                  key="add"
+                  type="button"
+                  id={optionId}
+                  role="option"
+                  aria-selected={isActive}
+                  className="step-search-add"
+                  onClick={handleAddSpeciality}
+                >
+                  New speciality “{query.trim()}”
+                </button>
+              );
+            }
+            return (
               <button
-                key={speciality.name}
+                key={option.name}
                 type="button"
+                id={optionId}
+                role="option"
+                aria-selected={isActive}
                 className="step-search-speciality"
-                onClick={() => handleSelectSpeciality(speciality)}
+                onClick={() => handleSelectSpeciality({ name: option.name })}
               >
-                <div className="step-search-speciality-title">{speciality.name}</div>
+                <div className="step-search-speciality-title">{option.name}</div>
               </button>
-            ))
-          ) : (
-            <button type="button" className="step-search-add" onClick={handleAddSpeciality}>
-              New speciality “{query.trim()}”
-            </button>
-          )}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- ServiceSearchBase and SpecialitySearchBase (the "Search or create service/speciality" pickers used in Organization > Specialities) had zero keyboard navigation - no listbox semantics and no arrow-key handling, so a keyboard-only user could only reach the search-and-create options via Tab.
- Wired the shared `useListboxKeyboardNav` hook (from `apps/frontend/src/app/ui/inputs/Dropdown/useDropdownKeyboardNav.ts`) into each component independently, adding `role="listbox"`/`role="option"`, `aria-expanded`/`aria-haspopup`/`aria-controls`/`aria-activedescendant`, `aria-selected`, and ArrowUp/ArrowDown/Home/End/Enter/Escape handling over the existing filtered-results-or-create-row list.
- Existing search/filter, create-new, and click-to-select behavior is unchanged - this is purely additive keyboard support. The two files were left as separate components per the audit's scope note (their duplication is a separate, deliberately out-of-scope concern).
- Updated existing tests/stories that queried dropdown rows via `getByRole('button', ...)` to `getByRole('option', ...)`, since the rows now correctly expose `role="option"` inside the `listbox`.

## Verified
- `npx tsc --noEmit` (apps/frontend) - clean.
- `pnpm --filter frontend exec eslint` on changed files - clean.
- Full monorepo `pnpm run lint` + `pnpm run type-check` via the pre-push hook - all 17 tasks passed.
- Targeted Jest: `ServiceSearchBase|SpecialitySearchBase` and all `ServiceSearch|SpecialitySearch` suites (68 tests across 7 suites) - all passing.
- Mutation-checked every added/changed test: reverted only the two source files to `origin/dev`, reran, confirmed all 11 tests in the two Base test files failed, then restored the fix and confirmed `git diff HEAD` matched the intended change before committing.

## Test plan
- [x] ArrowDown moves the highlighted option; Enter selects it (both components).
- [x] ArrowDown + Enter also drives the "create new" row when nothing matches (keyboard-only add flow).
- [x] Escape closes the results listbox without selecting anything.
- [x] Existing click-to-select and create-new-by-click flows still pass unchanged.
- [x] Storybook play-function stories updated to match the new `option` role.