### PR TITLE
feat(backend,frontend): add CONSENT template kind, surface signed consent docs

### DIFF
--- a/apps/backend/src/controllers/app/document.controller.ts
+++ b/apps/backend/src/controllers/app/document.controller.ts
@@ -417,6 +417,45 @@ export const DocumentController = {
     }
   },
 
+  listConsentForPms: async (
+    req: Request<{ patientId?: string }>,
+    res: Response,
+  ) => {
+    try {
+      const orgReq = req as OrgRequest;
+      const organisationId = orgReq.organisationId;
+      const pmsUserId = resolveVerifiedUserId(req);
+      if (!pmsUserId) {
+        return res
+          .status(401)
+          .json({ message: "Not authenticated as PMS user." });
+      }
+
+      const { patientId } = req.params;
+
+      if (!patientId) {
+        return res.status(400).json({ message: "Companion ID is required." });
+      }
+
+      if (!organisationId) {
+        return res.status(400).json({ message: "organisationId is required." });
+      }
+
+      const docs = await DocumentService.listConsentDocumentsForPms({
+        patientId,
+        organisationId,
+      });
+
+      return res.status(200).json(docs);
+    } catch (error) {
+      if (error instanceof DocumentServiceError) {
+        return res.status(error.statusCode).json({ message: error.message });
+      }
+      logger.error("Failed to list consent documents for PMS", error);
+      return res.status(500).json({ message: "Unable to fetch documents." });
+    }
+  },
+
   getForParent: async (req: Request<{ id: string }>, res: Response) => {
     try {
       const authUserId = resolveVerifiedUserId(req);

--- a/apps/backend/src/routers/document.router.ts
+++ b/apps/backend/src/routers/document.router.ts
@@ -109,6 +109,15 @@ router.get(
   DocumentController.listForPms,
 );
 
+// List just the consent documents for companion, from the e-signing portal (PMS)
+router.get(
+  "/pms/:patientId/consent",
+  requireWebAuth,
+  withOrgPermissions(),
+  requirePermission("document:view:any"),
+  DocumentController.listConsentForPms,
+);
+
 // Get document details (PMS)
 router.get(
   "/pms/details/:documentId",

--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -1,3 +1,4 @@
+import type { TemplateKind } from "@yosemite-crew/database";
 import { prisma } from "src/config/prisma";
 import {
   deleteFromS3,
@@ -396,6 +397,7 @@ const loadAppointmentForDocumentLookup = async (appointmentId: string) => {
 const loadRenderedDocumentsForAppointments = async (params: {
   appointmentIds: string[];
   organisationId: string;
+  kind?: TemplateKind;
 }) => {
   if (params.appointmentIds.length === 0) {
     return [];
@@ -404,6 +406,7 @@ const loadRenderedDocumentsForAppointments = async (params: {
   const renderedDocuments = (await prisma.renderedDocument.findMany({
     where: {
       organisationId: params.organisationId,
+      ...(params.kind ? { kind: params.kind } : {}),
       OR: [
         {
           templateInstance: {
@@ -787,6 +790,34 @@ export const DocumentService = {
         new Date(right.updatedAt).getTime() -
         new Date(left.updatedAt).getTime(),
     );
+  },
+
+  /**
+   * Just the e-signing-portal (Documenso) documents that are actually
+   * consent, for the companion-history Consent section - not every
+   * RenderedDocument (SOAP notes, prescriptions, invoices, ...) and not the
+   * plain uploaded Document rows listForPms also returns. Deliberately a
+   * narrow sibling rather than a listForPms option: listForPms feeds three
+   * other consumers (PMS docs tab, mobile app tab, companion-history
+   * timeline) and widening its existing merge is riskier than adding this.
+   */
+  async listConsentDocumentsForPms(params: {
+    patientId: string;
+    organisationId: string;
+  }): Promise<DocumentDto[]> {
+    const patientId = normalizeStringId(params.patientId, "patientId");
+    await assertPmsCanAccessCompanion(params.organisationId, patientId);
+
+    const appointmentIds = await loadAppointmentIdsForPatient({
+      patientId,
+      organisationId: params.organisationId,
+    });
+
+    return loadRenderedDocumentsForAppointments({
+      appointmentIds,
+      organisationId: params.organisationId,
+      kind: "CONSENT",
+    });
   },
 
   async getByIdForParent(

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -1250,11 +1250,14 @@ export const TemplateService = {
     search?: string;
     allowedKinds?: readonly TemplateKind[];
   }) {
-    const requestedKinds = filters?.kind
-      ? (Array.isArray(filters.kind) ? filters.kind : [filters.kind]).map(
-          toStorageTemplateKind,
-        )
-      : undefined;
+    let requestedKindsInput:
+      ReadonlyArray<TemplateKind | TemplateContractKind> | undefined;
+    if (filters?.kind) {
+      requestedKindsInput = Array.isArray(filters.kind)
+        ? filters.kind
+        : [filters.kind];
+    }
+    const requestedKinds = requestedKindsInput?.map(toStorageTemplateKind);
     const allowedKinds = filters?.allowedKinds;
 
     let kindFilter: Prisma.TemplateWhereInput["kind"];

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -542,17 +542,21 @@ const resolveTemplateModeFromContext = async (
 };
 
 /**
- * Templates can be requested by one kind or several (a CONSENT lookup has to
- * match both CONSENT and the legacy FORM-tagged templates authored before
- * CONSENT existed as a storage value - see normalizeResolverKind). Collapses
- * that either shape to what Prisma's `kind` field actually accepts.
+ * One kind or several - a CONSENT lookup has to match both CONSENT and the
+ * legacy FORM-tagged templates authored before CONSENT existed as a storage
+ * value (see normalizeResolverKind), so every kind filter accepts either shape.
+ */
+type TemplateKindFilter =
+  | TemplateKind
+  | TemplateContractKind
+  | ReadonlyArray<TemplateKind | TemplateContractKind>;
+
+/**
+ * Collapses either shape of TemplateKindFilter to what Prisma's `kind` field
+ * actually accepts.
  */
 const toKindFilter = (
-  kind:
-    | TemplateKind
-    | TemplateContractKind
-    | ReadonlyArray<TemplateKind | TemplateContractKind>
-    | undefined,
+  kind: TemplateKindFilter | undefined,
 ): Prisma.TemplateWhereInput["kind"] => {
   if (!kind) return undefined;
   const storageKinds = (Array.isArray(kind) ? kind : [kind]).map(
@@ -1207,10 +1211,7 @@ export const TemplateService = {
   async listForOrganisation(
     organisationId: string,
     filters?: {
-      kind?:
-        | TemplateKind
-        | TemplateContractKind
-        | ReadonlyArray<TemplateKind | TemplateContractKind>;
+      kind?: TemplateKindFilter;
       status?: TemplateStatus;
       scope?: TemplateScope;
       search?: string;
@@ -1241,10 +1242,7 @@ export const TemplateService = {
    * explicit `kind` filter can only narrow further, never widen.
    */
   async listLibrary(filters?: {
-    kind?:
-      | TemplateKind
-      | TemplateContractKind
-      | ReadonlyArray<TemplateKind | TemplateContractKind>;
+    kind?: TemplateKindFilter;
     status?: TemplateStatus;
     scope?: TemplateScope;
     search?: string;
@@ -1293,10 +1291,7 @@ export const TemplateService = {
     organisationId: string,
     ownerUserId: string,
     filters?: {
-      kind?:
-        | TemplateKind
-        | TemplateContractKind
-        | ReadonlyArray<TemplateKind | TemplateContractKind>;
+      kind?: TemplateKindFilter;
       status?: TemplateStatus;
       scope?: TemplateScope;
       search?: string;

--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -376,8 +376,6 @@ const toStorageTemplateKind = (kind: TemplateContractKind | TemplateKind) => {
       return "TASK_TEMPLATE" as TemplateKind;
     case "INPATIENT_SCHEDULE":
       return "CARE_PATHWAY" as TemplateKind;
-    case "CONSENT":
-      return "FORM" as TemplateKind;
     default:
       return kind;
   }
@@ -543,10 +541,34 @@ const resolveTemplateModeFromContext = async (
   return admission ? "INPATIENT" : "OUTPATIENT";
 };
 
+/**
+ * Templates can be requested by one kind or several (a CONSENT lookup has to
+ * match both CONSENT and the legacy FORM-tagged templates authored before
+ * CONSENT existed as a storage value - see normalizeResolverKind). Collapses
+ * that either shape to what Prisma's `kind` field actually accepts.
+ */
+const toKindFilter = (
+  kind:
+    | TemplateKind
+    | TemplateContractKind
+    | ReadonlyArray<TemplateKind | TemplateContractKind>
+    | undefined,
+): Prisma.TemplateWhereInput["kind"] => {
+  if (!kind) return undefined;
+  const storageKinds = (Array.isArray(kind) ? kind : [kind]).map(
+    toStorageTemplateKind,
+  );
+  return storageKinds.length > 1 ? { in: storageKinds } : storageKinds[0];
+};
+
 const normalizeResolverKind = (kind: TemplateContractKind): TemplateKind[] => {
   switch (kind) {
     case "CONSENT":
-      return ["FORM"];
+      // Additive, not a replacement: templates authored before CONSENT
+      // existed as a value are still stored as FORM, and nothing can
+      // retroactively relabel them, so appointment-time resolution has to
+      // keep finding those alongside newly-authored CONSENT templates.
+      return ["CONSENT", "FORM"];
     case "TASK_ASSIGNMENT":
       return ["TASK_TEMPLATE"];
     case "INPATIENT_SCHEDULE":
@@ -1185,7 +1207,10 @@ export const TemplateService = {
   async listForOrganisation(
     organisationId: string,
     filters?: {
-      kind?: TemplateKind | TemplateContractKind;
+      kind?:
+        | TemplateKind
+        | TemplateContractKind
+        | ReadonlyArray<TemplateKind | TemplateContractKind>;
       status?: TemplateStatus;
       scope?: TemplateScope;
       search?: string;
@@ -1195,7 +1220,7 @@ export const TemplateService = {
       where: {
         organisationId: ensureId(organisationId, "organisationId"),
         ownership: "ORG_TEMPLATE",
-        kind: filters?.kind ? toStorageTemplateKind(filters.kind) : undefined,
+        kind: toKindFilter(filters?.kind),
         status: filters?.status,
         scope: filters?.scope,
         ...buildTemplateSearchFilter(filters?.search),
@@ -1216,24 +1241,32 @@ export const TemplateService = {
    * explicit `kind` filter can only narrow further, never widen.
    */
   async listLibrary(filters?: {
-    kind?: TemplateKind | TemplateContractKind;
+    kind?:
+      | TemplateKind
+      | TemplateContractKind
+      | ReadonlyArray<TemplateKind | TemplateContractKind>;
     status?: TemplateStatus;
     scope?: TemplateScope;
     search?: string;
     allowedKinds?: readonly TemplateKind[];
   }) {
-    const requestedKind = filters?.kind
-      ? toStorageTemplateKind(filters.kind)
+    const requestedKinds = filters?.kind
+      ? (Array.isArray(filters.kind) ? filters.kind : [filters.kind]).map(
+          toStorageTemplateKind,
+        )
       : undefined;
     const allowedKinds = filters?.allowedKinds;
 
     let kindFilter: Prisma.TemplateWhereInput["kind"];
-    if (requestedKind && allowedKinds) {
-      kindFilter = allowedKinds.includes(requestedKind)
-        ? requestedKind
-        : { in: [] };
-    } else if (requestedKind) {
-      kindFilter = requestedKind;
+    if (requestedKinds && allowedKinds) {
+      const permitted = requestedKinds.filter((kind) =>
+        allowedKinds.includes(kind),
+      );
+      kindFilter =
+        permitted.length > 1 ? { in: permitted } : (permitted[0] ?? { in: [] });
+    } else if (requestedKinds) {
+      kindFilter =
+        requestedKinds.length > 1 ? { in: requestedKinds } : requestedKinds[0];
     } else if (allowedKinds) {
       kindFilter = { in: [...allowedKinds] };
     }
@@ -1257,7 +1290,10 @@ export const TemplateService = {
     organisationId: string,
     ownerUserId: string,
     filters?: {
-      kind?: TemplateKind | TemplateContractKind;
+      kind?:
+        | TemplateKind
+        | TemplateContractKind
+        | ReadonlyArray<TemplateKind | TemplateContractKind>;
       status?: TemplateStatus;
       scope?: TemplateScope;
       search?: string;
@@ -1268,7 +1304,7 @@ export const TemplateService = {
         organisationId: ensureId(organisationId, "organisationId"),
         ownerUserId: ensureId(ownerUserId, "ownerUserId"),
         ownership: "USER_TEMPLATE",
-        kind: filters?.kind ? toStorageTemplateKind(filters.kind) : undefined,
+        kind: toKindFilter(filters?.kind),
         status: filters?.status,
         scope: filters?.scope,
         ...buildTemplateSearchFilter(filters?.search),
@@ -1304,7 +1340,11 @@ export const TemplateService = {
     };
     const prismaKinds = normalizeResolverKind(parsed.kind);
     const filters = {
-      kind: prismaKinds[0],
+      // Every prismaKinds entry, not just the first - a CONSENT lookup must
+      // still find templates authored before CONSENT existed as a value and
+      // so remain stored as FORM (see normalizeResolverKind). Stays a scalar
+      // for every other kind, which only ever normalizes to one entry.
+      kind: prismaKinds.length > 1 ? prismaKinds : prismaKinds[0],
       status: TemplateStatus.PUBLISHED,
       scope: undefined as TemplateScope | undefined,
     };

--- a/apps/backend/test/controllers/app/document.controller.test.ts
+++ b/apps/backend/test/controllers/app/document.controller.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../src/services/document.service", () => {
       listForAppointmentPms: jest.fn(),
       update: jest.fn(),
       listForPms: jest.fn(),
+      listConsentDocumentsForPms: jest.fn(),
       getByIdForParent: jest.fn(),
       getByIdForPms: jest.fn(),
       deleteForParent: jest.fn(),
@@ -538,6 +539,63 @@ describe("DocumentController", () => {
       req.params = { patientId: "c1" };
       mockGenericError("listForPms");
       await DocumentController.listForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("listConsentForPms", () => {
+    it("should 401 if auth missing", async () => {
+      await DocumentController.listConsentForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(401);
+    });
+
+    it("should 400 if patientId missing", async () => {
+      (req as any).userId = "pms1";
+      req.params = {};
+      await DocumentController.listConsentForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(400);
+    });
+
+    it("should 400 if organisationId missing", async () => {
+      (req as any).userId = "pms1";
+      req.params = { patientId: "c1" };
+      await DocumentController.listConsentForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(400);
+    });
+
+    it("should succeed (200) and scope the lookup to patientId and organisationId", async () => {
+      (req as any).userId = "pms1";
+      (req as any).organisationId = "org1";
+      req.params = { patientId: "c1" };
+      mockedDocumentService.listConsentDocumentsForPms.mockResolvedValue(
+        [] as any,
+      );
+
+      await DocumentController.listConsentForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(
+        mockedDocumentService.listConsentDocumentsForPms,
+      ).toHaveBeenCalledWith({
+        patientId: "c1",
+        organisationId: "org1",
+      });
+    });
+
+    it("should handle service error", async () => {
+      (req as any).userId = "pms1";
+      (req as any).organisationId = "org1";
+      req.params = { patientId: "c1" };
+      mockServiceError("listConsentDocumentsForPms", 404);
+      await DocumentController.listConsentForPms(req as any, res as Response);
+      expect(statusMock).toHaveBeenCalledWith(404);
+    });
+
+    it("should handle generic error", async () => {
+      (req as any).userId = "pms1";
+      (req as any).organisationId = "org1";
+      req.params = { patientId: "c1" };
+      mockGenericError("listConsentDocumentsForPms");
+      await DocumentController.listConsentForPms(req as any, res as Response);
       expect(statusMock).toHaveBeenCalledWith(500);
     });
   });

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -337,6 +337,112 @@ describe("DocumentService", () => {
     });
   });
 
+  describe("listConsentDocumentsForPms", () => {
+    it("returns only CONSENT-kind rendered documents across every one of the patient's appointments", async () => {
+      const otherAppointmentId = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
+      mockedPrisma.appointment.findMany.mockResolvedValue([
+        { id: uuidAppointmentId },
+        { id: otherAppointmentId },
+      ] as any);
+      mockedPrisma.renderedDocument.findMany.mockResolvedValue([
+        {
+          id: "rd-consent-1",
+          organisationId: uuidOrganisationId,
+          sourceKind: "TEMPLATE_INSTANCE",
+          sourceId: "ti-1",
+          templateId: "tmpl-1",
+          templateVersion: 1,
+          kind: "CONSENT",
+          title: "Surgical consent",
+          status: "SIGNED",
+          pdfUrl: "https://cdn/consent.pdf",
+          signing: { status: "SIGNED" },
+          signedAt: now,
+          createdAt: now,
+          updatedAt: now,
+          templateInstance: {
+            appointmentId: uuidAppointmentId,
+            encounterId: null,
+          },
+          clinicalArtifact: null,
+        },
+      ] as any);
+
+      const result = await DocumentService.listConsentDocumentsForPms({
+        patientId: uuidPatientId,
+        organisationId: uuidOrganisationId,
+      });
+
+      expect(mockedPrisma.patientOrganisation.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organisationId: uuidOrganisationId,
+            patientId: uuidPatientId,
+          }),
+        }),
+      );
+      expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organisationId: uuidOrganisationId,
+            kind: "CONSENT",
+            OR: [
+              {
+                templateInstance: {
+                  is: {
+                    appointmentId: {
+                      in: [uuidAppointmentId, otherAppointmentId],
+                    },
+                  },
+                },
+              },
+              {
+                clinicalArtifact: {
+                  is: {
+                    appointmentId: {
+                      in: [uuidAppointmentId, otherAppointmentId],
+                    },
+                  },
+                },
+              },
+            ],
+          }),
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: "rd-consent-1",
+        category: "CONSENT",
+        signingStatus: "SIGNED",
+        pdfUrl: "https://cdn/consent.pdf",
+      });
+    });
+
+    it("returns nothing for a patient with no appointments, without querying rendered documents", async () => {
+      mockedPrisma.appointment.findMany.mockResolvedValue([]);
+
+      const result = await DocumentService.listConsentDocumentsForPms({
+        patientId: uuidPatientId,
+        organisationId: uuidOrganisationId,
+      });
+
+      expect(mockedPrisma.renderedDocument.findMany).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("rejects a patient the caller's organisation cannot access", async () => {
+      mockedPrisma.patientOrganisation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        DocumentService.listConsentDocumentsForPms({
+          patientId: uuidPatientId,
+          organisationId: uuidOrganisationId,
+        }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+      expect(mockedPrisma.appointment.findMany).not.toHaveBeenCalled();
+    });
+  });
+
   it("scopes the rendered-document lookup to an explicit appointmentId filter", async () => {
     const otherAppointmentId = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
     mockedPrisma.appointment.findMany.mockResolvedValue([

--- a/apps/backend/test/services/template.service.test.ts
+++ b/apps/backend/test/services/template.service.test.ts
@@ -695,7 +695,7 @@ describe("TemplateService.create", () => {
     expect(result).toEqual({ id: "created" });
   });
 
-  it("maps CONSENT to the FORM storage kind and binds the owner for user templates", async () => {
+  it("stores CONSENT as its own storage kind and binds the owner for user templates", async () => {
     const txTemplateCreate = jest.fn().mockResolvedValue({ id: "tpl-user" });
     (prisma.$transaction as jest.Mock).mockImplementation(
       async (callback: any) =>
@@ -719,7 +719,7 @@ describe("TemplateService.create", () => {
 
     expect(txTemplateCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
-        kind: "FORM",
+        kind: "CONSENT",
         ownerUserId: "user-9",
         updatedBy: "user-2",
         rules: undefined,
@@ -1647,7 +1647,7 @@ describe("TemplateService list methods", () => {
         where: expect.objectContaining({
           organisationId: "org-1",
           ownership: "ORG_TEMPLATE",
-          kind: "FORM",
+          kind: "CONSENT",
           status: "PUBLISHED",
           scope: "ORGANISATION",
           OR: [
@@ -1717,6 +1717,50 @@ describe("TemplateService list methods", () => {
     expect(prisma.template.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ kind: "CARE_PATHWAY" }),
+      }),
+    );
+  });
+
+  it("queries an IN filter when asked for more than one kind at once", async () => {
+    (prisma.template.findMany as jest.Mock).mockResolvedValue([]);
+
+    await TemplateService.listForOrganisation("org-1", {
+      kind: ["CONSENT", "FORM"],
+    });
+
+    expect(prisma.template.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ kind: { in: ["CONSENT", "FORM"] } }),
+      }),
+    );
+  });
+
+  it("intersects a multi-kind library request with the caller's allowed kinds", async () => {
+    (prisma.template.findMany as jest.Mock).mockResolvedValue([]);
+
+    await TemplateService.listLibrary({
+      kind: ["CONSENT", "FORM"],
+      allowedKinds: ["FORM"],
+    });
+
+    expect(prisma.template.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ kind: "FORM" }),
+      }),
+    );
+  });
+
+  it("denies a multi-kind library request with no overlap in the caller's allowed kinds", async () => {
+    (prisma.template.findMany as jest.Mock).mockResolvedValue([]);
+
+    await TemplateService.listLibrary({
+      kind: ["CONSENT"],
+      allowedKinds: ["FORM"],
+    });
+
+    expect(prisma.template.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ kind: { in: [] } }),
       }),
     );
   });
@@ -1920,6 +1964,36 @@ describe("TemplateService.resolve", () => {
       templateId: "c1",
       reason: "Matched organisation default template for kind (default).",
     });
+  });
+
+  it("resolves a CONSENT lookup against both CONSENT and legacy FORM-stored templates", async () => {
+    // Templates authored before CONSENT existed as a storage value are still
+    // FORM - normalizeResolverKind widens the lookup so a CONSENT resolve
+    // keeps finding them alongside anything newly stored as CONSENT.
+    listForOrganisationSpy.mockResolvedValue([
+      resolverTemplate({
+        id: "legacy-form-consent",
+        appliesTo: { defaultForKind: true },
+      }),
+    ] as never);
+    (prisma.templateVersion.findUnique as jest.Mock).mockResolvedValue({
+      id: "v-legacy",
+      version: 1,
+      schemaSnapshot: { sections: [] },
+      renderConfigSnapshot: null,
+      validationSnapshot: null,
+    });
+
+    const result = await TemplateService.resolve({
+      organisationId: "org-1",
+      kind: "CONSENT",
+    });
+
+    expect(listForOrganisationSpy).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ kind: ["CONSENT", "FORM"] }),
+    );
+    expect(result).toMatchObject({ templateId: "legacy-form-consent" });
   });
 
   it("falls back to a YC library default template", async () => {

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
@@ -10,6 +10,8 @@ import {
   revokePatientConsent,
   type PatientConsent,
 } from '@/app/features/companionHistory/services/patientConsentService';
+import { loadConsentDocumentsForCompanion } from '@/app/features/companions/services/companionDocumentService';
+import type { CompanionRecord } from '@/app/features/documents/types/companionDocuments';
 
 const notifyMock = jest.fn();
 let permissionsMock: string[] = ['appointments:view:any', 'appointments:edit:any'];
@@ -32,10 +34,15 @@ jest.mock('@/app/features/companionHistory/services/patientConsentService', () =
   revokePatientConsent: jest.fn(),
 }));
 
+jest.mock('@/app/features/companions/services/companionDocumentService', () => ({
+  loadConsentDocumentsForCompanion: jest.fn(),
+}));
+
 const fetchMock = fetchPatientConsents as jest.Mock;
 const grantMock = grantPatientConsent as jest.Mock;
 const revokeMock = revokePatientConsent as jest.Mock;
 const isAuthRedirectMock = isAuthRedirectError as jest.Mock;
+const loadSignedDocumentsMock = loadConsentDocumentsForCompanion as jest.Mock;
 
 const consent = (
   over: Partial<PatientConsent> & { id: string; consentType: PatientConsent['consentType'] }
@@ -61,6 +68,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   permissionsMock = ['appointments:view:any', 'appointments:edit:any'];
   fetchMock.mockResolvedValue([]);
+  loadSignedDocumentsMock.mockResolvedValue([]);
 });
 
 describe('ConsentListPanel', () => {
@@ -292,6 +300,43 @@ describe('ConsentListPanel', () => {
     const { container } = render(<ConsentListPanel companionId="comp-1" />);
     expect(container).toBeEmptyDOMElement();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('loads and renders signed consent documents from the e-signing portal', async () => {
+    const signedDoc: CompanionRecord = {
+      id: 'doc-1',
+      title: 'Surgical consent - Buddy',
+      category: 'HEALTH',
+      subcategory: 'SURGERY_OR_PROCEDURE',
+      attachments: [],
+      signedAt: '2026-02-01T00:00:00.000Z',
+      pdfUrl: 'https://files.example.com/consent-doc-1.pdf',
+      sourceKind: 'TEMPLATE_INSTANCE',
+    };
+    loadSignedDocumentsMock.mockResolvedValue([signedDoc]);
+    const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
+
+    render(<ConsentListPanel companionId="comp-1" />);
+
+    expect(await screen.findByText('Surgical consent - Buddy')).toBeInTheDocument();
+    expect(screen.getByText(/Signed Feb 1, 2026/)).toBeInTheDocument();
+    expect(loadSignedDocumentsMock).toHaveBeenCalledWith('comp-1');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'View signed document: Surgical consent - Buddy' })
+    );
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://files.example.com/consent-doc-1.pdf',
+      '_blank',
+      'noopener'
+    );
+    openSpy.mockRestore();
+  });
+
+  it('does not load signed documents when the member cannot view consents', () => {
+    permissionsMock = [];
+    render(<ConsentListPanel companionId="comp-1" />);
+    expect(loadSignedDocumentsMock).not.toHaveBeenCalled();
   });
 
   it('hides the edit controls when the member can view but not edit', async () => {

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -23,6 +23,8 @@ import type {
   ConsentType,
   PatientConsent,
 } from '@/app/features/companionHistory/services/patientConsentService';
+import type { CompanionRecord } from '@/app/features/documents/types/companionDocuments';
+import { formatDisplayDate } from '@/app/lib/date';
 
 /** The values the grant form emits. `expiresAt` is a raw `YYYY-MM-DD` (or ''). */
 export type ConsentFormValues = {
@@ -48,6 +50,13 @@ export type ConsentListProps = {
   creating?: boolean;
   /** Id of the consent currently being revoked, so its row shows a pending state. */
   revokingId?: string | null;
+  /**
+   * Signed/generated consent PDFs from the e-signing portal (Documenso).
+   * A separate data source from `consents` above - see
+   * `useSignedConsentDocuments` - so it renders as its own sub-list rather
+   * than being merged into rows it has no link to.
+   */
+  signedDocuments?: CompanionRecord[];
 };
 
 const STATUS_LABEL: Record<ConsentStatus, string> = {
@@ -391,6 +400,48 @@ const ConsentListBody = ({
   );
 };
 
+/** A single signed consent PDF from the e-signing portal - opens in a new tab. */
+const SignedDocumentRow = ({ document }: { document: CompanionRecord }) => {
+  const signedDate = formatDisplayDate(document.signedAt ?? undefined, '');
+  return (
+    <li className={rowClass}>
+      <span className="min-w-0">
+        <span className={clsx(titleClass, 'block truncate')}>{document.title}</span>
+        <span className={clsx(metaClass, 'mt-0.5 block text-[var(--ink-muted)]')}>
+          {signedDate ? `Signed ${signedDate}` : 'Signed'}
+        </span>
+      </span>
+      {document.pdfUrl ? (
+        <Secondary
+          size="compact"
+          text="View"
+          onClick={() => globalThis.open(document.pdfUrl ?? '', '_blank', 'noopener')}
+          ariaLabel={`View signed document: ${document.title}`}
+        />
+      ) : null}
+    </li>
+  );
+};
+
+/**
+ * The signed PDFs the e-signing portal produced, as their own sub-list -
+ * distinct from the manually-recorded consents above, since nothing links a
+ * given `PatientConsent` row to a given signed document.
+ */
+const SignedConsentDocuments = ({ documents }: { documents: CompanionRecord[] }) => {
+  if (documents.length === 0) return null;
+  return (
+    <div className="border-t border-[var(--divider)]">
+      <div className={clsx(fieldLabelClass, 'px-4 pt-3')}>Signed documents</div>
+      <ul className="divide-y divide-[var(--divider)]">
+        {documents.map((document) => (
+          <SignedDocumentRow key={document.id ?? document.title} document={document} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
 /**
  * Presentational clinical consent-list panel. Renders the consents the caller
  * supplies and surfaces grant/revoke intents through callbacks; it never
@@ -405,6 +456,7 @@ const ConsentList = ({
   onRevoke,
   creating = false,
   revokingId = null,
+  signedDocuments = [],
 }: ConsentListProps) => {
   const [showForm, setShowForm] = useState(false);
   const activeCount = useMemo(
@@ -443,6 +495,8 @@ const ConsentList = ({
         onRevoke={onRevoke}
         revokingId={revokingId}
       />
+
+      <SignedConsentDocuments documents={signedDocuments} />
     </section>
   );
 };

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.tsx
@@ -1,11 +1,50 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ConsentList from '@/app/features/companionHistory/components/ConsentList';
 import { useConsentList } from '@/app/features/companionHistory/components/useConsentList';
+import { loadConsentDocumentsForCompanion } from '@/app/features/companions/services/companionDocumentService';
+import type { CompanionRecord } from '@/app/features/documents/types/companionDocuments';
 
 export type ConsentListPanelProps = {
   /** The companion (patient) whose consents to load. `companionId === patientId`. */
   companionId: string;
+};
+
+/**
+ * The manually-recorded consents ({@link useConsentList}) are a separate data
+ * model from the signed PDFs the e-signing portal (Documenso) produces - there
+ * is no field linking one to the other, so this loads them independently
+ * rather than guessing a correspondence.
+ */
+const useSignedConsentDocuments = (companionId: string, canView: boolean) => {
+  const [documents, setDocuments] = useState<CompanionRecord[]>([]);
+
+  // Reset during render (React's recommended pattern, mirrors
+  // useConsentRecords above) rather than in the effect, so a companion
+  // change or a permission loss clears stale documents in the same render
+  // instead of a synchronous setState inside the effect body.
+  const [loadedFor, setLoadedFor] = useState({ companionId, canView });
+  if (companionId !== loadedFor.companionId || canView !== loadedFor.canView) {
+    setLoadedFor({ companionId, canView });
+    setDocuments([]);
+  }
+
+  useEffect(() => {
+    if (!canView || !companionId) return;
+    let active = true;
+    loadConsentDocumentsForCompanion(companionId)
+      .then((docs) => {
+        if (active) setDocuments(docs);
+      })
+      .catch(() => {
+        if (active) setDocuments([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [canView, companionId]);
+
+  return documents;
 };
 
 /**
@@ -16,6 +55,7 @@ export type ConsentListPanelProps = {
 const ConsentListPanel = ({ companionId }: ConsentListPanelProps) => {
   const { canView, canEdit, consents, loading, error, creating, revokingId, grant, revoke } =
     useConsentList(companionId);
+  const signedDocuments = useSignedConsentDocuments(companionId, canView);
 
   if (!canView) return null;
 
@@ -29,6 +69,7 @@ const ConsentListPanel = ({ companionId }: ConsentListPanelProps) => {
       onRevoke={revoke}
       creating={creating}
       revokingId={revokingId}
+      signedDocuments={signedDocuments}
     />
   );
 };

--- a/apps/frontend/src/app/features/companions/services/companionDocumentService.ts
+++ b/apps/frontend/src/app/features/companions/services/companionDocumentService.ts
@@ -48,6 +48,38 @@ export const loadCompanionDocument = async (companionId: string): Promise<Compan
   }
 };
 
+/**
+ * Just the signed/generated consent documents from the e-signing portal
+ * (Documenso), for the companion-history Consent section - not every
+ * document {@link loadCompanionDocument} returns.
+ */
+export const loadConsentDocumentsForCompanion = async (
+  companionId: string
+): Promise<CompanionRecord[]> => {
+  try {
+    if (!companionId) {
+      throw new Error('Companion ID missing');
+    }
+    const res = await getData<
+      CompanionRecord[] | { data?: CompanionRecord[]; documents?: CompanionRecord[] }
+    >('/v1/document/pms/' + companionId + '/consent', { _t: Date.now() });
+    const payload = res.data;
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    if (Array.isArray(payload?.data)) {
+      return payload.data;
+    }
+    if (Array.isArray(payload?.documents)) {
+      return payload.documents;
+    }
+    return [];
+  } catch (err) {
+    console.error('Failed to load consent documents:', err);
+    throw err;
+  }
+};
+
 export const loadDocumentDetails = async (documentId: string): Promise<CompanionRecord> => {
   try {
     if (!documentId) {

--- a/apps/frontend/src/app/features/companions/services/companionDocumentService.ts
+++ b/apps/frontend/src/app/features/companions/services/companionDocumentService.ts
@@ -23,14 +23,20 @@ export const createCompanionDocument = async (document: CompanionRecord, compani
   }
 };
 
-export const loadCompanionDocument = async (companionId: string): Promise<CompanionRecord[]> => {
+/**
+ * A companion-documents GET can come back as a bare array or wrapped under
+ * `data`/`documents`, depending on the endpoint - normalizes any of those
+ * to a plain array, defaulting to empty rather than throwing on a shape
+ * this hasn't seen.
+ */
+const fetchCompanionRecords = async (
+  url: string,
+  errorMessage: string
+): Promise<CompanionRecord[]> => {
   try {
-    if (!companionId) {
-      throw new Error('Companion ID missing');
-    }
     const res = await getData<
       CompanionRecord[] | { data?: CompanionRecord[]; documents?: CompanionRecord[] }
-    >('/v1/document/pms/' + companionId, { _t: Date.now() });
+    >(url, { _t: Date.now() });
     const payload = res.data;
     if (Array.isArray(payload)) {
       return payload;
@@ -43,9 +49,16 @@ export const loadCompanionDocument = async (companionId: string): Promise<Compan
     }
     return [];
   } catch (err) {
-    console.error('Failed to create service:', err);
+    console.error(errorMessage, err);
     throw err;
   }
+};
+
+export const loadCompanionDocument = async (companionId: string): Promise<CompanionRecord[]> => {
+  if (!companionId) {
+    throw new Error('Companion ID missing');
+  }
+  return fetchCompanionRecords('/v1/document/pms/' + companionId, 'Failed to create service:');
 };
 
 /**
@@ -56,28 +69,13 @@ export const loadCompanionDocument = async (companionId: string): Promise<Compan
 export const loadConsentDocumentsForCompanion = async (
   companionId: string
 ): Promise<CompanionRecord[]> => {
-  try {
-    if (!companionId) {
-      throw new Error('Companion ID missing');
-    }
-    const res = await getData<
-      CompanionRecord[] | { data?: CompanionRecord[]; documents?: CompanionRecord[] }
-    >('/v1/document/pms/' + companionId + '/consent', { _t: Date.now() });
-    const payload = res.data;
-    if (Array.isArray(payload)) {
-      return payload;
-    }
-    if (Array.isArray(payload?.data)) {
-      return payload.data;
-    }
-    if (Array.isArray(payload?.documents)) {
-      return payload.documents;
-    }
-    return [];
-  } catch (err) {
-    console.error('Failed to load consent documents:', err);
-    throw err;
+  if (!companionId) {
+    throw new Error('Companion ID missing');
   }
+  return fetchCompanionRecords(
+    '/v1/document/pms/' + companionId + '/consent',
+    'Failed to load consent documents:'
+  );
 };
 
 export const loadDocumentDetails = async (documentId: string): Promise<CompanionRecord> => {

--- a/apps/frontend/src/app/features/documents/types/companionDocuments.ts
+++ b/apps/frontend/src/app/features/documents/types/companionDocuments.ts
@@ -142,6 +142,12 @@ export type CompanionRecord = {
    * longer always 'DOCUMENT'.
    */
   sourceKind?: string;
+  /**
+   * The rendered PDF for a signed/generated record (Documenso e-signing).
+   * Only ever set for `sourceKind !== 'DOCUMENT'` rows - a plain uploaded
+   * file's file lives in `attachments` instead.
+   */
+  pdfUrl?: string | null;
   createdAt?: string;
   updatedAt?: string;
 };

--- a/packages/database/prisma/migrations/20260909230000_template_kind_consent/migration.sql
+++ b/packages/database/prisma/migrations/20260909230000_template_kind_consent/migration.sql
@@ -1,0 +1,10 @@
+-- Add a CONSENT member to TemplateKind so consent templates/documents can be
+-- told apart from plain forms at the DB level.
+--
+-- Additive only: existing rows keep whatever kind they already have (most
+-- pre-existing consent templates are stored as FORM, since CONSENT never
+-- existed as a value to pick) - nothing here backfills or relabels them.
+-- Postgres allows ADD VALUE outside an explicit transaction from PG12+; this
+-- migration only adds the value and does not use it, so it is safe to run as
+-- Prisma's own single-statement transaction.
+ALTER TYPE "TemplateKind" ADD VALUE IF NOT EXISTS 'CONSENT';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1938,6 +1938,7 @@ enum TemplateKind {
   TASK_TEMPLATE
   CARE_PATHWAY
   INVOICE
+  CONSENT
 }
 
 enum RenderedDocumentStatus {

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -20,12 +20,7 @@ import {
 
 export type TemplateStatus = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
 export type TemplateScope =
-  | 'ORGANISATION'
-  | 'SPECIALITY'
-  | 'SERVICE'
-  | 'APPOINTMENT_KIND'
-  | 'INPATIENT'
-  | 'OUTPATIENT';
+  'ORGANISATION' | 'SPECIALITY' | 'SERVICE' | 'APPOINTMENT_KIND' | 'INPATIENT' | 'OUTPATIENT';
 export type TemplateOwnershipType = 'YC_LIBRARY' | 'ORG_TEMPLATE' | 'USER_TEMPLATE';
 export type TemplateSource = 'YC_LIBRARY' | 'ORGANISATION' | 'USER';
 export type TemplateContractKind =
@@ -45,6 +40,7 @@ export type TemplateStorageKind =
   | 'VITAL_RECORD'
   | 'PRESCRIPTION'
   | 'DISCHARGE_SUMMARY'
+  | 'CONSENT'
   | TemplateLegacyKind;
 
 export type TemplateFieldType =
@@ -499,8 +495,6 @@ export const toLegacyTemplateKind = (kind: TemplateKind): TemplateStorageKind =>
       return 'TASK_TEMPLATE';
     case 'INPATIENT_SCHEDULE':
       return 'CARE_PATHWAY';
-    case 'CONSENT':
-      return 'FORM';
     default:
       return kind;
   }
@@ -1364,8 +1358,7 @@ const questionnaireToTemplateInput = (
   const form = fromFHIRQuestionnaire(questionnaire);
   const kind =
     (getStringExtension(questionnaire.extension, TEMPLATE_KIND_EXTENSION_URL) as
-      | TemplateStorageKind
-      | undefined) ??
+      TemplateStorageKind | undefined) ??
     (questionnaire.code?.[0]?.code as TemplateStorageKind | undefined) ??
     defaults?.kind ??
     'FORM';
@@ -1380,8 +1373,7 @@ const questionnaireToTemplateInput = (
       defaults?.ownerUserId,
     ownership:
       (getStringExtension(questionnaire.extension, TEMPLATE_OWNERSHIP_EXTENSION_URL) as
-        | TemplateOwnershipType
-        | undefined) ??
+        TemplateOwnershipType | undefined) ??
       defaults?.ownership ??
       'ORG_TEMPLATE',
     kind: normalizedKind,
@@ -1389,8 +1381,7 @@ const questionnaireToTemplateInput = (
     description: questionnaire.description ?? undefined,
     scope:
       (getStringExtension(questionnaire.extension, TEMPLATE_SCOPE_EXTENSION_URL) as
-        | TemplateScope
-        | undefined) ??
+        TemplateScope | undefined) ??
       defaults?.scope ??
       'ORGANISATION',
     rules: undefined,
@@ -1420,8 +1411,7 @@ const planDefinitionToTemplateInput = (
 ): TemplateUpsertInput => {
   const kind =
     (getStringExtension(planDefinition.extension, TEMPLATE_KIND_EXTENSION_URL) as
-      | TemplateStorageKind
-      | undefined) ??
+      TemplateStorageKind | undefined) ??
     (planDefinition.type?.coding?.[0]?.code as TemplateStorageKind | undefined) ??
     defaults?.kind ??
     'TASK_ASSIGNMENT';
@@ -1436,8 +1426,7 @@ const planDefinitionToTemplateInput = (
       defaults?.ownerUserId,
     ownership:
       (getStringExtension(planDefinition.extension, TEMPLATE_OWNERSHIP_EXTENSION_URL) as
-        | TemplateOwnershipType
-        | undefined) ??
+        TemplateOwnershipType | undefined) ??
       defaults?.ownership ??
       'ORG_TEMPLATE',
     kind: normalizedKind,
@@ -1445,8 +1434,7 @@ const planDefinitionToTemplateInput = (
     description: planDefinition.description ?? undefined,
     scope:
       (getStringExtension(planDefinition.extension, TEMPLATE_SCOPE_EXTENSION_URL) as
-        | TemplateScope
-        | undefined) ??
+        TemplateScope | undefined) ??
       defaults?.scope ??
       'ORGANISATION',
     rules: undefined,


### PR DESCRIPTION
## What

- Adds `CONSENT` as a real `TemplateKind` enum value (additive Postgres migration). Consent templates previously had no storage-level identity of their own - `CONSENT` was silently collapsed to `FORM` at every write and every filter, in two separately duplicated collapse functions (`toLegacyTemplateKind` in `@yosemite-crew/types`, `toStorageTemplateKind` in `template.service.ts`). Removed both collapse arms now that the value exists.
- Widens appointment-time template resolution (`normalizeResolverKind`) so a CONSENT lookup matches both `CONSENT`- and legacy `FORM`-stored consent templates - nothing can retroactively relabel templates that already exist, so this has to stay additive rather than switch over.
- Adds `DocumentService.listConsentDocumentsForPms`, a narrow sibling to `listForPms` that returns only `CONSENT`-kind rendered (Documenso e-signed) documents for a patient - not every document, and not the plain uploaded `Document` rows `listForPms` also returns. New route: `GET /v1/document/pms/:patientId/consent`.
- Surfaces those signed PDFs in the per-companion Consent section (`ConsentListPanel`) as their own "Signed documents" sub-list, separate from the manually-recorded `PatientConsent` entries - the two are different data models with no field linking one to the other, so a signed document is shown as itself rather than guessed onto a specific consent row.

## Why

Reported while checking the live companion-history page: the practice records "consent granted for X procedure" manually, but the actual signed PDF from the e-signing portal (Documenso) was nowhere visible in that section, and there was no way to filter e-signing-portal documents down to just the consent ones (every rendered document - SOAP notes, prescriptions, invoices - came back undifferentiated).

Separately investigated whether the e-signing portal's "sign-in doesn't happen automatically" report was fixable here - it's already tracked as #2637, root-caused to the Documenso host itself (their `/auth/external` endpoint doesn't provision an account for an unrecognized email), not something this repo can fix. No change included for that.

## Testing

- New migration: `ALTER TYPE "TemplateKind" ADD VALUE IF NOT EXISTS 'CONSENT'` - additive, no backfill, verified `pnpm --filter @yosemite-crew/database run prisma:generate` succeeds.
- `template.service.test.ts`: updated 2 pre-existing assertions that locked in the old FORM-collapse behavior, added 4 new tests (CONSENT storage kind on create, CONSENT+FORM widened resolve, multi-kind IN filter, allowedKinds intersection incl. no-overlap denial). Mutation-checked every new/changed assertion.
- `document.service.test.ts`: added 3 new tests for `listConsentDocumentsForPms` (kind-filtered merge across every appointment, empty-appointments short-circuit, cross-org access rejection). Mutation-checked.
- `ConsentListPanel.test.tsx`: added 2 new tests (loads and renders signed documents with a working View link, skips the fetch entirely when the member can't view consents). Mutation-checked.
- Full backend suite: 11609 passed. Full frontend suite: 13355 passed. `tsc --noEmit` clean on both apps.