### PR TITLE
fix(frontend): tokenize the payment-status page's status-icon colours

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
 import { PaymentStatusContent } from './PaymentStatusContent';
 
 type Outcome = 'paid' | 'unpaid' | 'no_payment_required';
@@ -99,9 +100,35 @@ export const Loading: Story = {
   beforeEach: stubStatus,
 };
 
+/** The icon circle, however many paths are drawn inside it - the first `<circle>` is always the ring. */
+const iconRing = (canvasElement: HTMLElement) =>
+  waitFor(() => {
+    const el = canvasElement.querySelector('svg circle');
+    if (!el) throw new Error('status icon has not rendered yet');
+    return el;
+  });
+
 export const Paid: Story = {
   parameters: withSession(SESSION.paid),
   beforeEach: stubStatus,
+  play: async ({ canvasElement }) => {
+    const ring = await iconRing(canvasElement);
+    // The app's own success token (#008f5d), not a generic Tailwind green.
+    await expect(getComputedStyle(ring).stroke).toBe('rgb(0, 143, 93)');
+  },
+};
+
+export const PaidDark: Story = {
+  name: 'Paid (dark)',
+  parameters: withSession(SESSION.paid),
+  globals: { theme: 'dark' },
+  beforeEach: stubStatus,
+  play: async ({ canvasElement }) => {
+    const ring = await iconRing(canvasElement);
+    // --success itself flips to #2bbd86 in dark; the fixed-light pin on this
+    // surface is what keeps the receipt's checkmark at the light value here.
+    await expect(getComputedStyle(ring).stroke).toBe('rgb(0, 143, 93)');
+  },
 };
 
 export const Unpaid: Story = {
@@ -113,6 +140,11 @@ export const NoPaymentRequired: Story = {
   name: 'No payment required',
   parameters: withSession(SESSION.noPayment),
   beforeEach: stubStatus,
+  play: async ({ canvasElement }) => {
+    const ring = await iconRing(canvasElement);
+    // The app's own danger token (#ea3729), not Tailwind's red-600 (#dc2626).
+    await expect(getComputedStyle(ring).stroke).toBe('rgb(234, 55, 41)');
+  },
 };
 
 export const MissingSession: Story = {

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -177,18 +177,18 @@ export function PaymentStatusContent() {
           <div className="relative flex items-center justify-center size-24 rounded-full">
             {(requestState === 'missing_session' || requestState === 'error') && (
               <svg className="size-24" viewBox="0 0 120 120" aria-hidden>
-                <circle cx="60" cy="60" r="46" fill="none" stroke="#dc2626" strokeWidth="6" />
+                <circle cx="60" cy="60" r="46" fill="none" stroke="var(--danger)" strokeWidth="6" />
                 <path
                   d="M42 42l36 36"
                   fill="none"
-                  stroke="#dc2626"
+                  stroke="var(--danger)"
                   strokeWidth="7"
                   strokeLinecap="round"
                 />
                 <path
                   d="M78 42l-36 36"
                   fill="none"
-                  stroke="#dc2626"
+                  stroke="var(--danger)"
                   strokeWidth="7"
                   strokeLinecap="round"
                 />
@@ -196,11 +196,18 @@ export function PaymentStatusContent() {
             )}
             {data?.status === 'paid' && (
               <svg className="size-24" viewBox="0 0 120 120" aria-hidden>
-                <circle cx="60" cy="60" r="46" fill="none" stroke="#16a34a" strokeWidth="6" />
+                <circle
+                  cx="60"
+                  cy="60"
+                  r="46"
+                  fill="none"
+                  stroke="var(--success)"
+                  strokeWidth="6"
+                />
                 <path
                   d="M38 62l16 16 30-34"
                   fill="none"
-                  stroke="#16a34a"
+                  stroke="var(--success)"
                   strokeWidth="7"
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -216,18 +223,18 @@ export function PaymentStatusContent() {
             )}
             {data?.status === 'no_payment_required' && (
               <svg className="size-24" viewBox="0 0 120 120" aria-hidden>
-                <circle cx="60" cy="60" r="46" fill="none" stroke="#dc2626" strokeWidth="6" />
+                <circle cx="60" cy="60" r="46" fill="none" stroke="var(--danger)" strokeWidth="6" />
                 <path
                   d="M42 42l36 36"
                   fill="none"
-                  stroke="#dc2626"
+                  stroke="var(--danger)"
                   strokeWidth="7"
                   strokeLinecap="round"
                 />
                 <path
                   d="M78 42l-36 36"
                   fill="none"
-                  stroke="#dc2626"
+                  stroke="var(--danger)"
                   strokeWidth="7"
                   strokeLinecap="round"
                 />

--- a/apps/frontend/src/app/__tests__/routes/public/payment-status-page.test.tsx
+++ b/apps/frontend/src/app/__tests__/routes/public/payment-status-page.test.tsx
@@ -90,6 +90,7 @@ describe('payment-status public page', () => {
     render(<PaymentStatusPage />);
 
     await waitFor(() => expect(screen.getByText('Payment complete')).toBeInTheDocument());
+    expect(document.querySelector('svg circle')).toHaveAttribute('stroke', 'var(--success)');
     expect(screen.getByText('Status paid')).toBeInTheDocument();
     expect(screen.getByText('Amount 100')).toBeInTheDocument();
     expect(screen.getByText('Session sess_1...BCDE')).toBeInTheDocument();
@@ -108,6 +109,7 @@ describe('payment-status public page', () => {
     render(<PaymentStatusPage />);
 
     await waitFor(() => expect(screen.getByText('Payment cancelled')).toBeInTheDocument());
+    expect(document.querySelector('svg circle')).toHaveAttribute('stroke', 'var(--danger)');
     expect(
       screen.getByText('This payment did not complete. If this looks wrong, contact support.')
     ).toBeInTheDocument();

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -2138,6 +2138,12 @@ body:has([data-yc-app]) {
      6.42:1. */
   --color-warning-100: #fef3e9;
   --color-warning-900: #874913;
+  /* The success accent, pinned for the same reason as the others: it flips to
+     #2bbd86 in dark, and PaymentStatusContent's paid-checkmark stroke reads
+     var(--success) directly on this fixed-white card. --danger does not need
+     the same pin - it is already declared to the identical #ea3729 in both
+     the light and dark scopes, so nothing here would change it either way. */
+  --success: #008f5d;
 }
 
 html[data-theme='dark'] body:has([data-yc-app]) {

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "52226c9a0241236cb111486f78b58603b3f11c50",
-  "total": 360,
+  "generated_at": "3cbac57a47b207cdd51f444936ca197eca9bce2e",
+  "total": 355,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -195,8 +195,8 @@
   "files": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": 1,
     "apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.stories.tsx": 1,
-    "apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx": 1,
-    "apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx": 11,
+    "apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx": 4,
+    "apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx": 3,
     "apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentAvatar.stories.tsx": 1,
     "apps/frontend/src/app/features/appointments/components/Calendar/common/NowIndicator.stories.tsx": 4,
     "apps/frontend/src/app/features/appointments/components/Calendar/common/SlotGridLines.stories.tsx": 2,


### PR DESCRIPTION
## What changed

Replaces the 8 hardcoded hex literals on `PaymentStatusContent`'s success/danger SVG status icons (`#16a34a`, `#dc2626` — generic Tailwind red-600/green-600) with `var(--danger)` / `var(--success)`, the app's own danger/success palette (`#ea3729` / `#008f5d`).

## Why

`--danger` is already declared to the identical `#ea3729` in both the light and dark scopes, so that half is a same-value rename. `--success` is not — it flips to `#2bbd86` in dark — and this card is one of the `[data-yc-surface='light']` fixed-light surfaces (`payment-status`, `success`, `accessibility/report`) that `globals.css` already pins ink tokens on for exactly this reason (a themed value on a surface that never itself flips). Extended that existing block with `--success`, following the same pattern and comment style already used there for the ink, brand-accent, card-bg and warning-ramp entries pinned for the same class of bug.

## Validation performed

- No existing test exercised this component's rendering at all — the story file had five variants and zero `play` functions. Added play functions to `Paid`, a new `PaidDark` (`globals: { theme: 'dark' }`, reusing `Paid`'s assertion) and `NoPaymentRequired`, each checking the icon ring's computed stroke colour. `PaidDark` is what actually exercises the new `globals.css` pin — without it, dark mode would render the icon at `#2bbd86` instead of staying at `#008f5d`.
- Mutation-checked against a real Storybook build + dev server, not just `tsc`: reverted both source files, confirmed exactly these 3 new play functions fail (`Paid`/`PaidDark` against the old `#16a34a`, `NoPaymentRequired` against the old `#dc2626`); restored, confirmed all 6 stories pass clean.
- `npx tsc --noEmit` clean, `pnpm run lint` clean (0 errors). Also ran the full Jest suite (1054/1054 suites pass) — `--testPathPatterns` doesn't actually filter in this project's Jest 30 setup right now (confirmed via `--listTests`, filed separately rather than fixed here since it's out of scope for a token-migration PR).
- `hardcoded-colours` baseline: 360 → 355.

## Impact area

`apps/frontend` only — the public `/payment-status` receipt page. No light-mode visual change from `--danger` (identical value); the paid checkmark now correctly stays at the app's success green in dark mode instead of shifting to generic Tailwind green.