### PR TITLE
fix(ci): pin the API PM2 interpreter

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -327,7 +327,7 @@ if [ -n "$CONTROL_FAILURES" ]; then
 fi
 
 say "cutover"
-pm2 restart "$PM2_TARGET" --update-env
+pm2 restart "$PM2_TARGET" --interpreter "$NODE_BIN/node" --update-env
 pm2 save
 # pm2 reporting "online" is not the same as serving, and checking the port
 # immediately races the boot. Give it time, then check what is actually true.

--- a/scripts/deploy/tests/migrate.test.sh
+++ b/scripts/deploy/tests/migrate.test.sh
@@ -887,6 +887,18 @@ else
      "probe=$POST_PROBE_LINE gate=$POST_GATE_LINE cutover=$CUTOVER_LINE"
 fi
 
+# PM2 persists this command into its saved process list. PATH protects this
+# deploy invocation, but an explicit interpreter also protects later hand
+# restarts from resolving the system Node instead of the repository's Node.
+PM2_TARGET_TOKEN="\$PM2_TARGET"
+NODE_INTERPRETER_TOKEN="\$NODE_BIN/node"
+if grep -qF "pm2 restart \"${PM2_TARGET_TOKEN}\" --interpreter \"${NODE_INTERPRETER_TOKEN}\" --update-env" "$DEPLOY_SH"; then
+  ok "api-deploy.sh persists the configured Node interpreter in PM2"
+else
+  no "api-deploy.sh persists the configured Node interpreter in PM2" \
+     "the cutover restart does not pass --interpreter \"\$NODE_BIN/node\""
+fi
+
 # The record is only useful if it is READ before the checkout moves the tree and
 # WRITTEN only once the cutover is verified. Both are orderings in the real file
 # that no stand-in can exercise, and both are the whole of #2714: reading after


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The API deploy exports the configured Node directory into `PATH`, but its PM2 restart does not record an explicit interpreter. A later hand restart with a different shell environment can therefore resolve the system Node version and crash the API during startup.

## What is the new behavior?

The cutover restart passes the configured Node binary to PM2 with `--interpreter` before saving the process list. The deploy regression suite pins the full restart command and fails if the interpreter flag is removed.

The separate boot-resurrection setup in the issue still requires privileged configuration on the host and is outside this repository change.

## Related Issue(s)

Refs #2866
