### PR TITLE
fix(frontend): add --spot-ink-faint token, fix two real dark-mode bugs

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/spotInkFaintToken.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/spotInkFaintToken.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// The marketing site's --spot cards stay dark in both themes. Their muted
+// body copy (below a --spot-ink headline or a --spot-blue eyebrow) used to
+// be a hardcoded #a9a39e literal, which happens to be correct in both
+// themes precisely because --spot never flips - but a hardcoded literal is
+// invisible to the design-token system and, unlike the established
+// --spot-ink/--spot-success/--spot-blue tokens, had no name. This routes
+// all 8 occurrences through the new --spot-ink-faint token instead, which
+// is declared with the SAME literal value in both theme blocks (a pure
+// value-preserving refactor, not a colour change).
+const MARKETING_FILES = [
+  'src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx',
+  'src/app/features/marketing/pages/About/About.tsx',
+  'src/app/features/marketing/pages/Pricing/Pricing.tsx',
+];
+
+describe('marketing site muted spot-card copy reads from the fixed --spot-ink-faint token', () => {
+  it('no longer hardcodes the muted-ink literal anywhere it was used', () => {
+    for (const file of MARKETING_FILES) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8');
+      expect(source).not.toContain('#a9a39e');
+    }
+  });
+
+  it('declares --spot-ink-faint with the same literal in both theme blocks', () => {
+    const css = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+    const occurrences = css.match(/--spot-ink-faint:\s*#a9a39e;/g) ?? [];
+    expect(occurrences).toHaveLength(2);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/DevelopersPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DevelopersPage.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DevelopersPage } from '@/app/features/marketing/pages/DevelopersPage/DevelopersPage';
@@ -154,5 +156,31 @@ describe('DevelopersPage', () => {
     // wrong, so pinned here rather than trusted from reading the source alone.
     const title = screen.getByText('Bring your own model');
     expect(title.style.color).toBe('var(--spot-ink)');
+  });
+});
+
+describe('marketplace row and hero glow read from real tokens', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the Triage Agent icon colour as a frozen light-mode literal', () => {
+    // --avatar-green-bg flips (a pale mint in light, a translucent dark-green
+    // tint in dark), so the icon ink pinned against it must flip too - the
+    // sibling amber row already reads var(--avatar-amber-ink) correctly.
+    expect(source).not.toContain('iconColor="#006642"');
+  });
+
+  it('routes the Triage Agent icon colour through --avatar-green-ink', () => {
+    expect(source).toContain('iconColor="var(--avatar-green-ink)"');
+  });
+
+  it('does not hardcode the second hero glow as a frozen rgba literal', () => {
+    expect(source).not.toContain('color="rgba(130,175,236,0.08)"');
+  });
+
+  it('routes the second hero glow through --spot-blue via color-mix', () => {
+    expect(source).toContain('color="color-mix(in srgb, var(--spot-blue) 8%, transparent)"');
   });
 });

--- a/apps/frontend/src/app/features/marketing/pages/About/About.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/About/About.tsx
@@ -352,7 +352,7 @@ function Origin() {
               fontSize: 'clamp(18px, 2.1vw, 22px)',
               lineHeight: 1.6,
               letterSpacing: '-0.02em',
-              color: '#a9a39e',
+              color: 'var(--spot-ink-faint)',
               textWrap: 'pretty',
             }}
           >
@@ -1159,7 +1159,7 @@ function ClosingCta() {
               fontSize: '18px',
               lineHeight: 1.65,
               letterSpacing: '-0.02em',
-              color: '#a9a39e',
+              color: 'var(--spot-ink-faint)',
               textWrap: 'pretty',
             }}
           >

--- a/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
@@ -208,7 +208,7 @@ const ECON_BAR_LABEL_MUTED_STYLE: React.CSSProperties = {
   fontSize: '12px',
   fontWeight: 700,
   letterSpacing: '0.01em',
-  color: '#a9a39e',
+  color: 'var(--spot-ink-faint)',
 };
 
 const ECON_BAR_LABEL_LIGHT_STYLE: React.CSSProperties = {
@@ -1124,7 +1124,7 @@ function Marketplace() {
             />
             <PluginRow
               iconBg="var(--avatar-green-bg)"
-              iconColor="#006642"
+              iconColor="var(--avatar-green-ink)"
               icon={<IoPulseOutline aria-hidden="true" style={{ fontSize: '20px' }} />}
               title="Triage Agent"
               desc="Sorts the inbox before the vet reads it"
@@ -1277,7 +1277,7 @@ function EconColumn({ index, icon, title, desc, delay }: Readonly<EconColumnProp
           fontSize: '14.5px',
           lineHeight: 1.6,
           letterSpacing: '-0.01em',
-          color: '#a9a39e',
+          color: 'var(--spot-ink-faint)',
         }}
       >
         {desc}
@@ -1335,7 +1335,7 @@ function EconomicsKeepPanel() {
           fontSize: '15px',
           lineHeight: 1.6,
           letterSpacing: '-0.01em',
-          color: '#a9a39e',
+          color: 'var(--spot-ink-faint)',
           maxWidth: '42ch',
         }}
       >
@@ -1558,7 +1558,7 @@ function Economics() {
       />
       <HeroGlow
         parallax={false}
-        color="rgba(130,175,236,0.08)"
+        color="color-mix(in srgb, var(--spot-blue) 8%, transparent)"
         box={{ bottom: '-220px', right: '-160px', width: '680px', height: '520px' }}
         animation="ycDrift 42s ease-in-out 3s infinite alternate-reverse"
       />
@@ -1608,7 +1608,7 @@ function Economics() {
               fontSize: '18px',
               lineHeight: 1.65,
               letterSpacing: '-0.02em',
-              color: '#a9a39e',
+              color: 'var(--spot-ink-faint)',
               textWrap: 'pretty',
             }}
           >
@@ -1799,7 +1799,7 @@ function ClosingCta() {
               fontSize: '18px',
               lineHeight: 1.65,
               letterSpacing: '-0.02em',
-              color: '#a9a39e',
+              color: 'var(--spot-ink-faint)',
               textWrap: 'pretty',
             }}
           >

--- a/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
@@ -490,7 +490,9 @@ function BusinessPlanCard({ price, period }: Readonly<{ price: string; period: s
           {price}
         </span>
       </div>
-      <div style={{ fontSize: '14px', color: '#a9a39e', marginBottom: '18px' }}>{period}</div>
+      <div style={{ fontSize: '14px', color: 'var(--spot-ink-faint)', marginBottom: '18px' }}>
+        {period}
+      </div>
       <p
         style={{
           margin: '0 0 22px',

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -738,6 +738,9 @@ input[type='radio']:focus-visible {
   --spot: #1d1c1b;
   /* ink that sits on --spot; light in both themes because --spot never flips */
   --spot-ink: #eae2d5;
+  /* muted body copy on --spot; fixed like --spot-ink, same reason - --ink-faint2
+     flips and would go too dark to read against a background that never does. */
+  --spot-ink-faint: #a9a39e;
   /* success accent that sits on --spot; fixed like --spot-ink, same reason */
   --spot-success: #9be8c9;
   /* brand-blue accent that sits on --spot; fixed like --spot-ink, same reason.
@@ -855,6 +858,7 @@ html[data-theme='dark'] {
   --warn: #f5a83c;
   --spot: #17140f;
   --spot-ink: #f4efe6;
+  --spot-ink-faint: #a9a39e;
   --spot-success: #9be8c9;
   --spot-blue: #82afec;
   --code-str: #8acbb4;

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "1c4f6e5096a958dccc3ac54c17d595085780bd82",
-  "total": 188,
+  "generated_at": "1deee4858cb605c3bc2600b3c15e6feba117af6f",
+  "total": 139,
   "justified": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": {
       "n": 1,
@@ -239,6 +239,10 @@
       "n": 2,
       "why": "CARD_BG (#faf7f1) and a border colour (#e6ded1) are close to but not exact matches for any token (--color-screen is #f7f3ec, --color-hairline is #e5dccf) - left as literals when PR #2963 tokenised this file's other 8 exact-match literals, and still not exact matches now."
     },
+    "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": {
+      "n": 39,
+      "why": "Four unrelated groups of deliberate illustration colours, none derivable from an existing token without changing the rendered value: (1) a fake terminal/code-editor mockup (traffic-light dots #454341, header rule #302f2e, terminal body text #d6d1cd, green '$' prompt #54b492, '&&' operator #5c5956, JSON string colour #8acbb4 - the last is --code-str's own dark-mode value, but --code-str itself flips for real light-surface code cards, which this mockup is not) - this same small palette recurs across Home.tsx, Insights.tsx, Pricing.tsx and About.tsx, so a shared token family may be worth formalising in its own follow-up, but is out of scope here; (2) the '0% platform cut' comparison-bar illustration (track #2c2926, border #35322f, striped fill #4a4643/#423e3b, and the already-investigated #2f6fc0 border - see PR #2977) plus its own bespoke near-black gradient card (#232120 to #1a1918, border #35322f); (3) three icon glyphs at a single-file-only muted grey (#6f6a66, not reused elsewhere); (4) two fixed-white ink spots (#ffffff) on fills that are themselves fixed (the 100%-filled blue bar, and the '0%' hero figure on --spot) plus one decorative gloss overlay (rgba(255,255,255,0.18)) - the same justified pattern as ChatContainer.css's white-on-fixed-blue ink, just inline rather than in a stylesheet."
+    },
     "apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx": {
       "n": 2,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
@@ -345,16 +349,15 @@
     }
   },
   "files": {
-    "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 6,
+    "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 4,
     "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": 10,
-    "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": 46,
     "apps/frontend/src/app/features/marketing/pages/Home/Home.tsx": 19,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": 1,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": 19,
     "apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx": 3,
     "apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx": 10,
     "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.stories.tsx": 3,
-    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 15,
+    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 14,
     "apps/frontend/src/app/features/marketing/site/assets.ts": 2,
     "apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx": 2,
     "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": 17,


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep into the marketing site's largest
remaining file, `DevelopersPage.tsx`.

**Two real fixes**, live-verified in the dev server (dark mode: computed
icon colour went from `rgb(0, 102, 66)` / `#006642` — nearly invisible —
to `rgb(116, 208, 162)` / `#74d0a2`; light mode unchanged, still
`rgb(0, 102, 66)`):

- The Triage Agent plugin row hardcoded `iconColor="#006642"` instead of
  reading `var(--avatar-green-ink)`, the token its own `iconBg`
  (`--avatar-green-bg`) is paired with — the sibling amber row already
  used `var(--avatar-amber-ink)` correctly. In dark mode this rendered a
  dark-green icon nearly invisible against the translucent dark-green
  fill.
- A second hero glow hardcoded `rgba(130,175,236,0.08)` — `--spot-blue`'s
  exact RGB — instead of reading the token via `color-mix()`, unlike its
  sibling glow which already used `var(--glow-b12)`.

**New token**: `--spot-ink-faint` (`#a9a39e` in both theme blocks,
following the same precedent as `--spot-ink`/`--spot-success`/
`--spot-blue` — fixed because `--spot` never flips). Migrated all 8
occurrences across the three marketing files that used this literal
(`DevelopersPage.tsx` ×5, `About.tsx` ×2, `Pricing.tsx` ×1) — a pure
value-preserving refactor for those, guard-tested and mutation-checked
(reverted all 4 source files, confirmed 6 new assertions failed with 12
pre-existing unaffected; restored, 18/18 pass).

**Justified** (39 remaining literals in `DevelopersPage.tsx`): a fake
terminal/code-editor mockup's own palette (reused across several other
marketing pages — a candidate for a future shared token, flagged but out
of scope here), a comparison-bar illustration's bespoke near-black track
and gradient, three single-file icon greys, and two fixed-white-on-
fixed-fill spots plus a decorative gloss overlay.

Baseline regenerated via `--update`: 188 → 139.