### PR TITLE
fix(frontend): route marketing success/brand ramp colours through tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/successBrandRampTokens.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/successBrandRampTokens.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// These marketing pages hardcoded copies of colours that already exist as
+// fixed (non-flipping) entries in the --color-success-*/--color-brand-*
+// ramps in globals.css (declared once, outside any theme block), instead
+// of reading the ramp. This routes each occurrence through its matching
+// token - a pure value-preserving refactor, not a colour change.
+const CASES = [
+  {
+    literal: '#8acbb4',
+    token: 'var(--color-success-300)',
+    files: [
+      'src/app/features/marketing/pages/Home/Home.tsx',
+      'src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx',
+    ],
+  },
+  {
+    literal: '#54b492',
+    token: 'var(--color-success-400)',
+    files: [
+      'src/app/features/marketing/pages/Pricing/Pricing.tsx',
+      'src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx',
+    ],
+  },
+  {
+    literal: '#33a57d',
+    token: 'var(--color-success-500)',
+    files: ['src/app/features/marketing/pages/Home/Home.tsx'],
+  },
+  {
+    literal: '#99bdec',
+    token: 'var(--color-brand-600)',
+    files: ['src/app/features/marketing/pages/Home/Home.tsx'],
+  },
+  {
+    literal: '#6aa1eb',
+    token: 'var(--color-brand-800)',
+    files: ['src/app/features/marketing/pages/Home/Home.tsx'],
+  },
+  {
+    literal: '#3b87ec',
+    token: 'var(--color-brand-925)',
+    files: ['src/app/features/marketing/pages/Home/Home.tsx'],
+  },
+];
+
+describe('marketing pages read success/brand ramp colours from the fixed tokens', () => {
+  for (const { literal, token, files } of CASES) {
+    describe(literal, () => {
+      for (const file of files) {
+        const source = readFileSync(join(process.cwd(), file), 'utf8');
+
+        it(`does not hardcode ${literal} as a frozen literal in ${file}`, () => {
+          expect(source).not.toContain(`'${literal}'`);
+        });
+
+        it(`routes through ${token} in ${file}`, () => {
+          expect(source).toContain(`'${token}'`);
+        });
+      }
+    });
+  }
+
+  it('declares each ramp entry once, outside any theme block, in globals.css', () => {
+    const css = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+    expect(css.match(/--color-success-300:\s*#8acbb4;/g) ?? []).toHaveLength(1);
+    expect(css.match(/--color-success-400:\s*#54b492;/g) ?? []).toHaveLength(1);
+    expect(css.match(/--color-success-500:\s*#33a57d;/g) ?? []).toHaveLength(1);
+    expect(css.match(/--color-brand-600:\s*#99bdec;/g) ?? []).toHaveLength(1);
+    expect(css.match(/--color-brand-800:\s*#6aa1eb;/g) ?? []).toHaveLength(1);
+    expect(css.match(/--color-brand-925:\s*#3b87ec;/g) ?? []).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx
@@ -472,14 +472,15 @@ function HeroTerminalCard() {
           color: '#d6d1cd',
         }}
       >
-        <span style={{ color: '#54b492' }}>$</span> git clone yosemitecrew/Yosemite-Crew
+        <span style={{ color: 'var(--color-success-400)' }}>$</span> git clone
+        yosemitecrew/Yosemite-Crew
         {'\n'}
-        <span style={{ color: '#54b492' }}>$</span> pnpm install{' '}
+        <span style={{ color: 'var(--color-success-400)' }}>$</span> pnpm install{' '}
         <span style={{ color: '#5c5956' }}>&amp;&amp;</span> pnpm dev
         {'\n'}
         <span style={{ color: 'var(--ink-faint)' }}>→ PIMS live on :3000</span>
         {'\n'}
-        <span style={{ color: '#54b492' }}>$</span>
+        <span style={{ color: 'var(--color-success-400)' }}>$</span>
         {' open localhost:3000/dev-docs'}
         <span
           style={{
@@ -866,9 +867,9 @@ function FhirBundleCard() {
           <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>
           {'\n  '}
           <span style={{ color: 'var(--cyan)' }}>&quot;resourceType&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;Bundle&quot;</span>,{'\n  '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;Bundle&quot;</span>,{'\n  '}
           <span style={{ color: 'var(--cyan)' }}>&quot;type&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;searchset&quot;</span>,{'\n  '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;searchset&quot;</span>,{'\n  '}
           <span style={{ color: 'var(--cyan)' }}>&quot;total&quot;</span>:{' '}
           <span style={{ color: 'var(--color-warning-400)' }}>3</span>,{'\n  '}
           <span style={{ color: 'var(--cyan)' }}>&quot;entry&quot;</span>:{' '}
@@ -876,20 +877,22 @@ function FhirBundleCard() {
           {'\n    '}
           <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>{' '}
           <span style={{ color: 'var(--cyan)' }}>&quot;code&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;rabies-vax&quot;</span>,{'\n      '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;rabies-vax&quot;</span>,
+          {'\n      '}
           <span style={{ color: 'var(--cyan)' }}>&quot;validYears&quot;</span>:{' '}
           <span style={{ color: 'var(--color-warning-400)' }}>3</span>,{'\n      '}
           <span style={{ color: 'var(--cyan)' }}>&quot;authority&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;EU&quot;</span>{' '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;EU&quot;</span>{' '}
           <span style={{ color: 'var(--ink-faint)' }}>{'},'}</span>
           {'\n    '}
           <span style={{ color: 'var(--ink-faint)' }}>{'{'}</span>{' '}
           <span style={{ color: 'var(--cyan)' }}>&quot;code&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;rabies-vax&quot;</span>,{'\n      '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;rabies-vax&quot;</span>,
+          {'\n      '}
           <span style={{ color: 'var(--cyan)' }}>&quot;validYears&quot;</span>:{' '}
           <span style={{ color: 'var(--color-warning-400)' }}>1</span>,{'\n      '}
           <span style={{ color: 'var(--cyan)' }}>&quot;authority&quot;</span>:{' '}
-          <span style={{ color: '#8acbb4' }}>&quot;US&quot;</span>{' '}
+          <span style={{ color: 'var(--color-success-300)' }}>&quot;US&quot;</span>{' '}
           <span style={{ color: 'var(--ink-faint)' }}>{'}'}</span>
           {'\n  '}
           <span style={{ color: 'var(--ink-faint)' }}>]</span>

--- a/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
@@ -524,9 +524,30 @@ function HeroRecoveryCard() {
     >
       <div style={HERO_STAT_CARD_STYLE}>
         <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 26 }}>
-          <span style={{ width: 4, height: '40%', background: '#99bdec', borderRadius: 2 }} />
-          <span style={{ width: 4, height: '65%', background: '#6aa1eb', borderRadius: 2 }} />
-          <span style={{ width: 4, height: '50%', background: '#3b87ec', borderRadius: 2 }} />
+          <span
+            style={{
+              width: 4,
+              height: '40%',
+              background: 'var(--color-brand-600)',
+              borderRadius: 2,
+            }}
+          />
+          <span
+            style={{
+              width: 4,
+              height: '65%',
+              background: 'var(--color-brand-800)',
+              borderRadius: 2,
+            }}
+          />
+          <span
+            style={{
+              width: 4,
+              height: '50%',
+              background: 'var(--color-brand-925)',
+              borderRadius: 2,
+            }}
+          />
           <span style={{ width: 4, height: '90%', background: 'var(--blue)', borderRadius: 2 }} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -1546,7 +1567,14 @@ function DevApiHeader() {
       >
         GET /fhir/Patient/bella
       </span>
-      <span style={{ fontSize: 12, fontWeight: 700, color: '#33a57d', letterSpacing: '0.06em' }}>
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          color: 'var(--color-success-500)',
+          letterSpacing: '0.06em',
+        }}
+      >
         200 OK
       </span>
     </div>
@@ -1570,12 +1598,12 @@ function DevApiResponse() {
       {'\n  '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;resourceType&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;Patient&quot;</span>
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;Patient&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>,</span>
       {'\n  '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;id&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;bella-2014&quot;</span>
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;bella-2014&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>,</span>
       {'\n  '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;extension&quot;</span>
@@ -1583,12 +1611,12 @@ function DevApiResponse() {
       {'\n    '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;url&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;.../animal-species&quot;</span>
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;.../animal-species&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>,</span>
       {'\n    '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;valueCode&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;canine&quot;</span>
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;canine&quot;</span>
       {'\n  '}
       <span style={{ color: 'var(--ink-faint)' }}>{'}],'}</span>
       {'\n  '}
@@ -1596,7 +1624,7 @@ function DevApiResponse() {
       <span style={{ color: 'var(--ink-faint)' }}>: [{'{'}</span>{' '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;text&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;Bella&quot;</span>{' '}
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;Bella&quot;</span>{' '}
       <span style={{ color: 'var(--ink-faint)' }}>{'}],'}</span>
       {'\n  '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;managingOrganization&quot;</span>
@@ -1604,7 +1632,7 @@ function DevApiResponse() {
       {'\n    '}
       <span style={{ color: 'var(--spot-blue)' }}>&quot;display&quot;</span>
       <span style={{ color: 'var(--ink-faint)' }}>:</span>{' '}
-      <span style={{ color: '#8acbb4' }}>&quot;Alpenblick Clinic&quot;</span>
+      <span style={{ color: 'var(--color-success-300)' }}>&quot;Alpenblick Clinic&quot;</span>
       {'\n  '}
       <span style={{ color: 'var(--ink-faint)' }}>{'}'}</span>
       {'\n'}

--- a/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
@@ -27,11 +27,11 @@ const FREE_FEATURES: FeatureItem[] = [
 ];
 
 const BUSINESS_FEATURES: FeatureItem[] = [
-  { label: 'Unlimited appointments & tools', dot: '#54b492' },
-  { label: 'Team, rooms & departments', dot: '#54b492' },
-  { label: 'Billing, invoicing & Stripe payments', dot: '#54b492' },
-  { label: 'Financial reporting & analytics', dot: '#54b492' },
-  { label: 'Dedicated Discord support', dot: '#54b492' },
+  { label: 'Unlimited appointments & tools', dot: 'var(--color-success-400)' },
+  { label: 'Team, rooms & departments', dot: 'var(--color-success-400)' },
+  { label: 'Billing, invoicing & Stripe payments', dot: 'var(--color-success-400)' },
+  { label: 'Financial reporting & analytics', dot: 'var(--color-success-400)' },
+  { label: 'Dedicated Discord support', dot: 'var(--color-success-400)' },
 ];
 
 const ENTERPRISE_FEATURES: FeatureItem[] = [

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "e98baad68cf758a50319418f8709bc3892e2a8d5",
-  "total": 122,
+  "generated_at": "f4fbd219def4e02ae69e7ce92b70bd833cef8229",
+  "total": 98,
   "justified": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": {
       "n": 1,
@@ -240,8 +240,12 @@
       "why": "CARD_BG (#faf7f1) and a border colour (#e6ded1) are close to but not exact matches for any token (--color-screen is #f7f3ec, --color-hairline is #e5dccf) - left as literals when PR #2963 tokenised this file's other 8 exact-match literals, and still not exact matches now."
     },
     "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": {
-      "n": 39,
-      "why": "Four unrelated groups of deliberate illustration colours, none derivable from an existing token without changing the rendered value: (1) a fake terminal/code-editor mockup (traffic-light dots #454341, header rule #302f2e, terminal body text #d6d1cd, green '$' prompt #54b492, '&&' operator #5c5956, JSON string colour #8acbb4 - the last is --code-str's own dark-mode value, but --code-str itself flips for real light-surface code cards, which this mockup is not) - this same small palette recurs across Home.tsx, Insights.tsx, Pricing.tsx and About.tsx, so a shared token family may be worth formalising in its own follow-up, but is out of scope here; (2) the '0% platform cut' comparison-bar illustration (track #2c2926, border #35322f, striped fill #4a4643/#423e3b, and the already-investigated #2f6fc0 border - see PR #2977) plus its own bespoke near-black gradient card (#232120 to #1a1918, border #35322f); (3) three icon glyphs at a single-file-only muted grey (#6f6a66, not reused elsewhere); (4) two fixed-white ink spots (#ffffff) on fills that are themselves fixed (the 100%-filled blue bar, and the '0%' hero figure on --spot) plus one decorative gloss overlay (rgba(255,255,255,0.18)) - the same justified pattern as ChatContainer.css's white-on-fixed-blue ink, just inline rather than in a stylesheet."
+      "n": 30,
+      "why": "Three unrelated groups of deliberate illustration colours, none derivable from an existing token without changing the rendered value: (1) the fake terminal/code-editor mockup's remaining chrome (traffic-light dots #454341, header rule #302f2e, terminal body text #d6d1cd, '&&' operator #5c5956) - its string colour (#8acbb4) and '$' prompt (#54b492) were tokenised via the fixed --color-success-300/-400 ramp entries once that ramp was discovered to be fixed (see this PR); (2) the '0% platform cut' comparison-bar illustration (track #2c2926, border #35322f, striped fill #4a4643/#423e3b, and the already-investigated #2f6fc0 border - see PR #2977) plus its own bespoke near-black gradient card (#232120 to #1a1918, border #35322f); (3) three icon glyphs at a single-file-only muted grey (#6f6a66, not reused elsewhere), two fixed-white ink spots (#ffffff) on fills that are themselves fixed (the 100%-filled blue bar, and the '0%' hero figure on --spot), and one decorative gloss overlay (rgba(255,255,255,0.18)) - the same justified pattern as ChatContainer.css's white-on-fixed-blue ink, just inline rather than in a stylesheet."
+    },
+    "apps/frontend/src/app/features/marketing/pages/Home/Home.tsx": {
+      "n": 9,
+      "why": "The same fake terminal/code-editor mockup chrome justified in DevelopersPage.tsx (traffic-light dots #454341 x3, header rule #302f2e x2, terminal body text #d6d1cd - its string/prompt colours were tokenised via --color-success-300/-500 in this PR, same as DevelopersPage.tsx's). Plus two more single-file bespoke spots: an avatar-stack placeholder background (#e6e3e0) and a phone-mockup bezel (#1d1c1b x2) - the bezel is a physical-device colour on a decorative illustration, not a themed app surface, the same reasoning as the media-overlay literals justified in Guides.tsx and InClinicTodayBand.tsx (PR #2990)."
     },
     "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": {
       "n": 8,
@@ -355,13 +359,12 @@
   "files": {
     "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 4,
     "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": 10,
-    "apps/frontend/src/app/features/marketing/pages/Home/Home.tsx": 19,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": 1,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": 19,
     "apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx": 3,
     "apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx": 10,
     "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.stories.tsx": 3,
-    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 14,
+    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 9,
     "apps/frontend/src/app/features/marketing/site/assets.ts": 2,
     "apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx": 2,
     "apps/frontend/src/app/features/marketing/site/marketing.css": 1,


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep. Investigating the fake
terminal/code-editor mockup literals flagged as "future work" in #2992
found something better than a new token: the colours already exist as
fixed (non-flipping, declared once outside any theme block) entries in
`globals.css`'s `--color-success-*`/`--color-brand-*` ramps.

Six literals, 24 occurrences across three files, all pure
value-preserving swaps — live-verified in the dev server: `Home.tsx`'s
bar-chart and JSON mockup render byte-identical computed colours
before/after; `Pricing.tsx`'s `--color-success-400` confirmed to resolve
to the same `#54b492` the literal was (its own page load was blocked by
an unrelated backend 404 in this frontend-only dev server):

- `#8acbb4` → `var(--color-success-300)` (`Home.tsx`'s JSON string
  colour, `DevelopersPage.tsx`'s — un-justifying the guess from #2992
  that this was `--code-str`'s dark value; it's the success ramp)
- `#54b492` → `var(--color-success-400)` (`Pricing.tsx`'s feature-list
  dots, `DevelopersPage.tsx`'s terminal `$` prompt)
- `#33a57d` → `var(--color-success-500)` (`Home.tsx`'s "200 OK" status
  text)
- `#99bdec`/`#6aa1eb`/`#3b87ec` → `var(--color-brand-600/800/925)`
  (`Home.tsx`'s hero mini bar-chart — the 4th bar already correctly read
  `var(--blue)`)

Guard-tested and mutation-checked (reverted all three source files,
confirmed 16 of 17 new assertions failed — the 17th checks
`globals.css`, untouched by design; restored, 33/33 pass including
`DevelopersPage`'s existing guards).

`DevelopersPage.tsx`'s justified-literal count and reasoning updated to
match (39 → 30, code-string/prompt language removed).

Baseline regenerated via `--update`: 122 → 98.