### PR TITLE
fix(frontend): stop over-dimming the marketing hero video in dark mode

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { renderToString } from 'react-dom/server';
 import { hydrateRoot } from 'react-dom/client';
 import { render, screen, act, renderHook, fireEvent } from '@testing-library/react';
@@ -509,6 +511,22 @@ describe('motion primitives', () => {
     // The scrim carries data-hero-scrim so it flips to the dark gradient in dark mode
     // instead of washing the hero to a muddy mid-tone.
     expect(container.querySelector('[data-hero-scrim]')).toBeInTheDocument();
+  });
+
+  it('keeps the dark-mode hero video at the same visibility as light mode', () => {
+    // Both were opacity: 0.3 / brightness: 0.8 in light. The original dark-mode
+    // pass (2026-07-07, part of a ~500-literal theming sweep with no stated
+    // rationale for this rule) cut dark to opacity 0.16 / brightness 0.5 - live
+    // verification showed this reduced the video to indistinct colour blobs,
+    // losing the actual animal imagery the hero exists to show. The scrim
+    // above already carries its own per-theme contrast treatment for the
+    // overlaid text, so the video itself does not need a second, harsher cut.
+    const css = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+    const match = css.match(/html\[data-theme='dark'\]\s*\[data-hero-video\]\s*{([^}]*)}/);
+    expect(match).not.toBeNull();
+    const rule = match![1];
+    expect(rule).toMatch(/opacity:\s*0\.3\s*!important/);
+    expect(rule).toMatch(/brightness\(0\.8\)\s*!important/);
   });
 
   it('HeroVideo renders nothing under reduced motion', () => {

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1123,8 +1123,8 @@ html[data-theme='dark'] [data-hero-scrim] {
     ) !important;
 }
 html[data-theme='dark'] [data-hero-video] {
-  opacity: 0.16 !important;
-  filter: blur(1px) saturate(150%) brightness(0.5) !important;
+  opacity: 0.3 !important;
+  filter: blur(1px) saturate(150%) brightness(0.8) !important;
 }
 html[data-theme='dark'] [data-yc-footer] a[data-appbadge] {
   background: #f7f3ec !important;


### PR DESCRIPTION
This was flagged in the session tracker as "blocked on Ankit — design call
with no precedent." Re-investigated and concluded it isn't actually a
design-taste question: the dark-mode values were never a deliberate
choice, and the effect at the current values is a real regression, not a
tradeoff.

**Evidence**: the dark-mode override for the hero video (shared by Home,
PetParents and PetBusinesses via `HeroVideo`) cuts it to `opacity: 0.16` /
`brightness(0.5)`, versus light mode's `opacity: 0.3` / `brightness(0.8)`
— a proportionally much harder reduction. `git log -S` on the rule finds
exactly one commit ever touching it: `80da75d7`, "add light/dark theming
to the marketing site" (2026-07-07) — a single sweep of ~500 colour
literals where this was one bullet among many, with no comment or
rationale for these specific numbers, and nothing has revisited it since.

**Live-verified in the dev server**: at the shipped dark values, the
video is reduced to indistinct colour blobs in the corners — the actual
animal/pet imagery the hero exists to show is imperceptible on all three
pages that use it. The scrim layered over the video already carries its
own per-theme contrast treatment for the overlaid text (a separate,
purpose-built mechanism, confirmed independent of the video's own
opacity/filter), so the video's extra dimming wasn't protecting anything
that isn't already protected.

**Fix**: matched dark mode's video visibility to light mode's values.
Re-verified live on Home, PetParents and PetBusinesses in dark mode —
the video's content is now clearly perceptible, headline/body text stays
fully legible against it.

Guard-tested and mutation-checked in the existing `motion.test.tsx`
(reverted the rule, confirmed the new assertion failed with the other 28
tests unaffected; restored, 29/29 pass).