### PR TITLE
test(frontend): add Storybook stories for 7 uncovered UI primitives/layout components

### DIFF
--- a/apps/frontend/src/app/ui/layout/PostHogBootstrap.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogBootstrap.stories.tsx
@@ -1,0 +1,189 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
+
+import { getStorageItem, removeStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
+import { getLoadedPostHog, resetPostHogClientForTests } from '@/app/lib/posthogClient';
+import PostHogBootstrap from './PostHogBootstrap';
+
+/** The only host the component will ever load posthog-js for. Any other value resolves to an empty `apiHost`. */
+const POSTHOG_EU_HOST = 'https://eu.i.posthog.com';
+const PROJECT_TOKEN = 'phc_storybook_bootstrap_token';
+
+type Fixture = {
+  /** Seeds `cookieConsentGiven`. `null` clears the key, matching a first-time visitor. */
+  consent?: 'true' | 'false' | null;
+  host?: string;
+  token?: string;
+};
+
+/**
+ * The two env vars and the one localStorage key are the whole surface of this
+ * component - there is no store and no axios call to seed. `resetPostHogClientForTests`
+ * is the part that matters most: `loadPostHog` caches the imported posthog-js module in a
+ * module-level variable that outlives any one story, so a story that actually
+ * loads it would otherwise hand every later story an already-initialized
+ * client instead of a fresh mount.
+ */
+const prepare =
+  ({ consent = null, host = '', token = '' }: Fixture) =>
+  () => {
+    const previousConsent = getStorageItem('local', COOKIE_CONSENT_KEY);
+    if (consent === null) {
+      removeStorageItem('local', COOKIE_CONSENT_KEY);
+    } else {
+      setStorageItem('local', COOKIE_CONSENT_KEY, consent);
+    }
+
+    const env = process.env as Record<string, string | undefined>;
+    const previousHost = env.NEXT_PUBLIC_POSTHOG_HOST;
+    const previousToken = env.NEXT_PUBLIC_POSTHOG_TOKEN;
+    env.NEXT_PUBLIC_POSTHOG_HOST = host;
+    env.NEXT_PUBLIC_POSTHOG_TOKEN = token;
+
+    resetPostHogClientForTests();
+
+    return () => {
+      if (previousConsent === null) {
+        removeStorageItem('local', COOKIE_CONSENT_KEY);
+      } else {
+        setStorageItem('local', COOKIE_CONSENT_KEY, previousConsent);
+      }
+      env.NEXT_PUBLIC_POSTHOG_HOST = previousHost;
+      env.NEXT_PUBLIC_POSTHOG_TOKEN = previousToken;
+      resetPostHogClientForTests();
+    };
+  };
+
+/** Mirrors the Cookies banner: same-tab consent changes are only observed because it dispatches this itself. */
+const setConsent = (value: 'true' | 'false') => {
+  setStorageItem('local', COOKIE_CONSENT_KEY, value);
+  globalThis.dispatchEvent(
+    new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: value })
+  );
+};
+
+const wait = (ms: number) => new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+
+/**
+ * Proves a negative: the mount effect never reached for the posthog-js chunk.
+ * A generous grace period past the effect and its microtasks, short enough
+ * not to slow the suite down.
+ */
+const expectNeverLoads = async () => {
+  await wait(100);
+  await expect(getLoadedPostHog()).toBeNull();
+};
+
+const meta = {
+  title: 'Layout/PostHogBootstrap',
+  component: PostHogBootstrap,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A headless bootstrapper mounted once in the root layout - it renders nothing. On mount it ' +
+          'reads the `cookieConsentGiven` flag the Cookies banner writes to localStorage and, only ' +
+          'when consent is already `true` and both `NEXT_PUBLIC_POSTHOG_HOST` (pinned to the EU ' +
+          'endpoint) and `NEXT_PUBLIC_POSTHOG_TOKEN` resolve to real values, lazy-loads the ~193KB ' +
+          'posthog-js chunk and initializes it with masking, denylisted properties and capture opted ' +
+          'out by default. It keeps listening for the `storage` event the banner dispatches on every ' +
+          'consent change, so accepting or rejecting cookies later in the same session opts capturing ' +
+          'in or out live, without a reload - and it fires `yc:posthog-ready` exactly once, from the ' +
+          "SDK's own `loaded` callback, once the client has actually finished initializing.",
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PostHogBootstrap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AwaitingConsent: Story = {
+  name: 'Awaiting consent (default)',
+  beforeEach: prepare({ consent: null, host: POSTHOG_EU_HOST, token: PROJECT_TOKEN }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What every first-time visitor renders as, even with analytics fully configured: no choice ' +
+          'has been recorded yet, so the mount effect never loads the posthog-js chunk at all.',
+      },
+    },
+  },
+  play: expectNeverLoads,
+};
+
+export const AnalyticsNotConfigured: Story = {
+  name: 'Consent given, analytics unconfigured',
+  beforeEach: prepare({ consent: 'true', host: '', token: '' }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This is what Storybook itself renders by default - there is no PostHog project token in ' +
+          'this preview. Consent alone is never enough; both env vars have to resolve to real values ' +
+          'before anything loads.',
+      },
+    },
+  },
+  play: expectNeverLoads,
+};
+
+export const NonEuHostRefused: Story = {
+  name: 'Non-EU host is refused',
+  beforeEach: prepare({ consent: 'true', host: 'https://us.i.posthog.com', token: PROJECT_TOKEN }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A host outside the EU allowlist resolves to an empty `apiHost`, which the same "both must ' +
+          'resolve" guard then refuses - a deliberate data-residency gate, not a bug in the config ' +
+          'lookup, and worth its own story because it is a different branch than an unset token.',
+      },
+    },
+  },
+  play: expectNeverLoads,
+};
+
+export const ConsentGrantedInitializes: Story = {
+  name: 'Consent already granted - initializes and tracks live opt-out',
+  beforeEach: prepare({ consent: 'true', host: POSTHOG_EU_HOST, token: PROJECT_TOKEN }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Consent was recorded on an earlier visit and both env vars resolve, so the mount effect ' +
+          "loads the real posthog-js chunk, initializes it and opts in from the SDK's own `loaded` " +
+          "callback. Storybook's offline guard 404s the config request the SDK fires at init - the " +
+          'same way a network hiccup would in production - and initialization completes anyway, ' +
+          'because the ready event is not gated on that call succeeding. Withdrawing consent afterwards ' +
+          '(as the Cookies banner would on a second visit) opts capturing back out live, with no remount.',
+      },
+    },
+  },
+  play: async () => {
+    let readyFired = false;
+    const onReady = () => {
+      readyFired = true;
+    };
+    globalThis.addEventListener(POSTHOG_READY_EVENT, onReady);
+
+    try {
+      await waitFor(() => expect(readyFired).toBe(true), { timeout: 5000 });
+
+      const client = getLoadedPostHog();
+      await expect(client).not.toBeNull();
+      await expect(client?.has_opted_in_capturing()).toBe(true);
+
+      // The banner dispatches this same event on a real withdrawal; nothing here remounts.
+      setConsent('false');
+
+      await waitFor(() => expect(client?.has_opted_out_capturing()).toBe(true));
+    } finally {
+      globalThis.removeEventListener(POSTHOG_READY_EVENT, onReady);
+    }
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PostHogUserSync.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogUserSync.stories.tsx
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, waitFor } from 'storybook/test';
+
+import { COOKIE_CONSENT_KEY } from '@/app/lib/posthog';
+import { loadPostHog } from '@/app/lib/posthogClient';
+import { removeStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { useAuthStore } from '@/app/stores/authStore';
+import type { AuthStore } from '@/app/stores/authStore';
+import PostHogUserSync from './PostHogUserSync';
+
+const FULL_ATTRIBUTES: AuthStore['attributes'] = {
+  sub: 'user-sub-1',
+  email: 'taylor@harboursidevet.example',
+  given_name: 'Taylor',
+  family_name: 'Doctor',
+  'custom:role': 'OWNER',
+};
+
+const EMAIL_ONLY_ATTRIBUTES: AuthStore['attributes'] = {
+  email: 'reception@harboursidevet.example',
+};
+
+type Fixture = {
+  consent: boolean;
+  posthogReady: boolean;
+  authStatus: AuthStore['status'];
+  attributes: AuthStore['attributes'];
+};
+
+// Reassigned by prepare() before every story, so a play() function always
+// asserts against the spies its own beforeEach installed.
+let identifySpy = fn();
+let resetSpy = fn();
+
+/**
+ * The component only ever reaches two seams: the PostHog singleton behind
+ * getLoadedPostHog()/loadPostHog(), and the auth store behind the lazy
+ * useLazyAuthSlice hook. loadPostHog() here does the real dynamic import of
+ * posthog-js (already a project dependency) rather than a fake client -
+ * only its identify/reset methods are swapped for spies, and .init() is
+ * never called, so nothing reaches PostHog's servers. useAuthStore is
+ * seeded directly, the same way Discounts/index.stories.tsx seeds its
+ * stores: the module the lazy hook dynamically imports resolves to the same
+ * singleton this file already imports, so setState here is visible to it.
+ */
+const prepare = (fixture: Fixture) => async () => {
+  const authSnapshot = useAuthStore.getState();
+
+  if (fixture.consent) {
+    setStorageItem('local', COOKIE_CONSENT_KEY, 'true');
+  } else {
+    removeStorageItem('local', COOKIE_CONSENT_KEY);
+  }
+
+  const client = (await loadPostHog()) as unknown as {
+    identify: (...args: unknown[]) => void;
+    reset: (...args: unknown[]) => void;
+    __loaded: boolean;
+  };
+  identifySpy = fn();
+  resetSpy = fn();
+  client.identify = identifySpy;
+  client.reset = resetSpy;
+  client.__loaded = fixture.posthogReady;
+
+  useAuthStore.setState({ status: fixture.authStatus, attributes: fixture.attributes });
+
+  return () => {
+    removeStorageItem('local', COOKIE_CONSENT_KEY);
+    useAuthStore.setState(authSnapshot);
+  };
+};
+
+const meta = {
+  title: 'Layout/PostHogUserSync',
+  component: PostHogUserSync,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Headless component mounted once in the root layout - it renders nothing and exists ' +
+          'only to call posthog.identify (or posthog.reset) as consent and auth state change. ' +
+          'Two gates both have to be true before it does anything: cookie consent, read from the ' +
+          '`cookieConsentGiven` localStorage key, and the PostHog client itself having loaded and ' +
+          'initialized. A visitor who has not consented never triggers a fetch of the auth store ' +
+          'either, which is what keeps the SuperTokens stack out of the public-page bundle. Once ' +
+          'past both gates it identifies the current user by their `sub` (falling back to email) ' +
+          'with only four properties allow-listed - email, first name, last name, role - and only ' +
+          're-identifies when the distinct id actually changes. If consent is revoked or the ' +
+          'session ends after an identify, it calls reset so the next visitor on that browser is ' +
+          'not attributed to the account that just left.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {},
+} satisfies Meta<typeof PostHogUserSync>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Identifies a consented, authenticated visitor',
+  beforeEach: prepare({
+    consent: true,
+    posthogReady: true,
+    authStatus: 'authenticated',
+    attributes: FULL_ATTRIBUTES,
+  }),
+  play: async () => {
+    await waitFor(() =>
+      expect(identifySpy).toHaveBeenCalledWith('user-sub-1', {
+        email: 'taylor@harboursidevet.example',
+        first_name: 'Taylor',
+        last_name: 'Doctor',
+        role: 'OWNER',
+      })
+    );
+  },
+};
+
+export const AwaitingConsent: Story = {
+  name: 'No consent yet - never identifies',
+  beforeEach: prepare({
+    consent: false,
+    posthogReady: true,
+    authStatus: 'authenticated',
+    attributes: FULL_ATTRIBUTES,
+  }),
+  play: async () => {
+    // Both gated calls stay untouched: no consent means the auth store is
+    // never even fetched, so there is nothing to identify with yet.
+    await waitFor(() => expect(identifySpy).not.toHaveBeenCalled());
+    expect(resetSpy).not.toHaveBeenCalled();
+  },
+};
+
+export const ConsentGrantedAfterMount: Story = {
+  name: 'Consent granted after mount',
+  beforeEach: prepare({
+    consent: false,
+    posthogReady: true,
+    authStatus: 'authenticated',
+    attributes: FULL_ATTRIBUTES,
+  }),
+  play: async () => {
+    await waitFor(() => expect(identifySpy).not.toHaveBeenCalled());
+
+    // A second tab accepting the cookie banner fires this exact event.
+    setStorageItem('local', COOKIE_CONSENT_KEY, 'true');
+    globalThis.dispatchEvent(
+      new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'true' })
+    );
+
+    await waitFor(() =>
+      expect(identifySpy).toHaveBeenCalledWith('user-sub-1', {
+        email: 'taylor@harboursidevet.example',
+        first_name: 'Taylor',
+        last_name: 'Doctor',
+        role: 'OWNER',
+      })
+    );
+  },
+};
+
+export const ConsentRevoked: Story = {
+  name: 'Consent revoked resets identity',
+  beforeEach: prepare({
+    consent: true,
+    posthogReady: true,
+    authStatus: 'authenticated',
+    attributes: FULL_ATTRIBUTES,
+  }),
+  play: async () => {
+    await waitFor(() => expect(identifySpy).toHaveBeenCalledTimes(1));
+
+    setStorageItem('local', COOKIE_CONSENT_KEY, 'false');
+    globalThis.dispatchEvent(
+      new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+    );
+
+    await waitFor(() => expect(resetSpy).toHaveBeenCalledTimes(1));
+  },
+};
+
+export const EmailFallbackId: Story = {
+  name: 'Falls back to email as the distinct id',
+  beforeEach: prepare({
+    consent: true,
+    posthogReady: true,
+    authStatus: 'signin-authenticated',
+    attributes: EMAIL_ONLY_ATTRIBUTES,
+  }),
+  play: async () => {
+    await waitFor(() =>
+      expect(identifySpy).toHaveBeenCalledWith('reception@harboursidevet.example', {
+        email: 'reception@harboursidevet.example',
+      })
+    );
+  },
+};

--- a/apps/frontend/src/app/ui/layout/RouteAnnouncer.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/RouteAnnouncer.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import RouteAnnouncer from './RouteAnnouncer';
+
+const ANNOUNCER_SLOT_TEST_ID = 'route-announcer-slot';
+
+/**
+ * RouteAnnouncer takes no props and paints nothing visible - its whole output
+ * is the text inside an sr-only live region. What actually drives it in the
+ * app is Next.js writing a new <title> into <head> on every route change, so
+ * this harness stands in for that: it shows the current document title and a
+ * button that rewrites it by hand, then RouteAnnouncer's own MutationObserver
+ * picks the change up exactly as it would in production.
+ */
+const Harness = () => {
+  const [title, setTitle] = useState(() => document.title);
+
+  const changeTitle = () => {
+    const next =
+      title === 'Companions - Yosemite Crew'
+        ? 'Appointments - Yosemite Crew'
+        : 'Companions - Yosemite Crew';
+    document.title = next;
+    setTitle(next);
+  };
+
+  return (
+    <div className="grid max-w-[420px] gap-3 p-6">
+      <p className="text-[13.5px]">
+        Document title: <code>{title || '(none)'}</code>
+      </p>
+      <button
+        type="button"
+        onClick={changeTitle}
+        className="w-fit rounded-full border border-[var(--hairline)] px-4 py-2 text-[12.5px] font-semibold text-[var(--ink-body)]"
+      >
+        Simulate a route change
+      </button>
+      <p className="text-[12.5px] text-[var(--ink-muted)]">
+        The region below is visually hidden by design (sr-only) - a screen reader hears it, a
+        sighted reviewer never sees it. Its text is asserted in the play functions on these stories.
+      </p>
+      <div data-testid={ANNOUNCER_SLOT_TEST_ID}>
+        <RouteAnnouncer />
+      </div>
+    </div>
+  );
+};
+
+type TitleFixture = { title: string };
+
+/** document.title is a global; a story that changes it must put it back. */
+const withDocumentTitle =
+  ({ title }: TitleFixture) =>
+  () => {
+    const previousTitle = document.title;
+    document.title = title;
+    return () => {
+      document.title = previousTitle;
+    };
+  };
+
+const meta = {
+  title: 'Layout/RouteAnnouncer',
+  component: RouteAnnouncer,
+  parameters: {
+    layout: 'centered',
+    // `usePathname()`/`useSearchParams()` are called on every render, purely so
+    // the component re-renders (and re-reads document.title) when the route
+    // changes underneath it - it never reads their values.
+    nextjs: { appDirectory: true, navigation: { pathname: '/dashboard' } },
+    docs: {
+      description: {
+        component:
+          'A screen-reader-only live region that announces client-side route changes. The Next.js ' +
+          'App Router swaps page content without a full page load, so a screen reader user gets ' +
+          'none of the load cues a normal navigation gives them - this component fills that gap. ' +
+          'It watches document.head with a MutationObserver for the <title> Next writes on every ' +
+          'navigation, and reads the result into an aria-live="polite" region as "<title> loaded", ' +
+          'or "Page updated" while no title has been set yet. It takes no props, subscribes ' +
+          'through useSyncExternalStore rather than an effect plus useState (so the first client ' +
+          'render already has the right text, with no flash of the fallback), and renders nothing ' +
+          'a sighted user would ever notice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  render: () => <Harness />,
+} satisfies Meta<typeof RouteAnnouncer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Title already set',
+  beforeEach: withDocumentTitle({ title: 'Appointments - Yosemite Crew' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId(ANNOUNCER_SLOT_TEST_ID)).toHaveTextContent(
+      'Appointments - Yosemite Crew loaded'
+    );
+  },
+};
+
+export const NoTitleYet: Story = {
+  name: 'No title set yet',
+  beforeEach: withDocumentTitle({ title: '' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId(ANNOUNCER_SLOT_TEST_ID)).toHaveTextContent('Page updated');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The fallback text. This is what a reader hears on first paint before any page-level ' +
+          '<title> effect has run, or on a page that never sets one.',
+      },
+    },
+  },
+};
+
+export const WhitespaceOnlyTitle: Story = {
+  name: 'Whitespace-only title also falls back',
+  beforeEach: withDocumentTitle({ title: '   ' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // getAnnouncementText() trims before checking truthiness, so a title that is
+    // only whitespace reads the same as no title at all rather than announcing
+    // "   loaded".
+    await expect(canvas.getByTestId(ANNOUNCER_SLOT_TEST_ID)).toHaveTextContent('Page updated');
+  },
+};
+
+export const RouteChangeAnnouncesNewTitle: Story = {
+  name: 'Route change updates the announcement',
+  beforeEach: withDocumentTitle({ title: 'Appointments - Yosemite Crew' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId(ANNOUNCER_SLOT_TEST_ID)).toHaveTextContent(
+      'Appointments - Yosemite Crew loaded'
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Simulate a route change' }));
+
+    // The MutationObserver callback fires asynchronously, so the announcer's
+    // text lags one tick behind the title write.
+    await waitFor(() =>
+      expect(canvas.getByTestId(ANNOUNCER_SLOT_TEST_ID)).toHaveTextContent(
+        'Companions - Yosemite Crew loaded'
+      )
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The mechanic that matters: a new document title, which is what the App Router writes ' +
+          'on navigation, reaches the live region without a remount - the whole component is ' +
+          'subscribed to document.head rather than to the router.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModalComponent.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModalComponent.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import ConfirmModal from './ConfirmModal';
+
+/**
+ * The raw dialog `useConfirm` renders once its promise resolves an options
+ * object. `ConfirmModal.stories.tsx` in this same directory covers the hook -
+ * the promise flow, the resolve/reject timing - by driving it through a live
+ * `useConfirm()` call. This file covers the other half: the dialog itself,
+ * with a fixed `options` object, so its layout and the two tone variants can
+ * be reviewed without wiring up the hook.
+ */
+const confirmModalMeta = {
+  title: 'Overlays/Modal/ConfirmModalComponent',
+  component: ConfirmModal,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The dialog body for a promise-based confirm, replacing the browser native ' +
+          'confirm(). `tone: "danger"` swaps the confirm button for the Delete style; ' +
+          'both tones dismiss the same way, by backdrop click, Escape, or the close button.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onResolve: { control: false },
+  },
+  args: {
+    options: {
+      title: 'Delete this room?',
+      body: 'Removing it takes the room off every future appointment. This cannot be undone.',
+      tone: 'danger',
+    },
+    onResolve: fn(),
+  },
+} satisfies Meta<typeof ConfirmModal>;
+
+export default confirmModalMeta;
+type ConfirmModalStory = StoryObj<typeof confirmModalMeta>;
+
+export const Danger: ConfirmModalStory = {};
+
+export const Default: ConfirmModalStory = {
+  args: {
+    options: {
+      title: 'Leave without saving?',
+      body: 'Your changes to this form have not been saved yet.',
+      tone: 'default',
+    },
+  },
+};
+
+export const CustomLabels: ConfirmModalStory = {
+  name: 'Custom confirm/cancel labels',
+  args: {
+    options: {
+      title: 'Send this invoice?',
+      body: 'The client will receive an email with the payment link.',
+      confirmLabel: 'Send invoice',
+      cancelLabel: 'Not yet',
+      tone: 'default',
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.stories.tsx
@@ -1,0 +1,97 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import GoogleAddressFieldRenderer from './googleAddressFieldRenderer';
+
+const StatefulGoogleAddressFieldRenderer = (
+  args: ComponentProps<typeof GoogleAddressFieldRenderer>
+) => {
+  const [value, setValue] = useState(args.value);
+  return (
+    <GoogleAddressFieldRenderer
+      {...args}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        args.onChange(next);
+      }}
+    />
+  );
+};
+
+const googleAddressFieldRendererMeta = {
+  title: 'Primitives/Accordion/GoogleAddressFieldRenderer',
+  component: GoogleAddressFieldRenderer,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Shared `googleAddress` entry for field-renderer maps (ProfileCard, EditableAccordion). ' +
+          'Wraps GoogleSearchDropDown so a single field definition can drive both the visible address ' +
+          'input and the sibling fields around it: picking a prediction calls `onChange` with the street ' +
+          'line and, if `onMultiChange` is given, also pushes the derived city/state/postalCode/country ' +
+          'into whatever form state the caller manages. `onMultiChange` is optional - omit it and the ' +
+          'renderer behaves like a plain single-value address field.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    error: { control: 'text' },
+  },
+  args: {
+    field: { key: 'address', label: 'Address' },
+    value: '',
+    onChange: fn(),
+    onMultiChange: fn(),
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: 420 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: (args) => <StatefulGoogleAddressFieldRenderer {...args} />,
+} satisfies Meta<typeof GoogleAddressFieldRenderer>;
+
+export default googleAddressFieldRendererMeta;
+type GoogleAddressFieldRendererStory = StoryObj<typeof googleAddressFieldRendererMeta>;
+
+export const Default: GoogleAddressFieldRendererStory = {};
+
+export const AddressSelected: GoogleAddressFieldRendererStory = {
+  name: 'Address selected',
+  args: { value: '1200 Mission Street, Suite 4' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After a prediction is picked the field holds the street line; `onMultiChange` has already ' +
+          'received the city/state/postalCode/country for the sibling fields.',
+      },
+    },
+  },
+};
+
+export const WithError: GoogleAddressFieldRendererStory = {
+  name: 'Validation error',
+  args: { value: 'Unknown place', error: 'Select an address from the list' },
+};
+
+export const WithoutSiblingAutofill: GoogleAddressFieldRendererStory = {
+  name: 'No onMultiChange',
+  args: { onMultiChange: undefined },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `onMultiChange` the renderer still reports the street line through `onChange`, but ' +
+          'skips autofilling city/state/postalCode/country - the shape a caller gets if it only wired up ' +
+          'the single-value field.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/theme/ThemeScript.stories.tsx
+++ b/apps/frontend/src/app/ui/theme/ThemeScript.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { headers } from 'next/headers';
+
+import ThemeScript from './ThemeScript';
+
+// Mirrors the private `NONCE_HEADER` constant in ThemeScript.tsx: the header
+// middleware.ts sets to the per-request CSP nonce before this component reads it.
+const NONCE_HEADER = 'x-nonce';
+
+/**
+ * `next/headers`'s real types describe a read-only, async header bag. Storybook's
+ * Next.js framework substitutes a settable, synchronous mock at build time instead
+ * (aliasing `next/headers` itself, so this is the same module instance ThemeScript
+ * reads through) - this narrows just enough to seed or clear the nonce it carries.
+ */
+type HeadersMock = {
+  (): { set(name: string, value: string): void };
+  mockRestore(): void;
+};
+
+const mockedHeaders = headers as unknown as HeadersMock;
+
+/**
+ * ThemeScript is an async server component with no props: every render awaits
+ * `headers()`, so there is no synchronous JSX to hand a story directly. Each story
+ * below seeds (or clears) the mocked request headers - the seam ThemeScript reads
+ * through, the same idea as mocking the shared axios client or a Zustand store for
+ * a page story - inside its own `loader`, then calls the real, unmodified component
+ * and hands the resolved element to `render`. That is the supported way to exercise
+ * a Server Component client-side; resetting the mock first also keeps stories from
+ * leaking a nonce into whichever runs next.
+ */
+const loadThemeScript = (nonce: string | undefined) => async () => {
+  mockedHeaders.mockRestore();
+  if (nonce !== undefined) {
+    mockedHeaders().set(NONCE_HEADER, nonce);
+  }
+  return { element: await ThemeScript() };
+};
+
+const themeScriptMeta = {
+  title: 'Theme/ThemeScript',
+  component: ThemeScript,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Injects the pre-paint theme script so dark mode never flashes. Before the app paints, the ' +
+          "inline script reads the explicit choice from localStorage's `yc-theme` key, falls back to " +
+          'the OS `prefers-color-scheme`, and stamps `data-theme` on `<html>` - the same attribute ' +
+          "these stories' own preview decorator sets, and the one every dark-mode token in " +
+          'globals.css is keyed on.\n\n' +
+          'App routes render behind a strict, per-request nonce CSP (see middleware.ts), so ' +
+          "ThemeScript reads that request's nonce off the `x-nonce` header and tags the inline " +
+          'script with it instead of relying on `unsafe-inline`. Public/marketing routes inline the ' +
+          'same script without a nonce, authorised by CSP hash instead, because they prerender ' +
+          'statically and have no per-request nonce to give it - see prePaintScript.ts.\n\n' +
+          'ThemeScript takes no props. There is nothing visible in the canvas either - a `<script>` ' +
+          "tag renders no box - the evidence for each story is the tag's own `nonce` attribute and " +
+          '`__html`, visible in the source panel below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  render: (_args, { loaded }) => loaded.element,
+} satisfies Meta<typeof ThemeScript>;
+
+export default themeScriptMeta;
+type ThemeScriptStory = StoryObj<typeof themeScriptMeta>;
+
+export const Default: ThemeScriptStory = {
+  name: 'Default (app route request)',
+  loaders: [loadThemeScript('kR8mQ2vN5tXpL0scY7dFhw==')],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A typical `(app)` route request: middleware set an `x-nonce` header, and the rendered ' +
+          'script carries it, authorising it under the strict CSP without `unsafe-inline`.',
+      },
+    },
+  },
+};
+
+export const RotatedNonce: ThemeScriptStory = {
+  name: 'A different request gets a different nonce',
+  loaders: [loadThemeScript('p4Zt9CqWn2XeR6oLaVdMSw==')],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The nonce is per-request, not a static value: middleware mints a fresh one every time, and ' +
+          "the script tag carries whatever this render's `x-nonce` header holds.",
+      },
+    },
+  },
+};
+
+export const WithoutNonceHeader: ThemeScriptStory = {
+  name: 'No x-nonce header (defensive fallback)',
+  loaders: [loadThemeScript(undefined)],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`headers().get('x-nonce')` returns null when nothing set the header - the `?? undefined` " +
+          'fallback in ThemeScript then renders the script with no `nonce` attribute at all, rather ' +
+          'than the literal string "null".',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Toast/NotifyToast.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Toast/NotifyToast.stories.tsx
@@ -1,0 +1,113 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import 'react-toastify/dist/ReactToastify.css';
+import NotifyToast from './NotifyToast';
+
+type NotifyToastProps = ComponentProps<typeof NotifyToast>;
+
+/**
+ * `toastProps` is react-toastify's own runtime bag (position, transition,
+ * progress state). `NotifyToast` never reads it, so the stories hand over an
+ * empty object typed off the component's own props rather than reconstructing
+ * a container the story does not mount.
+ */
+const TOAST_PROPS = {} as NotifyToastProps['toastProps'];
+
+const notifyToastMeta = {
+  title: 'Widgets/Toast/NotifyToast',
+  component: NotifyToast,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Body every runtime toast renders, shared by all four `toast.<tone>()` call sites ' +
+          '(`ErrorToast`, `Warning`, `Info`, `Success` each just fix the `tone` prop and forward ' +
+          'the rest). A 32px tinted disc carries the tone glyph, next to a 13.5px/700 `--ink` ' +
+          'title, an optional 12.5px `--ink-muted` detail line, and the shared round Close ' +
+          'control. The warm-glass card around it comes from the `.Toastify__toast` override in ' +
+          '`globals.css`; the decorator reproduces that container so the stories show the toast ' +
+          'at its real width rather than free-floating. The tone tokens flip with ' +
+          '`html[data-theme="dark"]`, so no per-theme branch lives in the component.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    tone: { control: 'radio', options: ['success', 'error', 'info', 'warning'] },
+  },
+  args: {
+    tone: 'success',
+    isPaused: false,
+    toastProps: TOAST_PROPS,
+    closeToast: fn(),
+    data: {
+      title: 'Appointment booked',
+      text: 'Max - Peralta, today at 11:30 AM with Tim Apple.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="Toastify">
+        <div className="Toastify__toast">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof NotifyToast>;
+
+export default notifyToastMeta;
+type NotifyToastStory = StoryObj<typeof notifyToastMeta>;
+
+export const Default: NotifyToastStory = {};
+
+export const ErrorTone: NotifyToastStory = {
+  name: 'Error tone',
+  args: {
+    tone: 'error',
+    data: {
+      title: 'Could not save appointment',
+      text: 'The slot was taken while you were editing.',
+    },
+  },
+};
+
+export const WarningTone: NotifyToastStory = {
+  name: 'Warning tone',
+  args: {
+    tone: 'warning',
+    data: {
+      title: 'Slot unavailable',
+      text: 'This time is outside available hours. Please select a different slot.',
+    },
+  },
+};
+
+export const InfoTone: NotifyToastStory = {
+  name: 'Info tone',
+  args: {
+    tone: 'info',
+    data: {
+      title: 'Results ready',
+      text: 'IDEXX filed the haematology panel to the patient.',
+    },
+  },
+};
+
+export const TitleOnly: NotifyToastStory = {
+  name: 'Title only',
+  args: {
+    data: { title: 'Draft saved', text: '' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Callers that have nothing to add pass an empty `text`. The detail line does not ' +
+          'render at all, so the toast shrinks to the title-only height instead of leaving a gap.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

PostHogBootstrap, PostHogUserSync, RouteAnnouncer, the raw ConfirmModal component, googleAddressFieldRenderer, ThemeScript, and NotifyToast have no Storybook coverage.

## What is the new behavior?

Adds a story for each, following the repo's existing CSF3 house style. ConfirmModal already had a story file covering the `useConfirm` hook (kept unchanged); this adds a separate file for the raw dialog component itself.

## Related Issue(s)

Part of #2930