### PR TITLE
fix(frontend): match the date-picker icon button to its pill-shaped toolbar neighbors

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.tsx
@@ -41,11 +41,14 @@ const AppointmentBoardToolbar = ({
   <div className="shrink-0 border-b border-card-border bg-neutral-0 px-3 py-2">
     <div className="flex w-full items-center gap-4">
       <div className="flex shrink-0 items-center gap-2 text-body-4-emphasis text-text-primary">
+        {/* rounded-full! overrides Datepicker's default field shape (rounded-xl) so
+            this icon button matches Back/Next's pill shape beside it */}
         <GlassTooltip content="Select date" side="bottom">
           <Datepicker
             currentDate={currentDate}
             setCurrentDate={setCurrentDate}
             placeholder="Select Date"
+            className="rounded-full!"
           />
         </GlassTooltip>
         <div className="flex items-center gap-2">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -400,11 +400,14 @@ const Header = ({
     >
       <div className="flex shrink-0 items-center gap-2.5">
         <GlassTooltip content="Select date" side="bottom">
+          {/* rounded-full! overrides Datepicker's default field shape (rounded-xl) so
+              this icon button matches its pill-shaped neighbors below (date nav, Today) */}
           <div className="relative z-150">
             <Datepicker
               currentDate={currentDate}
               setCurrentDate={setCurrentDate}
               placeholder="Select Date"
+              className="rounded-full!"
             />
           </div>
         </GlassTooltip>


### PR DESCRIPTION
## Summary
- Reported live: the calendar icon next to the date navigator ("< September 2026 >") looked out of place.
- Root cause: `Datepicker`'s icon-only variant defaults to `getFieldControlClassName()` (`rounded-xl`, generic form-field shape) - correct for its many `type="input"` callers (verified: all other 20 usages across the codebase pass `type="input"` explicitly). The two icon-only callers (Calendar header, Board toolbar) sit directly beside `rounded-full!` controls (date-nav pill, Today, Back/Next) with no override, so it read as a blocky rounded square wedged between pills.
- Fix: pass `className="rounded-full!"` at the two icon-only call sites only (`Header.tsx`, `AppointmentBoardToolbar.tsx`) - a targeted override via the component's existing `className` prop, not a change to the shared component's default (which stays correct for every `type="input"` form-field caller).

## Test plan
- [x] `Header.test.tsx` + `AppointmentBoard.test.tsx`: 54/54 passing (both already render the changed components; no new test needed for a static className prop with no logic branch)
- [x] Confirmed via grep that every other `<Datepicker>` usage passes `type="input"` and is unaffected
- [x] `tsc --noEmit` and eslint: clean on both changed files