### PR TITLE
fix(frontend): supply currency to PrescriptionEditor story fixtures

### DIFF
--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
@@ -152,6 +152,7 @@ const meta = {
     items,
     catalogItems: CATALOG,
     templateItems: TEMPLATES,
+    currency: 'USD',
     readOnly: false,
     onAddItem: fn(),
     onApplyTemplate: fn(),


### PR DESCRIPTION
## Summary
Every `PrescriptionEditor` story rendered a priced row (`priceCents` on the seeded items) without a `currency` arg, so `formatCents`/`formatMoney` threw `Currency code is required with currency style` and the whole story file crashed on mount. Pre-existing, unrelated to any recently merged PR — last touched by an earlier commit that never set `currency`.

Found during nightly QA of #2918 (which only changed a className on `FulfillmentDropdown`). Filed as #2947, this PR closes it.

Fix: added `currency: 'USD'` to the shared `meta.args`, matching every other story in this app that renders a money value (`AppointmentPaymentBadge`, `WorkspaceMetaBar`, `TotalBillContainer`, `TreatmentStep`, etc. all do the same).

Closes #2947

## Test plan
- [x] `npx tsc --noEmit` from `apps/frontend` — clean
- [x] `pnpm --filter frontend run lint` — 0 errors (1 pre-existing unrelated warning in a different file)
- [x] Ran Storybook locally, navigated to `workspace-prescriptioneditor--with-saved-prescriptions` — previously crashed, now renders both seeded rows with correct prices ($165, $90), zero console errors
- [x] Navigated to `workspace-prescriptioneditor--search-results-open` (the search-dropdown play-function story) — previously crashed, now runs and renders the dropdown exactly as its own assertions expect (template + 2 medications, correct badges/counts)