### PR TITLE
fix(repo): correct count-up, onboarding, and patient list behavior

### DIFF
--- a/apps/backend/src/controllers/web/patient-consent.controller.ts
+++ b/apps/backend/src/controllers/web/patient-consent.controller.ts
@@ -21,7 +21,7 @@ const ConsentTypeEnum = z.enum([
 const ConsentStatusEnum = z.enum(["ACTIVE", "REVOKED", "EXPIRED"]);
 
 const GrantBodySchema = z.object({
-  patientId: z.uuid(),
+  patientId: uuid(),
   consentType: ConsentTypeEnum,
   procedureDesc: z.string().max(2000).optional(),
   // `consentedBy` is deliberately NOT accepted from the body: the service uses
@@ -31,7 +31,7 @@ const GrantBodySchema = z.object({
   consentedAt: z.iso.datetime().optional(),
   expiresAt: z.iso.datetime().optional(),
   witnessedBy: z.string().max(200).optional(),
-  documentId: z.uuid().optional(),
+  documentId: uuid().optional(),
   notes: z.string().max(2000).optional(),
 });
 
@@ -40,7 +40,7 @@ const RevokeBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.uuid().optional(),
+  patientId: uuid().optional(),
   status: ConsentStatusEnum.optional(),
   consentType: ConsentTypeEnum.optional(),
 });

--- a/apps/backend/src/controllers/web/patient-problem.controller.ts
+++ b/apps/backend/src/controllers/web/patient-problem.controller.ts
@@ -13,7 +13,7 @@ const StatusEnum = z.enum(["ACTIVE", "INACTIVE", "RESOLVED"]);
 const SeverityEnum = z.enum(["MILD", "MODERATE", "SEVERE"]);
 
 const CreateBodySchema = z.object({
-  patientId: z.uuid(),
+  patientId: uuid(),
   encounterId: z.string().optional(),
   name: z.string().min(1).max(300),
   codeSystem: z.string().max(50).optional(),
@@ -39,7 +39,7 @@ const ResolveBodySchema = z.object({
 });
 
 const ListQuerySchema = z.object({
-  patientId: z.uuid().optional(),
+  patientId: uuid().optional(),
   status: StatusEnum.optional(),
 });
 

--- a/apps/backend/test/controllers/web/clinical/patient-consent.controller.test.ts
+++ b/apps/backend/test/controllers/web/clinical/patient-consent.controller.test.ts
@@ -13,6 +13,16 @@ import {
   runClinicalControllerSuite,
 } from "./clinical-suite";
 
+/**
+ * A 24-hex Mongo ObjectId, still live for patients migrated before the
+ * Postgres UUID cutover. patientId must accept it the same way every sibling
+ * clinical controller's patient/encounter filters do (see patient-allergy's
+ * LEGACY_PATIENT_ID) - a strict z.uuid() here 400s the request before the
+ * service lookup runs, which is exactly what shipped the "Could not load the
+ * consent list" banner for these patients.
+ */
+const LEGACY_PATIENT_ID = "507f1f77bcf86cd799439011";
+
 jest.mock("src/services/patient-consent.service", () => {
   const actual = jest.requireActual(
     "src/services/patient-consent.service",
@@ -55,6 +65,14 @@ runClinicalControllerSuite({
       invalidPayload: { consentType: "VERBAL" },
     },
     {
+      handler: "list",
+      params: { organisationId: ORG_ID },
+      query: { patientId: LEGACY_PATIENT_ID },
+      serviceMethod: "list",
+      expectArgs: [{ organisationId: ORG_ID, patientId: LEGACY_PATIENT_ID }],
+      fallback: "Failed to list consents",
+    },
+    {
       handler: "grant",
       params: { organisationId: ORG_ID },
       // `consentedBy` is the CONSENT_GRANTED audit actor, so it may only come
@@ -87,10 +105,13 @@ runClinicalControllerSuite({
       ],
       status: 201,
       fallback: "Failed to grant consent",
+      // documentId is validated with the same lenient bound as patientId (a
+      // Documenso/legacy reference is not a UUID either), so what makes a
+      // payload invalid now is exceeding the length bound, not the format.
       invalidPayload: {
         patientId: PATIENT_ID,
         consentType: "SURGICAL",
-        documentId: "not-a-uuid",
+        documentId: "x".repeat(65),
       },
     },
     {

--- a/apps/backend/test/controllers/web/clinical/patient-problem.controller.test.ts
+++ b/apps/backend/test/controllers/web/clinical/patient-problem.controller.test.ts
@@ -12,6 +12,16 @@ import {
   runClinicalControllerSuite,
 } from "./clinical-suite";
 
+/**
+ * A 24-hex Mongo ObjectId, still live for patients migrated before the
+ * Postgres UUID cutover. patientId must accept it the same way every sibling
+ * clinical controller's patient/encounter filters do (see patient-allergy's
+ * LEGACY_PATIENT_ID) - a strict z.uuid() here 400s the request before the
+ * service lookup runs, which is exactly what shipped the "Could not load the
+ * problem list" banner for these patients.
+ */
+const LEGACY_PATIENT_ID = "507f1f77bcf86cd799439011";
+
 jest.mock("src/services/patient-problem.service", () => {
   const actual = jest.requireActual(
     "src/services/patient-problem.service",
@@ -44,6 +54,14 @@ runClinicalControllerSuite({
       ],
       fallback: "Failed to list problems",
       invalidPayload: { status: "CHRONIC" },
+    },
+    {
+      handler: "list",
+      params: { organisationId: ORG_ID },
+      query: { patientId: LEGACY_PATIENT_ID },
+      serviceMethod: "list",
+      expectArgs: [{ organisationId: ORG_ID, patientId: LEGACY_PATIENT_ID }],
+      fallback: "Failed to list problems",
     },
     {
       handler: "create",

--- a/apps/frontend/src/app/__tests__/components/Modal/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Modal/index.test.tsx
@@ -136,6 +136,28 @@ describe('Modal', () => {
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
+  it.each(['drawer', 'centered'] as const)(
+    'scrims the %s variant with the same dim as every other overlay',
+    (variant) => {
+      // The drawer used to dim with a separate, lighter `--color-overlay-backdrop`
+      // token at a 2px blur while every other overlay in the app (centered, the
+      // phone sheet, the guide player) used `--sh55` at 6px - reported as the
+      // background behind a drawer panel reading washed-out/low-contrast next to
+      // any other overlay in the same app. Both variants now share one scrim.
+      render(
+        <Modal showModal setShowModal={jest.fn()} variant={variant}>
+          <div>Content</div>
+        </Modal>
+      );
+
+      const dialog = screen.getByRole('dialog');
+      const backdrop = dialog.previousElementSibling as HTMLElement;
+      expect(backdrop).toHaveAttribute('aria-hidden', 'true');
+      expect(backdrop.style.backgroundColor).toBe('var(--sh55)');
+      expect(backdrop.className).toContain('backdrop-blur-[6px]');
+    }
+  );
+
   it.each([
     ['sm', 'sm:w-[480px]'],
     ['md', 'sm:w-[680px]'],

--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -160,6 +160,25 @@ class BatchedIO {
   }
 }
 
+/**
+ * Captures the options every observer was constructed with, without acting on
+ * them - used to pin the rootMargin extension itself rather than simulate the
+ * geometry it guards against (the other mocks above never model geometry at
+ * all; they fire whatever they're told to).
+ */
+class OptionsCapturingIO {
+  static readonly optionsByCall: (IntersectionObserverInit | undefined)[] = [];
+  constructor(_cb: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    OptionsCapturingIO.optionsByCall.push(options);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [] as IntersectionObserverEntry[];
+  }
+}
+
 describe('motion primitives', () => {
   const OriginalIO = globalThis.IntersectionObserver;
   const OriginalMM = (globalThis as unknown as { matchMedia: unknown }).matchMedia;
@@ -375,6 +394,29 @@ describe('motion primitives', () => {
       expect(screen.getAllByText('128').at(-1)).toBeInTheDocument();
     } finally {
       (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = io;
+    }
+  });
+
+  it('CountUp extends its observer root upward like Reveal, so a jump past it still fires', () => {
+    // A jump straight past an element (End key, scrollbar drag, or navigating in
+    // already scrolled) moves it from below the viewport to above it without ever
+    // crossing a threshold, so no callback is delivered at all. Without the same
+    // rootMargin extension Reveal uses, CountUp's `inView` would stay false
+    // forever and the number would freeze at its initial placeholder even after
+    // the real value arrives - `display` is only ever written by the effect
+    // gated on `inView`.
+    OptionsCapturingIO.optionsByCall.length = 0;
+    (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+      OptionsCapturingIO;
+    render(<CountUp value="67,134" />);
+    render(
+      <Reveal>
+        <span>reveal probe</span>
+      </Reveal>
+    );
+    expect(OptionsCapturingIO.optionsByCall).toHaveLength(2);
+    for (const options of OptionsCapturingIO.optionsByCall) {
+      expect(options?.rootMargin).toBe('100000px 0px 0px 0px');
     }
   });
 

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -411,7 +411,17 @@ export function CountUp({ value, className, style }: Readonly<CountUpProps>) {
           }
         });
       },
-      { threshold: 0.35 }
+      {
+        threshold: 0.35,
+        // Same fix as Reveal's observer: without extending the root upward, a
+        // jump straight past this element (the End key, a scrollbar drag, or
+        // navigating in already scrolled) never crosses the threshold, so no
+        // callback ever fires, inView stays false forever, and the count-up
+        // freezes at its initial value even after the real number arrives -
+        // `display` is only ever written by the effect below, which is gated
+        // on inView.
+        rootMargin: '100000px 0px 0px 0px',
+      }
     );
     io.observe(node);
     return () => io.disconnect();

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
@@ -253,15 +253,26 @@ const StripeOnboarding = () => {
       {connectInstance && (
         <div className="w-full rounded-[20px] border border-[var(--hairline)] bg-[var(--screen)] px-6 py-6 shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]">
           <ConnectComponentsProvider connectInstance={connectInstance}>
+            {/* These three Stripe embeds report independent, unrelated pieces of
+                account state (e.g. charges can be disabled pending a bank/identity
+                requirement while tax registrations are already complete), so both
+                "still needs setup" and "already done" content can legitimately be
+                on screen at once. Each gets its own heading and a hairline divider
+                so they read as three separate steps rather than one contradictory
+                block - see the "weird view" report where they were unlabeled and
+                unseparated. */}
             <div className="flex flex-col gap-5" aria-label="Stripe onboarding steps">
-              <ConnectAccountOnboarding onExit={handleExit} onStepChange={handleStepChange} />
               <div className="flex flex-col gap-3">
+                <h2 className="text-center text-heading-2 text-text-primary">Account setup</h2>
+                <ConnectAccountOnboarding onExit={handleExit} onStepChange={handleStepChange} />
+              </div>
+              <div className="flex flex-col gap-3 border-t border-[var(--hairline)] pt-5">
                 <h2 className="text-center text-heading-2 text-text-primary">
                   Tax business details
                 </h2>
                 <ConnectTaxSettings />
               </div>
-              <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-3 border-t border-[var(--hairline)] pt-5">
                 <h2 className="text-center text-heading-2 text-text-primary">Tax registrations</h2>
                 <ConnectTaxRegistrations />
               </div>

--- a/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
@@ -54,10 +54,10 @@ const GuidePlayerModal = ({
       setShowModal={setShowModal}
       onClose={() => setCopied(false)}
       aria-label={`Guide: ${guide.title}`}
-      overlayClassName={`fixed inset-0 z-[1100] backdrop-blur-[2px] transition-opacity duration-200 ${
+      overlayClassName={`fixed inset-0 z-[1100] backdrop-blur-[6px] transition-opacity duration-200 ${
         showModal ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}
-      overlayStyle={{ backgroundColor: 'var(--color-overlay-backdrop)' }}
+      overlayStyle={{ backgroundColor: 'var(--sh55)' }}
       containerClassName={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[1200] flex w-[95vw] max-w-[920px] flex-col overflow-hidden rounded-[22px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_8px_20px_var(--sh10),0_36px_90px_var(--sh12)] transition-opacity duration-100 ${
         showModal ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}

--- a/apps/frontend/src/app/ui/overlays/Modal/Modal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/Modal.stories.tsx
@@ -89,9 +89,10 @@ const meta = {
           'Below 768px both re-form: `centered` becomes a bottom sheet with a grabber, `drawer` ' +
           'goes full-screen. Callers pass nothing extra for that, so the phone stories are the ' +
           'only place the swap is visible.\n\n' +
-          'The scrims differ as well, which is easy to miss without the stories side by side: the ' +
-          'centered panel and the phone sheet use `var(--sh55)` with a 6px blur, the desktop ' +
-          'drawer uses `--color-overlay-backdrop` with a 2px blur.',
+          'Both variants scrim with the same `var(--sh55)` at a 6px blur - the desktop drawer used ' +
+          'to dim with a lighter, separate `--color-overlay-backdrop` token at 2px, which under-dimmed ' +
+          'the drawer relative to every other overlay in the app and read as washed-out background ' +
+          'contrast behind the panel. Unified so every overlay in the app dims by the same amount.',
       },
     },
   },

--- a/apps/frontend/src/app/ui/overlays/Modal/index.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/index.tsx
@@ -163,10 +163,10 @@ const Modal = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       ignoreOutsideClick={isIgnoredOutsideTarget}
-      overlayClassName={`fixed backdrop-blur-[2px] inset-0 z-[1100] transition-opacity duration-300 ease-in-out ${fadeClass(
+      overlayClassName={`fixed backdrop-blur-[6px] inset-0 z-[1100] transition-opacity duration-300 ease-in-out ${fadeClass(
         showModal
       )}`}
-      overlayStyle={{ backgroundColor: 'var(--color-overlay-backdrop)' }}
+      overlayStyle={{ backgroundColor: 'var(--sh55)' }}
       containerClassName={`fixed top-0 right-0 bottom-0 m-3 p-3 h-[calc(100%-2rem)] w-[calc(100%-2rem)] ${DRAWER_WIDTHS[drawerSize]}
         bg-neutral-0 border border-card-border rounded-2xl z-[1200]
         shadow-[0_8px_20px_var(--sh10),0_36px_90px_var(--sh12)]

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
@@ -92,7 +92,7 @@ const meta = {
           'That is worth more than one interaction: the drawer carries five accordions (Org, ' +
           'Personal, Address and Professional details plus Availability), and it re-forms by ' +
           'breakpoint the same way the table does. Above 1280 the drawer is a 530px right-side ' +
-          'panel over a `--color-overlay-backdrop` scrim; below 768 `useIsPhone` swaps it to the ' +
+          'panel over a `--sh55` scrim; below 768 `useIsPhone` swaps it to the ' +
           'full-screen `yc-modal-fullscreen` form. Two quite different layouts, neither previously ' +
           'rendered.\n\n' +
           'The row control is itself two different elements by width, which is why the plays below ' +


### PR DESCRIPTION
## Summary

Three independent, user-reported bugs, batched into one PR:

- **Marketing site: numbers frozen on the Insights page.** `CountUp`'s own `IntersectionObserver` was missing the `rootMargin` extension `Reveal` already carries, so a scroll/navigation past a stat before it crossed the observer's threshold left `inView` false forever — the number stayed at its initial placeholder even after the real value resolved.
- **Stripe onboarding: three unlabeled sections read as one contradictory page.** `ConnectAccountOnboarding`, `ConnectTaxSettings`, and `ConnectTaxRegistrations` are independent Stripe Connect embeds that can legitimately disagree (an account can have complete tax registrations while still missing an unrelated requirement for charges), but they were stacked in one undivided card with no heading on the first section. Each now has its own heading and a divider.
- **Patient record: "Could not load the problem/consent list."** Both controllers validated `patientId` (and consent's `documentId`) with strict `z.uuid()` instead of the shared lenient id validator every sibling clinical controller uses, so a patient with a legacy non-UUID id 400'd before the query ever ran.
- **Bonus: Speciality panel's washed-out background.** The drawer Modal variant dimmed its backdrop with a separate, lighter token (`--color-overlay-backdrop`, 2px blur) than every other overlay in the app (`--sh55`, 6px blur — centered modals, the phone sheet, the guide player). Unified on `--sh55` across all ~26 drawer call sites.

## Test plan
- [x] `motion.test.tsx`: new test pins the `rootMargin` fix; mutation-checked (fails against pre-fix source)
- [x] `patient-problem.controller.test.ts` / `patient-consent.controller.test.ts`: new legacy-id (24-hex) test cases; mutation-checked
- [x] `components/Modal/index.test.tsx`: new test pins the unified scrim; mutation-checked
- [x] Stripe onboarding sectioning is a pure layout/heading change, verified by reading the component tree (no route auth available to load the live page in this environment)
- [x] tsc/eslint clean across all changed files