### PR TITLE
test(frontend): add Storybook stories for the 3 uncovered docs components

### DIFF
--- a/apps/frontend/src/app/features/docs/DocsSearch.stories.tsx
+++ b/apps/frontend/src/app/features/docs/DocsSearch.stories.tsx
@@ -1,0 +1,227 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import DocsSearch from './DocsSearch';
+import type { SearchDoc } from './searchIndex';
+import './docs.css';
+
+const INDEX_URL = '/docs/search-index.json';
+
+/**
+ * A small stand-in for the real 52-page, 108 KB corpus - just enough to show
+ * the two rules the component's own header comment claims: a title hit
+ * outranks a body hit, and every term in the query has to match or the
+ * document drops out entirely (so a second word can remove a result the
+ * first word matched on its own).
+ */
+const DOCS: SearchDoc[] = [
+  {
+    title: 'User API',
+    href: '/docs/apps/backend/routers/user',
+    section: 'Backend API',
+    text: 'requireWebAuth guards every route. UserController.getById returns the caller organisationId scoped profile.',
+  },
+  {
+    title: 'Organisation settings',
+    href: '/docs/apps/backend/routers/organisation',
+    section: 'Backend API',
+    text: 'Update the name, address and billing details for an organisation. Calls the organisationId scoped endpoints.',
+  },
+  {
+    title: 'Design tokens',
+    href: '/docs/ui-system/design-tokens',
+    section: 'UI System',
+    text: 'Colour, spacing and radius variables that back every warm-bone surface in the frontend.',
+  },
+  {
+    title: 'Rate limits',
+    href: '/docs/policies/rate-limits',
+    section: 'Policies',
+    text: 'Every API key is capped at 600 requests per minute; user endpoints share a lower per-user budget.',
+  },
+];
+
+/**
+ * The whole index is one `fetch(INDEX_URL)`, so the stories stub
+ * `globalThis.fetch` the way the rest of the suite does (see
+ * Footer.stories.tsx) - capture the real one, answer only this URL, and fall
+ * through to it (and so to the Storybook offline guard) for anything else.
+ */
+const withIndex = (docs: SearchDoc[]) => () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).startsWith(INDEX_URL)) {
+      return Promise.resolve(
+        new Response(JSON.stringify(docs), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+/** Never settles, so `docs` stays null and the panel reads its "Loading" line. */
+const withPendingIndex = () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).startsWith(INDEX_URL)) return new Promise<Response>(() => {});
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+/** A 500. The component's `.then` throws on a non-ok response and its `.catch` turns that into `loadFailed`. */
+const withFailingIndex = () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).startsWith(INDEX_URL)) {
+      return Promise.resolve(
+        new Response('', { status: 500, statusText: 'Internal Server Error' })
+      );
+    }
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+const searchbox = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('combobox', { name: 'Search the documentation' });
+
+const meta = {
+  title: 'Docs/DocsSearch',
+  component: DocsSearch,
+  parameters: {
+    layout: 'centered',
+    // Results render as next/link, which wants the App Router mock mounted.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'Client-side search for the documentation site. The index is a prerendered JSON route, ' +
+          'fetched once on first focus rather than on mount, so a reader who never searches never ' +
+          'pays for it - it is 108 KB for the whole 52-page corpus.\n\n' +
+          "Matching is deliberately simple: every term in the query must appear in a document's " +
+          'title or body text, or that document is dropped entirely, so a second word can remove a ' +
+          'result the first word matched on its own. A title hit outranks a body hit (10 points ' +
+          'against 1), ties break alphabetically by title, and the list is capped at 8 results. ' +
+          'There is no scoring library behind any of this - the corpus is small enough that it does ' +
+          'not need one.\n\n' +
+          'The results panel only opens once there is text to show it for; focusing an empty field ' +
+          'starts the fetch but shows nothing. A mousedown outside the component closes the panel ' +
+          'without clearing what was typed, and selecting a result does the same.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: withIndex(DOCS),
+} satisfies Meta<typeof DocsSearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Title outranks a body hit',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    await userEvent.type(input, 'user');
+
+    const options = await canvas.findAllByRole('option');
+    // "User API" matches in its title (10 points); "Rate limits" only matches
+    // in its body text ("user endpoints", 1 point) - and still outranks it,
+    // despite alphabetical order putting "Rate limits" first.
+    await expect(options).toHaveLength(2);
+    await expect(options[0]).toHaveTextContent('User API');
+    await expect(options[1]).toHaveTextContent('Rate limits');
+    await expect(input).toHaveAttribute('aria-expanded', 'true');
+  },
+};
+
+export const NarrowsWithASecondTerm: Story = {
+  name: 'A second term narrows the match',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    // "organisation" alone would also match "Organisation settings" - adding
+    // "user" drops it, since every term has to appear on a surviving document.
+    await userEvent.type(input, 'user organisation');
+
+    const options = await canvas.findAllByRole('option');
+    await expect(options).toHaveLength(1);
+    await expect(options[0]).toHaveTextContent('User API');
+  },
+};
+
+export const NoMatches: Story = {
+  name: 'No matches',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    await userEvent.type(input, 'radiograph');
+
+    await expect(await canvas.findByText('No matches for “radiograph”.')).toBeVisible();
+    await expect(canvas.queryAllByRole('option')).toHaveLength(0);
+  },
+};
+
+export const LoadingTheIndex: Story = {
+  name: 'Loading the index',
+  beforeEach: withPendingIndex,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    await userEvent.type(input, 'user');
+
+    await expect(await canvas.findByText('Loading…')).toBeVisible();
+    await expect(canvas.queryAllByRole('option')).toHaveLength(0);
+  },
+};
+
+export const IndexUnavailable: Story = {
+  name: 'Index could not be loaded',
+  beforeEach: withFailingIndex,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    await userEvent.type(input, 'user');
+
+    await expect(
+      await canvas.findByText('Search is unavailable right now. Use the sidebar to browse.')
+    ).toBeVisible();
+    await expect(canvas.queryAllByRole('option')).toHaveLength(0);
+  },
+};
+
+export const SelectingAResultCloses: Story = {
+  name: 'Selecting a result closes the panel',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = searchbox(canvasElement);
+    await userEvent.click(input);
+    await userEvent.type(input, 'user');
+
+    const options = await canvas.findAllByRole('option');
+    await userEvent.click(options[0]);
+
+    // The panel closes on selection; the typed query is left in the field.
+    await expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+    await expect(input).toHaveValue('user');
+  },
+};

--- a/apps/frontend/src/app/features/docs/DocsShell.stories.tsx
+++ b/apps/frontend/src/app/features/docs/DocsShell.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Element, Root, Text } from 'hast';
+import DocsShell from './DocsShell';
+import type { NavNode } from './docsNav';
+import type { TocEntry } from './render';
+
+/**
+ * Hand-built HAST, standing in for what render.ts's sanitised pipeline would
+ * hand back for a real markdown page - headings with ids for the table of
+ * contents, a paragraph, an in-corpus link and a fenced code block.
+ */
+const text = (value: string): Text => ({ type: 'text', value });
+
+const el = (
+  tagName: string,
+  children: Element['children'],
+  properties: Element['properties'] = {}
+): Element => ({ type: 'element', tagName, properties, children });
+
+const SAMPLE_TREE: Root = {
+  type: 'root',
+  children: [
+    el('h2', [text('Installation')], { id: 'installation' }),
+    el('p', [
+      text('Add the SDK with your package manager of choice: '),
+      el('code', [text('pnpm add @yosemite-crew/sdk')]),
+      text('.'),
+    ]),
+    el('h2', [text('Authentication')], { id: 'authentication' }),
+    el('p', [
+      text('Every request needs an API key, generated from the '),
+      el('a', [text('developer portal')], { href: '/developers' }),
+      text('.'),
+    ]),
+    el('h3', [text('Request headers')], { id: 'request-headers' }),
+    el('pre', [
+      el('code', [text('Authorization: Bearer <token>\nContent-Type: application/json')], {
+        className: ['language-http'],
+      }),
+    ]),
+    el('h2', [text('Rate limits')], { id: 'rate-limits' }),
+    el('p', [text('The default plan allows 600 requests per minute per organisation.')]),
+  ],
+};
+
+const NAV: NavNode[] = [
+  { kind: 'link', id: 'overview', title: 'Overview', href: '/docs' },
+  {
+    kind: 'section',
+    label: 'Guides',
+    items: [
+      {
+        kind: 'link',
+        id: 'notification-setup-guide',
+        title: 'Notification setup guide',
+        href: '/docs/notification-setup-guide',
+      },
+      {
+        kind: 'link',
+        id: 'backend-chat-implementation',
+        title: 'Backend chat implementation',
+        href: '/docs/backend-chat-implementation',
+      },
+    ],
+  },
+  {
+    kind: 'section',
+    label: 'Apps',
+    items: [
+      { kind: 'link', id: 'frontend-app', title: 'Frontend app', href: '/docs/frontend-app' },
+      { kind: 'link', id: 'backend-app', title: 'Backend app', href: '/docs/backend-app' },
+      { kind: 'link', id: 'openapi', title: 'OpenAPI reference', href: '/docs/openapi' },
+    ],
+  },
+  {
+    kind: 'section',
+    label: 'Backend API',
+    collapsed: true,
+    items: [
+      {
+        kind: 'link',
+        id: 'backend-index',
+        title: 'Backend API index',
+        href: '/docs/backend-index',
+      },
+    ],
+  },
+];
+
+const TOC: TocEntry[] = [
+  { id: 'installation', text: 'Installation', depth: 2 },
+  { id: 'authentication', text: 'Authentication', depth: 2 },
+  { id: 'request-headers', text: 'Request headers', depth: 3 },
+  { id: 'rate-limits', text: 'Rate limits', depth: 2 },
+];
+
+const EDIT_URL =
+  'https://github.com/YosemiteCrew/Yosemite-Crew/edit/dev/apps/frontend/content/docs/notification-setup-guide.md';
+
+const docsShellMeta = {
+  title: 'Docs/DocsShell',
+  component: DocsShell,
+  parameters: {
+    layout: 'fullscreen',
+    // DocsSidebar reads the active route through next/navigation, both to
+    // highlight the current link and to auto-expand the section it lives in.
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/notification-setup-guide' } },
+    docs: {
+      description: {
+        component:
+          'Chrome for every public documentation page: the top bar, the collapsible sidebar nav, ' +
+          'the breadcrumb trail, the page title, the sanitised document body, and the on-page ' +
+          'table of contents. The body is a HAST tree rendered through `toJsxRuntime`, never an ' +
+          'HTML string - render.ts sanitises the corpus markdown before this component ever sees ' +
+          'it, so there is no raw-HTML sink for a contributed doc page to exploit. `embedOpenApi` ' +
+          'additionally mounts a sandboxed iframe for the Redoc viewer, set only by the OpenAPI ' +
+          'reference page.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    embedOpenApi: { control: 'boolean' },
+  },
+  args: {
+    nav: NAV,
+    toc: TOC,
+    title: 'Notification setup guide',
+    breadcrumb: ['Docs', 'Guides', 'Notification setup guide'],
+    tree: SAMPLE_TREE,
+    editUrl: EDIT_URL,
+    embedOpenApi: false,
+  },
+} satisfies Meta<typeof DocsShell>;
+
+export default docsShellMeta;
+type DocsShellStory = StoryObj<typeof docsShellMeta>;
+
+export const Default: DocsShellStory = {};
+
+export const NoTableOfContents: DocsShellStory = {
+  name: 'No table of contents',
+  args: { toc: [] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A page with no h2/h3 headings gets an empty `toc`, and the "On this page" rail is ' +
+          'omitted entirely rather than rendered with nothing in it.',
+      },
+    },
+  },
+};
+
+export const OpenApiReference: DocsShellStory = {
+  name: 'OpenAPI reference (embedded viewer)',
+  args: {
+    embedOpenApi: true,
+    title: 'API Reference',
+    breadcrumb: ['Docs', 'Apps', 'API Reference'],
+  },
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/openapi' } },
+    docs: {
+      description: {
+        story:
+          'The sandboxed Redoc viewer renders below the document body - allowed to run scripts ' +
+          'and fetch the same-origin spec, and nothing else.',
+      },
+    },
+  },
+};
+
+export const DeepLinkIntoCollapsedSection: DocsShellStory = {
+  name: 'Deep link into a collapsed section',
+  args: {
+    title: 'Backend API index',
+    breadcrumb: ['Docs', 'Backend API', 'Backend API index'],
+  },
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/backend-index' } },
+    docs: {
+      description: {
+        story:
+          'Backend API is collapsed by default, but landing on one of its pages expands it anyway: ' +
+          'DocsSidebar starts a section open whenever it contains the current route, so a reader ' +
+          'who follows a deep link never lands inside a collapsed tree with no idea where they are.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/docs/DocsSidebar.stories.tsx
+++ b/apps/frontend/src/app/features/docs/DocsSidebar.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+import type { NavNode } from './docsNav';
+import DocsSidebar from './DocsSidebar';
+import './docs.css';
+
+/**
+ * A trimmed stand-in for the real nav `buildDocsNav` produces: a root link,
+ * two open sections, one section declared `collapsed: true` (mirrors the
+ * real Backend API section, which stays closed by default because it holds
+ * 36 router references), and a Policies section.
+ */
+const NAV: NavNode[] = [
+  { kind: 'link', id: 'overview', title: 'Overview', href: '/docs' },
+  {
+    kind: 'section',
+    label: 'Guides',
+    items: [
+      {
+        kind: 'link',
+        id: 'notification-setup-guide',
+        title: 'Notification setup',
+        href: '/docs/notification-setup-guide',
+      },
+      {
+        kind: 'link',
+        id: 'backend-chat-implementation',
+        title: 'Backend chat implementation',
+        href: '/docs/backend-chat-implementation',
+      },
+    ],
+  },
+  {
+    kind: 'section',
+    label: 'Apps',
+    items: [
+      { kind: 'link', id: 'frontend-app', title: 'Frontend app', href: '/docs/frontend-app' },
+      { kind: 'link', id: 'backend-app', title: 'Backend app', href: '/docs/backend-app' },
+      { kind: 'link', id: 'mobile-app', title: 'Mobile app', href: '/docs/mobile-app' },
+    ],
+  },
+  {
+    kind: 'section',
+    label: 'Backend API',
+    collapsed: true,
+    items: [
+      { kind: 'link', id: 'backend-index', title: 'Router index', href: '/docs/backend-index' },
+      {
+        kind: 'link',
+        id: 'appointments-router',
+        title: 'Appointments router',
+        href: '/docs/appointments-router',
+      },
+      {
+        kind: 'link',
+        id: 'invoices-router',
+        title: 'Invoices router',
+        href: '/docs/invoices-router',
+      },
+    ],
+  },
+  {
+    kind: 'section',
+    label: 'Policies',
+    items: [
+      { kind: 'link', id: 'contributing', title: 'Contributing', href: '/docs/contributing' },
+      { kind: 'link', id: 'security', title: 'Security', href: '/docs/security' },
+    ],
+  },
+];
+
+const docsSidebarMeta = {
+  title: 'Docs/DocsSidebar',
+  component: DocsSidebar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The documentation sidebar nav. Sections collapse and expand client-side, but every ' +
+          'entry is a plain anchor, so the nav works with JavaScript disabled and every page ' +
+          "stays crawlable. A section's declared `collapsed` flag is a default only: it is " +
+          'overridden and the section opens automatically when it contains the current page, ' +
+          'so deep-linking into one of the 36 backend router references does not land the ' +
+          'reader in a collapsed tree with no idea where they are.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    nav: NAV,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 280, background: 'var(--page)', padding: '20px 12px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DocsSidebar>;
+
+export default docsSidebarMeta;
+type DocsSidebarStory = StoryObj<typeof docsSidebarMeta>;
+
+export const Default: DocsSidebarStory = {
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/notification-setup-guide' } },
+  },
+};
+
+export const ActiveInsideCollapsedSection: DocsSidebarStory = {
+  name: 'Active page inside a collapsed section',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/invoices-router' } },
+  },
+};
+
+export const TopLevelLinkActive: DocsSidebarStory = {
+  name: 'Top-level link active',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs' } },
+  },
+};
+
+export const NoActivePage: DocsSidebarStory = {
+  name: 'No page matches the current route',
+  parameters: {
+    // A page that was renamed or removed from the nav: nothing highlights,
+    // and the Backend API section stays collapsed since it holds no match.
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/renamed-page' } },
+  },
+};
+
+export const TogglesASection: DocsSidebarStory = {
+  name: 'Clicking a section header toggles it',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/docs/notification-setup-guide' } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = canvas.getByRole('button', { name: /Apps/ });
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(header);
+
+    await expect(header).toHaveAttribute('aria-expanded', 'false');
+    const content = canvasElement.querySelector('#docs-section-apps');
+    await expect(content).toHaveAttribute('hidden');
+
+    // Toggling back reopens it.
+    await userEvent.click(header);
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+    await expect(content).not.toHaveAttribute('hidden');
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

DocsSearch, DocsShell, and DocsSidebar have no Storybook coverage.

## What is the new behavior?

Adds a story for each, following the repo's existing CSF3 house style.

## Related Issue(s)

Part of #2930