### PR TITLE
fix(frontend): replace the patient picker's native select and stop auto-showing video captions

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/CompanionSelect.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/CompanionSelect.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import {
+  CompanionSelect,
+  type CompanionSelectOption,
+} from '@/app/features/appointments/components/CompanionSelect';
+
+const companions: CompanionSelectOption[] = [
+  { id: 'c1', name: 'Bella', ownerName: 'Maria Chen' },
+  { id: 'c2', name: 'Rocky' },
+];
+
+describe('CompanionSelect', () => {
+  it('renders a searchable dropdown trigger labelled with the stacked label, not a native select', () => {
+    render(
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value=""
+        onChange={jest.fn()}
+        companions={companions}
+      />
+    );
+
+    expect(screen.getByText('Companion')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: 'Companion' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(screen.getByText('Select a companion')).toBeInTheDocument();
+  });
+
+  it('appends the owner name only when the companion has one', async () => {
+    const user = userEvent.setup();
+    render(
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value=""
+        onChange={jest.fn()}
+        companions={companions}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Companion' }));
+
+    expect(screen.getByRole('option', { name: 'Bella — Maria Chen' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Rocky' })).toBeInTheDocument();
+  });
+
+  it('calls onChange with the picked companion id', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value=""
+        onChange={onChange}
+        companions={companions}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Companion' }));
+    await user.click(screen.getByRole('option', { name: 'Rocky' }));
+
+    expect(onChange).toHaveBeenCalledWith('c2');
+  });
+
+  it('shows the current selection by id', () => {
+    render(
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value="c1"
+        onChange={jest.fn()}
+        companions={companions}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Companion: Bella — Maria Chen' })
+    ).toBeInTheDocument();
+  });
+
+  it('disables itself and shows emptyLabel when there are no companions to pick', () => {
+    render(
+      <CompanionSelect
+        label="Companion"
+        placeholder="Select a companion"
+        emptyLabel="No companions available"
+        value=""
+        onChange={jest.fn()}
+        companions={[]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Companion' })).toBeDisabled();
+    expect(screen.getByText('No companions available')).toBeInTheDocument();
+    expect(screen.queryByText('Select a companion')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
@@ -130,7 +130,9 @@ describe('FrontDeskBoard', () => {
     // `showAll` so the completed row actually renders - without it the board
     // filters terminal statuses out and the assertions below would pass for the
     // wrong reason.
-    render(<FrontDeskBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} showAll {...handlers()} />);
+    render(
+      <FrontDeskBoard entries={[row('1', 'COMPLETED', 'STANDARD')]} showAll {...handlers()} />
+    );
 
     expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start consult' })).not.toBeInTheDocument();
@@ -216,7 +218,8 @@ describe('FrontDeskBoard', () => {
     await user.click(screen.getByRole('button', { name: /Check in patient/ }));
     expect(screen.getByText('Patient')).toBeInTheDocument();
 
-    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByLabelText('Patient'));
+    await user.click(screen.getByRole('option', { name: 'Bruno — Sarah' }));
     await user.selectOptions(screen.getByLabelText('Triage priority'), 'IMMEDIATE');
     await user.click(screen.getByRole('button', { name: 'Check in patient' }));
 
@@ -242,7 +245,8 @@ describe('FrontDeskBoard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /Check in patient/ }));
-    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByLabelText('Patient'));
+    await user.click(screen.getByRole('option', { name: 'Bruno' }));
     await user.clear(screen.getByLabelText('Arrived at'));
     await user.type(screen.getByLabelText('Arrived at'), '2026-09-05T07:15');
     await user.type(screen.getByLabelText('Triage note'), 'Vomiting since morning');
@@ -300,7 +304,8 @@ describe('FrontDeskBoard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /Check in patient/ }));
-    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByLabelText('Patient'));
+    await user.click(screen.getByRole('option', { name: 'Bruno — Sarah' }));
     await user.click(screen.getByRole('button', { name: 'Check in patient' }));
 
     expect(props.onAdd).not.toHaveBeenCalled();
@@ -332,7 +337,8 @@ describe('FrontDeskBoard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /Check in patient/ }));
-    await user.selectOptions(screen.getByLabelText('Patient'), 'patient-9');
+    await user.click(screen.getByLabelText('Patient'));
+    await user.click(screen.getByRole('option', { name: 'Bruno' }));
     await user.click(screen.getByRole('button', { name: 'Check in patient' }));
 
     expect(props.onAdd).toHaveBeenCalled();
@@ -360,7 +366,9 @@ describe('FrontDeskBoard', () => {
   it('toggles the show-all view via the header control', async () => {
     const user = userEvent.setup();
     const props = handlers();
-    render(<FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} showAll={false} {...props} />);
+    render(
+      <FrontDeskBoard entries={[row('1', 'WAITING', 'STANDARD')]} showAll={false} {...props} />
+    );
 
     await user.click(screen.getByRole('button', { name: 'Show all' }));
     expect(props.onToggleShowAll).toHaveBeenCalledWith(true);

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Waitlist.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Waitlist.test.tsx
@@ -112,7 +112,10 @@ describe('Waitlist', () => {
     await user.click(screen.getByRole('button', { name: /Add to waitlist/ }));
     expect(screen.getByText('Companion')).toBeInTheDocument();
 
-    await user.selectOptions(screen.getByRole('combobox'), 'patient-1');
+    // CompanionSelect is a searchable LabelDropdown, not a native <select>: open
+    // it, then pick the rendered option row rather than selectOptions.
+    await user.click(screen.getByLabelText('Companion'));
+    await user.click(screen.getByRole('option', { name: 'Bruno — Sarah' }));
     await user.type(screen.getByPlaceholderText('e.g. Dental, Vaccination'), 'Dental');
     // The submit button is the one inside the open form (type=submit).
     await user.click(screen.getByRole('button', { name: 'Add to waitlist' }));

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/playerMediaCsp.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/playerMediaCsp.test.tsx
@@ -163,6 +163,11 @@ describe('the video players and media-src', () => {
     expect(track).toHaveAttribute('kind', 'captions');
     // Root-relative, so it is served by us and permitted by 'self'.
     expect(track?.getAttribute('src')).toMatch(/^\/captions\/.+\.vtt$/);
+    // Not `default`: that attribute auto-enables the track for every viewer,
+    // burning the "no narration" note in as a visible subtitle on every play
+    // instead of leaving it an opt-in a deaf viewer reaches for via the
+    // player's own CC control.
+    expect(track).not.toHaveAttribute('default');
   });
 
   it('ships a captions file that is real WebVTT and is not empty', () => {

--- a/apps/frontend/src/app/features/appointments/components/CompanionSelect.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CompanionSelect.stories.tsx
@@ -19,15 +19,15 @@ const companionSelectMeta = {
           'The companion picker shared by the appointment panels that put a patient on a list ' +
           '(the waitlist and the check-in board). Each panel names the same control differently - ' +
           '"Companion" on the waitlist, "Patient" at the front desk - so the wording is passed in as ' +
-          'props while the select markup stays one definition. The select disables itself and swaps ' +
-          'the placeholder for `emptyLabel` when `companions` is empty, and appends the owner name to ' +
-          'an option only when a companion has one.',
+          'props while the markup stays one definition: a searchable LabelDropdown, not a native ' +
+          '`<select>` (whose open option list is unstyleable browser chrome). The control disables ' +
+          'itself and swaps the placeholder for `emptyLabel` when `companions` is empty, and appends ' +
+          'the owner name to an option only when a companion has one.',
       },
     },
   },
   tags: ['autodocs'],
   args: {
-    id: 'waitlist-companion',
     label: 'Companion',
     placeholder: 'Select a companion',
     emptyLabel: 'No companions available',
@@ -64,7 +64,6 @@ export const WithoutOwnerNames: CompanionSelectStory = {
 export const CheckInWording: CompanionSelectStory = {
   name: 'Reused at the check-in board',
   args: {
-    id: 'checkin-patient',
     label: 'Patient',
     placeholder: 'Select a patient',
     emptyLabel: 'No patients waiting',

--- a/apps/frontend/src/app/features/appointments/components/CompanionSelect.tsx
+++ b/apps/frontend/src/app/features/appointments/components/CompanionSelect.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { panelFieldLabelClass, panelInputClass } from '@/app/ui/primitives/PanelStates/PanelStates';
+import React, { useMemo } from 'react';
+import { panelFieldLabelClass } from '@/app/ui/primitives/PanelStates/PanelStates';
+import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import type { DropdownOption } from '@/app/hooks/useDropdown';
 
 export type CompanionSelectOption = {
   id: string;
@@ -7,14 +9,27 @@ export type CompanionSelectOption = {
   ownerName?: string;
 };
 
+const toDropdownOption = (companion: CompanionSelectOption): DropdownOption => ({
+  value: companion.id,
+  label: companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name,
+});
+
 /**
  * The companion picker shared by the appointment panels that put a patient on a
  * list (the waitlist and the check-in board). Each panel names the same control
  * differently - "Companion" on the waitlist, "Patient" at the front desk - so
  * the wording is passed in while the markup stays one definition.
+ *
+ * This was a native `<select>`. Its closed state took the app's field styling,
+ * but the open option list is browser chrome - no CSS reaches an `<option>`'s
+ * font, radius, or hover colour in any engine - so it rendered as a plain OS
+ * list dropped over the app the moment a clinic opened it, on a form that can
+ * carry a hundred-plus patients with no way to filter them. `LabelDropdown` is
+ * the searchable combobox every other picker in this app already uses (see
+ * TaskAssigneeSelect): a real, styled option list, and typing narrows it
+ * instead of scrolling it.
  */
 export const CompanionSelect = ({
-  id,
   label,
   placeholder,
   emptyLabel,
@@ -22,8 +37,6 @@ export const CompanionSelect = ({
   onChange,
   companions,
 }: {
-  /** Omitted by panels whose label already wraps the control. */
-  id?: string;
   label: string;
   placeholder: string;
   /** Shown in place of the placeholder when there is nothing to pick. */
@@ -31,22 +44,22 @@ export const CompanionSelect = ({
   value: string;
   onChange: (value: string) => void;
   companions: CompanionSelectOption[];
-}) => (
-  <label className="flex flex-col gap-1" htmlFor={id}>
-    <span className={panelFieldLabelClass}>{label}</span>
-    <select
-      id={id}
-      className={panelInputClass}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={companions.length === 0}
-    >
-      <option value="">{companions.length === 0 ? emptyLabel : placeholder}</option>
-      {companions.map((companion) => (
-        <option key={companion.id} value={companion.id}>
-          {companion.ownerName ? `${companion.name} — ${companion.ownerName}` : companion.name}
-        </option>
-      ))}
-    </select>
-  </label>
-);
+}) => {
+  const options = useMemo(() => companions.map(toDropdownOption), [companions]);
+  const hasCompanions = companions.length > 0;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className={panelFieldLabelClass}>{label}</span>
+      <LabelDropdown
+        placeholder={label}
+        hideLabel
+        options={options}
+        defaultOption={value || undefined}
+        onSelect={(option) => onChange(option.value)}
+        emptyLabel={hasCompanions ? placeholder : emptyLabel}
+        disabled={!hasCompanions}
+      />
+    </div>
+  );
+};

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
@@ -434,7 +434,6 @@ const AddCheckInForm = (props: AddCheckInFormProps) => {
       className="flex flex-col gap-3 border-b border-[var(--divider)] px-4 py-3"
     >
       <CompanionSelect
-        id="checkin-companion"
         label="Patient"
         placeholder="Select a patient"
         emptyLabel="No patients available"

--- a/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.tsx
@@ -125,14 +125,13 @@ const GuidePlayerModal = ({
               which reads as a broken feature rather than as "this film has no
               speech". So the track carries what a captioner would actually
               write for speech-free media: it names the non-speech audio, says
-              there is no narration, and stops. */}
-          <track
-            kind="captions"
-            src="/captions/no-narration.en.vtt"
-            srcLang="en"
-            label="English"
-            default
-          />
+              there is no narration, and stops.
+
+              No `default`: that attribute forces the browser to auto-enable
+              the track for every viewer, so this note was burning in as a
+              visible subtitle over every play instead of being an opt-in a
+              deaf viewer reaches for via the player's own CC control. */}
+          <track kind="captions" src="/captions/no-narration.en.vtt" srcLang="en" label="English" />
           Your browser cannot play this video.
         </video>
       </div>

--- a/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.tsx
@@ -57,13 +57,14 @@ const VideoPlayerModal = ({
             <source src={activeVideo.videoUrl} type="video/mp4" />
             {/* Same real captions file as GuidePlayerModal, and the same reason:
                 the data: URL this used to carry was refused by our own CSP on
-                every play. */}
+                every play. No `default`: see GuidePlayerModal - that attribute
+                auto-enables the track for every viewer, burning the caption in
+                as a visible subtitle instead of leaving it an opt-in via CC. */}
             <track
               kind="captions"
               src="/captions/no-narration.en.vtt"
               srcLang="en"
               label="English"
-              default
             />
           </video>
         ) : (


### PR DESCRIPTION
## What changed

- **CompanionSelect** (the patient/companion picker on the waitlist and front-desk check-in board) is rebuilt on `LabelDropdown` instead of a native `<select>`. A native select's open option list is unstyleable browser chrome in every engine, so it rendered as a plain OS dropdown dropped over the app - visible live on the Appointments waitlist and reported directly. `LabelDropdown` is the same searchable combobox every other picker in this app already uses (TaskAssigneeSelect, InventoryFilters, ChangeStatusModal), so a clinic with 100+ patients gets a real styled list they can filter by typing instead of scrolling.
- **Video captions no longer auto-display for every viewer.** The two video players' `<track>` element carried a `default` attribute, which forces browsers to auto-enable it - so the "no narration" accessibility note (added earlier to satisfy Sonar S4084 under a CSP that blocks `data:` URLs) was burning in as a visible subtitle on every play instead of staying an opt-in a deaf viewer reaches for via the player's own CC control.
- Includes the earlier, already-merged work from this branch: mounting the previously-orphaned Documents panel on the companion history page, and fixing the squashed calendar-icon toggle button (a `w-full`/`w-10` specificity conflict).

Rebased onto current `dev` (48 commits had landed since this branch's base, including PR #2952's consent-template-kind feature and PR #2953's dependency security fixes).

## Why

All four issues were found live on dev.yosemitecrew.com during a UI sweep, three of them from direct user reports (the squashed calendar icon, the unstyled waitlist/front-desk dropdown, the orphaned Documents panel).

## Validation

- Targeted Jest: 11 suites / 142 tests passing (CompanionSelect, Waitlist, FrontDeskBoard, WaitlistPanel, FrontDeskBoardPanel, CompanionHistoryPage, the two video-player CSP/caption tests, DocumentsListPanel, ConsentListPanel).
- Mutation-checked the new/changed assertions (owner-name suffix logic, the `not.toHaveAttribute('default')` caption check) by temporarily reverting the fix and confirming the test fails.
- `tsc --noEmit` clean, `eslint` clean on all touched files.
- `scripts/ci/check-hardcoded-colours.mjs`: no new hardcoded colours introduced.
- Live-verified visually in Storybook: the CompanionSelect dropdown now renders the app's own styled option list (screenshot taken), and the calendar-icon button measures an exact 40x40px (was non-square before the fix).

## Impact area

Frontend only (`apps/frontend`): appointments (Waitlist, FrontDeskBoard, CompanionSelect), video player modals (guides, generic video), companion history page.