### PR TITLE
fix(frontend): replace hardcoded hex in DeveloperApiKeys/DeveloperDocs with tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperApiKeys.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperApiKeys.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -207,5 +209,33 @@ describe('DeveloperApiKeys page', () => {
 
     await user.click(screen.getByRole('button', { name: 'Revoke' }));
     expect(await screen.findByText(/Could not revoke the API key/)).toBeInTheDocument();
+  });
+});
+
+describe('reveal panel reads ink from the fixed --spot-ink token', () => {
+  // .DevApiKeys-reveal is painted from --spot, which stays dark in both
+  // themes. Its paragraph, secret chip and code ink must come from
+  // --spot-ink (fixed the same way), not a frozen cream literal - otherwise
+  // light mode shows the dark-mode ink shade instead of the light-tuned one.
+  const css = readFileSync(
+    join(process.cwd(), 'src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css'),
+    'utf8'
+  );
+
+  it('does not hardcode the reveal panel ink as a frozen cream literal', () => {
+    expect(css).not.toMatch(/\.DevApiKeys-reveal p\s*{[^}]*color:\s*#f4efe6/);
+    expect(css).not.toMatch(/\.DevApiKeys-secret\s*{[^}]*rgba\(\s*244,\s*239,\s*230/);
+    expect(css).not.toMatch(/\.DevApiKeys-secret code\s*{[^}]*color:\s*#f4efe6/);
+  });
+
+  it('routes the reveal panel ink through --spot-ink', () => {
+    expect(css).toMatch(/\.DevApiKeys-reveal p\s*{[^}]*color:\s*var\(--spot-ink\)/);
+    expect(css).toMatch(
+      /\.DevApiKeys-secret\s*{[^}]*background:\s*color-mix\(in srgb, var\(--spot-ink\) 6%/
+    );
+    expect(css).toMatch(
+      /\.DevApiKeys-secret\s*{[^}]*border:\s*1px solid color-mix\(in srgb, var\(--spot-ink\) 16%/
+    );
+    expect(css).toMatch(/\.DevApiKeys-secret code\s*{[^}]*color:\s*var\(--spot-ink\)/);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 jest.mock('@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard', () => ({
   __esModule: true,
@@ -224,5 +226,39 @@ describe('DeveloperDocs reader', () => {
     fireEvent.click(screen.getByRole('button', { name: /Copy page/i }));
     await waitFor(() => expect(writeText).toHaveBeenCalled());
     expect(screen.getByRole('button', { name: /Copy page/i })).toBeInTheDocument();
+  });
+});
+
+describe('code panel reads ink from the fixed --spot-ink token', () => {
+  // .DocsCodePanel is painted from --spot, which stays dark in both themes.
+  // Its header border, label and code ink must come from --spot-ink (fixed
+  // the same way), not a frozen cream literal - otherwise light mode shows
+  // the dark-mode ink shade instead of the light-tuned one. .DocsMethod's
+  // ink stays a literal, justified in the baseline: it is pinned to
+  // --color-cyan's fixed fill, not --spot, so --spot-ink does not apply.
+  const css = readFileSync(
+    join(process.cwd(), 'src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css'),
+    'utf8'
+  );
+
+  it('does not hardcode the code panel chrome as frozen cream literals', () => {
+    expect(css).not.toMatch(/\.DocsCodePanelHead\s*{[^}]*rgba\(\s*244,\s*239,\s*230/);
+    expect(css).not.toMatch(/\.DocsCodePanelLabel\s*{[^}]*color:\s*rgba\(\s*244,\s*239,\s*230/);
+    expect(css).not.toMatch(/\.DocsCodePre\s*{[^}]*color:\s*#f4efe6/);
+  });
+
+  it('routes the code panel chrome through --spot-ink', () => {
+    expect(css).toMatch(
+      /\.DocsCodePanelHead\s*{[^}]*border-bottom:\s*1px solid color-mix\(in srgb, var\(--spot-ink\) 10%/
+    );
+    expect(css).toMatch(
+      /\.DocsCodePanelLabel\s*{[^}]*color:\s*color-mix\(in srgb, var\(--spot-ink\) 55%/
+    );
+    expect(css).toMatch(/\.DocsCodePre\s*{[^}]*color:\s*var\(--spot-ink\)/);
+  });
+
+  it('keeps .DocsMethod ink pinned to --color-cyan as a justified literal', () => {
+    expect(css).toMatch(/\.DocsMethod\s*{[^}]*background:\s*var\(--color-cyan\)/);
+    expect(css).toMatch(/\.DocsMethod\s*{[^}]*color:\s*#1d1c1b/);
   });
 });

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
@@ -32,7 +32,7 @@
 
 .DevApiKeys-reveal p {
   margin: 0;
-  color: #f4efe6;
+  color: var(--spot-ink);
 }
 
 .DevApiKeys-secret {
@@ -41,8 +41,8 @@
   gap: 12px;
   flex-wrap: wrap;
   padding: 13px 15px;
-  background: rgba(244, 239, 230, 0.06);
-  border: 1px solid rgba(244, 239, 230, 0.16);
+  background: color-mix(in srgb, var(--spot-ink) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--spot-ink) 16%, transparent);
   border-radius: 14px;
 }
 
@@ -52,7 +52,7 @@
   font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 13.5px;
   line-height: 1.5;
-  color: #f4efe6;
+  color: var(--spot-ink);
   word-break: break-all;
 }
 

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
@@ -310,6 +310,10 @@
   padding: 3px 9px;
   border-radius: 7px;
   background: var(--color-cyan);
+  /* Ink pinned against --color-cyan's fixed fill, same reasoning as
+     DeveloperPlugins' .dev-website-cta.primary and DeveloperSettings'
+     .dev-switch.on .dev-switch-thumb: --color-cyan never flips, so a
+     token that resolves through --ink would go cream-on-cyan in espresso. */
   color: #1d1c1b;
   font-size: 10.5px;
   font-weight: 800;
@@ -366,14 +370,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  border-bottom: 1px solid rgba(244, 239, 230, 0.1);
+  border-bottom: 1px solid color-mix(in srgb, var(--spot-ink) 10%, transparent);
 }
 
 .DocsCodePanelLabel {
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: rgba(244, 239, 230, 0.55);
+  color: color-mix(in srgb, var(--spot-ink) 55%, transparent);
 }
 
 .DocsCodeCopy {
@@ -395,7 +399,7 @@
   font-family: ui-monospace, monospace;
   font-size: 11px;
   line-height: 1.65;
-  color: #f4efe6;
+  color: var(--spot-ink);
   overflow-x: auto;
 }
 

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "b1695c39f5ed856660294ffd4618873568e62594",
-  "total": 279,
+  "generated_at": "4a58a4724ab515a7aaed28e8be7e81d46b7c9020",
+  "total": 271,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -106,6 +106,10 @@
     "apps/frontend/src/app/features/companions/pages/Companions/SpeciesTabs.stories.tsx": {
       "n": 1,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
+    },
+    "apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css": {
+      "n": 1,
+      "why": "`.DocsMethod`'s ink is pinned to #1d1c1b for the same reason as DeveloperPlugins' `.dev-website-cta.primary` and DeveloperSettings' `.dev-switch.on .dev-switch-thumb`: its fill is --color-cyan, which is declared once and never flips, so a token that resolves through --ink would go cream-on-cyan in espresso. No token exists for ink pinned against a --color-cyan fill specifically."
     },
     "apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.css": {
       "n": 2,
@@ -230,8 +234,6 @@
     "apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx": 2,
     "apps/frontend/src/app/features/companionHistory/components/AuditTimeline.stories.tsx": 4,
     "apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx": 2,
-    "apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css": 4,
-    "apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css": 4,
     "apps/frontend/src/app/features/guides/pages/Guides.tsx": 5,
     "apps/frontend/src/app/features/legal/pages/TrustCenter.stories.tsx": 5,
     "apps/frontend/src/app/features/legal/pages/TrustCenter.tsx": 2,


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep. Two developer-portal files paint a
card from `--spot`, the fixed-dark background that never flips, but their
ink/tints hardcoded the dark-mode literal of `--spot-ink` (`#f4efe6`)
directly instead of reading the token — so light mode showed the dark-tuned
ink instead of the light-tuned one (`#eae2d5`). Same bug shape as #2974,
#2978, #2979, #2980.

- `DeveloperApiKeys.css` — `.DevApiKeys-reveal p`, `.DevApiKeys-secret`
  (background/border), `.DevApiKeys-secret code`: 4 literals, all migrated.
- `DeveloperDocs.css` — `.DocsCodePanelHead`, `.DocsCodePanelLabel`,
  `.DocsCodePre`: 3 literals migrated to `--spot-ink` /
  `color-mix(in srgb, var(--spot-ink) N%, transparent)`.
- `DeveloperDocs.css`'s `.DocsMethod` keeps its `#1d1c1b` literal — pinned
  to `--color-cyan`'s fixed fill, not `--spot`, the same justified pattern
  as DeveloperPlugins' `.dev-website-cta.primary` and DeveloperSettings'
  `.dev-switch.on .dev-switch-thumb`. Added to the baseline's `justified`
  map with a cross-reference.

Baseline regenerated via `--update`: 279 → 271.

Added source-text guard tests to both pages' existing test files
(`DeveloperApiKeys.test.tsx`, `DeveloperDocs.test.tsx`). Mutation-checked:
reverted both CSS files to their pre-fix state, confirmed the 4 new
assertions failed (28 pre-existing tests unaffected), restored, confirmed
all 32 pass.

`tsc --noEmit` and `eslint` clean on all touched files.