### PR TITLE
fix(frontend): route AuthShell's brand-panel colours through real tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/AuthShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/AuthShell.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { IoCalendarOutline } from 'react-icons/io5';
@@ -83,5 +85,48 @@ describe('AuthShell', () => {
     expect(container.querySelector('[data-brandpanel="true"]')).toHaveStyle({
       color: 'var(--spot-ink)',
     });
+  });
+});
+
+describe('brand panel reads ink and glow colours from real tokens', () => {
+  // BRAND_PANEL_STYLE is painted from a fixed near-black gradient, never
+  // themed, so everything on it must read a token that either never flips
+  // (--spot-ink, --blue, --color-cyan, --pink, --color-accent-dark) rather
+  // than a hardcoded copy of one theme's resolved value.
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/site/AuthShell.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the point-icon ink as a frozen light-mode literal', () => {
+    expect(source).not.toContain("color: '#8fb6f5'");
+  });
+
+  it('routes the point-icon ink through --color-accent-dark', () => {
+    expect(source).toContain("color: 'var(--color-accent-dark)'");
+  });
+
+  it('does not hardcode the spot-ink tints as frozen rgba literals', () => {
+    expect(source).not.toMatch(/rgba\(234,\s*226,\s*213/);
+  });
+
+  it('routes the spot-ink tints through color-mix', () => {
+    expect(source).toMatch(/color-mix\(in srgb, var\(--spot-ink\) 10%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--spot-ink\) 16%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--spot-ink\) 18%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--spot-ink\) 5%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--spot-ink\) 22%, transparent\)/);
+  });
+
+  it('does not hardcode the ambient glows as frozen rgba literals', () => {
+    expect(source).not.toContain('rgba(37,123,237,0.26)');
+    expect(source).not.toContain('rgba(92,225,230,0.14)');
+    expect(source).not.toContain('rgba(255,144,212,0.10)');
+  });
+
+  it('routes the ambient glows through --blue, --color-cyan and --pink', () => {
+    expect(source).toMatch(/color-mix\(in srgb, var\(--blue\) 26%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--color-cyan\) 14%, transparent\)/);
+    expect(source).toMatch(/color-mix\(in srgb, var\(--pink\) 10%, transparent\)/);
   });
 });

--- a/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
+++ b/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
@@ -24,12 +24,12 @@ const BRAND_POINT_ICON_STYLE: CSSProperties = {
   width: 38,
   height: 38,
   borderRadius: 11,
-  background: 'rgba(234,226,213,0.10)',
-  border: '1px solid rgba(234,226,213,0.16)',
+  background: 'color-mix(in srgb, var(--spot-ink) 10%, transparent)',
+  border: '1px solid color-mix(in srgb, var(--spot-ink) 16%, transparent)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: '#8fb6f5',
+  color: 'var(--color-accent-dark)',
 };
 
 const GITHUB_STAR_PILL_STYLE: CSSProperties = {
@@ -40,8 +40,8 @@ const GITHUB_STAR_PILL_STYLE: CSSProperties = {
   textDecoration: 'none',
   padding: '10px 16px 10px 14px',
   borderRadius: 9999,
-  border: '1px solid rgba(234,226,213,0.18)',
-  background: 'rgba(234,226,213,0.05)',
+  border: '1px solid color-mix(in srgb, var(--spot-ink) 18%, transparent)',
+  background: 'color-mix(in srgb, var(--spot-ink) 5%, transparent)',
   color: 'var(--spot-ink)',
   fontSize: 14,
   letterSpacing: '-0.01em',
@@ -159,7 +159,11 @@ export function AuthBrandContent({
           {stars ? `Star on GitHub · ${stars}` : 'Star on GitHub'}
         </span>
         <span
-          style={{ width: 1, height: 13, background: 'rgba(234,226,213,0.22)' }}
+          style={{
+            width: 1,
+            height: 13,
+            background: 'color-mix(in srgb, var(--spot-ink) 22%, transparent)',
+          }}
           aria-hidden="true"
         />
         <span style={{ color: '#b7ac9d' }}>building in the open</span>
@@ -208,7 +212,8 @@ export function AuthShell({ brand, topRight, children }: Readonly<AuthShellProps
               right: -140,
               width: 620,
               height: 520,
-              background: 'radial-gradient(closest-side, rgba(37,123,237,0.26), transparent 70%)',
+              background:
+                'radial-gradient(closest-side, color-mix(in srgb, var(--blue) 26%, transparent), transparent 70%)',
               animation: 'ycDrift 36s ease-in-out infinite alternate',
             }}
           />
@@ -219,7 +224,8 @@ export function AuthShell({ brand, topRight, children }: Readonly<AuthShellProps
               left: -160,
               width: 600,
               height: 500,
-              background: 'radial-gradient(closest-side, rgba(92,225,230,0.14), transparent 70%)',
+              background:
+                'radial-gradient(closest-side, color-mix(in srgb, var(--color-cyan) 14%, transparent), transparent 70%)',
               animation: 'ycDrift 46s ease-in-out 4s infinite alternate-reverse',
             }}
           />
@@ -230,7 +236,8 @@ export function AuthShell({ brand, topRight, children }: Readonly<AuthShellProps
               right: -80,
               width: 360,
               height: 320,
-              background: 'radial-gradient(closest-side, rgba(255,144,212,0.10), transparent 70%)',
+              background:
+                'radial-gradient(closest-side, color-mix(in srgb, var(--pink) 10%, transparent), transparent 70%)',
               animation: 'ycDrift 54s ease-in-out 2s infinite alternate',
             }}
           />

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "1deee4858cb605c3bc2600b3c15e6feba117af6f",
-  "total": 139,
+  "generated_at": "e98baad68cf758a50319418f8709bc3892e2a8d5",
+  "total": 122,
   "justified": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": {
       "n": 1,
@@ -243,6 +243,10 @@
       "n": 39,
       "why": "Four unrelated groups of deliberate illustration colours, none derivable from an existing token without changing the rendered value: (1) a fake terminal/code-editor mockup (traffic-light dots #454341, header rule #302f2e, terminal body text #d6d1cd, green '$' prompt #54b492, '&&' operator #5c5956, JSON string colour #8acbb4 - the last is --code-str's own dark-mode value, but --code-str itself flips for real light-surface code cards, which this mockup is not) - this same small palette recurs across Home.tsx, Insights.tsx, Pricing.tsx and About.tsx, so a shared token family may be worth formalising in its own follow-up, but is out of scope here; (2) the '0% platform cut' comparison-bar illustration (track #2c2926, border #35322f, striped fill #4a4643/#423e3b, and the already-investigated #2f6fc0 border - see PR #2977) plus its own bespoke near-black gradient card (#232120 to #1a1918, border #35322f); (3) three icon glyphs at a single-file-only muted grey (#6f6a66, not reused elsewhere); (4) two fixed-white ink spots (#ffffff) on fills that are themselves fixed (the 100%-filled blue bar, and the '0%' hero figure on --spot) plus one decorative gloss overlay (rgba(255,255,255,0.18)) - the same justified pattern as ChatContainer.css's white-on-fixed-blue ink, just inline rather than in a stylesheet."
     },
+    "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": {
+      "n": 8,
+      "why": "The brand panel's own bespoke near-black gradient (#2a2723 to #131210, matching DevelopersPage.tsx's EconomicsCard pattern - see PR #2992). The remaining five (subtitle/footer ink #b7ac9d x2, point text #d8cec0, star icon gold #ffd479, 'Star on GitHub' emphasis white #fff) are single-file bespoke choices with no matching token - #fff in particular is a deliberately brighter emphasis colour next to surrounding --spot-ink copy, the same pattern as Pricing.tsx's price figure and DevelopersPage.tsx's '0%' hero figure."
+    },
     "apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx": {
       "n": 2,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
@@ -360,7 +364,6 @@
     "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 14,
     "apps/frontend/src/app/features/marketing/site/assets.ts": 2,
     "apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx": 2,
-    "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": 17,
     "apps/frontend/src/app/features/marketing/site/marketing.css": 1,
     "apps/frontend/src/app/features/marketing/site/motion.stories.tsx": 2,
     "apps/frontend/src/app/features/marketing/site/motion.tsx": 7,


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep into the auth pages' shared brand
panel (`AuthShell.tsx`), which is painted from a permanently-dark
gradient — never themed.

Nine literals were hardcoded copies of values that already have a fixed
(non-flipping) token, so each becomes a pure value-preserving swap,
live-verified in the dev server against `/signin` in both light and dark
app theme — both render byte-identical to before (confirmed via computed
style, e.g. the point icon still resolves to `rgb(143, 182, 245)`):

- `iconColor '#8fb6f5'` → `var(--color-accent-dark)` — the same fix
  already applied to SignIn/SignUp in #2990, in the component both pages
  share.
- Five `rgba(234,226,213,N)` tints → `color-mix(in srgb, var(--spot-ink)
  N%, transparent)` — `234,226,213` is `--spot-ink`'s own light-block
  value.
- Three ambient background glows, each an exact RGB match for a token
  that is genuinely fixed across both theme blocks (unlike the flipping
  `--glow-*` family, which would change the glow's intensity on an
  app-theme toggle even though this panel never changes):
  `rgba(37,123,237,.26)` → `--blue`, `rgba(92,225,230,.14)` →
  `--color-cyan`, `rgba(255,144,212,.1)` → `--pink`.

Guard-tested and mutation-checked in the existing `AuthShell.test.tsx`
(reverted the file, confirmed 6 new assertions failed with 5 pre-existing
unaffected; restored, 11/11 pass).

The remaining 8 literals are justified: the panel's own bespoke gradient
stops (matching `DevelopersPage.tsx`'s `EconomicsCard` pattern from
#2992) and five single-file bespoke ink/accent choices with no matching
token.

Baseline regenerated via `--update`: 139 → 122.