### PR TITLE
ci(repo): enforce attribution rule on commit messages

### DIFF
--- a/.github/workflows/forbidden-terms.yml
+++ b/.github/workflows/forbidden-terms.yml
@@ -346,6 +346,14 @@ jobs:
             > "${RUNNER_TEMP}/surfaces/diff"
           git diff --name-only --diff-filter=ACMRT "${MERGE_BASE}" refs/remotes/origin/gate-head \
             > "${RUNNER_TEMP}/surfaces/names"
+          # The attribution arm reads only `messages`: this range is the set of
+          # commits the pull request introduces. A matching trailer quoted in a
+          # pull-request body therefore remains outside the arm.
+          #
+          # Residual: a feature branch that merges upstream commits also puts
+          # those messages in this range. Feature branches here do not use that
+          # shape and dependency pull requests contain one commit, so the risk
+          # is small but non-zero.
           git log --format=%B "${MERGE_BASE}..refs/remotes/origin/gate-head" \
             > "${RUNNER_TEMP}/surfaces/messages"
           # Through env and never interpolated into the script: the title and

--- a/scripts/ci/forbidden-terms.mjs
+++ b/scripts/ci/forbidden-terms.mjs
@@ -60,6 +60,24 @@ const ALLOWED_PROSE = path.join(import.meta.dirname, 'forbidden-terms-allowed-pr
  */
 export const SURFACES = new Set(['diff', 'names', 'messages', 'branch', 'title', 'body']);
 
+/** The only surface whose text can describe commits introduced by this pull request. */
+export const ATTRIBUTION_SURFACE = 'messages';
+
+// Keep assistant names separate so this source never contains a complete trailer.
+const ASSISTANTS = 'claude|codex|copilot';
+
+/** Attribution forms forbidden by repository convention on introduced commit messages. */
+export const ATTRIBUTION_PATTERN = new RegExp(
+  [
+    String.raw`co-authored-by:.*(${ASSISTANTS})`,
+    String.raw`generated (with|by).*(${ASSISTANTS})`,
+    String.raw`(${ASSISTANTS}) code`,
+    String.raw`made with (${ASSISTANTS})`,
+    String.raw`\u{1F916} generated`,
+  ].join('|'),
+  'iu'
+);
+
 /** Raised for anything that means "the guard could not run" - always exit 2. */
 class GuardError extends Error {}
 
@@ -492,6 +510,7 @@ function runScan(argv) {
   process.chdir(root);
 
   const findings = [];
+  const attributions = [];
   for (const surface of SURFACES) {
     let text;
     let fd;
@@ -538,33 +557,50 @@ function runScan(argv) {
       if (fd !== undefined) closeSync(fd);
     }
     findings.push(...scanSurface(pattern, surface, text));
+    if (surface === ATTRIBUTION_SURFACE) {
+      attributions.push(...scanSurface(ATTRIBUTION_PATTERN, surface, text));
+    }
   }
 
-  if (findings.length === 0) {
+  if (findings.length === 0 && attributions.length === 0) {
     process.stdout.write(
-      `forbidden-terms: clean - ${SURFACES.size} surfaces read, no named external product on any of them.\n`
+      `forbidden-terms: clean - ${SURFACES.size} surfaces read, no named external product on any of them, ` +
+        `no AI-attribution trailer on the '${ATTRIBUTION_SURFACE}' surface.\n`
     );
     return 0;
   }
 
-  process.stderr.write(
-    `forbidden-terms: BLOCKED - a named external product appears on ${findings.length} line(s).\n\n`
-  );
-  for (const finding of findings) {
-    // Only the diff surface has a file of its own; for the others the "file" IS
-    // the surface, and `[names] names:1` reads worse than `[names] entry 1`.
-    const where =
-      finding.file === finding.surface
-        ? `entry ${finding.line}`
-        : `${finding.file}:${finding.line}`;
-    process.stderr.write(`  [${finding.surface}] ${where}\n`);
+  if (findings.length > 0) {
+    process.stderr.write(
+      `forbidden-terms: BLOCKED - a named external product appears on ${findings.length} line(s).\n\n`
+    );
+    for (const finding of findings) {
+      const where =
+        finding.file === finding.surface
+          ? `entry ${finding.line}`
+          : `${finding.file}:${finding.line}`;
+      process.stderr.write(`  [${finding.surface}] ${where}\n`);
+    }
+    process.stderr.write(
+      '\nThese repositories are public. Draw on prior art freely; never name the source in code,\n' +
+        'comments, tests, fixtures, docs, commit messages, branch names or pull-request text.\n' +
+        'Describe the behaviour and the clinical need instead.\n\n' +
+        'The match itself is deliberately not printed: this log is public.\n'
+    );
   }
-  process.stderr.write(
-    '\nThese repositories are public. Draw on prior art freely; never name the source in code,\n' +
-      'comments, tests, fixtures, docs, commit messages, branch names or pull-request text.\n' +
-      'Describe the behaviour and the clinical need instead.\n\n' +
-      'The match itself is deliberately not printed: this log is public.\n'
-  );
+
+  if (attributions.length > 0) {
+    process.stderr.write(
+      `${findings.length > 0 ? '\n' : ''}forbidden-terms: BLOCKED - an AI-attribution trailer appears in ` +
+        `${attributions.length} commit-message line(s) this pull request introduces.\n\n`
+    );
+    for (const attribution of attributions) {
+      process.stderr.write(`  [${attribution.surface}] entry ${attribution.line}\n`);
+    }
+    process.stderr.write(
+      '\nCommits here carry no AI-attribution footer. Amend the commit or rebase the branch, then force-push.\n'
+    );
+  }
   return 1;
 }
 

--- a/scripts/ci/forbidden-terms.test.mjs
+++ b/scripts/ci/forbidden-terms.test.mjs
@@ -28,6 +28,7 @@ import test from 'node:test';
 
 import {
   addedLines,
+  ATTRIBUTION_SURFACE,
   compilePattern,
   corpusLines,
   scanSurface,
@@ -1027,6 +1028,95 @@ test("this repository's own prose passes every surface", () => {
   const result = run(['scan', '--dir', dir], { FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC) });
   assert.equal(result.code, 0);
   assert.match(result.stdout, /clean/);
+});
+
+// ---------------------------------------------------------------------------
+// Attribution on introduced commit messages
+// ---------------------------------------------------------------------------
+
+const ASSISTANT = 'cla' + 'ude';
+const AI_TRAILER = `Co-authored-by: ${ASSISTANT} <assistant@example.invalid>`;
+const HUMAN_TRAILER = 'Co-authored-by: A Human <human@example.invalid>';
+
+function scanWith(overrides) {
+  return run(['scan', '--dir', surfaceDir(overrides)], {
+    FORBIDDEN_TERMS_PATTERN_B64: b64(SYNTHETIC),
+  });
+}
+
+test('an attribution trailer in an introduced commit message blocks the run', () => {
+  const result = scanWith({
+    messages: ['feat(api): add the thing', '', AI_TRAILER, ''].join('\n'),
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /BLOCKED - an AI-attribution trailer/);
+  assert.match(result.stderr, /\[messages\] entry 3/);
+});
+
+test('the same trailer in a pull-request body does not trigger the attribution arm', () => {
+  const result = scanWith({ body: `Upstream release notes:\n\n${AI_TRAILER}\n` });
+
+  assert.equal(result.code, 0);
+  assert.doesNotMatch(result.stdout, /BLOCKED/);
+});
+
+test('the same trailer in a diff fixture does not trigger the attribution arm', () => {
+  const diff = [
+    '--- /dev/null',
+    '+++ b/some.test.ts',
+    '@@ -0,0 +1,1 @@',
+    `+${AI_TRAILER}`,
+    '',
+  ].join('\n');
+  const result = scanWith({ diff });
+
+  assert.equal(result.code, 0);
+});
+
+test('human co-author and DCO trailers remain allowed', () => {
+  const result = scanWith({
+    messages: `feat(api): add the thing\n\n${HUMAN_TRAILER}\nSigned-off-by: A Human <human@example.invalid>\n`,
+  });
+
+  assert.equal(result.code, 0);
+});
+
+test('a clean run reports both checks', () => {
+  const result = scanWith({});
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /6 surfaces read/);
+  assert.match(result.stdout, /no AI-attribution trailer on the 'messages' surface/);
+});
+
+test('both checks identify themselves when both fail', () => {
+  const term = SYNTHETIC.split('|')[0];
+  const result = scanWith({ messages: `feat(api): ${term} import\n\n${AI_TRAILER}\n` });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /BLOCKED - a named external product/);
+  assert.match(result.stderr, /BLOCKED - an AI-attribution trailer/);
+});
+
+test('the messages surface is built from the pull request merge-base range', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const body = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/u.test(line))
+    .join('\n');
+  const collectors = [...body.matchAll(/git log[^\n]*?"\$\{([A-Z_]+)\}\.\.([^"]+)"/gu)];
+
+  assert.notEqual(collectors.length, 0, 'no commit-message range collector found');
+  for (const [, base, head] of collectors) {
+    assert.equal(base, 'MERGE_BASE');
+    assert.match(head, /gate-head$/u);
+  }
+});
+
+test('the attribution arm is fixed to the messages surface', () => {
+  assert.equal(SURFACES.has(ATTRIBUTION_SURFACE), true);
+  assert.equal(ATTRIBUTION_SURFACE, 'messages');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The forbidden-terms workflow scans introduced commit messages for the private prior-art term list, while the repository's no-AI-attribution convention is enforced only by local hooks. Commits created outside a provisioned checkout can therefore reach a pull request without that check.

## What is the new behavior?

The guard now applies a public attribution pattern only to the `messages` surface assembled from the pull request's merge-base range. A matching introduced commit message blocks the run and identifies only its line number. The same text in a pull request body or diff fixture remains allowed, and ordinary human co-author and DCO trailers remain valid.

The workflow documents the remaining edge case: merged upstream commits also enter the merge-base range, although Yosemite Crew feature branches do not use that shape.

Validation:

- `node --test scripts/ci/forbidden-terms.test.mjs` - 68 tests passed.
- `node --test scripts/ci/tests-must-be-able-to-fail.test.mjs` - 18 tests passed.
- `pnpm run lint` - 10 tasks succeeded with existing warnings only.
- `pnpm run type-check` - 17 tasks succeeded.
- Prettier, actionlint, staged secret scanning, ESLint, and secretlint passed.
- Mutation checks confirmed that removing the scan arm breaks the blocking test and changing its surface to `body` breaks the body-isolation test.

## Related Issue(s)

Fixes #2817
