### PR TITLE
fix(frontend): add listbox/option ARIA roles to the canonical Dropdown family

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/Dropdown.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/Dropdown.test.tsx
@@ -530,6 +530,28 @@ describe('Dropdown Component', () => {
     expect(container).toHaveClass('custom-class-test');
   });
 
+  it('exposes listbox/option ARIA roles with aria-selected on the panel', () => {
+    render(
+      <Dropdown
+        placeholder="Select"
+        value="Option B"
+        onChange={mockOnChange}
+        options={['Option A', 'Option B']}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+
+    const optionA = screen.getByRole('option', { name: 'Option A' });
+    const optionB = screen.getByRole('option', { name: 'Option B' });
+    expect(optionA).toHaveAttribute('aria-selected', 'false');
+    expect(optionB).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('has no axe accessibility violations', async () => {
     const { container } = render(
       <Dropdown

--- a/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
@@ -363,6 +363,28 @@ describe('LabelDropdown', () => {
     expect(screen.getByText('Consultation')).toBeInTheDocument();
   });
 
+  it('exposes listbox/option ARIA roles with aria-selected on the panel', () => {
+    render(
+      <LabelDropdown
+        placeholder="Species"
+        options={options}
+        defaultOption="cat"
+        onSelect={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Species/i }));
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const options_ = screen.getAllByRole('option');
+    expect(options_).toHaveLength(2);
+
+    const canine = screen.getByRole('option', { name: 'Canine' });
+    const feline = screen.getByRole('option', { name: 'Feline' });
+    expect(canine).toHaveAttribute('aria-selected', 'false');
+    expect(feline).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('has no axe accessibility violations', async () => {
     const { container } = render(
       <LabelDropdown placeholder="Species" options={options} onSelect={jest.fn()} />

--- a/apps/frontend/src/app/__tests__/components/Inputs/MultiSelectDropdown/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/MultiSelectDropdown/index.test.tsx
@@ -45,7 +45,7 @@ describe('MultiSelectDropdown', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Select/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'One', pressed: false }));
+    fireEvent.click(screen.getByRole('option', { name: 'One', selected: false }));
     expect(onChange).toHaveBeenCalledWith(['One']);
 
     rerender(
@@ -59,7 +59,7 @@ describe('MultiSelectDropdown', () => {
 
     expect(screen.getByText('One')).toBeInTheDocument();
 
-    const selectedOption = screen.getByRole('button', { name: 'One', pressed: true });
+    const selectedOption = screen.getByRole('option', { name: 'One', selected: true });
     fireEvent.click(selectedOption);
     expect(onChange).toHaveBeenCalledWith([]);
   });
@@ -157,9 +157,9 @@ describe('MultiSelectDropdown', () => {
     expect(onChange).toHaveBeenCalledWith(['One']);
 
     fireEvent.click(trigger);
-    expect(screen.getByRole('button', { name: 'One', pressed: false })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'One', selected: false })).toBeInTheDocument();
     fireEvent.keyDown(trigger, { key: 'Escape' });
-    expect(screen.queryByRole('button', { name: 'One', pressed: false })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'One', selected: false })).not.toBeInTheDocument();
   });
 
   it('filters options and shows an empty search state', () => {
@@ -330,7 +330,7 @@ describe('MultiSelectDropdown', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Select/i }));
-    expect(screen.getByRole('button', { name: 'One', pressed: false })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'One', selected: false })).toBeInTheDocument();
   });
 
   it('toggles the dropdown when the chevron icon is clicked', () => {
@@ -390,12 +390,12 @@ describe('MultiSelectDropdown', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Select/i }));
 
-    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Two', pressed: false }));
+    fireEvent.mouseEnter(screen.getByRole('option', { name: 'Two', selected: false }));
 
-    expect(screen.getByRole('button', { name: 'Two', pressed: false })).toHaveClass(
+    expect(screen.getByRole('option', { name: 'Two', selected: false })).toHaveClass(
       'bg-card-hover'
     );
-    expect(screen.getByRole('button', { name: 'One', pressed: false })).not.toHaveClass(
+    expect(screen.getByRole('option', { name: 'One', selected: false })).not.toHaveClass(
       'bg-card-hover'
     );
   });
@@ -405,5 +405,25 @@ describe('MultiSelectDropdown', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Select/i }));
     expect(screen.getByText('No options available')).toBeInTheDocument();
+  });
+
+  it('exposes listbox/option ARIA roles with aria-selected on the panel', () => {
+    render(
+      <MultiSelectDropdown
+        placeholder="Select"
+        value={['One']}
+        onChange={jest.fn()}
+        options={['One', 'Two']}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select/i }));
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+
+    expect(screen.getByRole('option', { name: 'One', selected: true })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Two', selected: false })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/calculators/CalculatorBrowser.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/calculators/CalculatorBrowser.test.tsx
@@ -33,7 +33,7 @@ describe('CalculatorBrowser', () => {
     render(<CalculatorBrowser />);
 
     await user.click(screen.getByRole('button', { name: /Calculator: Fluid rate/ }));
-    await user.click(await screen.findByRole('button', { name: 'Constant rate infusion' }));
+    await user.click(await screen.findByRole('option', { name: 'Constant rate infusion' }));
 
     expect(screen.getByText(/How much drug to add to a fluid bag/i)).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
@@ -576,7 +576,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /room: ward a/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Ward B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward B' }));
     // Selecting a room auto-selects that room's first unit, so the Unit dropdown
     // now reflects "B" (unit-b) rather than the placeholder.
     expect(screen.getByRole('button', { name: 'Unit: B' })).toBeInTheDocument();
@@ -736,7 +736,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /room/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Exam Room 2' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Exam Room 2' }));
 
     await waitFor(() => {
       expect(updateAppointment).toHaveBeenCalledWith(
@@ -774,7 +774,7 @@ describe('AppointmentWorkspace container', () => {
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /hospitalize patient/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /room/i }).at(-1)!);
-    fireEvent.click(screen.getByRole('button', { name: 'Ward A' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward A' }));
     fireEvent.click(screen.getByRole('button', { name: /convert to inpatient/i }));
 
     await waitFor(() => {
@@ -830,7 +830,7 @@ describe('AppointmentWorkspace container', () => {
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /hospitalize patient/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /room/i }).at(-1)!);
-    fireEvent.click(screen.getByRole('button', { name: 'Ward B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward B' }));
 
     expect(screen.getByRole('button', { name: 'Unit: B' })).toBeInTheDocument();
 
@@ -899,18 +899,18 @@ describe('AppointmentWorkspace container', () => {
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /hospitalize patient/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /room/i }).at(-1)!);
-    fireEvent.click(screen.getByRole('button', { name: 'Ward A' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward A' }));
     fireEvent.click(screen.getByRole('button', { name: 'Additional Service / Package' }));
 
     expect(
-      screen.getByRole('button', { name: /Hospitalization monitoring Service/i })
+      screen.getByRole('option', { name: /Hospitalization monitoring Service/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Inpatient care package Package/i })
+      screen.getByRole('option', { name: /Inpatient care package Package/i })
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Hospitalization monitoring Service/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Inpatient care package Package/i }));
+    fireEvent.click(screen.getByRole('option', { name: /Hospitalization monitoring Service/i }));
+    fireEvent.click(screen.getByRole('option', { name: /Inpatient care package Package/i }));
 
     expect(
       screen.getByRole('button', { name: /Hospitalization monitoring, Inpatient care package/i })
@@ -988,7 +988,7 @@ describe('AppointmentWorkspace container', () => {
     expect(screen.getByRole('button', { name: 'Unit: A' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() => {
       expect(assignEncounterUnit).toHaveBeenCalledWith(
@@ -1169,7 +1169,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() => {
       expect(assignEncounterUnit).toHaveBeenCalledWith(
@@ -1218,7 +1218,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() => {
       expect(admitAppointment).toHaveBeenCalledWith(
@@ -1673,7 +1673,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() =>
       expect(mockNotify).toHaveBeenCalledWith(
@@ -1697,7 +1697,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() =>
       expect(admitAppointment).toHaveBeenCalledWith(
@@ -1739,7 +1739,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /room/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Exam Room 2' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Exam Room 2' }));
 
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith(
@@ -1760,7 +1760,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() =>
       expect(mockNotify).toHaveBeenCalledWith(
@@ -2087,7 +2087,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     // The missing-admission recovery routes into handleAdmit, which refuses because
     // the un-checked-in appointment can't be admitted yet.
@@ -3145,7 +3145,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: A' }));
-    fireEvent.click(screen.getByRole('button', { name: 'B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'B' }));
 
     await waitFor(() =>
       expect(mockNotify).toHaveBeenCalledWith('error', {
@@ -3172,7 +3172,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: unit-x' }));
-    fireEvent.click(screen.getByRole('button', { name: 'unit-x' }));
+    fireEvent.click(screen.getByRole('option', { name: 'unit-x' }));
 
     await waitFor(() =>
       expect(admitAppointment).toHaveBeenCalledWith(
@@ -3208,7 +3208,7 @@ describe('AppointmentWorkspace container', () => {
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     const reselectUnit = async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Unit: unit-x' }));
-      fireEvent.click(screen.getByRole('button', { name: 'unit-x' }));
+      fireEvent.click(screen.getByRole('option', { name: 'unit-x' }));
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
@@ -3250,7 +3250,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /room: ward a/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Ward B' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward B' }));
 
     await waitFor(() =>
       expect(mockNotify).toHaveBeenCalledWith(
@@ -3287,7 +3287,7 @@ describe('AppointmentWorkspace container', () => {
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /hospitalize patient/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /room/i }).at(-1)!);
-    fireEvent.click(screen.getByRole('button', { name: 'Ward A' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Ward A' }));
   };
 
   it('omits the expected stay when the tentative discharge date is cleared', async () => {
@@ -3329,7 +3329,7 @@ describe('AppointmentWorkspace container', () => {
     await openHospitalizationAndPickRoom(makeAppointment(new Date()));
 
     fireEvent.click(screen.getByRole('button', { name: /assigned support/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Nina' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Nina' }));
     fireEvent.click(screen.getByRole('button', { name: /convert to inpatient/i }));
 
     await waitFor(() =>
@@ -3400,8 +3400,8 @@ describe('AppointmentWorkspace container', () => {
     } as Appointment);
 
     fireEvent.click(screen.getByRole('button', { name: 'Additional Service / Package' }));
-    fireEvent.click(screen.getByRole('button', { name: /Hospitalization monitoring Service/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Inpatient care package Package/i }));
+    fireEvent.click(screen.getByRole('option', { name: /Hospitalization monitoring Service/i }));
+    fireEvent.click(screen.getByRole('option', { name: /Inpatient care package Package/i }));
     fireEvent.click(screen.getByRole('button', { name: /convert to inpatient/i }));
 
     await waitFor(() =>
@@ -3497,7 +3497,7 @@ describe('AppointmentWorkspace container', () => {
 
     expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unit: unit-x' }));
-    fireEvent.click(screen.getByRole('button', { name: 'unit-x' }));
+    fireEvent.click(screen.getByRole('option', { name: 'unit-x' }));
 
     await waitFor(() =>
       expect(admitAppointment).toHaveBeenCalledWith(

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -414,11 +414,11 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
     fireEvent.change(screen.getByLabelText('Order notes'), { target: { value: 'Fasted sample' } });
     fireEvent.change(screen.getByLabelText('Collection date'), { target: { value: '2026-06-03' } });
     fireEvent.click(screen.getByRole('button', { name: /veterinarian: dr\. tim apple/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Sarah Mitchell' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Sarah Mitchell' }));
     fireEvent.click(screen.getByRole('button', { name: /technician: sarah mitchell/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Dr. Tim Apple' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Dr. Tim Apple' }));
     fireEvent.click(screen.getByRole('button', { name: /test type: reference lab/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'In-house' }));
+    fireEvent.click(screen.getByRole('option', { name: 'In-house' }));
 
     expect(hook.setNotes).toHaveBeenCalledWith('Fasted sample');
     expect(hook.setSpecimenCollectionDate).toHaveBeenCalledWith('2026-06-03');

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/QuickActionsModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/QuickActionsModal.test.tsx
@@ -653,7 +653,7 @@ describe('TasksPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /new task/i }));
     // Shared task form: pick an assignee, set the title, save.
     fireEvent.click(screen.getAllByRole('button', { name: /assigned to/i })[0]);
-    fireEvent.click(await screen.findByRole('button', { name: 'Dr. Tim Apple' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Dr. Tim Apple' }));
     fireEvent.change(screen.getByLabelText('Task'), {
       target: { value: 'Recheck incision' },
     });
@@ -678,7 +678,7 @@ describe('TasksPanel', () => {
     expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /new task/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /assigned to/i })[0]);
-    fireEvent.click(await screen.findByRole('button', { name: 'Yasmin Hadid' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Yasmin Hadid' }));
     fireEvent.change(screen.getByLabelText('Task'), {
       target: { value: 'Give meds at 8pm' },
     });
@@ -757,7 +757,7 @@ describe('TasksPanel', () => {
     render(<TasksPanel appointmentId={APPT} />);
 
     fireEvent.click(screen.getAllByRole('button', { name: /assigned to/i })[0]);
-    fireEvent.click(screen.getByRole('button', { name: 'Dr. Tim Apple' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Dr. Tim Apple' }));
     // Reassignment persists to the backing task (single source of truth) so the
     // Schedule timeline reflects the same assignee — no divergent local update.
     await waitFor(() => expect(updateTask).toHaveBeenCalled());

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -899,7 +899,7 @@ describe('TreatmentStep', () => {
     // Qty is a plain input; Frequency is the shared (room/unit-style) LabelDropdown.
     fireEvent.change(screen.getAllByLabelText('Qty')[0], { target: { value: '20' } });
     fireEvent.click(screen.getAllByRole('button', { name: /^Frequency/ })[0]);
-    fireEvent.click(screen.getByRole('button', { name: 'Every 12 hours' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Every 12 hours' }));
     expect(useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.prescription[0].qty).toBe(
       '20'
     );
@@ -1402,7 +1402,7 @@ describe('TreatmentStep', () => {
 
     // Reassigning persists via updateTask.
     fireEvent.click(screen.getAllByRole('button', { name: /assigned to/i })[0]);
-    fireEvent.click(screen.getByRole('button', { name: 'Dr. Tim Apple' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Dr. Tim Apple' }));
     await waitFor(() => expect(updateTask).toHaveBeenCalled());
   });
 

--- a/apps/frontend/src/app/__tests__/routes/public/accessibility-report-page.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/public/accessibility-report-page.test.tsx
@@ -155,7 +155,7 @@ describe('AccessibilityReportPage', () => {
       target: { value: 'https://app.example.com/appointments' },
     });
     fireEvent.click(screen.getByRole('button', { name: /How severe is the impact/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'Very difficult to use' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Very difficult to use' }));
     fireEvent.change(screen.getByLabelText(/Describe the barrier/i), {
       target: { value: 'Cannot tab to the submit button.' },
     });
@@ -283,11 +283,11 @@ describe('AccessibilityReportPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /How severe is the impact/i }));
 
     expect(
-      screen.getByRole('button', { name: 'Cannot use the feature at all' })
+      screen.getByRole('option', { name: 'Cannot use the feature at all' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Very difficult to use' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Inconvenient but workable' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Not sure' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Very difficult to use' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Inconvenient but workable' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Not sure' })).toBeInTheDocument();
   });
 
   it('breadcrumb links back to accessibility statement', () => {

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
@@ -170,6 +170,7 @@ const Dropdown = ({
       filteredList={filteredList}
       setActiveIndex={setActiveIndex}
       selectOption={selectOption}
+      value={value}
     />
   );
 

--- a/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
@@ -17,6 +17,8 @@ type DropdownPanelProps = {
   filteredList: DropdownOption[];
   setActiveIndex: (index: number) => void;
   selectOption: (option: DropdownOption) => void;
+  /** Currently selected value, so each option row can report `aria-selected`. */
+  value: string;
 };
 
 const DropdownPanel = ({
@@ -34,9 +36,11 @@ const DropdownPanel = ({
   filteredList,
   setActiveIndex,
   selectOption,
+  value,
 }: DropdownPanelProps) => (
   <div
     id={listboxId}
+    role="listbox"
     aria-label={placeholder}
     data-portal-dropdown
     className={`select-input-dropdown ${shouldPortal ? 'select-input-dropdown-portal' : ''} ${dropdownClassName ?? ''}`}
@@ -69,11 +73,14 @@ const DropdownPanel = ({
       const label: string = option.label ?? option.value ?? '';
       const valueToSend: string = option.value ?? option.label ?? '';
       const isActive = activeOptionId === `${listboxId}-option-${valueToSend}`;
+      const isSelected = valueToSend === value;
       return (
         <button
           key={valueToSend || label}
           id={`${listboxId}-option-${valueToSend}`}
           type="button"
+          role="option"
+          aria-selected={isSelected}
           className={`select-input-dropdown-item ${isActive ? 'select-input-dropdown-item-active' : ''}`}
           onMouseEnter={() => setActiveIndex(index)}
           onClick={() => selectOption(option)}

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
@@ -74,6 +74,8 @@ type DropdownPanelProps = {
   noOptionsMessage?: string;
   onOptionHover: (option: DropdownOption) => void;
   onOptionSelect: (option: DropdownOption) => void;
+  /** Currently selected value, so each option row can report `aria-selected`. */
+  selectedValue?: string;
 };
 
 const DropdownPanel = ({
@@ -88,6 +90,7 @@ const DropdownPanel = ({
   noOptionsMessage,
   onOptionHover,
   onOptionSelect,
+  selectedValue,
 }: DropdownPanelProps) => {
   const emptyMessage = searchQuery
     ? 'No matches found'
@@ -95,6 +98,7 @@ const DropdownPanel = ({
   return (
     <div
       id={listboxId}
+      role="listbox"
       aria-label={placeholder}
       data-portal-dropdown
       data-terminology-lock={isTerminologyLocked ? 'true' : undefined}
@@ -107,6 +111,8 @@ const DropdownPanel = ({
             key={option.value}
             id={`${listboxId}-option-${option.value}`}
             type="button"
+            role="option"
+            aria-selected={option.value === selectedValue}
             className={optionClassName(activeOptionId === `${listboxId}-option-${option.value}`)}
             onMouseEnter={() => onOptionHover(option)}
             onClick={() => onOptionSelect(option)}
@@ -314,6 +320,7 @@ const LabelDropdown = ({
       noOptionsMessage={noOptionsMessage}
       onOptionHover={(option) => setActiveIndex(filteredOptions.indexOf(option))}
       onOptionSelect={selectOption}
+      selectedValue={selected?.value}
     />
   );
 

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
@@ -45,6 +45,7 @@ const MultiSelectPanel = ({
 }: MultiSelectPanelProps) => (
   <div
     id={listboxId}
+    role="listbox"
     data-portal-dropdown
     className="border-[var(--blue)] max-h-50 overflow-y-auto scrollbar-hidden z-200 rounded-b-[12px] border border-t bg-[var(--screen)] shadow-[0_16px_34px_var(--sh12)] flex flex-col items-stretch w-full px-3 py-2.5"
     style={shouldPortal && portalStyle ? portalStyle : undefined}
@@ -56,7 +57,8 @@ const MultiSelectPanel = ({
           <button
             type="button"
             id={`${listboxId}-option-${option.value}`}
-            aria-pressed={isSelected}
+            role="option"
+            aria-selected={isSelected}
             className={`flex items-center justify-between gap-2 px-5 py-2 text-left text-[13px] hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full ${
               activeOptionId === `${listboxId}-option-${option.value}`
                 ? 'bg-card-hover text-text-primary!'


### PR DESCRIPTION
## Summary
- `DropdownPanel.tsx` (canonical `Dropdown`), `LabelDropdown.tsx`, and `MultiSelectDropdown/index.tsx` rendered their option lists as a bare set of `role="button"` rows with no listbox semantics, so screen readers announced neither the option set nor which value was currently selected.
- Added `role="listbox"` to each panel container and `role="option"` + `aria-selected` to each option row.
- `MultiSelectDropdown`'s prior `aria-pressed` is replaced by `aria-selected`, since `role="option"` doesn't support `aria-pressed` per the ARIA spec.
- `Dropdown`/`DropdownPanel` needed the currently selected `value` threaded down one extra prop to compute `aria-selected` per row; `LabelDropdown` and `MultiSelectDropdown` already had the selected value in scope.

## Verified
- `pnpm --filter frontend lint` — clean, 0 errors/warnings on changed files.
- `tsc --noEmit` (run from `apps/frontend`) — clean, 0 errors.
- Full frontend jest suite (1052 test suites / 13307 tests) — 1 pre-existing regression found and fixed (`TreatmentStep.test.tsx`, an "assigned to" dropdown option query still expecting `role: 'button'`), then a full re-run of all directly affected suites passed clean (9 suites / 375 tests).
- Mutation-check: reverted only the 4 source files to `origin/dev`, re-ran the affected suites — 9 suites / 39 tests failed as expected (confirms the new/changed assertions actually exercise the ARIA change, not vacuous). Restored the fix, confirmed `git diff HEAD -- <source files>` matches the intended change exactly, and re-ran the same suites clean (9 suites / 375 tests passing).
- Monorepo-wide `turbo run lint` and `turbo run type-check` (pre-push hook, all 11 packages) — 0 errors; only pre-existing warnings unrelated to this change (backend `sonarjs` warnings, one nested-function warning in `useLazyAuthStore.ts`).

## Test plan
- [x] `Dropdown.test.tsx`, `LabelDropdown.test.tsx`, `MultiSelectDropdown/index.test.tsx` each gained a test asserting `role="listbox"` on the panel and `role="option"` + correct `aria-selected` on each row.
- [x] `MultiSelectDropdown/index.test.tsx`'s pre-existing `aria-pressed`-based assertions were migrated to `role: 'option'` / `selected`.
- [x] Consumer tests that clicked dropdown options via `getByRole('button', { name: ... })` updated to `getByRole('option', { name: ... })`: `CalculatorBrowser.test.tsx`, `AppointmentWorkspace.test.tsx`, `DiagnosticsStep.test.tsx`, `QuickActionsModal.test.tsx`, `TreatmentStep.test.tsx`, `accessibility-report-page.test.tsx`.
- [x] Verified `FlagListPanel.test.tsx` and `ConsentListPanel.test.tsx` don't import any Dropdown component and are unaffected.