### PR TITLE
fix(frontend): await find* queries wrapped in expect() in panel stories

### DIFF
--- a/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
@@ -238,7 +238,7 @@ export const Default: AllergyListPanelStory = {
   name: 'Allergies loaded',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByRole('heading', { level: 2, name: 'Allergies' })).toBeVisible();
+    await expect(await canvas.findByRole('heading', { level: 2, name: 'Allergies' })).toBeVisible();
     await expect(canvas.getByText('Penicillin')).toBeVisible();
     await expect(canvas.getByText('Life-threatening')).toBeVisible();
     await expect(canvas.getByText('Chicken protein')).toBeVisible();
@@ -250,7 +250,7 @@ export const Default: AllergyListPanelStory = {
     const allergenInput = await canvas.findByLabelText('Allergen');
     await userEvent.type(allergenInput, 'Latex');
     await userEvent.click(canvas.getByRole('button', { name: 'Save allergy' }));
-    await expect(canvas.findByText('Latex')).toBeVisible();
+    await expect(await canvas.findByText('Latex')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save allergy' })).not.toBeInTheDocument();
 
     // Real resolve flow: submits through the hook, into the mocked POST.
@@ -266,7 +266,9 @@ export const Empty: AllergyListPanelStory = {
   beforeEach: prepare({ fixture: { kind: 'resolves', allergies: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('No allergies recorded for this patient yet.')).toBeVisible();
+    await expect(
+      await canvas.findByText('No allergies recorded for this patient yet.')
+    ).toBeVisible();
     await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
   },
 };
@@ -306,7 +308,7 @@ export const ReadOnly: AllergyListPanelStory = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('Penicillin')).toBeVisible();
+    await expect(await canvas.findByText('Penicillin')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Add allergy' })).not.toBeInTheDocument();
     await expect(
       canvas.queryByRole('button', { name: 'Resolve Chicken protein' })

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
@@ -260,8 +260,10 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
-    await expect(canvas.findByText('Cranial cruciate ligament repair (left stifle)')).toBeVisible();
+    await expect(await canvas.findByRole('heading', { name: 'Consents' })).toBeVisible();
+    await expect(
+      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
+    ).toBeVisible();
     await expect(canvas.getByText('2 active')).toBeVisible();
 
     // Grant: the form POSTs through the mocked adapter, which appends the
@@ -279,7 +281,7 @@ export const Default: Story = {
       'li'
     ) as HTMLElement;
     await expect(newRow).not.toBeNull();
-    await expect(canvas.findByText('3 active')).toBeVisible();
+    await expect(await canvas.findByText('3 active')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save consent' })).not.toBeInTheDocument();
 
     // Revoke: scoped to the new row, so the identically labelled "Revoke
@@ -292,11 +294,13 @@ export const Default: Story = {
     );
     await userEvent.click(rowCanvas.getByRole('button', { name: 'Revoke consent' }));
 
-    await expect(rowCanvas.findByText('Reason: Client rescheduled the procedure.')).toBeVisible();
+    await expect(
+      await rowCanvas.findByText('Reason: Client rescheduled the procedure.')
+    ).toBeVisible();
     await expect(
       rowCanvas.queryByRole('button', { name: 'Revoke Surgical consent' })
     ).not.toBeInTheDocument();
-    await expect(canvas.findByText('2 active')).toBeVisible();
+    await expect(await canvas.findByText('2 active')).toBeVisible();
   },
 };
 
@@ -305,7 +309,9 @@ export const Empty: Story = {
   beforeEach: prepare({ fixture: { kind: 'resolves', records: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('No consents recorded for this patient yet.')).toBeVisible();
+    await expect(
+      await canvas.findByText('No consents recorded for this patient yet.')
+    ).toBeVisible();
     await expect(canvas.queryByText(/active/)).not.toBeInTheDocument();
   },
 };
@@ -346,7 +352,9 @@ export const ReadOnly: Story = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('Cranial cruciate ligament repair (left stifle)')).toBeVisible();
+    await expect(
+      await canvas.findByText('Cranial cruciate ligament repair (left stifle)')
+    ).toBeVisible();
     // The field is still there to read; the controls are absent rather than disabled.
     await expect(canvas.queryByRole('button', { name: 'Record consent' })).not.toBeInTheDocument();
     await expect(canvas.queryByRole('button', { name: /^Revoke/ })).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
@@ -227,7 +227,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByRole('heading', { level: 2, name: 'Patient flags' })).toBeVisible();
+    await expect(
+      await canvas.findByRole('heading', { level: 2, name: 'Patient flags' })
+    ).toBeVisible();
     await expect(canvas.getByText('2 active')).toBeVisible();
     await expect(canvas.getByText('Bites when startled')).toBeVisible();
     await expect(canvas.getByText('Jumps low fences')).toBeVisible();
@@ -244,7 +246,7 @@ export const Empty: Story = {
   beforeEach: prepare({ fixture: { kind: 'resolves', flags: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('No active flags for this patient.')).toBeVisible();
+    await expect(await canvas.findByText('No active flags for this patient.')).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Add flag' })).toBeEnabled();
   },
 };
@@ -284,7 +286,7 @@ export const ReadOnly: Story = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('Bites when startled')).toBeVisible();
+    await expect(await canvas.findByText('Bites when startled')).toBeVisible();
     // Flags are still readable; only the edit affordances are gone.
     await expect(canvas.queryByRole('button', { name: 'Add flag' })).not.toBeInTheDocument();
     await expect(
@@ -306,7 +308,7 @@ export const AddingAFlag: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Save flag' }));
 
     // The form closes and the list is reloaded, so the new flag joins the seeded ones.
-    await expect(canvas.findByText('Needs sedation for X-rays')).toBeVisible();
+    await expect(await canvas.findByText('Needs sedation for X-rays')).toBeVisible();
     await expect(canvas.getByText('3 active')).toBeVisible();
     await expect(canvas.queryByLabelText('Flag title')).not.toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
@@ -236,7 +236,9 @@ export const Default: ProblemListPanelStory = {
   name: 'Problems loaded',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByRole('heading', { level: 2, name: 'Problem list' })).toBeVisible();
+    await expect(
+      await canvas.findByRole('heading', { level: 2, name: 'Problem list' })
+    ).toBeVisible();
     await expect(canvas.getByText('Chronic kidney disease')).toBeVisible();
     await expect(canvas.getByText('Severe')).toBeVisible();
     await expect(canvas.getByText('Otitis externa (left ear)')).toBeVisible();
@@ -249,7 +251,7 @@ export const Default: ProblemListPanelStory = {
     const titleInput = await canvas.findByLabelText('Problem title');
     await userEvent.type(titleInput, 'Seasonal allergies');
     await userEvent.click(canvas.getByRole('button', { name: 'Save problem' }));
-    await expect(canvas.findByText('Seasonal allergies')).toBeVisible();
+    await expect(await canvas.findByText('Seasonal allergies')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Save problem' })).not.toBeInTheDocument();
 
     // Real resolve flow: submits through the panel, into the mocked POST.
@@ -269,7 +271,9 @@ export const Empty: ProblemListPanelStory = {
   beforeEach: prepare({ fixture: { kind: 'resolves', problems: [] } }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('No problems recorded for this patient yet.')).toBeVisible();
+    await expect(
+      await canvas.findByText('No problems recorded for this patient yet.')
+    ).toBeVisible();
     await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
   },
 };
@@ -309,7 +313,7 @@ export const ReadOnly: ProblemListPanelStory = {
   }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByText('Chronic kidney disease')).toBeVisible();
+    await expect(await canvas.findByText('Chronic kidney disease')).toBeVisible();
     await expect(canvas.queryByRole('button', { name: 'Add problem' })).not.toBeInTheDocument();
     await expect(
       canvas.queryByRole('button', { name: 'Resolve Otitis externa (left ear)' })


### PR DESCRIPTION
## What changed
ProblemListPanel.stories.tsx, FlagListPanel.stories.tsx, AllergyListPanel.stories.tsx, and ConsentListPanel.stories.tsx each had several `expect(canvas.findByRole(...)).toBeVisible()` / `expect(canvas.findByText(...)).toBeVisible()` assertions that never awaited the `find*` query before handing it to `expect()`. Wrapped each with an inner await (`expect(await canvas.findByRole(...))`), matching the pattern `DocumentsListPanel.stories.tsx` already used correctly.

## Why
`find*` queries return a Promise. `expect(aPromise).toBeVisible()` throws synchronously ("received value must be an HTMLElement... Received has value: Promise {}") instead of waiting for the element, aborting the play function at the first such line and leaving every assertion after it unreached. This was flagged as a follow-up while fixing an unrelated a11y bug in the same directory ([#2972](https://github.com/YosemiteCrew/Yosemite-Crew/pull/2972)) - `test-storybook` run against these panels surfaced it.

Confirmed pre-existing, not introduced by #2972 or this change: `git show origin/dev` on each file (before this PR) shows the same unawaited pattern already present.

## Impact area
`apps/frontend` only, Storybook story files under `src/app/features/companionHistory/components/`. No production code touched - these are play-function test assertions only.

## Validation performed
- `npx tsc --noemit` - clean
- `pnpm --filter frontend run lint` - clean (0 errors; 1 pre-existing warning in an unrelated file)
- Targeted jest: `companionHistory` - 421/421 passing
- `test-storybook` against the 4 fixed files: the heading/text assertions that previously aborted the play function immediately (the exact lines this PR touches) now correctly wait for and find their target elements, confirmed via isolated per-file runs. Some of these files also have a few pre-existing, unrelated play-test failures (e.g. a `role="alert"` not rendering on `LoadFailed` stories) that are present identically on unmodified `origin/dev` and are out of scope for this change - confirmed via `git show origin/dev` before touching anything. Local runs on this dev machine were also intermittently affected by heavy concurrent CPU load from other sessions (Playwright timeouts hitting their exact ceiling), which is why this repo's CI already treats this check as advisory rather than blocking.