### PR TITLE
fix(frontend): tokenize the payment-link pulse ring's frozen success colour

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PaymentLinkStatus.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PaymentLinkStatus.test.tsx
@@ -1,9 +1,27 @@
 import React from 'react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PaymentLinkStatus from '@/app/features/appointments/pages/AppointmentWorkspace/components/PaymentLinkStatus';
 
 describe('PaymentLinkStatus', () => {
+  it('pulses the ring off the --success token, not a frozen literal', () => {
+    // jsdom does not run @keyframes, so this checks the declaration itself
+    // rather than a rendered computed style: the ring has to track
+    // var(--success) (which flips in dark mode) rather than a hardcoded
+    // rgba(0, 143, 93, ...) that would freeze at the light-mode value.
+    const css = readFileSync(
+      join(
+        process.cwd(),
+        'src/app/features/appointments/pages/AppointmentWorkspace/components/PaymentLinkStatus.css'
+      ),
+      'utf8'
+    );
+    expect(css).not.toMatch(/rgba\(\s*0\s*,\s*143\s*,\s*93/);
+    expect(css).toContain('color-mix(in srgb, var(--success) 35%, transparent)');
+  });
+
   it('renders the design’s pulsing dot beside a ready-link status', () => {
     const { container } = render(
       <PaymentLinkStatus status={{ isSent: false, label: 'Stripe · payment link ready' }} />

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PaymentLinkStatus.css
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PaymentLinkStatus.css
@@ -7,13 +7,13 @@
 
 @keyframes ycWorkspacePulseDot {
   0% {
-    box-shadow: 0 0 0 0 rgba(0, 143, 93, 0.35);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 35%, transparent);
   }
   60% {
-    box-shadow: 0 0 0 6px rgba(0, 143, 93, 0);
+    box-shadow: 0 0 0 6px transparent;
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(0, 143, 93, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "fff0be16efd1ee44d30cd99e574eb8d6484e1a1a",
-  "total": 350,
+  "generated_at": "45fcfc9bcaf70d4922dd663c0da4fe8fe9673deb",
+  "total": 347,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -201,7 +201,6 @@
     "apps/frontend/src/app/features/appointments/components/Calendar/common/NowIndicator.stories.tsx": 4,
     "apps/frontend/src/app/features/appointments/components/Calendar/common/SlotGridLines.stories.tsx": 2,
     "apps/frontend/src/app/features/appointments/components/Calendar/common/StaffInput.stories.tsx": 2,
-    "apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PaymentLinkStatus.css": 3,
     "apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/RxBadge.stories.tsx": 1,
     "apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TitleAddIcon.stories.tsx": 1,
     "apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx": 4,


### PR DESCRIPTION
## What changed

The workspace payment-link status dot's pulse-ring `@keyframes` hardcoded `rgba(0, 143, 93, X)` — the RGB channels of `--success`'s light-mode value (`#008f5d`) — so the ring stayed light green even in dark mode, while the dot itself right next to it (`style={{ background: 'var(--success)' }}`) correctly flipped to `#2bbd86`. Replaced with `color-mix(in srgb, var(--success) 35%, transparent)` for the visible step; the two fade-out steps are alpha 0, which is exactly `transparent` regardless of what colour it would have faded from, so they need no token at all.

## Why

`color-mix()` is already an established pattern in this codebase (`globals.css` already uses `color-mix(in srgb, var(--blue-text) 12%, var(--neutral-0, var(--screen)))` elsewhere) — this is the same technique applied to fade a token colour toward `transparent` instead of toward an opaque background.

## Validation performed

- Live-verified in the browser (`color-mix()` isn't testable via jsdom): probed the exact declaration's computed value in both themes via a throwaway element — light resolves to `rgb(0, 143, 93)` at 0.35 alpha, an exact match for the literal it replaces; dark resolves to `rgb(43, 189, 134)`, matching `--success`'s dark value, which the old literal never could.
- jsdom doesn't run `@keyframes`, so a rendered-style assertion can't catch this the way it did for the JS-driven fixes earlier in this sweep. Added a source-text test instead — reads the CSS file directly and asserts it contains the `color-mix()` declaration and no `rgba(0, 143, 93` literal — the same technique `cardSurface.test.ts` already uses elsewhere in this repo for exactly this class of CSS-only change.
- Mutation-checked: reverted the CSS, confirmed the new assertion fails; restored, confirmed all 4 tests in the file pass.
- `npx tsc --noEmit` clean, `pnpm run lint` clean (0 errors).
- `hardcoded-colours` baseline: 350 → 347.

## Impact area

`apps/frontend` only — the workspace payment-link status pulse ring. No light-mode visual change (pixel-identical); dark mode now correctly tracks the theme instead of staying frozen at the light-mode green.