### PR TITLE
feat(frontend): show point-of-care lab results

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/PocLabListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/PocLabListPanel.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { isAuthRedirectError } from '@/app/services/axios';
+import PocLabListPanel from '@/app/features/companionHistory/components/PocLabListPanel';
+import {
+  fetchPocLabResults,
+  type PointOfCareLabResult,
+} from '@/app/features/companionHistory/services/pocLabService';
+
+let permissionsMock = ['appointments:view:any'];
+
+jest.mock('@/app/hooks/usePermissions', () => ({
+  usePermissions: () => ({ can: (permission: string) => permissionsMock.includes(permission) }),
+}));
+
+jest.mock('@/app/services/axios', () => ({
+  isAuthRedirectError: jest.fn(() => false),
+}));
+
+jest.mock('@/app/features/companionHistory/services/pocLabService', () => ({
+  fetchPocLabResults: jest.fn(),
+}));
+
+const fetchMock = fetchPocLabResults as jest.Mock;
+const isAuthRedirectMock = isAuthRedirectError as jest.Mock;
+
+const labResult = (
+  overrides: Partial<PointOfCareLabResult> & { id: string }
+): PointOfCareLabResult => ({
+  organisationId: 'org-1',
+  patientId: 'patient-1',
+  encounterId: null,
+  conductedAt: '2026-06-30T10:00:00.000Z',
+  conductedBy: 'staff-1',
+  testType: 'CBC',
+  analyzerName: 'ProCyte One',
+  sampleType: 'Whole blood',
+  results: [
+    {
+      name: 'Haematocrit',
+      value: 28,
+      unit: '%',
+      referenceRangeLow: 37,
+      referenceRangeHigh: 55,
+      flag: 'L',
+    },
+  ],
+  overallInterpretation: 'Mild non-regenerative anaemia',
+  abnormalFlags: ['Haematocrit'],
+  criticalFlags: [],
+  followUpRecommended: true,
+  notes: 'Repeat in one week',
+  createdAt: '2026-06-30T10:00:00.000Z',
+  updatedAt: '2026-06-30T10:00:00.000Z',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  permissionsMock = ['appointments:view:any'];
+  fetchMock.mockResolvedValue([]);
+});
+
+describe('PocLabListPanel', () => {
+  it('loads the patient list and expands a result detail', async () => {
+    fetchMock.mockResolvedValue([labResult({ id: 'lab-1' })]);
+    const { container } = render(<PocLabListPanel companionId="patient-1" />);
+
+    expect(await screen.findByText('Complete blood count')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith({ patientId: 'patient-1' });
+    expect(screen.queryByText('Mild non-regenerative anaemia')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Complete blood count/ }));
+
+    expect(screen.getByText('Haematocrit')).toBeInTheDocument();
+    expect(screen.getByText('Reference 37–55')).toBeInTheDocument();
+    expect(screen.getByText('28 %')).toBeInTheDocument();
+    expect(screen.getByText('Mild non-regenerative anaemia')).toBeInTheDocument();
+    expect(screen.getByText('Repeat in one week')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+
+    await userEvent.click(screen.getByRole('button', { name: /Complete blood count/ }));
+    expect(screen.queryByText('Haematocrit')).not.toBeInTheDocument();
+  });
+
+  it('shows critical and abnormal summaries with bounded reference ranges', async () => {
+    fetchMock.mockResolvedValue([
+      labResult({ id: 'critical', criticalFlags: ['Potassium'], followUpRecommended: false }),
+      labResult({
+        id: 'abnormal',
+        testType: 'BLOOD_CHEMISTRY',
+        results: [
+          { name: 'Creatinine', value: 210, referenceRangeHigh: 159, flag: 'HH' },
+          { name: 'Albumin', value: 18, referenceRangeLow: 22 },
+          { name: 'Sample quality', value: 'Haemolysed' },
+        ],
+        abnormalFlags: ['Creatinine'],
+        criticalFlags: [],
+        overallInterpretation: null,
+        notes: null,
+      }),
+    ]);
+    render(<PocLabListPanel companionId="patient-1" />);
+
+    expect(await screen.findByText('Critical')).toBeInTheDocument();
+    expect(screen.getByText('Abnormal')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Blood chemistry/ }));
+    expect(screen.getByText('Reference Up to 159')).toBeInTheDocument();
+    expect(screen.getByText('Reference From 22')).toBeInTheDocument();
+    expect(screen.getByText('Haemolysed')).toBeInTheDocument();
+  });
+
+  it('shows empty and error states', async () => {
+    const { rerender } = render(<PocLabListPanel companionId="patient-1" />);
+    expect(await screen.findByText('No in-house lab results recorded.')).toBeInTheDocument();
+
+    fetchMock.mockRejectedValueOnce(new Error('failed'));
+    rerender(<PocLabListPanel companionId="patient-2" />);
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not load in-house lab results'
+    );
+  });
+
+  it('does not show a load error for an authentication redirect', async () => {
+    fetchMock.mockRejectedValue(new Error('redirecting'));
+    isAuthRedirectMock.mockReturnValue(true);
+    render(<PocLabListPanel companionId="patient-1" />);
+
+    expect(await screen.findByText('No in-house lab results recorded.')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('reloads when the companion changes', async () => {
+    fetchMock
+      .mockResolvedValueOnce([labResult({ id: 'lab-1' })])
+      .mockResolvedValueOnce([
+        labResult({ id: 'lab-2', patientId: 'patient-2', testType: 'URINALYSIS' }),
+      ]);
+    const { rerender } = render(<PocLabListPanel companionId="patient-1" />);
+    await screen.findByText('Complete blood count');
+
+    rerender(<PocLabListPanel companionId="patient-2" />);
+
+    expect(await screen.findByText('Urinalysis')).toBeInTheDocument();
+    expect(screen.queryByText('Complete blood count')).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenLastCalledWith({ patientId: 'patient-2' });
+  });
+
+  it('renders nothing without view permission or a companion id', async () => {
+    permissionsMock = [];
+    const { container, rerender } = render(<PocLabListPanel companionId="patient-1" />);
+    expect(container).toBeEmptyDOMElement();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    permissionsMock = ['appointments:view:any'];
+    rerender(<PocLabListPanel companionId="" />);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/__snapshots__/PocLabListPanel.test.tsx.snap
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/__snapshots__/PocLabListPanel.test.tsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`PocLabListPanel loads the patient list and expands a result detail 1`] = `
+<div>
+  <section
+    aria-labelledby="poc-lab-heading"
+    class="flex w-full flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]"
+  >
+    <header
+      class="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3"
+    >
+      <span
+        aria-hidden="true"
+        class="text-[var(--ink-muted)]"
+      >
+        <svg
+          fill="currentColor"
+          height="17"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 512 512"
+          width="17"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M176 48h160M118 304h276M208 48v93.48a64.1 64.1 0 0 1-9.88 34.18L73.21 373.49C48.4 412.78 76.63 464 123.08 464h265.84c46.45 0 74.68-51.22 49.87-90.51L313.87 175.66a64.1 64.1 0 0 1-9.87-34.18V48"
+            fill="none"
+            stroke-linecap="round"
+            stroke-miterlimit="10"
+            stroke-width="32"
+          />
+        </svg>
+      </span>
+      <h3
+        class="text-[13.5px] font-bold text-[var(--ink)]"
+        id="poc-lab-heading"
+      >
+        In-house lab results
+      </h3>
+      <span
+        class="yc-status-pill inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] ml-2 tabular-nums"
+        style="background-color: var(--color-pill-neutral-bg); color: var(--color-pill-neutral-text); border-color: var(--color-pill-neutral-border); border-style: solid;"
+        title="1 recorded"
+      >
+        1 recorded
+      </span>
+    </header>
+    <ul>
+      <li
+        class="border-t border-[var(--divider)] first:border-t-0"
+      >
+        <button
+          aria-expanded="true"
+          class="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--blue)]"
+          type="button"
+        >
+          <span
+            class="min-w-0"
+          >
+            <span
+              class="text-[13px] font-bold text-[var(--ink)] block"
+            >
+              Complete blood count
+            </span>
+            <span
+              class="text-[11.5px] text-[var(--ink-faint)] mt-0.5 block"
+            >
+              Jun 30, 2026 · Whole blood · ProCyte One
+            </span>
+          </span>
+          <span
+            class="flex shrink-0 items-center gap-1.5"
+          >
+            <span
+              class="yc-status-pill inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] "
+              style="background-color: var(--color-pill-warning-bg); color: var(--color-pill-warning-text); border-color: var(--color-pill-warning-border); border-style: solid;"
+              title="Abnormal"
+            >
+              Abnormal
+            </span>
+            <span
+              class="yc-status-pill inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] "
+              style="background-color: var(--color-pill-info-bg); color: var(--color-pill-info-text); border-color: var(--color-pill-info-border); border-style: solid;"
+              title="Follow-up"
+            >
+              Follow-up
+            </span>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="16"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m112 328 144-144 144 144"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="48"
+              />
+            </svg>
+          </span>
+        </button>
+        <div
+          class="border-t border-[var(--divider)] bg-[var(--inset)] px-4 py-3"
+        >
+          <ul
+            aria-label="Complete blood count parameters"
+          >
+            <li
+              class="grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-t border-[var(--divider)] py-2 first:border-t-0"
+            >
+              <span
+                class="min-w-0"
+              >
+                <span
+                  class="text-[13px] font-bold text-[var(--ink)] block"
+                >
+                  Haematocrit
+                </span>
+                <span
+                  class="text-[11.5px] text-[var(--ink-faint)]"
+                >
+                  Reference 37–55
+                </span>
+              </span>
+              <span
+                class="flex items-center gap-2 text-[13px] font-semibold text-[var(--ink)]"
+              >
+                <span>
+                  28 %
+                </span>
+                <span
+                  class="yc-status-pill inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] "
+                  style="background-color: var(--color-pill-warning-bg); color: var(--color-pill-warning-text); border-color: var(--color-pill-warning-border); border-style: solid;"
+                  title="L"
+                >
+                  L
+                </span>
+              </span>
+            </li>
+          </ul>
+          <div
+            class="mt-3 border-t border-[var(--divider)] pt-3"
+          >
+            <span
+              class="text-[13px] font-bold text-[var(--ink)]"
+            >
+              Interpretation
+            </span>
+            <p
+              class="text-[11.5px] text-[var(--ink-faint)] mt-1 text-[var(--ink-muted)]"
+            >
+              Mild non-regenerative anaemia
+            </p>
+          </div>
+          <div
+            class="mt-3"
+          >
+            <span
+              class="text-[13px] font-bold text-[var(--ink)]"
+            >
+              Notes
+            </span>
+            <p
+              class="text-[11.5px] text-[var(--ink-faint)] mt-1 text-[var(--ink-muted)]"
+            >
+              Repeat in one week
+            </p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </section>
+</div>
+`;

--- a/apps/frontend/src/app/__tests__/features/companionHistory/services/pocLabService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/services/pocLabService.test.ts
@@ -1,0 +1,102 @@
+import { AxiosError } from 'axios';
+import { fetchPocLabResults } from '@/app/features/companionHistory/services/pocLabService';
+import { getData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+
+jest.mock('@/app/services/axios', () => ({ getData: jest.fn() }));
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn() },
+}));
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+let mockOrgId: string | null = ORG_ID;
+
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: { getState: () => ({ primaryOrgId: mockOrgId }) },
+}));
+
+const getMock = getData as jest.Mock;
+const errorMock = logger.error as jest.Mock;
+const warnMock = logger.warn as jest.Mock;
+const BASE = `/v1/pms/organisation/${ORG_ID}/poc-lab`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOrgId = ORG_ID;
+});
+
+describe('pocLabService', () => {
+  it('fetches patient results and passes an optional test type', async () => {
+    getMock.mockResolvedValue({ data: [{ id: 'lab-1' }] });
+
+    await expect(
+      fetchPocLabResults({ patientId: 'patient-1', testType: 'BLOOD_CHEMISTRY' })
+    ).resolves.toEqual([{ id: 'lab-1' }]);
+    expect(getMock).toHaveBeenCalledWith(BASE, {
+      patientId: 'patient-1',
+      testType: 'BLOOD_CHEMISTRY',
+    });
+  });
+
+  it('omits the test type when it is not supplied', async () => {
+    getMock.mockResolvedValue({ data: [] });
+    await fetchPocLabResults({ patientId: 'patient-1' });
+    expect(getMock).toHaveBeenCalledWith(BASE, { patientId: 'patient-1' });
+  });
+
+  it('rejects missing patient and organisation ids before requesting', async () => {
+    await expect(fetchPocLabResults({ patientId: '' })).rejects.toThrow('Patient ID missing');
+    mockOrgId = null;
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).rejects.toThrow(
+      'No active organisation selected.'
+    );
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsafe organisation path segment', async () => {
+    mockOrgId = '../other-org';
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).rejects.toThrow(
+      'Organisation ID contains unsupported characters'
+    );
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list and logs only the type for a malformed response', async () => {
+    const payload = { patientName: 'Private' };
+    getMock.mockResolvedValue({ data: payload });
+
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).resolves.toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(expect.any(String), 'object');
+    expect(warnMock.mock.calls[0]).not.toContainEqual(payload);
+  });
+
+  it('logs an Axios server message and rethrows the error without logging its body', async () => {
+    const error = new AxiosError('request failed');
+    const responseData = { message: 'Unavailable', patientName: 'Private' };
+    error.response = { data: responseData } as never;
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith(
+      'Failed to load point-of-care lab results:',
+      'Unavailable'
+    );
+    expect(errorMock.mock.calls[0]).not.toContainEqual(responseData);
+  });
+
+  it('falls back to the Axios message when no server message exists', async () => {
+    const error = new AxiosError('offline');
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load point-of-care lab results:', 'offline');
+  });
+
+  it('logs and rethrows a non-Axios error', async () => {
+    const error = new Error('raw');
+    getMock.mockRejectedValue(error);
+
+    await expect(fetchPocLabResults({ patientId: 'patient-1' })).rejects.toBe(error);
+    expect(errorMock).toHaveBeenCalledWith('Failed to load point-of-care lab results:', error);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/CompanionHistory/CompanionHistoryPage.test.tsx
@@ -147,6 +147,11 @@ jest.mock('@/app/features/companionHistory/components/FlagListPanel', () => ({
   default: ({ companionId }: any) => <div data-testid="flag-list-panel">{companionId}</div>,
 }));
 
+jest.mock('@/app/features/companionHistory/components/PocLabListPanel', () => ({
+  __esModule: true,
+  default: ({ companionId }: any) => <div data-testid="poc-lab-list-panel">{companionId}</div>,
+}));
+
 jest.mock('@/app/ui/layout/PhoneShell/useIsPhone', () => ({
   useIsPhone: () => mockIsPhone,
   PHONE_MEDIA_QUERY: '(max-width: 767px)',
@@ -357,6 +362,7 @@ describe('CompanionHistoryPage', () => {
     expect(screen.getByTestId('allergy-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByTestId('consent-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByTestId('flag-list-panel')).toHaveTextContent('c-1');
+    expect(screen.getByTestId('poc-lab-list-panel')).toHaveTextContent('c-1');
     expect(screen.getByText("Buddy's overview")).toBeInTheDocument();
     expect(screen.getByText('Labrador / Canine')).toBeInTheDocument();
 

--- a/apps/frontend/src/app/features/companionHistory/components/PocLabListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/PocLabListPanel.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+import { PocLabList } from './PocLabListPanel';
+import type { PointOfCareLabResult } from '@/app/features/companionHistory/services/pocLabService';
+
+const results: PointOfCareLabResult[] = [
+  {
+    id: 'lab-1',
+    organisationId: 'org-1',
+    patientId: 'patient-1',
+    encounterId: null,
+    conductedAt: '2026-06-30T10:00:00.000Z',
+    conductedBy: 'staff-1',
+    testType: 'BLOOD_CHEMISTRY',
+    analyzerName: 'Catalyst One',
+    sampleType: 'Serum',
+    results: [
+      {
+        name: 'Creatinine',
+        value: 210,
+        unit: 'µmol/L',
+        referenceRangeLow: 44,
+        referenceRangeHigh: 159,
+        flag: 'H',
+      },
+      {
+        name: 'Potassium',
+        value: 6.9,
+        unit: 'mmol/L',
+        referenceRangeLow: 3.5,
+        referenceRangeHigh: 5.8,
+        flag: 'HH',
+      },
+    ],
+    overallInterpretation: 'Azotaemia with marked hyperkalaemia.',
+    abnormalFlags: ['Creatinine'],
+    criticalFlags: ['Potassium'],
+    followUpRecommended: true,
+    notes: 'Confirm potassium on a fresh sample.',
+    createdAt: '2026-06-30T10:00:00.000Z',
+    updatedAt: '2026-06-30T10:00:00.000Z',
+  },
+  {
+    id: 'lab-2',
+    organisationId: 'org-1',
+    patientId: 'patient-1',
+    encounterId: null,
+    conductedAt: '2026-05-14T08:30:00.000Z',
+    conductedBy: 'staff-2',
+    testType: 'CBC',
+    analyzerName: 'ProCyte One',
+    sampleType: 'Whole blood',
+    results: [{ name: 'Haematocrit', value: 42, unit: '%', flag: 'N' }],
+    overallInterpretation: 'Within expected limits.',
+    abnormalFlags: [],
+    criticalFlags: [],
+    followUpRecommended: false,
+    notes: null,
+    createdAt: '2026-05-14T08:30:00.000Z',
+    updatedAt: '2026-05-14T08:30:00.000Z',
+  },
+];
+
+const meta = {
+  title: 'CompanionHistory/PocLabList',
+  component: PocLabList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: { records: results, loading: false, error: null },
+} satisfies Meta<typeof PocLabList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Blood chemistry/ }));
+    await expect(canvas.getByText('Azotaemia with marked hyperkalaemia.')).toBeVisible();
+  },
+};
+
+export const Empty: Story = { args: { records: [] } };
+export const Loading: Story = { args: { records: [], loading: true } };
+export const WithError: Story = {
+  args: { records: [], error: 'Could not load in-house lab results. Please try again.' },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/PocLabListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/PocLabListPanel.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { IoChevronDownOutline, IoChevronUpOutline, IoFlaskOutline } from 'react-icons/io5';
+import { usePermissions } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { isAuthRedirectError } from '@/app/services/axios';
+import {
+  ClinicalListEmpty,
+  ClinicalListError,
+  ClinicalListLoadingRows,
+  cardClass,
+  formatDate,
+  metaClass,
+  titleClass,
+} from '@/app/features/companionHistory/components/ClinicalListChrome';
+import {
+  fetchPocLabResults,
+  type LabResultParameter,
+  type PocTestType,
+  type PointOfCareLabResult,
+} from '@/app/features/companionHistory/services/pocLabService';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+
+const LOAD_ERROR = 'Could not load in-house lab results. Please try again.';
+
+const TEST_TYPE_LABEL: Record<PocTestType, string> = {
+  CBC: 'Complete blood count',
+  BLOOD_CHEMISTRY: 'Blood chemistry',
+  URINALYSIS: 'Urinalysis',
+  FECAL_FLOAT: 'Faecal float',
+  CYTOLOGY: 'Cytology',
+  COAGULATION: 'Coagulation',
+  ELECTROLYTES: 'Electrolytes',
+  THYROID_PANEL: 'Thyroid panel',
+  CORTISOL: 'Cortisol',
+  GLUCOSE_CURVE: 'Glucose curve',
+  BLOOD_GAS: 'Blood gas',
+  OTHER: 'Other test',
+};
+
+const RESULT_FLAG_TONE: Record<NonNullable<LabResultParameter['flag']>, StatusTone> = {
+  H: 'warning',
+  L: 'warning',
+  HH: 'danger',
+  LL: 'danger',
+  N: 'success',
+};
+
+const formatReferenceRange = (result: LabResultParameter): string | null => {
+  const { referenceRangeLow: low, referenceRangeHigh: high } = result;
+  if (low === undefined && high === undefined) return null;
+  if (low === undefined) return `Up to ${high}`;
+  if (high === undefined) return `From ${low}`;
+  return `${low}–${high}`;
+};
+
+const formatResultValue = (result: LabResultParameter): string =>
+  result.unit ? `${result.value} ${result.unit}` : String(result.value);
+
+const ResultParameter = ({ result }: { result: LabResultParameter }) => {
+  const range = formatReferenceRange(result);
+  return (
+    <li className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-t border-[var(--divider)] py-2 first:border-t-0">
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block')}>{result.name}</span>
+        {range ? <span className={metaClass}>{`Reference ${range}`}</span> : null}
+      </span>
+      <span className="flex items-center gap-2 text-[13px] font-semibold text-[var(--ink)]">
+        <span>{formatResultValue(result)}</span>
+        {result.flag ? (
+          <StatusPill label={result.flag} tone={RESULT_FLAG_TONE[result.flag]} />
+        ) : null}
+      </span>
+    </li>
+  );
+};
+
+const LabResultDetails = ({ record }: { record: PointOfCareLabResult }) => (
+  <div className="border-t border-[var(--divider)] bg-[var(--inset)] px-4 py-3">
+    <ul aria-label={`${TEST_TYPE_LABEL[record.testType]} parameters`}>
+      {record.results.map((result) => (
+        <ResultParameter key={`${result.name}:${result.value}`} result={result} />
+      ))}
+    </ul>
+    {record.overallInterpretation ? (
+      <div className="mt-3 border-t border-[var(--divider)] pt-3">
+        <span className={titleClass}>{'Interpretation'}</span>
+        <p className={clsx(metaClass, 'mt-1 text-[var(--ink-muted)]')}>
+          {record.overallInterpretation}
+        </p>
+      </div>
+    ) : null}
+    {record.notes ? (
+      <div className="mt-3">
+        <span className={titleClass}>{'Notes'}</span>
+        <p className={clsx(metaClass, 'mt-1 text-[var(--ink-muted)]')}>{record.notes}</p>
+      </div>
+    ) : null}
+  </div>
+);
+
+const LabResultRow = ({
+  record,
+  expanded,
+  onToggle,
+}: {
+  record: PointOfCareLabResult;
+  expanded: boolean;
+  onToggle: () => void;
+}) => {
+  const conductedAt = formatDate(record.conductedAt);
+  const hasCritical = record.criticalFlags.length > 0;
+  const hasAbnormal = record.abnormalFlags.length > 0;
+  return (
+    <li className="border-t border-[var(--divider)] first:border-t-0">
+      <button
+        type="button"
+        className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--blue)]"
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <span className="min-w-0">
+          <span className={clsx(titleClass, 'block')}>{TEST_TYPE_LABEL[record.testType]}</span>
+          <span className={clsx(metaClass, 'mt-0.5 block')}>
+            {[conductedAt, record.sampleType, record.analyzerName].filter(Boolean).join(' · ')}
+          </span>
+        </span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {hasCritical ? <StatusPill label="Critical" tone="danger" /> : null}
+          {!hasCritical && hasAbnormal ? <StatusPill label="Abnormal" tone="warning" /> : null}
+          {record.followUpRecommended ? <StatusPill label="Follow-up" tone="info" /> : null}
+          {expanded ? (
+            <IoChevronUpOutline size={16} aria-hidden="true" />
+          ) : (
+            <IoChevronDownOutline size={16} aria-hidden="true" />
+          )}
+        </span>
+      </button>
+      {expanded ? <LabResultDetails record={record} /> : null}
+    </li>
+  );
+};
+
+export const PocLabList = ({
+  records,
+  loading,
+  error,
+}: {
+  records: PointOfCareLabResult[];
+  loading: boolean;
+  error: string | null;
+}) => {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  let body;
+  if (loading) body = <ClinicalListLoadingRows />;
+  else if (error) body = <ClinicalListError error={error} />;
+  else if (records.length === 0)
+    body = <ClinicalListEmpty message="No in-house lab results recorded." />;
+  else {
+    body = (
+      <ul>
+        {records.map((record) => (
+          <LabResultRow
+            key={record.id}
+            record={record}
+            expanded={expandedId === record.id}
+            onToggle={() => setExpandedId((current) => (current === record.id ? null : record.id))}
+          />
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <section className={cardClass} aria-labelledby="poc-lab-heading">
+      <header className="flex items-center gap-2 border-b border-[var(--divider)] px-4 py-3">
+        <span className="text-[var(--ink-muted)]" aria-hidden="true">
+          <IoFlaskOutline size={17} />
+        </span>
+        <h3 id="poc-lab-heading" className="text-[13.5px] font-bold text-[var(--ink)]">
+          In-house lab results
+        </h3>
+        {!loading && !error && records.length > 0 ? (
+          <StatusPill
+            label={`${records.length} recorded`}
+            tone="neutral"
+            className="ml-2 tabular-nums"
+          />
+        ) : null}
+      </header>
+      {body}
+    </section>
+  );
+};
+
+const PocLabListPanelContent = ({ companionId }: { companionId: string }) => {
+  const [state, setState] = useState<{
+    records: PointOfCareLabResult[];
+    loading: boolean;
+    error: string | null;
+  }>({ records: [], loading: true, error: null });
+
+  useEffect(() => {
+    if (!companionId) return;
+    let active = true;
+    fetchPocLabResults({ patientId: companionId })
+      .then((result) => {
+        if (active) setState({ records: result, loading: false, error: null });
+      })
+      .catch((requestError) => {
+        if (!active) return;
+        const error = isAuthRedirectError(requestError) ? null : LOAD_ERROR;
+        setState({ records: [], loading: false, error });
+      });
+    return () => {
+      active = false;
+    };
+  }, [companionId]);
+
+  return <PocLabList {...state} />;
+};
+
+const PocLabListPanel = ({ companionId }: { companionId: string }) => {
+  const permissions = usePermissions();
+  const canView = permissions.can(PERMISSIONS.APPOINTMENTS_VIEW_ANY);
+
+  if (!canView) return null;
+  return <PocLabListPanelContent key={companionId} companionId={companionId} />;
+};
+
+export default PocLabListPanel;

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -59,6 +59,7 @@ import { PERMISSIONS } from '@/app/lib/permissions';
 import AllergyListPanel from '@/app/features/companionHistory/components/AllergyListPanel';
 import ConsentListPanel from '@/app/features/companionHistory/components/ConsentListPanel';
 import FlagListPanel from '@/app/features/companionHistory/components/FlagListPanel';
+import PocLabListPanel from '@/app/features/companionHistory/components/PocLabListPanel';
 import { isCompanionRevampEnabled } from '@/app/lib/featureFlags';
 import ShareCompanionCardModal from '@/app/features/companionCard/components/ShareCompanionCardModal';
 import { buildStaffCard } from '@/app/features/companionCard/lib/buildStaffCard';
@@ -712,6 +713,11 @@ const CompanionHistoryDesktopBody = ({
     {hasCompanionId ? (
       <PermissionGate allOf={[PERMISSIONS.COMPANIONS_VIEW_ANY]}>
         <FlagListPanel companionId={companionId} />
+      </PermissionGate>
+    ) : null}
+    {hasCompanionId ? (
+      <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}>
+        <PocLabListPanel companionId={companionId} />
       </PermissionGate>
     ) : null}
 

--- a/apps/frontend/src/app/features/companionHistory/services/pocLabService.ts
+++ b/apps/frontend/src/app/features/companionHistory/services/pocLabService.ts
@@ -1,0 +1,97 @@
+import axios from 'axios';
+import { getData } from '@/app/services/axios';
+import { logger } from '@/app/lib/logger';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+export type PocTestType =
+  | 'CBC'
+  | 'BLOOD_CHEMISTRY'
+  | 'URINALYSIS'
+  | 'FECAL_FLOAT'
+  | 'CYTOLOGY'
+  | 'COAGULATION'
+  | 'ELECTROLYTES'
+  | 'THYROID_PANEL'
+  | 'CORTISOL'
+  | 'GLUCOSE_CURVE'
+  | 'BLOOD_GAS'
+  | 'OTHER';
+
+export type LabResultParameter = {
+  name: string;
+  value: number | string;
+  unit?: string;
+  referenceRangeLow?: number;
+  referenceRangeHigh?: number;
+  flag?: 'H' | 'L' | 'HH' | 'LL' | 'N';
+};
+
+export type PointOfCareLabResult = {
+  id: string;
+  organisationId: string;
+  patientId: string;
+  encounterId: string | null;
+  conductedAt: string;
+  conductedBy: string | null;
+  testType: PocTestType;
+  analyzerName: string | null;
+  sampleType: string | null;
+  results: LabResultParameter[];
+  overallInterpretation: string | null;
+  abnormalFlags: string[];
+  criticalFlags: string[];
+  followUpRecommended: boolean | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const safePathSegment = (value: string, label: string): string => {
+  const match = PATH_SEGMENT.exec(value)?.[0];
+  if (!match) throw new Error(`${label} contains unsupported characters`);
+  return match;
+};
+
+const requireOrgId = (): string => {
+  const orgId = useOrgStore.getState().primaryOrgId;
+  if (!orgId) throw new Error('No active organisation selected.');
+  return safePathSegment(orgId, 'Organisation ID');
+};
+
+export type FetchPocLabResultsParams = {
+  patientId: string;
+  testType?: PocTestType;
+};
+
+export const fetchPocLabResults = async ({
+  patientId,
+  testType,
+}: FetchPocLabResultsParams): Promise<PointOfCareLabResult[]> => {
+  if (!patientId) throw new Error('Patient ID missing');
+  const organisationId = requireOrgId();
+  try {
+    const params: Record<string, string> = { patientId };
+    if (testType) params.testType = testType;
+    const response = await getData<PointOfCareLabResult[]>(
+      `/v1/pms/organisation/${organisationId}/poc-lab`,
+      params
+    );
+    if (!Array.isArray(response.data)) {
+      logger.warn('point-of-care lab list was not an array; got', typeof response.data);
+      return [];
+    }
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      logger.error(
+        'Failed to load point-of-care lab results:',
+        error.response?.data?.message ?? error.message
+      );
+    } else {
+      logger.error('Failed to load point-of-care lab results:', error);
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. This implements the approved PointOfCareLab item from the PIMS parity backlog; no standalone issue exists.
- [x] All existing tests and lints pass.

## What is the current behavior?

Companion History does not show point-of-care lab results even though the mounted API exposes them.

## What is the new behavior?

- Adds an authenticated companion-history panel for in-house lab results.
- Shows test metadata, abnormal and critical status, follow-up state, parameters, interpretation, and notes.
- Handles permission, loading, empty, error, and auth-redirect states using the existing clinical-list patterns.
- Adds Storybook coverage plus component, service, page-wiring, snapshot, validation, and error-path tests.

Validation:

- `npx tsc --noemit` - exit 0.
- `pnpm --filter frontend run lint` - exit 0 with one pre-existing warning outside this change.
- Targeted Jest with coverage - 3 suites, 47 tests, and 1 snapshot passed; new production files meet or exceed 98.21% branch coverage and have 100% statements, functions, and lines.
- `pnpm --filter frontend run build` - exit 0; 119 static pages generated.
- `npx react-doctor@latest --verbose --scope changed --base origin/dev` - exit 0; score 100/100 with no findings in changed files.
- Pre-push `pnpm run lint` and `pnpm run type-check` hooks - exit 0 across the monorepo.

## Related Issue(s)

No standalone issue; PIMS parity backlog item.
