### PR TITLE
test(frontend): add Storybook stories for the 5 uncovered companionHistory panels

### DIFF
--- a/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
@@ -1,0 +1,328 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type {
+  CreatePatientAllergyInput,
+  PatientAllergy,
+} from '@/app/features/companionHistory/services/patientAllergyService';
+import AllergyListPanel from './AllergyListPanel';
+
+const ORG_ID = 'org-storybook-companion-history';
+const COMPANION_ID = 'patient-storybook-fenn';
+
+const membership = (revoked: string[] = []): UserOrganization => ({
+  practitionerReference: 'Practitioner/vet-fenn',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const allergy = (
+  over: Partial<PatientAllergy> & Pick<PatientAllergy, 'id' | 'allergen'>
+): PatientAllergy => ({
+  organisationId: ORG_ID,
+  patientId: COMPANION_ID,
+  allergyType: 'DRUG',
+  severity: 'MILD',
+  reaction: null,
+  status: 'ACTIVE',
+  onsetDate: null,
+  resolvedDate: null,
+  notes: null,
+  recordedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const PENICILLIN = allergy({
+  id: 'allergy-penicillin',
+  allergen: 'Penicillin',
+  allergyType: 'DRUG',
+  severity: 'LIFE_THREATENING',
+  status: 'ACTIVE',
+  reaction: 'Anaphylaxis, facial swelling',
+  onsetDate: '2025-11-02T00:00:00.000Z',
+  notes: 'Confirmed by intradermal test.',
+});
+const CHICKEN = allergy({
+  id: 'allergy-chicken',
+  allergen: 'Chicken protein',
+  allergyType: 'FOOD',
+  severity: 'MODERATE',
+  status: 'ACTIVE',
+  reaction: 'Chronic pruritus',
+  onsetDate: '2026-01-04T00:00:00.000Z',
+});
+const GRASS = allergy({
+  id: 'allergy-grass',
+  allergen: 'Grass pollen',
+  allergyType: 'ENVIRONMENTAL',
+  severity: 'MILD',
+  status: 'UNCONFIRMED',
+});
+
+const SAMPLE: PatientAllergy[] = [PENICILLIN, CHICKEN, GRASS];
+const BY_ID: Record<string, PatientAllergy> = Object.fromEntries(SAMPLE.map((a) => [a.id, a]));
+
+type ListFixture =
+  | { kind: 'resolves'; allergies: PatientAllergy[] }
+  /** Held open on purpose: the only way to hold the loading skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects' };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The panel reads and writes `/v1/pms/organisation/:id/patient-allergies` through
+ * the shared axios instance, so its adapter is the seam. A create POST is echoed
+ * back as the record the server would store; a resolve POST looks the record up
+ * by the id in its URL and marks it resolved. The list GET is driven by the
+ * fixture so each story can show a different load outcome.
+ */
+const buildAdapter =
+  (fixture: ListFixture): AxiosAdapter =>
+  (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (!url.includes('/patient-allergies')) return Promise.resolve(respond(config, []));
+
+    if (method === 'post' && url.endsWith('/resolve')) {
+      const id = url.split('/').slice(-2, -1)[0] ?? '';
+      const existing = BY_ID[id] ?? allergy({ id, allergen: 'Allergy' });
+      return Promise.resolve(
+        respond(config, {
+          ...existing,
+          status: 'RESOLVED',
+          resolvedDate: '2026-02-01T00:00:00.000Z',
+        })
+      );
+    }
+
+    if (method === 'post') {
+      const body = JSON.parse(String(config.data ?? '{}')) as CreatePatientAllergyInput;
+      return Promise.resolve(
+        respond(
+          config,
+          allergy({
+            id: 'allergy-new',
+            allergen: body.allergen,
+            allergyType: body.allergyType,
+            severity: body.severity,
+            reaction: body.reaction ?? null,
+            notes: body.notes ?? null,
+            onsetDate: body.onsetDate ?? null,
+            status: 'ACTIVE',
+          })
+        )
+      );
+    }
+
+    if (fixture.kind === 'pending') return new Promise<never>(() => {});
+    if (fixture.kind === 'rejects') {
+      return Promise.reject(
+        Object.assign(new Error('Request failed with status code 403'), {
+          isAxiosError: true,
+          config,
+          response: {
+            status: 403,
+            statusText: 'Forbidden',
+            data: {},
+            headers: {},
+            config,
+          },
+        })
+      );
+    }
+    return Promise.resolve(respond(config, fixture.allergies));
+  };
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The panel gates on `appointments:view:any` / `appointments:edit:any` from
+ * `usePermissions`, which is itself derived from `useOrgStore`'s active
+ * membership - so the stories seed a real membership on that store rather than
+ * mocking the permission hook. `revoked` reproduces exactly how a practice
+ * takes a right off one person.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: ListFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+    const orgSnapshot = useOrgStore.getState();
+    api.defaults.adapter = buildAdapter(fixture);
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useOrgStore.setState(orgSnapshot);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused read is logged by the axios wrapper on its way to the hook's catch,
+ * and the render check treats a console error as a broken story. Only that
+ * line is dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some((arg) => typeof arg === 'string' && arg.includes('API getData error'));
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const allergyListPanelMeta = {
+  title: 'CompanionHistory/AllergyListPanel',
+  component: AllergyListPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Data container for `AllergyList`. It calls `useAllergyList` for the signed-in ' +
+          "member's permissions (`appointments:view:any` / `appointments:edit:any` on the " +
+          "active organisation from `useOrgStore`), fetches the patient's allergies from the " +
+          'patient-allergies API, and forwards the create and resolve callbacks. All state ' +
+          'lives in the hook, not this component - it renders nothing when the member cannot ' +
+          'view allergies on the active organisation, and otherwise just projects the hook ' +
+          'onto the presentational `AllergyList`.\n\n' +
+          "The stories seed `useOrgStore` with a real membership so the hook's own permission " +
+          'check runs unmocked, and swap the shared axios adapter to answer the ' +
+          'patient-allergies endpoints from fixtures instead of a live backend.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    companionId: {
+      control: 'text',
+      description: 'The companion (patient) whose allergies to load. `companionId === patientId`.',
+    },
+  },
+  args: {
+    companionId: COMPANION_ID,
+  },
+  beforeEach: prepare({ fixture: { kind: 'resolves', allergies: SAMPLE } }),
+} satisfies Meta<typeof AllergyListPanel>;
+
+export default allergyListPanelMeta;
+type AllergyListPanelStory = StoryObj<typeof allergyListPanelMeta>;
+
+export const Default: AllergyListPanelStory = {
+  name: 'Allergies loaded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 3, name: 'Allergies' })).toBeVisible();
+    await expect(canvas.getByText('Penicillin')).toBeVisible();
+    await expect(canvas.getByText('Life-threatening')).toBeVisible();
+    await expect(canvas.getByText('Chicken protein')).toBeVisible();
+    await expect(canvas.getByText('Grass pollen')).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Add allergy' })).toBeEnabled();
+
+    // Real create flow: submits through the hook, into the mocked POST.
+    await userEvent.click(canvas.getByRole('button', { name: 'Add allergy' }));
+    const allergenInput = await canvas.findByLabelText('Allergen');
+    await userEvent.type(allergenInput, 'Latex');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save allergy' }));
+    await expect(await canvas.findByText('Latex')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: 'Save allergy' })).not.toBeInTheDocument();
+
+    // Real resolve flow: submits through the hook, into the mocked POST.
+    await userEvent.click(canvas.getByRole('button', { name: 'Resolve Chicken protein' }));
+    await waitFor(() =>
+      expect(canvas.getByText('Chicken protein').closest('li')).toHaveTextContent('Resolved')
+    );
+  },
+};
+
+export const Empty: AllergyListPanelStory = {
+  name: 'No allergies recorded',
+  beforeEach: prepare({ fixture: { kind: 'resolves', allergies: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText('No allergies recorded for this patient yet.')
+    ).toBeVisible();
+    await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
+  },
+};
+
+export const Loading: AllergyListPanelStory = {
+  name: 'Loading the allergy list',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 3, name: 'Allergies' });
+    await waitFor(() =>
+      expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull()
+    );
+    await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No allergies recorded for this patient yet.')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: AllergyListPanelStory = {
+  name: 'Allergy list failed to load',
+  beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Could not load the allergy list. Please try again.');
+    await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: AllergyListPanelStory = {
+  name: 'View only - edit permission revoked',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', allergies: SAMPLE },
+    revoked: ['appointments:edit:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Penicillin')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: 'Add allergy' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Resolve Chicken protein' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const NoAccess: AllergyListPanelStory = {
+  name: 'View permission revoked - renders nothing',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', allergies: SAMPLE },
+    revoked: ['appointments:view:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
@@ -238,7 +238,7 @@ export const Default: AllergyListPanelStory = {
   name: 'Allergies loaded',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByRole('heading', { level: 3, name: 'Allergies' })).toBeVisible();
+    await expect(canvas.findByRole('heading', { level: 3, name: 'Allergies' })).toBeVisible();
     await expect(canvas.getByText('Penicillin')).toBeVisible();
     await expect(canvas.getByText('Life-threatening')).toBeVisible();
     await expect(canvas.getByText('Chicken protein')).toBeVisible();
@@ -250,7 +250,7 @@ export const Default: AllergyListPanelStory = {
     const allergenInput = await canvas.findByLabelText('Allergen');
     await userEvent.type(allergenInput, 'Latex');
     await userEvent.click(canvas.getByRole('button', { name: 'Save allergy' }));
-    await expect(await canvas.findByText('Latex')).toBeVisible();
+    await expect(canvas.findByText('Latex')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save allergy' })).not.toBeInTheDocument();
 
     // Real resolve flow: submits through the hook, into the mocked POST.
@@ -308,7 +308,7 @@ export const ReadOnly: AllergyListPanelStory = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText('Penicillin')).toBeVisible();
+    await expect(canvas.findByText('Penicillin')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Add allergy' })).not.toBeInTheDocument();
     await expect(
       canvas.queryByRole('button', { name: 'Resolve Chicken protein' })

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
@@ -266,9 +266,7 @@ export const Empty: AllergyListPanelStory = {
   beforeEach: prepare({ fixture: { kind: 'resolves', allergies: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByText('No allergies recorded for this patient yet.')
-    ).toBeVisible();
+    await expect(canvas.findByText('No allergies recorded for this patient yet.')).toBeVisible();
     await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
   },
 };

--- a/apps/frontend/src/app/features/companionHistory/components/ClinicalListChrome.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ClinicalListChrome.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import React, { useState } from 'react';
+import { IoMedkitOutline } from 'react-icons/io5';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import {
+  ClinicalListEmpty,
+  ClinicalListError,
+  ClinicalListHeader,
+  ClinicalListLoadingRows,
+  cardClass,
+  formatDate,
+  metaClass,
+  rowClass,
+  titleClass,
+} from './ClinicalListChrome';
+
+/**
+ * Sample rows for the card body under the header. `ClinicalListHeader` itself
+ * takes no row data - the caller (ProblemList, AllergyList, ...) owns the list
+ * and picks which of these three bodies to render. These stand in for that so
+ * the header's count pill has something real to count.
+ */
+const SAMPLE_PROBLEMS = [
+  { id: 'p1', name: 'Osteoarthritis, left hip', onset: '2026-01-12' },
+  { id: 'p2', name: 'Chronic kidney disease, stage 2', onset: '2025-02-03' },
+];
+
+const SampleRows = () => (
+  <ul className="divide-y divide-[var(--divider)]">
+    {SAMPLE_PROBLEMS.map((problem) => (
+      <li key={problem.id} className={rowClass}>
+        <span>
+          <span className={titleClass}>{problem.name}</span>
+          <span className={`${metaClass} mt-0.5 block`}>Onset {formatDate(problem.onset)}</span>
+        </span>
+        <StatusPill label="Active" tone="warning" />
+      </li>
+    ))}
+  </ul>
+);
+
+const meta = {
+  title: 'CompanionHistory/ClinicalListChrome',
+  component: ClinicalListHeader,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Section header shared by the clinical-record lists in the companion history ' +
+          '(problem list, allergies, and any list built on the same ClinicalListChrome ' +
+          "pieces). It shows the list's icon and title, an 'N active' count pill once data " +
+          'has loaded (withheld while loading, on error, or when the count is zero, so a ' +
+          'stale or meaningless number is never shown), and, for callers with edit rights, ' +
+          "a toggle button that swaps between the add label and 'Close' as the inline " +
+          'create form opens and closes. The rest of ClinicalListChrome - the loading ' +
+          'skeleton, empty message and error banner - fills the body below it in these ' +
+          'stories, the same way ProblemList and AllergyList compose it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    loading: { control: 'boolean' },
+    canEdit: { control: 'boolean' },
+    showForm: { control: 'boolean' },
+    icon: { control: false },
+  },
+  args: {
+    icon: <IoMedkitOutline size={18} />,
+    headingId: 'problem-list-heading',
+    title: 'Problem list',
+    activeCount: 2,
+    loading: false,
+    error: null,
+    canEdit: true,
+    showForm: false,
+    onToggle: fn(),
+    addLabel: 'Add problem',
+  },
+  render: (args) => (
+    <section className={cardClass} style={{ maxWidth: 480 }} aria-labelledby={args.headingId}>
+      <ClinicalListHeader {...args} />
+      {args.error ? (
+        <ClinicalListError error={args.error} />
+      ) : args.loading ? (
+        <ClinicalListLoadingRows />
+      ) : args.activeCount === 0 ? (
+        <ClinicalListEmpty message="No problems recorded for this patient yet." />
+      ) : (
+        <SampleRows />
+      )}
+    </section>
+  ),
+} satisfies Meta<typeof ClinicalListHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const Empty: Story = {
+  args: { activeCount: 0 },
+};
+
+export const ErrorState: Story = {
+  name: 'Load failed',
+  args: { error: 'Could not load problems.' },
+};
+
+export const ReadOnly: Story = {
+  name: 'No edit permission',
+  args: { canEdit: false },
+};
+
+/**
+ * `ClinicalListHeader`'s args are static per story, so this demo keeps its own
+ * `showForm` state (the way `ProblemList` really does) to give the toggle
+ * button something to actually flip - real interactive behaviour worth a
+ * play() assertion, unlike the presentational stories above.
+ */
+const ToggleDemo = () => {
+  const [showForm, setShowForm] = useState(false);
+  return (
+    <section className={cardClass} style={{ maxWidth: 480 }} aria-labelledby="toggle-demo-heading">
+      <ClinicalListHeader
+        icon={<IoMedkitOutline size={18} />}
+        headingId="toggle-demo-heading"
+        title="Problem list"
+        activeCount={2}
+        loading={false}
+        canEdit
+        showForm={showForm}
+        onToggle={() => setShowForm((open) => !open)}
+        addLabel="Add problem"
+      />
+      {showForm ? (
+        <p className="px-4 py-3 text-[12.5px] text-[var(--ink-faint)]">
+          Add-problem form goes here.
+        </p>
+      ) : (
+        <SampleRows />
+      )}
+    </section>
+  );
+};
+
+export const TogglingTheForm: Story = {
+  name: 'Toggling the add form',
+  render: () => <ToggleDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const openButton = canvas.getByRole('button', { name: 'Add problem' });
+    await expect(openButton).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(openButton);
+
+    const closeButton = canvas.getByRole('button', { name: 'Close' });
+    await expect(closeButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.getByText('Add-problem form goes here.')).toBeVisible();
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
@@ -260,7 +260,7 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
+    await expect(canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
     await expect(
       await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
     ).toBeVisible();
@@ -281,7 +281,7 @@ export const Default: Story = {
       'li'
     ) as HTMLElement;
     await expect(newRow).not.toBeNull();
-    await expect(await canvas.findByText('3 active')).toBeVisible();
+    await expect(canvas.findByText('3 active')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save consent' })).not.toBeInTheDocument();
 
     // Revoke: scoped to the new row, so the identically labelled "Revoke
@@ -300,7 +300,7 @@ export const Default: Story = {
     await expect(
       rowCanvas.queryByRole('button', { name: 'Revoke Surgical consent' })
     ).not.toBeInTheDocument();
-    await expect(await canvas.findByText('2 active')).toBeVisible();
+    await expect(canvas.findByText('2 active')).toBeVisible();
   },
 };
 

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
@@ -261,9 +261,7 @@ export const Default: Story = {
     const canvas = within(canvasElement);
 
     await expect(canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
-    await expect(
-      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
-    ).toBeVisible();
+    await expect(canvas.findByText('Cranial cruciate ligament repair (left stifle)')).toBeVisible();
     await expect(canvas.getByText('2 active')).toBeVisible();
 
     // Grant: the form POSTs through the mocked adapter, which appends the
@@ -294,9 +292,7 @@ export const Default: Story = {
     );
     await userEvent.click(rowCanvas.getByRole('button', { name: 'Revoke consent' }));
 
-    await expect(
-      await rowCanvas.findByText('Reason: Client rescheduled the procedure.')
-    ).toBeVisible();
+    await expect(rowCanvas.findByText('Reason: Client rescheduled the procedure.')).toBeVisible();
     await expect(
       rowCanvas.queryByRole('button', { name: 'Revoke Surgical consent' })
     ).not.toBeInTheDocument();
@@ -309,9 +305,7 @@ export const Empty: Story = {
   beforeEach: prepare({ fixture: { kind: 'resolves', records: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByText('No consents recorded for this patient yet.')
-    ).toBeVisible();
+    await expect(canvas.findByText('No consents recorded for this patient yet.')).toBeVisible();
     await expect(canvas.queryByText(/active/)).not.toBeInTheDocument();
   },
 };
@@ -352,9 +346,7 @@ export const ReadOnly: Story = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
-    ).toBeVisible();
+    await expect(canvas.findByText('Cranial cruciate ligament repair (left stifle)')).toBeVisible();
     // The field is still there to read; the controls are absent rather than disabled.
     await expect(canvas.queryByRole('button', { name: 'Record consent' })).not.toBeInTheDocument();
     await expect(canvas.queryByRole('button', { name: /^Revoke/ })).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
@@ -1,0 +1,375 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import ConsentListPanel from './ConsentListPanel';
+import type {
+  CreatePatientConsentInput,
+  PatientConsent,
+} from '@/app/features/companionHistory/services/patientConsentService';
+
+const ORG_ID = 'org-storybook-consents';
+const COMPANION_ID = 'companion-fenn';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+/**
+ * OWNER carries both `appointments:view:any` and `appointments:edit:any` by
+ * default, so revoking one is the only way to reach the read-only or hidden
+ * stories - the same way a real practice narrows a member's access.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const consent = (over: Partial<PatientConsent>): PatientConsent => ({
+  id: over.id ?? 'consent-1',
+  organisationId: ORG_ID,
+  patientId: COMPANION_ID,
+  consentType: over.consentType ?? 'SURGICAL',
+  status: over.status ?? 'ACTIVE',
+  procedureDesc: over.procedureDesc ?? null,
+  consentedByName: over.consentedByName ?? null,
+  consentedAt: over.consentedAt ?? '2026-01-10T09:00:00.000Z',
+  expiresAt: over.expiresAt ?? null,
+  witnessedBy: over.witnessedBy ?? null,
+  revokedAt: over.revokedAt ?? null,
+  revokedReason: over.revokedReason ?? null,
+  documentId: null,
+  notes: over.notes ?? null,
+  createdAt: over.createdAt ?? '2026-01-10T09:00:00.000Z',
+  updatedAt: over.updatedAt ?? '2026-01-10T09:00:00.000Z',
+});
+
+const SAMPLE: PatientConsent[] = [
+  consent({
+    id: 'consent-1',
+    consentType: 'SURGICAL',
+    status: 'ACTIVE',
+    procedureDesc: 'Cranial cruciate ligament repair (left stifle)',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2026-01-08T09:00:00.000Z',
+    witnessedBy: 'Dr. Okafor',
+    notes: 'Owner briefed on anaesthetic risk and post-op physiotherapy.',
+  }),
+  consent({
+    id: 'consent-2',
+    consentType: 'DNR',
+    status: 'ACTIVE',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2026-01-08T09:05:00.000Z',
+    notes: 'Do not resuscitate on cardiac or respiratory arrest.',
+  }),
+  consent({
+    id: 'consent-3',
+    consentType: 'DATA_SHARING',
+    status: 'EXPIRED',
+    consentedByName: 'Lena Hartmann',
+    consentedAt: '2025-01-02T09:00:00.000Z',
+    expiresAt: '2026-01-02T00:00:00.000Z',
+  }),
+];
+
+type ConsentsFixture =
+  { kind: 'resolves'; records: PatientConsent[] } | { kind: 'pending' } | { kind: 'rejects' };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The panel reads and writes `/patient-consents` through the shared axios
+ * instance (via `useConsentList`), so its adapter is the seam. A resolving
+ * fixture keeps a mutable `records` array behind the closure: granting POSTs a
+ * new row onto it and the panel's own refetch-after-grant reads the mutation
+ * straight back, while revoking POSTs to `.../revoke` and the response IS the
+ * updated row - the same two round trips `useConsentList` drives against the
+ * real API.
+ */
+const buildAdapter = (fixture: ConsentsFixture): AxiosAdapter => {
+  let records = fixture.kind === 'resolves' ? [...fixture.records] : [];
+  let nextId = records.length + 1;
+
+  return (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (!url.includes('/patient-consents')) {
+      return Promise.resolve(respond(config, []));
+    }
+
+    if (method === 'get') {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed with status code 500'), {
+            isAxiosError: true,
+            config,
+            response: {
+              status: 500,
+              statusText: 'Internal Server Error',
+              data: { message: 'Consent service unavailable' },
+              headers: {},
+              config,
+            },
+          })
+        );
+      }
+      return Promise.resolve(respond(config, records));
+    }
+
+    if (method === 'post' && url.endsWith('/revoke')) {
+      const id = url.split('/').at(-2) ?? '';
+      const body = JSON.parse(String(config.data ?? '{}')) as { revokedReason?: string };
+      records = records.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              status: 'REVOKED' as const,
+              revokedAt: '2026-02-01T10:00:00.000Z',
+              revokedReason: body.revokedReason ?? null,
+            }
+          : r
+      );
+      return Promise.resolve(
+        respond(
+          config,
+          records.find((r) => r.id === id)
+        )
+      );
+    }
+
+    if (method === 'post') {
+      const body = JSON.parse(String(config.data ?? '{}')) as CreatePatientConsentInput;
+      const created = consent({
+        id: `consent-${nextId++}`,
+        consentType: body.consentType,
+        procedureDesc: body.procedureDesc ?? null,
+        consentedByName: body.consentedByName ?? null,
+        witnessedBy: body.witnessedBy ?? null,
+        notes: body.notes ?? null,
+        expiresAt: body.expiresAt ?? null,
+        consentedAt: '2026-02-01T10:00:00.000Z',
+      });
+      records = [...records, created];
+      return Promise.resolve(respond(config, created));
+    }
+
+    return Promise.resolve(respond(config, []));
+  };
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: ConsentsFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+    const orgSnapshot = useOrgStore.getState();
+    api.defaults.adapter = buildAdapter(fixture);
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useOrgStore.setState(orgSnapshot);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A rejected load is logged twice on its way to the hook's `catch` - once by
+ * `getData` itself and once by `patientConsentService`'s own wrapper - and the
+ * render check treats a console error as a broken story. Only those two lines
+ * are dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some(
+        (arg) =>
+          typeof arg === 'string' &&
+          (arg.includes('API getData error') || arg.includes('Failed to load patient consents'))
+      );
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'CompanionHistory/ConsentListPanel',
+  component: ConsentListPanel,
+  tags: ['autodocs'],
+  args: {
+    companionId: COMPANION_ID,
+  },
+  beforeEach: prepare({ fixture: { kind: 'resolves', records: SAMPLE } }),
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Data container for `ConsentList`. All state - the load, the grant form, the revoke ' +
+          'flow - lives in `useConsentList`, which reads the active organisation from `useOrgStore` ' +
+          'and calls the patient-consent endpoints through the shared axios client directly; this ' +
+          'component only projects that state onto the presentational list and never fetches ' +
+          'itself. It renders nothing when the member lacks `appointments:view:any` on the active ' +
+          'organisation, and gates the grant and revoke controls on `appointments:edit:any` - both ' +
+          'derived from the membership role rather than a prop. The stories seed `useOrgStore` with ' +
+          'an organisation and membership and answer the consent endpoints from a mocked axios ' +
+          'adapter, the same seam `Finance/Discounts` uses for its own page-level stories.',
+      },
+    },
+  },
+} satisfies Meta<typeof ConsentListPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Consents loaded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
+    await expect(
+      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
+    ).toBeVisible();
+    await expect(canvas.getByText('2 active')).toBeVisible();
+
+    // Grant: the form POSTs through the mocked adapter, which appends the
+    // record and then answers the refetch useConsentList makes right after -
+    // the same round trip the real API drives.
+    await userEvent.click(canvas.getByRole('button', { name: 'Record consent' }));
+    await userEvent.type(
+      canvas.getByLabelText('Procedure'),
+      'Dental extraction, upper right canine'
+    );
+    await userEvent.type(canvas.getByLabelText('Consented by'), 'Priya Anand');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save consent' }));
+
+    const newRow = (await canvas.findByText('Dental extraction, upper right canine')).closest(
+      'li'
+    ) as HTMLElement;
+    await expect(newRow).not.toBeNull();
+    await expect(await canvas.findByText('3 active')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: 'Save consent' })).not.toBeInTheDocument();
+
+    // Revoke: scoped to the new row, so the identically labelled "Revoke
+    // Surgical consent" button on consent-1 is left untouched.
+    const rowCanvas = within(newRow);
+    await userEvent.click(rowCanvas.getByRole('button', { name: 'Revoke Surgical consent' }));
+    await userEvent.type(
+      rowCanvas.getByLabelText('Reason for revoking'),
+      'Client rescheduled the procedure.'
+    );
+    await userEvent.click(rowCanvas.getByRole('button', { name: 'Revoke consent' }));
+
+    await expect(
+      await rowCanvas.findByText('Reason: Client rescheduled the procedure.')
+    ).toBeVisible();
+    await expect(
+      rowCanvas.queryByRole('button', { name: 'Revoke Surgical consent' })
+    ).not.toBeInTheDocument();
+    await expect(await canvas.findByText('2 active')).toBeVisible();
+  },
+};
+
+export const Empty: Story = {
+  name: 'No consents recorded',
+  beforeEach: prepare({ fixture: { kind: 'resolves', records: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText('No consents recorded for this patient yet.')
+    ).toBeVisible();
+    await expect(canvas.queryByText(/active/)).not.toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading the list',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { name: 'Consents' });
+    // The skeleton rows stand in for the list; nothing real has arrived yet.
+    await expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull();
+    await expect(canvas.queryByText(/active/)).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No consents recorded for this patient yet.')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: Story = {
+  name: 'List failed to load',
+  beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Could not load the consent list. Please try again.');
+    await expect(
+      canvas.queryByText('No consents recorded for this patient yet.')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Edit permission revoked - no grant or revoke controls',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', records: SAMPLE },
+    revoked: ['appointments:edit:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
+    ).toBeVisible();
+    // The field is still there to read; the controls are absent rather than disabled.
+    await expect(canvas.queryByRole('button', { name: 'Record consent' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /^Revoke/ })).not.toBeInTheDocument();
+  },
+};
+
+export const Hidden: Story = {
+  name: 'View permission missing - renders nothing',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', records: SAMPLE },
+    revoked: ['appointments:view:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    // canView is derived synchronously from the store, seeded by beforeEach
+    // before this mounts, so there is no flash of content to wait out.
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
@@ -246,7 +246,7 @@ export const Empty: Story = {
   beforeEach: prepare({ fixture: { kind: 'resolves', flags: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText('No active flags for this patient.')).toBeVisible();
+    await expect(canvas.findByText('No active flags for this patient.')).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Add flag' })).toBeEnabled();
   },
 };
@@ -286,7 +286,7 @@ export const ReadOnly: Story = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText('Bites when startled')).toBeVisible();
+    await expect(canvas.findByText('Bites when startled')).toBeVisible();
     // Flags are still readable; only the edit affordances are gone.
     await expect(canvas.queryByRole('button', { name: 'Add flag' })).not.toBeInTheDocument();
     await expect(
@@ -308,7 +308,7 @@ export const AddingAFlag: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Save flag' }));
 
     // The form closes and the list is reloaded, so the new flag joins the seeded ones.
-    await expect(await canvas.findByText('Needs sedation for X-rays')).toBeVisible();
+    await expect(canvas.findByText('Needs sedation for X-rays')).toBeVisible();
     await expect(canvas.getByText('3 active')).toBeVisible();
     await expect(canvas.queryByLabelText('Flag title')).not.toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
@@ -227,9 +227,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole('heading', { level: 3, name: 'Patient flags' })
-    ).toBeVisible();
+    await expect(canvas.findByRole('heading', { level: 3, name: 'Patient flags' })).toBeVisible();
     await expect(canvas.getByText('2 active')).toBeVisible();
     await expect(canvas.getByText('Bites when startled')).toBeVisible();
     await expect(canvas.getByText('Jumps low fences')).toBeVisible();

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
@@ -1,0 +1,315 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type {
+  FlagSeverity,
+  PatientFlag,
+  PatientFlagType,
+} from '@/app/features/companionHistory/services/patientFlagService';
+import FlagListPanel from './FlagListPanel';
+
+const ORG_ID = 'org-storybook-flag-panel';
+const COMPANION_ID = 'companion-bramble';
+
+const membership = (revoked: string[] = []) => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-alvarez',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const flag = (
+  overrides: Partial<PatientFlag> & Pick<PatientFlag, 'id' | 'title' | 'flagType' | 'severity'>
+): PatientFlag => ({
+  organisationId: ORG_ID,
+  patientId: COMPANION_ID,
+  description: null,
+  isActive: true,
+  createdBy: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  createdAt: '2026-02-10T09:00:00.000Z',
+  updatedAt: '2026-02-10T09:00:00.000Z',
+  ...overrides,
+});
+
+const FLAGS: PatientFlag[] = [
+  flag({
+    id: 'flag-aggression',
+    title: 'Bites when startled',
+    flagType: 'AGGRESSION',
+    severity: 'HIGH',
+    description: 'Approach from the front and speak before touching.',
+  }),
+  flag({
+    id: 'flag-escape',
+    title: 'Jumps low fences',
+    flagType: 'ESCAPE_RISK',
+    severity: 'CRITICAL',
+  }),
+];
+
+type FlagFixture =
+  | { kind: 'resolves'; flags: PatientFlag[] }
+  /** Held open on purpose: the only way to hold the loading skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects' };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The panel reads and writes `/v1/pms/organisation/:id/patient-flags` (and its
+ * `/:flagId/resolve` transition) through the shared axios instance, so its
+ * adapter is the seam. A resolved fixture keeps its own mutable copy of the
+ * list so a create is reflected in the refetch `useCreateFlag` makes right
+ * after - the same round trip the real backend does.
+ */
+const buildAdapter = (fixture: FlagFixture): AxiosAdapter => {
+  let flags = fixture.kind === 'resolves' ? fixture.flags : [];
+  return (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+    if (!url.includes('/patient-flags')) return Promise.resolve(respond(config, []));
+
+    if (method === 'get') {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed with status code 500'), {
+            isAxiosError: true,
+            config,
+            response: {
+              status: 500,
+              statusText: 'Internal Server Error',
+              data: {},
+              headers: {},
+              config,
+            },
+          })
+        );
+      }
+      return Promise.resolve(respond(config, flags));
+    }
+
+    const resolveMatch = /\/patient-flags\/([^/]+)\/resolve$/.exec(url);
+    if (method === 'post' && resolveMatch) {
+      const [, id] = resolveMatch;
+      flags = flags.map((item) =>
+        item.id === id ? { ...item, isActive: false, resolvedAt: new Date().toISOString() } : item
+      );
+      const updated = flags.find((item) => item.id === id) ?? flags[0];
+      return Promise.resolve(respond(config, updated));
+    }
+
+    if (method === 'post' && /\/patient-flags$/.test(url)) {
+      const body = JSON.parse(String(config.data ?? '{}')) as {
+        patientId: string;
+        title: string;
+        flagType: PatientFlagType;
+        severity: FlagSeverity;
+        description?: string;
+      };
+      const created: PatientFlag = {
+        id: `flag-new-${flags.length + 1}`,
+        organisationId: ORG_ID,
+        patientId: body.patientId,
+        flagType: body.flagType,
+        severity: body.severity,
+        title: body.title,
+        description: body.description ?? null,
+        isActive: true,
+        createdBy: null,
+        resolvedAt: null,
+        resolvedBy: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      flags = [...flags, created];
+      return Promise.resolve(respond(config, created));
+    }
+
+    return Promise.resolve(respond(config, []));
+  };
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * Seeds the org store the panel's `usePatientFlags` reads (for the primary
+ * organisation and the signed-in membership's permissions) and points the
+ * shared axios instance at the fixture adapter - the same mocking approach
+ * `Discounts/index.stories.tsx` uses for finance.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: FlagFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+    const snapshot = useOrgStore.getState();
+    api.defaults.adapter = buildAdapter(fixture);
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useOrgStore.setState(snapshot);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused load is logged twice on its way to the hook's catch (once by the
+ * shared axios wrapper, once by the service's own `requestWithLog`), and the
+ * render check treats a console error as a broken story. Only those two
+ * expected lines are dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const text = args.filter((arg) => typeof arg === 'string').join(' ');
+    const expected =
+      text.includes('API getData error') || text.includes('Failed to load patient flags');
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'CompanionHistory/FlagListPanel',
+  component: FlagListPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Data container for the presentational `FlagList`. All state - the loaded flags, ' +
+          'the create- and resolve-in-flight ids, and the derived view/edit permissions - lives ' +
+          'in `usePatientFlags`; this component is a thin projection that renders nothing when ' +
+          'the signed-in user lacks `companions:view:any` for the active organisation. Flags are ' +
+          'loaded, and reloaded after a create, from the shared patient-flags endpoint scoped to ' +
+          'the primary organisation and the given companion; resolving a flag calls its own ' +
+          'endpoint and drops it from the active list locally rather than reloading.\n\n' +
+          'The stories seed `useOrgStore` with a membership (the same way ' +
+          "`Discounts/index.stories.tsx` seeds finance's stores) and answer the patient-flags " +
+          'endpoint from the shared axios adapter, so a real create/resolve round trip runs ' +
+          'entirely in the browser.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    companionId: COMPANION_ID,
+  },
+  beforeEach: prepare({ fixture: { kind: 'resolves', flags: FLAGS } }),
+} satisfies Meta<typeof FlagListPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 3, name: 'Patient flags' })
+    ).toBeVisible();
+    await expect(canvas.getByText('2 active')).toBeVisible();
+    await expect(canvas.getByText('Bites when startled')).toBeVisible();
+    await expect(canvas.getByText('Jumps low fences')).toBeVisible();
+
+    // Resolving one drops it from the active list and the count, with no reload.
+    await userEvent.click(canvas.getByRole('button', { name: 'Resolve Bites when startled' }));
+    await waitFor(() => expect(canvas.queryByText('Bites when startled')).not.toBeInTheDocument());
+    await expect(canvas.getByText('1 active')).toBeVisible();
+  },
+};
+
+export const Empty: Story = {
+  name: 'No active flags',
+  beforeEach: prepare({ fixture: { kind: 'resolves', flags: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No active flags for this patient.')).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Add flag' })).toBeEnabled();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading the flags',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 3, name: 'Patient flags' });
+    // The skeleton rows render in place of the list while the fetch is pending.
+    await waitFor(() =>
+      expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull()
+    );
+    await expect(canvas.queryByText('Bites when startled')).not.toBeInTheDocument();
+    // The active-count badge only appears once loading settles.
+    await expect(canvas.queryByText(/\d+ active/)).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: Story = {
+  name: 'Flags failed to load',
+  beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Could not load patient flags. Please try again.');
+    await expect(canvas.queryByText('Bites when startled')).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Companion edit revoked - view only',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', flags: FLAGS },
+    revoked: ['companions:edit:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Bites when startled')).toBeVisible();
+    // Flags are still readable; only the edit affordances are gone.
+    await expect(canvas.queryByRole('button', { name: 'Add flag' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Resolve Bites when startled' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const AddingAFlag: Story = {
+  name: 'Adding a flag',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Bites when startled');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add flag' }));
+    await userEvent.type(await canvas.findByLabelText('Flag title'), 'Needs sedation for X-rays');
+    await userEvent.selectOptions(canvas.getByLabelText('Flag type'), 'SPECIAL_HANDLING');
+    await userEvent.selectOptions(canvas.getByLabelText('Severity'), 'HIGH');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save flag' }));
+
+    // The form closes and the list is reloaded, so the new flag joins the seeded ones.
+    await expect(await canvas.findByText('Needs sedation for X-rays')).toBeVisible();
+    await expect(canvas.getByText('3 active')).toBeVisible();
+    await expect(canvas.queryByLabelText('Flag title')).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
@@ -236,9 +236,7 @@ export const Default: ProblemListPanelStory = {
   name: 'Problems loaded',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole('heading', { level: 3, name: 'Problem list' })
-    ).toBeVisible();
+    await expect(canvas.findByRole('heading', { level: 3, name: 'Problem list' })).toBeVisible();
     await expect(canvas.getByText('Chronic kidney disease')).toBeVisible();
     await expect(canvas.getByText('Severe')).toBeVisible();
     await expect(canvas.getByText('Otitis externa (left ear)')).toBeVisible();
@@ -271,9 +269,7 @@ export const Empty: ProblemListPanelStory = {
   beforeEach: prepare({ fixture: { kind: 'resolves', problems: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByText('No problems recorded for this patient yet.')
-    ).toBeVisible();
+    await expect(canvas.findByText('No problems recorded for this patient yet.')).toBeVisible();
     await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
   },
 };

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
@@ -251,7 +251,7 @@ export const Default: ProblemListPanelStory = {
     const titleInput = await canvas.findByLabelText('Problem title');
     await userEvent.type(titleInput, 'Seasonal allergies');
     await userEvent.click(canvas.getByRole('button', { name: 'Save problem' }));
-    await expect(await canvas.findByText('Seasonal allergies')).toBeVisible();
+    await expect(canvas.findByText('Seasonal allergies')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save problem' })).not.toBeInTheDocument();
 
     // Real resolve flow: submits through the panel, into the mocked POST.
@@ -313,7 +313,7 @@ export const ReadOnly: ProblemListPanelStory = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText('Chronic kidney disease')).toBeVisible();
+    await expect(canvas.findByText('Chronic kidney disease')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Add problem' })).not.toBeInTheDocument();
     await expect(
       canvas.queryByRole('button', { name: 'Resolve Otitis externa (left ear)' })

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
@@ -1,0 +1,333 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type {
+  CreatePatientProblemInput,
+  PatientProblem,
+} from '@/app/features/companionHistory/services/patientProblemService';
+import ProblemListPanel from './ProblemListPanel';
+
+const ORG_ID = 'org-storybook-companion-history';
+const COMPANION_ID = 'patient-storybook-bramble';
+
+const membership = (revoked: string[] = []): UserOrganization => ({
+  practitionerReference: 'Practitioner/vet-bramble',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const problem = (
+  over: Partial<PatientProblem> & Pick<PatientProblem, 'id' | 'name'>
+): PatientProblem => ({
+  organisationId: ORG_ID,
+  patientId: COMPANION_ID,
+  encounterId: null,
+  codeSystem: null,
+  code: null,
+  status: 'ACTIVE',
+  severity: null,
+  onsetDate: null,
+  resolvedDate: null,
+  notes: null,
+  recordedBy: null,
+  createdAt: '2026-01-10T09:00:00.000Z',
+  updatedAt: '2026-01-10T09:00:00.000Z',
+  ...over,
+});
+
+const KIDNEY = problem({
+  id: 'problem-kidney',
+  name: 'Chronic kidney disease',
+  severity: 'SEVERE',
+  status: 'ACTIVE',
+  code: 'N18.9',
+  onsetDate: '2025-11-02T00:00:00.000Z',
+  notes: 'IRIS stage 3. Monitoring phosphate and blood pressure.',
+});
+const OTITIS = problem({
+  id: 'problem-otitis',
+  name: 'Otitis externa (left ear)',
+  severity: 'MODERATE',
+  status: 'ACTIVE',
+  onsetDate: '2026-01-04T00:00:00.000Z',
+});
+const WOUND = problem({
+  id: 'problem-wound',
+  name: 'Post-operative wound',
+  severity: 'MODERATE',
+  status: 'RESOLVED',
+  onsetDate: '2025-08-01T00:00:00.000Z',
+  resolvedDate: '2025-08-20T00:00:00.000Z',
+});
+
+const SAMPLE: PatientProblem[] = [KIDNEY, OTITIS, WOUND];
+const BY_ID: Record<string, PatientProblem> = Object.fromEntries(SAMPLE.map((p) => [p.id, p]));
+
+type ListFixture =
+  | { kind: 'resolves'; problems: PatientProblem[] }
+  /** Held open on purpose: the only way to hold the loading skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects' };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The panel reads and writes `/v1/pms/organisation/:id/patient-problems` through
+ * the shared axios instance, so its adapter is the seam. A create POST is echoed
+ * back as the record the server would store; a resolve POST looks the record up
+ * by the id in its URL and marks it resolved. The list GET is driven by the
+ * fixture so each story can show a different load outcome.
+ */
+const buildAdapter =
+  (fixture: ListFixture): AxiosAdapter =>
+  (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (!url.includes('/patient-problems')) return Promise.resolve(respond(config, []));
+
+    if (method === 'post' && url.endsWith('/resolve')) {
+      const id = url.split('/').slice(-2, -1)[0] ?? '';
+      const existing = BY_ID[id] ?? problem({ id, name: 'Problem' });
+      return Promise.resolve(
+        respond(config, {
+          ...existing,
+          status: 'RESOLVED',
+          resolvedDate: '2026-02-01T00:00:00.000Z',
+        })
+      );
+    }
+
+    if (method === 'post') {
+      const body = JSON.parse(String(config.data ?? '{}')) as CreatePatientProblemInput;
+      return Promise.resolve(
+        respond(
+          config,
+          problem({
+            id: 'problem-new',
+            name: body.name,
+            severity: body.severity ?? null,
+            notes: body.notes ?? null,
+            onsetDate: body.onsetDate ?? null,
+            status: 'ACTIVE',
+          })
+        )
+      );
+    }
+
+    if (fixture.kind === 'pending') return new Promise<never>(() => {});
+    if (fixture.kind === 'rejects') {
+      return Promise.reject(
+        Object.assign(new Error('Request failed with status code 500'), {
+          isAxiosError: true,
+          config,
+          response: {
+            status: 500,
+            statusText: 'Internal Server Error',
+            data: {},
+            headers: {},
+            config,
+          },
+        })
+      );
+    }
+    return Promise.resolve(respond(config, fixture.problems));
+  };
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The panel gates on `appointments:view:any` / `appointments:edit:any` from
+ * `usePermissions`, which is itself derived from `useOrgStore`'s active
+ * membership - so the stories seed a real membership on that store rather than
+ * mocking the permission hook. `revoked` reproduces exactly how a practice
+ * takes a right off one person.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: ListFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+    const orgSnapshot = useOrgStore.getState();
+    api.defaults.adapter = buildAdapter(fixture);
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useOrgStore.setState(orgSnapshot);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused read is logged by the axios wrapper on its way to the panel's
+ * catch, and the render check treats a console error as a broken story. Only
+ * that line is dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some((arg) => typeof arg === 'string' && arg.includes('API getData error'));
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const problemListPanelMeta = {
+  title: 'CompanionHistory/ProblemListPanel',
+  component: ProblemListPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Data container for `ProblemList`. It calls `usePermissions` directly for the ' +
+          "signed-in member's `appointments:view:any` / `appointments:edit:any` grants on the " +
+          "active organisation (from `useOrgStore`), fetches the companion's problems from the " +
+          'patient-problems API on mount, and wires the create and resolve callbacks to that ' +
+          'same service. All state - loading, the fetched list, the create/resolve in-flight ' +
+          'flags - lives in this component; `ProblemList` itself is a pure presentational ' +
+          'component that only renders what it is given. It renders nothing when the member ' +
+          'cannot view problems.\n\n' +
+          'The stories seed `useOrgStore` with a real membership so the permission check runs ' +
+          'unmocked, and swap the shared axios adapter to answer the patient-problems endpoints ' +
+          'from fixtures instead of a live backend.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    companionId: {
+      control: 'text',
+      description: 'The companion (patient) whose problems to load.',
+    },
+  },
+  args: {
+    companionId: COMPANION_ID,
+  },
+  beforeEach: prepare({ fixture: { kind: 'resolves', problems: SAMPLE } }),
+} satisfies Meta<typeof ProblemListPanel>;
+
+export default problemListPanelMeta;
+type ProblemListPanelStory = StoryObj<typeof problemListPanelMeta>;
+
+export const Default: ProblemListPanelStory = {
+  name: 'Problems loaded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 3, name: 'Problem list' })
+    ).toBeVisible();
+    await expect(canvas.getByText('Chronic kidney disease')).toBeVisible();
+    await expect(canvas.getByText('Severe')).toBeVisible();
+    await expect(canvas.getByText('Otitis externa (left ear)')).toBeVisible();
+    await expect(canvas.getByText('Post-operative wound')).toBeVisible();
+    await expect(canvas.getByText('2 active')).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Add problem' })).toBeEnabled();
+
+    // Real create flow: submits through the panel, into the mocked POST.
+    await userEvent.click(canvas.getByRole('button', { name: 'Add problem' }));
+    const titleInput = await canvas.findByLabelText('Problem title');
+    await userEvent.type(titleInput, 'Seasonal allergies');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save problem' }));
+    await expect(await canvas.findByText('Seasonal allergies')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: 'Save problem' })).not.toBeInTheDocument();
+
+    // Real resolve flow: submits through the panel, into the mocked POST.
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Resolve Otitis externa (left ear)' })
+    );
+    await waitFor(() =>
+      expect(canvas.getByText('Otitis externa (left ear)').closest('li')).toHaveTextContent(
+        'Resolved'
+      )
+    );
+  },
+};
+
+export const Empty: ProblemListPanelStory = {
+  name: 'No problems recorded',
+  beforeEach: prepare({ fixture: { kind: 'resolves', problems: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText('No problems recorded for this patient yet.')
+    ).toBeVisible();
+    await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
+  },
+};
+
+export const Loading: ProblemListPanelStory = {
+  name: 'Loading the problem list',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 3, name: 'Problem list' });
+    await waitFor(() =>
+      expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull()
+    );
+    await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No problems recorded for this patient yet.')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: ProblemListPanelStory = {
+  name: 'Problem list failed to load',
+  beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Could not load the problem list. Please try again.');
+    await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: ProblemListPanelStory = {
+  name: 'View only - edit permission revoked',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', problems: SAMPLE },
+    revoked: ['appointments:edit:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Chronic kidney disease')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: 'Add problem' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Resolve Otitis externa (left ear)' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const NoAccess: ProblemListPanelStory = {
+  name: 'View permission revoked - renders nothing',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', problems: SAMPLE },
+    revoked: ['appointments:view:any'],
+  }),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

AllergyListPanel, ClinicalListChrome, ConsentListPanel, FlagListPanel, and ProblemListPanel have no Storybook coverage.

## What is the new behavior?

Adds a story for each, following the repo's existing CSF3 house style, mocking useOrgStore and the shared axios client where the panel reads them.

## Related Issue(s)

Part of #2930