### PR TITLE
test(frontend): add Storybook stories for 9 uncovered page containers

### DIFF
--- a/apps/frontend/src/app/features/companions/components/AddCompanion/index.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanion/index.stories.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { toParentResponseDTO, type Organisation } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type {
+  BreedCodeEntry,
+  SpeciesCodeEntry,
+} from '@/app/features/companions/services/codeEntriesService';
+import type { StoredParent } from '@/app/features/companions/pages/Companions/types';
+
+import AddCompanion from './index';
+
+const ORG_ID = 'org-add-companion-story';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Larkspur Boarding',
+  type: 'BOARDER',
+  phoneNo: '+44 20 7946 0102',
+  taxId: 'TAX-4471',
+  isVerified: true,
+};
+
+/* Local parts, not a UTC literal: the Datepicker formats off local hours, so a
+   `...T00:00:00.000Z` fixture renders a day earlier west of Greenwich. */
+const BIRTH_DATE = new Date(1989, 10, 2);
+
+const HARTMANN: StoredParent = {
+  id: 'parent-hartmann',
+  firstName: 'Lena',
+  lastName: 'Hartmann',
+  email: 'lena.hartmann@example.com',
+  phoneNumber: '+493090182055',
+  birthDate: BIRTH_DATE,
+  address: {
+    addressLine: 'Wallstrasse 14',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10179',
+    country: 'Germany',
+  },
+  createdFrom: 'pms',
+};
+
+const SPECIES_ENTRIES: SpeciesCodeEntry[] = [
+  { code: 'YC-SPC-001', display: 'Canine' },
+  { code: 'YC-SPC-002', display: 'Feline' },
+  { code: 'YC-SPC-003', display: 'Equine' },
+];
+
+const BREED_ENTRIES: BreedCodeEntry[] = [
+  { code: 'YC-BRD-001', display: 'Beagle', meta: { speciesCode: 'YC-SPC-001' } },
+  { code: 'YC-BRD-002', display: 'Whippet', meta: { speciesCode: 'YC-SPC-001' } },
+];
+
+/* ------------------------------------------------------------------ *
+ * Keeping the modal off the wire
+ *
+ * The two steps together reach the API through three ESM service functions -
+ * `searchParent`, `fetchSpeciesCodeEntries` and `fetchBreedCodeEntries` - all of
+ * which go through the shared axios instance. An ESM export cannot be
+ * reassigned, so the seam is `api.defaults.adapter` itself, the same one
+ * Discounts/index.stories.tsx answers from. Save is never clicked, so the
+ * create/link endpoints are never reached and need no fixture here - that flow
+ * is Companion.stories.tsx's job.
+ * ------------------------------------------------------------------ */
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+  if (url.includes('/fhir/v1/parent/pms/search')) {
+    return Promise.resolve(respond(config, [HARTMANN].map(toParentResponseDTO)));
+  }
+  if (url.includes('/v1/codes/entries')) {
+    const type = (config.params as Record<string, unknown> | undefined)?.type;
+    return Promise.resolve(respond(config, type === 'BREED' ? BREED_ENTRIES : SPECIES_ENTRIES));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The modal reads its companion noun ("Companion information" vs "Patient
+ * details") through `useCompanionTerminologyText`, resolved from
+ * `primaryOrgId` and `orgsById[id].type` - so both are seeded. The previous
+ * store state and adapter are restored on unmount so neighbouring stories are
+ * unaffected.
+ */
+const prepare = () => {
+  clearInFlightGetRequests();
+  const orgSnapshot = useOrgStore.getState();
+  api.defaults.adapter = buildAdapter();
+  useOrgStore.setState({ primaryOrgId: ORG_ID, orgsById: { [ORG_ID]: ORG } });
+
+  return () => {
+    api.defaults.adapter = REAL_ADAPTER;
+    useOrgStore.setState(orgSnapshot);
+    clearInFlightGetRequests();
+  };
+};
+
+/**
+ * `showModal` is owned by whichever page opens this modal in the app. Held
+ * here so the header's Close button visibly does something, while
+ * `args.setShowModal` still records every call for the play functions to
+ * assert against.
+ */
+const ControlledAddCompanion = (args: React.ComponentProps<typeof AddCompanion>) => {
+  const [showModal, setShowModal] = useState(args.showModal);
+  return (
+    <AddCompanion
+      {...args}
+      showModal={showModal}
+      setShowModal={(value) => {
+        setShowModal(value);
+        args.setShowModal(value);
+      }}
+    />
+  );
+};
+
+/**
+ * The modal portals to `document.body` (a native `<dialog>`, labelled by the
+ * same `aria-label` the component passes to `Modal`), so nothing it renders is
+ * inside the story's own `canvasElement`.
+ */
+const openDialog = () => within(document.body).findByRole('dialog', { name: 'Add companion' });
+
+/** `LabelDropdown`'s testid says colour/blood-group; it is actually the species/breed row. */
+const speciesBreedRow = (dialogEl: HTMLElement) => {
+  const row = dialogEl.querySelector<HTMLElement>(
+    '[data-testid="companion-color-blood-group-row"]'
+  );
+  if (!row) throw new Error('species/breed row is missing');
+  return row;
+};
+
+/**
+ * Reaches step 2 with a record that passes validation by picking a search
+ * result, rather than typing all eight required parent fields by hand -
+ * exactly how PrefilledParent reaches the same state in Parent.stories.tsx.
+ */
+const advanceToCompanionStep = async (dialogEl: HTMLElement) => {
+  const canvas = within(dialogEl);
+  await userEvent.type(canvas.getByRole('textbox', { name: 'Search parent' }), 'Har');
+  const match = await canvas.findByRole('button', { name: 'Lena Hartmann' }, { timeout: 3000 });
+  await userEvent.click(match);
+  await waitFor(async () => {
+    await expect(canvas.getByRole('textbox', { name: "Parent's name" })).toHaveValue('Lena');
+  });
+  await userEvent.click(canvas.getByRole('button', { name: 'Next' }));
+  await waitFor(async () => {
+    await expect(canvas.getByRole('tab', { name: 'Companion information' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+};
+
+const addCompanionMeta = {
+  title: 'Companions/AddCompanion',
+  component: AddCompanion,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The add-companion modal: a two-step wizard in a centered Modal, step 1 collecting the ' +
+          "client (Parent) and step 2 the patient record (Companion). Both steps' own fields, " +
+          'validation and layout are covered in their own stories (Parent.stories.tsx, ' +
+          'Companion.stories.tsx) - this file only tests what belongs to the shell that wires them ' +
+          'together.\n\n' +
+          'That wiring is imperative, not just two panels behind a tab strip. Clicking the second ' +
+          'tab does not switch steps directly - `handleLabelChange` calls `validateStep()` through a ' +
+          'ref on the mounted Parent section first, and only advances if it returns true. The Next ' +
+          'button inside Parent calls the same validation, so there are two triggers for one gate.\n\n' +
+          '`mode` is forwarded straight through to the Companion step, where it removes seven fields ' +
+          'rather than restyling them. The tab label, the step counter and the Companion accordion ' +
+          "title all read the org's companion noun through `useCompanionTerminologyText`, so a " +
+          'BOARDER org here reads "companion" throughout rather than "patient".\n\n' +
+          'The parent search, species list and breed list are answered from a stub adapter rather ' +
+          'than the live API.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    onCompanionCreated: fn(),
+    mode: 'default',
+  },
+  argTypes: {
+    mode: { control: 'radio', options: ['default', 'fasttrack'] },
+  },
+  render: (args) => <ControlledAddCompanion {...args} />,
+  beforeEach: prepare,
+} satisfies Meta<typeof AddCompanion>;
+
+export default addCompanionMeta;
+type AddCompanionStory = StoryObj<typeof addCompanionMeta>;
+
+export const Default: AddCompanionStory = {
+  name: 'Step 1: parent details',
+  play: async ({ args }) => {
+    const dialogEl = await openDialog();
+    const canvas = within(dialogEl);
+
+    await expect(canvas.getByRole('heading', { name: 'Add companion' })).toBeInTheDocument();
+    await expect(canvas.getByText('Step 1 of 2 · parent details')).toBeInTheDocument();
+
+    const parentsTab = canvas.getByRole('tab', { name: 'Parents details' });
+    const companionTab = canvas.getByRole('tab', { name: 'Companion information' });
+    await expect(parentsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(companionTab).toHaveAttribute('aria-selected', 'false');
+
+    // Proves the wizard mounted the right section; the section's own fields
+    // are Parent.stories.tsx's job.
+    await expect(canvas.getByRole('textbox', { name: "Parent's name" })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Close' }));
+    await expect(args.setShowModal).toHaveBeenCalledWith(false);
+  },
+};
+
+export const BlockedWithoutParentDetails: AddCompanionStory = {
+  name: 'Second tab is gated on parent validation',
+  play: async ({ args }) => {
+    const dialogEl = await openDialog();
+    const canvas = within(dialogEl);
+
+    // The tab click routes through the same imperative validateStep() the Next
+    // button uses - with nothing filled in it must refuse the step change
+    // rather than switch and leave step 1's errors stranded off-screen.
+    await userEvent.click(canvas.getByRole('tab', { name: 'Companion information' }));
+
+    await waitFor(async () => {
+      await expect(canvas.getByText('First name is required')).toBeInTheDocument();
+    });
+    await expect(canvas.getByRole('tab', { name: 'Parents details' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    // The gate is a refusal to mount, not a hidden section.
+    await expect(canvas.queryByRole('textbox', { name: 'Name' })).not.toBeInTheDocument();
+    await expect(args.setShowModal).not.toHaveBeenCalled();
+  },
+};
+
+export const AdvancesToCompanionStep: AddCompanionStory = {
+  name: 'Picking a client advances to step 2',
+  play: async () => {
+    const dialogEl = await openDialog();
+    await advanceToCompanionStep(dialogEl);
+    const canvas = within(dialogEl);
+
+    await expect(canvas.getByText('Step 2 of 2 · companion details')).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+
+    // Two columns in default mode: species and breed share a row, the same
+    // measurement Companion.stories.tsx's own Default story uses.
+    const row = within(speciesBreedRow(dialogEl));
+    const species = row.getByRole('button', { name: 'Species: Canine' });
+    const breed = row.getByRole('button', { name: 'Breed' });
+    await expect(species.getBoundingClientRect().top).toBe(breed.getBoundingClientRect().top);
+    await expect(
+      canvas.getByRole('button', { name: 'Blood group (optional)' })
+    ).toBeInTheDocument();
+  },
+};
+
+export const FastTrackMode: AddCompanionStory = {
+  name: 'Fast-track mode collapses step 2',
+  args: { mode: 'fasttrack' },
+  play: async () => {
+    const dialogEl = await openDialog();
+    await advanceToCompanionStep(dialogEl);
+    const canvas = within(dialogEl);
+
+    // One column, so breed sits below species instead of beside it - `mode`
+    // reaching the mounted section, not just a label on the modal itself.
+    const row = within(speciesBreedRow(dialogEl));
+    const species = row.getByRole('button', { name: 'Species: Canine' });
+    const breed = row.getByRole('button', { name: 'Breed' });
+    await expect(breed.getBoundingClientRect().top).toBeGreaterThan(
+      species.getBoundingClientRect().top
+    );
+
+    // Fast track drops the field entirely rather than hiding it.
+    await expect(canvas.queryByRole('button', { name: 'Blood group (optional)' })).toBeNull();
+  },
+};

--- a/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.stories.tsx
+++ b/apps/frontend/src/app/features/compliance/pages/ControlledSubstances/index.stories.tsx
@@ -1,0 +1,547 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import type {
+  ControlledSubstanceLog,
+  CreateControlledSubstanceLogInput,
+} from '@/app/features/compliance/types/controlledSubstance';
+import ControlledSubstances from './index';
+
+const ORG_ID = 'org-storybook-controlled-substances';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+/**
+ * OWNER carries both `controlled-drug-register:read` and `:record` by
+ * default, so the read-only story is only reachable through
+ * `revokedPermissions` - which is also how a practice really takes recording
+ * rights off one person while leaving the register itself visible.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+type LogsFixture =
+  | { kind: 'resolves'; logs: ControlledSubstanceLog[] }
+  /** Held open on purpose: the only way to hold the skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects'; message: string };
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * These are what let the guards pass on REAL data. The obvious alternative, the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, works only under the dev server: a
+ * production/static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect -
+ * which is exactly how these stories rendered an empty page in the static build
+ * that Chromatic publishes.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+const entry = (overrides: Partial<ControlledSubstanceLog>): ControlledSubstanceLog => ({
+  id: 'log-1',
+  organisationId: ORG_ID,
+  patientId: null,
+  encounterId: null,
+  loggedAt: '2026-09-03T14:30:00.000Z',
+  drug: 'Ketamine',
+  deaSchedule: 'III',
+  lotNumber: null,
+  strength: null,
+  unit: 'ML',
+  amountDrawn: 1,
+  amountAdministered: 1,
+  amountWasted: 0,
+  wastedWitness: null,
+  balanceBefore: null,
+  balanceAfter: null,
+  administeredBy: null,
+  notes: null,
+  createdAt: '2026-09-03T14:31:00.000Z',
+  updatedAt: '2026-09-03T14:31:00.000Z',
+  ...overrides,
+});
+
+const LOGS: ControlledSubstanceLog[] = [
+  entry({
+    id: 'log-1',
+    drug: 'Fentanyl citrate',
+    deaSchedule: 'II',
+    unit: 'ML',
+    strength: 0.05,
+    amountDrawn: 2,
+    amountAdministered: 1.5,
+    amountWasted: 0.5,
+    wastedWitness: 'Dr. Alvarez',
+    balanceBefore: 10,
+    balanceAfter: 8,
+    administeredBy: 'Dr. Weber',
+    notes: 'Premedication before dental.',
+  }),
+  entry({
+    id: 'log-2',
+    drug: 'Ketamine',
+    deaSchedule: 'III',
+    unit: 'MG',
+    amountDrawn: 100,
+    amountAdministered: 80,
+    amountWasted: 20,
+    // Compliance red flag: waste with no witness recorded.
+    wastedWitness: null,
+    balanceBefore: 500,
+    balanceAfter: 400,
+    administeredBy: 'Dr. Reyes',
+  }),
+  entry({
+    id: 'log-3',
+    drug: 'Diazepam',
+    deaSchedule: 'IV',
+    unit: 'ML',
+    strength: 5,
+    amountDrawn: 1,
+    amountAdministered: 1,
+    administeredBy: 'Dr. Weber',
+  }),
+  entry({
+    id: 'log-4',
+    drug: 'Phenobarbital',
+    deaSchedule: 'V',
+    unit: 'TABLET',
+    amountDrawn: 3,
+    amountAdministered: 3,
+    administeredBy: 'Dr. Reyes',
+  }),
+];
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The page lists and creates through
+ * `/v1/pms/organisation/:id/controlled-substance-logs`, both through the
+ * shared axios instance, so its adapter is the seam. A POST is echoed back as
+ * the row the server would store - `administeredBy` stamped server-side, never
+ * taken from the request body, matching `controlled-substance-log.controller.ts`.
+ * `OrgGuard` itself (not this page) calls the two finance endpoints below on
+ * every route via `useLoadSubscriptionCounterForPrimaryOrg`, so they are
+ * answered too rather than left to reject.
+ */
+const buildAdapter =
+  (fixture: LogsFixture): AxiosAdapter =>
+  (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (url.includes('/controlled-substance-logs')) {
+      if (method === 'post') {
+        const body = JSON.parse(String(config.data ?? '{}')) as CreateControlledSubstanceLogInput;
+        return Promise.resolve(
+          respond(
+            config,
+            entry({
+              id: 'log-new',
+              patientId: body.patientId ?? null,
+              encounterId: body.encounterId ?? null,
+              loggedAt: body.loggedAt,
+              drug: body.drug,
+              deaSchedule: body.deaSchedule,
+              lotNumber: body.lotNumber ?? null,
+              strength: body.strength ?? null,
+              unit: body.unit,
+              amountDrawn: body.amountDrawn,
+              amountAdministered: body.amountAdministered,
+              amountWasted: body.amountWasted ?? 0,
+              wastedWitness: body.wastedWitness ?? null,
+              balanceBefore: body.balanceBefore ?? null,
+              balanceAfter: body.balanceAfter ?? null,
+              administeredBy: 'Dr. Weber',
+              notes: body.notes ?? null,
+            })
+          )
+        );
+      }
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed with status code 403'), {
+            isAxiosError: true,
+            config,
+            response: {
+              status: 403,
+              statusText: 'Forbidden',
+              data: { message: fixture.message },
+              headers: {},
+              config,
+            },
+          })
+        );
+      }
+      return Promise.resolve(respond(config, fixture.logs));
+    }
+    if (url.includes('/v1/finance/subscriptions/current')) {
+      return Promise.resolve(
+        respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } })
+      );
+    }
+    if (url.includes('/v1/finance/usage-snapshots')) {
+      return Promise.resolve(respond(config, { data: [] }));
+    }
+    return Promise.resolve(respond(config, []));
+  };
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`. The stories satisfy the guards with real
+ * data - an authenticated session, a verified org, an active membership, a
+ * profile past onboarding step 3 and one availability row - rather than with the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works under the dev server:
+ * a static build inlines every `process.env.NEXT_PUBLIC_*` read at build time, so
+ * assigning one at runtime changes nothing and the guards redirect.
+ *
+ * `OrgGuard` fires its eleven org-scoped loaders regardless of which page it
+ * wraps, so each of their stores is seeded with an entry for this org too, and
+ * short-circuits on `Object.hasOwn(...ByOrgId, primaryOrgId)` rather than
+ * reaching the network.
+ */
+const prepare =
+  ({ fixture, revoked = [] }: { fixture: LogsFixture; revoked?: string[] }) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter(fixture);
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useTeamStore.setState({ teamIdsByOrgId: emptyIndex, status: 'loaded' });
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: emptyIndex,
+      appointmentsById: {},
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {},
+      companionsIdsByOrgId: emptyIndex,
+      status: 'loaded',
+    });
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: { [ORG_ID]: { orgId: ORG_ID, currency: 'GBP' } },
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused list is logged by the axios wrapper on its way to the hook's catch,
+ * and the render check treats a console error as a broken story. Only that
+ * line is dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some((arg) => typeof arg === 'string' && arg.includes('API getData error'));
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'Compliance/ControlledSubstances',
+  component: ControlledSubstances,
+  parameters: {
+    layout: 'fullscreen',
+    // Both guards read usePathname.
+    nextjs: { appDirectory: true, navigation: { pathname: '/controlled-substances' } },
+    docs: {
+      description: {
+        component:
+          'The Controlled Substances page: an auditable log of every controlled-drug draw, ' +
+          'administration and waste for the organisation, filtered by drug name and a ' +
+          'from/to date range.\n\n' +
+          'Entries are listed and created through the compliance controlled-substance-logs ' +
+          'endpoint. The date bounds are applied server-side so the register stays correct as ' +
+          'an org accumulates entries past what one response holds, while the drug-name filter ' +
+          'runs client-side over the returned rows so a keystroke does not fire a request. A ' +
+          'waste amount with no witness recorded is flagged inline as a compliance gap rather ' +
+          'than silently accepted, and the form itself refuses to save one.\n\n' +
+          'The page sits behind `controlled-drug-register:read`, checked both by the route and ' +
+          'again by `PermissionGate`; the Add entry action is a separate check behind ' +
+          '`controlled-drug-register:record`, so a viewer can read the register without being ' +
+          'able to append to it. The stories lift `ProtectedRoute` and `OrgGuard` with real data ' +
+          '- an authenticated session, a verified org, an active membership, a profile past ' +
+          'onboarding step 3 and one availability row - seed every org-scoped store OrgGuard ' +
+          'would otherwise load, and answer the register endpoint from the shared axios adapter.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare({ fixture: { kind: 'resolves', logs: LOGS } }),
+} satisfies Meta<typeof ControlledSubstances>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The register renders a phone card list and the desktop table for the same
+ * rows at once - Tailwind's `md:hidden` / `hidden md:block` toggles which is
+ * visible, both stay mounted - so a drug name matches twice in the DOM.
+ * Scoping to the table (named by its `<caption>`) picks the desktop copy.
+ */
+const findRegisterTable = async (canvasElement: HTMLElement) =>
+  within(
+    await within(canvasElement).findByRole('table', { name: /controlled substance register/i })
+  );
+
+export const Loaded: Story = {
+  name: 'Entries in range',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: 'Controlled drug register' })
+    ).toBeVisible();
+
+    const table = await findRegisterTable(canvasElement);
+    await expect(table.getByText('Fentanyl citrate')).toBeVisible();
+    await expect(table.getByText('Ketamine')).toBeVisible();
+    await expect(table.getByText('Diazepam')).toBeVisible();
+    await expect(table.getByText('Phenobarbital')).toBeVisible();
+
+    // The compliance flag on the row wasted with no witness.
+    await expect(table.getByText('Witness missing')).toBeVisible();
+    await expect(table.getByText('Witness: Dr. Alvarez')).toBeVisible();
+
+    await expect(
+      canvas.getByRole('button', { name: 'Add a controlled substance entry' })
+    ).toBeEnabled();
+  },
+};
+
+export const Empty: Story = {
+  name: 'No entries in range',
+  beforeEach: prepare({ fixture: { kind: 'resolves', logs: [] } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No controlled substance entries yet.')).toBeVisible();
+    await expect(
+      canvas.getByText('Log a draw, administration or waste to start the compliance register.')
+    ).toBeVisible();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading the register',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 1, name: 'Controlled drug register' });
+    // A pulsing placeholder stands in for the table; no rows, no empty state.
+    await waitFor(() => expect(canvasElement.querySelector('.animate-pulse')).not.toBeNull());
+    await expect(
+      canvas.queryByText('No controlled substance entries yet.')
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: Story = {
+  name: 'Register could not be loaded',
+  beforeEach: [
+    prepare({
+      fixture: { kind: 'rejects', message: 'The controlled substance register is unavailable.' },
+    }),
+    muteExpectedFailureLogs,
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    // The server's own wording, surfaced verbatim.
+    await expect(alert).toHaveTextContent('The controlled substance register is unavailable.');
+    await expect(canvas.queryByText('Fentanyl citrate')).not.toBeInTheDocument();
+  },
+};
+
+export const EntryLogged: Story = {
+  name: 'Logging a new entry',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Add a controlled substance entry' })
+    );
+
+    const form = await canvas.findByRole('form', { name: 'Add controlled substance entry' });
+    const withinForm = within(form);
+    await userEvent.type(withinForm.getByLabelText('Drug name'), 'Buprenorphine');
+    await userEvent.type(withinForm.getByLabelText('Amount drawn'), '2');
+    await userEvent.type(withinForm.getByLabelText('Amount administered'), '2');
+    await userEvent.click(
+      withinForm.getByRole('button', { name: 'Save this controlled substance entry' })
+    );
+
+    // The form closes only once the create actually resolves, so its
+    // disappearance is the proof the POST round-tripped through the adapter.
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole('form', { name: 'Add controlled substance entry' })
+      ).not.toBeInTheDocument()
+    );
+    const table = await findRegisterTable(canvasElement);
+    await expect(table.getByText('Fentanyl citrate')).toBeVisible();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Recording revoked - no Add entry',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', logs: LOGS },
+    revoked: ['controlled-drug-register:record'],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The register itself is still readable...
+    const table = await findRegisterTable(canvasElement);
+    await expect(table.getByText('Fentanyl citrate')).toBeVisible();
+    // ...but the action to append to it is gone, not merely disabled.
+    await expect(
+      canvas.queryByRole('button', { name: 'Add a controlled substance entry' })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.stories.tsx
@@ -1,0 +1,529 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Appointment, Invoice, Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type { StoredCompanion } from '@/app/features/companions/pages/Companions/types';
+import type { BillingSubscription } from '@/app/features/billing/types/billing';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Finance from './index';
+
+const ORG_ID = 'org-storybook-finance';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Willowbrook Animal Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+const appointment = (
+  id: string,
+  companionName: string,
+  parentName: string,
+  typeName: string
+): Appointment => {
+  const patient: Appointment['patient'] = {
+    id: `companion-${id}`,
+    name: companionName,
+    species: 'Dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: parentName },
+  };
+  return {
+    id,
+    organisationId: ORG_ID,
+    patient,
+    companion: patient,
+    appointmentType: { name: typeName },
+    appointmentDate: new Date('2026-08-30T09:30:00.000Z'),
+    startTime: new Date('2026-08-30T09:30:00.000Z'),
+    endTime: new Date('2026-08-30T10:00:00.000Z'),
+    timeSlot: '09:30 AM',
+    durationMinutes: 30,
+    status: 'COMPLETED',
+  };
+};
+
+const APPOINTMENTS: Appointment[] = [
+  appointment('appt-1', 'Biscuit', 'Milo Ferraro', 'Wellness exam'),
+  appointment('appt-2', 'Juniper', 'Ava Lindqvist', 'Dental cleaning'),
+];
+
+const companion = (id: string, name: string, breed: string): StoredCompanion => ({
+  id,
+  organisationId: ORG_ID,
+  parentId: 'parent-otis',
+  name,
+  type: 'dog',
+  breed,
+  dateOfBirth: new Date(2020, 5, 12),
+  gender: 'male',
+  isInsured: false,
+});
+
+/**
+ * `pat-otis` backs the third invoice, which was converted from an estimate and
+ * so carries a bare `patientId` and no `appointmentId` - the row/card renderers
+ * fall back to this store to name it rather than showing "Unlinked invoice".
+ */
+const COMPANIONS: StoredCompanion[] = [companion('pat-otis', 'Otis Kowalczyk', 'Cocker spaniel')];
+
+/**
+ * `paidAt` is `new Date()` at module load rather than a fixed timestamp: the
+ * header's "collected this week" figure is a real 7-day window computed against
+ * the clock at render time (`computeFinanceMetrics(invoices)`, no injected
+ * `now`), so a hardcoded past date would pass today and silently drop out of the
+ * window - and out of the story - after a week.
+ */
+const invoice = (over: Partial<Invoice> = {}): Invoice => ({
+  id: 'inv-storybook-1',
+  organisationId: ORG_ID,
+  items: [{ name: 'Wellness exam', quantity: 1, unitPrice: 210, total: 210 }],
+  subtotal: 210,
+  totalAmount: 210,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'GBP',
+  status: 'PAID',
+  createdAt: new Date('2026-08-30T10:15:00.000Z'),
+  updatedAt: new Date('2026-08-30T10:15:00.000Z'),
+  ...over,
+});
+
+const INVOICES: Invoice[] = [
+  invoice({
+    id: 'inv-paid',
+    appointmentId: 'appt-1',
+    items: [
+      { name: 'Wellness exam', quantity: 1, unitPrice: 210, total: 210 },
+      { name: 'Heartworm test', quantity: 1, unitPrice: 40, total: 40 },
+    ],
+    subtotal: 250,
+    totalAmount: 250,
+    status: 'PAID',
+    paidAt: new Date(),
+  }),
+  invoice({
+    id: 'inv-awaiting',
+    appointmentId: 'appt-2',
+    items: [{ name: 'Dental cleaning', quantity: 1, unitPrice: 180.5, total: 180.5 }],
+    subtotal: 180.5,
+    totalAmount: 180.5,
+    paymentCollectionMethod: 'PAYMENT_LINK',
+    status: 'AWAITING_PAYMENT',
+  }),
+  invoice({
+    id: 'inv-converted',
+    // Converted from an estimate: a patient but no appointment (#comment above).
+    patientId: 'pat-otis',
+    items: [{ name: 'Cruciate repair (TPLO)', quantity: 1, unitPrice: 640, total: 640 }],
+    subtotal: 640,
+    totalAmount: 640,
+    depositCollectedAmount: 100,
+    status: 'PENDING',
+  }),
+];
+
+const SUBSCRIPTION: BillingSubscription = {
+  orgId: ORG_ID,
+  currency: 'GBP',
+  canAcceptPayments: true,
+  connectChargesEnabled: true,
+};
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * These are what let the guards pass on REAL data. The obvious alternative, the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, works only under the dev server: a
+ * production/static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect -
+ * which is exactly how these stories rendered an empty page in the static build
+ * that Chromatic publishes.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * Finance itself makes no request of its own - `useInvoicesForPrimaryOrg` is a
+ * plain store selector - but something in the guarded shell asks for the
+ * subscription/usage endpoints the way Discounts and Estimates observed, so the
+ * adapter answers those defensively and echoes anything else back empty rather
+ * than letting a real request escape the story.
+ */
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+  if (url.includes('/v1/finance/subscriptions/current')) {
+    return Promise.resolve(respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } }));
+  }
+  if (url.includes('/v1/finance/usage-snapshots')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`. The stories satisfy the
+ * guards with real data - an authenticated session, a verified org, an active
+ * membership, a profile past onboarding step 3 and one availability row -
+ * rather than with the `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works
+ * under the dev server: a static build inlines every `process.env.NEXT_PUBLIC_*`
+ * read at build time, so assigning one at runtime changes nothing and the
+ * guards redirect.
+ *
+ * Every org-scoped store OrgGuard's loaders would otherwise reach for is seeded
+ * so each short-circuits on `Object.hasOwn(...ByOrgId, primaryOrgId)` rather
+ * than hitting the network. Invoices, appointments and companions are seeded
+ * for real: Finance reads and renders them directly.
+ */
+const prepare =
+  ({
+    invoices = INVOICES,
+    subscription = SUBSCRIPTION,
+    companions = COMPANIONS,
+    revoked = [],
+  }: {
+    invoices?: Invoice[];
+    subscription?: BillingSubscription;
+    companions?: StoredCompanion[];
+    revoked?: string[];
+  } = {}) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      search: useSearchStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter();
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: { ...OWNER, revokedPermissions: revoked } },
+      status: 'loaded',
+    });
+    useTeamStore.setState({ teamIdsByOrgId: emptyIndex, status: 'loaded' });
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, APPOINTMENTS);
+    useCompanionStore.setState({
+      companionsById: Object.fromEntries(companions.map((row) => [row.id, row])),
+      companionsIdsByOrgId: { [ORG_ID]: companions.map((row) => row.id) },
+      status: 'loaded',
+    });
+    useInvoiceStore.getState().setInvoicesForOrg(ORG_ID, invoices);
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({ subscriptionByOrgId: { [ORG_ID]: subscription } });
+    // The shared search bar writes here; a query left by another story would filter this list.
+    useSearchStore.setState({ query: '' });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useSearchStore.setState(snapshots.search);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+const meta = {
+  title: 'Finance/Finance',
+  component: Finance,
+  parameters: {
+    layout: 'fullscreen',
+    // OrgGuard and ProtectedRoute both read usePathname.
+    nextjs: { appDirectory: true, navigation: { pathname: '/finance' } },
+    docs: {
+      description: {
+        component:
+          'The finance landing page: the invoice ledger, its status filter, the "collected this ' +
+          'week / outstanding" header figures, and the Stripe connection state, in one of two ' +
+          'layouts picked by `useIsPhone` - a responsive table with a phone card list swapped in ' +
+          'below.\n\n' +
+          'Nothing here fetches. `useInvoicesForPrimaryOrg` and `useSubscriptionForPrimaryOrg` are ' +
+          'plain Zustand selectors, so the page renders whatever the store already holds; loading ' +
+          "is someone else's effect. The header total only carries a currency when every invoice " +
+          'agrees on one (`sharedCurrency`) - a mixed-currency org sees the fallback instead of a ' +
+          'total that quietly mislabels itself. An invoice converted from an estimate carries a ' +
+          'bare `patientId` and no appointment, so its row and card fall back to the companion ' +
+          'store to name it rather than reading "Unlinked invoice".\n\n' +
+          'The page sits behind `billing:view:any`; the "Connect Stripe" banner and the Stripe ' +
+          'settings link both need `org:edit` + `subscription:edit:any` on top. The stories lift ' +
+          'the route guards with real data - an authenticated session, a verified org, an active ' +
+          'membership, a profile past onboarding, one availability row - rather than the dev-only ' +
+          'bypass flag, and seed every org-scoped store OrgGuard would otherwise load, including ' +
+          'real invoices, appointments and companions.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare(),
+} satisfies Meta<typeof Finance>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loaded: Story = {
+  name: 'Three invoices across statuses',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: /^Finance/ })).toBeVisible();
+    await expect(canvas.getByText('Finance (3)')).toBeVisible();
+
+    // One PAID invoice paid just now, so the whole of it is "this week".
+    // The other two are unsettled, so their totals (minus any deposit) sum
+    // into "outstanding": £180.50 + (£640 - £100 deposit) = £720.50.
+    await expect(
+      canvas.getByText('£250.00 collected this week · £720.50 outstanding')
+    ).toBeVisible();
+
+    await expect(canvas.getByRole('link', { name: 'View estimates' })).toHaveAttribute(
+      'href',
+      '/finance/estimates'
+    );
+    await expect(canvas.getByRole('link', { name: 'Manage discounts' })).toHaveAttribute(
+      'href',
+      '/finance/discounts'
+    );
+    await expect(canvas.getByRole('link', { name: 'View insurance claims' })).toHaveAttribute(
+      'href',
+      '/finance/insurance-claims'
+    );
+
+    // Charges are enabled and this role can manage Stripe, so the pill is the
+    // settings link rather than the plain "connected" badge.
+    await expect(canvas.getByRole('link', { name: 'Stripe settings' })).toHaveAttribute(
+      'href',
+      `/stripe-onboarding?orgId=${ORG_ID}`
+    );
+    // The banner only shows when payments are NOT yet accepted.
+    await expect(
+      canvas.queryByRole('heading', { name: 'Connect Stripe account' })
+    ).not.toBeInTheDocument();
+
+    await expect(canvas.getByRole('group', { name: 'Filter invoices by status' })).toBeVisible();
+
+    // One row per invoice, named by its own id rather than a shared label.
+    await expect(canvas.getByRole('button', { name: 'View invoice inv-paid' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'View invoice inv-awaiting' })).toBeVisible();
+    // The estimate-converted invoice is named from the companion store fallback.
+    await expect(canvas.getByRole('button', { name: 'View invoice inv-converted' })).toBeVisible();
+    await expect(canvas.getByText('Otis Kowalczyk')).toBeVisible();
+  },
+};
+
+export const ConnectStripeBanner: Story = {
+  name: 'Payments not yet connected',
+  beforeEach: prepare({
+    subscription: { orgId: ORG_ID, currency: 'GBP', canAcceptPayments: false },
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const banner = await canvas.findByRole('link', { name: 'Connect Stripe account' });
+    await expect(banner).toHaveAttribute('href', `/stripe-onboarding?orgId=${ORG_ID}`);
+    await expect(
+      canvas.getByText('Connect Stripe before you start receiving card payments from pet parents.')
+    ).toBeVisible();
+    // Charges are not enabled, so the header pill has nothing to show.
+    await expect(canvas.queryByRole('link', { name: 'Stripe settings' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Stripe · connected')).not.toBeInTheDocument();
+  },
+};
+
+export const NoInvoices: Story = {
+  name: 'No invoices yet',
+  beforeEach: prepare({ invoices: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Finance (0)')).toBeVisible();
+    await expect(canvas.getByText('£0.00 collected this week · £0.00 outstanding')).toBeVisible();
+    // Both table bands render the same empty copy; only one is visible at this
+    // width, but the text itself exists in each.
+    await expect(canvas.getAllByText('No invoices yet').length).toBeGreaterThan(0);
+    await expect(
+      canvas.queryByRole('button', { name: 'View invoice inv-paid' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const StatusFilterPaid: Story = {
+  name: 'Filtering to one status',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('button', { name: 'View invoice inv-paid' });
+
+    const filters = canvas.getByRole('group', { name: 'Filter invoices by status' });
+    await userEvent.click(within(filters).getByRole('button', { name: 'Paid' }));
+
+    await expect(canvas.getByRole('button', { name: 'View invoice inv-paid' })).toBeVisible();
+    await expect(
+      canvas.queryByRole('button', { name: 'View invoice inv-awaiting' })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'View invoice inv-converted' })
+    ).not.toBeInTheDocument();
+    // The header total is unfiltered - it still sums every invoice, not just
+    // the visible rows.
+    await expect(canvas.getByText('Finance (3)')).toBeVisible();
+  },
+};
+
+export const NoBillingAccess: Story = {
+  name: 'Billing view revoked',
+  beforeEach: prepare({ revoked: ['billing:view:any'] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/Your role \(Owner\) can.t view this section\./)
+    ).toBeVisible();
+    await expect(
+      canvas.queryByRole('button', { name: 'View invoice inv-paid' })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('group', { name: 'Filter invoices by status' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: KPI tiles and cards',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Collected · wk')).toBeVisible();
+    await expect(canvas.getByText('£250.00')).toBeVisible();
+    await expect(canvas.getByText('Outstanding')).toBeVisible();
+    await expect(canvas.getByText('£720.50')).toBeVisible();
+
+    // The desktop nav row's Estimates/Discounts/Insurance links have a phone
+    // equivalent up top; without it there is no route to /finance/estimates
+    // anywhere in the app on a phone.
+    await expect(canvas.getByRole('link', { name: 'View estimates' })).toHaveAttribute(
+      'href',
+      '/finance/estimates'
+    );
+
+    await expect(canvas.getByRole('button', { name: 'View invoice inv-paid' })).toBeVisible();
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.stories.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.stories.tsx
@@ -1,0 +1,732 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type {
+  CensusEntry,
+  LabOrder,
+  LabResult,
+  OrgIntegration,
+} from '@/app/features/integrations/services/types';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import IdexxWorkspace from './index';
+
+const ORG_ID = 'org-storybook-idexx';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * These are what let the guards pass on REAL data. The obvious alternative, the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, works only under the dev server: a
+ * production/static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect -
+ * which is exactly how these stories rendered an empty page in the static build
+ * that Chromatic publishes.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+/** Enabled, valid credentials - the state that renders the workspace instead of `NotConnectedState`. */
+const IDEXX_INTEGRATION: OrgIntegration = {
+  id: 'integration-idexx',
+  organisationId: ORG_ID,
+  provider: 'IDEXX',
+  status: 'enabled',
+  credentialsStatus: 'valid',
+  lastValidatedAt: '2026-09-08T10:00:00.000Z',
+  enabledAt: '2026-06-01T09:00:00.000Z',
+  lastSyncAt: '2026-09-09T07:58:00.000Z',
+};
+
+const IDEXX_INTEGRATION_DISABLED: OrgIntegration = {
+  ...IDEXX_INTEGRATION,
+  status: 'disabled',
+  credentialsStatus: 'missing',
+  enabledAt: null,
+  lastSyncAt: null,
+};
+
+/**
+ * One order, matched to Bramble's result below by `idexxOrderId` <-> `orderId`.
+ * That match is what the page reads `appointmentId` through to render the
+ * "Open appointment labs" link - it has no appointment id of its own.
+ */
+const ORDERS: LabOrder[] = [
+  {
+    _id: 'order-1001',
+    organisationId: ORG_ID,
+    provider: 'IDEXX',
+    companionId: 'pat-bramble',
+    appointmentId: 'appt-5041',
+    patientName: 'Bramble Fitzgerald',
+    status: 'Complete',
+    modality: 'REFLAB',
+    idexxOrderId: 'IDX-1001',
+    uiUrl: null,
+    pdfUrl: null,
+    tests: ['CHEM17', 'CBC'],
+    veterinarian: 'Dr. Weber',
+    createdAt: '2026-09-08T08:00:00.000Z',
+    updatedAt: '2026-09-09T07:40:00.000Z',
+  },
+];
+
+/** Three results spanning the three status tones the table draws: success, progress, danger. */
+const RESULTS: LabResult[] = [
+  {
+    _id: 'res-1',
+    provider: 'IDEXX',
+    resultId: 'RES-9001',
+    orderId: 'IDX-1001',
+    requisitionId: 'REQ-9001',
+    clientId: 'client-1',
+    clientFirstName: 'Harriet',
+    clientLastName: 'Fitzgerald',
+    patientId: 'pat-bramble',
+    patientName: 'Bramble Fitzgerald',
+    modality: 'REFLAB',
+    status: 'Final',
+    statusDetail: null,
+    accessionId: 'ACC-30045',
+    createdAt: '2026-09-08T08:10:00.000Z',
+    updatedAt: '2026-09-09T07:42:00.000Z',
+    rawPayload: {
+      categories: [
+        {
+          name: 'Chemistry 17 panel',
+          tests: [
+            {
+              name: 'ALT',
+              result: '412',
+              units: 'U/L',
+              referenceRange: '10-100',
+              outOfRange: true,
+            },
+            {
+              name: 'Glucose',
+              result: '92',
+              units: 'mg/dL',
+              referenceRange: '70-120',
+              outOfRange: false,
+            },
+          ],
+        },
+      ],
+      runSummaries: [{ id: 'run-1', code: 'CHEM17', name: 'Chemistry 17 panel' }],
+    },
+  },
+  {
+    _id: 'res-2',
+    provider: 'IDEXX',
+    resultId: 'RES-9002',
+    orderId: 'IDX-1002',
+    requisitionId: 'REQ-9002',
+    clientId: 'client-2',
+    clientFirstName: 'Priya',
+    clientLastName: 'Delacroix',
+    patientId: 'pat-saffron',
+    patientName: 'Saffron Delacroix',
+    modality: 'INHOUSE',
+    status: 'Running',
+    statusDetail: 'Analyzer in progress',
+    accessionId: 'ACC-30046',
+    createdAt: '2026-09-09T07:10:00.000Z',
+    updatedAt: '2026-09-09T07:15:00.000Z',
+    rawPayload: { categories: [], runSummaries: [] },
+  },
+  {
+    _id: 'res-3',
+    provider: 'IDEXX',
+    resultId: 'RES-9003',
+    orderId: 'IDX-1003',
+    requisitionId: 'REQ-9003',
+    clientId: 'client-3',
+    clientFirstName: 'Dominic',
+    clientLastName: 'Marchetti',
+    patientId: 'pat-otis',
+    patientName: 'Otis Marchetti',
+    modality: 'REFLAB',
+    status: 'Cancelled',
+    statusDetail: 'Insufficient sample volume',
+    accessionId: 'ACC-30047',
+    createdAt: '2026-09-08T06:00:00.000Z',
+    updatedAt: '2026-09-08T09:20:00.000Z',
+    rawPayload: { categories: [], runSummaries: [] },
+  },
+];
+
+/** Patient ids line up with the results above, so the census strip and the IVLS Device ID column agree. */
+const CENSUS: CensusEntry[] = [
+  {
+    id: 1,
+    patient: {
+      patientId: 'pat-bramble',
+      name: 'Bramble Fitzgerald',
+      speciesCode: 'CANINE',
+      client: { firstName: 'Harriet', lastName: 'Fitzgerald' },
+    },
+    veterinarian: 'Dr. Weber',
+    ivls: [{ serialNumber: 'VETLAB-771', displayName: 'VetLab UA' }],
+    confirmed: true,
+  },
+  {
+    id: 2,
+    patient: {
+      patientId: 'pat-saffron',
+      name: 'Saffron Delacroix',
+      speciesCode: 'FELINE',
+      client: { firstName: 'Priya', lastName: 'Delacroix' },
+    },
+    veterinarian: 'Dr. Osei',
+    ivls: [],
+    confirmed: false,
+  },
+  {
+    id: 3,
+    patient: {
+      patientId: 'pat-otis',
+      name: 'Otis Marchetti',
+      speciesCode: 'CANINE',
+      client: { firstName: 'Dominic', lastName: 'Marchetti' },
+    },
+    veterinarian: 'Dr. Weber',
+    ivls: [{ serialNumber: 'CATALYST-118', displayName: 'Catalyst One' }],
+    confirmed: true,
+  },
+];
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+const rejection = (config: InternalAxiosRequestConfig, message: string, status = 503) =>
+  Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    config,
+    response: {
+      status,
+      statusText: status === 404 ? 'Not Found' : 'Service Unavailable',
+      data: { message },
+      headers: {},
+      config,
+    },
+  });
+
+type RefreshFixture =
+  | { kind: 'resolves'; results: LabResult[]; census: CensusEntry[]; orders: LabOrder[] }
+  /** Held open on purpose: the only way to hold the syncing skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects'; message: string };
+
+const pathOf = (config: InternalAxiosRequestConfig): string =>
+  new URL(String(config.url ?? ''), 'https://yosemite.local').pathname.toLowerCase();
+
+/**
+ * The page's own `refresh()` fires three parallel calls on mount - results,
+ * census, and an order search - and this fixture answers all three together, so
+ * a story can put them in one shared state (loaded / stuck loading / failed)
+ * with a single fixture value. The order-by-id, result-by-id, and PDF endpoints
+ * a story's play() reaches on demand (order lookup, "Review") always answer
+ * from the fixed ORDERS/RESULTS fixtures above instead, since only the
+ * "resolves" stories ever click into them.
+ */
+const buildAdapter =
+  (fixture: RefreshFixture): AxiosAdapter =>
+  (config: InternalAxiosRequestConfig) => {
+    const path = pathOf(config);
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (path.endsWith('/idexx/orders/search') && method === 'post') {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') return Promise.reject(rejection(config, fixture.message));
+      return Promise.resolve(respond(config, fixture.orders));
+    }
+    if (path.includes('/idexx/orders/')) {
+      const orderId = path.split('/').filter(Boolean).pop() ?? '';
+      const match = ORDERS.find((order) => order.idexxOrderId.toLowerCase() === orderId);
+      return match
+        ? Promise.resolve(respond(config, match))
+        : Promise.reject(rejection(config, 'Order not found.', 404));
+    }
+    if (path.endsWith('/idexx/census')) {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') return Promise.reject(rejection(config, fixture.message));
+      return Promise.resolve(respond(config, fixture.census));
+    }
+    if (path.endsWith('/pdf')) {
+      return Promise.resolve({
+        data: new Blob(['%PDF-1.4 fake IDEXX result'], { type: 'application/pdf' }),
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      });
+    }
+    if (path.endsWith('/idexx/results')) {
+      if (fixture.kind === 'pending') return new Promise<never>(() => {});
+      if (fixture.kind === 'rejects') return Promise.reject(rejection(config, fixture.message));
+      return Promise.resolve(respond(config, fixture.results));
+    }
+    if (path.includes('/idexx/results/')) {
+      const resultId = path.split('/').filter(Boolean).pop() ?? '';
+      const match = RESULTS.find((result) => result.resultId.toLowerCase() === resultId);
+      return match
+        ? Promise.resolve(respond(config, match))
+        : Promise.reject(rejection(config, 'Result not found.', 404));
+    }
+    if (path.includes('/v1/integration/pms/organisation')) {
+      return Promise.resolve(respond(config, [IDEXX_INTEGRATION]));
+    }
+    if (path.includes('/v1/finance/subscriptions/current')) {
+      return Promise.resolve(
+        respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } })
+      );
+    }
+    if (path.includes('/v1/finance/usage-snapshots')) {
+      return Promise.resolve(respond(config, { data: [] }));
+    }
+    return Promise.resolve(respond(config, []));
+  };
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`. The stories satisfy the guards with real
+ * data - an authenticated session, a verified org, an active membership, a
+ * profile past onboarding step 3 and one availability row - rather than with the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works under the dev server:
+ * a static build inlines every `process.env.NEXT_PUBLIC_*` read at build time, so
+ * assigning one at runtime changes nothing and the guards redirect.
+ *
+ * Every org-scoped store OrgGuard loads is seeded with an entry for this org so
+ * it short-circuits rather than reaching the network - `useIntegrationStore` is
+ * the one exception: it is seeded for real, because IdexxWorkspace itself reads
+ * it through `useIntegrationByProviderForPrimaryOrg('IDEXX')` to choose between
+ * the workspace and `NotConnectedState`.
+ */
+const prepare =
+  ({
+    fixture,
+    integration = IDEXX_INTEGRATION,
+  }: {
+    fixture: RefreshFixture;
+    integration?: OrgIntegration | null;
+  }) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      search: useSearchStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter(fixture);
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: OWNER },
+      status: 'loaded',
+    });
+    useTeamStore.setState({ teamIdsByOrgId: emptyIndex, status: 'loaded' });
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({
+      integrationIdsByOrgId: { [ORG_ID]: integration ? [integration.id as string] : [] },
+      integrationsById: integration ? { [integration.id as string]: integration } : {},
+      status: 'loaded',
+    });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: emptyIndex,
+      appointmentsById: {},
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {},
+      companionsIdsByOrgId: emptyIndex,
+      status: 'loaded',
+    });
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: { [ORG_ID]: { orgId: ORG_ID, currency: 'GBP' } },
+    });
+    // The shared header search box writes here; a query left by another story
+    // would filter the results list this page reads it against.
+    useSearchStore.setState({ query: '' });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useSearchStore.setState(snapshots.search);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+/**
+ * A refused read/write is logged by the axios wrapper on its way to the hook's
+ * catch (`API getData error:` for the two GETs, `API postData error:` for the
+ * order search POST), and the render check treats a console error as a broken
+ * story. Only those two lines are dropped; anything else still reaches the
+ * console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some(
+        (arg) =>
+          typeof arg === 'string' &&
+          (arg.includes('API getData error') || arg.includes('API postData error'))
+      );
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'Integrations/IdexxWorkspace',
+  component: IdexxWorkspace,
+  parameters: {
+    layout: 'fullscreen',
+    // Both guards read usePathname; this is the real route the page is mounted at.
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments/idexx-workspace' } },
+    docs: {
+      description: {
+        component:
+          "The IDEXX Hub workspace: today's patient census, the lab-results table with " +
+          'modality and awaiting-review filters, an order-lookup accordion, and the result ' +
+          'detail drawer with its per-test reference-range meter. It fires three IDEXX reads in ' +
+          'parallel on mount and every 30s while auto-refresh stays on, and picks between three ' +
+          'whole-page shapes on its own rather than by prop: `NotConnectedState` when the org has ' +
+          'no enabled IDEXX integration, a syncing skeleton while the first fetch is still in ' +
+          'flight, and the workspace once data lands.\n\n' +
+          'There is no acknowledgement state for a result yet - the API is read-only and carries ' +
+          'none - so "awaiting review" is derived purely from completion: every completed ' +
+          'result stays in the queue rather than risking a client-side ack that one vet sees ' +
+          'clear while a colleague still sees it queued. A row\'s "Open appointment labs" link ' +
+          "only appears when that result's order id is also present among the fetched orders - " +
+          'labs are appointment-scoped and this page has no appointment id of its own to link ' +
+          'with otherwise.\n\n' +
+          'The stories satisfy `ProtectedRoute` + `OrgGuard` with real data - an authenticated ' +
+          'session, a verified org, an owner membership, a profile past onboarding step 3 and one ' +
+          'availability row - seed every org-scoped store the guard would otherwise load, and ' +
+          'answer the IDEXX endpoints from the shared axios adapter. A separate story file, ' +
+          '`IdexxWorkspace states`, exercises `NotConnectedState` and the syncing skeleton in ' +
+          'isolation at pixel level; the stories here instead prove the real page - guards, ' +
+          'stores and all - picks between them correctly.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', results: RESULTS, census: CENSUS, orders: ORDERS },
+  }),
+} satisfies Meta<typeof IdexxWorkspace>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Connected workspace',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /IDEXX diagnostics/ })
+    ).toBeVisible();
+    // One completed result (Bramble's), so the subtitle carries a live count.
+    await expect(await canvas.findByText('1 results awaiting review')).toBeVisible();
+
+    const censusSection = canvas.getByRole('region', { name: 'Census overview' });
+    await expect(within(censusSection).getByText('Bramble Fitzgerald')).toBeVisible();
+    await expect(within(censusSection).getByText('Saffron Delacroix')).toBeVisible();
+    await expect(within(censusSection).getByText('3 results')).toBeVisible();
+    await expect(within(censusSection).getByText('across 3 patients today')).toBeVisible();
+
+    /* Scoped to the desktop table on purpose: the same row also renders inside
+       the tablet-pruned table and the phone card list, all three permanently in
+       the DOM and swapped by breakpoint CSS rather than by conditional render -
+       an unscoped getByText would fail on "multiple elements" at any width. */
+    const table = canvas.getByRole('table');
+    await expect(within(table).getByText('Bramble Fitzgerald')).toBeVisible();
+    await expect(within(table).getByText('ACC-30046')).toBeVisible();
+    await expect(within(table).getByText('Cancelled')).toBeVisible();
+    // The completed result gets "Review"; the other two get "Details".
+    await expect(within(table).getByRole('button', { name: 'Review' })).toBeEnabled();
+    await expect(within(table).getAllByRole('button', { name: 'Details' })).toHaveLength(2);
+    // Resolved through the fetched order, not carried on the result itself.
+    await expect(
+      within(table).getByRole('link', { name: 'Open appointment labs for result RES-9001' })
+    ).toHaveAttribute(
+      'href',
+      '/appointments?appointmentId=appt-5041&open=labs&subLabel=idexx-labs'
+    );
+
+    // Both accordions default open: patient census and order lookup.
+    await expect(canvas.getByRole('button', { name: 'Patient census' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(canvas.getByLabelText('IDEXX order ID')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Lookup order' })).toBeDisabled();
+  },
+};
+
+export const ResultDetailOpened: Story = {
+  name: 'Reviewing a result opens its detail',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const table = await canvas.findByRole('table');
+    await userEvent.click(within(table).getByRole('button', { name: 'Review' }));
+
+    await waitFor(() => {
+      expect(canvasElement.ownerDocument.body.querySelector('dialog[open]')).not.toBeNull();
+    });
+    const dialog = canvasElement.ownerDocument.body.querySelector('dialog[open]') as HTMLElement;
+    const modal = within(dialog);
+
+    // Title is the accession id, not the internal result id.
+    await expect(modal.getByText('ACC-30045')).toBeVisible();
+    // Loaded via getIdexxResultById, not read off the row that opened it.
+    await expect(await modal.findByText('ALT')).toBeVisible();
+    await expect(modal.getByText('412 U/L')).toBeVisible();
+    await expect(modal.getByText('10-100')).toBeVisible();
+    await expect(
+      modal.getByRole('link', { name: 'Open appointment labs for result RES-9001' })
+    ).toHaveAttribute(
+      'href',
+      '/appointments?appointmentId=appt-5041&open=labs&subLabel=idexx-labs'
+    );
+    await expect(modal.getByRole('button', { name: 'Open in appointment labs' })).toBeEnabled();
+    await expect(modal.getByRole('button', { name: 'Open results PDF' })).toBeEnabled();
+  },
+};
+
+export const FiltersNarrowResults: Story = {
+  name: 'Modality and awaiting-review filters narrow the table',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const table = await canvas.findByRole('table');
+    await expect(within(table).getByText('Bramble Fitzgerald')).toBeVisible();
+    await expect(within(table).getByText('Saffron Delacroix')).toBeVisible();
+    await expect(within(table).getByText('Otis Marchetti')).toBeVisible();
+
+    // "Reference Lab" keeps the two REFLAB results and drops the in-house one.
+    await userEvent.click(canvas.getByRole('button', { name: 'Reference Lab' }));
+    await waitFor(() =>
+      expect(within(table).queryByText('Saffron Delacroix')).not.toBeInTheDocument()
+    );
+    await expect(within(table).getByText('Bramble Fitzgerald')).toBeVisible();
+    await expect(within(table).getByText('Otis Marchetti')).toBeVisible();
+
+    // "Awaiting review" narrows further to the one completed result.
+    await userEvent.click(canvas.getByRole('button', { name: 'Awaiting review' }));
+    await waitFor(() =>
+      expect(within(table).queryByText('Otis Marchetti')).not.toBeInTheDocument()
+    );
+    await expect(within(table).getByText('Bramble Fitzgerald')).toBeVisible();
+  },
+};
+
+export const NotConnected: Story = {
+  name: 'No enabled IDEXX integration',
+  beforeEach: prepare({
+    fixture: { kind: 'resolves', results: [], census: [], orders: [] },
+    integration: IDEXX_INTEGRATION_DISABLED,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("IDEXX isn't connected yet")).toBeVisible();
+    await expect(
+      canvas.getByRole('link', { name: 'Enable IDEXX in Integrations' })
+    ).toHaveAttribute('href', '/integrations');
+    await expect(
+      canvas.getByText(
+        'IDEXX integration availability is currently limited to the USA, Canada, and the UK.'
+      )
+    ).toBeVisible();
+    // Not the results table - nothing was ever fetched for a disabled integration.
+    await expect(canvas.queryByRole('table')).not.toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Syncing on first load',
+  beforeEach: prepare({ fixture: { kind: 'pending' } }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /IDEXX diagnostics/ })
+    ).toBeVisible();
+    await expect(await canvas.findByText('Syncing with IDEXX…')).toBeVisible();
+    // The skeleton replaces the table entirely while nothing has landed yet.
+    await expect(canvas.queryByRole('table')).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: Story = {
+  name: 'Refresh failed',
+  beforeEach: [
+    prepare({
+      fixture: {
+        kind: 'rejects',
+        message: 'IDEXX Reference Lab service is temporarily unavailable.',
+      },
+    }),
+    muteExpectedFailureLogs,
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    // The server's own wording, through the shared error-message helper.
+    await expect(alert).toHaveTextContent(
+      'Unable to load IDEXX Hub data. (503): IDEXX Reference Lab service is temporarily unavailable.'
+    );
+    // The integration is still enabled, so this is the empty workspace, not the not-connected card.
+    await expect(canvas.queryByText("IDEXX isn't connected yet")).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: cards replace the table',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /IDEXX diagnostics/ })
+    ).toBeVisible();
+    // The table is desktop/tablet only; a phone gets a stacked card per result.
+    await expect(canvas.queryByRole('table')).not.toBeInTheDocument();
+
+    const reviewButton = await canvas.findByRole('button', { name: 'Review' });
+    const card = reviewButton.closest('[class*="rounded-2xl"]') as HTMLElement;
+    await expect(within(card).getByText('ACC-30045')).toBeVisible();
+    await expect(within(card).getByText('Bramble Fitzgerald')).toBeVisible();
+
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};

--- a/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryAlerts/InventoryAlertsPanel.stories.tsx
@@ -1,0 +1,268 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type {
+  ExpiringAlertBatch,
+  LowStockAlertItem,
+} from '@/app/features/inventory/services/inventoryAlertsService';
+import InventoryAlertsPanel from './InventoryAlertsPanel';
+
+const ORG_ID = 'org-storybook-inventory';
+const DAY_MS = 86_400_000;
+
+/** Offsets from "now" rather than fixed dates, so the relative-day labels
+ *  ("in 3 days", "2 days ago") stay correct no matter when this renders. */
+const isoDaysFromNow = (days: number): string => new Date(Date.now() + days * DAY_MS).toISOString();
+
+const LOW_STOCK_ITEMS: LowStockAlertItem[] = [
+  {
+    id: 'item-flea-guard',
+    name: 'FleaGuard Chewables 20mg',
+    onHand: 0,
+    reorderLevel: 15,
+    unitOfMeasure: 'tablets',
+    category: 'Parasiticides',
+    sku: 'FG-20-CHEW',
+  },
+  {
+    id: 'item-amoxicillin',
+    name: 'Amoxicillin 250mg',
+    onHand: 8,
+    reorderLevel: 20,
+    unitOfMeasure: 'capsules',
+    category: 'Antibiotics',
+    sku: 'AMX-250',
+  },
+  {
+    id: 'item-iv-fluid',
+    name: 'Lactated Ringer IV Fluid 1L',
+    onHand: 3,
+    reorderLevel: 10,
+    unitOfMeasure: 'bags',
+    category: 'Fluids',
+    sku: 'LRS-1L',
+  },
+  {
+    id: 'item-suture',
+    name: 'Absorbable Suture 3-0',
+    onHand: 12,
+    reorderLevel: 25,
+    category: 'Surgical',
+    sku: 'SUT-30',
+  },
+];
+
+const EXPIRING_BATCHES: ExpiringAlertBatch[] = [
+  {
+    id: 'batch-rabies',
+    itemId: 'item-rabies-vaccine',
+    batchNumber: 'RB-2024-118',
+    expiryDate: isoDaysFromNow(-2),
+    quantity: 6,
+    inventoryItem: { name: 'Rabies Vaccine 1mL' },
+  },
+  {
+    id: 'batch-heartworm',
+    itemId: 'item-heartworm',
+    batchNumber: 'HW-0592',
+    expiryDate: isoDaysFromNow(3),
+    quantity: 40,
+    inventoryItem: { name: 'Heartworm Preventative Chews' },
+  },
+  {
+    // The current handler doesn't include the item relation on every batch,
+    // and expiryDate itself can be unset - both fall back gracefully.
+    id: 'batch-suture-lot',
+    itemId: 'item-suture',
+    batchNumber: 'SUT-3092',
+    expiryDate: null,
+    quantity: 15,
+    inventoryItem: null,
+  },
+];
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+type AlertsFixture =
+  | { kind: 'resolves'; lowStock: LowStockAlertItem[]; expiring: ExpiringAlertBatch[] }
+  /** Held open on purpose: the only way to hold the loading skeleton still. */
+  | { kind: 'pending' }
+  | { kind: 'rejects' };
+
+/**
+ * The panel fetches through `fetchLowStockAlerts` / `fetchExpiringAlerts`, both of
+ * which route through the shared axios instance, so the adapter is the seam. Both
+ * calls resolve, hang, or reject together per fixture - the panel doesn't
+ * distinguish which endpoint failed, it always shows one generic error.
+ */
+const buildAdapter =
+  (fixture: AlertsFixture): AxiosAdapter =>
+  (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+
+    if (fixture.kind === 'pending') return new Promise<never>(() => {});
+    if (fixture.kind === 'rejects') {
+      return Promise.reject(
+        Object.assign(new Error('Request failed with status code 500'), {
+          isAxiosError: true,
+          config,
+          response: {
+            status: 500,
+            statusText: 'Internal Server Error',
+            data: { message: 'Inventory alerts are temporarily unavailable.' },
+            headers: {},
+            config,
+          },
+        })
+      );
+    }
+
+    if (url.includes('/alerts/low-stock'))
+      return Promise.resolve(respond(config, fixture.lowStock));
+    if (url.includes('/alerts/expiring')) return Promise.resolve(respond(config, fixture.expiring));
+    return Promise.resolve(respond(config, []));
+  };
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+const prepare = (fixture: AlertsFixture) => () => {
+  clearInFlightGetRequests();
+  api.defaults.adapter = buildAdapter(fixture);
+
+  return () => {
+    api.defaults.adapter = REAL_ADAPTER;
+    clearInFlightGetRequests();
+  };
+};
+
+/**
+ * A refused fetch is logged by the axios wrapper on its way to the panel's catch,
+ * and the render check treats a console error as a broken story. Only that
+ * line is dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some((arg) => typeof arg === 'string' && arg.includes('API getData error'));
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+const meta = {
+  title: 'Inventory/InventoryAlertsPanel',
+  component: InventoryAlertsPanel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Data container for `InventoryAlerts`: it loads low-stock and expiring-batch alerts ' +
+          'for an organisation in parallel and hands the presentational component the arrays ' +
+          'plus loading/error - fetching lives here, rendering lives in `InventoryAlerts`.\n\n' +
+          'A missing `organisationId` is treated as "nothing to show" rather than an error - ' +
+          'both lists are cleared and the fetch is skipped entirely, which is how the panel ' +
+          'behaves before an org is selected. A failed fetch (either call) replaces both lists ' +
+          'with one generic error banner rather than surfacing which endpoint failed. The ' +
+          'effect re-runs whenever `organisationId` or `expiringWindowDays` changes, and guards ' +
+          'against setting state after the org switches or the panel unmounts mid-flight.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    organisationId: ORG_ID,
+    expiringWindowDays: 30,
+    onViewLowStock: fn(),
+    onViewExpiring: fn(),
+  },
+  argTypes: {
+    organisationId: { control: 'text' },
+    expiringWindowDays: { control: 'number' },
+  },
+  beforeEach: prepare({ kind: 'resolves', lowStock: LOW_STOCK_ITEMS, expiring: EXPIRING_BATCHES }),
+} satisfies Meta<typeof InventoryAlertsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Low stock and expiring items',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('FleaGuard Chewables 20mg')).toBeVisible();
+    await expect(canvas.getByText('Out of stock')).toBeVisible();
+    await expect(canvas.getByText('Rabies Vaccine 1mL')).toBeVisible();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    // Four low-stock items, three expiring batches - the counts stay distinct
+    // on the "View all" buttons even though only the first three rows render.
+    await expect(canvas.getByRole('button', { name: 'View all 4 in catalog' })).toBeEnabled();
+    await userEvent.click(canvas.getByRole('button', { name: 'View all 3 in catalog' }));
+    await expect(args.onViewExpiring).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const Empty: Story = {
+  name: 'No alerts',
+  beforeEach: prepare({ kind: 'resolves', lowStock: [], expiring: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('No low-stock items')).toBeVisible();
+    await expect(canvas.getByText('Nothing expiring in the next 30 days')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading alerts',
+  beforeEach: prepare({ kind: 'pending' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Low stock')).toBeVisible();
+    await expect(canvas.getByText('Expiring soon')).toBeVisible();
+    // The skeleton rows are the loading tell: both lists render one, hidden from
+    // the accessibility tree, in place of real rows or the empty-state copy.
+    await waitFor(() =>
+      expect(canvasElement.querySelectorAll('ul[aria-hidden="true"]').length).toBe(2)
+    );
+    await expect(canvas.queryByText('No low-stock items')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+  },
+};
+
+export const FetchFailed: Story = {
+  name: 'Fetch failed',
+  beforeEach: [prepare({ kind: 'rejects' }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Unable to load inventory alerts right now.');
+    // Both lists clear rather than showing stale or partial data.
+    await expect(canvas.getByText('No low-stock items')).toBeVisible();
+    await expect(canvas.getByText('Nothing expiring in the next 30 days')).toBeVisible();
+  },
+};
+
+export const NoOrganisation: Story = {
+  name: 'No organisation selected',
+  args: { organisationId: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Skips the fetch entirely rather than requesting alerts for no organisation.
+    await expect(canvas.getByText('No low-stock items')).toBeVisible();
+    await expect(canvas.getByText('Nothing expiring in the next 30 days')).toBeVisible();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.stories.tsx
@@ -1,0 +1,566 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type {
+  DispenseRequestApi,
+  DispenseRequestStatus,
+} from '@/app/features/inventory/services/dispensaryService';
+import type {
+  InventoryItem,
+  InventoryTurnoverItem,
+} from '@/app/features/inventory/pages/Inventory/types';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Inventory from './index';
+
+const ORG_ID = 'org-storybook-inventory';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+/** Builds a realistic HOSPITAL catalog row. `stockHealth` is set explicitly
+ * rather than left to derive from stock/expiry math - `displayStatusLabel`
+ * reads the explicit value first, so this is what the table, the card and the
+ * subtitle counts actually key off. */
+const buildItem = (
+  id: string,
+  name: string,
+  overrides: Partial<InventoryItem> = {}
+): InventoryItem => ({
+  id,
+  organisationId: ORG_ID,
+  businessType: 'HOSPITAL',
+  currency: 'GBP',
+  status: 'ACTIVE',
+  stockHealth: 'HEALTHY',
+  sku: `SKU-${id}`,
+  basicInfo: {
+    name,
+    category: 'Medicine',
+    subCategory: 'Antibiotic',
+    department: 'Pharmacy',
+    description: '',
+    status: 'Active',
+    visibleInInventory: true,
+  },
+  classification: {},
+  pricing: { purchaseCost: '8', selling: '14' },
+  vendor: {
+    supplierName: 'VetSupply Co',
+    brand: '',
+    vendor: 'VetSupply Co',
+    license: '',
+    paymentTerms: 'Net 30',
+  },
+  stock: {
+    current: '120',
+    allocated: '10',
+    available: '110',
+    reorderLevel: '20',
+    reorderQuantity: '50',
+    stockLocation: 'Pharmacy',
+    abcClass: 'Class A',
+  },
+  batch: {
+    batch: 'B-2026-01',
+    manufactureDate: '2026-01-01',
+    expiryDate: '2027-01-01',
+  },
+  ...overrides,
+});
+
+const CATALOG_ITEMS: InventoryItem[] = [
+  buildItem('item-amoxicillin', 'Amoxicillin 250mg'),
+  buildItem('item-gauze', 'Surgical gauze pads', {
+    stockHealth: 'LOW_STOCK',
+    basicInfo: {
+      name: 'Surgical gauze pads',
+      category: 'Surgical supply',
+      subCategory: 'Suture',
+      department: 'Pharmacy',
+      description: '',
+      status: 'Active',
+      visibleInInventory: true,
+    },
+    stock: {
+      current: '15',
+      allocated: '5',
+      available: '10',
+      reorderLevel: '20',
+      reorderQuantity: '40',
+      stockLocation: 'Surgery',
+      abcClass: 'Class B',
+    },
+  }),
+  buildItem('item-rabies', 'Rabies vaccine', {
+    stockHealth: 'EXPIRED',
+    basicInfo: {
+      name: 'Rabies vaccine',
+      category: 'Vaccine',
+      subCategory: 'Rabies',
+      department: 'Pharmacy',
+      description: '',
+      status: 'Active',
+      visibleInInventory: true,
+    },
+    batch: {
+      batch: 'B-2025-04',
+      manufactureDate: '2024-10-01',
+      expiryDate: '2025-01-01',
+    },
+  }),
+];
+
+const TURNOVER_ITEMS: InventoryTurnoverItem[] = [];
+
+const buildDispenseRequest = (
+  id: string,
+  status: DispenseRequestStatus,
+  overrides: Partial<DispenseRequestApi> = {}
+): DispenseRequestApi => ({
+  id,
+  prescriptionId: `rx-${id}`,
+  organisationId: ORG_ID,
+  status,
+  medications: [
+    {
+      inventoryItemId: 'item-amoxicillin',
+      inventoryItemName: 'Amoxicillin 250mg',
+      quantity: 2,
+      priceCents: 1400,
+      fulfillment: 'PATIENT',
+    },
+  ],
+  metadata: null,
+  patientName: 'Biscuit',
+  parentName: 'Jamie Okafor',
+  petBreed: 'Beagle',
+  petAge: '4y',
+  patientImageUrl: null,
+  leadName: 'Dr. Weber',
+  location: 'Pharmacy',
+  invoiceId: null,
+  paymentStatus: null,
+  currency: 'GBP',
+  requestedBy: 'vet-weber',
+  reviewedBy: null,
+  requestedAt: '2026-09-08T09:00:00.000Z',
+  reviewedAt: null,
+  createdAt: '2026-09-08T09:00:00.000Z',
+  updatedAt: '2026-09-08T09:00:00.000Z',
+  prescription: {
+    id: `rx-${id}`,
+    artifactId: `artifact-${id}`,
+    artifact: {
+      id: `artifact-${id}`,
+      kind: 'PRESCRIPTION',
+      status: 'ACTIVE',
+      appointmentId: 'appt-1',
+      summary: 'Amoxicillin course',
+    },
+  },
+  ...overrides,
+});
+
+const DISPENSE_REQUESTS: DispenseRequestApi[] = [
+  buildDispenseRequest('req-1', 'PENDING'),
+  buildDispenseRequest('req-2', 'DISPENSED', {
+    patientName: 'Whiskers',
+    parentName: 'Alex Chen',
+    petBreed: 'Domestic shorthair',
+    petAge: '2y',
+    reviewedAt: '2026-09-08T10:15:00.000Z',
+    medications: [
+      {
+        inventoryItemId: 'item-gauze',
+        inventoryItemName: 'Surgical gauze pads',
+        quantity: 1,
+        priceCents: 500,
+        fulfillment: 'IN_HOUSE',
+      },
+    ],
+  }),
+];
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * Everything the CATALOG itself shows comes straight out of `useInventoryStore`
+ * (each story seeds `itemsById`/`itemIdsByOrgId`/`statusByOrgId` directly, the
+ * same way the real store looks once `useInventoryModule` has loaded it), so the
+ * adapter only has to answer the calls the page makes on top of that: the
+ * dispensary request list, the low-stock/expiring alert panel, and the two
+ * calls OrgGuard's subscription loader makes. Nothing else should reach the
+ * network; the catch-all below keeps any stray call from throwing instead of
+ * silently doing nothing.
+ */
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+
+  if (url.includes('/prescription-dispense-requests')) {
+    return Promise.resolve(respond(config, DISPENSE_REQUESTS));
+  }
+  if (url.includes('/alerts/low-stock') || url.includes('/alerts/expiring')) {
+    return Promise.resolve(respond(config, []));
+  }
+  if (url.includes('/v1/finance/subscriptions/current')) {
+    return Promise.resolve(respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } }));
+  }
+  if (url.includes('/v1/finance/usage-snapshots')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+type InventoryFixture = {
+  items?: InventoryItem[];
+  inventoryStatus?: 'loaded' | 'loading' | 'error';
+  inventoryError?: string | null;
+};
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`, and `OrgGuard` itself
+ * calls `useInventoryModule` and ten other org-scoped loaders regardless of
+ * which page it wraps - so every store those loaders touch is seeded here with
+ * real data (an authenticated session, a verified org, an active OWNER
+ * membership, a profile past onboarding step 3, one availability row, and an
+ * empty index for every org-scoped list) rather than with the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works under the dev
+ * server: a static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect.
+ *
+ * The catalog itself is seeded straight into `useInventoryStore` with
+ * `lastFetchedByOrgId` already set, so `useInventoryModule`'s own effect sees
+ * data as already loaded and never reaches for the network - the same state the
+ * real store is in after a normal load. Dispensary records are different: the
+ * page fetches them itself into local state on every mount, so those come from
+ * the axios adapter instead.
+ */
+const prepare =
+  (fixture: InventoryFixture = {}) =>
+  () => {
+    const { items = CATALOG_ITEMS, inventoryStatus = 'loaded', inventoryError = null } = fixture;
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      search: useSearchStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter();
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: OWNER },
+      status: 'loaded',
+    });
+    useTeamStore.setState({ teamIdsByOrgId: emptyIndex, status: 'loaded' });
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: emptyIndex,
+      appointmentsById: {},
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {},
+      companionsIdsByOrgId: emptyIndex,
+      status: 'loaded',
+    });
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: { [ORG_ID]: { orgId: ORG_ID, currency: 'GBP' } },
+    });
+    // The shared header writes here; a query left by another story would filter the catalog.
+    useSearchStore.setState({ query: '' });
+
+    useInventoryStore.setState({
+      itemsById: Object.fromEntries(items.map((item) => [item.id as string, item])),
+      itemIdsByOrgId: { [ORG_ID]: items.map((item) => item.id as string) },
+      turnoverByOrgId: { [ORG_ID]: TURNOVER_ITEMS },
+      statusByOrgId: { [ORG_ID]: inventoryStatus },
+      errorByOrgId: { [ORG_ID]: inventoryError },
+      // A 'loading' fixture leaves this unset so `useInventoryModule`'s effect
+      // does not think a load already finished - it never fires a fetch anyway
+      // while status is 'loading', so the story holds still on purpose.
+      lastFetchedByOrgId: inventoryStatus === 'loading' ? {} : fetchedAt,
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useSearchStore.setState(snapshots.search);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+const inventoryMeta = {
+  title: 'Inventory/Inventory',
+  component: Inventory,
+  parameters: {
+    layout: 'fullscreen',
+    // OrgGuard and the "Back to invoices"-style links read usePathname.
+    nextjs: { appDirectory: true, navigation: { pathname: '/inventory' } },
+    docs: {
+      description: {
+        component:
+          "The inventory page: a three-way view over one organisation's stock - a paginated " +
+          'Catalog table, a Dispensary queue of prescription requests waiting to be pulled from ' +
+          'stock, and a Turnover analytics view - plus the low-stock/expiring alerts panel, the ' +
+          'add-item and item-detail modals, and a phone-only card catalog below the 768px ' +
+          'breakpoint.\n\n' +
+          'Stock health is shown from whichever source is more specific: an explicit ' +
+          '`stockHealth` on the item when the backend has computed one, otherwise a value ' +
+          'derived from batch expiry and reorder level. The catalog and the low-stock alert count ' +
+          'agree on the same predicate for "below reorder point" (LOW_STOCK or OUT_OF_STOCK), so ' +
+          'the two never disagree about how many items need attention.\n\n' +
+          'The page sits behind `inventory:view:any`, and the Dispensary tab and its Dispense ' +
+          'action are hidden unless the membership also carries `prescription:view:any` / ' +
+          '`prescription:edit:any` - the seeded OWNER role carries all of them. The stories seed ' +
+          'the catalog straight into the inventory store (the same state it is in once a real ' +
+          'load finishes, so no network call is needed to show it), seed every other org-scoped ' +
+          'store OrgGuard loads, and answer the dispensary and alerts endpoints from the shared ' +
+          'axios adapter.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare(),
+} satisfies Meta<typeof Inventory>;
+
+export default inventoryMeta;
+type InventoryStory = StoryObj<typeof inventoryMeta>;
+
+export const Default: InventoryStory = {
+  name: 'Catalog with mixed stock health',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The count lives in its own <span> next to the title, not in one text node
+    // with it - "3" is checked below via the subtitle counts and the visible rows.
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /^Inventory/ })
+    ).toBeVisible();
+    // One low-stock row and one expired batch, counted the same way the alert panel counts them.
+    await expect(canvas.getByText('1 item below reorder point · 1 expired batch')).toBeVisible();
+
+    await expect(canvas.getByRole('button', { name: 'View Amoxicillin 250mg' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Restock Surgical gauze pads' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'New product' })).toBeEnabled();
+
+    // Catalog / Dispensary / Turnover, in that order.
+    await expect(canvas.getByRole('group', { name: 'Inventory view' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Catalog' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  },
+};
+
+export const EmptyCatalog: InventoryStory = {
+  name: 'No items in the catalog',
+  beforeEach: prepare({ items: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 1, name: /^Inventory/ });
+    await expect(canvas.getByText('0 items below reorder point · 0 expired batches')).toBeVisible();
+    // The empty state renders once for the table layout and once for the card
+    // layout (CSS picks one per breakpoint), so it is asserted as "at least one".
+    await expect((await canvas.findAllByText('No items yet')).length).toBeGreaterThan(0);
+    await expect(canvas.queryByRole('button', { name: /^View / })).not.toBeInTheDocument();
+  },
+};
+
+export const LoadingCatalog: InventoryStory = {
+  name: 'Loading the catalog',
+  beforeEach: prepare({ items: [], inventoryStatus: 'loading' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 1, name: /^Inventory/ });
+    await expect(canvas.getByText('Loading inventory…')).toBeVisible();
+    await expect(canvas.queryByRole('button', { name: /^View / })).not.toBeInTheDocument();
+  },
+};
+
+export const LoadFailed: InventoryStory = {
+  name: 'Catalog failed to load',
+  beforeEach: prepare({
+    items: [],
+    inventoryStatus: 'error',
+    inventoryError: 'Unable to load inventory right now.',
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Unable to load inventory right now.')).toBeVisible();
+    await expect((await canvas.findAllByText('No items yet')).length).toBeGreaterThan(0);
+  },
+};
+
+export const Dispensary: InventoryStory = {
+  name: 'Switching to the Dispensary queue',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole('heading', { level: 1, name: /^Inventory/ });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Dispensary' }));
+
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: /^Dispensary/ })
+    ).toBeVisible();
+
+    // A pending request names the pet and, by its last name, the pet parent.
+    // Rendered once for the table layout and once for the card layout.
+    await expect((await canvas.findAllByText('Biscuit • Okafor')).length).toBeGreaterThan(0);
+    await expect(
+      canvas.getByRole('button', { name: 'Dispense prescription for Biscuit' })
+    ).toBeEnabled();
+
+    // Already dispensed: no Dispense action left to take.
+    await expect(canvas.getAllByText('Whiskers • Chen').length).toBeGreaterThan(0);
+    await expect(
+      canvas.queryByRole('button', { name: 'Dispense prescription for Whiskers' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Phone: InventoryStory = {
+  name: 'Phone: bespoke card catalog below the table',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The phone catalog's own low-stock filter pill only exists below the breakpoint.
+    await expect(await canvas.findByRole('button', { name: 'Low (1)' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'View Amoxicillin 250mg' })).toBeVisible();
+    // "New product" moves to the phone shell's FAB, which this page does not render.
+    await expect(canvas.queryByRole('button', { name: 'New product' })).not.toBeInTheDocument();
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/index.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/index.stories.tsx
@@ -1,0 +1,590 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type {
+  Organisation,
+  OrganisationRoom,
+  Speciality,
+  UserOrganization,
+} from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type { BillingSubscription } from '@/app/features/billing/types/billing';
+import type { OrganizationDocument } from '@/app/features/documents/types/document';
+import type { SpecialityRevamp } from '@/app/features/organization/types/revamp';
+import type { Team } from '@/app/features/organization/types/team';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import Organization from './index';
+
+const ORG_ID = 'org-storybook-organization';
+
+const ORG_VERIFIED: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+/**
+ * `computeOrgOnboardingStep` reads the full address, not just `isVerified`:
+ * below step 2 the unverified-owner branch of `OrgGuard` forces a redirect to
+ * `/create-org` before this page is ever reached. The verified fixture above
+ * gets away without one because that check only runs on the unverified path.
+ */
+const ORG_UNVERIFIED: Organisation = {
+  ...ORG_VERIFIED,
+  isVerified: false,
+  address: {
+    addressLine: '14 Harbour Row',
+    city: 'Bristol',
+    state: 'Bristol',
+    postalCode: 'BS1 4RN',
+    country: 'United Kingdom',
+  },
+};
+
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const TEAM_MEMBERS: Team[] = [
+  {
+    _id: 'team-marsh',
+    practionerId: 'vet-marsh',
+    organisationId: ORG_ID,
+    name: 'Dr. Elena Marsh',
+    role: 'VETERINARIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+  {
+    _id: 'team-reyes',
+    practionerId: 'tech-reyes',
+    organisationId: ORG_ID,
+    name: 'Tom Reyes',
+    role: 'TECHNICIAN',
+    speciality: [],
+    status: 'Off-Duty',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+];
+
+const ROOMS: OrganisationRoom[] = [
+  {
+    id: 'room-surgery-1',
+    name: 'Surgery 1',
+    organisationId: ORG_ID,
+    code: 'SURG-1',
+    type: 'SURGERY',
+    capabilities: ['Orthopaedic'],
+  },
+  {
+    id: 'room-exam-a',
+    name: 'Exam room A',
+    organisationId: ORG_ID,
+    code: 'EXAM-A',
+    type: 'EXAM_ROOM',
+  },
+];
+
+const DOCUMENTS: OrganizationDocument[] = [
+  {
+    _id: 'doc-consent',
+    organisationId: ORG_ID,
+    title: 'Surgical consent form',
+    description: 'Signed before any procedure requiring anaesthesia.',
+    fileUrl: '',
+    category: 'GENERAL',
+  },
+  {
+    _id: 'doc-privacy',
+    organisationId: ORG_ID,
+    title: 'Privacy policy',
+    fileUrl: 'https://example.com/privacy.pdf',
+    category: 'PRIVACY_POLICY',
+  },
+];
+
+const SPECIALITIES: SpecialityRevamp[] = [
+  {
+    id: 'spec-dentistry',
+    name: 'Dentistry',
+    organisationId: ORG_ID,
+    headVetId: 'vet-marsh',
+    teamMemberIds: ['tech-reyes'],
+    activeServiceCount: 4,
+    activePackageCount: 1,
+  },
+];
+
+/**
+ * A second, older representation of the same speciality. `Specialities.tsx`
+ * itself renders from `useRevampCatalogStore` (`SPECIALITIES` above), but the
+ * phone screen's accordion (`PhoneOrganization`) and the desktop drawer's
+ * initial selection both come from `useSpecialitiesWithServiceNamesForPrimaryOrg`,
+ * which reads the older `useSpecialityStore` instead - so both stores need an
+ * entry for the name to appear in every place it can show up on this page.
+ */
+const SPECIALITIES_LEGACY: Speciality[] = [
+  {
+    _id: 'spec-dentistry',
+    organisationId: ORG_ID,
+    name: 'Dentistry',
+    headUserId: 'vet-marsh',
+    teamMemberIds: ['tech-reyes'],
+  },
+];
+
+const SUBSCRIPTION: BillingSubscription = {
+  orgId: ORG_ID,
+  currency: 'GBP',
+  canAcceptPayments: true,
+  connectChargesEnabled: true,
+  connectPayoutsEnabled: true,
+};
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * These are what let the guards pass on REAL data. The obvious alternative, the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, works only under the dev server: a
+ * production/static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect -
+ * which is exactly how these stories rendered an empty page in the static build
+ * that Chromatic publishes.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: 'user-storybook',
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The page itself makes no request of its own - every section reads a Zustand
+ * store - but `BookingRequests` calls `bookingRequestsApi.list` on mount
+ * regardless of what `OrgGuard` has already loaded, and it expects the nested
+ * `{ data: { data: [...] } }` shape `getData` unwraps, not the bare array the
+ * generic fallback below returns. Answering it explicitly is what keeps the
+ * section from setting its list state to `undefined` and crashing on the next
+ * render's `.filter`. The two finance calls OrgGuard's subscription loader
+ * makes are answered the same defensive way Discounts/Estimates/Finance do.
+ */
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+  if (url.includes('/booking-page/')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  if (url.includes('/v1/finance/subscriptions/current')) {
+    return Promise.resolve(respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } }));
+  }
+  if (url.includes('/v1/finance/usage-snapshots')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`, and it renders eleven
+ * dynamically-imported sections of its own once the org is verified - the
+ * heaviest composition in the app. The stories satisfy the guards with real
+ * data - an authenticated session, an org past onboarding, an active
+ * membership, a profile past onboarding step 3 and one availability row -
+ * rather than the dev-only bypass flag, which only works under the dev server:
+ * a static build inlines every `process.env.NEXT_PUBLIC_*` read at build time,
+ * so assigning one at runtime changes nothing and the guards redirect.
+ *
+ * Every org-scoped store OrgGuard's eleven loaders would otherwise reach for is
+ * seeded so each short-circuits rather than hitting the network. Team, rooms,
+ * documents and the specialities catalog are seeded for real: this page renders
+ * them directly, not through a loading state.
+ */
+const prepare =
+  ({
+    org = ORG_VERIFIED,
+    revoked = [],
+    teams = TEAM_MEMBERS,
+    rooms = ROOMS,
+    documents = DOCUMENTS,
+    specialities = SPECIALITIES,
+    legacySpecialities = SPECIALITIES_LEGACY,
+    subscription = SUBSCRIPTION,
+  }: {
+    org?: Organisation;
+    revoked?: string[];
+    teams?: Team[];
+    rooms?: OrganisationRoom[];
+    documents?: OrganizationDocument[];
+    specialities?: SpecialityRevamp[];
+    legacySpecialities?: Speciality[];
+    subscription?: BillingSubscription;
+  } = {}) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      revampCatalog: useRevampCatalogStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter();
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({ status: 'authenticated' });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: org },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, teams);
+    useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, legacySpecialities);
+    useOrganisationRoomStore.getState().setRoomsForOrg(ORG_ID, rooms);
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.setState({ taskIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganizationDocumentStore.getState().setDocumentsForOrg(ORG_ID, documents);
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: emptyIndex,
+      appointmentsById: {},
+      status: 'loaded',
+    });
+    useCompanionStore.setState({
+      companionsById: {},
+      companionsIdsByOrgId: emptyIndex,
+      status: 'loaded',
+    });
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({ subscriptionByOrgId: { [ORG_ID]: subscription } });
+    // `loadOrganisationCatalog` only skips the network once SOME seeded
+    // speciality carries this org id, so an empty `specialities` fixture is
+    // still answered - by the adapter's own empty-array fallback - rather than
+    // left to redirect a real request out of the story.
+    useRevampCatalogStore.setState({
+      specialities,
+      services: [],
+      packages: [],
+      loadedSpecialityIds: [],
+      status: specialities.length ? 'ready' : 'idle',
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useRevampCatalogStore.setState(snapshots.revampCatalog);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+const meta = {
+  title: 'Organization/Organization',
+  component: Organization,
+  parameters: {
+    layout: 'fullscreen',
+    // ProtectedRoute and OrgGuard both read usePathname; /organization is the
+    // one route in `appRoutes` marked `verify: false`, which is what lets an
+    // unverified org land on it instead of being bounced to /create-org.
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The organisation settings page: the clinic profile band, the specialities/services ' +
+          'catalog and - once the organisation is verified - the team roster, rooms, payment ' +
+          'status, documents, e-signing, linked medical devices, online booking setup and ' +
+          'booking requests. Laid out as two columns on desktop and swapped below the phone ' +
+          'breakpoint (`useIsPhone`) for a purpose-built scroll screen with the same data.\n\n' +
+          'An unverified organisation sees a deliberately smaller page: specialities/services ' +
+          'and the delete-organisation control, nothing else. That is not a loading state - it ' +
+          'is the actual shape of the page while an organisation is still working through ' +
+          'verification, which is why a story that always shows the full grid would hide a real ' +
+          "branch of this component's own render logic rather than just a guard redirect.\n\n" +
+          'Each section is independently gated behind its own `PermissionGate` - view rooms, view ' +
+          'the team roster, view billing, view documents, view specialities - so a role missing ' +
+          'one permission loses one card rather than the whole page. That composition is only ' +
+          'visible with every section mounted together, which is what these stories are for: ' +
+          'each section already has its own file covering its internal states in depth. The ' +
+          'stories here lift `ProtectedRoute` and `OrgGuard` with real data rather than the ' +
+          "dev-only bypass flag, and seed every org-scoped store the guard's eleven loaders would " +
+          'otherwise reach for.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare(),
+} satisfies Meta<typeof Organization>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Verified: Story = {
+  name: 'Verified organisation',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: 'Organization' })
+    ).toBeVisible();
+    await expect(
+      canvas.getByText('Clinic profile, team, rooms, specialities and the services you offer')
+    ).toBeVisible();
+
+    // The clinic profile band, always drawn first regardless of verification.
+    await expect(canvas.getByText('Harbourside Veterinary Group')).toBeVisible();
+    await expect(canvas.getByText('VERIFIED')).toBeVisible();
+
+    // Verified-only sections: team, rooms and payment sit in the right/left
+    // columns of the grid this branch renders.
+    await expect(canvas.getByRole('heading', { name: 'Team (2)' })).toBeVisible();
+    await expect(canvas.getByText('Dr. Elena Marsh')).toBeVisible();
+    await expect(canvas.getByText('Tom Reyes')).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'Rooms (2)' })).toBeVisible();
+    await expect(canvas.getByText('Surgery 1')).toBeVisible();
+    await expect(canvas.getByText('Payments · Stripe')).toBeVisible();
+    await expect(canvas.getByText('Charges and payouts enabled')).toBeVisible();
+
+    // Specialities renders in both branches - here fed by the real catalog store.
+    // `SpecialitiesTableRevamp` swaps a table for a card grid on a container
+    // query keyed to ITS OWN width, not the viewport, so only the section
+    // header is asserted here rather than which of the two layouts a
+    // particular column width happens to select.
+    await expect(canvas.getByText('Specialties, services & packages')).toBeVisible();
+
+    // The rest of the verified-only content further down the page.
+    await expect(canvas.getByRole('heading', { name: 'Linked medical devices' })).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'Documents' })).toBeVisible();
+    await expect(canvas.getByText('Surgical consent form')).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'E-signing' })).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'Online booking' })).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'Booking requests' })).toBeVisible();
+    await expect(
+      await canvas.findByText(
+        'No booking requests yet. Confirmed requests from your public booking page appear here.'
+      )
+    ).toBeVisible();
+
+    // OWNER holds `org:delete`, so the danger band sits at the bottom of the page.
+    await expect(canvas.getByRole('button', { name: 'Delete organization' })).toBeEnabled();
+  },
+};
+
+export const Unverified: Story = {
+  name: 'Unverified organisation',
+  beforeEach: prepare({ org: ORG_UNVERIFIED }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole('heading', { level: 1, name: 'Organization' })
+    ).toBeVisible();
+    await expect(canvas.getByText('PENDING')).toBeVisible();
+
+    // The reduced branch: specialities and the delete control, nothing else.
+    await expect(canvas.getByText('Specialties, services & packages')).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Delete organization' })).toBeEnabled();
+
+    // None of the verified-only sections mount at all - not hidden, absent.
+    await expect(canvas.queryByRole('heading', { name: /^Team/ })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: /^Rooms/ })).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Payments · Stripe')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('heading', { name: 'Linked medical devices' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Documents' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'E-signing' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Online booking' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('heading', { name: 'Booking requests' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  name: 'Verified organisation with nothing set up yet',
+  beforeEach: prepare({
+    teams: [],
+    rooms: [],
+    documents: [],
+    specialities: [],
+    legacySpecialities: [],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { name: 'Team (0)' })).toBeVisible();
+    await expect(canvas.getByText('No team members yet.')).toBeVisible();
+    await expect(canvas.getByText('No rooms added yet.')).toBeVisible();
+    await expect(
+      canvas.getByText('No documents yet. Add clinic-wide templates and files.')
+    ).toBeVisible();
+    // The revamp catalog is genuinely empty here rather than mid-fetch: the
+    // fixture seeds it empty and the adapter answers the mount-effect's own
+    // load with an empty list too, so this is the resting empty state.
+    // `SpecialitiesTableRevamp` renders BOTH its table and card layouts and
+    // lets a container query hide one, so the empty message legitimately
+    // exists twice in the DOM at once - `getAllByText` avoids the ambiguity
+    // error a plain `getByText` would throw on either responsive layout.
+    await expect(await canvas.findAllByText('No specialities yet')).toHaveLength(2);
+  },
+};
+
+export const RestrictedByRole: Story = {
+  name: 'Several sections restricted by role',
+  beforeEach: prepare({
+    revoked: [
+      PERMISSIONS.SPECIALITIES_VIEW_ANY,
+      PERMISSIONS.ROOM_VIEW_ANY,
+      PERMISSIONS.TEAMS_VIEW_ANY,
+      PERMISSIONS.DOCUMENT_VIEW_ANY,
+      PERMISSIONS.SUBSCRIPTION_VIEW_ANY,
+    ],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Each gated section loses its content but keeps its place on the page -
+    // this is the behaviour that is only visible with every section composed
+    // together, since no individual section's own story can show five losing
+    // their content on one screen at once.
+    await expect(
+      await canvas.findByText("Your role (Owner) can't view specialities, services and packages.")
+    ).toBeVisible();
+    await expect(canvas.getByText("Your role (Owner) can't view rooms.")).toBeVisible();
+    await expect(canvas.getByText("Your role (Owner) can't view the team roster.")).toBeVisible();
+    await expect(canvas.getByText("Your role (Owner) can't view documents.")).toBeVisible();
+    await expect(
+      canvas.getByText("Your role (Owner) can't view billing and subscription.")
+    ).toBeVisible();
+
+    // Sections with no PermissionGate of their own are unaffected.
+    await expect(canvas.getByRole('heading', { name: 'Online booking' })).toBeVisible();
+    await expect(canvas.getByRole('heading', { name: 'Linked medical devices' })).toBeVisible();
+    await expect(canvas.queryByText('Dr. Elena Marsh')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Surgery 1')).not.toBeInTheDocument();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Below the phone breakpoint the whole page swaps for `PhoneOrganization`,
+    // a different component tree rather than a CSS reflow of the desktop one.
+    await expect(await canvas.findByLabelText('Go back')).toBeVisible();
+    await expect(canvas.getByText('Organization')).toBeVisible();
+    await expect(canvas.getByText('Team · 2')).toBeVisible();
+    await expect(canvas.getByText('Dr. Elena Marsh')).toBeVisible();
+    await expect(canvas.getByText('Specialities & services')).toBeVisible();
+    await expect(canvas.getByText('Dentistry · 0 services')).toBeVisible();
+    await expect(canvas.getByText('Stripe payments connected')).toBeVisible();
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};

--- a/apps/frontend/src/app/features/settings/pages/Settings/index.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/index.stories.tsx
@@ -1,0 +1,377 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import type { APActorSettings } from '@/app/features/federation/types/federation';
+import ProtectedSettings from './index';
+
+const ORG_ID = 'org-storybook-settings';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+  isActive: true,
+  // Read by CrossClinicMessagingPreference. Undefined would render "Current
+  // setting unavailable" rather than a real toggle.
+  crossOrgMessagingEnabled: true,
+};
+
+/**
+ * OWNER carries `teams:edit:any` in the role table, so the read-only story below
+ * is only reachable through `revokedPermissions` - which is also how a practice
+ * really takes scheduling rights off one person. See `Sections/PreferenceGroup`'s
+ * `readOnly` prop and `Settings/index.tsx`'s `canEditClinicPreferences`.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-weber',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: 'user-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+/**
+ * No `userId`: an org-level row with no owner reads as everyone's clinic-wide
+ * default (`usePrimaryAvailability`'s non-user-specific fallback), which is
+ * what makes the Personal card's hours summary render without also having to
+ * match this fixture's id against the seeded membership's practitioner id.
+ */
+const dayRow = (dayOfWeek: string, startTime: string, endTime: string): ApiDayAvailability => ({
+  _id: `availability-${dayOfWeek.toLowerCase()}`,
+  organisationId: ORG_ID,
+  dayOfWeek,
+  slots: [{ startTime, endTime, isAvailable: true }],
+});
+
+const WORKING_WEEK: ApiDayAvailability[] = [dayRow('MONDAY', '09:00', '17:00')];
+
+const ACTOR: APActorSettings = {
+  uri: 'https://harbourside.vet/ap/organizations/harbourside',
+  preferredUsername: 'harbourside',
+  publicKeyId: 'https://harbourside.vet/ap/organizations/harbourside#main-key',
+  inboxUri: 'https://harbourside.vet/ap/organizations/harbourside/inbox',
+  outboxUri: 'https://harbourside.vet/ap/organizations/harbourside/outbox',
+  followersUri: 'https://harbourside.vet/ap/organizations/harbourside/followers',
+  followingUri: 'https://harbourside.vet/ap/organizations/harbourside/following',
+  sharedInboxUri: 'https://harbourside.vet/ap/inbox',
+  summary: 'Mixed-practice hospital in Bristol.',
+  iconUrl: null,
+  createdAt: '2026-01-14T09:00:00.000Z',
+  licenseTokenStatus: 'valid',
+  isVerified: true,
+  directoryListed: true,
+};
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * Settings sits behind `ProtectedRoute` only - it has no `OrgGuard`, so unlike a
+ * finance page this story does not need to seed the eleven org-scoped loaders.
+ * `ProtectedRoute` reads only `useAuthStore`.
+ *
+ * The stores below are exactly the ones the page's own imports and its Section
+ * children touch: `useOrgStore` (org, membership, permissions), `useAuthStore`
+ * (auth + the Personal card's identity), `useUserProfileStore` (the preference
+ * rows that read `usePrimaryOrgProfile`) and `useAvailabilityStore` (the hours
+ * summary and editor).
+ *
+ * `FederationSection` is the one child that fetches unconditionally on mount -
+ * eight cards over one actor/followers/following/referrals API - so the shared
+ * axios adapter is stubbed for its `/ap/manage/*` reads, with a catch-all
+ * fallback for everything else a child section may touch (the security card's
+ * MFA status probe, the hours-editor's practitioner-profile lookup, and every
+ * preference row's best-effort write) so nothing left unstubbed logs a
+ * `console.error` on the way to its own catch.
+ */
+const buildAdapter = (federationActor: APActorSettings | 'reject'): AxiosAdapter => {
+  return (config: InternalAxiosRequestConfig) => {
+    const url = String(config.url ?? '');
+    const method = String(config.method ?? 'get').toLowerCase();
+
+    if (method === 'get' && url.endsWith('/ap/manage/actor')) {
+      if (federationActor === 'reject') {
+        return Promise.reject(
+          Object.assign(new Error('Request failed with status code 403'), {
+            isAxiosError: true,
+            config,
+            response: {
+              status: 403,
+              statusText: 'Forbidden',
+              data: { message: 'Federation is switched off on this instance' },
+              headers: {},
+              config,
+            },
+          })
+        );
+      }
+      return Promise.resolve(respond(config, federationActor));
+    }
+    if (method === 'get' && /\/ap\/manage\/(followers|following)$/.test(url)) {
+      return Promise.resolve(respond(config, []));
+    }
+    if (method === 'get' && /\/ap\/manage\/referrals\/(inbound|outbound)$/.test(url)) {
+      return Promise.resolve(respond(config, []));
+    }
+    // Catch-all: any other read resolves empty rather than hitting the network,
+    // and any other write is accepted, mirroring the finance stories' fallback.
+    return Promise.resolve(respond(config, method === 'get' ? [] : { data: {} }));
+  };
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * A refused federation read is logged by the axios wrapper (`getData`'s own
+ * `logger.error('API getData error:', ...)`) on its way to the card's catch,
+ * and the render check treats a console error as a broken story. Only that
+ * one line is dropped; anything else still reaches the console.
+ */
+const muteExpectedFailureLogs = () => {
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const expected = args
+      .slice(0, 2)
+      .some((arg) => typeof arg === 'string' && arg.includes('API getData error'));
+    if (!expected) original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+};
+
+type PrepareConfig = {
+  authStatus?: 'authenticated' | 'checking';
+  revoked?: string[];
+  federationActor?: APActorSettings | 'reject';
+};
+
+const prepare =
+  ({ authStatus = 'authenticated', revoked = [], federationActor = ACTOR }: PrepareConfig = {}) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      auth: useAuthStore.getState(),
+      org: useOrgStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+    };
+
+    api.defaults.adapter = buildAdapter(federationActor);
+
+    useAuthStore.setState({
+      status: authStatus,
+      attributes:
+        authStatus === 'authenticated'
+          ? {
+              sub: 'user-storybook',
+              given_name: 'Amelia',
+              family_name: 'Weber',
+              email: 'amelia.weber@harbourside.vet',
+            }
+          : null,
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+      error: null,
+    });
+    useUserProfileStore.setState({
+      profilesByOrgId: { [ORG_ID]: PROFILE },
+      status: 'loaded',
+      error: null,
+    });
+    useAvailabilityStore.setState({
+      availabilitiesById: Object.fromEntries(WORKING_WEEK.map((row) => [row._id, row])),
+      availabilityIdsByOrgId: { [ORG_ID]: WORKING_WEEK.map((row) => row._id) },
+      status: 'loaded',
+      error: null,
+    });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useAuthStore.setState(snapshots.auth);
+      useOrgStore.setState(snapshots.org);
+      useUserProfileStore.setState(snapshots.profile);
+      useAvailabilityStore.setState(snapshots.availability);
+      clearInFlightGetRequests();
+    };
+  };
+
+const meta = {
+  title: 'Settings/Settings',
+  component: ProtectedSettings,
+  parameters: {
+    layout: 'fullscreen',
+    // CompanionTerminologyPreference reads router.refresh(); YourOrganizations'
+    // "New organization" and DeleteProfile's post-delete redirect are next/link
+    // and next/navigation respectively.
+    nextjs: { appDirectory: true, navigation: { pathname: '/settings' } },
+    docs: {
+      description: {
+        component:
+          'The Settings page: every preference a clinic account can touch, split into two ' +
+          'bands by who a change affects rather than by topic - "Personal" (this account, this ' +
+          'device) and "Organisation" (the whole clinic).\n\n' +
+          'That split is the point of the page. Grouping by topic previously put per-user ' +
+          'controls under a card labelled "Workspace preferences" next to a device-only theme ' +
+          'toggle, so the label pointed away from the truth about what a click would change. ' +
+          'Scope is the axis that decides whether a click is safe, so it is the axis the page ' +
+          'renders on.\n\n' +
+          'Most rows auto-save on change or on blur - the header carries the one "Changes save ' +
+          'automatically" indicator rather than a Save button per row - so only failures surface ' +
+          'a toast. The organisation band mixes two permissions: the scheduling group is gated ' +
+          'by `teams:edit:any` and federation by `integrations:edit:any`, which a Supervisor ' +
+          'role holds only the first of, so each group states its own read-only banner rather ' +
+          'than the band carrying one verdict for both.\n\n' +
+          'The page itself sits behind `ProtectedRoute` only (no organisation guard), so the ' +
+          'stories seed just the auth, org, profile and availability stores its Section children ' +
+          'read, and stub the shared axios adapter for `FederationSection`, the one child that ' +
+          'fetches unconditionally on mount.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare(),
+} satisfies Meta<typeof ProtectedSettings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Owner, full preferences',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Settings' })).toBeVisible();
+
+    // The two scope bands, in order. Level 2: the Personal CARD below reuses
+    // the same word as its own (level 3) PreferenceGroup title.
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Personal' })).toBeVisible();
+    await expect(canvas.getByText('Settings for you, not for the clinic.')).toBeVisible();
+    await expect(canvas.getByRole('heading', { level: 2, name: 'Organisation' })).toBeVisible();
+
+    // The Personal card, resolved from the seeded auth/org/profile stores.
+    await expect(
+      await canvas.findByText('amelia.weber@harbourside.vet · Owner · Internal medicine')
+    ).toBeVisible();
+
+    // Editable, because the seeded membership carries teams:edit:any.
+    const crossClinicToggle = canvas.getByRole('switch', { name: 'Cross-clinic messaging' });
+    await expect(crossClinicToggle).toBeEnabled();
+    await expect(crossClinicToggle).toHaveAttribute('aria-checked', 'true');
+
+    // Federation resolves through the stubbed adapter rather than staying on
+    // its own loading skeleton.
+    await expect(await canvas.findByText('Federation identity')).toBeVisible();
+    await expect(canvas.getByText('@harbourside')).toBeVisible();
+  },
+};
+
+export const LoadingSession: Story = {
+  name: 'Session still checking: skeleton only',
+  beforeEach: prepare({ authStatus: 'checking' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // `ProtectedRoute` renders the settings-variant `PageSkeleton` and nothing
+    // of the real page while the session is unresolved.
+    await waitFor(() => expect(canvasElement.querySelector('.animate-pulse')).not.toBeNull());
+    await expect(
+      canvas.queryByRole('heading', { level: 1, name: 'Settings' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Cross-clinic messaging')).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnlyOrganisation: Story = {
+  name: 'Scheduling rights revoked: organisation band is read-only',
+  beforeEach: prepare({ revoked: ['teams:edit:any'] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Settings' })).toBeVisible();
+
+    // The banner names who can change it, and the toggle is disabled rather than hidden.
+    await expect(
+      canvas.getByText(
+        'These apply to everyone at this clinic, not just you. Managed by a clinic administrator.'
+      )
+    ).toBeVisible();
+    await expect(canvas.getByRole('switch', { name: 'Cross-clinic messaging' })).toBeDisabled();
+    await expect(canvas.getByLabelText('Outpatient')).toBeDisabled();
+    await expect(canvas.getByLabelText('Inpatient')).toBeDisabled();
+
+    // Federation is a separate permission (integrations:edit:any) and is unaffected.
+    await expect(await canvas.findByText('Federation identity')).toBeVisible();
+  },
+};
+
+export const FederationUnavailable: Story = {
+  name: 'Federation could not be loaded',
+  beforeEach: [prepare({ federationActor: 'reject' }), muteExpectedFailureLogs],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The rest of the page renders normally; only the federation card degrades
+    // to its own "could not be loaded" state rather than taking the page down.
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Settings' })).toBeVisible();
+    await expect(await canvas.findByText(/Federation settings could not be loaded/)).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Try again' })).toBeEnabled();
+    await expect(canvas.getByText('Cross-clinic messaging')).toBeVisible();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Settings' })).toBeVisible();
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  },
+};

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.stories.tsx
@@ -1,0 +1,544 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import type {
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import type { Team } from '@/app/features/organization/types/team';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useInventoryStore } from '@/app/stores/inventoryStore';
+import { useInvoiceStore } from '@/app/stores/invoiceStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import type { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useSearchStore } from '@/app/stores/searchStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Tasks from './index';
+
+const ORG_ID = 'org-storybook-tasks';
+const ELENA = 'practitioner-elena';
+const RAVI = 'practitioner-ravi';
+const MARTA = 'parent-marta';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Harbourside Veterinary Group',
+  type: 'HOSPITAL',
+  phoneNo: '+44 20 7946 0958',
+  taxId: 'GB-2291-8871',
+  isVerified: true,
+};
+
+/**
+ * Every shipped role carries `tasks:view:any` and `tasks:edit:any`, so both the
+ * denied and the read-only stories are only reachable through `revokedPermissions`
+ * - which is also how a practice really takes those rights off one person.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  id: 'membership-owner',
+  practitionerReference: `Practitioner/${ELENA}`,
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const teamMember = (practionerId: string, name: string): Team => ({
+  _id: `team-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+/** Elena is the signed-in user throughout - `authStore.attributes.sub` below. */
+const TEAM: Team[] = [teamMember(ELENA, 'Dr. Elena Marsh'), teamMember(RAVI, 'Dr. Ravi Patel')];
+
+const PARENT: StoredParent = {
+  id: MARTA,
+  firstName: 'Marta',
+  lastName: 'Alvarez',
+  email: 'marta.alvarez@example.com',
+  phoneNumber: '+34 600 000 000',
+  address: { city: 'Barcelona', country: 'ES' },
+  createdFrom: 'pms',
+};
+
+const COMPANION: StoredCompanion = {
+  id: 'companion-kiko',
+  organisationId: ORG_ID,
+  parentId: MARTA,
+  name: 'Kiko',
+  type: 'dog',
+  breed: 'Border Collie',
+  dateOfBirth: new Date('2019-04-18T00:00:00.000Z'),
+  gender: 'male',
+  isInsured: false,
+};
+
+const task = (
+  over: Partial<Task> & Pick<Task, '_id' | 'name' | 'assignedTo' | 'status'>
+): Task => ({
+  organisationId: ORG_ID,
+  assignedBy: ELENA,
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'CARE',
+  priority: 'MEDIUM',
+  description: '',
+  // Fixed instant so the rendered date/time do not depend on the machine running this.
+  dueAt: new Date('2026-09-12T12:00:00.000Z'),
+  ...over,
+});
+
+const TASKS: Task[] = [
+  task({
+    _id: 'task-pending',
+    name: 'Prep surgical suite for TPLO',
+    assignedTo: RAVI,
+    status: 'PENDING',
+    category: 'PROCEDURE',
+    priority: 'HIGH',
+  }),
+  task({
+    _id: 'task-in-progress',
+    name: 'Midday medication round',
+    assignedTo: ELENA,
+    assignedBy: RAVI,
+    status: 'IN_PROGRESS',
+    category: 'MEDICATION',
+    priority: 'HIGH',
+    companionId: COMPANION.id,
+  }),
+  task({
+    _id: 'task-completed',
+    name: 'Post-op discharge call',
+    assignedTo: RAVI,
+    status: 'COMPLETED',
+    category: 'COMMUNICATION',
+    completedAt: new Date('2026-09-10T15:00:00.000Z'),
+    completedBy: RAVI,
+  }),
+  task({
+    _id: 'task-parent',
+    name: 'Give evening ear drops',
+    assignedTo: MARTA,
+    status: 'PENDING',
+    audience: 'PARENT_TASK',
+    category: 'MEDICATION',
+    companionId: COMPANION.id,
+  }),
+];
+
+/**
+ * Enough of a profile and one published availability day to clear
+ * `computeTeamOnboardingStep`. Below step 3 `OrgGuard` redirects the whole route
+ * to /team-onboarding, so an incomplete fixture does not render a worse story -
+ * it renders no story at all.
+ *
+ * These are what let the guards pass on REAL data. The obvious alternative, the
+ * `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, works only under the dev server: a
+ * production/static build inlines every `process.env.NEXT_PUBLIC_*` read at
+ * build time, so assigning one at runtime is a no-op and the guards redirect -
+ * which is exactly how these stories rendered an empty page in the static build
+ * that Chromatic publishes.
+ */
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  userId: ELENA,
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1989-11-02',
+    phoneNumber: '+44 20 7946 0958',
+    address: {
+      addressLine: '14 Harbour Row',
+      city: 'Bristol',
+      state: 'Bristol',
+      postalCode: 'BS1 4RN',
+      country: 'United Kingdom',
+    },
+  },
+  professionalDetails: {
+    qualification: 'BVSc MRCVS',
+    yearsOfExperience: 8,
+    specialization: 'Internal medicine',
+  },
+  status: 'COMPLETED',
+};
+
+const AVAILABILITY: ApiDayAvailability = {
+  _id: 'availability-monday',
+  userId: ELENA,
+  organisationId: ORG_ID,
+  dayOfWeek: 'MONDAY',
+  slots: [
+    { startTime: '09:00', endTime: '17:00', isAvailable: true },
+  ] as ApiDayAvailability['slots'],
+};
+
+const respond = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+});
+
+/**
+ * The page itself never calls axios directly - every list it shows comes
+ * straight out of the seeded stores. But `OrgGuard` unconditionally runs
+ * `useLoadSubscriptionCounterForPrimaryOrg` on every org-scoped route, and that
+ * hook always hits the finance endpoints below regardless of what the current
+ * page is about, so the adapter still has to answer them.
+ */
+const buildAdapter = (): AxiosAdapter => (config: InternalAxiosRequestConfig) => {
+  const url = String(config.url ?? '');
+  if (url.includes('/v1/finance/subscriptions/current')) {
+    return Promise.resolve(respond(config, { data: { organisationId: ORG_ID, currency: 'GBP' } }));
+  }
+  if (url.includes('/v1/finance/usage-snapshots')) {
+    return Promise.resolve(respond(config, { data: [] }));
+  }
+  return Promise.resolve(respond(config, []));
+};
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+/**
+ * The page ships behind `ProtectedRoute` and `OrgGuard`. The stories satisfy the
+ * guards with real data - an authenticated session, a verified org, an active
+ * membership, a profile past onboarding step 3 and one availability row - rather
+ * than with the `NEXT_PUBLIC_DISABLE_AUTH_GUARD` bypass, which only works under
+ * the dev server: a static build inlines every `process.env.NEXT_PUBLIC_*` read
+ * at build time, so assigning one at runtime changes nothing and the guards
+ * redirect.
+ *
+ * `OrgGuard` also runs its other ten org-scoped loaders on this route, so every
+ * store they touch is seeded with an entry for this org so they short-circuit on
+ * `Object.hasOwn(...ByOrgId, primaryOrgId)` rather than reaching the network.
+ * Team, task, companion and parent data are seeded for real: the calendar,
+ * board and list panes all resolve assignee and companion names from them.
+ */
+const prepare =
+  ({
+    tasks = TASKS,
+    team = TEAM,
+    companions = [COMPANION],
+    revoked = [],
+  }: {
+    tasks?: Task[];
+    team?: Team[];
+    companions?: StoredCompanion[];
+    revoked?: string[];
+  } = {}) =>
+  () => {
+    clearInFlightGetRequests();
+
+    const snapshots = {
+      appointment: useAppointmentStore.getState(),
+      auth: useAuthStore.getState(),
+      profile: useUserProfileStore.getState(),
+      availability: useAvailabilityStore.getState(),
+      companion: useCompanionStore.getState(),
+      document: useOrganizationDocumentStore.getState(),
+      forms: useFormsStore.getState(),
+      integration: useIntegrationStore.getState(),
+      inventory: useInventoryStore.getState(),
+      invoice: useInvoiceStore.getState(),
+      org: useOrgStore.getState(),
+      parent: useParentStore.getState(),
+      room: useOrganisationRoomStore.getState(),
+      search: useSearchStore.getState(),
+      speciality: useSpecialityStore.getState(),
+      subscription: useSubscriptionStore.getState(),
+      task: useTaskStore.getState(),
+      team: useTeamStore.getState(),
+    };
+    api.defaults.adapter = buildAdapter();
+
+    const emptyIndex = { [ORG_ID]: [] as string[] };
+    const fetchedAt = { [ORG_ID]: new Date().toISOString() };
+
+    useAuthStore.setState({
+      status: 'authenticated',
+      attributes: {
+        sub: ELENA,
+        email: 'elena.marsh@example.com',
+        given_name: 'Elena',
+        family_name: 'Marsh',
+      },
+    });
+    useUserProfileStore.setState({ profilesByOrgId: { [ORG_ID]: PROFILE }, status: 'loaded' });
+    useAvailabilityStore.setState({
+      availabilitiesById: { [AVAILABILITY._id]: AVAILABILITY },
+      availabilityIdsByOrgId: { [ORG_ID]: [AVAILABILITY._id] },
+      status: 'loaded',
+    });
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgIds: [ORG_ID],
+      orgsById: { [ORG_ID]: ORG },
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, team);
+    useSpecialityStore.setState({ specialityIdsByOrgId: emptyIndex, status: 'loaded' });
+    useOrganisationRoomStore.setState({ roomIdsByOrgId: emptyIndex, status: 'loaded' });
+    useInvoiceStore.setState({ invoiceIdsByOrgId: emptyIndex, status: 'loaded' });
+    useTaskStore.getState().setTasksForOrg(ORG_ID, tasks);
+    useOrganizationDocumentStore.setState({ documentIdsByOrgId: emptyIndex, status: 'loaded' });
+    useIntegrationStore.setState({ integrationIdsByOrgId: emptyIndex, status: 'loaded' });
+    useAppointmentStore.setState({
+      appointmentIdsByOrgId: emptyIndex,
+      appointmentsById: {},
+      status: 'loaded',
+    });
+    useCompanionStore.getState().setCompanionsForOrg(ORG_ID, companions);
+    useParentStore.getState().setParents([PARENT]);
+    useFormsStore.setState({ lastFetchedByOrgId: fetchedAt, loading: false });
+    useInventoryStore.setState({ lastFetchedByOrgId: fetchedAt });
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: { [ORG_ID]: { orgId: ORG_ID, currency: 'GBP' } },
+    });
+    // The shared mobile search bar writes here; a query left by another story
+    // would filter this one's list before it even renders.
+    useSearchStore.setState({ query: '' });
+
+    return () => {
+      api.defaults.adapter = REAL_ADAPTER;
+      useTeamStore.setState(snapshots.team);
+      useTaskStore.setState(snapshots.task);
+      useSubscriptionStore.setState(snapshots.subscription);
+      useSpecialityStore.setState(snapshots.speciality);
+      useSearchStore.setState(snapshots.search);
+      useParentStore.setState(snapshots.parent);
+      useOrganisationRoomStore.setState(snapshots.room);
+      useOrgStore.setState(snapshots.org);
+      useInvoiceStore.setState(snapshots.invoice);
+      useInventoryStore.setState(snapshots.inventory);
+      useIntegrationStore.setState(snapshots.integration);
+      useFormsStore.setState(snapshots.forms);
+      useOrganizationDocumentStore.setState(snapshots.document);
+      useCompanionStore.setState(snapshots.companion);
+      useAvailabilityStore.setState(snapshots.availability);
+      useUserProfileStore.setState(snapshots.profile);
+      useAuthStore.setState(snapshots.auth);
+      useAppointmentStore.setState(snapshots.appointment);
+      clearInFlightGetRequests();
+    };
+  };
+
+/** Switches the planner from its default Calendar pane to List or Board. */
+const switchView = async (canvasElement: HTMLElement, label: 'List' | 'Board') => {
+  const canvas = within(canvasElement);
+  await userEvent.click(await canvas.findByRole('button', { name: label }));
+};
+
+const meta = {
+  title: 'Tasks/Tasks',
+  component: Tasks,
+  parameters: {
+    layout: 'fullscreen',
+    // Both guards read usePathname.
+    nextjs: { appDirectory: true, navigation: { pathname: '/tasks' } },
+    docs: {
+      description: {
+        component:
+          'The Tasks page: one list of to-dos shared between three panes - a day/week/team ' +
+          'Calendar, a status Board, and a sortable List - plus the dialogs that create, view, ' +
+          'change the status of, and reschedule a task.\n\n' +
+          'All three panes read the same filtered list, computed once in the page from the ' +
+          'audience pill, the status pill, the search query and (in List and phone Calendar) the ' +
+          '"My tasks / Team" scope toggle. The Board view ignores the status filter outright - a ' +
+          'status pill would be redundant next to four status columns - and the scope toggle only ' +
+          'applies while its own row is on screen, so a "My tasks" choice made in List cannot leak ' +
+          'into Calendar as a filter with no visible way to clear it.\n\n' +
+          'Cancelled is dropped from the status pills shown here (the shared list still carries it ' +
+          'in full for other surfaces), and the calendar header keeps only the pet-parent audience ' +
+          'pill, since it already has its own Day/Week/Team switcher for staff scope.\n\n' +
+          'The stories lift the route guards with real data - an authenticated session, a verified ' +
+          'org, an active membership, a profile past onboarding step 3 and one availability row - ' +
+          'seed every org-scoped store `OrgGuard` would otherwise load, and answer the two finance ' +
+          'calls its subscription loader always makes, regardless of what the page itself is about.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: prepare(),
+} satisfies Meta<typeof Tasks>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Calendar view (default)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Tasks (4)' })).toBeVisible();
+    await expect(canvas.getByText(/Track to-dos, assign the team or pet parents/)).toBeVisible();
+
+    // Calendar is the default pane, opened on Week. The calendar itself is
+    // behind a `next/dynamic` import, so its own Day/Week/Team switch is
+    // awaited rather than read synchronously.
+    await expect(canvas.getByRole('button', { name: 'Calendar', pressed: true })).toBeVisible();
+    await expect(await canvas.findByRole('button', { name: 'Week', pressed: true })).toBeVisible();
+
+    // Desktop calendar hides the standalone filter row - the pet-parent pill and
+    // the Day/Week/Team switcher already live in the calendar's own header.
+    await expect(canvas.queryByRole('group', { name: 'Task scope' })).not.toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText('Search tasks')).toBeInTheDocument();
+  },
+};
+
+export const ListView: Story = {
+  name: 'List view',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await switchView(canvasElement, 'List');
+
+    // The filter row appears only once List is active: audience, status and
+    // scope pills, plus the desktop "New task" action next to them.
+    await expect(await canvas.findByRole('button', { name: 'Pending' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'In progress' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Completed' })).toBeVisible();
+    // Cancelled is trimmed from this page's pill row.
+    await expect(canvas.queryByRole('button', { name: 'Cancelled' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Pet parents' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'New task' })).toBeEnabled();
+
+    /* All four seeded tasks are on screen, named rather than printed as ids.
+       The list renders through TWO always-mounted siblings - a `GenericTable`
+       row and a `PaginatedCardList` card for the same data - switched by a CSS
+       breakpoint rather than by React, so each name can legitimately match more
+       than one node; counted rather than fetched singly. */
+    await expect(
+      (await canvas.findAllByText('Prep surgical suite for TPLO')).length
+    ).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('Midday medication round').length).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('Post-op discharge call').length).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('Give evening ear drops').length).toBeGreaterThan(0);
+  },
+};
+
+export const BoardView: Story = {
+  name: 'Board view',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await switchView(canvasElement, 'Board');
+
+    // Four status columns. Their labels are sentence case in the DOM - the
+    // ALL-CAPS look is a CSS `uppercase` transform, not the rendered text.
+    await expect((await canvas.findAllByText('Pending')).length).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('In progress').length).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('Completed').length).toBeGreaterThan(0);
+    await expect(canvas.getAllByText('Cancelled').length).toBeGreaterThan(0);
+
+    await expect(canvas.getByText('Prep surgical suite for TPLO')).toBeVisible();
+    // The signed-in assignee's own card reads "you" rather than her full name.
+    await expect(canvas.getByText('Midday medication round')).toBeVisible();
+    await expect(canvas.getByText('you')).toBeVisible();
+
+    // Only the Pending column offers a quick-add action, and only because this
+    // fixture's membership can edit tasks.
+    await expect(canvas.getByRole('button', { name: 'Add task to Pending' })).toBeEnabled();
+    // The empty Cancelled column names itself rather than rendering nothing.
+    await expect(canvas.getAllByText('No tasks').length).toBeGreaterThan(0);
+  },
+};
+
+export const NoTasks: Story = {
+  name: 'No tasks yet',
+  beforeEach: prepare({ tasks: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Tasks (0)' })).toBeVisible();
+
+    await switchView(canvasElement, 'List');
+    // Same table + card duplication as the populated list: count rather than
+    // fetch a single node.
+    await expect((await canvas.findAllByText('No tasks yet')).length).toBeGreaterThan(0);
+    await expect(
+      canvas.getAllByText('Tasks appear here as soon as there are any.').length
+    ).toBeGreaterThan(0);
+  },
+};
+
+export const PermissionDenied: Story = {
+  name: 'Tasks view revoked - denied state',
+  beforeEach: prepare({ revoked: ['tasks:view:any'] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The title bar and its Calendar/Board/List switch sit ABOVE the
+    // `PermissionGate`, so they still render with the real task count; only the
+    // gated body underneath is swapped for the denied card.
+    await expect(await canvas.findByRole('heading', { level: 1, name: 'Tasks (4)' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'List' })).toBeVisible();
+    await expect(await canvas.findByText(/You.t have access to Tasks/)).toBeVisible();
+    await expect(
+      canvas.getByText(/Your role \(Owner\) can.t view tasks and assignments\./)
+    ).toBeVisible();
+    // Nothing from the guarded planner leaks out from behind the denied card.
+    await expect(canvas.queryByText('Prep surgical suite for TPLO')).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Task edit revoked - no New task, no quick-add',
+  beforeEach: prepare({ revoked: ['tasks:edit:any', 'tasks:edit:own'] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await switchView(canvasElement, 'List');
+
+    // Viewing still works; only the create/mutate affordances are gone.
+    await expect(
+      (await canvas.findAllByText('Prep surgical suite for TPLO')).length
+    ).toBeGreaterThan(0);
+    await expect(canvas.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+
+    await switchView(canvasElement, 'Board');
+    // Wait for the board to finish loading before asserting the button's absence.
+    await expect((await canvas.findAllByText('Pending')).length).toBeGreaterThan(0);
+    await expect(
+      canvas.queryByRole('button', { name: 'Add task to Pending' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Below 768px the calendar pane shows the filter row too - it is the only
+    // way to reach the pet-parent and scope filters without a List switch.
+    await expect(await canvas.findByRole('button', { name: 'Pending' })).toBeVisible();
+    await waitFor(() =>
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth)
+    );
+  },
+};


### PR DESCRIPTION
## What is the current behavior?

AddCompanion, ControlledSubstances, Finance, IdexxWorkspace, InventoryAlertsPanel, Inventory, Organization, Settings, and Tasks have no Storybook coverage.

## What is the new behavior?

Adds a story for each. The page-level containers mock every Zustand store and the shared axios client the page actually reads, the same mechanics already proven in Discounts/index.stories.tsx and Estimates/index.stories.tsx, including enough profile/availability fixture data to clear the onboarding-step guard so the real page renders instead of redirecting.

## Related Issue(s)

Part of #2930