### PR TITLE
fix(frontend): surface Documenso-signed documents on the patient record

### DIFF
--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -238,6 +238,7 @@ export interface DocumentDto {
   templateId?: string | null;
   templateVersion?: number | null;
   signingStatus?: string;
+  signedAt?: string | null;
   pdfUrl?: string | null;
   createdAt: string;
   updatedAt: string;
@@ -278,6 +279,7 @@ type RenderedDocumentRow = {
   status: string;
   pdfUrl: string | null;
   signing: unknown;
+  signedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
   templateInstance: {
@@ -314,6 +316,7 @@ const mapDocumentToDto = (doc: PrismaDocumentRow): DocumentDto => ({
   templateId: null,
   templateVersion: null,
   signingStatus: doc.pmsVisible ? "SIGNED" : "NOT_STARTED",
+  signedAt: null,
   pdfUrl: null,
   createdAt: doc.createdAt.toISOString(),
   updatedAt: doc.updatedAt.toISOString(),
@@ -365,6 +368,7 @@ const mapRenderedDocumentToDto = (
     document.signing,
     document.status,
   ),
+  signedAt: document.signedAt ? document.signedAt.toISOString() : null,
   pdfUrl: document.pdfUrl,
   createdAt: document.createdAt.toISOString(),
   updatedAt: document.updatedAt.toISOString(),
@@ -389,22 +393,26 @@ const loadAppointmentForDocumentLookup = async (appointmentId: string) => {
   };
 };
 
-const loadRenderedAppointmentDocuments = async (params: {
-  appointmentId: string;
+const loadRenderedDocumentsForAppointments = async (params: {
+  appointmentIds: string[];
   organisationId: string;
 }) => {
+  if (params.appointmentIds.length === 0) {
+    return [];
+  }
+
   const renderedDocuments = (await prisma.renderedDocument.findMany({
     where: {
       organisationId: params.organisationId,
       OR: [
         {
           templateInstance: {
-            is: { appointmentId: params.appointmentId },
+            is: { appointmentId: { in: params.appointmentIds } },
           },
         },
         {
           clinicalArtifact: {
-            is: { appointmentId: params.appointmentId },
+            is: { appointmentId: { in: params.appointmentIds } },
           },
         },
       ],
@@ -427,6 +435,24 @@ const loadRenderedAppointmentDocuments = async (params: {
   })) as unknown as RenderedDocumentRow[];
 
   return renderedDocuments.map(mapRenderedDocumentToDto);
+};
+
+// Appointment.patient is a JSON blob (no relational FK), so every other
+// patient-scoped appointment lookup in the codebase matches it the same way
+// - see appointmentService.getAppointmentsForCompanion.
+const loadAppointmentIdsForPatient = async (params: {
+  patientId: string;
+  organisationId: string;
+}): Promise<string[]> => {
+  const appointments = await prisma.appointment.findMany({
+    where: {
+      organisationId: params.organisationId,
+      patient: { path: ["id"], equals: params.patientId },
+    },
+    select: { id: true },
+  });
+
+  return appointments.map((appointment) => appointment.id);
 };
 
 const createDocumentRecord = async (
@@ -719,23 +745,48 @@ export const DocumentService = {
     const patientId = normalizeStringId(params.patientId, "patientId");
     await assertPmsCanAccessCompanion(params.organisationId, patientId);
 
-    const docs = (await prisma.document.findMany({
-      where: {
-        patientId,
-        pmsVisible: true,
-        category: params.category ? params.category.toUpperCase() : undefined,
-        subcategory: params.subcategory
-          ? params.subcategory.toUpperCase()
-          : undefined,
-        appointmentId: params.appointmentId
-          ? normalizeStringId(params.appointmentId, "appointmentId")
-          : undefined,
-      },
-      orderBy: [{ issueDate: "desc" }, { createdAt: "desc" }],
-      include: { attachments: true },
-    })) as unknown as PrismaDocumentRow[];
+    const appointmentId = params.appointmentId
+      ? normalizeStringId(params.appointmentId, "appointmentId")
+      : undefined;
 
-    return docs.map(mapDocumentToDto);
+    const [docs, renderedDocs] = await Promise.all([
+      prisma.document.findMany({
+        where: {
+          patientId,
+          pmsVisible: true,
+          category: params.category ? params.category.toUpperCase() : undefined,
+          subcategory: params.subcategory
+            ? params.subcategory.toUpperCase()
+            : undefined,
+          appointmentId,
+        },
+        orderBy: [{ issueDate: "desc" }, { createdAt: "desc" }],
+        include: { attachments: true },
+      }) as unknown as Promise<PrismaDocumentRow[]>,
+      (async () => {
+        // Signed/generated documents (Documenso e-signing) live on
+        // RenderedDocument, reached only via the appointment/encounter it was
+        // rendered for - there is no direct patientId column to filter by, so
+        // every one of the patient's own appointments has to be resolved first.
+        const patientAppointmentIds = await loadAppointmentIdsForPatient({
+          patientId,
+          organisationId: params.organisationId,
+        });
+        const scopedAppointmentIds = appointmentId
+          ? patientAppointmentIds.filter((id) => id === appointmentId)
+          : patientAppointmentIds;
+        return loadRenderedDocumentsForAppointments({
+          appointmentIds: scopedAppointmentIds,
+          organisationId: params.organisationId,
+        });
+      })(),
+    ]);
+
+    return [...docs.map(mapDocumentToDto), ...renderedDocs].sort(
+      (left, right) =>
+        new Date(right.updatedAt).getTime() -
+        new Date(left.updatedAt).getTime(),
+    );
   },
 
   async getByIdForParent(
@@ -815,8 +866,8 @@ export const DocumentService = {
         orderBy: { createdAt: "desc" },
         include: { attachments: true },
       }),
-      loadRenderedAppointmentDocuments({
-        appointmentId,
+      loadRenderedDocumentsForAppointments({
+        appointmentIds: [appointmentId],
         organisationId: appointmentLookup.organisationId,
       }),
     ]);
@@ -865,8 +916,8 @@ export const DocumentService = {
         orderBy: { createdAt: "desc" },
         include: { attachments: true },
       }),
-      loadRenderedAppointmentDocuments({
-        appointmentId,
+      loadRenderedDocumentsForAppointments({
+        appointmentIds: [appointmentId],
         organisationId: params.organisationId,
       }),
     ]);

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -52,6 +52,7 @@ jest.mock("src/config/prisma", () => ({
     },
     appointment: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
     },
     $transaction: jest.fn(async (fn: any) => fn(prisma)),
   },
@@ -106,6 +107,7 @@ const resetPrisma = () => {
   mockedPrisma.documentAttachment.deleteMany.mockReset();
   mockedPrisma.renderedDocument.findMany.mockReset();
   mockedPrisma.appointment.findUnique.mockReset();
+  mockedPrisma.appointment.findMany.mockReset();
   mockedPrisma.$transaction.mockReset();
   mockedPrisma.$transaction.mockImplementation(async (fn: any) => fn(prisma));
 };
@@ -152,6 +154,9 @@ describe("DocumentService", () => {
       organisationId: uuidOrganisationId,
       patient: { id: uuidPatientId },
     } as any);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+    ] as any);
     mockedUpload.generatePresignedDownloadUrl.mockResolvedValue(
       "https://download/url",
     );
@@ -251,6 +256,137 @@ describe("DocumentService", () => {
       }),
     );
     expect(result).toHaveLength(1);
+  });
+
+  it("merges Documenso-signed documents from every one of the patient's appointments", async () => {
+    const otherAppointmentId = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
+    mockedPrisma.document.findMany.mockResolvedValue([]);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+      { id: otherAppointmentId },
+    ] as any);
+    mockedPrisma.renderedDocument.findMany.mockResolvedValue([
+      {
+        id: "rd-1",
+        organisationId: uuidOrganisationId,
+        sourceKind: "TEMPLATE_INSTANCE",
+        sourceId: "ti-1",
+        templateId: "tmpl-1",
+        templateVersion: 2,
+        kind: "CONSENT_FORM",
+        title: "Surgical consent",
+        status: "SIGNED",
+        pdfUrl: "https://cdn/consent.pdf",
+        signing: { status: "SIGNED" },
+        createdAt: now,
+        updatedAt: now,
+        templateInstance: {
+          appointmentId: uuidAppointmentId,
+          encounterId: null,
+        },
+        clinicalArtifact: null,
+      },
+    ] as any);
+
+    const result = await DocumentService.listForPms({
+      patientId: uuidPatientId,
+      organisationId: uuidOrganisationId,
+    });
+
+    expect(mockedPrisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organisationId: uuidOrganisationId,
+          patient: { path: ["id"], equals: uuidPatientId },
+        },
+      }),
+    );
+    expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organisationId: uuidOrganisationId,
+          OR: [
+            {
+              templateInstance: {
+                is: {
+                  appointmentId: {
+                    in: [uuidAppointmentId, otherAppointmentId],
+                  },
+                },
+              },
+            },
+            {
+              clinicalArtifact: {
+                is: {
+                  appointmentId: {
+                    in: [uuidAppointmentId, otherAppointmentId],
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "rd-1",
+      sourceKind: "TEMPLATE_INSTANCE",
+      signingStatus: "SIGNED",
+      pdfUrl: "https://cdn/consent.pdf",
+    });
+  });
+
+  it("scopes the rendered-document lookup to an explicit appointmentId filter", async () => {
+    const otherAppointmentId = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+      { id: otherAppointmentId },
+    ] as any);
+    mockedPrisma.renderedDocument.findMany.mockResolvedValue([]);
+
+    await DocumentService.listForPms({
+      patientId: uuidPatientId,
+      organisationId: uuidOrganisationId,
+      appointmentId: uuidAppointmentId,
+    });
+
+    expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            {
+              templateInstance: {
+                is: { appointmentId: { in: [uuidAppointmentId] } },
+              },
+            },
+            {
+              clinicalArtifact: {
+                is: { appointmentId: { in: [uuidAppointmentId] } },
+              },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("never queries rendered documents for an appointment outside the patient's own history", async () => {
+    const foreignAppointmentId = "99999999-0000-4111-8222-333333333333";
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+    ] as any);
+
+    const result = await DocumentService.listForPms({
+      patientId: uuidPatientId,
+      organisationId: uuidOrganisationId,
+      appointmentId: foreignAppointmentId,
+    });
+
+    expect(mockedPrisma.renderedDocument.findMany).not.toHaveBeenCalled();
+    expect(result.every((doc) => doc.sourceKind !== "TEMPLATE_INSTANCE")).toBe(
+      true,
+    );
   });
 
   describe("listForAppointmentPms tenant scope", () => {

--- a/apps/frontend/src/app/__tests__/ui/SectionContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/SectionContainer.test.tsx
@@ -101,4 +101,19 @@ describe('SectionContainer', () => {
     );
     expect(screen.getByText('SLOT')).toBeInTheDocument();
   });
+
+  it('lets a wide titleSlot wrap onto its own line instead of squeezing the title', () => {
+    const { container } = render(
+      <SectionContainer title="Dental care package" titleSlot={<span>SLOT</span>}>
+        child
+      </SectionContainer>
+    );
+    // The title row must be able to wrap - without it, a `shrink-0` slot (badge
+    // pills, etc.) never gives width back to the `truncate`d title, so a narrow
+    // container (a side drawer) squeezes a short, legible title down to a couple
+    // of visible characters. See SpecialityInfo's "Services & Packages" ->
+    // PackagesTab card for the real report.
+    const headerRow = container.querySelector('.mb-4');
+    expect(headerRow).toHaveClass('flex-wrap');
+  });
 });

--- a/apps/frontend/src/app/features/documents/components/recordLifecycle.ts
+++ b/apps/frontend/src/app/features/documents/components/recordLifecycle.ts
@@ -21,10 +21,13 @@ export type RecordLifecycleFilter =
  *                    clinical artifact), i.e. generated.
  *  4. uploader ids — a human (pet parent or clinic staff) put the file there.
  *
- * Only arm 4 resolves from data that ships today; arms 1–3 depend on fields the
- * endpoint does not populate yet, so their tabs stay hidden until it does (see
- * `getAvailableLifecycleTabs`). There is deliberately no "requested" derivation:
- * nothing in the current payload distinguishes a record awaiting its file.
+ * Arms 2–4 resolve from data `listForPms` ships today: it merges in the
+ * patient's `RenderedDocument` rows (Documenso e-signing), which carry a real
+ * `signedAt` and a non-'DOCUMENT' `sourceKind`. Arm 1 still depends on a
+ * `lifecycle` field no endpoint populates yet, so its tab stays hidden until it
+ * does (see `getAvailableLifecycleTabs`) — there is deliberately no "requested"
+ * derivation: nothing in the current payload distinguishes a record awaiting
+ * its file.
  *
  * Explicitly NOT used as signals, because each would fabricate a state:
  *  - `syncedFromPms` means "created through the PMS by a staff user" (the
@@ -33,9 +36,10 @@ export type RecordLifecycleFilter =
  *  - `attachments.length === 0` is not "awaiting a file": the create endpoint
  *    rejects a document with no attachments, and the only rows that legitimately
  *    carry an empty array are rendered (generated) documents.
- *  - the DTO's `signingStatus` is, on this endpoint, `pmsVisible ? 'SIGNED' :
- *    'NOT_STARTED'` over a list already filtered to `pmsVisible: true`, so it is
- *    the constant 'SIGNED' and carries no signing information.
+ *  - the DTO's `signingStatus` is 'SIGNED' for every plain uploaded document too
+ *    (`pmsVisible ? 'SIGNED' : 'NOT_STARTED'` over a list already filtered to
+ *    `pmsVisible: true`), so it cannot tell a signed record from an uploaded
+ *    one apart — `signedAt` is the honest, upload-vs-signed-specific signal.
  */
 export const deriveRecordLifecycle = (record: CompanionRecord): RecordLifecycle | undefined => {
   if (record.lifecycle) return record.lifecycle;

--- a/apps/frontend/src/app/features/documents/types/companionDocuments.ts
+++ b/apps/frontend/src/app/features/documents/types/companionDocuments.ts
@@ -127,25 +127,19 @@ export type CompanionRecord = {
    */
   lifecycle?: RecordLifecycle;
   /**
-   * When the record was signed. Optional because no signing signal exists for
-   * documents today: form submissions carry `signing.status`, plain documents
-   * do not.
-   *
-   * BACKEND: add `signedAt` to `DocumentDto`. The DTO's existing `signingStatus`
-   * cannot be used — `mapDocumentToDto` derives it as
-   * `pmsVisible ? 'SIGNED' : 'NOT_STARTED'` and `listForPms` only returns
-   * `pmsVisible: true` rows, so it is the constant 'SIGNED'.
+   * When the record was signed (Documenso e-signing). Only rendered documents
+   * (`sourceKind !== 'DOCUMENT'`) ever carry a value — a plain uploaded file has
+   * no signing event, so `mapDocumentToDto` always sends `null` for it. Still
+   * optional because older payloads (and any endpoint that has not adopted the
+   * `RenderedDocument` merge) omit the field entirely rather than send `null`.
    */
   signedAt?: string | null;
   /**
    * What produced the record: 'DOCUMENT' for an uploaded file, or a rendered
    * document's kind (e.g. 'TEMPLATE_INSTANCE', 'CLINICAL_ARTIFACT') for one the
-   * system generated. Already part of the backend's `DocumentDto`; optional
-   * here because `listForPms` returns only plain documents, so it is always
-   * 'DOCUMENT' today.
-   *
-   * BACKEND: merge rendered documents into `DocumentService.listForPms`, the
-   * way `listForAppointmentParent` already does.
+   * system generated. `listForPms` merges in the patient's `RenderedDocument`
+   * rows the same way `listForAppointmentParent` already did, so this is no
+   * longer always 'DOCUMENT'.
    */
   sourceKind?: string;
   createdAt?: string;

--- a/apps/frontend/src/app/ui/primitives/SectionContainer/SectionContainer.tsx
+++ b/apps/frontend/src/app/ui/primitives/SectionContainer/SectionContainer.tsx
@@ -64,8 +64,12 @@ const SectionContainer = ({
     >
       {/* Static header row: title (with optional leading icon) on the left, the
           optional slot right-aligned. `truncate` keeps a long title on one line
-          while the slot stays pinned right. */}
-      <div className="mb-4 flex items-center justify-between gap-3">
+          while the slot stays pinned right - but `shrink-0` on the slot means it
+          never gives width back, so a slot with real content (e.g. two badge
+          pills) squeezed the title to a couple of characters in a narrow
+          container. `flex-wrap` lets the slot drop to its own line instead of
+          fighting the title for space; each still gets `min-w-0`/`shrink-0`. */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
         <span
           className={`flex min-w-0 items-center gap-2 leading-snug ${titleTypography}`}
           style={titleStyle}


### PR DESCRIPTION
## What changed
- `DocumentService.listForPms` (backend) now merges in the patient's `RenderedDocument` rows (Documenso e-signing output), the same way the appointment-scoped `listForAppointmentParent`/`listForAppointmentPms` siblings already do - resolved across every one of the patient's own appointments, or scoped to a single one when the caller filters by `appointmentId`.
- Wires `signedAt` through both DTO mappers, completing two `BACKEND:` TODOs already recorded in the frontend's own `companionDocuments.ts` types file.
- Fixes a real, separate UI bug found while visually verifying the drawer this feeds: `SectionContainer`'s title row pinned an optional `titleSlot` (e.g. two badge pills) with `shrink-0` while the title kept `min-w-0 truncate`, so in a narrow container (a side drawer) a short title like "Dental care package" collapsed to "Dental car...". `flex-wrap` lets the slot drop to its own line instead of fighting the title for space.

## Why
The per-patient "Signed"/"Generated" document tabs (`CompanionDocumentsSection`) already existed in the UI with working tab-derivation logic, but the backing endpoint only ever queried the plain `Document` table, so those tabs stayed permanently empty. The fix is a bug fix completing already-planned plumbing, not a new feature.

## Impact area
- `apps/backend/src/services/document.service.ts` (+ its test suite)
- `apps/frontend/src/app/features/documents/{types/companionDocuments.ts,components/recordLifecycle.ts}` (doc-comment updates, no behaviour change)
- `apps/frontend/src/app/ui/primitives/SectionContainer/SectionContainer.tsx` (+ its test suite) - shared primitive, 21 consumers; full consumer test suite re-run, no regressions.

## Validation performed
- New Jest coverage for the `listForPms` merge (patient-wide, single-appointment-filtered, and cross-patient-appointment-scoping cases), mutation-checked.
- New Jest coverage for `SectionContainer`'s wrap fix, mutation-checked.
- `npx eslint` / `npx tsc --noEmit` clean on every touched file.
- Full backend test suite (11,602 tests) green.
- All 17 Jest suites covering every `SectionContainer` consumer (398 tests) green - no regression.
- `check-hardcoded-colours.mjs` clean (no baseline drift).
- Visually verified live in Storybook: `PackagesTab`'s "Narrow container (side drawer)" story reproduced the title truncation before the fix and rendered correctly after.