### PR TITLE
docs(repo): document appointment OpenAPI schemas

### DIFF
--- a/apps/frontend/public/static/openapi/openapi.yaml
+++ b/apps/frontend/public/static/openapi/openapi.yaml
@@ -223,8 +223,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentListEnvelope'
   /fhir/v1/appointment/mobile/documentUpload:
     post:
       tags:
@@ -254,8 +253,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/UploadUrlEnvelope'
         500:
           description: Response
           content:
@@ -285,8 +283,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentListEnvelope'
   '/fhir/v1/appointment/mobile/{appointmentId}/reschedule':
     patch:
       tags:
@@ -313,8 +310,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/mobile/{appointmentId}/cancel':
     patch:
       tags:
@@ -341,8 +337,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/mobile/{appointmentId}/checkin':
     patch:
       tags:
@@ -363,8 +358,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/mobile/{appointmentId}':
     get:
       tags:
@@ -385,8 +379,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentDataEnvelope'
   /fhir/v1/appointment/pms:
     post:
       tags:
@@ -451,8 +444,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentListEnvelope'
   '/fhir/v1/appointment/pms/organisation/{organisationId}/companion/{companionId}':
     get:
       tags:
@@ -478,8 +470,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentListEnvelope'
   '/fhir/v1/appointment/pms/{organisationId}/{appointmentId}/accept':
     patch:
       tags:
@@ -548,8 +539,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/pms/{organisationId}/{appointmentId}/cancel':
     patch:
       tags:
@@ -581,8 +571,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/pms/{organisationId}/{appointmentId}/checkin':
     patch:
       tags:
@@ -608,8 +597,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/fhir/v1/appointment/pms/{organisationId}/{appointmentId}':
     patch:
       tags:
@@ -666,8 +654,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentDataEnvelope'
   '/fhir/v1/appointment/pms/{organisationId}/{appointmentId}/forms':
     post:
       tags:
@@ -699,8 +686,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/AppointmentEnvelope'
   '/v1/audit-trail/companion/{companionId}':
     get:
       tags:
@@ -10153,6 +10139,41 @@ components:
       required:
         - resourceType
         - participant
+    AppointmentDataEnvelope:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: '#/components/schemas/Appointment'
+    AppointmentEnvelope:
+      type: object
+      required: [message, data]
+      properties:
+        message:
+          type: string
+        data:
+          $ref: '#/components/schemas/Appointment'
+    AppointmentListEnvelope:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Appointment'
+    UploadUrlEnvelope:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [url, key]
+          properties:
+            url:
+              type: string
+              format: uri
+            key:
+              type: string
     AppointmentParticipant:
       type: object
       properties:
@@ -14431,10 +14452,12 @@ components:
         - organisationId
     UploadUrlBody:
       type: object
+      required: [patientId, mimeType]
       properties:
-        companionId:
+        patientId:
           type: string
-      additionalProperties: true
+        mimeType:
+          type: string
     DocumentRequestBody:
       type: object
       properties:
@@ -14515,6 +14538,9 @@ components:
           type: string
         isEmergency:
           type: boolean
+        durationMinutes:
+          type: integer
+          minimum: 1
       additionalProperties: true
       required:
         - startTime

--- a/scripts/ci/openapi-drift-baseline.json
+++ b/scripts/ci/openapi-drift-baseline.json
@@ -2,5 +2,5 @@
   "_comment": "Ratchet ceilings for scripts/ci/openapi-drift.mjs. These are known, tracked debt (#2941-#2944), not a target - the gate fails only if a count goes ABOVE its ceiling, so a PR cannot make the gap wider. Lower a ceiling by hand after doing real completion work, or regenerate with --update-baseline after such work. Never raise a ceiling to make a failing PR pass - that defeats the point of the ratchet.",
   "missingFromSpec": 793,
   "staleInSpec": 34,
-  "placeholderSchemas": 376
+  "placeholderSchemas": 362
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The published OpenAPI document describes 14 appointment request or response shapes as unrestricted objects. Client developers cannot determine the returned appointment envelope, appointment list shape, or presigned-upload fields from the specification.

## What is the new behavior?

The mobile and PMS appointment operations now reference concrete schemas for appointment detail, appointment lists, mutation responses, and presigned-upload responses. The upload request documents the controller's required `patientId` and `mimeType` fields, and the reschedule request includes `durationMinutes`.

The OpenAPI drift ratchet drops from 376 to 362 placeholder schemas.

Validation performed:

- OpenAPI drift check: 1,046 mounted routes, no missing organisation headers, 362 placeholder schemas.
- YAML parse and component-reference check: 512 schema references resolved.
- Prettier check passed for both changed files.
- Repository pre-push gate passed: 10 lint tasks and 17 type-check tasks.

## Related Issue(s)

Fixes #2944
