### PR TITLE
fix(frontend): replace hardcoded hex in DeveloperWebsiteBuilder with tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperWebsiteBuilder.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperWebsiteBuilder.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -47,5 +49,41 @@ describe('DeveloperWebsiteBuilder page', () => {
     const { container } = render(<DeveloperWebsiteBuilder />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+});
+
+describe('promo panel reads ink from the fixed --spot-ink/--color-cyan tokens', () => {
+  // .dev-wb-promo is painted from --spot, which stays dark in both themes.
+  // Its badge tint, title, body and step markers must come from
+  // --spot-ink/--color-cyan (fixed the same way), not the flipping --ink -
+  // otherwise light mode collapses toward 1:1 contrast, the same class of
+  // bug fixed on DeveloperPortalHome (#2967), DeveloperPlugins (#2974) and
+  // DeveloperSettings (#2978).
+  const css = readFileSync(
+    join(
+      process.cwd(),
+      'src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css'
+    ),
+    'utf8'
+  );
+
+  it('does not hardcode the promo panel copy as a frozen cream or cyan literal', () => {
+    expect(css).not.toMatch(/\.dev-wb-promo-title\s*{[^}]*color:\s*#f4efe6/);
+    expect(css).not.toMatch(/\.dev-wb-promo-body\s*{[^}]*rgba\(\s*244,\s*239,\s*230/);
+    expect(css).not.toMatch(/\.dev-wb-step-label\s*{[^}]*color:\s*#f4efe6/);
+    expect(css).not.toMatch(/\.dev-wb-badge\s*{[^}]*rgba\(\s*92,\s*225,\s*230/);
+    expect(css).not.toMatch(/\.dev-wb-step-num\s*{[^}]*rgba\(\s*92,\s*225,\s*230/);
+  });
+
+  it('routes the promo panel copy through --spot-ink and the tints through --color-cyan', () => {
+    expect(css).toMatch(/\.dev-wb-promo-title\s*{[^}]*color:\s*var\(--spot-ink\)/);
+    expect(css).toMatch(/\.dev-wb-promo-body\s*{[^}]*color-mix\(in srgb, var\(--spot-ink\) 60%/);
+    expect(css).toMatch(/\.dev-wb-step-label\s*{[^}]*color:\s*var\(--spot-ink\)/);
+    expect(css).toMatch(
+      /\.dev-wb-badge\s*{[^}]*background:\s*color-mix\(in srgb, var\(--color-cyan\) 12%/
+    );
+    expect(css).toMatch(
+      /\.dev-wb-step-num\s*{[^}]*background:\s*color-mix\(in srgb, var\(--color-cyan\) 16%/
+    );
   });
 });

--- a/apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css
@@ -58,8 +58,8 @@
   align-items: center;
   padding: 4px 12px;
   border-radius: 9999px;
-  background: rgba(92, 225, 230, 0.12);
-  border: 1px solid rgba(92, 225, 230, 0.3);
+  background: color-mix(in srgb, var(--color-cyan) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-cyan) 30%, transparent);
   color: var(--color-cyan);
   font-weight: 700;
   text-transform: uppercase;
@@ -72,7 +72,7 @@
   font-weight: 400;
   line-height: 1.3;
   letter-spacing: -0.015em;
-  color: #f4efe6;
+  color: var(--spot-ink);
   max-width: 860px;
   text-wrap: balance;
 }
@@ -85,7 +85,7 @@
   margin: 0;
   font-size: 13px;
   line-height: 1.6;
-  color: rgba(244, 239, 230, 0.6);
+  color: color-mix(in srgb, var(--spot-ink) 60%, transparent);
 }
 
 .dev-wb-steps {
@@ -106,7 +106,7 @@
   width: 20px;
   height: 20px;
   border-radius: 9999px;
-  background: rgba(92, 225, 230, 0.16);
+  background: color-mix(in srgb, var(--color-cyan) 16%, transparent);
   color: var(--color-cyan);
   display: flex;
   align-items: center;
@@ -119,7 +119,7 @@
 .dev-wb-step-label {
   font-size: 12.5px;
   font-weight: 600;
-  color: #f4efe6;
+  color: var(--spot-ink);
 }
 
 .dev-wb-section-head {

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "9d564294508046d8fe3699c41e97a7813dcdd12a",
-  "total": 297,
+  "generated_at": "1044d499c968f60127de86602659f835e2bc3e61",
+  "total": 291,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -232,7 +232,6 @@
     "apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx": 2,
     "apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css": 4,
     "apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css": 4,
-    "apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css": 6,
     "apps/frontend/src/app/features/guides/pages/Guides.tsx": 5,
     "apps/frontend/src/app/features/integrations/pages/Integrations/integrations.css": 3,
     "apps/frontend/src/app/features/legal/pages/TrustCenter.stories.tsx": 5,


### PR DESCRIPTION
## Summary
- The website-builder promo card (`.dev-wb-promo`) is painted from `--spot`, which stays dark in both themes — its badge tint, title, body and step markers were hardcoded to the dark-mode literals instead of `--spot-ink`/`--color-cyan`, so this wasn't a live contrast bug. Routes all 6 through the established tokens, matching the same pattern already fixed on DeveloperPortalHome (#2967), DeveloperPlugins (#2974) and DeveloperSettings (#2978).
- No literals needed justifying this time — a clean 6-for-6 tokenization.
- Hardcoded-hex baseline: 297 → 291.

## Test plan
- [x] Added a source-text guard test asserting the promo panel routes through `--spot-ink`/`--color-cyan`, not the frozen literals.
- [x] Mutation-checked: reverted the CSS, confirmed the 2 new assertions failed; restored, confirmed all 5 tests pass.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on touched files.
- [x] `scripts/ci/check-hardcoded-colours.mjs` — no new hardcoded colours, baseline regenerated via `--update`.