### PR TITLE
fix(frontend): add keyboard navigation to GoogleSearchDropDown

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Inputs/GoogleSearchDropDown/GoogleSearchDropDown.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/GoogleSearchDropDown/GoogleSearchDropDown.test.tsx
@@ -449,7 +449,7 @@ describe('GoogleSearchDropDown Component', () => {
       await Promise.resolve();
     });
 
-    const suggestion = await screen.findByRole('button', { name: /123 Test St/ });
+    const suggestion = await screen.findByRole('option', { name: /123 Test St/ });
     fireEvent.mouseDown(suggestion);
 
     await waitFor(() => expect(mockSetFormData).toHaveBeenCalled());
@@ -550,7 +550,7 @@ describe('GoogleSearchDropDown Component', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(await screen.findByRole('button', { name: /Result/ })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: /Result/ })).toBeInTheDocument();
 
     // Click outside
     fireEvent.mouseDown(screen.getByTestId('outside'));
@@ -706,7 +706,7 @@ describe('GoogleSearchDropDown Component', () => {
       await Promise.resolve();
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
   });
 
   it('sends an empty API key header when the env var is absent', async () => {
@@ -779,7 +779,7 @@ describe('GoogleSearchDropDown Component', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const button = await screen.findByRole('button');
+    const button = await screen.findByRole('option');
     await act(async () => {
       fireEvent.mouseDown(button);
     });
@@ -992,15 +992,15 @@ describe('GoogleSearchDropDown Component', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(await screen.findByRole('button', { name: /Result/ })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: /Result/ })).toBeInTheDocument();
 
     // Blur closes the dropdown but keeps predictions in state.
     fireEvent.blur(input);
-    expect(screen.queryByRole('button', { name: /Result/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Result/ })).not.toBeInTheDocument();
 
     // Refocus should reopen because predictions.length > 0.
     fireEvent.focus(input);
-    expect(await screen.findByRole('button', { name: /Result/ })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: /Result/ })).toBeInTheDocument();
   });
 
   it('selects a prediction via pointerdown as well as mousedown', async () => {
@@ -1046,7 +1046,7 @@ describe('GoogleSearchDropDown Component', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const button = await screen.findByRole('button', { name: /Pointer Place/ });
+    const button = await screen.findByRole('option', { name: /Pointer Place/ });
     await act(async () => {
       fireEvent.pointerDown(button);
     });
@@ -1058,6 +1058,116 @@ describe('GoogleSearchDropDown Component', () => {
       })
     );
     process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = savedKey;
+  });
+
+  // --- 8. Keyboard navigation ---
+
+  it('ArrowDown moves the highlighted prediction', async () => {
+    await openWithSuggestions([
+      {
+        placePrediction: {
+          placeId: 'p_first',
+          structuredFormat: { mainText: { text: 'First Place' } },
+        },
+      },
+      {
+        placePrediction: {
+          placeId: 'p_second',
+          structuredFormat: { mainText: { text: 'Second Place' } },
+        },
+      },
+    ]);
+
+    const input = screen.getByRole('textbox');
+    const firstOption = await screen.findByRole('option', { name: /First Place/ });
+    const secondOption = screen.getByRole('option', { name: /Second Place/ });
+
+    // Opening the list highlights the first prediction by default.
+    expect(firstOption).toHaveAttribute('aria-selected', 'true');
+    expect(secondOption).toHaveAttribute('aria-selected', 'false');
+    expect(input).toHaveAttribute('aria-activedescendant', firstOption.id);
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(firstOption).toHaveAttribute('aria-selected', 'false');
+    expect(secondOption).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', secondOption.id);
+  });
+
+  it('Enter selects the highlighted prediction', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: 'p_enter',
+              structuredFormat: { mainText: { text: 'Enter Place' } },
+            },
+          },
+        ],
+      }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'p_enter', displayName: { text: 'Enter Place' } }),
+    });
+
+    render(
+      <ControlledGoogleSearchDropDown
+        intype="text"
+        inname="address"
+        inlabel="Address"
+        initialValue=""
+        onChange={mockOnChange}
+        setFormData={mockSetFormData}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'Ent' } });
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await screen.findByRole('option', { name: /Enter Place/ });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    // Enter picked the highlighted (only) prediction — same effect a click would have.
+    expect(mockSetFormData).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('places/p_enter'),
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('Escape closes the dropdown without selecting', async () => {
+    await openWithSuggestions([
+      {
+        placePrediction: {
+          placeId: 'p_esc',
+          structuredFormat: { mainText: { text: 'Escape Place' } },
+        },
+      },
+    ]);
+
+    const input = screen.getByRole('textbox');
+    await screen.findByRole('option', { name: /Escape Place/ });
+    const callsBeforeEscape = mockOnChange.mock.calls.length;
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    // Escape must not select: no place-details GET, no extra onChange beyond typing.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledTimes(callsBeforeEscape);
   });
 
   it('renders safely when value is nullish', () => {

--- a/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.tsx
+++ b/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.tsx
@@ -5,6 +5,7 @@ import { UserProfile } from '@/app/features/users/types/profile';
 import { logger } from '@/app/lib/logger';
 import Field from '@/app/ui/Field';
 import Input from '@/app/ui/Input';
+import { useListboxKeyboardNav } from '@/app/ui/inputs/Dropdown/useDropdownKeyboardNav';
 
 type GoogleSearchDropDownProps = {
   intype: string;
@@ -71,6 +72,12 @@ const getAddrComponent = (
 
 const getPredictionPrimaryText = (prediction: Prediction) =>
   prediction.mainText?.trim() || prediction.description?.trim() || 'Unknown location';
+
+// Same identity used for the React list key and the option's DOM id, so the
+// keyboard-nav hook (which only sees the option, not its index) can recover
+// it via `predictions.indexOf(option)`.
+const getPredictionKey = (prediction: Prediction, index: number) =>
+  prediction.placeId ?? `${prediction.kind}-${prediction.description}-${index}`;
 
 const getPredictionSecondaryText = (prediction: Prediction) => {
   const secondary = prediction.secondaryText?.trim();
@@ -201,6 +208,7 @@ const GoogleSearchDropDown = ({
   onAddressSelect,
 }: Readonly<GoogleSearchDropDownProps>) => {
   const uid = useId();
+  const listboxId = useId();
   const errorId = error ? `${uid}-message` : undefined;
   const isFocusedRef = useRef(false);
   const [open, setOpen] = useState(false);
@@ -322,6 +330,26 @@ const GoogleSearchDropDown = ({
     }, 0);
   };
 
+  // Space must still type a space into the address query - only Enter
+  // confirms - mirroring SearchDropdown's own keydown handler, the closest
+  // sibling for an async/debounced search list, which omits Space-to-select
+  // for the same reason.
+  const { activeIndex, activeOptionId, handleKeyDown, setActiveIndex } = useListboxKeyboardNav({
+    open: isDropdownOpen,
+    openDropdown: () => setOpen(true),
+    closeDropdown: () => setOpen(false),
+    disabled: readonly,
+    options: predictions,
+    listboxId,
+    selectionKey: value,
+    getOptionValue: (option) => getPredictionKey(option, predictions.indexOf(option)),
+    isOptionSelected: () => false,
+    selectOption: (option) => {
+      void selectPrediction(option);
+    },
+    spaceSkipsInput: true,
+  });
+
   const autofillFromPlace = (details: PlaceDetails | undefined, fullPredictionText?: string) => {
     const { name, website, phone, normalizedAddress } = derivePlaceAutofill(
       details,
@@ -383,6 +411,10 @@ const GoogleSearchDropDown = ({
           required
           error={Boolean(error)}
           aria-describedby={errorId}
+          aria-expanded={isDropdownOpen}
+          aria-controls={isDropdownOpen ? listboxId : undefined}
+          aria-activedescendant={activeOptionId}
+          onKeyDown={handleKeyDown}
           onFocus={() => {
             if (suppressNextOpenRef.current) return;
             onFocus();
@@ -397,37 +429,50 @@ const GoogleSearchDropDown = ({
         />
         {isDropdownOpen && (
           <div
+            id={listboxId}
+            role="listbox"
+            aria-label={inlabel}
             className="border-[var(--blue)] max-h-[200px] overflow-y-auto scrollbar-hidden z-99 absolute top-full left-0 rounded-b-[12px] border-l border-r border-b bg-neutral-0 flex flex-col items-center w-full px-[12px] py-[10px]"
             onPointerDown={(e) => e.preventDefault()}
           >
-            {predictions?.map((pred, index: number) => (
-              <button
-                className="flex w-full flex-col items-start gap-1 rounded-2xl! px-[1.25rem] py-2 text-left hover:bg-card-hover"
-                key={pred.placeId ?? `${pred.kind}-${pred.description}-${index}`}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  selectPrediction(pred);
-                  inputRef.current?.focus();
-                }}
-                onPointerDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  selectPrediction(pred);
-                  inputRef.current?.focus();
-                }}
-              >
-                <span className="w-full text-left text-[13px] font-medium text-text-primary">
-                  {getPredictionPrimaryText(pred)}
-                </span>
-                {getPredictionSecondaryText(pred) ? (
-                  <span className="w-full text-left text-[12px] font-medium text-text-secondary">
-                    {getPredictionSecondaryText(pred)}
+            {predictions?.map((pred, index: number) => {
+              const optionId = `${listboxId}-option-${getPredictionKey(pred, index)}`;
+              const isActive = index === activeIndex;
+              return (
+                <button
+                  className={`flex w-full flex-col items-start gap-1 rounded-2xl! px-[1.25rem] py-2 text-left hover:bg-card-hover ${
+                    isActive ? 'bg-card-hover' : ''
+                  }`}
+                  key={optionId}
+                  id={optionId}
+                  role="option"
+                  aria-selected={isActive}
+                  type="button"
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    selectPrediction(pred);
+                    inputRef.current?.focus();
+                  }}
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    selectPrediction(pred);
+                    inputRef.current?.focus();
+                  }}
+                >
+                  <span className="w-full text-left text-[13px] font-medium text-text-primary">
+                    {getPredictionPrimaryText(pred)}
                   </span>
-                ) : null}
-              </button>
-            ))}
+                  {getPredictionSecondaryText(pred) ? (
+                    <span className="w-full text-left text-[12px] font-medium text-text-secondary">
+                      {getPredictionSecondaryText(pred)}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- GoogleSearchDropDown (Google Places address autocomplete, used in Add Companion, Onboarding Org/Address/Team steps, and Organization profile) had no keyboard support at all for its predictions list - no Arrow/Home/End/Enter/Escape handling, no listbox/option ARIA roles, no aria-activedescendant. A keyboard-only user could not select a predicted address.
- Wires the existing shared `useListboxKeyboardNav` hook (from the Dropdown family, `apps/frontend/src/app/ui/inputs/Dropdown/useDropdownKeyboardNav.ts`) into the component: ArrowUp/Down moves a roving highlighted index through the predictions, Home/End jump to the first/last, Enter selects the highlighted prediction, Escape closes the list without selecting.
- Adds `role="listbox"` on the predictions container and `role="option"` / `aria-selected` on each prediction, plus `aria-expanded` / `aria-controls` / `aria-activedescendant` on the input.
- Deliberate deviation from a literal "Space also selects": `spaceSkipsInput: true` is passed so Space still types a literal space character into the address query instead of confirming a selection. This mirrors SearchDropdown's own hand-rolled keydown handler (the closest sibling - also a live/debounced text-search list), which likewise never binds Space to select, for the same reason: unlike a closed-trigger dropdown, this is a free-text input where users routinely type multi-word queries ("New York", "1600 Amphitheatre").
- No changes to fetch/debounce timing, the Google Places API integration, or existing click-to-select behavior - purely additive keyboard/ARIA support.

## Verified
- `npx tsc --noEmit` (apps/frontend) - clean, 0 errors.
- `pnpm --filter frontend run lint` - 0 errors (1 pre-existing warning in an unrelated file).
- Aikido SAST/secrets scan on both changed files - 0 issues.
- Pre-push hook (turbo lint + type-check across the monorepo) - 17/17 tasks passed.

## Test plan
- [x] `GoogleSearchDropDown.test.tsx`: 28/28 passing, including 3 new keyboard tests (ArrowDown moves the highlight, Enter selects the highlighted prediction, Escape closes without selecting). Coverage on the changed file: 100% statements/lines; the small number of uncovered branches/functions are pre-existing lines untouched by this diff.
- [x] Mutation-checked the 3 new tests: reverted only the source file to origin/dev, reran - all 3 failed as expected (role="option" didn't exist yet) - then restored the fix and reran to confirm 28/28 pass again.
- [x] Updated 8 pre-existing `getByRole('button', ...)` queries in the test file to `getByRole('option', ...)` to match the new ARIA role on prediction items (the component's own click behavior is unchanged - only the accessible role of the already-existing `<button>` elements changed).
- [x] Consumer suites that render or mock this component (googleAddressFieldRenderer, PersonalStep, AddCompanionCentralModal, EditableAccordion, OrgStep, AddressStep, Parent, testMocks, ProfileCard): 271/271 passing, no changes needed - all mock the component or never query it by role.