### PR TITLE
fix(repo): justify bespoke shadow/tint literals in six widget files

### DIFF
--- a/apps/frontend/src/app/ui/widgets/Faq/Faq.css
+++ b/apps/frontend/src/app/ui/widgets/Faq/Faq.css
@@ -38,6 +38,11 @@
      1.34:1. --color-surface-card is the real card surface and has a dark
      value. */
   background: var(--color-surface-card);
+  /* A near-black-navy shadow, not one of the --sh* tokens (see
+     LaunchGrowTab.css's .LaunchTabDiv.active for the same reasoning - no
+     --sh* value is a byte-identical match across both themes). Justified in
+     the hardcoded-colours baseline, along with the expanded-state shadow
+     below (close to but not an exact match for --blue's rgb(37, 123, 237)). */
   box-shadow: 0 5px 16px 0 rgba(8, 15, 52, 0.06);
   transition:
     border-color 180ms ease,

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
@@ -34,6 +34,10 @@
 
 .LaunchTabDiv.active {
   flex-grow: 25;
+  /* Plain black, not one of the --sh* shadow tokens: --sh05 is
+     rgba(29, 28, 27, 0.05) in light and rgba(0, 0, 0, 0.2) in dark - swapping
+     this to a token would change the rendered light-mode shadow, not
+     preserve it. Justified in the hardcoded-colours baseline. */
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
@@ -216,6 +220,11 @@
     left: 15px;
     right: 15px;
     height: 50px;
+    /* The fixed light-blue tint from Launchtabs' second entry
+       (LaunchGrowTab.tsx, growtab.color '#E9F2FD') at 95% opacity - reused
+       here by design, but only within this one widget, so a global token
+       would carry no benefit beyond these two spots. Justified in the
+       hardcoded-colours baseline, alongside the .tsx array's own literals. */
     background: rgba(233, 242, 253, 0.95);
     border-radius: 25px;
     align-items: center;
@@ -252,6 +261,11 @@
        was missed when the desktop one moved. */
     background: var(--blue-strong);
     color: var(--white-text);
+    /* A standalone colored glow - the desktop active tab (above) uses a
+       plain black shadow instead, so this has no desktop twin to derive
+       from. Close to but not an exact match for --blue's rgb(37, 123, 237);
+       treating it as --blue-derived would be guessing at a value change, not
+       preserving one. Justified in the hardcoded-colours baseline. */
     box-shadow: 0px 2px 8px rgba(36, 122, 237, 0.3);
     flex-grow: 1;
     flex-shrink: 1;

--- a/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css
+++ b/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css
@@ -26,6 +26,11 @@
   color: var(--white-text);
   background: var(--color-linkedin-blue);
   border-radius: 50%;
+  /* Plain black, not one of the --sh* shadow tokens - see LaunchGrowTab.css's
+     .LaunchTabDiv.active for the same reasoning: no --sh* value is a
+     byte-identical match across both themes, so swapping to one would change
+     the rendered shadow rather than preserve it. Justified in the
+     hardcoded-colours baseline, along with the hover state below. */
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
   transition:
     transform 0.15s ease,

--- a/apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.css
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.css
@@ -59,6 +59,9 @@
   position: relative;
   border: 1px solid var(--color-card-border);
   border-radius: 12px;
+  /* A warm-brown shadow (~10% alpha, 8-digit hex), not one of the --sh*
+     tokens or --ink (#1d1c1b) - a distinct bespoke value with no exact token
+     match. Justified in the hardcoded-colours baseline. */
   box-shadow: 0px 0px 30px 0px #4738271a;
 }
 .preview-img {

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "4a58a4724ab515a7aaed28e8be7e81d46b7c9020",
-  "total": 271,
+  "generated_at": "bba5e754b47cfdaf364877ceb0d430b3e831072c",
+  "total": 256,
   "justified": {
     "apps/frontend/src/app/features/appointments/components/Availability/Availability.tsx": {
       "n": 1,
@@ -214,6 +214,30 @@
     "apps/frontend/src/app/ui/theme/themeCore.ts": {
       "n": 2,
       "why": "The fallback for <meta name=\"theme-color\"> when getComputedStyle has not yet resolved --page (first paint, and SSR-hydration order). The meta element's content attribute is read by the browser chrome, which does not resolve CSS custom properties, so it must be a literal colour."
+    },
+    "apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.stories.tsx": {
+      "n": 4,
+      "why": "The #fff/#ccc pair (in a documentation string, not CSS) and the rgb(255, 255, 255)/rgb(204, 204, 204) pair (computed-style assertions) all describe recharts' own default tooltip styling - the story deliberately passes no custom styling to either <Tooltip />, so the bubble renders recharts' bare default and reads no design token at all. Not app-authored colour; tokenising would misrepresent what the story documents."
+    },
+    "apps/frontend/src/app/ui/widgets/Faq/Faq.css": {
+      "n": 2,
+      "why": "Two bespoke box-shadow literals: the resting-state shadow is a near-black-navy tint with no byte-identical match in the --sh* family (see LaunchGrowTab.css's .LaunchTabDiv.active for why swapping to a --sh* token would change the rendered light-mode shadow rather than preserve it); the expanded-state shadow is close to but not an exact match for --blue's rgb(37, 123, 237), so treating it as --blue-derived would be a value change, not a preserving refactor."
+    },
+    "apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css": {
+      "n": 3,
+      "why": "Three independent bespoke literals, all commented at their declarations: the active-tab shadow is plain black with no byte-identical --sh* match; the mobile tab-nav background is the fixed light-blue tint from LaunchGrowTab.tsx's growtab.color ('#E9F2FD') at 95% opacity, reused only within this one widget; the mobile active-tab glow is a standalone colored shadow (the desktop active tab uses plain black instead) close to but not an exact match for --blue's rgb(37, 123, 237)."
+    },
+    "apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.tsx": {
+      "n": 3,
+      "why": "Fixed light-blue tab tints (ids 2-4 of Launchtabs), deliberately NOT theme-flipping: LaunchGrowTab.css's .BuildText pins --ink-fixed against these backgrounds specifically because they stay light in both themes (a themed ink there put fixed-dark text on a dark card at 1.16:1 in espresso). Single-purpose pastels invented for this tab set, not derived from the shared palette - id 1 already reads through the real --blue-strong token, these three don't have an equivalent. '#E9F2FD' reappears once more in LaunchGrowTab.css's mobile-tab-nav background at 95% opacity, the only overlap and still local to this widget."
+    },
+    "apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css": {
+      "n": 2,
+      "why": "Two plain-black box-shadow literals (resting and hover state on the LinkedIn badge) with no byte-identical match in the --sh* family - see LaunchGrowTab.css's .LaunchTabDiv.active for the same reasoning."
+    },
+    "apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.css": {
+      "n": 1,
+      "why": "A warm-brown 8-digit-hex box-shadow (~10% alpha) with no exact match in --sh* or --ink (#1d1c1b) - a distinct bespoke value."
     }
   },
   "files": {
@@ -261,12 +285,6 @@
     "apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.stories.tsx": 2,
     "apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.stories.tsx": 3,
     "apps/frontend/src/app/ui/overlays/PdfPreviewOverlay.stories.tsx": 6,
-    "apps/frontend/src/app/ui/overlays/Toast/Toast.css": 2,
-    "apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.stories.tsx": 4,
-    "apps/frontend/src/app/ui/widgets/Faq/Faq.css": 2,
-    "apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css": 3,
-    "apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.tsx": 3,
-    "apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css": 2,
-    "apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.css": 1
+    "apps/frontend/src/app/ui/overlays/Toast/Toast.css": 2
   }
 }


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep, but this batch narrows scope
instead of tokenizing — each of these 15 literals is a genuinely bespoke
choice with no exact match in the existing token set, so migrating any of
them to a token would change the rendered value rather than preserve it.

- `LaunchGrowTab.css`/`.tsx` (6) — three fixed light-blue tab tints
  (ids 2-4 of `Launchtabs`) with dark ink deliberately pinned against them
  (`--ink-fixed`, same pattern as id 1's `--blue-strong` fill), a plain
  black active-tab shadow, a reused (within this file only) tint on the
  mobile nav pill, and a standalone colored glow with no desktop twin.
- `TeamSlide.css` (2) — plain-black LinkedIn-badge shadows, same "no
  byte-identical `--sh*` match" reasoning as the `LaunchGrowTab` case.
- `Faq.css` (2) — a near-black-navy resting shadow and a blue-tinted
  expanded-state shadow, close to but not an exact match for `--blue`.
- `UploadImage.css` (1) — a warm-brown 8-digit-hex shadow, no exact match
  anywhere in the token set.
- `DynamicChart/ChartCanvas.stories.tsx` (4) — recharts' own uncustomized
  default tooltip styling (both a doc-string description and the computed
  style assertion that verifies it), not app-authored colour at all.

Every CSS declaration gets an explanatory comment at the call site; the
`.tsx` files (left untouched, to keep this PR's diff CSS/JSON-only and
keep `tests-must-be-able-to-fail` uninvolved) are documented directly in
the baseline's own justification instead.

Baseline regenerated via `--update`: 271 → 256. No `.ts`/`.tsx` files
touched, so `tsc` is a no-op here; `eslint` doesn't lint `.css`.