### PR TITLE
docs(repo): add impartial veterinary software buyer skill

### DIFF
--- a/.agents/skills/yosemite-vet-software-buyer/SKILL.md
+++ b/.agents/skills/yosemite-vet-software-buyer/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: yosemite-vet-software-buyer
+description: Help veterinary software buyers define requirements, evaluate any software category, compare quotes, uncover hidden contract terms, and plan a safe purchase or exit. Use for questions about what to buy, what to ask in demos, full costs, renewals, data rights, integrations, AI tools, or reviewing a veterinary software agreement. Provides impartial guidance under Yosemite Crew; does not promote a supplier or provide clinical advice.
+---
+
+# Yosemite Crew Veterinary Software Buyer
+
+Help a practice decide whether to buy, what evidence to require, what the commitment really costs, and what must change before signing. Optimize for the buyer's stated needs, budget, staff capacity, and ability to leave.
+
+## Independence
+
+- Yosemite Crew is the publisher, not the default recommendation. Apply identical evidence, pricing, security, and contract criteria to it and every other supplier. Never award points for affiliation, commissions, sponsorship, popularity, open-source status, or a preferred technology model.
+- Be impartial in recommendations without claiming organizational independence from the publisher. If presenting the service as Yosemite Crew's advice, identify that affiliation plainly. Disclose a known commercial interest when relevant; do not invent claims about independence, funding, or the absence of referral fees.
+- Do not insert sales calls, lead forms, affiliate links, or a Yosemite Crew product pitch. Recommend another supplier, a limited add-on, improving the existing setup, or buying nothing when the evidence supports it.
+- The packaged guidance and generic buyer outputs must contain no third-party comparison brands, buying-guide website links, copied frameworks, attributed inspiration, or account of how this skill was developed. Write original explanations. Do not import a research bibliography into buyer materials.
+- Specific comparisons may name the products the buyer wants evaluated. Preserve evidence from their quotes and agreements using document titles, versions, page numbers, and sections. Do not hide uncertainty or refuse a buyer's request for supporting evidence. Follow the buyer's requested citation format and applicable tool requirements when researching live claims.
+
+## Start With the Actual Decision
+
+Use information already supplied. Ask only for missing details that would change the answer; offer a useful preliminary answer while they are gathered. A buyer with one cancellation question does not need a full procurement questionnaire.
+
+Establish as relevant:
+
+- Country and state or region; currency; practice type and species; number of sites, clinicians, other users, and after-hours needs.
+- The software category, the problem to solve, the current tools, and whether this is a new practice, replacement, add-on, acquisition, or renewal.
+- The three most important workflows, required integrations, unacceptable failure modes, budget, purchasing deadline, and staff time available for implementation.
+- Any actual quote, order form, agreement, data-processing terms, renewal notice, or demo evidence. Do not request identifiable client records for evaluation.
+
+Define unfamiliar terms once: PIMS is the practice's main records and administration system; an integration exchanges information between systems; an API is one way that exchange is provided.
+
+## Choose the Relevant Depth
+
+1. **General buying advice or product evaluation:** read [Buyer Evaluation](references/buyer-evaluation.md). Select the appropriate category tests and produce a practical shortlist of questions or an evaluation plan.
+2. **Quote, renewal, contract, cancellation, or data-rights review:** read [Contract Review](references/contract-review.md). Review the actual wording and incorporated documents before drawing conclusions.
+3. **Cost comparison, scoring, or recommendation:** read [Costs and Decisions](references/costs-and-decisions.md). Use the buyer's figures and requirements. Keep unresolved commitments visible.
+
+Read multiple references only when the assignment needs them. Scale the work to the exposure: a small scheduling add-on and a hospital-wide records replacement need different levels of diligence.
+
+## Evidence Before Recommendations
+
+For material findings, distinguish:
+
+| Status                            | Meaning                                                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Verified in the reviewed material | The supplied document or observed test supports this particular statement. Identify which one.                                   |
+| Supplier claim                    | A statement in marketing, a demo, a message, or documentation that has not been independently tested or contractually committed. |
+| Unknown                           | Evidence is missing, ambiguous, stale, or in conflict. Say what would resolve it.                                                |
+| Demonstrated limitation           | A relevant test failed or an applicable term expressly limits the capability.                                                    |
+| Proposed requirement              | A protection or acceptance condition the buyer wants; not an existing right or promised feature.                                 |
+
+Do not claim hands-on testing without having performed or observed it. A demo demonstrates only the scenario and environment shown. Reviews provide leads for questions, not proof of a defect, fit, or market-wide performance.
+
+Check current, region-specific supplier information for live recommendations. Prices, product versions, integration scope, contract terms, certifications, and availability can change. If live research is unavailable, compare the supplied evidence and identify the gaps; do not populate a remembered ranking. No evidence is not evidence that a capability is absent.
+
+Capture the product, plan, region, document version, and assessment date. A public agreement may be superseded by the buyer's signed order or regional terms. A partner API agreement does not automatically govern a clinic's subscription.
+
+## Decision Rules
+
+- Identify essential conditions before scoring: usable records and export where relevant, required workflows, confirmed integration availability, acceptable financial commitment, privacy and security appropriate to the data, and a workable exit.
+- A failed essential condition disqualifies the candidate for that buyer. An unknown essential condition blocks purchase approval until resolved. A high average score cannot cancel either result.
+- Distinguish current product capability from a contractual commitment. Roadmap features are unavailable today; promises need a dated deliverable, acceptance condition, and remedy before reliance.
+- Treat cloud, local-server, managed hosting, and self-hosting as operating choices. Price ownership, maintenance, backups, security, upgrades, and support for each. Accessible source code does not prove inexpensive operation or usable data export.
+- For clinical tools, assess human oversight and record integrity. This is software purchasing advice, not diagnosis, dosing, or permission to practice remotely.
+- Legal enforceability depends on the relevant jurisdiction and complete agreement. Explain the commercial effect in plain language, separate it from a legal conclusion, and flag a concrete issue for local advice when necessary. Do not invent universal retention periods, cancellation rights, or compliance guarantees.
+
+## Deliver an Answer the Buyer Can Act On
+
+Lead with the appropriate conclusion: **ready for a limited trial**, **shortlist provisionally**, **negotiate before buying**, **not suitable for the stated needs**, **keep the current setup**, or **insufficient evidence**. Do not imply the buyer has approved a purchase.
+
+For a substantial review, include:
+
+1. The buyer's context and assumptions.
+2. The most consequential findings, each with evidence, practical impact, and a specific question or requested change.
+3. Cost over the chosen horizon, minimum contractual commitment, and unresolved charges.
+4. Relevant workflow tests and essential conditions still outstanding.
+5. A concise recommendation, alternatives, and the next concrete action.
+
+Use a table for comparable options or clauses. Describe risks as facts and possibilities, not accusations. Avoid generic best-software lists, fear-based savings estimates, and false numerical precision. In generic examples use Candidate A and Candidate B, with all invented facts labeled hypothetical.
+
+Preparing questions, calculations, and proposed wording does not authorize sending them, creating a trial account, entering payment details, accepting terms, booking a sales call, canceling a service, or moving records. Perform external actions only when the buyer explicitly requests them and the relevant details are established.

--- a/.agents/skills/yosemite-vet-software-buyer/agents/openai.yaml
+++ b/.agents/skills/yosemite-vet-software-buyer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Yosemite Crew Veterinary Software Buyer'
+  short_description: 'Impartial vet software buying and contract guidance'
+  default_prompt: 'Use $yosemite-vet-software-buyer to help me assess veterinary software, uncover hidden costs and contract risks, and decide what to verify before buying without favoring any supplier.'

--- a/.agents/skills/yosemite-vet-software-buyer/references/buyer-evaluation.md
+++ b/.agents/skills/yosemite-vet-software-buyer/references/buyer-evaluation.md
@@ -1,0 +1,95 @@
+# Buyer Evaluation
+
+## Establish Whether a Purchase Helps
+
+Describe the friction as an observable workflow: who performs it, how often, what fails, and what improvement would be valuable. Ask whether configuration, training, an already-paid feature, or an existing integration could solve it. Do not assume replacing the main records system is necessary to improve one workflow.
+
+Include the people doing the work: reception, nursing or technician staff, clinicians, the practice manager, and finance where relevant. An owner's approval does not demonstrate that frontline staff can use the tool.
+
+| Starting point       | What changes the decision                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New practice         | Opening dependencies, initial volumes, future staffing, hardware, internet, training, and how the first appointment reaches the first reconciled invoice. |
+| Replacement          | Unsolved pain, export rights, data quality, overlap costs, migration scope, training capacity, and the next cancellation deadline.                        |
+| Add-on               | Whether the core system already covers the need; duplicated records, extra logins, sync failures, and responsibility across suppliers.                    |
+| Acquisition          | Transferability of licenses, change-of-control clauses, inherited contracts, access credentials, data authority, and ability to preserve continuity.      |
+| Renewal              | Actual usage, unused licenses, support history, new prices, changed terms, and whether an upgrade restarts the commitment.                                |
+| Multiple sites       | Permission boundaries, shared clients, location-specific inventory and pricing, consolidated reporting, and site sale or closure.                         |
+| Mobile or ambulatory | Real connectivity, offline behavior, sync conflicts, mobile hardware, printing, routing, and field billing.                                               |
+
+Write a small requirements table: workflow, essential or desirable, acceptance test, responsible staff role, and evidence needed. Avoid counting a long feature list as a needs assessment.
+
+## Test the Category Being Bought
+
+| Category                                           | Ask the supplier to demonstrate                                                                                                                        | Less obvious buying questions                                                                                                                                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Main practice system and clinical records          | Booking through check-in, consult, diagnostics, dispensing, invoice, payment, and follow-up; correct a finalized note without losing its history.      | Migration of attachments and histories; permissions; multiple owners; audit trails; read-only access after cancellation; report reconciliation.                                                                 |
+| Booking and scheduling                             | Appointment types with different durations, clinician and equipment availability, rescheduling, a cancellation, and two simultaneous booking attempts. | Instant confirmed booking or merely a request; synchronization delay; timezone behavior; deposits; message fees; waitlist rules.                                                                                |
+| Client communications and apps                     | A multi-patient household, consent choices, a reply reaching the right team, and suppression of inappropriate reminders.                               | Number ownership and portability; per-segment text billing; delivery charges; messaging quotas; manual review and patient-status rules; exportable consent history.                                             |
+| AI reception and phone tools                       | A routine booking, an urgent-sounding call transferred to a human, an unsupported request, an accent or language variation, and a failed handoff.      | Per-minute costs, overages, recordings, consent, number portability, downtime routing, staff escalation, and who monitors unhandled calls. Do not let purchase testing become automated clinical triage advice. |
+| AI scribe and clinical assistance                  | A fictional encounter with negation, units, corrections, several speakers, and similar patient names; clinician review before finalizing.              | Raw recording retention; transcript versus note export; model-training and secondary-use rights; subgroup validation; correction time; quotas and failed-session charges.                                       |
+| Diagnostics, imaging, and laboratory tools         | An order with correct patient identifiers, a corrected result, a large image set, and viewing or exporting data outside the product.                   | Native images versus rendered reports; measurements and annotations; device compatibility; storage and retrieval charges; clinical validation and supported species.                                            |
+| Treatment boards and inpatient tools               | A shift handover, changed treatment timing, an overdue task, a completed task linked to billing, and downtime reconciliation.                          | Concurrent updates, escalation ownership, who can correct an entry, audit history, dependencies on the main system, and 24-hour support scope.                                                                  |
+| Inventory, pharmacy, and prescribing               | Purchase order through receiving, partial pack use, return, expiry, batch traceability, and stock reconciliation.                                      | Pack-to-unit conversions; site transfers; supplier restrictions; minimum purchases; dispensing fees; locally applicable prescription and controlled-drug records.                                               |
+| Payments and finance                               | Split tender, deposits, partial refunds, a disputed payment, settlement, and accounting reconciliation.                                                | Compulsory processing, effective rates, reserves, terminal leases, cancellation of the separate merchant agreement, portability of payment tokens, and reconciliation exports.                                  |
+| Wellness plans and subscriptions                   | Enrollment, failed payment, cancellation, unused entitlements, a refund, and transfer to another patient or site where permitted.                      | Who carries credit risk, discount clawbacks, fees per plan, remaining care obligations, and whether the plan survives a software change.                                                                        |
+| Telehealth and remote monitoring                   | Scheduling, consent, human review, recording relevant information, failed connection, and escalation to in-person care.                                | Jurisdictional rules, professional eligibility, emergency exclusions, monitoring hours, false alerts, client accessibility, and record export.                                                                  |
+| Analytics, accounting, and group reporting         | Trace a dashboard figure back to original records; explain a refund, time boundary, site transfer, and corrected entry.                                | Data definitions, latency, mappings, permitted benchmarking, export granularity, historical comparability, and cost per entity.                                                                                 |
+| Reputation, marketing, and other operational tools | The exact campaign or task, approval, recipient controls, reporting, and account handover.                                                             | Ownership of domains, content, lists, numbers and ad accounts; agency access; platform dependencies; asset export; promises of outcomes. Check current platform rules for review solicitation.                  |
+
+For an unlisted category, use the same questions: what job, who uses it, what data enters and leaves, what can fail, who fixes it, what is charged, and how the practice stops using it.
+
+## Run a Useful Demo or Trial
+
+Choose a few representative scenarios plus the highest-consequence failure. Give each candidate the same task and let a future user attempt it. Use fictional or properly de-identified material in an authorized environment. Do not upload a live practice database to obtain a quote or casual demo.
+
+Record completion, correctness, time, manual re-entry, help required, and unresolved exceptions. A recording or screenshot is useful evidence only for what it actually shows. Do not promise a trial is free until billing activation, cancellation, and data treatment are understood.
+
+Useful cross-category scenarios:
+
+- Two staff update the same item; confirm the outcome and history.
+- A task fails halfway; confirm what was saved, how staff notice, and how they recover.
+- Remove an employee's access; confirm the account and relevant sessions are disabled.
+- Correct a patient link or factual error; confirm a durable audit trail.
+- Export a representative sample and have the receiving person open and interpret it.
+- Interrupt the connection in a permitted demo environment; distinguish offline operation, cached read-only access, and complete unavailability.
+
+Do not run intrusive security tests, disrupt a live system, or imply a demo confirms security architecture.
+
+## Understand an Integration
+
+The presence of an integration name or logo does not specify what works. Record:
+
+| Question                 | Required answer                                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| What moves?              | Exact records and fields, including attachments, corrections, refunds, and consent where relevant.          |
+| Which direction?         | Read-only, write-only, two-way, or a manual export and import.                                              |
+| When?                    | Trigger, synchronization interval, expected delay, and backfill limits.                                     |
+| Who can get it?          | Actual product version, plan, region, partner approval, and availability today.                             |
+| What happens on failure? | Notification, retry, duplicate prevention, conflict handling, reconciliation, and accountable support team. |
+| What does it cost?       | Charges from both suppliers, middleware, installation, volumes, support, and future changes.                |
+| What can change?         | API scopes, rate limits, deprecation notice, loss of partner access, and fallback or exit rights.           |
+| How do we verify?        | A demonstration of the buyer's exact workflow and written confirmation of production support.               |
+
+Do not confuse API access with an unlimited right to export, migrate, or connect another application. Technical access and contractual permission are separate checks.
+
+## Protect Records and Continuity
+
+For tools holding material practice data, require a named person to own migration and recovery. Identify the data to preserve: patient and client relationships, clinical histories, attachments, images, active appointments, invoices and balances, stock, prescriptions, consents, and audit history as applicable.
+
+Specify source and destination totals, mapping rules, representative record checks, and reconciliation tolerances. Financial balances and patient identity errors require explicit resolution; do not average them away. Investigate exclusions rather than accepting a statement that the migration is complete.
+
+Before a major change, agree a tested backup and restore process, a read-only legacy-access plan, a cutover owner, and criteria for delaying go-live. A rollback after new records have been created needs reconciliation; restoring an old snapshot can discard new clinical and financial activity.
+
+Ask for recovery objectives in plain language: maximum tolerable lost work and target time to restore service. Confirm what an outage excludes, what the practice can still do, how downtime records are captured, and who reconciles them afterward.
+
+For self-hosting, explicitly assign updates, monitoring, backups, restoration, encryption, identity management, hosting bills, and incident response. For managed services, identify what the supplier handles and what still belongs to the practice.
+
+## Evidence of Security and Support
+
+Ask about individual accounts, role permissions, multi-factor authentication, offboarding, encryption, audit logs, backup separation and restore testing, incident notification, subprocessors, and where data is stored and accessed. Match the depth to the information and operational dependency involved.
+
+A security certification or report is evidence with a date, scope, and exceptions, not a blanket guarantee. Ask whether it covers the actual service and hosting arrangement. An online calculator using no stored identifiers does not have the same exposure as a records system or recorded consultation service.
+
+Record support hours and timezone, channels, severity definitions, initial response versus resolution targets, escalation, training limits, and charges. Availability of a phone number does not establish round-the-clock technical support.
+
+Ask comparable practices about concrete incidents, actual training effort, unexpected charges, and whether they have exercised an export. Treat supplied references as selected experiences rather than a representative satisfaction survey.

--- a/.agents/skills/yosemite-vet-software-buyer/references/contract-review.md
+++ b/.agents/skills/yosemite-vet-software-buyer/references/contract-review.md
@@ -1,0 +1,69 @@
+# Contract Review
+
+## Establish the Applicable Agreement
+
+Collect only what is needed: quote or order form, main agreement, service schedule, implementation scope, support commitments, data-processing terms, and separate payment, AI, integration, or hardware terms. Include incorporated policies and amendments relevant to the question.
+
+Record legal entity, product and plan, region, currency, effective date, version, parties, and signature or acceptance status. Determine the agreement's stated order of precedence. Do not assume the newest public page overrides an existing signed agreement, or that a sales email overrides standard terms.
+
+An annual term can coexist with an earlier termination right. Read the cancellation and fee consequences together before calculating a full-year liability. Likewise, a monthly invoice does not establish monthly cancellation rights.
+
+For each finding report: **document and section; what it says; practical consequence; severity; requested clarification or change**. Quote only the minimum necessary text. Separate a present term, an ambiguity, a missing protection, and a suggested negotiation position. The checklist is not evidence that a particular supplier has a problematic clause.
+
+## Clauses to Examine
+
+| Area                             | What to inspect                                                                                                                              | Ask or negotiate                                                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Acceptance and billing start     | Whether signature, first login, trial expiry, migration work, or go-live creates obligations.                                                | Confirm the binding event, initial invoice, trial conversion, and a delay remedy if opening or implementation slips.                                         |
+| Term and renewal                 | Initial duration, renewal duration, minimum users or sites, and upgrade-triggered extensions.                                                | State the term and commitment separately from billing frequency; confirm whether expansion resets the clock.                                                 |
+| Cancellation notice              | Calendar months versus days, delivery address, required method, receipt rule, timezone, and whether notice only works at term end.           | Calculate the deadline only from established dates and wording; request written acknowledgment. A reminder is not cancellation.                              |
+| Early exit and refunds           | Remaining fees, accelerated balances, termination for convenience or cause, cure period, and unused prepaid amounts.                         | Identify the actual financial exit consequence and exceptions; do not infer a penalty solely from annual renewal.                                            |
+| Price changes                    | Introductory rates, renewal increases, indexation, new user pricing, currency and taxes, and incorporated online schedules.                  | Fix the applicable rate basis; request an increase cap or notice and exit option before a material increase. Label proposed caps as negotiation targets.     |
+| Usage and overages               | Billable users, locums, concurrent access, locations, messages, segments, minutes, storage, AI usage, API calls, and fair-use definitions.   | Obtain included quantities, chargeable events, overage rates, alerts, caps, and downgrade terms in writing.                                                  |
+| Add-ons and bundles              | Functions priced separately despite a bundled description; tied processing, lab, pharmacy, or communications arrangements.                   | Itemize optional and compulsory items and the price without the bundle.                                                                                      |
+| Payments and hardware            | Processing rates, card mix, settlement timing, reserves, disputes, refunds, terminal ownership or lease, and separate cancellation terms.    | Calculate effective cost; identify every counterparty and obligation that survives canceling the software.                                                   |
+| Implementation                   | Deliverables, exclusions, responsibilities, migration method, training, travel, milestones, and acceptance by silence or passage of time.    | Define measurable acceptance, issue correction, rescheduling, payment milestones, and a failed-implementation remedy.                                        |
+| Data use                         | Distinguish customer content, personal data, recordings, outputs, anonymized or de-identified data, derived statistics, and feedback.        | Clarify permitted purposes, recipients, duration, secondary use, resale, benchmarking, model training, and whether choices cover subprocessors.              |
+| Data export                      | Included data, formats, attachments, histories, relationships, export limits, assistance charges, timing, and access during a dispute.       | Require a sample export, a complete scope, predictable charges and delivery time, and a process the next system can use.                                     |
+| Retention and deletion           | Active access ending before retrieval, short export windows, backup exceptions, and deletion timing.                                         | Agree workable retrieval and verification before deletion; reconcile retention duties and obtain deletion confirmation where applicable.                     |
+| AI terms                         | Data sent to model providers, recording consent, human verification, training rights, model changes, usage limits, and liability exclusions. | Separate input, raw audio, transcript, and generated note treatment; require appropriate human review and clear controls over secondary use.                 |
+| Privacy and subprocessors        | Controller and processor roles for each activity, processing locations, transfers, breach assistance, audits, and subprocessor changes.      | Confirm the applicable processing agreement and mechanisms; establish notice, escalation, and available options for material changes.                        |
+| Availability and support         | Uptime calculation, excluded periods and dependencies, maintenance, service credits, claim deadlines, and sole-remedy language.              | Agree severity-specific response and restoration expectations, escalation, and remedy for repeated material failure. Credits may not cover operational loss. |
+| Changes and discontinuation      | Unilateral changes to prices, terms, core features, APIs, or third-party availability; continued use as acceptance.                          | Seek clear notice, version records, continuity, and an exit or refund option for materially reduced service.                                                 |
+| Suspension                       | Billing disputes, suspected misuse, security events, thresholds, cure periods, and access to essential records.                              | Agree proportionate notice when feasible and a continuity or read-only export route compatible with security needs.                                          |
+| Liability and indemnities        | Liability caps and exclusions; whose losses are covered; one-sided indemnities; data incidents and third-party claims.                       | Identify the concrete exposure for qualified local review; do not call a cap automatically invalid or demand an invented universal minimum.                  |
+| Assignment and ownership changes | Sale of a practice or site, supplier acquisition, affiliate sharing, assignment consent, and fees.                                           | Confirm transfer rights and whether changed ownership alters service, data use, price, or exit options.                                                      |
+| Publicity and disputes           | Automatic logo or testimonial permissions, confidentiality, review restrictions, governing law, forum, arbitration, and costs.               | Request explicit publicity consent and flag material dispute constraints for jurisdiction-specific advice.                                                   |
+
+## A Practical Risk Scale
+
+- **Blocker:** The wording or demonstrated behavior prevents an essential requirement or creates an unacceptable exposure for this buyer. Do not recommend signing while it remains.
+- **Material issue:** A cost or operational risk needs clarification, negotiation, or a buyer-approved mitigation before commitment.
+- **Manageable condition:** An understood obligation with a named owner and workable response. Explain the tradeoff.
+- **Unknown:** The relevant document, fact, or interpretation is unavailable. Do not convert this to either a pass or an accusation.
+
+Describe why an issue matters to this practice. A retrieval deadline can be a blocker for a records replacement and immaterial to a tool storing no practice data.
+
+## Proposed Wording
+
+These are original commercial discussion points, not ready-to-sign legal provisions. Adapt them to the actual agreement and have material legal wording reviewed locally. Do not present a requested protection as a right the buyer already has.
+
+**Complete export:** Ask for an agreed schedule of included records, attachments, audit history, identifiers, and relationships, in documented machine-readable formats plus readable clinical documents where necessary. Specify delivery time, fees, assistance, and the access period needed to validate the result.
+
+**Renewal:** Ask the supplier to state the initial and renewal terms, cancellation method and deadline, renewal price basis, and notice of material price changes before the cancellation deadline.
+
+**Data use:** Ask that processing necessary to deliver the service be distinguished from optional marketing, resale, benchmarking, and model training, with explicit terms for retained and derived data and each relevant third party.
+
+**Implementation acceptance:** Identify the specific workflows, data reconciliations, staff readiness, and interfaces that constitute acceptance, and agree how defects and delayed delivery are handled before further payment or full rollout.
+
+**Material service change:** Ask what notice, alternative service, transition assistance, and termination or refund rights apply if a critical function or required integration is withdrawn.
+
+## Jurisdiction and Date
+
+Identify country and relevant state or region before discussing enforceability. Verify current authoritative guidance when offering a legal conclusion. Business purchases may not have the same cancellation protections as consumer purchases; do not assume a cooling-off period.
+
+For UK and European contexts, examine applicable data-protection requirements, the actual data flows, controller and processor roles, international transfers, and any applicable software-switching requirements. Do not treat UK and EU rules as identical. For covered EU services, check current Data Act provisions and dates before judging switching charges; do not assume every exit-related charge is prohibited.
+
+For the United States, identify relevant state veterinary record, privacy, recording, prescribing, and business-contract requirements. Do not assume a human-health privacy badge settles a veterinary practice's obligations. Other countries need their own local review rather than imported UK or US rules.
+
+Treat retention as a category-specific obligation involving the record type, local rules, and applicable insurance or professional requirements. Do not invent a worldwide number of years. A general compliance label is not proof that the practice's configuration and use are compliant.

--- a/.agents/skills/yosemite-vet-software-buyer/references/costs-and-decisions.md
+++ b/.agents/skills/yosemite-vet-software-buyer/references/costs-and-decisions.md
@@ -1,0 +1,118 @@
+# Costs and Decisions
+
+## Calculate the Same Scope
+
+Use a common currency, tax treatment, user and site count, volume assumptions, start date, and time horizon. Show 12 months for an ordinary first comparison and a longer horizon when commitment or migration makes it relevant. State the actual horizon rather than calling every estimate a lifetime cost.
+
+Separate invoiced cash costs, internal staff effort, contingent exit costs, and uncertain opportunity costs. Use actual quotes when supplied. Mark unknown charges as unknown, never zero. Do not treat a lower-bound subtotal as a complete total.
+
+| Cost layer                    | Include when relevant                                                                                                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Initial cash                  | Setup, data extraction, cleanup, migration, integration work, hardware, installation, training, travel, and nonrefundable deposits.                                    |
+| Recurring cash                | Base subscription, clinician and staff accounts, sites, required modules, hosting, backups, support, interfaces, messaging, AI usage, and storage.                     |
+| Transactions and variable use | Card processing, per-transaction fees, disputes, refunds, texts and segments, minutes, usage above quotas, and required minimum purchases.                             |
+| Transition cash               | Overlapping subscriptions, temporary staffing, overtime, legacy access, and paid correction work.                                                                      |
+| Exit cash                     | Notice-period commitments not already counted, early-termination charges if applicable, export assistance, hardware obligations, and replacement migration.            |
+| Internal effort               | Training, data checking, maintenance, troubleshooting, manual re-entry, and administration. State hours and a supplied loaded hourly cost separately from cash outlay. |
+| Opportunity cost              | Documented, scenario-based operational disruption. Treat lost capacity or revenue as uncertain and separate from payroll and profit.                                   |
+
+For recurring amounts, calculate each period with its applicable price, license count, and consumption; include price increases from the date they apply. A flat multiplication is valid only when the rate and quantities are stable.
+
+```text
+Cash cost over horizon = initial cash + sum of recurring and usage cash
+                      + transition cash + exit cash incurred in that horizon
+
+Internal effort value = sum of hours by role x relevant loaded hourly cost
+
+Payment cost = sum of processed volume by rate category x applicable rate
+             + number of chargeable transactions x per-transaction fee
+             + relevant fixed, dispute, refund, and other charges
+
+Usage overage = max(0, chargeable usage - included allowance) x overage rate
+```
+
+Report minimum contractual commitment separately. Use remaining unavoidable payments after applying the actual termination rights, notice terms, credits, and refunds. Do not double count it on top of the same subscription payments in total cost.
+
+Prevent double counting between the subscription and bundled items, between initial and migration fees, and between payment volume fees and per-transaction costs already included in a quoted blended rate. Confirm whether taxes are recoverable rather than silently excluding them.
+
+## Original Hypothetical Example
+
+The following is arithmetic practice, not a market price estimate. Both candidates are assumed to have equal required scope, fixed rates for 12 months, equal taxes excluded, and no other charges for this example only. Actual missing fees remain unknown.
+
+| Item                                    | Candidate A | Candidate B |
+| --------------------------------------- | ----------: | ----------: |
+| Base each month                         |         300 |         550 |
+| Required modules each month             |         180 |           0 |
+| Initial setup                           |       2,000 |         800 |
+| Year-one cost before payment processing |       7,760 |       7,400 |
+| Illustrative processing rate            |        2.7% |        2.2% |
+| Annual processed volume                 |     600,000 |     600,000 |
+| Processing cost, percentage only        |      16,200 |      13,200 |
+| Combined illustrative cash cost         |      23,960 |      20,600 |
+
+Candidate B's base price is higher but the assumed first-year cash cost is 3,360 lower. This is a cost comparison, not a recommendation: workflow, terms, security, implementation, and unknown charges can change the choice. In a real comparison include card mix, fixed transaction charges, settlement terms, and whether those rates are actually available.
+
+## Benefits Without Invented Savings
+
+Measure a baseline and then the same task with the proposed tool. Distinguish time released, actual cash saved, added capacity used, and contribution earned. Avoid claiming that all saved minutes turn into revenue or reduced payroll.
+
+```text
+Potential time released per month = relevant tasks per month
+                                 x observed minutes saved per task / 60
+
+Potential labor value = time released x loaded hourly cost
+
+Break-even incremental contribution per month = incremental monthly cash cost
+                                             + initial incremental cash / chosen months
+```
+
+Report labor value as capacity unless reduced expenditure is evidenced. If projecting added appointments, constrain them by demand and staffing, and use contribution after variable costs rather than gross revenue. Do not add the value of saved time and the contribution from appointments using that same time without a defensible separation.
+
+Use buyer-supplied low, expected, and high usage or migration-effort scenarios where uncertainty matters. Show which assumptions would change the decision. Do not insert unverified industry percentages for revenue leakage, migration loss, AI accuracy, or productivity.
+
+## Score Only What Evidence Supports
+
+Start with essential conditions. Record each as pass, fail, or unknown with the evidence and owner of the next check. A fail or unknown cannot be canceled by a high score elsewhere.
+
+If there are several plausible options, agree a few weighted criteria before scoring. Categories might include workflow fit, staff usability, integration fit, commercial terms, full cost, implementation, support, and operational resilience. Avoid counting the same benefit twice under different headings.
+
+Weights express this buyer's preferences, not an industry standard. Use nonnegative weights with a positive total; normalize them to 100 for presentation. Set the applicable criteria once for every candidate. If a criterion is inapplicable to the purchase, remove it for all candidates before scoring; do not drop a weak criterion for one supplier.
+
+| Score   | Evidence of fit for this buyer                                               |
+| ------- | ---------------------------------------------------------------------------- |
+| 0       | Evidence establishes the requirement cannot be met.                          |
+| 1       | Major limitation or costly workaround.                                       |
+| 2       | Partly meets the requirement with material tradeoffs.                        |
+| 3       | Meets the agreed acceptance criteria.                                        |
+| 4       | Meets the criteria with demonstrated additional value relevant to the buyer. |
+| Unknown | Insufficient evidence; not a zero or a pass.                                 |
+
+Keep supplier statements, observed test results, and contractual commitments identifiable alongside each score. A statement about a capability alone should remain provisional until the evidence required for that criterion is obtained.
+
+For weights totaling 100:
+
+```text
+Evidence coverage = sum of weights with an evidenced score
+Lower supported score = sum of weight x evidenced score / 4
+Upper possible score = lower supported score + sum of unknown weights
+```
+
+The resulting interval is an evidence range, not a statistical confidence interval or probability of success. Do not renormalize over the known criteria: a product with one good answer must not appear perfect. When evidence is complete the lower and upper values coincide.
+
+Hypothetical check: weights 40, 35, and 25; scores 3, unknown, and 2. Evidence coverage is 65%; the supported score range is 42.5 to 77.5 out of 100. The unknown criterion still needs evaluation. An unresolved essential condition independently blocks purchase approval.
+
+If candidate ranges overlap or reasonable changes in weights change the winner, describe the tradeoff and collect the evidence most likely to resolve it. Do not manufacture a ranking.
+
+## Buyer Decision Memo
+
+Use only the sections that help the specific decision:
+
+1. **Recommendation:** What to do now, why, and the conditions that would change it.
+2. **Context:** Category, jurisdiction, practice size, must-have workflows, budget, dates, and assumptions.
+3. **Essential conditions:** Pass, fail, and unknown, each with evidence.
+4. **Comparison:** Same-scope costs, minimum commitment, material strengths and limitations, and evidence status.
+5. **Contract findings:** Clause reference, commercial consequence, requested change, and next owner.
+6. **Trial and transition:** Acceptance scenarios, readiness conditions, records continuity, and exit arrangements.
+7. **Open questions:** Prioritized by consequence and whether the answer can change the decision.
+
+The final action should be concrete: obtain a complete export sample, clarify a renewal deadline, request an itemized quote, test a named workflow, negotiate a particular term, or decline an unsuitable option. A sales call is not the automatic next step.

--- a/.claude/skills/yosemite-vet-software-buyer/SKILL.md
+++ b/.claude/skills/yosemite-vet-software-buyer/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: yosemite-vet-software-buyer
+description: Help veterinary software buyers define requirements, evaluate any software category, compare quotes, uncover hidden contract terms, and plan a safe purchase or exit. Use for questions about what to buy, what to ask in demos, full costs, renewals, data rights, integrations, AI tools, or reviewing a veterinary software agreement. Provides impartial guidance under Yosemite Crew; does not promote a supplier or provide clinical advice.
+---
+
+# Yosemite Crew Veterinary Software Buyer
+
+Help a practice decide whether to buy, what evidence to require, what the commitment really costs, and what must change before signing. Optimize for the buyer's stated needs, budget, staff capacity, and ability to leave.
+
+## Independence
+
+- Yosemite Crew is the publisher, not the default recommendation. Apply identical evidence, pricing, security, and contract criteria to it and every other supplier. Never award points for affiliation, commissions, sponsorship, popularity, open-source status, or a preferred technology model.
+- Be impartial in recommendations without claiming organizational independence from the publisher. If presenting the service as Yosemite Crew's advice, identify that affiliation plainly. Disclose a known commercial interest when relevant; do not invent claims about independence, funding, or the absence of referral fees.
+- Do not insert sales calls, lead forms, affiliate links, or a Yosemite Crew product pitch. Recommend another supplier, a limited add-on, improving the existing setup, or buying nothing when the evidence supports it.
+- The packaged guidance and generic buyer outputs must contain no third-party comparison brands, buying-guide website links, copied frameworks, attributed inspiration, or account of how this skill was developed. Write original explanations. Do not import a research bibliography into buyer materials.
+- Specific comparisons may name the products the buyer wants evaluated. Preserve evidence from their quotes and agreements using document titles, versions, page numbers, and sections. Do not hide uncertainty or refuse a buyer's request for supporting evidence. Follow the buyer's requested citation format and applicable tool requirements when researching live claims.
+
+## Start With the Actual Decision
+
+Use information already supplied. Ask only for missing details that would change the answer; offer a useful preliminary answer while they are gathered. A buyer with one cancellation question does not need a full procurement questionnaire.
+
+Establish as relevant:
+
+- Country and state or region; currency; practice type and species; number of sites, clinicians, other users, and after-hours needs.
+- The software category, the problem to solve, the current tools, and whether this is a new practice, replacement, add-on, acquisition, or renewal.
+- The three most important workflows, required integrations, unacceptable failure modes, budget, purchasing deadline, and staff time available for implementation.
+- Any actual quote, order form, agreement, data-processing terms, renewal notice, or demo evidence. Do not request identifiable client records for evaluation.
+
+Define unfamiliar terms once: PIMS is the practice's main records and administration system; an integration exchanges information between systems; an API is one way that exchange is provided.
+
+## Choose the Relevant Depth
+
+1. **General buying advice or product evaluation:** read [Buyer Evaluation](references/buyer-evaluation.md). Select the appropriate category tests and produce a practical shortlist of questions or an evaluation plan.
+2. **Quote, renewal, contract, cancellation, or data-rights review:** read [Contract Review](references/contract-review.md). Review the actual wording and incorporated documents before drawing conclusions.
+3. **Cost comparison, scoring, or recommendation:** read [Costs and Decisions](references/costs-and-decisions.md). Use the buyer's figures and requirements. Keep unresolved commitments visible.
+
+Read multiple references only when the assignment needs them. Scale the work to the exposure: a small scheduling add-on and a hospital-wide records replacement need different levels of diligence.
+
+## Evidence Before Recommendations
+
+For material findings, distinguish:
+
+| Status                            | Meaning                                                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Verified in the reviewed material | The supplied document or observed test supports this particular statement. Identify which one.                                   |
+| Supplier claim                    | A statement in marketing, a demo, a message, or documentation that has not been independently tested or contractually committed. |
+| Unknown                           | Evidence is missing, ambiguous, stale, or in conflict. Say what would resolve it.                                                |
+| Demonstrated limitation           | A relevant test failed or an applicable term expressly limits the capability.                                                    |
+| Proposed requirement              | A protection or acceptance condition the buyer wants; not an existing right or promised feature.                                 |
+
+Do not claim hands-on testing without having performed or observed it. A demo demonstrates only the scenario and environment shown. Reviews provide leads for questions, not proof of a defect, fit, or market-wide performance.
+
+Check current, region-specific supplier information for live recommendations. Prices, product versions, integration scope, contract terms, certifications, and availability can change. If live research is unavailable, compare the supplied evidence and identify the gaps; do not populate a remembered ranking. No evidence is not evidence that a capability is absent.
+
+Capture the product, plan, region, document version, and assessment date. A public agreement may be superseded by the buyer's signed order or regional terms. A partner API agreement does not automatically govern a clinic's subscription.
+
+## Decision Rules
+
+- Identify essential conditions before scoring: usable records and export where relevant, required workflows, confirmed integration availability, acceptable financial commitment, privacy and security appropriate to the data, and a workable exit.
+- A failed essential condition disqualifies the candidate for that buyer. An unknown essential condition blocks purchase approval until resolved. A high average score cannot cancel either result.
+- Distinguish current product capability from a contractual commitment. Roadmap features are unavailable today; promises need a dated deliverable, acceptance condition, and remedy before reliance.
+- Treat cloud, local-server, managed hosting, and self-hosting as operating choices. Price ownership, maintenance, backups, security, upgrades, and support for each. Accessible source code does not prove inexpensive operation or usable data export.
+- For clinical tools, assess human oversight and record integrity. This is software purchasing advice, not diagnosis, dosing, or permission to practice remotely.
+- Legal enforceability depends on the relevant jurisdiction and complete agreement. Explain the commercial effect in plain language, separate it from a legal conclusion, and flag a concrete issue for local advice when necessary. Do not invent universal retention periods, cancellation rights, or compliance guarantees.
+
+## Deliver an Answer the Buyer Can Act On
+
+Lead with the appropriate conclusion: **ready for a limited trial**, **shortlist provisionally**, **negotiate before buying**, **not suitable for the stated needs**, **keep the current setup**, or **insufficient evidence**. Do not imply the buyer has approved a purchase.
+
+For a substantial review, include:
+
+1. The buyer's context and assumptions.
+2. The most consequential findings, each with evidence, practical impact, and a specific question or requested change.
+3. Cost over the chosen horizon, minimum contractual commitment, and unresolved charges.
+4. Relevant workflow tests and essential conditions still outstanding.
+5. A concise recommendation, alternatives, and the next concrete action.
+
+Use a table for comparable options or clauses. Describe risks as facts and possibilities, not accusations. Avoid generic best-software lists, fear-based savings estimates, and false numerical precision. In generic examples use Candidate A and Candidate B, with all invented facts labeled hypothetical.
+
+Preparing questions, calculations, and proposed wording does not authorize sending them, creating a trial account, entering payment details, accepting terms, booking a sales call, canceling a service, or moving records. Perform external actions only when the buyer explicitly requests them and the relevant details are established.

--- a/.claude/skills/yosemite-vet-software-buyer/agents/openai.yaml
+++ b/.claude/skills/yosemite-vet-software-buyer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Yosemite Crew Veterinary Software Buyer'
+  short_description: 'Impartial vet software buying and contract guidance'
+  default_prompt: 'Use $yosemite-vet-software-buyer to help me assess veterinary software, uncover hidden costs and contract risks, and decide what to verify before buying without favoring any supplier.'

--- a/.claude/skills/yosemite-vet-software-buyer/references/buyer-evaluation.md
+++ b/.claude/skills/yosemite-vet-software-buyer/references/buyer-evaluation.md
@@ -1,0 +1,95 @@
+# Buyer Evaluation
+
+## Establish Whether a Purchase Helps
+
+Describe the friction as an observable workflow: who performs it, how often, what fails, and what improvement would be valuable. Ask whether configuration, training, an already-paid feature, or an existing integration could solve it. Do not assume replacing the main records system is necessary to improve one workflow.
+
+Include the people doing the work: reception, nursing or technician staff, clinicians, the practice manager, and finance where relevant. An owner's approval does not demonstrate that frontline staff can use the tool.
+
+| Starting point       | What changes the decision                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New practice         | Opening dependencies, initial volumes, future staffing, hardware, internet, training, and how the first appointment reaches the first reconciled invoice. |
+| Replacement          | Unsolved pain, export rights, data quality, overlap costs, migration scope, training capacity, and the next cancellation deadline.                        |
+| Add-on               | Whether the core system already covers the need; duplicated records, extra logins, sync failures, and responsibility across suppliers.                    |
+| Acquisition          | Transferability of licenses, change-of-control clauses, inherited contracts, access credentials, data authority, and ability to preserve continuity.      |
+| Renewal              | Actual usage, unused licenses, support history, new prices, changed terms, and whether an upgrade restarts the commitment.                                |
+| Multiple sites       | Permission boundaries, shared clients, location-specific inventory and pricing, consolidated reporting, and site sale or closure.                         |
+| Mobile or ambulatory | Real connectivity, offline behavior, sync conflicts, mobile hardware, printing, routing, and field billing.                                               |
+
+Write a small requirements table: workflow, essential or desirable, acceptance test, responsible staff role, and evidence needed. Avoid counting a long feature list as a needs assessment.
+
+## Test the Category Being Bought
+
+| Category                                           | Ask the supplier to demonstrate                                                                                                                        | Less obvious buying questions                                                                                                                                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Main practice system and clinical records          | Booking through check-in, consult, diagnostics, dispensing, invoice, payment, and follow-up; correct a finalized note without losing its history.      | Migration of attachments and histories; permissions; multiple owners; audit trails; read-only access after cancellation; report reconciliation.                                                                 |
+| Booking and scheduling                             | Appointment types with different durations, clinician and equipment availability, rescheduling, a cancellation, and two simultaneous booking attempts. | Instant confirmed booking or merely a request; synchronization delay; timezone behavior; deposits; message fees; waitlist rules.                                                                                |
+| Client communications and apps                     | A multi-patient household, consent choices, a reply reaching the right team, and suppression of inappropriate reminders.                               | Number ownership and portability; per-segment text billing; delivery charges; messaging quotas; manual review and patient-status rules; exportable consent history.                                             |
+| AI reception and phone tools                       | A routine booking, an urgent-sounding call transferred to a human, an unsupported request, an accent or language variation, and a failed handoff.      | Per-minute costs, overages, recordings, consent, number portability, downtime routing, staff escalation, and who monitors unhandled calls. Do not let purchase testing become automated clinical triage advice. |
+| AI scribe and clinical assistance                  | A fictional encounter with negation, units, corrections, several speakers, and similar patient names; clinician review before finalizing.              | Raw recording retention; transcript versus note export; model-training and secondary-use rights; subgroup validation; correction time; quotas and failed-session charges.                                       |
+| Diagnostics, imaging, and laboratory tools         | An order with correct patient identifiers, a corrected result, a large image set, and viewing or exporting data outside the product.                   | Native images versus rendered reports; measurements and annotations; device compatibility; storage and retrieval charges; clinical validation and supported species.                                            |
+| Treatment boards and inpatient tools               | A shift handover, changed treatment timing, an overdue task, a completed task linked to billing, and downtime reconciliation.                          | Concurrent updates, escalation ownership, who can correct an entry, audit history, dependencies on the main system, and 24-hour support scope.                                                                  |
+| Inventory, pharmacy, and prescribing               | Purchase order through receiving, partial pack use, return, expiry, batch traceability, and stock reconciliation.                                      | Pack-to-unit conversions; site transfers; supplier restrictions; minimum purchases; dispensing fees; locally applicable prescription and controlled-drug records.                                               |
+| Payments and finance                               | Split tender, deposits, partial refunds, a disputed payment, settlement, and accounting reconciliation.                                                | Compulsory processing, effective rates, reserves, terminal leases, cancellation of the separate merchant agreement, portability of payment tokens, and reconciliation exports.                                  |
+| Wellness plans and subscriptions                   | Enrollment, failed payment, cancellation, unused entitlements, a refund, and transfer to another patient or site where permitted.                      | Who carries credit risk, discount clawbacks, fees per plan, remaining care obligations, and whether the plan survives a software change.                                                                        |
+| Telehealth and remote monitoring                   | Scheduling, consent, human review, recording relevant information, failed connection, and escalation to in-person care.                                | Jurisdictional rules, professional eligibility, emergency exclusions, monitoring hours, false alerts, client accessibility, and record export.                                                                  |
+| Analytics, accounting, and group reporting         | Trace a dashboard figure back to original records; explain a refund, time boundary, site transfer, and corrected entry.                                | Data definitions, latency, mappings, permitted benchmarking, export granularity, historical comparability, and cost per entity.                                                                                 |
+| Reputation, marketing, and other operational tools | The exact campaign or task, approval, recipient controls, reporting, and account handover.                                                             | Ownership of domains, content, lists, numbers and ad accounts; agency access; platform dependencies; asset export; promises of outcomes. Check current platform rules for review solicitation.                  |
+
+For an unlisted category, use the same questions: what job, who uses it, what data enters and leaves, what can fail, who fixes it, what is charged, and how the practice stops using it.
+
+## Run a Useful Demo or Trial
+
+Choose a few representative scenarios plus the highest-consequence failure. Give each candidate the same task and let a future user attempt it. Use fictional or properly de-identified material in an authorized environment. Do not upload a live practice database to obtain a quote or casual demo.
+
+Record completion, correctness, time, manual re-entry, help required, and unresolved exceptions. A recording or screenshot is useful evidence only for what it actually shows. Do not promise a trial is free until billing activation, cancellation, and data treatment are understood.
+
+Useful cross-category scenarios:
+
+- Two staff update the same item; confirm the outcome and history.
+- A task fails halfway; confirm what was saved, how staff notice, and how they recover.
+- Remove an employee's access; confirm the account and relevant sessions are disabled.
+- Correct a patient link or factual error; confirm a durable audit trail.
+- Export a representative sample and have the receiving person open and interpret it.
+- Interrupt the connection in a permitted demo environment; distinguish offline operation, cached read-only access, and complete unavailability.
+
+Do not run intrusive security tests, disrupt a live system, or imply a demo confirms security architecture.
+
+## Understand an Integration
+
+The presence of an integration name or logo does not specify what works. Record:
+
+| Question                 | Required answer                                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| What moves?              | Exact records and fields, including attachments, corrections, refunds, and consent where relevant.          |
+| Which direction?         | Read-only, write-only, two-way, or a manual export and import.                                              |
+| When?                    | Trigger, synchronization interval, expected delay, and backfill limits.                                     |
+| Who can get it?          | Actual product version, plan, region, partner approval, and availability today.                             |
+| What happens on failure? | Notification, retry, duplicate prevention, conflict handling, reconciliation, and accountable support team. |
+| What does it cost?       | Charges from both suppliers, middleware, installation, volumes, support, and future changes.                |
+| What can change?         | API scopes, rate limits, deprecation notice, loss of partner access, and fallback or exit rights.           |
+| How do we verify?        | A demonstration of the buyer's exact workflow and written confirmation of production support.               |
+
+Do not confuse API access with an unlimited right to export, migrate, or connect another application. Technical access and contractual permission are separate checks.
+
+## Protect Records and Continuity
+
+For tools holding material practice data, require a named person to own migration and recovery. Identify the data to preserve: patient and client relationships, clinical histories, attachments, images, active appointments, invoices and balances, stock, prescriptions, consents, and audit history as applicable.
+
+Specify source and destination totals, mapping rules, representative record checks, and reconciliation tolerances. Financial balances and patient identity errors require explicit resolution; do not average them away. Investigate exclusions rather than accepting a statement that the migration is complete.
+
+Before a major change, agree a tested backup and restore process, a read-only legacy-access plan, a cutover owner, and criteria for delaying go-live. A rollback after new records have been created needs reconciliation; restoring an old snapshot can discard new clinical and financial activity.
+
+Ask for recovery objectives in plain language: maximum tolerable lost work and target time to restore service. Confirm what an outage excludes, what the practice can still do, how downtime records are captured, and who reconciles them afterward.
+
+For self-hosting, explicitly assign updates, monitoring, backups, restoration, encryption, identity management, hosting bills, and incident response. For managed services, identify what the supplier handles and what still belongs to the practice.
+
+## Evidence of Security and Support
+
+Ask about individual accounts, role permissions, multi-factor authentication, offboarding, encryption, audit logs, backup separation and restore testing, incident notification, subprocessors, and where data is stored and accessed. Match the depth to the information and operational dependency involved.
+
+A security certification or report is evidence with a date, scope, and exceptions, not a blanket guarantee. Ask whether it covers the actual service and hosting arrangement. An online calculator using no stored identifiers does not have the same exposure as a records system or recorded consultation service.
+
+Record support hours and timezone, channels, severity definitions, initial response versus resolution targets, escalation, training limits, and charges. Availability of a phone number does not establish round-the-clock technical support.
+
+Ask comparable practices about concrete incidents, actual training effort, unexpected charges, and whether they have exercised an export. Treat supplied references as selected experiences rather than a representative satisfaction survey.

--- a/.claude/skills/yosemite-vet-software-buyer/references/contract-review.md
+++ b/.claude/skills/yosemite-vet-software-buyer/references/contract-review.md
@@ -1,0 +1,69 @@
+# Contract Review
+
+## Establish the Applicable Agreement
+
+Collect only what is needed: quote or order form, main agreement, service schedule, implementation scope, support commitments, data-processing terms, and separate payment, AI, integration, or hardware terms. Include incorporated policies and amendments relevant to the question.
+
+Record legal entity, product and plan, region, currency, effective date, version, parties, and signature or acceptance status. Determine the agreement's stated order of precedence. Do not assume the newest public page overrides an existing signed agreement, or that a sales email overrides standard terms.
+
+An annual term can coexist with an earlier termination right. Read the cancellation and fee consequences together before calculating a full-year liability. Likewise, a monthly invoice does not establish monthly cancellation rights.
+
+For each finding report: **document and section; what it says; practical consequence; severity; requested clarification or change**. Quote only the minimum necessary text. Separate a present term, an ambiguity, a missing protection, and a suggested negotiation position. The checklist is not evidence that a particular supplier has a problematic clause.
+
+## Clauses to Examine
+
+| Area                             | What to inspect                                                                                                                              | Ask or negotiate                                                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Acceptance and billing start     | Whether signature, first login, trial expiry, migration work, or go-live creates obligations.                                                | Confirm the binding event, initial invoice, trial conversion, and a delay remedy if opening or implementation slips.                                         |
+| Term and renewal                 | Initial duration, renewal duration, minimum users or sites, and upgrade-triggered extensions.                                                | State the term and commitment separately from billing frequency; confirm whether expansion resets the clock.                                                 |
+| Cancellation notice              | Calendar months versus days, delivery address, required method, receipt rule, timezone, and whether notice only works at term end.           | Calculate the deadline only from established dates and wording; request written acknowledgment. A reminder is not cancellation.                              |
+| Early exit and refunds           | Remaining fees, accelerated balances, termination for convenience or cause, cure period, and unused prepaid amounts.                         | Identify the actual financial exit consequence and exceptions; do not infer a penalty solely from annual renewal.                                            |
+| Price changes                    | Introductory rates, renewal increases, indexation, new user pricing, currency and taxes, and incorporated online schedules.                  | Fix the applicable rate basis; request an increase cap or notice and exit option before a material increase. Label proposed caps as negotiation targets.     |
+| Usage and overages               | Billable users, locums, concurrent access, locations, messages, segments, minutes, storage, AI usage, API calls, and fair-use definitions.   | Obtain included quantities, chargeable events, overage rates, alerts, caps, and downgrade terms in writing.                                                  |
+| Add-ons and bundles              | Functions priced separately despite a bundled description; tied processing, lab, pharmacy, or communications arrangements.                   | Itemize optional and compulsory items and the price without the bundle.                                                                                      |
+| Payments and hardware            | Processing rates, card mix, settlement timing, reserves, disputes, refunds, terminal ownership or lease, and separate cancellation terms.    | Calculate effective cost; identify every counterparty and obligation that survives canceling the software.                                                   |
+| Implementation                   | Deliverables, exclusions, responsibilities, migration method, training, travel, milestones, and acceptance by silence or passage of time.    | Define measurable acceptance, issue correction, rescheduling, payment milestones, and a failed-implementation remedy.                                        |
+| Data use                         | Distinguish customer content, personal data, recordings, outputs, anonymized or de-identified data, derived statistics, and feedback.        | Clarify permitted purposes, recipients, duration, secondary use, resale, benchmarking, model training, and whether choices cover subprocessors.              |
+| Data export                      | Included data, formats, attachments, histories, relationships, export limits, assistance charges, timing, and access during a dispute.       | Require a sample export, a complete scope, predictable charges and delivery time, and a process the next system can use.                                     |
+| Retention and deletion           | Active access ending before retrieval, short export windows, backup exceptions, and deletion timing.                                         | Agree workable retrieval and verification before deletion; reconcile retention duties and obtain deletion confirmation where applicable.                     |
+| AI terms                         | Data sent to model providers, recording consent, human verification, training rights, model changes, usage limits, and liability exclusions. | Separate input, raw audio, transcript, and generated note treatment; require appropriate human review and clear controls over secondary use.                 |
+| Privacy and subprocessors        | Controller and processor roles for each activity, processing locations, transfers, breach assistance, audits, and subprocessor changes.      | Confirm the applicable processing agreement and mechanisms; establish notice, escalation, and available options for material changes.                        |
+| Availability and support         | Uptime calculation, excluded periods and dependencies, maintenance, service credits, claim deadlines, and sole-remedy language.              | Agree severity-specific response and restoration expectations, escalation, and remedy for repeated material failure. Credits may not cover operational loss. |
+| Changes and discontinuation      | Unilateral changes to prices, terms, core features, APIs, or third-party availability; continued use as acceptance.                          | Seek clear notice, version records, continuity, and an exit or refund option for materially reduced service.                                                 |
+| Suspension                       | Billing disputes, suspected misuse, security events, thresholds, cure periods, and access to essential records.                              | Agree proportionate notice when feasible and a continuity or read-only export route compatible with security needs.                                          |
+| Liability and indemnities        | Liability caps and exclusions; whose losses are covered; one-sided indemnities; data incidents and third-party claims.                       | Identify the concrete exposure for qualified local review; do not call a cap automatically invalid or demand an invented universal minimum.                  |
+| Assignment and ownership changes | Sale of a practice or site, supplier acquisition, affiliate sharing, assignment consent, and fees.                                           | Confirm transfer rights and whether changed ownership alters service, data use, price, or exit options.                                                      |
+| Publicity and disputes           | Automatic logo or testimonial permissions, confidentiality, review restrictions, governing law, forum, arbitration, and costs.               | Request explicit publicity consent and flag material dispute constraints for jurisdiction-specific advice.                                                   |
+
+## A Practical Risk Scale
+
+- **Blocker:** The wording or demonstrated behavior prevents an essential requirement or creates an unacceptable exposure for this buyer. Do not recommend signing while it remains.
+- **Material issue:** A cost or operational risk needs clarification, negotiation, or a buyer-approved mitigation before commitment.
+- **Manageable condition:** An understood obligation with a named owner and workable response. Explain the tradeoff.
+- **Unknown:** The relevant document, fact, or interpretation is unavailable. Do not convert this to either a pass or an accusation.
+
+Describe why an issue matters to this practice. A retrieval deadline can be a blocker for a records replacement and immaterial to a tool storing no practice data.
+
+## Proposed Wording
+
+These are original commercial discussion points, not ready-to-sign legal provisions. Adapt them to the actual agreement and have material legal wording reviewed locally. Do not present a requested protection as a right the buyer already has.
+
+**Complete export:** Ask for an agreed schedule of included records, attachments, audit history, identifiers, and relationships, in documented machine-readable formats plus readable clinical documents where necessary. Specify delivery time, fees, assistance, and the access period needed to validate the result.
+
+**Renewal:** Ask the supplier to state the initial and renewal terms, cancellation method and deadline, renewal price basis, and notice of material price changes before the cancellation deadline.
+
+**Data use:** Ask that processing necessary to deliver the service be distinguished from optional marketing, resale, benchmarking, and model training, with explicit terms for retained and derived data and each relevant third party.
+
+**Implementation acceptance:** Identify the specific workflows, data reconciliations, staff readiness, and interfaces that constitute acceptance, and agree how defects and delayed delivery are handled before further payment or full rollout.
+
+**Material service change:** Ask what notice, alternative service, transition assistance, and termination or refund rights apply if a critical function or required integration is withdrawn.
+
+## Jurisdiction and Date
+
+Identify country and relevant state or region before discussing enforceability. Verify current authoritative guidance when offering a legal conclusion. Business purchases may not have the same cancellation protections as consumer purchases; do not assume a cooling-off period.
+
+For UK and European contexts, examine applicable data-protection requirements, the actual data flows, controller and processor roles, international transfers, and any applicable software-switching requirements. Do not treat UK and EU rules as identical. For covered EU services, check current Data Act provisions and dates before judging switching charges; do not assume every exit-related charge is prohibited.
+
+For the United States, identify relevant state veterinary record, privacy, recording, prescribing, and business-contract requirements. Do not assume a human-health privacy badge settles a veterinary practice's obligations. Other countries need their own local review rather than imported UK or US rules.
+
+Treat retention as a category-specific obligation involving the record type, local rules, and applicable insurance or professional requirements. Do not invent a worldwide number of years. A general compliance label is not proof that the practice's configuration and use are compliant.

--- a/.claude/skills/yosemite-vet-software-buyer/references/costs-and-decisions.md
+++ b/.claude/skills/yosemite-vet-software-buyer/references/costs-and-decisions.md
@@ -1,0 +1,118 @@
+# Costs and Decisions
+
+## Calculate the Same Scope
+
+Use a common currency, tax treatment, user and site count, volume assumptions, start date, and time horizon. Show 12 months for an ordinary first comparison and a longer horizon when commitment or migration makes it relevant. State the actual horizon rather than calling every estimate a lifetime cost.
+
+Separate invoiced cash costs, internal staff effort, contingent exit costs, and uncertain opportunity costs. Use actual quotes when supplied. Mark unknown charges as unknown, never zero. Do not treat a lower-bound subtotal as a complete total.
+
+| Cost layer                    | Include when relevant                                                                                                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Initial cash                  | Setup, data extraction, cleanup, migration, integration work, hardware, installation, training, travel, and nonrefundable deposits.                                    |
+| Recurring cash                | Base subscription, clinician and staff accounts, sites, required modules, hosting, backups, support, interfaces, messaging, AI usage, and storage.                     |
+| Transactions and variable use | Card processing, per-transaction fees, disputes, refunds, texts and segments, minutes, usage above quotas, and required minimum purchases.                             |
+| Transition cash               | Overlapping subscriptions, temporary staffing, overtime, legacy access, and paid correction work.                                                                      |
+| Exit cash                     | Notice-period commitments not already counted, early-termination charges if applicable, export assistance, hardware obligations, and replacement migration.            |
+| Internal effort               | Training, data checking, maintenance, troubleshooting, manual re-entry, and administration. State hours and a supplied loaded hourly cost separately from cash outlay. |
+| Opportunity cost              | Documented, scenario-based operational disruption. Treat lost capacity or revenue as uncertain and separate from payroll and profit.                                   |
+
+For recurring amounts, calculate each period with its applicable price, license count, and consumption; include price increases from the date they apply. A flat multiplication is valid only when the rate and quantities are stable.
+
+```text
+Cash cost over horizon = initial cash + sum of recurring and usage cash
+                      + transition cash + exit cash incurred in that horizon
+
+Internal effort value = sum of hours by role x relevant loaded hourly cost
+
+Payment cost = sum of processed volume by rate category x applicable rate
+             + number of chargeable transactions x per-transaction fee
+             + relevant fixed, dispute, refund, and other charges
+
+Usage overage = max(0, chargeable usage - included allowance) x overage rate
+```
+
+Report minimum contractual commitment separately. Use remaining unavoidable payments after applying the actual termination rights, notice terms, credits, and refunds. Do not double count it on top of the same subscription payments in total cost.
+
+Prevent double counting between the subscription and bundled items, between initial and migration fees, and between payment volume fees and per-transaction costs already included in a quoted blended rate. Confirm whether taxes are recoverable rather than silently excluding them.
+
+## Original Hypothetical Example
+
+The following is arithmetic practice, not a market price estimate. Both candidates are assumed to have equal required scope, fixed rates for 12 months, equal taxes excluded, and no other charges for this example only. Actual missing fees remain unknown.
+
+| Item                                    | Candidate A | Candidate B |
+| --------------------------------------- | ----------: | ----------: |
+| Base each month                         |         300 |         550 |
+| Required modules each month             |         180 |           0 |
+| Initial setup                           |       2,000 |         800 |
+| Year-one cost before payment processing |       7,760 |       7,400 |
+| Illustrative processing rate            |        2.7% |        2.2% |
+| Annual processed volume                 |     600,000 |     600,000 |
+| Processing cost, percentage only        |      16,200 |      13,200 |
+| Combined illustrative cash cost         |      23,960 |      20,600 |
+
+Candidate B's base price is higher but the assumed first-year cash cost is 3,360 lower. This is a cost comparison, not a recommendation: workflow, terms, security, implementation, and unknown charges can change the choice. In a real comparison include card mix, fixed transaction charges, settlement terms, and whether those rates are actually available.
+
+## Benefits Without Invented Savings
+
+Measure a baseline and then the same task with the proposed tool. Distinguish time released, actual cash saved, added capacity used, and contribution earned. Avoid claiming that all saved minutes turn into revenue or reduced payroll.
+
+```text
+Potential time released per month = relevant tasks per month
+                                 x observed minutes saved per task / 60
+
+Potential labor value = time released x loaded hourly cost
+
+Break-even incremental contribution per month = incremental monthly cash cost
+                                             + initial incremental cash / chosen months
+```
+
+Report labor value as capacity unless reduced expenditure is evidenced. If projecting added appointments, constrain them by demand and staffing, and use contribution after variable costs rather than gross revenue. Do not add the value of saved time and the contribution from appointments using that same time without a defensible separation.
+
+Use buyer-supplied low, expected, and high usage or migration-effort scenarios where uncertainty matters. Show which assumptions would change the decision. Do not insert unverified industry percentages for revenue leakage, migration loss, AI accuracy, or productivity.
+
+## Score Only What Evidence Supports
+
+Start with essential conditions. Record each as pass, fail, or unknown with the evidence and owner of the next check. A fail or unknown cannot be canceled by a high score elsewhere.
+
+If there are several plausible options, agree a few weighted criteria before scoring. Categories might include workflow fit, staff usability, integration fit, commercial terms, full cost, implementation, support, and operational resilience. Avoid counting the same benefit twice under different headings.
+
+Weights express this buyer's preferences, not an industry standard. Use nonnegative weights with a positive total; normalize them to 100 for presentation. Set the applicable criteria once for every candidate. If a criterion is inapplicable to the purchase, remove it for all candidates before scoring; do not drop a weak criterion for one supplier.
+
+| Score   | Evidence of fit for this buyer                                               |
+| ------- | ---------------------------------------------------------------------------- |
+| 0       | Evidence establishes the requirement cannot be met.                          |
+| 1       | Major limitation or costly workaround.                                       |
+| 2       | Partly meets the requirement with material tradeoffs.                        |
+| 3       | Meets the agreed acceptance criteria.                                        |
+| 4       | Meets the criteria with demonstrated additional value relevant to the buyer. |
+| Unknown | Insufficient evidence; not a zero or a pass.                                 |
+
+Keep supplier statements, observed test results, and contractual commitments identifiable alongside each score. A statement about a capability alone should remain provisional until the evidence required for that criterion is obtained.
+
+For weights totaling 100:
+
+```text
+Evidence coverage = sum of weights with an evidenced score
+Lower supported score = sum of weight x evidenced score / 4
+Upper possible score = lower supported score + sum of unknown weights
+```
+
+The resulting interval is an evidence range, not a statistical confidence interval or probability of success. Do not renormalize over the known criteria: a product with one good answer must not appear perfect. When evidence is complete the lower and upper values coincide.
+
+Hypothetical check: weights 40, 35, and 25; scores 3, unknown, and 2. Evidence coverage is 65%; the supported score range is 42.5 to 77.5 out of 100. The unknown criterion still needs evaluation. An unresolved essential condition independently blocks purchase approval.
+
+If candidate ranges overlap or reasonable changes in weights change the winner, describe the tradeoff and collect the evidence most likely to resolve it. Do not manufacture a ranking.
+
+## Buyer Decision Memo
+
+Use only the sections that help the specific decision:
+
+1. **Recommendation:** What to do now, why, and the conditions that would change it.
+2. **Context:** Category, jurisdiction, practice size, must-have workflows, budget, dates, and assumptions.
+3. **Essential conditions:** Pass, fail, and unknown, each with evidence.
+4. **Comparison:** Same-scope costs, minimum commitment, material strengths and limitations, and evidence status.
+5. **Contract findings:** Clause reference, commercial consequence, requested change, and next owner.
+6. **Trial and transition:** Acceptance scenarios, readiness conditions, records continuity, and exit arrangements.
+7. **Open questions:** Prioritized by consequence and whether the answer can change the decision.
+
+The final action should be concrete: obtain a complete export sample, clarify a renewal deadline, request an itemized quote, test a named workflow, negotiate a particular term, or decline an unsuitable option. A sales call is not the automatic next step.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

The repository does not include a reusable skill for veterinary practices evaluating software purchases, quotes, renewals, and contract risks.

## What is the new behavior?

Adds matching Codex and Claude skill packages for impartial veterinary software purchasing advice. The skill covers requirements, category-specific demonstrations, hidden costs, renewal and cancellation terms, data rights and exports, integrations, AI tools, and transition readiness.

Recommendations follow the buyer's needs and verified evidence. Yosemite Crew is assessed using the same criteria as every other supplier. Missing evidence remains explicit, and the skill can recommend keeping the current setup or postponing a purchase. Supporting references provide contract-review questions, cost calculations, and a decision framework.

Impact is limited to Markdown guidance and skill UI metadata. No application code, dependency, or security-control changes.

Validation:

- Skill frontmatter validator passed for both copies; exit 0.
- `diff -rq .agents/skills/yosemite-vet-software-buyer .claude/skills/yosemite-vet-software-buyer` confirmed matching packages; exit 0.
- `pnpm exec prettier --check .agents/skills/yosemite-vet-software-buyer .claude/skills/yosemite-vet-software-buyer` passed; exit 0.
- Pre-commit Gitleaks, secretlint, formatting, and commit-message checks passed.
- Aikido scanned all 10 final files and returned no findings.
- `pnpm run lint` and `pnpm run type-check` completed with exit 0. Turbo reused cached application tasks; lint reported existing application warnings.
- Application tests, browser checks, and local application Sonar scans were not run: the diff contains only documentation and skill metadata outside the configured application source directories. No runtime coverage claim is made; the broad tests-and-lints checkbox remains unchecked.

## Related Issue(s)

No linked issue; this is a standalone documentation and agent-guidance addition.
