### PR TITLE
fix(frontend): replace hardcoded hex in DeveloperSettings with design tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperSettings.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperSettings.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -157,6 +159,35 @@ describe('DeveloperSettings', () => {
     expect(notifyMock).toHaveBeenCalledWith(
       'warning',
       expect.objectContaining({ title: 'Notification preferences coming soon' })
+    );
+  });
+});
+
+describe('secret card reads ink from the fixed --spot-ink/--color-cyan tokens', () => {
+  // .dev-secret-card is painted from --spot, which stays dark in both themes.
+  // Its icon tint, body text and cancel-link ink must come from
+  // --spot-ink/--color-cyan (fixed the same way), not the flipping --ink -
+  // otherwise light mode collapses toward 1:1 contrast, the same class of bug
+  // fixed on DeveloperPortalHome (PR #2967) and DeveloperPlugins (PR #2974).
+  const css = readFileSync(
+    join(
+      process.cwd(),
+      'src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css'
+    ),
+    'utf8'
+  );
+
+  it('does not hardcode the secret card copy as a frozen cream literal', () => {
+    expect(css).not.toMatch(/\.dev-secret-text\s*{[^}]*color:\s*#f4efe6/);
+    expect(css).not.toMatch(/\.dev-secret-cancel\s*{[^}]*rgba\(\s*244,\s*239,\s*230/);
+    expect(css).not.toMatch(/\.dev-secret-icon\s*{[^}]*rgba\(\s*92,\s*225,\s*230/);
+  });
+
+  it('routes the secret card copy through --spot-ink and the icon tint through --color-cyan', () => {
+    expect(css).toMatch(/\.dev-secret-text\s*{[^}]*color:\s*var\(--spot-ink\)/);
+    expect(css).toMatch(/\.dev-secret-cancel\s*{[^}]*color-mix\(in srgb, var\(--spot-ink\) 60%/);
+    expect(css).toMatch(
+      /\.dev-secret-icon\s*{[^}]*background:\s*color-mix\(in srgb, var\(--color-cyan\) 14%/
     );
   });
 });

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
@@ -311,6 +311,12 @@
   border: 1px solid var(--color-card-border);
 }
 
+/* Fixed dark, for the same reason as the off thumb above: the track is
+   --color-cyan, which is declared once and never flips, so the thumb needs a
+   fixed ink rather than --ink (which goes cream in espresso and would vanish
+   on the still-cyan track). No token exists yet for ink pinned against a
+   --color-cyan fill specifically - see DeveloperPlugins.css's
+   .dev-website-cta.primary for the same unresolved case. */
 .dev-switch.on .dev-switch-thumb {
   background: #1d1c1b;
   border-color: #1d1c1b;
@@ -331,7 +337,7 @@
   width: 34px;
   height: 34px;
   border-radius: 11px;
-  background: rgba(92, 225, 230, 0.14);
+  background: color-mix(in srgb, var(--color-cyan) 14%, transparent);
   color: var(--color-cyan);
   display: flex;
   align-items: center;
@@ -344,7 +350,7 @@
   min-width: 0;
   font-size: 12px;
   line-height: 1.5;
-  color: #f4efe6;
+  color: var(--spot-ink);
 }
 
 .dev-secret-action {
@@ -358,7 +364,7 @@
 }
 
 .dev-secret-cancel {
-  color: rgba(244, 239, 230, 0.6);
+  color: color-mix(in srgb, var(--spot-ink) 60%, transparent);
   background: transparent;
   border: none;
   cursor: pointer;

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "afd532f02bbd91e033f510fabaf94a01eb1f5e12",
-  "total": 330,
+  "generated_at": "29963e5964d9c19c2ed22d2efce23738a420d564",
+  "total": 324,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -106,6 +106,10 @@
     "apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.stories.tsx": {
       "n": 2,
       "why": "Both occurrences are Storybook play-function test assertions comparing a computed style against a literal, not a colour authored in this codebase: 'rgba(0, 0, 0, 0)' is the browser's own canonical getComputedStyle() value for 'nothing painted here' (a border-colour assertion), and 'rgb(244, 239, 230)' is the expected computed colour of .dev-website-title inside the Dark story, verifying it renders --spot-ink's dark-mode value. A design-token reference would never match a computed style string, so both literals have to stay exactly this to keep testing what they test."
+    },
+    "apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css": {
+      "n": 3,
+      "why": "The switch thumb's two fixed colours are both explained at their declarations: #ffffff (off) is the design system's own `.switch::after` spec - the previous --color-surface-card resolved to --screen and flipped, vanishing at 1:1-ish contrast against the espresso track (see the comment there). #1d1c1b x2 (on-state thumb) is ink pinned against --color-cyan's fill, which is declared once and never flips - the same unresolved 'no token for ink on a --color-cyan fill' case as DeveloperPlugins.css's .dev-website-cta.primary."
     },
     "apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.stories.tsx": {
       "n": 1,
@@ -222,7 +226,6 @@
     "apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx": 2,
     "apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css": 4,
     "apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css": 4,
-    "apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css": 6,
     "apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css": 6,
     "apps/frontend/src/app/features/guides/pages/Guides.tsx": 5,
     "apps/frontend/src/app/features/integrations/pages/Integrations/integrations.css": 3,


### PR DESCRIPTION
## Summary
- The secret-rotation card (`.dev-secret-card`) is painted from `--spot`, which stays dark in both themes — its icon tint, body text and cancel-link ink were hardcoded to the dark-mode literals instead of `--spot-ink`/`--color-cyan`, so this wasn't a live contrast bug, matching the same pattern already fixed on DeveloperPortalHome (#2967) and DeveloperPlugins (#2974).
- Left the toggle switch's two fixed-colour thumbs alone and justified them in the baseline: the off-state `#ffffff` already has an explanatory comment at its declaration (the design system's own `.switch::after` spec), and the on-state `#1d1c1b` is ink pinned against `--color-cyan`'s fixed fill — the same "no token exists for this yet" case as DeveloperPlugins.css's `.dev-website-cta.primary`, now cross-referenced in both places' comments since it's recurring.
- Hardcoded-hex baseline: 330 → 324.

## Test plan
- [x] Added a source-text guard test asserting the secret card routes through `--spot-ink`/`--color-cyan`, not the frozen literals.
- [x] Mutation-checked: reverted the CSS, confirmed the 2 new assertions failed; restored, confirmed all 11 tests pass.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on touched files.
- [x] `scripts/ci/check-hardcoded-colours.mjs` — no new hardcoded colours, baseline regenerated via `--update`.