### PR TITLE
fix(backend): create a front-desk arrival record when an appointment is checked in from the Board

### DIFF
--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1050,6 +1050,53 @@ const ensureEncounterOnCheckIn = async (args: {
   return { encounterId: createdEncounter.id, caseId };
 };
 
+/**
+ * The front desk's arrival list and an appointment's own CHECKED_IN status
+ * are two independent state machines that share vocabulary without being
+ * wired together in this direction: `checkInAppointment` runs whenever an
+ * appointment is marked CHECKED_IN, which happens both when the front desk
+ * actually checks someone in (a PatientCheckIn row already exists by then)
+ * AND when staff move it there directly from the Board's "Change status"
+ * modal, which never creates one at all - so the Board shows the patient as
+ * checked in while the front desk's arrival list shows nobody.
+ *
+ * Best-effort and outside the status-change transaction on purpose: this is
+ * a visibility aid for the front desk, not a precondition for the status
+ * change itself, so a failure here must never roll back or block staff from
+ * marking someone checked in.
+ */
+const ensureFrontDeskArrival = async (
+  appointmentId: string,
+  organisationId: string,
+  row: AppointmentRow,
+): Promise<void> => {
+  try {
+    const existing = await prisma.patientCheckIn.findFirst({
+      where: { appointmentId },
+      select: { id: true },
+    });
+    if (existing) return;
+
+    const patientId = getPatientId(row.patient);
+    const clientId = getParentIdFromPatient(row.patient);
+    if (!patientId || !clientId) return;
+
+    const now = new Date();
+    await prisma.patientCheckIn.create({
+      data: {
+        organisationId,
+        patientId,
+        clientId,
+        appointmentId,
+        arrivedAt: now,
+        waitStartedAt: now,
+      },
+    });
+  } catch {
+    // Never let the arrival record block or fail the status change it rode in on.
+  }
+};
+
 const assertLeadAvailability = async (args: {
   tx: TransactionClient;
   organisationId: string;
@@ -1858,6 +1905,8 @@ export const AppointmentPrismaService = {
         },
       });
     });
+
+    await ensureFrontDeskArrival(appointmentId, organisationId, row);
 
     return toResponse(updated);
   },

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -112,6 +112,10 @@ jest.mock("../../src/config/prisma", () => ({
       findFirst: jest.fn(),
       create: jest.fn(),
     },
+    patientCheckIn: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
   },
 }));
 
@@ -2374,6 +2378,85 @@ describe("AppointmentPrismaService", () => {
         message: "caseId could not be resolved for check-in.",
         statusCode: 400,
       });
+    });
+  });
+
+  describe("checkInAppointment front-desk arrival sync", () => {
+    beforeEach(() => {
+      // encounterId already set so ensureEncounterOnCheckIn short-circuits -
+      // these tests are about the arrival-record sync, not case/encounter
+      // resolution (covered separately above).
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "UPCOMING", encounterId: "enc_1" }),
+      );
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ status: "CHECKED_IN", encounterId: "enc_1" }),
+      );
+      mockedPrisma.invoice.findMany.mockResolvedValue([]);
+    });
+
+    it("creates a PatientCheckIn row when none exists yet for this appointment", async () => {
+      mockedPrisma.patientCheckIn.findFirst.mockResolvedValue(null);
+      mockedPrisma.patientCheckIn.create.mockResolvedValue({
+        id: "ci_1",
+      } as any);
+
+      await AppointmentPrismaService.checkInAppointment("appt_1", "org_1");
+
+      expect(mockedPrisma.patientCheckIn.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { appointmentId: "appt_1" } }),
+      );
+      expect(mockedPrisma.patientCheckIn.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            organisationId: "org_1",
+            patientId: "comp_1",
+            clientId: "parent_1",
+            appointmentId: "appt_1",
+            arrivedAt: expect.any(Date),
+            waitStartedAt: expect.any(Date),
+          }),
+        }),
+      );
+    });
+
+    it("does not create a second PatientCheckIn row when one already exists for this appointment", async () => {
+      mockedPrisma.patientCheckIn.findFirst.mockResolvedValue({
+        id: "ci_existing",
+      } as any);
+
+      await AppointmentPrismaService.checkInAppointment("appt_1", "org_1");
+
+      expect(mockedPrisma.patientCheckIn.create).not.toHaveBeenCalled();
+    });
+
+    it("still checks the appointment in when the arrival-record write fails", async () => {
+      mockedPrisma.patientCheckIn.findFirst.mockResolvedValue(null);
+      mockedPrisma.patientCheckIn.create.mockRejectedValue(
+        new Error("db down"),
+      );
+
+      const result = await AppointmentPrismaService.checkInAppointment(
+        "appt_1",
+        "org_1",
+      );
+
+      expect(result.status).toBe("CHECKED_IN");
+    });
+
+    it("skips creating an arrival record when the appointment's patient/parent ids cannot be resolved", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({
+          status: "UPCOMING",
+          encounterId: "enc_1",
+          patient: { id: "comp_1" } as any,
+        }),
+      );
+      mockedPrisma.patientCheckIn.findFirst.mockResolvedValue(null);
+
+      await AppointmentPrismaService.checkInAppointment("appt_1", "org_1");
+
+      expect(mockedPrisma.patientCheckIn.create).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- Reported live: an appointment showed as checked in on the Board, but Front-desk's "Arrivals" panel said "No patients are checked in" for the same patient.
- Root cause: `checkInAppointment` runs whenever an appointment moves to `CHECKED_IN`, which happens two ways - the front desk actually checking someone in (a `PatientCheckIn` row already exists by then), and staff moving it there directly from the Board's "Change status" modal (`UPCOMING -> CHECKED_IN` is an allowed transition there, see `apps/frontend/src/app/lib/appointments.ts:24`) - which never created a `PatientCheckIn` row at all. The Arrivals panel only ever lists real `PatientCheckIn` rows, so it showed nobody.
- Fix: `checkInAppointment` now best-effort ensures a `PatientCheckIn` row exists for the appointment (idempotent - skips if the front-desk path already created one).
- Deliberately outside the status-change transaction: this is a visibility aid for the front desk, not a precondition for the status change, so a failure here (missing patient/parent ids, a transient DB error) must never block or roll back staff marking someone checked in.

## Test plan
- [x] `appointment.prisma.service.test.ts`: 172/172 passing, including 4 new tests (creates the record, skips when one already exists, still checks in when the write fails, skips when patient/parent ids can't be resolved)
- [x] `patient-check-in.service.test.ts`: 24/24 passing, no regression on the existing front-desk-initiated check-in path
- [x] Mutation-checked all 4 new tests individually via targeted internal mutation (not just a whole-file revert, since 3 of the 4 guard clauses are new logic that a whole-file revert can't meaningfully isolate) - each one genuinely fails when its specific guard is removed
- [x] `tsc --noEmit` and eslint: zero new findings versus the same pre-existing baseline confirmed on unmodified `dev` (9 pre-existing `tx`-implicit-any tsc errors, unchanged; lint delta proportional to the new `prisma.*` calls, same known worktree-local typed-lint artifact documented on #2911)