### PR TITLE
fix(backend): sync appointment status when a front-desk check-in closes out

### DIFF
--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -2387,6 +2387,107 @@ export const AppointmentPrismaService = {
     return toResponse(updated);
   },
 
+  /**
+   * Same gap as `syncAppointmentOnArrival` (patient-check-in.service.ts), for
+   * the other end of a visit: PatientCheckIn.COMPLETED never touched the
+   * linked Appointment, so the Calendar kept showing "Checked in" for a visit
+   * the front desk had already closed out. A front-desk completion can land
+   * with the appointment still at CHECKED_IN - staff never explicitly moved
+   * it to IN_PROGRESS - so this bridges through IN_PROGRESS first;
+   * `assertAppointmentTransition` only allows one hop at a time. Also runs
+   * the same billing-readiness side effect `updateAppointmentPMS` runs on its
+   * own COMPLETED branch, so a visit closed from the front desk is actually
+   * closed out, not just relabelled.
+   */
+  async completeAppointment(appointmentId: string, organisationId: string) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
+
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+
+    const needsInProgressBridge = row.status === "CHECKED_IN";
+    if (needsInProgressBridge) {
+      assertAppointmentTransition(
+        row.status,
+        "IN_PROGRESS",
+        "completeAppointment",
+      );
+    } else {
+      assertAppointmentTransition(
+        row.status,
+        "COMPLETED",
+        "completeAppointment",
+      );
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      if (needsInProgressBridge) {
+        await tx.appointment.update({
+          where: { id: appointmentId },
+          data: { status: "IN_PROGRESS", updatedAt: new Date() },
+        });
+      }
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: { status: "COMPLETED", updatedAt: new Date() },
+      });
+    });
+
+    await InvoiceService.markAppointmentReadyForBilling(appointmentId, {
+      organisationId: row.organisationId,
+    });
+
+    return toResponse(updated);
+  },
+
+  /**
+   * Same gap as `completeAppointment`, for the NO_SHOW terminal status. Only
+   * reachable from UPCOMING per `assertAppointmentTransition` - a no-op in
+   * the common case where the check-in already advanced the appointment to
+   * CHECKED_IN, which is correct: a patient the desk has a check-in record
+   * for did show up.
+   */
+  async markAppointmentNoShow(appointmentId: string, organisationId: string) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
+
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    assertAppointmentTransition(row.status, "NO_SHOW", "markAppointmentNoShow");
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "NO_SHOW", updatedAt: new Date() },
+    });
+
+    return toResponse(updated);
+  },
+
   async getById(
     appointmentId: string,
     scope: AppointmentAccessScope,

--- a/apps/backend/src/services/patient-check-in.service.ts
+++ b/apps/backend/src/services/patient-check-in.service.ts
@@ -133,6 +133,60 @@ const syncAppointmentRoom = async (
   }
 };
 
+/**
+ * Same gap as `syncAppointmentOnArrival`, for the other end of a visit:
+ * completing a check-in here never told the linked Appointment, so the
+ * Calendar kept showing "Checked in" for a visit the front desk had already
+ * closed out. Best-effort for the same reason - a check-in isn't always
+ * linked to an appointment, and one that's stale or already terminal
+ * shouldn't block the front desk from closing its own record.
+ */
+const syncAppointmentOnComplete = async (
+  appointmentId: string | undefined,
+  organisationId: string,
+): Promise<void> => {
+  if (!appointmentId) return;
+  try {
+    await AppointmentPrismaService.completeAppointment(
+      appointmentId,
+      organisationId,
+    );
+  } catch (err) {
+    if (err instanceof AppointmentPrismaServiceError) return;
+    throw err;
+  }
+};
+
+/** Same gap as `syncAppointmentOnComplete`, for cancelling a check-in. */
+const syncAppointmentOnCancel = async (
+  appointmentId: string | undefined,
+): Promise<void> => {
+  if (!appointmentId) return;
+  try {
+    await AppointmentPrismaService.cancelAppointment(appointmentId);
+  } catch (err) {
+    if (err instanceof AppointmentPrismaServiceError) return;
+    throw err;
+  }
+};
+
+/** Same gap as `syncAppointmentOnComplete`, for marking a check-in no-show. */
+const syncAppointmentOnNoShow = async (
+  appointmentId: string | undefined,
+  organisationId: string,
+): Promise<void> => {
+  if (!appointmentId) return;
+  try {
+    await AppointmentPrismaService.markAppointmentNoShow(
+      appointmentId,
+      organisationId,
+    );
+  } catch (err) {
+    if (err instanceof AppointmentPrismaServiceError) return;
+    throw err;
+  }
+};
+
 export const PatientCheckInService = {
   async create(params: CreateCheckInParams) {
     const record = await prisma.patientCheckIn.create({
@@ -253,11 +307,18 @@ export const PatientCheckInService = {
         409,
       );
     }
-    return prisma.patientCheckIn.update({
+    const record = await prisma.patientCheckIn.update({
       where: { id },
       data: { status: "COMPLETED" },
       select: checkInSelect,
     });
+
+    await syncAppointmentOnComplete(
+      existing.appointmentId ?? undefined,
+      organisationId,
+    );
+
+    return record;
   },
 
   async cancel(id: string, organisationId: string) {
@@ -268,11 +329,15 @@ export const PatientCheckInService = {
         409,
       );
     }
-    return prisma.patientCheckIn.update({
+    const record = await prisma.patientCheckIn.update({
       where: { id },
       data: { status: "CANCELLED" },
       select: checkInSelect,
     });
+
+    await syncAppointmentOnCancel(existing.appointmentId ?? undefined);
+
+    return record;
   },
 
   async markNoShow(id: string, organisationId: string) {
@@ -283,11 +348,18 @@ export const PatientCheckInService = {
         409,
       );
     }
-    return prisma.patientCheckIn.update({
+    const record = await prisma.patientCheckIn.update({
       where: { id },
       data: { status: "NO_SHOW" },
       select: checkInSelect,
     });
+
+    await syncAppointmentOnNoShow(
+      existing.appointmentId ?? undefined,
+      organisationId,
+    );
+
+    return record;
   },
 
   async assignRoom(id: string, organisationId: string, roomId: string) {

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -3621,6 +3621,161 @@ describe("AppointmentPrismaService", () => {
     });
   });
 
+  describe("completeAppointment", () => {
+    it("requires an appointmentId", async () => {
+      await expect(
+        AppointmentPrismaService.completeAppointment("", "org_1"),
+      ).rejects.toMatchObject({
+        message: "appointmentId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.completeAppointment("appt_1", ""),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("throws 404 when the appointment does not exist", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.completeAppointment("appt_1", "org_1"),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+    });
+
+    it("completes an IN_PROGRESS appointment directly", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "IN_PROGRESS" }),
+      );
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ status: "COMPLETED" }),
+      );
+
+      const result = await AppointmentPrismaService.completeAppointment(
+        "appt_1",
+        "org_1",
+      );
+
+      expect(mockedPrisma.appointment.update).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe("COMPLETED");
+    });
+
+    it("bridges a CHECKED_IN appointment through IN_PROGRESS on its way to COMPLETED", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "CHECKED_IN" }),
+      );
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ status: "COMPLETED" }),
+      );
+
+      const result = await AppointmentPrismaService.completeAppointment(
+        "appt_1",
+        "org_1",
+      );
+
+      expect(mockedPrisma.appointment.update).toHaveBeenCalledTimes(2);
+      expect(mockedPrisma.appointment.update.mock.calls[0][0].data.status).toBe(
+        "IN_PROGRESS",
+      );
+      expect(mockedPrisma.appointment.update.mock.calls[1][0].data.status).toBe(
+        "COMPLETED",
+      );
+      expect(result.status).toBe("COMPLETED");
+    });
+
+    it("rejects completing an appointment that was never checked in", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "UPCOMING" }),
+      );
+
+      await expect(
+        AppointmentPrismaService.completeAppointment("appt_1", "org_1"),
+      ).rejects.toMatchObject({ statusCode: 409 });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+    });
+
+    it("marks the appointment ready for billing after completing", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "IN_PROGRESS", organisationId: "org_1" }),
+      );
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ status: "COMPLETED" }),
+      );
+
+      await AppointmentPrismaService.completeAppointment("appt_1", "org_1");
+
+      expect(
+        mockedInvoiceService.markAppointmentReadyForBilling,
+      ).toHaveBeenCalledWith("appt_1", { organisationId: "org_1" });
+    });
+  });
+
+  describe("markAppointmentNoShow", () => {
+    it("requires an appointmentId", async () => {
+      await expect(
+        AppointmentPrismaService.markAppointmentNoShow("", "org_1"),
+      ).rejects.toMatchObject({
+        message: "appointmentId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.markAppointmentNoShow("appt_1", ""),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
+    it("throws 404 when the appointment does not exist", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.markAppointmentNoShow("appt_1", "org_1"),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+    });
+
+    it("marks an UPCOMING appointment as NO_SHOW", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "UPCOMING" }),
+      );
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({ status: "NO_SHOW" }),
+      );
+
+      const result = await AppointmentPrismaService.markAppointmentNoShow(
+        "appt_1",
+        "org_1",
+      );
+
+      expect(result.status).toBe("NO_SHOW");
+    });
+
+    it("rejects marking no-show an appointment already CHECKED_IN", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
+        makeRow({ status: "CHECKED_IN" }),
+      );
+
+      await expect(
+        AppointmentPrismaService.markAppointmentNoShow("appt_1", "org_1"),
+      ).rejects.toMatchObject({ statusCode: 409 });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getById guard clauses and payment states", () => {
     it("requires an appointmentId", async () => {
       await expect(

--- a/apps/backend/test/services/patient-check-in.service.test.ts
+++ b/apps/backend/test/services/patient-check-in.service.test.ts
@@ -28,6 +28,9 @@ jest.mock("../../src/services/appointment.prisma.service", () => {
     AppointmentPrismaService: {
       checkInAppointment: jest.fn(),
       updateAppointmentRoom: jest.fn(),
+      completeAppointment: jest.fn(),
+      cancelAppointment: jest.fn(),
+      markAppointmentNoShow: jest.fn(),
     },
     AppointmentPrismaServiceError,
   };
@@ -48,6 +51,12 @@ const mockedCheckInAppointment =
   AppointmentPrismaService.checkInAppointment as jest.Mock;
 const mockedUpdateAppointmentRoom =
   AppointmentPrismaService.updateAppointmentRoom as jest.Mock;
+const mockedCompleteAppointment =
+  AppointmentPrismaService.completeAppointment as jest.Mock;
+const mockedCancelAppointment =
+  AppointmentPrismaService.cancelAppointment as jest.Mock;
+const mockedMarkAppointmentNoShow =
+  AppointmentPrismaService.markAppointmentNoShow as jest.Mock;
 
 const arrivedAt = new Date("2026-06-30T09:00:00Z");
 const baseCheckIn = {
@@ -279,6 +288,74 @@ describe("PatientCheckInService", () => {
         PatientCheckInService.complete("checkin-1", "org-1"),
       ).rejects.toThrow(PatientCheckInError);
     });
+
+    it("does not touch the appointment when the check-in is not linked to one", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue(
+        baseCheckIn,
+      );
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        status: "COMPLETED",
+      });
+      await PatientCheckInService.complete("checkin-1", "org-1");
+      expect(mockedCompleteAppointment).not.toHaveBeenCalled();
+    });
+
+    it("completes the linked appointment so the Calendar reflects the visit closing", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "COMPLETED",
+      });
+      mockedCompleteAppointment.mockResolvedValue(undefined);
+
+      await PatientCheckInService.complete("checkin-1", "org-1");
+
+      expect(mockedCompleteAppointment).toHaveBeenCalledWith("appt-1", "org-1");
+    });
+
+    it("still completes the check-in when the appointment cannot be transitioned", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "COMPLETED",
+      });
+      mockedCompleteAppointment.mockRejectedValue(
+        new AppointmentPrismaServiceError(
+          "Appointment cannot transition from REQUESTED to COMPLETED in completeAppointment.",
+          409,
+        ),
+      );
+
+      const result = await PatientCheckInService.complete("checkin-1", "org-1");
+
+      expect(result.status).toBe("COMPLETED");
+    });
+
+    it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "COMPLETED",
+      });
+      mockedCompleteAppointment.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        PatientCheckInService.complete("checkin-1", "org-1"),
+      ).rejects.toThrow("db down");
+    });
   });
 
   describe("cancel", () => {
@@ -292,6 +369,71 @@ describe("PatientCheckInService", () => {
       );
       const result = await PatientCheckInService.cancel("checkin-1", "org-1");
       expect(result.status).toBe("CANCELLED");
+    });
+
+    it("does not touch the appointment when the check-in is not linked to one", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue(
+        baseCheckIn,
+      );
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        status: "CANCELLED",
+      });
+      await PatientCheckInService.cancel("checkin-1", "org-1");
+      expect(mockedCancelAppointment).not.toHaveBeenCalled();
+    });
+
+    it("cancels the linked appointment so the Calendar reflects the cancellation", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "CANCELLED",
+      });
+      mockedCancelAppointment.mockResolvedValue(undefined);
+
+      await PatientCheckInService.cancel("checkin-1", "org-1");
+
+      expect(mockedCancelAppointment).toHaveBeenCalledWith("appt-1");
+    });
+
+    it("still cancels the check-in when the appointment cannot be transitioned", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "CANCELLED",
+      });
+      mockedCancelAppointment.mockRejectedValue(
+        new AppointmentPrismaServiceError("Appointment not found", 404),
+      );
+
+      const result = await PatientCheckInService.cancel("checkin-1", "org-1");
+
+      expect(result.status).toBe("CANCELLED");
+    });
+
+    it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "CANCELLED",
+      });
+      mockedCancelAppointment.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        PatientCheckInService.cancel("checkin-1", "org-1"),
+      ).rejects.toThrow("db down");
     });
   });
 
@@ -319,6 +461,80 @@ describe("PatientCheckInService", () => {
       await expect(
         PatientCheckInService.markNoShow("checkin-1", "org-1"),
       ).rejects.toThrow(PatientCheckInError);
+    });
+
+    it("does not touch the appointment when the check-in is not linked to one", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue(
+        baseCheckIn,
+      );
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        status: "NO_SHOW",
+      });
+      await PatientCheckInService.markNoShow("checkin-1", "org-1");
+      expect(mockedMarkAppointmentNoShow).not.toHaveBeenCalled();
+    });
+
+    it("marks the linked appointment no-show so the Calendar reflects it", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "NO_SHOW",
+      });
+      mockedMarkAppointmentNoShow.mockResolvedValue(undefined);
+
+      await PatientCheckInService.markNoShow("checkin-1", "org-1");
+
+      expect(mockedMarkAppointmentNoShow).toHaveBeenCalledWith(
+        "appt-1",
+        "org-1",
+      );
+    });
+
+    it("still marks the check-in no-show when the appointment cannot be transitioned (e.g. already CHECKED_IN)", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "NO_SHOW",
+      });
+      mockedMarkAppointmentNoShow.mockRejectedValue(
+        new AppointmentPrismaServiceError(
+          "Appointment cannot transition from CHECKED_IN to NO_SHOW in markAppointmentNoShow.",
+          409,
+        ),
+      );
+
+      const result = await PatientCheckInService.markNoShow(
+        "checkin-1",
+        "org-1",
+      );
+
+      expect(result.status).toBe("NO_SHOW");
+    });
+
+    it("still throws an unexpected non-appointment error rather than swallowing it", async () => {
+      (mockedPrisma.patientCheckIn.findFirst as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+      });
+      (mockedPrisma.patientCheckIn.update as jest.Mock).mockResolvedValue({
+        ...baseCheckIn,
+        appointmentId: "appt-1",
+        status: "NO_SHOW",
+      });
+      mockedMarkAppointmentNoShow.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        PatientCheckInService.markNoShow("checkin-1", "org-1"),
+      ).rejects.toThrow("db down");
     });
   });
 


### PR DESCRIPTION
## What changed

`PatientCheckIn.complete` / `.cancel` / `.markNoShow` only ever wrote the `PatientCheckIn` row. They never touched the linked `Appointment`, so after Front Desk marked a visit **Completed**, the Calendar's own status badge on that appointment kept showing **Checked in** — the two screens read two different state machines (`CheckInStatus` vs `AppointmentStatus`) that were only ever wired together at arrival (`syncAppointmentOnArrival`, which sets `CHECKED_IN`).

This closes the same gap for the other three transitions:

- `AppointmentPrismaService.completeAppointment` (new) — bridges `CHECKED_IN` → `IN_PROGRESS` → `COMPLETED` in one call, since a front-desk completion can land with the appointment never explicitly moved to `IN_PROGRESS`. Also runs the same `InvoiceService.markAppointmentReadyForBilling` side effect the Calendar's own completion path (`updateAppointmentPMS`) already runs, so a visit closed from the front desk is actually closed out for billing, not just relabelled.
- `AppointmentPrismaService.markAppointmentNoShow` (new) — mirrors `checkInAppointment`'s shape for the `NO_SHOW` terminal status.
- `patient-check-in.service.ts`'s `complete`/`cancel`/`markNoShow` now call their appointment counterpart (`completeAppointment` / the existing `cancelAppointment` / `markAppointmentNoShow`) after writing the check-in, the same best-effort way check-in creation already syncs `CHECKED_IN` — a stale, unlinked, or already-terminal appointment throws `AppointmentPrismaServiceError`, which is caught and swallowed rather than blocking the front desk from closing its own record.

## Why

Reported: front desk marks an appointment Completed in Arrivals, but the Calendar's own appointment popup still shows "Checked in" for the same appointment — the two views were never actually synced past the initial check-in.

## Impact area

`apps/backend` only — `AppointmentPrismaService` (new `completeAppointment`, `markAppointmentNoShow`) and `PatientCheckInService` (`complete`/`cancel`/`markNoShow` now sync the linked appointment). No frontend or API contract changes; the check-in endpoints' request/response shapes are unchanged.

## Validation performed

- `npx tsc --noemit` — clean.
- `npx eslint` on all four touched files — 0 errors (1 pre-existing warning, unrelated line).
- Targeted Jest: `patient-check-in.service.test.ts`, `appointment.prisma.service.test.ts`, `patient-check-in.controller.test.ts` — 244/244 passing, including new coverage for every new sync path (linked-appointment success, unlinked no-op, appointment-transition-rejected best-effort swallow, unexpected-error passthrough) and the `completeAppointment` bridging/billing logic.
- Mutation-checked: reverted the `complete` handler's sync call, confirmed the new tests fail (2 failures, exact expected shape), then restored the fix and re-ran green.