### PR TITLE
test(frontend): add Storybook stories for the 7 uncovered InsuranceClaims section components

### DIFF
--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import CreateInsuranceClaimDialog, { type CompanionChoice } from './CreateInsuranceClaimDialog';
+
+const COMPANIONS: CompanionChoice[] = [
+  { id: 'pt-bramble', name: 'Bramble (Cavalier King Charles Spaniel)' },
+  { id: 'pt-whiskers', name: 'Whiskers (Domestic Shorthair)' },
+];
+
+const meta = {
+  title: 'InsuranceClaims/CreateInsuranceClaimDialog',
+  component: CreateInsuranceClaimDialog,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The insurance-claim create dialog. A claim always starts as a DRAFT, so there is no ' +
+          'status control here - the claim is submitted and progressed later from its detail ' +
+          'panel. This component owns only the modal shell, the save-time dismissal guard and the ' +
+          'error line; the draft state and its validation live in `useInsuranceClaimDraft`, and ' +
+          'the fields themselves in `InsuranceClaimFormFields`.\n\n' +
+          'A create request cannot be cancelled once it is in flight, so every dismissal route is ' +
+          'closed while `saving` is true - the Cancel button is disabled, and `CenterModal` also ' +
+          'stops responding to Escape and an outside click, not just the visible button. The error ' +
+          'line prefers the client-side validation message over the caller-supplied `error` prop, ' +
+          'so a request is only ever sent once the form is locally valid.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+    saving: { control: 'boolean' },
+    error: { control: 'text' },
+    currency: { control: 'text' },
+  },
+  args: {
+    open: true,
+    setOpen: fn(),
+    companions: COMPANIONS,
+    currency: 'GBP',
+    saving: false,
+    error: null,
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof CreateInsuranceClaimDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Saving: Story = {
+  name: 'Saving (every dismissal route closed)',
+  args: { saving: true },
+};
+
+export const ServerError: Story = {
+  name: 'Server rejected the claim',
+  args: { error: 'This insurer already has an open claim for the selected policy.' },
+};
+
+export const NoCompanions: Story = {
+  name: 'No companions to file for',
+  args: { companions: [] },
+};
+
+export const ValidationError: Story = {
+  name: 'Refuses an incomplete claim',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Create this insurance claim' }));
+
+    // Caught locally by useInsuranceClaimDraft before any request goes out.
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      'Choose a companion for this claim.'
+    );
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const SubmittedSuccessfully: Story = {
+  name: 'Fills the form and submits',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.selectOptions(
+      canvas.getByRole('combobox', { name: 'Companion' }),
+      'pt-bramble'
+    );
+    await userEvent.type(canvas.getByLabelText('Insurer'), 'Pawsome Insurance');
+    await userEvent.type(canvas.getByLabelText('Policy number'), 'POL-4471');
+    await userEvent.type(canvas.getByLabelText('Submitted amount (£)'), '250');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Create this insurance claim' }));
+
+    await expect(args.onSubmit).toHaveBeenCalledWith({
+      patientId: 'pt-bramble',
+      insurerName: 'Pawsome Insurance',
+      policyNumber: 'POL-4471',
+      submittedAmount: 250,
+      currency: 'GBP',
+    });
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.stories.tsx
@@ -1,0 +1,252 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import InsuranceClaimDetail from './InsuranceClaimDetail';
+import type { InsuranceClaim } from '@/app/features/finance/types/insuranceClaim';
+
+const ORG_ID = 'org-insurance-claim-detail';
+
+/**
+ * OWNER carries `billing:edit:any` by default (see ROLE_PERMISSIONS), which is
+ * what gates the whole action section - the status form and the Submit/Cancel
+ * buttons. `revoked` reproduces a practice that has taken billing rights off
+ * one person without touching their role.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  practitionerReference: 'Practitioner/vet-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+/**
+ * `PermissionGate` reads `useOrgStore` through `usePermissions`, so every
+ * story needs a loaded membership even though every other prop on this
+ * component arrives as an arg, not store state.
+ */
+const withMembership =
+  (revoked: string[] = []) =>
+  () => {
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    return () => useOrgStore.setState(snapshot);
+  };
+
+const buildClaim = (overrides: Partial<InsuranceClaim>): InsuranceClaim => ({
+  id: 'claim-1',
+  organisationId: ORG_ID,
+  patientId: 'patient-1',
+  invoiceId: 'invoice-4471',
+  encounterId: null,
+  insurerName: 'Petsure',
+  policyNumber: 'PS-2291-0087',
+  claimNumber: null,
+  submittedAmount: 980,
+  approvedAmount: null,
+  paidAmount: null,
+  currency: 'GBP',
+  status: 'DRAFT',
+  submittedAt: null,
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-08-15T09:00:00.000Z',
+  updatedAt: '2026-08-15T09:00:00.000Z',
+  ...overrides,
+});
+
+const DRAFT_CLAIM = buildClaim({});
+
+const AWAITING_REVIEW_CLAIM = buildClaim({
+  id: 'claim-2',
+  status: 'SUBMITTED',
+  claimNumber: 'PS-CLM-5510',
+  submittedAt: '2026-08-16T09:00:00.000Z',
+  notes: 'Dental extraction, x-rays attached to the original submission.',
+});
+
+const APPROVED_CLAIM = buildClaim({
+  id: 'claim-3',
+  insurerName: 'Bought By Many',
+  status: 'APPROVED',
+  submittedAmount: 980,
+  approvedAmount: 640,
+  claimNumber: 'BBM-8841',
+  submittedAt: '2026-08-10T09:00:00.000Z',
+  approvedAt: '2026-08-14T09:00:00.000Z',
+});
+
+const PAID_CLAIM = buildClaim({
+  id: 'claim-4',
+  insurerName: 'Agria',
+  status: 'PAID',
+  submittedAmount: 1240.6,
+  approvedAmount: 1240.6,
+  paidAmount: 1100,
+  claimNumber: 'AG-5512',
+  submittedAt: '2026-07-20T09:00:00.000Z',
+  approvedAt: '2026-07-24T09:00:00.000Z',
+  paidAt: '2026-08-02T09:00:00.000Z',
+});
+
+const statusForm = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByLabelText('Move claim to');
+
+const meta = {
+  title: 'InsuranceClaims/InsuranceClaimDetail',
+  component: InsuranceClaimDetail,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'One selected claim: its amounts and dates, and the lifecycle actions the backend ' +
+          'will currently accept for its status. Purely presentational - every value and every ' +
+          'callback arrives as a prop, and the parent page decides which claim is selected.\n\n' +
+          "The status picker only ever offers a transition the service's own status endpoint " +
+          'would accept (`nextReviewStatuses` mirrors `CLAIM_STATUS_TRANSITIONS`), and it echoes ' +
+          "the service's amount rules (`assertClaimAmountsCoherent`) before sending anything, so " +
+          'an approved amount above the submitted ask or a paid amount above the approved figure ' +
+          'is caught locally rather than round-tripping to a 409. The whole action section - the ' +
+          'form and the Submit/Cancel buttons - sits behind `billing:edit:any`, so a read-only ' +
+          'user sees the claim but no way to change it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: withMembership(),
+  args: {
+    claim: AWAITING_REVIEW_CLAIM,
+    companionName: 'Bruno',
+    pendingAction: null,
+    error: null,
+    onSubmit: fn(),
+    onCancel: fn(),
+    onUpdateStatus: fn(),
+  },
+  argTypes: {
+    pendingAction: { control: 'radio', options: ['submit', 'cancel', 'status'] },
+    error: { control: 'text' },
+  },
+} satisfies Meta<typeof InsuranceClaimDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AwaitingReview: Story = {
+  name: 'Submitted, awaiting review',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Bruno')).toBeVisible();
+    await expect(canvas.getByText('Petsure')).toBeVisible();
+    await expect(canvas.getByText('£980.00')).toBeVisible();
+    // A SUBMITTED claim can still be cancelled but not re-submitted.
+    await expect(canvas.getByRole('button', { name: 'Cancel this claim' })).toBeEnabled();
+    await expect(
+      canvas.queryByRole('button', { name: 'Submit this claim to the insurer' })
+    ).toBeNull();
+    // The default target is "Under review", which needs no amount yet.
+    await expect(statusForm(canvasElement)).toHaveValue('UNDER_REVIEW');
+    await expect(canvas.queryByLabelText('Approved amount')).toBeNull();
+  },
+};
+
+export const Draft: Story = {
+  name: 'Draft - submit or cancel, no review form yet',
+  args: { claim: DRAFT_CLAIM },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // Nothing to review yet, so the picker is absent entirely.
+    await expect(canvas.queryByLabelText('Move claim to')).toBeNull();
+    await expect(canvas.getByRole('link', { name: 'View the invoice' })).toHaveAttribute(
+      'href',
+      '/finance?invoiceId=invoice-4471'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Submit this claim to the insurer' }));
+    await expect(args.onSubmit).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const ApprovedAwaitingPayment: Story = {
+  name: 'Approved - recording the paid amount',
+  args: { claim: APPROVED_CLAIM },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // The only remaining transition is PAID, which needs a paid amount.
+    await expect(statusForm(canvasElement)).toHaveValue('PAID');
+    const paidInput = canvas.getByLabelText('Paid amount');
+    const update = canvas.getByRole('button', { name: "Update this claim's status" });
+
+    // Nothing entered yet - the client-side echo of the service's rule catches it.
+    await userEvent.click(update);
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      'Enter the amount the insurer paid.'
+    );
+    await expect(args.onUpdateStatus).not.toHaveBeenCalled();
+
+    // Above the approved figure (640) is refused the same way a 409 would be.
+    await userEvent.type(paidInput, '700');
+    await userEvent.click(update);
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      'Paid amount cannot exceed the approved amount.'
+    );
+
+    await userEvent.clear(paidInput);
+    await userEvent.type(paidInput, '600');
+    await userEvent.click(update);
+    await expect(args.onUpdateStatus).toHaveBeenCalledWith({ status: 'PAID', paidAmount: 600 });
+    await expect(canvas.queryByRole('alert')).toBeNull();
+  },
+};
+
+export const Paid: Story = {
+  name: 'Paid - a closed claim has no actions left',
+  args: { claim: PAID_CLAIM },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('£1,100.00')).toBeVisible();
+    await expect(canvas.queryByLabelText('Move claim to')).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Cancel this claim' })).toBeNull();
+    await expect(
+      canvas.queryByRole('button', { name: 'Submit this claim to the insurer' })
+    ).toBeNull();
+  },
+};
+
+export const StatusUpdateFailed: Story = {
+  name: 'Status update failed',
+  args: {
+    claim: AWAITING_REVIEW_CLAIM,
+    error: 'The insurer already recorded a decision for this claim.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent(
+      'The insurer already recorded a decision for this claim.'
+    );
+    // The form is still usable - the error is a retry prompt, not a lockout.
+    await expect(canvas.getByRole('button', { name: "Update this claim's status" })).toBeEnabled();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Billing edit revoked - claim visible, no actions',
+  beforeEach: withMembership(['billing:edit:any']),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Petsure')).toBeVisible();
+    await expect(canvas.queryByLabelText('Move claim to')).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Cancel this claim' })).toBeNull();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import InsuranceClaimFormFields, { type CompanionChoice } from './InsuranceClaimFormFields';
+import type { ClaimDraft } from './useInsuranceClaimDraft';
+
+const emptyDraft: ClaimDraft = {
+  patientId: '',
+  insurerName: '',
+  policyNumber: '',
+  submittedAmount: '',
+  invoiceId: '',
+  encounterId: '',
+  notes: '',
+};
+
+const filledDraft: ClaimDraft = {
+  patientId: 'companion-bramble',
+  insurerName: 'Trupanion',
+  policyNumber: 'TRU-88213-UK',
+  submittedAmount: '412.50',
+  invoiceId: 'inv-2291',
+  encounterId: 'enc-7734',
+  notes: 'Follow-up dental cleaning after the July extraction; owner asked for itemised receipt.',
+};
+
+const companions: CompanionChoice[] = [
+  { id: 'companion-bramble', name: 'Bramble' },
+  { id: 'companion-otis', name: 'Otis' },
+  { id: 'companion-willow', name: 'Willow' },
+];
+
+const insuranceClaimFormFieldsMeta = {
+  title: 'InsuranceClaims/InsuranceClaimFormFields',
+  component: InsuranceClaimFormFields,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The insurance claim create form's fields: a companion picker, the insurer's name " +
+          'and policy number, the submitted amount labelled with the org currency symbol, and ' +
+          'two optional free-text links - invoice ID and encounter ID - plus optional notes. ' +
+          'The invoice and encounter fields are free text rather than pickers because a claim ' +
+          'can be filed before either record exists.\n\n' +
+          'Presentational: every field is controlled from `draft` and reports changes through ' +
+          '`setField` with a partial patch. The draft state, its validation and the payload it ' +
+          'builds all live in `useInsuranceClaimDraft`, not here.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    currency: {
+      control: 'select',
+      options: ['USD', 'GBP', 'EUR', 'INR'],
+    },
+  },
+  args: {
+    draft: emptyDraft,
+    setField: fn(),
+    currency: 'USD',
+    companions,
+  },
+} satisfies Meta<typeof InsuranceClaimFormFields>;
+
+export default insuranceClaimFormFieldsMeta;
+type InsuranceClaimFormFieldsStory = StoryObj<typeof insuranceClaimFormFieldsMeta>;
+
+export const Default: InsuranceClaimFormFieldsStory = {};
+
+export const Filled: InsuranceClaimFormFieldsStory = {
+  name: 'Filled-in claim',
+  args: {
+    draft: filledDraft,
+  },
+};
+
+export const NoCompanions: InsuranceClaimFormFieldsStory = {
+  name: 'No companions to choose from',
+  args: {
+    companions: [],
+  },
+};
+
+export const IndianRupeeCurrency: InsuranceClaimFormFieldsStory = {
+  name: 'Non-USD currency (INR)',
+  args: {
+    draft: { ...emptyDraft, patientId: 'companion-otis', submittedAmount: '18500' },
+    currency: 'INR',
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimList.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, within } from 'storybook/test';
+
+import InsuranceClaimList from './InsuranceClaimList';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+
+const claim = (
+  id: string,
+  insurerName: string,
+  status: InsuranceClaimStatus,
+  amounts: { submitted: number; approved?: number | null; paid?: number | null },
+  claimNumber: string | null = null,
+  currency = 'GBP'
+): InsuranceClaim => ({
+  id,
+  organisationId: 'org-1',
+  patientId: 'pat-1',
+  invoiceId: null,
+  encounterId: null,
+  insurerName,
+  policyNumber: 'PS-2291',
+  claimNumber,
+  submittedAmount: amounts.submitted,
+  approvedAmount: amounts.approved ?? null,
+  paidAmount: amounts.paid ?? null,
+  currency,
+  status,
+  submittedAt: '2026-08-28T09:00:00.000Z',
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+});
+
+const meta = {
+  title: 'InsuranceClaims/InsuranceClaimList',
+  component: InsuranceClaimList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The insurance claims list, rendered through the shared `GenericTable` so it inherits ' +
+          "the app's column-header typography, contrast, sticky behaviour and pager rather than " +
+          'maintaining a second finance table of its own.\n\n' +
+          'The first column stacks the insurer over its policy number, the way the invoice table ' +
+          'stacks a primary and a quiet second line, so the finance tables read as one family. ' +
+          'Submitted, Approved and Paid are three separate money columns rather than one figure: ' +
+          'Approved and Paid are nullable until the claim has moved past that stage, and render as ' +
+          'a dash rather than a misleading zero. Claim number follows the same rule - it is ' +
+          'assigned once the claim moves off DRAFT, so a fresh claim renders a dash there too.\n\n' +
+          "The open claim is highlighted through GenericTable's row hook rather than dropped: " +
+          'without it, the detail panel a caller renders below this list could belong to any row ' +
+          'on screen.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    claims: [
+      claim('c1', 'Petsure', 'DRAFT', { submitted: 420 }),
+      claim(
+        'c2',
+        'Bought By Many',
+        'PARTIALLY_APPROVED',
+        { submitted: 980, approved: 640 },
+        'BBM-8841'
+      ),
+      claim('c3', 'Agria', 'PAID', { submitted: 1240.6, approved: 1240.6, paid: 1100 }, 'AG-5512'),
+    ],
+    activeClaimId: 'c2',
+    onSelect: fn(),
+  },
+} satisfies Meta<typeof InsuranceClaimList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'A row per claim',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Petsure')).toBeInTheDocument();
+    await expect(canvas.getByText('PS-2291')).toBeInTheDocument();
+    // Both decimals survive: 1240.6 must not print as "£1,241".
+    await expect(canvas.getByText('£1,240.60')).toBeInTheDocument();
+    await expect(canvas.getByText('£1,100.00')).toBeInTheDocument();
+    // A draft claim has no claim number and no settled amounts yet - all dashes.
+    await expect(canvas.getAllByText('-').length).toBeGreaterThanOrEqual(2);
+    await expect(canvas.getByText('Partially approved')).toBeInTheDocument();
+    // The open claim's row is the one GenericTable highlights.
+    await expect(canvasElement.querySelector('tbody tr.bg-card-hover')).not.toBeNull();
+  },
+};
+
+export const EmptyState: Story = {
+  name: 'No claims yet',
+  args: { claims: [], activeClaimId: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No claims yet')).toBeVisible();
+    await expect(canvas.getByText('Claims appear here as soon as there are any.')).toBeVisible();
+  },
+};
+
+export const NoActiveClaim: Story = {
+  name: 'No claim is open yet',
+  args: { activeClaimId: null },
+  play: async ({ canvasElement }) => {
+    // Nothing in the list should carry the active row's highlight.
+    await expect(canvasElement.querySelector('tbody tr.bg-card-hover')).toBeNull();
+  },
+};
+
+export const DifferentCurrency: Story = {
+  name: 'A currency with no minor unit',
+  args: {
+    claims: [claim('c4', 'Zenoaq Cover', 'SUBMITTED', { submitted: 45000 }, 'ZC-1120', 'JPY')],
+    activeClaimId: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // JPY has no minor unit, so Intl prints no decimals - not "¥45,000.00".
+    await expect(canvas.getByText('¥45,000')).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimStatusBadge.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import InsuranceClaimStatusBadge from './InsuranceClaimStatusBadge';
+
+const meta = {
+  title: 'InsuranceClaims/InsuranceClaimStatusBadge',
+  component: InsuranceClaimStatusBadge,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The claim's lifecycle badge, shown in the claims table and on the claim detail page. It " +
+          'is a thin wrapper around `StatusPill`: `claimStatusBadge` resolves the status to the same ' +
+          'label and pill-token set the status filter row uses, so the badge and the filter can never ' +
+          'read differently for the same status. It has no interaction of its own - moving a claim to ' +
+          'a new status happens through the status control on the claim page, not through this badge.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: [
+        'DRAFT',
+        'SUBMITTED',
+        'UNDER_REVIEW',
+        'APPROVED',
+        'PARTIALLY_APPROVED',
+        'REJECTED',
+        'PAID',
+        'CANCELLED',
+      ],
+    },
+  },
+  args: {
+    status: 'SUBMITTED',
+  },
+} satisfies Meta<typeof InsuranceClaimStatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A freshly submitted claim - the most common state in an active claims list. */
+export const Default: Story = {};
+
+/** Before submission, using the neutral token shared with other "not yet sent" states. */
+export const Draft: Story = { args: { status: 'DRAFT' } };
+
+/** A partial payout decision - its own accent tone, distinct from a full approval. */
+export const PartiallyApproved: Story = { args: { status: 'PARTIALLY_APPROVED' } };
+
+/** The claim's successful end state. */
+export const Paid: Story = { args: { status: 'PAID' } };
+
+/** The insurer declined the claim - the one danger-toned state on this badge. */
+export const Rejected: Story = { args: { status: 'REJECTED' } };
+
+/** Withdrawn by the practice rather than declined by the insurer, so it gets its own tone. */
+export const Cancelled: Story = { args: { status: 'CANCELLED' } };

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsHeader.stories.tsx
@@ -1,0 +1,218 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import type {
+  InsuranceClaim,
+  InsuranceClaimStatus,
+} from '@/app/features/finance/types/insuranceClaim';
+import type { CompanionChoice } from '@/app/features/finance/pages/InsuranceClaims/Sections/CreateInsuranceClaimDialog';
+import InsuranceClaimsHeader from './InsuranceClaimsHeader';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * `New insurance claim` sits behind `PermissionGate`, which reads the
+ * signed-in membership from the org store rather than being told the answer
+ * by a prop - so the story seeds the store the gate actually reads, the same
+ * way `InvoiceCreditNotes.stories.tsx` does. Every shipped role carries
+ * `billing:edit:any`, so a read-only view only exists through
+ * `revokedPermissions`, which the `NoEditPermission` story below uses.
+ */
+const seedRole = (revokedPermissions: string[] = []) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: {
+      [ORG_ID]: {
+        id: 'membership-1',
+        practitionerReference: 'Practitioner/practitioner-1',
+        organizationReference: `Organization/${ORG_ID}`,
+        roleCode: 'OWNER' as UserOrganization['roleCode'],
+        roleDisplay: 'Owner',
+        active: true,
+        revokedPermissions,
+      },
+    },
+    status: 'loaded',
+  });
+};
+
+const claim = (
+  overrides: Partial<InsuranceClaim> & { id: string; status: InsuranceClaimStatus }
+): InsuranceClaim => ({
+  organisationId: ORG_ID,
+  patientId: 'pat-1',
+  invoiceId: null,
+  encounterId: null,
+  insurerName: 'Petsure',
+  policyNumber: 'PS-2291',
+  claimNumber: null,
+  submittedAmount: 420,
+  approvedAmount: null,
+  paidAmount: null,
+  currency: 'GBP',
+  submittedAt: null,
+  approvedAt: null,
+  paidAt: null,
+  rejectionReason: null,
+  notes: null,
+  externalClaimRef: null,
+  createdAt: '2026-08-28T09:00:00.000Z',
+  updatedAt: '2026-08-28T09:00:00.000Z',
+  ...overrides,
+});
+
+const CLAIMS: InsuranceClaim[] = [
+  claim({ id: 'c1', status: 'DRAFT', submittedAmount: 420 }),
+  claim({
+    id: 'c2',
+    status: 'SUBMITTED',
+    insurerName: 'Bought By Many',
+    policyNumber: 'BBM-8841',
+    claimNumber: 'CLM-5567',
+    submittedAmount: 199.5,
+    submittedAt: '2026-08-29T10:00:00.000Z',
+  }),
+  claim({
+    id: 'c3',
+    status: 'PAID',
+    insurerName: 'ManyPets',
+    policyNumber: 'MP-7781',
+    claimNumber: 'CLM-5569',
+    submittedAmount: 88,
+    approvedAmount: 88,
+    paidAmount: 88,
+    invoiceId: 'inv-1',
+    submittedAt: '2026-08-20T10:00:00.000Z',
+    approvedAt: '2026-08-22T10:00:00.000Z',
+    paidAt: '2026-08-24T10:00:00.000Z',
+  }),
+];
+
+const COMPANIONS: CompanionChoice[] = [
+  { id: 'comp-1', name: 'Marnie' },
+  { id: 'comp-2', name: 'Rufus' },
+];
+
+const meta = {
+  title: 'InsuranceClaims/InsuranceClaimsHeader',
+  component: InsuranceClaimsHeader,
+  parameters: {
+    layout: 'padded',
+    // `Secondary`'s "Invoices" control renders a next/link `<Link>`.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The Insurance claims page header: a title with a live count and an info tooltip, ' +
+          'a money sub-line, and - stacked on the right - the page actions above the status ' +
+          'filter row, the same anatomy Finance and Estimates use.\n\n' +
+          'The sub-line is derived, not passed in: `summariseClaims` adds up `submittedAmount` ' +
+          'for every DRAFT/SUBMITTED/UNDER_REVIEW claim as "with insurers" and `paidAmount` for ' +
+          'every PAID claim as "paid back", so it only ever tells the truth the row data can ' +
+          'prove - a claim under review counts what was asked for, not what might be approved. ' +
+          '`sharedCurrency` picks the one currency the claims agree on and falls back to the ' +
+          "organisation's currency where they do not.\n\n" +
+          '"New insurance claim" sits behind `billing:edit:any` and is separately disabled when ' +
+          'there are no companions to file a claim for.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    claims: CLAIMS,
+    currency: 'GBP',
+    activeStatus: 'all',
+    onStatusChange: fn(),
+    companions: COMPANIONS,
+    onCreate: fn(),
+  },
+  argTypes: {
+    currency: { control: 'text' },
+    activeStatus: { control: 'text' },
+  },
+  beforeEach: () => seedRole(),
+} satisfies Meta<typeof InsuranceClaimsHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Default',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 1, name: /Insurance claims/ })).toBeVisible();
+    await expect(canvas.getByText('(3)')).toBeVisible();
+    // 420 + 199.5 in progress; 88 paid back.
+    await expect(canvas.getByText('£619.50 with insurers · £88.00 paid back')).toBeVisible();
+    await expect(canvas.getByRole('link', { name: 'Back to invoices' })).toHaveAttribute(
+      'href',
+      '/finance'
+    );
+    await expect(
+      canvas.getByRole('button', { name: 'Create a new insurance claim' })
+    ).toBeEnabled();
+  },
+};
+
+export const Empty: Story = {
+  name: 'No claims yet',
+  args: { claims: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('(0)')).toBeVisible();
+    await expect(canvas.getByText('£0.00 with insurers · £0.00 paid back')).toBeVisible();
+  },
+};
+
+export const NoCompanionsDisablesCreate: Story = {
+  name: 'No companions - Create is disabled',
+  args: { companions: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The button stays visible (the permission is held); it is the lack of a
+    // companion to file against that disables it, not a permission denial.
+    await expect(
+      canvas.getByRole('button', { name: 'Create a new insurance claim' })
+    ).toBeDisabled();
+  },
+};
+
+export const NoEditPermission: Story = {
+  name: 'Billing edit revoked - no Create button',
+  beforeEach: () => seedRole(['billing:edit:any']),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The gate renders nothing rather than a disabled control, so the row is
+    // just the Invoices link and the filters.
+    await expect(
+      canvas.queryByRole('button', { name: 'Create a new insurance claim' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'Back to invoices' })).toBeVisible();
+  },
+};
+
+export const ActiveStatusFilter: Story = {
+  name: 'A status filter is active',
+  args: { activeStatus: 'PAID' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Paid' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  },
+};
+
+export const ChangingTheFilter: Story = {
+  name: 'Picking a filter calls onStatusChange',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Submitted' }));
+    await expect(args.onStatusChange).toHaveBeenCalledWith('SUBMITTED');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Create a new insurance claim' }));
+    await expect(args.onCreate).toHaveBeenCalledTimes(1);
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimsStates.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import InsuranceClaimsStates from './InsuranceClaimsStates';
+
+const insuranceClaimsStatesMeta = {
+  title: 'InsuranceClaims/InsuranceClaimsStates',
+  component: InsuranceClaimsStates,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The insurance claims list's loading, error and empty placeholders. The three states " +
+          'are mutually exclusive with the claims table and with each other - loading wins over ' +
+          'error, error wins over empty - so the component returns null once there are claims to ' +
+          'show, letting the page read as `<States/>` then the table rather than three inline ' +
+          'branches in the page itself.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    loading: { control: 'boolean' },
+    error: { control: 'text' },
+    isEmpty: { control: 'boolean' },
+    emptyMessage: { control: 'text' },
+  },
+  args: {
+    loading: false,
+    error: null,
+    isEmpty: false,
+    emptyMessage: 'No claims match the current filters.',
+    onReload: fn(),
+  },
+} satisfies Meta<typeof InsuranceClaimsStates>;
+
+export default insuranceClaimsStatesMeta;
+type InsuranceClaimsStatesStory = StoryObj<typeof insuranceClaimsStatesMeta>;
+
+export const Default: InsuranceClaimsStatesStory = {
+  name: 'Claims present (renders nothing)',
+};
+
+export const Loading: InsuranceClaimsStatesStory = {
+  args: { loading: true },
+};
+
+export const Error: InsuranceClaimsStatesStory = {
+  args: { error: 'Could not load insurance claims. Please try again.' },
+};
+
+export const Empty: InsuranceClaimsStatesStory = {
+  args: { isEmpty: true },
+};
+
+export const EmptyFromFilter: InsuranceClaimsStatesStory = {
+  name: 'Empty from an active filter',
+  args: {
+    isEmpty: true,
+    emptyMessage: 'No claims match "Trupanion" in Submitted.',
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

CreateInsuranceClaimDialog, InsuranceClaimDetail, InsuranceClaimFormFields, InsuranceClaimList, InsuranceClaimStatusBadge, InsuranceClaimsHeader, and InsuranceClaimsStates have no Storybook coverage.

## What is the new behavior?

Adds a story for each, following the repo's existing CSF3 house style.

## Related Issue(s)

Part of #2930