### PR TITLE
test(frontend): add Storybook stories for 5 uncovered appointments components

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/CompanionSelect.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CompanionSelect.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { CompanionSelect, type CompanionSelectOption } from './CompanionSelect';
+
+const companions: CompanionSelectOption[] = [
+  { id: 'c1', name: 'Bella', ownerName: 'Maria Chen' },
+  { id: 'c2', name: 'Rocky', ownerName: 'James Okafor' },
+  { id: 'c3', name: 'Whiskers', ownerName: 'Priya Nair' },
+];
+
+const companionSelectMeta = {
+  title: 'Appointments/CompanionSelect',
+  component: CompanionSelect,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The companion picker shared by the appointment panels that put a patient on a list ' +
+          '(the waitlist and the check-in board). Each panel names the same control differently - ' +
+          '"Companion" on the waitlist, "Patient" at the front desk - so the wording is passed in as ' +
+          'props while the select markup stays one definition. The select disables itself and swaps ' +
+          'the placeholder for `emptyLabel` when `companions` is empty, and appends the owner name to ' +
+          'an option only when a companion has one.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    id: 'waitlist-companion',
+    label: 'Companion',
+    placeholder: 'Select a companion',
+    emptyLabel: 'No companions available',
+    value: '',
+    onChange: fn(),
+    companions,
+  },
+} satisfies Meta<typeof CompanionSelect>;
+
+export default companionSelectMeta;
+type CompanionSelectStory = StoryObj<typeof companionSelectMeta>;
+
+export const Default: CompanionSelectStory = {};
+
+export const Selected: CompanionSelectStory = {
+  args: { value: 'c2' },
+};
+
+export const Empty: CompanionSelectStory = {
+  name: 'No companions to pick',
+  args: { companions: [], value: '' },
+};
+
+export const WithoutOwnerNames: CompanionSelectStory = {
+  name: 'Companions without an owner on file',
+  args: {
+    companions: [
+      { id: 'c1', name: 'Bella' },
+      { id: 'c2', name: 'Rocky' },
+    ],
+  },
+};
+
+export const CheckInWording: CompanionSelectStory = {
+  name: 'Reused at the check-in board',
+  args: {
+    id: 'checkin-patient',
+    label: 'Patient',
+    placeholder: 'Select a patient',
+    emptyLabel: 'No patients waiting',
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.stories.tsx
@@ -1,0 +1,591 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, OrganisationRoom, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import type {
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import type {
+  CreateCheckInPayload,
+  PatientCheckIn,
+} from '@/app/features/appointments/services/patientCheckInService';
+import FrontDeskBoardPanel from './FrontDeskBoardPanel';
+
+// `assertOrganisationId` accepts a UUID or a 24-hex legacy Mongo id, and every
+// transition call (`assertUuid`) requires the check-in id itself to be a
+// UUID - a slug like "checkin-1" would throw inside the service before any
+// request is made. These ids are shaped to pass both checks.
+const ORG_ID = 'a1a1a1a1-b2b2-4c3c-8d4d-e5e5e5e5e5e5';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+/**
+ * OWNER carries every permission, so `revoked` is the only way to reach the
+ * read-only board a receptionist without edit rights would actually see.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const QUINN: StoredParent = {
+  id: 'parent-quinn',
+  firstName: 'Quinn',
+  lastName: 'Ander',
+  email: 'quinn.ander@example.com',
+  address: {},
+  createdFrom: 'pms',
+};
+const MARA: StoredParent = {
+  id: 'parent-mara',
+  firstName: 'Mara',
+  lastName: 'Voss',
+  email: 'mara.voss@example.com',
+  address: {},
+  createdFrom: 'pms',
+};
+const JULES: StoredParent = {
+  id: 'parent-jules',
+  firstName: 'Jules',
+  lastName: 'Byrne',
+  email: 'jules.byrne@example.com',
+  address: {},
+  createdFrom: 'pms',
+};
+
+const BRAMBLE: StoredCompanion = {
+  id: 'companion-bramble',
+  organisationId: ORG_ID,
+  parentId: QUINN.id,
+  name: 'Bramble',
+  type: 'dog',
+  breed: 'Cavalier King Charles Spaniel',
+  dateOfBirth: new Date('2021-04-02'),
+  gender: 'female',
+  isInsured: true,
+};
+const OTIS: StoredCompanion = {
+  id: 'companion-otis',
+  organisationId: ORG_ID,
+  parentId: MARA.id,
+  name: 'Otis',
+  type: 'cat',
+  breed: 'British Shorthair',
+  dateOfBirth: new Date('2019-08-15'),
+  gender: 'male',
+  isInsured: false,
+};
+const PERCY: StoredCompanion = {
+  id: 'companion-percy',
+  organisationId: ORG_ID,
+  parentId: JULES.id,
+  name: 'Percy',
+  type: 'dog',
+  breed: 'Border Collie',
+  dateOfBirth: new Date('2022-02-10'),
+  gender: 'male',
+  isInsured: true,
+};
+const NOVA: StoredCompanion = {
+  id: 'companion-nova',
+  organisationId: ORG_ID,
+  parentId: JULES.id,
+  name: 'Nova',
+  type: 'cat',
+  breed: 'Domestic Shorthair',
+  dateOfBirth: new Date('2023-06-01'),
+  gender: 'female',
+  isInsured: false,
+};
+
+const EXAM_1: OrganisationRoom = {
+  id: 'room-exam-1',
+  organisationId: ORG_ID,
+  name: 'Exam 1',
+  code: 'EX1',
+  type: 'EXAM_ROOM',
+};
+const EXAM_2: OrganisationRoom = {
+  id: 'room-exam-2',
+  organisationId: ORG_ID,
+  name: 'Exam 2',
+  code: 'EX2',
+  type: 'EXAM_ROOM',
+};
+
+const minutesAgo = (n: number): string => new Date(Date.now() - n * 60_000).toISOString();
+
+/**
+ * `waitMinutes` is set explicitly on every fixture row so the displayed wait
+ * time is fixed at render time rather than drifting off `arrivedAt` and the
+ * clock the story happens to run at.
+ */
+const PERCY_WAITING: PatientCheckIn = {
+  id: '11111111-1111-4111-8111-111111111111',
+  organisationId: ORG_ID,
+  patientId: PERCY.id,
+  clientId: JULES.id,
+  appointmentId: null,
+  arrivedAt: minutesAgo(2),
+  triagePriority: 'IMMEDIATE',
+  triageNote: 'Active seizure',
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: null,
+  seenAt: null,
+  waitMinutes: 2,
+  status: 'WAITING',
+  notes: null,
+  createdAt: minutesAgo(2),
+  updatedAt: minutesAgo(2),
+};
+const BRAMBLE_WAITING: PatientCheckIn = {
+  id: '22222222-2222-4222-8222-222222222222',
+  organisationId: ORG_ID,
+  patientId: BRAMBLE.id,
+  clientId: QUINN.id,
+  appointmentId: null,
+  arrivedAt: minutesAgo(25),
+  triagePriority: 'URGENT',
+  triageNote: 'Limping on left hind leg',
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: null,
+  seenAt: null,
+  waitMinutes: 25,
+  status: 'WAITING',
+  notes: null,
+  createdAt: minutesAgo(25),
+  updatedAt: minutesAgo(25),
+};
+const OTIS_IN_CONSULT: PatientCheckIn = {
+  id: '33333333-3333-4333-8333-333333333333',
+  organisationId: ORG_ID,
+  patientId: OTIS.id,
+  clientId: MARA.id,
+  appointmentId: null,
+  arrivedAt: minutesAgo(33),
+  triagePriority: 'STANDARD',
+  triageNote: null,
+  assignedRoomId: EXAM_1.id,
+  checkedInBy: null,
+  waitStartedAt: minutesAgo(33),
+  seenAt: minutesAgo(8),
+  waitMinutes: 8,
+  status: 'IN_CONSULTATION',
+  notes: 'Annual wellness check',
+  createdAt: minutesAgo(33),
+  updatedAt: minutesAgo(8),
+};
+const NOVA_COMPLETED: PatientCheckIn = {
+  id: '44444444-4444-4444-8444-444444444444',
+  organisationId: ORG_ID,
+  patientId: NOVA.id,
+  clientId: JULES.id,
+  appointmentId: null,
+  arrivedAt: minutesAgo(70),
+  triagePriority: 'NON_URGENT',
+  triageNote: null,
+  assignedRoomId: EXAM_2.id,
+  checkedInBy: null,
+  waitStartedAt: minutesAgo(70),
+  seenAt: minutesAgo(60),
+  waitMinutes: 55,
+  status: 'COMPLETED',
+  notes: null,
+  createdAt: minutesAgo(70),
+  updatedAt: minutesAgo(10),
+};
+const BRAMBLE_CANCELLED: PatientCheckIn = {
+  id: '55555555-5555-4555-8555-555555555555',
+  organisationId: ORG_ID,
+  patientId: BRAMBLE.id,
+  clientId: QUINN.id,
+  appointmentId: null,
+  arrivedAt: minutesAgo(95),
+  triagePriority: 'LESS_URGENT',
+  triageNote: 'No-show reschedule request',
+  assignedRoomId: null,
+  checkedInBy: null,
+  waitStartedAt: null,
+  seenAt: null,
+  waitMinutes: 12,
+  status: 'CANCELLED',
+  notes: null,
+  createdAt: minutesAgo(95),
+  updatedAt: minutesAgo(90),
+};
+
+const CHECKINS_ACTIVE: PatientCheckIn[] = [PERCY_WAITING, BRAMBLE_WAITING, OTIS_IN_CONSULT];
+const CHECKINS_WITH_HISTORY: PatientCheckIn[] = [
+  ...CHECKINS_ACTIVE,
+  NOVA_COMPLETED,
+  BRAMBLE_CANCELLED,
+];
+
+type CheckInFixture =
+  | { kind: 'resolves'; entries: PatientCheckIn[] }
+  | /** Held open on purpose: the only way to hold the loading skeleton still. */ {
+      kind: 'pending';
+    }
+  | { kind: 'rejects'; message: string };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+const axiosError = (config: InternalAxiosRequestConfig, message: string): unknown =>
+  Object.assign(new Error(message), {
+    isAxiosError: true,
+    config,
+    response: {
+      status: 500,
+      statusText: 'Internal Server Error',
+      data: { message },
+      headers: {},
+      config,
+    },
+  });
+
+/**
+ * The panel reads and writes `/v1/pms/organisation/:id/check-in` (list,
+ * create) and its `/:checkInId/<action>` transitions through the shared axios
+ * instance. Every write mutates this closure's own list, so a click that
+ * triggers an action's own refetch (see the Default story) sees the real
+ * updated row rather than a canned response.
+ */
+const buildAdapter = (fixture: CheckInFixture): AxiosAdapter => {
+  let entries = fixture.kind === 'resolves' ? [...fixture.entries] : [];
+  return (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (url.endsWith('/check-in')) {
+      if (method === 'get') {
+        if (fixture.kind === 'pending') return new Promise<never>(() => {});
+        if (fixture.kind === 'rejects') return Promise.reject(axiosError(config, fixture.message));
+        return Promise.resolve(respond(config, entries));
+      }
+      if (method === 'post') {
+        const body = JSON.parse(String(config.data ?? '{}')) as CreateCheckInPayload;
+        const created: PatientCheckIn = {
+          id: `66666666-6666-4666-8666-${String(entries.length).padStart(12, '0')}`,
+          organisationId: ORG_ID,
+          patientId: body.patientId,
+          clientId: body.clientId,
+          appointmentId: body.appointmentId ?? null,
+          arrivedAt: body.arrivedAt,
+          triagePriority: body.triagePriority ?? 'STANDARD',
+          triageNote: body.triageNote ?? null,
+          assignedRoomId: null,
+          checkedInBy: body.checkedInBy ?? null,
+          waitStartedAt: null,
+          seenAt: null,
+          waitMinutes: 0,
+          status: 'WAITING',
+          notes: body.notes ?? null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        entries = [...entries, created];
+        return Promise.resolve(respond(config, created));
+      }
+    }
+
+    const transitionMatch = /\/check-in\/([^/]+)\/(seen|complete|cancel|no-show|room)$/.exec(url);
+    if (transitionMatch && method === 'post') {
+      const [, id, action] = transitionMatch;
+      const index = entries.findIndex((entry) => entry.id === id);
+      if (index === -1) return Promise.reject(axiosError(config, 'Check-in not found'));
+      const updated: PatientCheckIn = { ...entries[index] };
+      if (action === 'seen') {
+        updated.status = 'IN_CONSULTATION';
+        updated.seenAt = new Date().toISOString();
+      } else if (action === 'complete') {
+        updated.status = 'COMPLETED';
+      } else if (action === 'cancel') {
+        updated.status = 'CANCELLED';
+      } else if (action === 'no-show') {
+        updated.status = 'NO_SHOW';
+      } else if (action === 'room') {
+        const body = JSON.parse(String(config.data ?? '{}')) as { roomId: string };
+        updated.assignedRoomId = body.roomId;
+      }
+      entries = entries.map((entry, i) => (i === index ? updated : entry));
+      return Promise.resolve(respond(config, updated));
+    }
+
+    return Promise.resolve(respond(config, []));
+  };
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * Seeds the organisation, companion, parent and room stores directly - the
+ * same `Object.hasOwn(...ByOrgId, primaryOrgId)` short-circuit the panel's
+ * loader hooks check, so seeding the id index (like the Discounts stories do)
+ * skips their network calls entirely rather than needing them mocked too.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: CheckInFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      org: useOrgStore.getState(),
+      companion: useCompanionStore.getState(),
+      parent: useParentStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter(fixture);
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {
+        [BRAMBLE.id]: BRAMBLE,
+        [OTIS.id]: OTIS,
+        [PERCY.id]: PERCY,
+        [NOVA.id]: NOVA,
+      },
+      companionsIdsByOrgId: { [ORG_ID]: [BRAMBLE.id, OTIS.id, PERCY.id, NOVA.id] },
+      status: 'loaded',
+    });
+    useParentStore.setState({
+      parentsById: { [QUINN.id]: QUINN, [MARA.id]: MARA, [JULES.id]: JULES },
+      parentIds: [QUINN.id, MARA.id, JULES.id],
+      status: 'loaded',
+    });
+    useOrganisationRoomStore.setState({
+      roomsById: { [EXAM_1.id]: EXAM_1, [EXAM_2.id]: EXAM_2 },
+      roomIdsByOrgId: { [ORG_ID]: [EXAM_1.id, EXAM_2.id] },
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useOrganisationRoomStore.setState(snapshots.room);
+      useParentStore.setState(snapshots.parent);
+      useCompanionStore.setState(snapshots.companion);
+      useOrgStore.setState(snapshots.org);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A rejected load is logged twice on its way to the hook's catch (once by the
+ * shared axios wrapper, once by the service's own `logFailure`), and the
+ * render check treats a console error as a broken story. Only those two
+ * expected lines are dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some(
+        (arg) =>
+          typeof arg === 'string' &&
+          (arg.includes('API getData error') || arg.includes('Failed to load check-ins'))
+      );
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const frontDeskBoardPanelMeta = {
+  title: 'Appointments/FrontDeskBoardPanel',
+  component: FrontDeskBoardPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'FrontDeskBoardPanel is the data container for the check-in board: it owns no markup ' +
+          'of its own, it wires `useFrontDeskBoard` (organisation-scoped check-ins, the ' +
+          'companion and room lookups, and the seen/complete/cancel/no-show/assign-room/add ' +
+          'actions) onto the presentational `FrontDeskBoard`. The one decision it makes itself ' +
+          'is permission gating: a user without `appointments:edit:any` or ' +
+          '`appointments:edit:own` has every edit handler withheld, and `FrontDeskBoard` hides ' +
+          'the button or control that handler belongs to rather than rendering it disabled. ' +
+          'The show-all toggle is not gated - it only changes what is visible, not what can be ' +
+          'changed, so it stays available regardless of edit rights.\n\n' +
+          'The stories seed the organisation, companion, parent and room Zustand stores ' +
+          'directly and answer the check-in REST endpoints from the shared axios adapter with ' +
+          'an in-memory list that mutates on every write, so an action button’s round trip ' +
+          'reflects a real refetch rather than a canned response.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: prepare({ fixture: { kind: 'resolves', entries: CHECKINS_ACTIVE } }),
+} satisfies Meta<typeof FrontDeskBoardPanel>;
+
+export default frontDeskBoardPanelMeta;
+type FrontDeskBoardPanelStory = StoryObj<typeof frontDeskBoardPanelMeta>;
+
+export const Default: FrontDeskBoardPanelStory = {
+  name: 'Active check-ins, sorted by triage',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 3, name: 'Arrivals' })).toBeVisible();
+
+    // Three active check-ins; the completed/cancelled fixtures live only in
+    // the ShowAllToggle story, so nothing here is filtered.
+    const rows = await canvas.findAllByRole('listitem');
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('Percy'), // IMMEDIATE
+      expect.stringContaining('Bramble'), // URGENT
+      expect.stringContaining('Otis'), // STANDARD
+    ]);
+    await expect(canvas.getByText(String(3))).toBeVisible();
+
+    // Room metadata resolved from the room store, and a live wait time from
+    // the fixture's own `waitMinutes` rather than a clock-derived value.
+    await expect(canvas.getByText('Room: Exam 1')).toBeVisible();
+    await expect(canvas.getByLabelText('Waiting 25 min')).toBeVisible();
+
+    // A WAITING row offers seen/no-show/cancel; the IN_CONSULTATION row
+    // offers complete/cancel - both gated by `canEdit`, true for this fixture.
+    await expect(canvas.getAllByRole('button', { name: 'Start consult' })).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: 'Complete' })).toBeEnabled();
+
+    // Completing Otis's consultation posts the transition, refetches, and the
+    // now-COMPLETED row drops out of the active-only default view.
+    await userEvent.click(canvas.getByRole('button', { name: 'Complete' }));
+    await waitFor(() => expect(canvas.queryByText('Otis')).not.toBeInTheDocument());
+    await expect(canvas.getByText(String(2))).toBeVisible();
+  },
+};
+
+export const Loading: FrontDeskBoardPanelStory = {
+  name: 'Loading the board',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 3, name: 'Arrivals' });
+    // Three placeholder rows stand in for the list; they are `aria-hidden`,
+    // so no real listitem or the count pill has appeared yet.
+    await waitFor(() =>
+      expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull()
+    );
+    await expect(canvas.queryAllByRole('listitem')).toHaveLength(0);
+    await expect(canvas.queryByText(String(3))).not.toBeInTheDocument();
+  },
+};
+
+export const EmptyBoard: FrontDeskBoardPanelStory = {
+  name: 'No patients checked in',
+  beforeEach: prepare({ fixture: { kind: 'resolves', entries: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No patients are checked in')).toBeVisible();
+
+    // Opening the add form and submitting without a patient selected is real
+    // client-side validation, not a network round trip.
+    await userEvent.click(canvas.getByRole('button', { name: 'Check in patient' }));
+    await expect(await canvas.findByLabelText('Patient')).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: 'Check in patient' }));
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      'Choose a patient to check in.'
+    );
+  },
+};
+
+export const LoadFailed: FrontDeskBoardPanelStory = {
+  name: 'Board could not load',
+  beforeEach: [
+    prepare({ fixture: { kind: 'rejects', message: 'Check-in service unavailable.' } }),
+    muteExpectedFailureLogs,
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The hook's catch always reports this fixed copy, not the server's own
+    // message - so the alert text is independent of what the fixture rejects with.
+    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+      'Unable to load the check-in board right now.'
+    );
+    // The error banner and the empty body are not mutually exclusive - both
+    // render at once, since `checkIns` never left its initial empty array.
+    await expect(canvas.getByText('No patients are checked in')).toBeVisible();
+  },
+};
+
+export const ReadOnly: FrontDeskBoardPanelStory = {
+  name: 'Edit permission revoked - view only',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', entries: CHECKINS_ACTIVE },
+    revoked: ['appointments:edit:any', 'appointments:edit:own'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Rows still render - viewing the board is not what canEdit gates.
+    await expect(await canvas.findAllByRole('listitem')).toHaveLength(3);
+
+    // Every edit control is withheld: no transition buttons, no add button,
+    // no room-assign dropdown, even though Otis already has a room assigned.
+    await expect(canvas.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Check in patient' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Assign room')).not.toBeInTheDocument();
+
+    // The show-all toggle is not part of edit gating, so it is still there.
+    await expect(canvas.getByRole('button', { name: 'Show all' })).toBeEnabled();
+  },
+};
+
+export const ShowAllToggle: FrontDeskBoardPanelStory = {
+  name: 'Show all reveals completed and cancelled',
+  beforeEach: prepare({ fixture: { kind: 'resolves', entries: CHECKINS_WITH_HISTORY } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findAllByRole('listitem')).toHaveLength(3);
+    const toggle = canvas.getByRole('button', { name: 'Show all' });
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(toggle);
+
+    await expect(await canvas.findByRole('button', { name: 'Active only' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(await canvas.findAllByRole('listitem')).toHaveLength(5);
+    await expect(canvas.getByText(String(5))).toBeVisible();
+    await expect(canvas.getByText('Completed')).toBeVisible();
+    await expect(canvas.getByText('Cancelled')).toBeVisible();
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Waitlist/WaitlistPanel.stories.tsx
@@ -1,0 +1,358 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import type {
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import type { WaitlistEntry } from '@/app/features/appointments/services/waitlistService';
+import WaitlistPanel from './WaitlistPanel';
+
+const ORG_ID = 'org-storybook-waitlist-panel';
+
+const membership = (revoked: string[] = []) => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-fields',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const companion = (id: string, name: string, parentId: string): StoredCompanion => ({
+  id,
+  organisationId: ORG_ID,
+  parentId,
+  name,
+  type: 'dog',
+  breed: 'Labrador',
+  dateOfBirth: new Date('2020-03-01'),
+  gender: 'female',
+  isInsured: false,
+});
+
+const parent = (id: string, firstName: string, lastName: string): StoredParent => ({
+  id,
+  firstName,
+  lastName,
+  email: `${firstName.toLowerCase()}@example.com`,
+  address: {},
+  createdFrom: 'pms',
+});
+
+// Shadow is deliberately not on the waitlist yet - the Add story puts it there.
+const COMPANIONS: StoredCompanion[] = [
+  companion('companion-nova', 'Nova', 'parent-reyes'),
+  companion('companion-biscuit', 'Biscuit', 'parent-ortiz'),
+  companion('companion-shadow', 'Shadow', 'parent-lindqvist'),
+];
+const PARENTS: StoredParent[] = [
+  parent('parent-reyes', 'Maria', 'Reyes'),
+  parent('parent-ortiz', 'Daniel', 'Ortiz'),
+  parent('parent-lindqvist', 'Elin', 'Lindqvist'),
+];
+
+const entry = (
+  overrides: Partial<WaitlistEntry> & Pick<WaitlistEntry, 'id' | 'patientId' | 'status'>
+): WaitlistEntry => ({
+  organisationId: ORG_ID,
+  requestedBy: null,
+  preferredLeadId: null,
+  appointmentType: null,
+  earliestDate: null,
+  latestDate: null,
+  notes: null,
+  offeredAt: null,
+  bookedAt: null,
+  expiresAt: null,
+  createdAt: '2026-08-18T09:00:00.000Z',
+  updatedAt: '2026-08-18T09:00:00.000Z',
+  ...overrides,
+});
+
+const ENTRIES: WaitlistEntry[] = [
+  entry({
+    id: 'wl-nova',
+    patientId: 'companion-nova',
+    status: 'WAITING',
+    appointmentType: 'Dental',
+    createdAt: '2026-08-18T09:00:00.000Z',
+  }),
+  entry({
+    id: 'wl-biscuit',
+    patientId: 'companion-biscuit',
+    status: 'OFFERED',
+    appointmentType: 'Vaccination',
+    offeredAt: '2026-08-21T09:00:00.000Z',
+    createdAt: '2026-08-19T09:00:00.000Z',
+  }),
+];
+
+type WaitlistFixture =
+  | { kind: 'resolves'; entries: WaitlistEntry[] }
+  /** Held open on purpose: the only way to hold the loading skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects' };
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The panel reads and writes `/v1/pms/organisation/:id/waitlist` (and its
+ * `/:entryId/offer|cancel` transitions) through the shared axios instance, so
+ * its adapter is the seam. A resolved fixture keeps its own mutable copy of the
+ * list so an add/offer/cancel is reflected in the refetch the hook makes right
+ * after - the same round trip the real backend does.
+ */
+const buildAdapter = (fixture: WaitlistFixture): AxiosAdapter => {
+  let entries = fixture.kind === 'resolves' ? fixture.entries : [];
+  return (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+    if (!url.includes('/waitlist')) return Promise.resolve(respond(config, []));
+
+    if (method === 'get') {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed with status code 500'), {
+            isAxiosError: true,
+            config,
+            response: {
+              status: 500,
+              statusText: 'Internal Server Error',
+              data: {},
+              headers: {},
+              config,
+            },
+          })
+        );
+      }
+      return Promise.resolve(respond(config, entries));
+    }
+
+    if (/\/waitlist$/.test(url)) {
+      const body = JSON.parse(String(config.data ?? '{}')) as {
+        patientId: string;
+        appointmentType?: string;
+        notes?: string;
+      };
+      const created = entry({
+        id: `wl-new-${entries.length + 1}`,
+        patientId: body.patientId,
+        status: 'WAITING',
+        appointmentType: body.appointmentType ?? null,
+        notes: body.notes ?? null,
+        createdAt: new Date().toISOString(),
+      });
+      entries = [...entries, created];
+      return Promise.resolve(respond(config, created));
+    }
+
+    const transition = /\/waitlist\/([^/]+)\/(offer|cancel)$/.exec(url);
+    if (transition) {
+      const [, id, action] = transition;
+      const nextStatus = action === 'offer' ? 'OFFERED' : 'CANCELLED';
+      entries = entries.map((e) => (e.id === id ? { ...e, status: nextStatus } : e));
+      const updated = entries.find((e) => e.id === id) ?? entries[0];
+      return Promise.resolve(respond(config, updated));
+    }
+
+    return Promise.resolve(respond(config, []));
+  };
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * Seeds the org, companion and parent stores the container's hooks read, and
+ * points the shared axios instance at the fixture adapter. Mirrors the
+ * companions store the way `Discounts/index.stories.tsx` seeds finance's
+ * stores - each is pre-populated with an entry for this org so the loader
+ * hooks short-circuit rather than reaching the network.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: WaitlistFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+    const snapshots = {
+      org: useOrgStore.getState(),
+      companion: useCompanionStore.getState(),
+      parent: useParentStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter(fixture);
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: Object.fromEntries(COMPANIONS.map((c) => [c.id, c])),
+      companionsIdsByOrgId: { [ORG_ID]: COMPANIONS.map((c) => c.id) },
+      status: 'loaded',
+    });
+    useParentStore.setState({
+      parentsById: Object.fromEntries(PARENTS.map((p) => [p.id, p])),
+      status: 'loaded',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useParentStore.setState(snapshots.parent);
+      useCompanionStore.setState(snapshots.companion);
+      useOrgStore.setState(snapshots.org);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused load is logged twice on its way to the hook's catch (once by the
+ * shared axios wrapper, once by the service's own `logFailure`), and the
+ * render check treats a console error as a broken story. Only those two
+ * expected lines are dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const text = args.filter((a) => typeof a === 'string').join(' ');
+    const expected = text.includes('API getData error') || text.includes('Failed to load waitlist');
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'Appointments/WaitlistPanel',
+  component: WaitlistPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Data container for the presentational `Waitlist`. It loads the primary ' +
+          "organisation's waitlist, resolves each entry's companion and owner names from " +
+          'the companions store (an entry itself only carries a patient id), and wires the ' +
+          'offer/cancel/add actions from `useWaitlist` onto the panel. "Book" has no service ' +
+          'call of its own here - a waitlist entry has no time slot to book directly, so it ' +
+          'calls `onBookAppointment` to open the ordinary New Appointment form and lets staff ' +
+          'pick a slot through the normal create flow. Edit actions (offer, cancel, add, book) ' +
+          'are withheld entirely, not just disabled, when the signed-in user lacks the ' +
+          '`appointments:edit:any`/`appointments:edit:own` permission.\n\n' +
+          'The stories seed the org/companion/parent stores the container reads and answer ' +
+          'the waitlist endpoint from the shared axios adapter, the same mocking approach ' +
+          '`Discounts/index.stories.tsx` uses for finance.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    onBookAppointment: fn(),
+  },
+  beforeEach: prepare({ fixture: { kind: 'resolves', entries: ENTRIES } }),
+} satisfies Meta<typeof WaitlistPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 3, name: 'Waitlist' })).toBeVisible();
+    await expect(canvas.getByText('Nova')).toBeVisible();
+    await expect(canvas.getByText('Maria Reyes')).toBeVisible();
+    await expect(canvas.getByText('Offered')).toBeVisible();
+
+    // "Book" has no service call of its own - it hands the entry straight to
+    // the caller-supplied onBookAppointment, which opens the New Appointment form.
+    await userEvent.click(canvas.getAllByRole('button', { name: 'Book appointment' })[0]);
+    await expect(args.onBookAppointment).toHaveBeenCalledTimes(1);
+    await expect(args.onBookAppointment).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wl-nova' })
+    );
+  },
+};
+
+export const Empty: Story = {
+  name: 'No entries',
+  beforeEach: prepare({ fixture: { kind: 'resolves', entries: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No one is on the waitlist')).toBeVisible();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading the waitlist',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 3, name: 'Waitlist' });
+    // The skeleton rows render in place of the list while the fetch is pending.
+    await waitFor(() =>
+      expect(canvasElement.querySelector('ul[aria-hidden="true"]')).not.toBeNull()
+    );
+    await expect(canvas.queryByText('Nova')).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: Story = {
+  name: 'Waitlist failed to load',
+  beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Unable to load the waitlist right now.');
+    await expect(canvas.getByText('No one is on the waitlist')).toBeVisible();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Appointment edit revoked - actions hidden',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', entries: ENTRIES },
+    revoked: ['appointments:edit:any', 'appointments:edit:own'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Nova')).toBeVisible();
+    // The rows and their status are still readable; only the edit actions are gone.
+    await expect(canvas.queryByRole('button', { name: 'Add to waitlist' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Book appointment' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Offer' })).not.toBeInTheDocument();
+  },
+};
+
+export const AddingAnEntry: Story = {
+  name: 'Adding a companion to the waitlist',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Nova');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add to waitlist' }));
+    await userEvent.selectOptions(await canvas.findByLabelText('Companion'), 'companion-shadow');
+    await userEvent.type(canvas.getByLabelText('Requested service'), 'Grooming');
+    await userEvent.click(canvas.getByRole('button', { name: 'Add to waitlist' }));
+
+    // The form closes and the list is refetched, so the new row appears.
+    await expect(await canvas.findByText('Shadow')).toBeVisible();
+    await expect(canvas.getByText('Elin Lindqvist')).toBeVisible();
+    await expect(canvas.queryByLabelText('Companion')).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.stories.tsx
@@ -147,6 +147,9 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  argTypes: {
+    visitType: { control: 'radio', options: ['Outpatient', 'Inpatient'] },
+  },
   args: {
     patientLabel: 'Patient',
     patientQuery: '',

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.stories.tsx
@@ -1,0 +1,425 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Appointment, Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Appointments from './index';
+
+const ORG_ID = 'org-storybook-appointments';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Blackthorn Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 161 496 0142',
+  taxId: 'GB-4471-2093',
+  isVerified: true,
+};
+
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-lindqvist',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * `pmsPreferences` is what keeps `/appointments` itself from being redirected:
+ * `OrgGuard` sends an OWNER's first visit to `/dashboard` unless the profile's
+ * preferred landing screen already IS Appointments, and separately restores the
+ * saved `appointmentView` on mount - overriding whatever `resolveDefaultAppointmentsView`
+ * read from local storage. `TABLE` is chosen here because it is the one view
+ * that renders through the already-proven `Tables/Appointments` component.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 161 496 0142',
+    address: {
+      addressLine: '9 Blackthorn Mews',
+      city: 'Manchester',
+      state: 'Greater Manchester',
+      postalCode: 'M1 4BT',
+      country: 'United Kingdom',
+    },
+    pmsPreferences: {
+      defaultOpenScreen: 'APPOINTMENTS',
+      appointmentView: 'TABLE',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+/* Local Date constructors, not UTC literals: the list's date/time cells format
+   through the org's preferred time zone, so a '...T09:30:00.000Z' fixture would
+   render a different hour - and in some zones a different day - depending on
+   where the story runs. */
+const appointment = (
+  id: string,
+  companionName: string,
+  overrides: Partial<Appointment> = {}
+): Appointment => {
+  const who = {
+    id: `companion-${id}`,
+    name: companionName,
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: 'Priya Nakamura' },
+  };
+  return {
+    id,
+    patient: who,
+    companion: who,
+    lead: { id: 'pract-lead-1', name: 'Dr. Sasha Lindqvist' },
+    appointmentType: {
+      id: 'type-wellness',
+      name: 'Wellness exam',
+      speciality: { id: 'spec-general', name: 'General practice' },
+    },
+    organisationId: ORG_ID,
+    appointmentDate: new Date(2026, 5, 15, 9, 30),
+    startTime: new Date(2026, 5, 15, 9, 30),
+    endTime: new Date(2026, 5, 15, 10, 0),
+    timeSlot: '09:30 - 10:00',
+    durationMinutes: 30,
+    status: 'UPCOMING',
+    concern: 'Annual check-up',
+    ...overrides,
+  };
+};
+
+const MARIGOLD = appointment('appt-marigold', 'Marigold');
+const OTIS = appointment('appt-otis', 'Otis', {
+  status: 'CHECKED_IN',
+  startTime: new Date(2026, 5, 15, 11, 0),
+  endTime: new Date(2026, 5, 15, 11, 30),
+  timeSlot: '11:00 - 11:30',
+  concern: 'Vomiting since yesterday',
+});
+/* No lead at all: a completed visit affords no edit actions regardless of permission. */
+const COCO = appointment('appt-coco', 'Coco', {
+  status: 'COMPLETED',
+  lead: undefined,
+  startTime: new Date(2026, 5, 15, 13, 0),
+  endTime: new Date(2026, 5, 15, 13, 30),
+  timeSlot: '13:00 - 13:30',
+  concern: 'Post-op check',
+});
+
+const BASE_APPOINTMENTS: Appointment[] = [MARIGOLD, OTIS, COCO];
+
+/* `hasEmergency` only lights up for a future, still-open booking, so this one
+   is built from `Date.now()` rather than a fixed date that would age out. */
+const emergencyAppointment = (): Appointment =>
+  appointment('appt-zephyr', 'Zephyr', {
+    isEmergency: true,
+    startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    endTime: new Date(Date.now() + 2.5 * 60 * 60 * 1000),
+    appointmentDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    concern: 'Hit by car',
+  });
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The page itself reads every appointment, companion, team and org fact out of
+ * the pre-seeded stores below, so it never calls the shared axios instance
+ * directly. What DOES still reach it: `OrgGuard`'s subscription-counter loader,
+ * which fetches unconditionally on every mount, and the always-mounted "New
+ * appointment" dialog and the per-appointment detail modals, whose own data
+ * needs are out of scope for this page-level story. The adapter answers the
+ * two known finance calls and falls back to an empty 200 for anything else, so
+ * nothing from this tree ever reaches the real network.
+ */
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+  if (url.includes('/v1/finance/subscriptions/current')) {
+    return Promise.resolve(respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } }));
+  }
+  if (url.includes('/v1/finance/usage-snapshots')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`. The stories satisfy the guards with real
+ * data - an authenticated session, a verified org, an active membership, a
+ * profile past onboarding step 3 and one availability row - rather than with the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works under the dev server:
+ * a static build inlines every `process.env.NEXT_PUBLIC_*` read at build time, so
+ * assigning one at runtime changes nothing and the guards redirect.
+ *
+ * Every org-scoped store OrgGuard's eleven loaders would otherwise fetch is
+ * seeded with an entry for this org so each short-circuits on
+ * `Object.hasOwn(...ByOrgId, primaryOrgId)` rather than reaching the network.
+ * Companions and their parents are left empty on purpose: the page enriches an
+ * appointment's companion from that store when a match exists but renders the
+ * appointment's own embedded companion fields when it does not, and every
+ * fixture below already carries a full companion record.
+ */
+const prepare =
+  ({ appointments, revoked = [] }: { appointments: Appointment[]; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      parent: useParentStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      search: useSearchStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter();
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useTeamStore.setState({ teamIdsByOrgId: emptyIndex, status: 'loaded' });
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.setState({
+      appointmentsById: Object.fromEntries(appointments.map((a) => [a.id as string, a])),
+      appointmentIdsByOrgId: { [ORG_ID]: appointments.map((a) => a.id as string) },
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {},
+      companionsIdsByOrgId: emptyIndex,
+      companionIdsByParentId: {},
+      status: 'loaded',
+    });
+    useParentStore.setState({ parentsById: {}, parentIds: [], status: 'loaded' });
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: { [ORG_ID]: { orgId: ORG_ID, currency: 'GBP' } },
+    });
+    // The shared header writes here; a query left by another story would filter this list.
+    useSearchStore.setState({ query: '' });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useSearchStore.setState(snapshots.search);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useParentStore.setState(snapshots.parent);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+const meta = {
+  title: 'Appointments/Appointments',
+  component: Appointments,
+  parameters: {
+    layout: 'fullscreen',
+    // Both guards read usePathname; the landing-screen check inside OrgGuard
+    // also keys off this exact pathname.
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments' } },
+    docs: {
+      description: {
+        component:
+          'The appointments page: a calendar/board/list toggle over one shared filtered list, ' +
+          'two collapsible panels above it (Waitlist, Front desk), and the create/detail/reschedule/ ' +
+          'status/room dialogs the list and calendar open into.\n\n' +
+          'The three views are dynamically imported and preloaded together so switching is instant, ' +
+          'and which one opens first is not a hardcoded default - it is read from the signed-in ' +
+          "user's `pmsPreferences.appointmentView`, falling back to the board view when the " +
+          'preference is unset. A companion in the list is never rendered from the raw appointment ' +
+          'alone: photo, gender, date of birth and the parent name are merged in live from the ' +
+          'companion store whenever that companion has since been edited there, so the row reflects ' +
+          "the parent's current record rather than whatever was true when the booking was made.\n\n" +
+          'The whole surface sits behind `appointments:view:any`, and every edit action - the row ' +
+          'menu items, "New appointment", drag-to-reschedule - additionally requires ' +
+          '`appointments:edit:any` or, for a booking led by the signed-in practitioner, ' +
+          '`appointments:edit:own`. The stories satisfy `ProtectedRoute` and `OrgGuard` with real ' +
+          'data rather than the dev-only auth-bypass flag, seed the org-scoped stores OrgGuard would ' +
+          'otherwise load, and answer the two finance calls its subscription loader always makes.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare({ appointments: BASE_APPOINTMENTS }),
+} satisfies Meta<typeof Appointments>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Three appointments booked',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* The title carries a live count - "Appointments (3)" - so it is matched on
+       its stem rather than in full. */
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /^Appointments/ })
+    ).toBeVisible();
+    await expect(canvas.getAllByRole('button', { name: /^Actions for / })).toHaveLength(3);
+    await expect(canvas.getByRole('button', { name: 'New appointment' })).toBeEnabled();
+  },
+};
+
+export const Empty: Story = {
+  name: 'No appointments booked',
+  beforeEach: prepare({ appointments: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /^Appointments/ })
+    ).toBeVisible();
+    // The table and the card list both render their own copy of the same empty state.
+    await expect(canvas.getAllByText('No appointments yet')).toHaveLength(2);
+    await expect(canvas.queryByRole('button', { name: /^Actions for / })).not.toBeInTheDocument();
+  },
+};
+
+export const ViewDenied: Story = {
+  name: 'View permission revoked',
+  beforeEach: prepare({ appointments: BASE_APPOINTMENTS, revoked: ['appointments:view:any'] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The role keeps appointments:view:own, so the route itself still opens -
+    // it is this page's own gate, scoped to view:any, that denies the content.
+    await expect(await canvas.findByText("You don't have access to Appointments")).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: /^Actions for / })).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Edit permission revoked - no New appointment',
+  beforeEach: prepare({
+    appointments: BASE_APPOINTMENTS,
+    revoked: ['appointments:edit:any', 'appointments:edit:own'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The list is still there to read; the create action is absent rather than disabled.
+    await expect(canvas.getAllByRole('button', { name: /^Actions for / })).toHaveLength(3);
+    await expect(canvas.queryByRole('button', { name: 'New appointment' })).not.toBeInTheDocument();
+  },
+};
+
+export const Emergency: Story = {
+  name: 'An emergency booking present',
+  beforeEach: prepare({ appointments: [...BASE_APPOINTMENTS, emergencyAppointment()] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('button', { name: /^Actions for / })).toHaveLength(4);
+    // The row-level chip; the Emergencies filter pill also lights up from the
+    // same `hasEmergency` flag, but the chip is what a reader actually sees.
+    await expect(canvas.getByText('Emergency')).toBeVisible();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Below `xl` the table gives way to a per-companion card list.
+    await expect(await canvas.findByLabelText('View appointment for Marigold')).toBeInTheDocument();
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

CompanionSelect, FrontDeskBoardPanel, WaitlistPanel, and the Appointments page container have no Storybook coverage.

## What is the new behavior?

Adds a story for each, following the repo's existing CSF3 house style. Also includes a small additive argTypes entry to AddAppointmentCentralModal's existing story (it already had coverage; this only adds a visitType control).

## Related Issue(s)

Part of #2930