### PR TITLE
fix(frontend): tokenize the chat presence-dot pulse's frozen success colour

### DIFF
--- a/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ProtectedChatContainer, {
   ChatContainer,
@@ -3327,5 +3329,22 @@ describe('ChannelPreviewWrapper + ChatClosedFooter', () => {
     render(<ChatClosedFooter closedAt={new Date(Date.now() - 5 * 60 * 1000).toISOString()} />);
     expect(screen.getByText('Chat session closed')).toBeInTheDocument();
     expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+  });
+});
+
+describe('presence-dot pulse reads off the --success token, not a frozen literal', () => {
+  const css = readFileSync(
+    join(process.cwd(), 'src/app/features/chat/components/ChatContainer.css'),
+    'utf8'
+  );
+
+  it('does not hardcode --success light value as a frozen rgba', () => {
+    expect(css).not.toMatch(/rgba\(\s*0\s*,\s*143\s*,\s*93/);
+  });
+
+  it('mixes --success toward transparent for the pulse, and fades fully transparent at rest', () => {
+    expect(css).toContain('color-mix(in srgb, var(--success) 35%, transparent)');
+    expect(css).toContain('box-shadow: 0 0 0 6px transparent;');
+    expect(css).toContain('box-shadow: 0 0 0 0 transparent;');
   });
 });

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -3,13 +3,13 @@
 /* Gentle pulse for the online presence dot (conversation-row avatar + header). */
 @keyframes ycPulseDot {
   0% {
-    box-shadow: 0 0 0 0 rgba(0, 143, 93, 0.35);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 35%, transparent);
   }
   60% {
-    box-shadow: 0 0 0 6px rgba(0, 143, 93, 0);
+    box-shadow: 0 0 0 6px transparent;
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(0, 143, 93, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "211cc649dc2a0a1963a85e52bdb9f47fc4067c0f",
-  "total": 304,
+  "generated_at": "9d564294508046d8fe3699c41e97a7813dcdd12a",
+  "total": 297,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -82,6 +82,14 @@
     "apps/frontend/src/app/features/chat/components/ChatComposer.stories.tsx": {
       "n": 1,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
+    },
+    "apps/frontend/src/app/features/chat/components/ChatContainer.css": {
+      "n": 2,
+      "why": "--str-chat__on-primary-color and --str-chat__on-unread-badge-color are white ink sitting on var(--blue), which is declared identically (#257bed) in both light and dark blocks - it does not actually flip, so a fixed white literal carries no theme risk here, unlike the --spot-family cases elsewhere in this sweep where the underlying surface does flip."
+    },
+    "apps/frontend/src/app/features/chat/components/ChatContainer.stories.tsx": {
+      "n": 2,
+      "why": "Both occurrences are Storybook play-function test assertions comparing a computed style against 'rgb(241, 235, 225)' - the resolved value of --screen-2, verifying the footer/empty-state icon actually painted the intended surface rather than falling through to a stylesheet that failed to apply. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
     },
     "apps/frontend/src/app/features/chat/components/ChatSidebarHeader.stories.tsx": {
       "n": 1,
@@ -220,8 +228,6 @@
     "apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/AllDocumentsTable.stories.tsx": 6,
     "apps/frontend/src/app/features/auth/pages/SignIn/SignIn.tsx": 2,
     "apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx": 2,
-    "apps/frontend/src/app/features/chat/components/ChatContainer.css": 5,
-    "apps/frontend/src/app/features/chat/components/ChatContainer.stories.tsx": 2,
     "apps/frontend/src/app/features/companionHistory/components/AuditTimeline.stories.tsx": 4,
     "apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx": 2,
     "apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css": 4,


### PR DESCRIPTION
## Summary
- `.chat-presence-dot`'s `ycPulseDot` keyframe hardcoded `--success`'s light-mode RGB channels directly (`rgba(0, 143, 93, *)`) — the same class of bug already fixed on the payment-link pulse ring (#2966): the ring stayed light green in dark mode instead of tracking the token. `color-mix(in srgb, var(--success) 35%, transparent)` fixes the pulse's peak; the two zero-alpha keyframe stops just need `transparent`, since 0% of any colour mixed with transparent is transparent regardless of which colour.
- Left the two `--str-chat__on-*-color: #ffffff` overrides alone and justified them in the baseline: they sit on `var(--blue)`, which is declared identically in both light and dark blocks and so never actually flips — tokenizing these would carry zero theme benefit.
- Justified `ChatContainer.stories.tsx`'s two `--screen-2` computed-style test assertions too, matching the same "test oracle, not an authored colour" pattern used throughout this baseline.
- Hardcoded-hex baseline: 304 → 297.

## Test plan
- [x] Added a source-text guard test asserting the pulse routes through `--success`/`transparent`, not the frozen literal.
- [x] Mutation-checked: reverted the CSS, confirmed the 2 new assertions failed; restored, confirmed all 162 tests pass.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on touched files.
- [x] `scripts/ci/check-hardcoded-colours.mjs` — no new hardcoded colours, baseline regenerated via `--update`.