### PR TITLE
fix(ci): let the repo-stats summary regex cross the chart placeholder

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -114,7 +114,19 @@ jobs:
             text = "\n".join(parser.chunks)
 
           def extract_cumulative(label: str) -> int | None:
-            match = re.search(rf"{label}\s*Cumulative:\s*([0-9,]+)", text, re.IGNORECASE)
+            # The markdown report keeps each section's `<div id="chart_..."
+            # class="full-width-chart"></div>` placeholder as literal text
+            # between the heading and "Cumulative: N" - `\s*` cannot cross
+            # that non-whitespace tag, so this always returned None for every
+            # field. `.*?` (DOTALL) matches the same zero-width gap in the
+            # HTML-parsed path (that div contributes no text, so the heading
+            # and "Cumulative:" already sit adjacent there) and additionally
+            # spans the markdown path's div tag, binding to the nearest
+            # following "Cumulative:" - the section's own, since each section
+            # has exactly one.
+            match = re.search(
+              rf"{label}.*?Cumulative:\s*([0-9,]+)", text, re.IGNORECASE | re.DOTALL
+            )
             if not match:
               return None
             return int(match.group(1).replace(",", ""))


### PR DESCRIPTION
## What changed
`extract_cumulative` in `.github/workflows/repo-stats.yml` used `\s*` between a section heading (e.g. "Total clones") and "Cumulative: N", assuming only whitespace separates them. The markdown report keeps each section's `<div id="chart_..." class="full-width-chart"></div>` chart placeholder as literal text in that gap, so `\s*` never bridged it. Switched to `.*?` with `re.DOTALL` - the same pattern already used by `extract_top`/`extract_top_until` in this same script.

## Why
Found while verifying the GHRS token rotation. Every field this function produces - views and clones, unique and total alike - silently came back `null`. The public site only ever surfaced one of them (`repositoryClones`), and a separate frontend fallback (summing the raw per-day series from the charts data) happened to mask it there, which is why nobody noticed. This fixes the actual source instead of continuing to rely on that fallback.

## Impact area
`.github/workflows/repo-stats.yml` only - a nightly/manually-dispatched workflow, no app code touched.

## Validation performed
- Extracted the exact regex logic (before/after) into a standalone script and ran it against the real `report.md` content on the `github-repo-stats` data branch: the old pattern returns `None` for all four fields (`Unique visitors`, `Total views`, `Unique cloners`, `Total clones`); the fixed one correctly extracts `1605`, `13765`, `24405`, `97389` - matching the raw report exactly.
- Checked the HTML-parsed fallback path (used when `report.md` is absent) is unaffected: that div contributes no text there, so the heading and "Cumulative:" already sit adjacent, which `.*?` still matches with zero width - verified with a synthetic HTML fragment through the same `TextExtractor`.
- Validated the workflow YAML parses (`yaml.safe_load`) and the embedded Python block parses (`ast.parse`) after the edit.