### PR TITLE
fix(backend): stop signed consent PDFs duplicating in the companion documents panel

### DIFF
--- a/apps/backend/src/controllers/app/document.controller.ts
+++ b/apps/backend/src/controllers/app/document.controller.ts
@@ -399,12 +399,17 @@ export const DocumentController = {
         return res.status(400).json({ message: "organisationId is required." });
       }
 
+      // Signed consent PDFs already have their own dedicated list
+      // (listConsentForPms, below) that the companion-history Consent panel
+      // renders - without this exclusion they would also come back here and
+      // render a second time in the generic Documents panel.
       const docs = await DocumentService.listForPms({
         patientId,
         organisationId,
         category: getFirstQueryValue(category),
         subcategory: getFirstQueryValue(subcategory),
         appointmentId: getFirstQueryValue(appointmentId),
+        excludeKind: "CONSENT",
       });
 
       return res.status(200).json(docs);

--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -398,6 +398,7 @@ const loadRenderedDocumentsForAppointments = async (params: {
   appointmentIds: string[];
   organisationId: string;
   kind?: TemplateKind;
+  excludeKind?: TemplateKind;
 }) => {
   if (params.appointmentIds.length === 0) {
     return [];
@@ -407,6 +408,7 @@ const loadRenderedDocumentsForAppointments = async (params: {
     where: {
       organisationId: params.organisationId,
       ...(params.kind ? { kind: params.kind } : {}),
+      ...(params.excludeKind ? { kind: { not: params.excludeKind } } : {}),
       OR: [
         {
           templateInstance: {
@@ -744,6 +746,7 @@ export const DocumentService = {
     category?: string;
     subcategory?: string;
     appointmentId?: string;
+    excludeKind?: TemplateKind;
   }): Promise<DocumentDto[]> {
     const patientId = normalizeStringId(params.patientId, "patientId");
     await assertPmsCanAccessCompanion(params.organisationId, patientId);
@@ -781,6 +784,7 @@ export const DocumentService = {
         return loadRenderedDocumentsForAppointments({
           appointmentIds: scopedAppointmentIds,
           organisationId: params.organisationId,
+          excludeKind: params.excludeKind,
         });
       })(),
     ]);

--- a/apps/backend/test/controllers/app/document.controller.test.ts
+++ b/apps/backend/test/controllers/app/document.controller.test.ts
@@ -521,6 +521,7 @@ describe("DocumentController", () => {
         category: undefined,
         subcategory: undefined,
         appointmentId: undefined,
+        excludeKind: "CONSENT",
       });
     });
 
@@ -540,6 +541,19 @@ describe("DocumentController", () => {
       mockGenericError("listForPms");
       await DocumentController.listForPms(req as any, res as Response);
       expect(statusMock).toHaveBeenCalledWith(500);
+    });
+
+    it("excludes signed consent documents, which the dedicated consent list already covers", async () => {
+      (req as any).userId = "pms1";
+      (req as any).organisationId = "org1";
+      req.params = { patientId: "c1" };
+      req.query = {};
+      mockedDocumentService.listForPms.mockResolvedValue([] as any);
+
+      await DocumentController.listForPms(req as any, res as Response);
+      expect(mockedDocumentService.listForPms).toHaveBeenCalledWith(
+        expect.objectContaining({ excludeKind: "CONSENT" }),
+      );
     });
   });
 

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -337,6 +337,97 @@ describe("DocumentService", () => {
     });
   });
 
+  it("excludes CONSENT-kind rendered documents when excludeKind is set", async () => {
+    mockedPrisma.document.findMany.mockResolvedValue([]);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+    ] as any);
+    // Signed consent PDFs are excluded before this ever reaches the app -
+    // Postgres itself filters them via the `kind: { not: ... }` clause below,
+    // so the mocked rows already reflect what filtered results look like.
+    mockedPrisma.renderedDocument.findMany.mockResolvedValue([
+      {
+        id: "rd-soap-1",
+        organisationId: uuidOrganisationId,
+        sourceKind: "TEMPLATE_INSTANCE",
+        sourceId: "ti-1",
+        templateId: "tmpl-1",
+        templateVersion: 1,
+        kind: "SOAP_NOTE",
+        title: "Soap note",
+        status: "SIGNED",
+        pdfUrl: "https://cdn/soap.pdf",
+        signing: { status: "SIGNED" },
+        signedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        templateInstance: {
+          appointmentId: uuidAppointmentId,
+          encounterId: null,
+        },
+        clinicalArtifact: null,
+      },
+    ] as any);
+
+    const result = await DocumentService.listForPms({
+      patientId: uuidPatientId,
+      organisationId: uuidOrganisationId,
+      excludeKind: "CONSENT",
+    });
+
+    expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          kind: { not: "CONSENT" },
+        }),
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result.some((doc) => doc.category === "CONSENT")).toBe(false);
+  });
+
+  it("still merges CONSENT-kind rendered documents when excludeKind is not set (companion-history timeline)", async () => {
+    mockedPrisma.document.findMany.mockResolvedValue([]);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: uuidAppointmentId },
+    ] as any);
+    mockedPrisma.renderedDocument.findMany.mockResolvedValue([
+      {
+        id: "rd-consent-1",
+        organisationId: uuidOrganisationId,
+        sourceKind: "TEMPLATE_INSTANCE",
+        sourceId: "ti-1",
+        templateId: "tmpl-1",
+        templateVersion: 1,
+        kind: "CONSENT",
+        title: "Surgical consent",
+        status: "SIGNED",
+        pdfUrl: "https://cdn/consent.pdf",
+        signing: { status: "SIGNED" },
+        signedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        templateInstance: {
+          appointmentId: uuidAppointmentId,
+          encounterId: null,
+        },
+        clinicalArtifact: null,
+      },
+    ] as any);
+
+    const result = await DocumentService.listForPms({
+      patientId: uuidPatientId,
+      organisationId: uuidOrganisationId,
+    });
+
+    const callArgs = mockedPrisma.renderedDocument.findMany.mock
+      .calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(callArgs.where.kind).toBeUndefined();
+    expect(result.some((doc) => doc.category === "CONSENT")).toBe(true);
+  });
+
   describe("listConsentDocumentsForPms", () => {
     it("returns only CONSENT-kind rendered documents across every one of the patient's appointments", async () => {
       const otherAppointmentId = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";


### PR DESCRIPTION
## What changed

- `DocumentService.listForPms` (the endpoint behind the companion history page's generic Documents panel, `GET /v1/document/pms/:patientId`) merges every one of a patient's `RenderedDocument` rows into the list it returns, with no kind filter. That includes CONSENT-kind e-signed PDFs - the exact same rows `listConsentDocumentsForPms` already serves to the dedicated Consent panel (`GET /v1/document/pms/:patientId/consent`, added in #2952).
- Since #2973 mounted the generic Documents panel (`DocumentsListPanel` / `CompanionDocumentsSection`) alongside the Consent panel (`ConsentListPanel`) on the same companion history page, a signed consent document rendered twice: once in the "Signed" lifecycle tab of the Documents panel, once in the Consent panel's own sub-list.
- Adds an opt-in `excludeKind` filter to `DocumentService.listForPms` (and the shared `loadRenderedDocumentsForAppointments` helper it calls), and wires `excludeKind: "CONSENT"` only in the PMS docs tab controller handler (`DocumentController.listForPms`). Every other kind (FORM, SOAP_NOTE, PRESCRIPTION, DISCHARGE_SUMMARY, etc.) and every plain uploaded `Document` row is unaffected - the Documents panel still shows everything else exactly as before.
- `listForPms`'s other caller, `companion-history.service.ts` (the companion-history timeline), does not pass `excludeKind`, so its existing behaviour - including CONSENT documents in the timeline - is unchanged.

## Why

Two independently-built features (the generic Documents panel mounted in #2973, and the Consent panel's own consent-kind fetch added in #2952) never got reconciled once both landed on the same page, so the same signed consent PDF showed up in two places at once. `listConsentDocumentsForPms` is the purpose-built, authoritative source for consent documents, so the fix excludes them from the generic list instead.

## Validation

- Targeted Jest: `document.service.test.ts` + both `document.controller.test.ts` suites (app and top-level) - 294 tests passing.
- Mutation-checked the new/changed assertions: reverted the `excludeKind: "CONSENT"` wiring in the controller and reran - both the exact-match and objectContaining assertions failed as expected; reverted the `excludeKind` handling in `loadRenderedDocumentsForAppointments` and reran - the new service-level assertion on the Prisma `where` clause failed as expected. Restored both and confirmed green again.
- `tsc` (backend `type-check`) and `eslint` on all touched files: clean.
- Pre-push hooks (staged-secret scan, full monorepo lint + type-check via turbo, 17 tasks) passed.
- Aikido MCP was unavailable in this session (connection timeout) so a local Aikido pass could not be run before pushing; no local Sonar scan was run either since this change is backend-only. Both run as part of CI (`_sonar` stage in `ci.yaml`) - will check the PR's SonarCloud quality gate before merging.

## Impact area

Backend only (`apps/backend`): `DocumentService.listForPms`, `DocumentController.listForPms` (the `GET /v1/document/pms/:patientId` PMS docs tab endpoint). No changes to `listConsentDocumentsForPms`, the companion-history timeline consumer, or any frontend code - the frontend already renders whatever the endpoint returns.