### PR TITLE
docs(repo): replace 106 opaque request/response placeholders with real schemas

### DIFF
--- a/apps/frontend/public/static/openapi/openapi.yaml
+++ b/apps/frontend/public/static/openapi/openapi.yaml
@@ -72,8 +72,182 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: AdverseEventReport
+              required:
+                - reporter
+                - patient
+                - product
+              description: AdverseEventReport submitted by the mobile app (apps/backend/src/controllers/web/adverse-event.controller.ts createFromMobile, typed Request<unknown, unknown, AdverseEventReport>). reporter/patient/companion/product/destinations/consent are stored as Prisma Json columns on AdverseEventReport with no fixed shape at the database level, but the application-level contract is the AdverseEventReporterInfo/AdverseEventPatientInfo/AdverseEventProductInfo/AdverseEventDestinations/AdverseEventConsent types in packages/types/src/adverse-event.ts, which is what req.body is typed against. AdverseEventService.createFromMobile (apps/backend/src/services/adverse-event.service.ts) throws a 400 if reporter.firstName, reporter.email, patient.name or product.productName are missing; destinations and consent are read with optional chaining and default safely if omitted, so they are not enforced at runtime even though the TS type marks them non-optional.
+              properties:
+                organisationId:
+                  type: string
+                  description: Selected clinic/organisation id.
+                appointmentId:
+                  type: string
+                  nullable: true
+                reporter:
+                  type: object
+                  required:
+                    - type
+                    - firstName
+                    - lastName
+                    - email
+                  properties:
+                    userId:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                        - PARENT
+                        - CO_PARENT
+                        - CLINIC_STAFF
+                    firstName:
+                      type: string
+                    lastName:
+                      type: string
+                    phoneNumber:
+                      type: string
+                    email:
+                      type: string
+                    dateOfBirth:
+                      type: string
+                      description: ISO date string.
+                    addressLine:
+                      type: string
+                    city:
+                      type: string
+                    state:
+                      type: string
+                    postalCode:
+                      type: string
+                    country:
+                      type: string
+                    currency:
+                      type: string
+                patient:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    patientId:
+                      type: string
+                    companionId:
+                      type: string
+                    name:
+                      type: string
+                    breed:
+                      type: string
+                    dateOfBirth:
+                      type: string
+                    gender:
+                      type: string
+                    currentWeight:
+                      type: string
+                    color:
+                      type: string
+                    neuteredStatus:
+                      type: string
+                    bloodGroup:
+                      type: string
+                    microchipNumber:
+                      type: string
+                    passportNumber:
+                      type: string
+                    insured:
+                      type: string
+                    insuranceCompany:
+                      type: string
+                    insurancePolicyNumber:
+                      type: string
+                    countryOfOrigin:
+                      type: string
+                    originDetails:
+                      type: string
+                companion:
+                  type: object
+                  description: Same shape as patient. Accepted on the payload type but never read by AdverseEventService.createFromMobile; the stored/returned companion always mirrors patient instead.
+                  properties:
+                    patientId:
+                      type: string
+                    companionId:
+                      type: string
+                    name:
+                      type: string
+                    breed:
+                      type: string
+                    dateOfBirth:
+                      type: string
+                    gender:
+                      type: string
+                    currentWeight:
+                      type: string
+                    color:
+                      type: string
+                    neuteredStatus:
+                      type: string
+                    bloodGroup:
+                      type: string
+                    microchipNumber:
+                      type: string
+                    passportNumber:
+                      type: string
+                    insured:
+                      type: string
+                    insuranceCompany:
+                      type: string
+                    insurancePolicyNumber:
+                      type: string
+                    countryOfOrigin:
+                      type: string
+                    originDetails:
+                      type: string
+                product:
+                  type: object
+                  required:
+                    - productName
+                  properties:
+                    productName:
+                      type: string
+                    brandName:
+                      type: string
+                    manufacturingCountry:
+                      type: string
+                    batchNumber:
+                      type: string
+                    numberOfTimesUsed:
+                      type: number
+                    quantityUsed:
+                      type: number
+                    dosageForm:
+                      type: string
+                    administrationRoute:
+                      type: string
+                    reasonToUse:
+                      type: string
+                    conditionBefore:
+                      type: string
+                    conditionAfter:
+                      type: string
+                    eventDate:
+                      type: string
+                    productImageUrl:
+                      type: string
+                destinations:
+                  type: object
+                  properties:
+                    sendToManufacturer:
+                      type: boolean
+                    sendToHospital:
+                      type: boolean
+                    sendToAuthority:
+                      type: boolean
+                consent:
+                  type: object
+                  properties:
+                    agreedToContact:
+                      type: boolean
+                    agreedToTermsAt:
+                      type: string
+                      format: date-time
       responses:
         201:
           description: Response
@@ -108,7 +282,39 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                description: RegulatoryAuthority row returned as-is by prisma.regulatoryAuthority.findFirst (apps/backend/src/controllers/web/adverse-event.controller.ts getRegulatoryAuthorityInof), matched by iso2 or country query param. Only id is non-nullable in the Prisma model (packages/database/prisma/schema.prisma); every other column is optional.
+                properties:
+                  id:
+                    type: string
+                  country:
+                    type: string
+                    nullable: true
+                  iso2:
+                    type: string
+                    nullable: true
+                  iso3:
+                    type: string
+                    nullable: true
+                  authorityName:
+                    type: string
+                    nullable: true
+                  phone:
+                    type: string
+                    nullable: true
+                  email:
+                    type: string
+                    nullable: true
+                  website:
+                    type: string
+                    nullable: true
+                  notes:
+                    type: string
+                    nullable: true
+                  sourceUrl:
+                    type: string
+                    nullable: true
   '/v1/adverse-event/organisation/{organisationId}':
     get:
       tags:
@@ -133,8 +339,199 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: Reports for the organisation from AdverseEventService.listForOrganisation, each mapped through toDomainFromPrisma (apps/backend/src/services/adverse-event.service.ts).
+                items:
+                  type: object
+                  required:
+                    - id
+                    - appointmentId
+                    - reporter
+                    - patient
+                    - companion
+                    - product
+                    - destinations
+                    - consent
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    organisationId:
+                      type: string
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    reporter:
+                      type: object
+                      properties:
+                        userId:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - PARENT
+                            - CO_PARENT
+                            - CLINIC_STAFF
+                        firstName:
+                          type: string
+                        lastName:
+                          type: string
+                        phoneNumber:
+                          type: string
+                        email:
+                          type: string
+                        dateOfBirth:
+                          type: string
+                        addressLine:
+                          type: string
+                        city:
+                          type: string
+                        state:
+                          type: string
+                        postalCode:
+                          type: string
+                        country:
+                          type: string
+                        currency:
+                          type: string
+                      description: Persisted from the request's reporter object; stored as a Prisma Json column with no DB-level shape (see packages/types/src/adverse-event.ts AdverseEventReporterInfo for the application contract).
+                    patient:
+                      type: object
+                      properties:
+                        patientId:
+                          type: string
+                        companionId:
+                          type: string
+                        name:
+                          type: string
+                        breed:
+                          type: string
+                        dateOfBirth:
+                          type: string
+                        gender:
+                          type: string
+                        currentWeight:
+                          type: string
+                        color:
+                          type: string
+                        neuteredStatus:
+                          type: string
+                        bloodGroup:
+                          type: string
+                        microchipNumber:
+                          type: string
+                        passportNumber:
+                          type: string
+                        insured:
+                          type: string
+                        insuranceCompany:
+                          type: string
+                        insurancePolicyNumber:
+                          type: string
+                        countryOfOrigin:
+                          type: string
+                        originDetails:
+                          type: string
+                    companion:
+                      type: object
+                      description: AdverseEventReport has no companion DB column; toDomainFromPrisma always sets this to the same value as patient.
+                      properties:
+                        patientId:
+                          type: string
+                        companionId:
+                          type: string
+                        name:
+                          type: string
+                        breed:
+                          type: string
+                        dateOfBirth:
+                          type: string
+                        gender:
+                          type: string
+                        currentWeight:
+                          type: string
+                        color:
+                          type: string
+                        neuteredStatus:
+                          type: string
+                        bloodGroup:
+                          type: string
+                        microchipNumber:
+                          type: string
+                        passportNumber:
+                          type: string
+                        insured:
+                          type: string
+                        insuranceCompany:
+                          type: string
+                        insurancePolicyNumber:
+                          type: string
+                        countryOfOrigin:
+                          type: string
+                        originDetails:
+                          type: string
+                    product:
+                      type: object
+                      properties:
+                        productName:
+                          type: string
+                        brandName:
+                          type: string
+                        manufacturingCountry:
+                          type: string
+                        batchNumber:
+                          type: string
+                        numberOfTimesUsed:
+                          type: number
+                        quantityUsed:
+                          type: number
+                        dosageForm:
+                          type: string
+                        administrationRoute:
+                          type: string
+                        reasonToUse:
+                          type: string
+                        conditionBefore:
+                          type: string
+                        conditionAfter:
+                          type: string
+                        eventDate:
+                          type: string
+                        productImageUrl:
+                          type: string
+                    destinations:
+                      type: object
+                      properties:
+                        sendToManufacturer:
+                          type: boolean
+                        sendToHospital:
+                          type: boolean
+                        sendToAuthority:
+                          type: boolean
+                    consent:
+                      type: object
+                      properties:
+                        agreedToContact:
+                          type: boolean
+                        agreedToTermsAt:
+                          type: string
+                          format: date-time
+                    status:
+                      type: string
+                      enum:
+                        - DRAFT
+                        - SUBMITTED
+                        - REVIEWING
+                        - FORWARDED
+                        - CLOSED
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/adverse-event/{id}':
     get:
       tags:
@@ -154,7 +551,196 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - appointmentId
+                  - reporter
+                  - patient
+                  - companion
+                  - product
+                  - destinations
+                  - consent
+                  - status
+                  - createdAt
+                  - updatedAt
+                description: Single report from AdverseEventService.getById, mapped through toDomainFromPrisma (apps/backend/src/services/adverse-event.service.ts). A missing id returns 404 with {message} instead (not this schema).
+                properties:
+                  id:
+                    type: string
+                  organisationId:
+                    type: string
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  reporter:
+                    type: object
+                    properties:
+                      userId:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - PARENT
+                          - CO_PARENT
+                          - CLINIC_STAFF
+                      firstName:
+                        type: string
+                      lastName:
+                        type: string
+                      phoneNumber:
+                        type: string
+                      email:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      addressLine:
+                        type: string
+                      city:
+                        type: string
+                      state:
+                        type: string
+                      postalCode:
+                        type: string
+                      country:
+                        type: string
+                      currency:
+                        type: string
+                    description: Stored as a Prisma Json column with no DB-level shape; see packages/types/src/adverse-event.ts AdverseEventReporterInfo for the application contract.
+                  patient:
+                    type: object
+                    properties:
+                      patientId:
+                        type: string
+                      companionId:
+                        type: string
+                      name:
+                        type: string
+                      breed:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      gender:
+                        type: string
+                      currentWeight:
+                        type: string
+                      color:
+                        type: string
+                      neuteredStatus:
+                        type: string
+                      bloodGroup:
+                        type: string
+                      microchipNumber:
+                        type: string
+                      passportNumber:
+                        type: string
+                      insured:
+                        type: string
+                      insuranceCompany:
+                        type: string
+                      insurancePolicyNumber:
+                        type: string
+                      countryOfOrigin:
+                        type: string
+                      originDetails:
+                        type: string
+                  companion:
+                    type: object
+                    description: AdverseEventReport has no companion DB column; toDomainFromPrisma always sets this to the same value as patient.
+                    properties:
+                      patientId:
+                        type: string
+                      companionId:
+                        type: string
+                      name:
+                        type: string
+                      breed:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      gender:
+                        type: string
+                      currentWeight:
+                        type: string
+                      color:
+                        type: string
+                      neuteredStatus:
+                        type: string
+                      bloodGroup:
+                        type: string
+                      microchipNumber:
+                        type: string
+                      passportNumber:
+                        type: string
+                      insured:
+                        type: string
+                      insuranceCompany:
+                        type: string
+                      insurancePolicyNumber:
+                        type: string
+                      countryOfOrigin:
+                        type: string
+                      originDetails:
+                        type: string
+                  product:
+                    type: object
+                    properties:
+                      productName:
+                        type: string
+                      brandName:
+                        type: string
+                      manufacturingCountry:
+                        type: string
+                      batchNumber:
+                        type: string
+                      numberOfTimesUsed:
+                        type: number
+                      quantityUsed:
+                        type: number
+                      dosageForm:
+                        type: string
+                      administrationRoute:
+                        type: string
+                      reasonToUse:
+                        type: string
+                      conditionBefore:
+                        type: string
+                      conditionAfter:
+                        type: string
+                      eventDate:
+                        type: string
+                      productImageUrl:
+                        type: string
+                  destinations:
+                    type: object
+                    properties:
+                      sendToManufacturer:
+                        type: boolean
+                      sendToHospital:
+                        type: boolean
+                      sendToAuthority:
+                        type: boolean
+                  consent:
+                    type: object
+                    properties:
+                      agreedToContact:
+                        type: boolean
+                      agreedToTermsAt:
+                        type: string
+                        format: date-time
+                  status:
+                    type: string
+                    enum:
+                      - DRAFT
+                      - SUBMITTED
+                      - REVIEWING
+                      - FORWARDED
+                      - CLOSED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/adverse-event/{id}/status':
     patch:
       tags:
@@ -173,8 +759,18 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: '{ status: AdverseEventStatus }'
+              required:
+                - status
+              description: 'Body typed as { status: AdverseEventStatus } in AdverseEventController.updateStatus (apps/backend/src/controllers/web/adverse-event.controller.ts); passed straight to AdverseEventService.updateStatus which does prisma.adverseEventReport.update({ data: { status } }).'
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - DRAFT
+                    - SUBMITTED
+                    - REVIEWING
+                    - FORWARDED
+                    - CLOSED
       responses:
         200:
           description: Response
@@ -182,7 +778,195 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - appointmentId
+                  - reporter
+                  - patient
+                  - companion
+                  - product
+                  - destinations
+                  - consent
+                  - status
+                  - createdAt
+                  - updatedAt
+                description: The updated report returned by AdverseEventService.updateStatus, mapped through toDomainFromPrisma - same shape as GET /v1/adverse-event/{id}.
+                properties:
+                  id:
+                    type: string
+                  organisationId:
+                    type: string
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  reporter:
+                    type: object
+                    properties:
+                      userId:
+                        type: string
+                      type:
+                        type: string
+                        enum:
+                          - PARENT
+                          - CO_PARENT
+                          - CLINIC_STAFF
+                      firstName:
+                        type: string
+                      lastName:
+                        type: string
+                      phoneNumber:
+                        type: string
+                      email:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      addressLine:
+                        type: string
+                      city:
+                        type: string
+                      state:
+                        type: string
+                      postalCode:
+                        type: string
+                      country:
+                        type: string
+                      currency:
+                        type: string
+                  patient:
+                    type: object
+                    properties:
+                      patientId:
+                        type: string
+                      companionId:
+                        type: string
+                      name:
+                        type: string
+                      breed:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      gender:
+                        type: string
+                      currentWeight:
+                        type: string
+                      color:
+                        type: string
+                      neuteredStatus:
+                        type: string
+                      bloodGroup:
+                        type: string
+                      microchipNumber:
+                        type: string
+                      passportNumber:
+                        type: string
+                      insured:
+                        type: string
+                      insuranceCompany:
+                        type: string
+                      insurancePolicyNumber:
+                        type: string
+                      countryOfOrigin:
+                        type: string
+                      originDetails:
+                        type: string
+                  companion:
+                    type: object
+                    description: AdverseEventReport has no companion DB column; toDomainFromPrisma always sets this to the same value as patient.
+                    properties:
+                      patientId:
+                        type: string
+                      companionId:
+                        type: string
+                      name:
+                        type: string
+                      breed:
+                        type: string
+                      dateOfBirth:
+                        type: string
+                      gender:
+                        type: string
+                      currentWeight:
+                        type: string
+                      color:
+                        type: string
+                      neuteredStatus:
+                        type: string
+                      bloodGroup:
+                        type: string
+                      microchipNumber:
+                        type: string
+                      passportNumber:
+                        type: string
+                      insured:
+                        type: string
+                      insuranceCompany:
+                        type: string
+                      insurancePolicyNumber:
+                        type: string
+                      countryOfOrigin:
+                        type: string
+                      originDetails:
+                        type: string
+                  product:
+                    type: object
+                    properties:
+                      productName:
+                        type: string
+                      brandName:
+                        type: string
+                      manufacturingCountry:
+                        type: string
+                      batchNumber:
+                        type: string
+                      numberOfTimesUsed:
+                        type: number
+                      quantityUsed:
+                        type: number
+                      dosageForm:
+                        type: string
+                      administrationRoute:
+                        type: string
+                      reasonToUse:
+                        type: string
+                      conditionBefore:
+                        type: string
+                      conditionAfter:
+                        type: string
+                      eventDate:
+                        type: string
+                      productImageUrl:
+                        type: string
+                  destinations:
+                    type: object
+                    properties:
+                      sendToManufacturer:
+                        type: boolean
+                      sendToHospital:
+                        type: boolean
+                      sendToAuthority:
+                        type: boolean
+                  consent:
+                    type: object
+                    properties:
+                      agreedToContact:
+                        type: boolean
+                      agreedToTermsAt:
+                        type: string
+                        format: date-time
+                  status:
+                    type: string
+                    enum:
+                      - DRAFT
+                      - SUBMITTED
+                      - REVIEWING
+                      - FORWARDED
+                      - CLOSED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   /fhir/v1/appointment/mobile:
     post:
       tags:
@@ -708,7 +1492,81 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'Caveat: in the current router, GET and POST /v1/audit-trail/companion both map to AuditTrailController.listForCompanion, and that handler immediately returns 405 {message} when req.method === "GET" - so this 200 is not actually reachable via GET in the code as written today. This schema documents the real body the same handler sends on success (called via POST with patientId in the body): res.status(200).json(results) where results = AuditTrailService.listForOrganisation(...), built by buildCursorResponse from prisma.auditTrail.findMany rows (apps/backend/src/services/audit-trail.service.ts).'
+                required:
+                  - entries
+                  - nextCursor
+                properties:
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - organisationId
+                        - patientId
+                        - eventType
+                        - occurredAt
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        organisationId:
+                          type: string
+                        patientId:
+                          type: string
+                        eventType:
+                          type: string
+                          description: AuditEventType enum value - one of roughly 180 values covering appointment, invoice, document, form, task, companion-card, vaccination and other clinical/administrative events (packages/database/prisma/schema.prisma); too numerous to enumerate reliably here.
+                        actorType:
+                          type: string
+                          nullable: true
+                          enum:
+                            - PMS_USER
+                            - PARENT
+                            - SYSTEM
+                        actorId:
+                          type: string
+                          nullable: true
+                        actorName:
+                          type: string
+                          nullable: true
+                        entityType:
+                          type: string
+                          nullable: true
+                          enum:
+                            - PATIENT_ORGANISATION
+                            - APPOINTMENT
+                            - ENCOUNTER
+                            - INVOICE
+                            - DOCUMENT
+                            - FORM
+                            - TASK
+                            - PARENT
+                            - COMPANION
+                        entityId:
+                          type: string
+                          nullable: true
+                        metadata:
+                          type: object
+                          nullable: true
+                          additionalProperties: true
+                          description: metadata is a Prisma Json column with no fixed shape; its keys vary by eventType.
+                        occurredAt:
+                          type: string
+                          format: date-time
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                  nextCursor:
+                    type: string
+                    format: date-time
+                    nullable: true
+                    description: ISO timestamp of the last returned entry's occurredAt, for cursor pagination via the `before` param; null when the page is empty.
   '/v1/audit-trail/appointment/{appointmentId}':
     get:
       tags:
@@ -736,7 +1594,81 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'Caveat: in the current router, GET and POST /v1/audit-trail/appointment both map to AuditTrailController.listForAppointment, and that handler immediately returns 405 {message} when req.method === "GET" - so this 200 is not actually reachable via GET in the code as written today. This schema documents the real body the same handler sends on success (called via POST with appointmentId in the body): res.status(200).json(results) where results = AuditTrailService.listForAppointment(...), built by buildCursorResponse from prisma.auditTrail.findMany rows (apps/backend/src/services/audit-trail.service.ts). Same entry shape as the companion endpoint; this handler does not accept eventTypes/entityTypes filters.'
+                required:
+                  - entries
+                  - nextCursor
+                properties:
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - organisationId
+                        - patientId
+                        - eventType
+                        - occurredAt
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        organisationId:
+                          type: string
+                        patientId:
+                          type: string
+                        eventType:
+                          type: string
+                          description: AuditEventType enum value - one of roughly 180 values (packages/database/prisma/schema.prisma); too numerous to enumerate reliably here.
+                        actorType:
+                          type: string
+                          nullable: true
+                          enum:
+                            - PMS_USER
+                            - PARENT
+                            - SYSTEM
+                        actorId:
+                          type: string
+                          nullable: true
+                        actorName:
+                          type: string
+                          nullable: true
+                        entityType:
+                          type: string
+                          nullable: true
+                          enum:
+                            - PATIENT_ORGANISATION
+                            - APPOINTMENT
+                            - ENCOUNTER
+                            - INVOICE
+                            - DOCUMENT
+                            - FORM
+                            - TASK
+                            - PARENT
+                            - COMPANION
+                        entityId:
+                          type: string
+                          nullable: true
+                        metadata:
+                          type: object
+                          nullable: true
+                          additionalProperties: true
+                          description: metadata is a Prisma Json column with no fixed shape; its keys vary by eventType (audit rows for appointments are also matched via metadata.appointmentId when entityType isn't APPOINTMENT).
+                        occurredAt:
+                          type: string
+                          format: date-time
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                  nextCursor:
+                    type: string
+                    format: date-time
+                    nullable: true
+                    description: ISO timestamp of the last returned entry's occurredAt; null when the page is empty.
   /v1/authUser/signup:
     post:
       tags:
@@ -752,7 +1684,69 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - success
+                  - authUser
+                  - parentLinked
+                  - parent
+                properties:
+                  success:
+                    type: boolean
+                  authUser:
+                    type: object
+                    description: AuthUserMobileService.createOrGetAuthUser result (the AuthUserMobile row).
+                    required:
+                      - id
+                      - authProvider
+                      - providerUserId
+                      - email
+                      - parentId
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      id:
+                        type: string
+                      authProvider:
+                        type: string
+                        enum:
+                          - cognito
+                          - firebase
+                          - supertokens
+                      providerUserId:
+                        type: string
+                      email:
+                        type: string
+                      parentId:
+                        type: string
+                        nullable: true
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                  parentLinked:
+                    type: boolean
+                    description: true when an existing Parent row was auto-linked by verified email (AuthUserMobileService.autoLinkParentByEmail).
+                  parent:
+                    type: object
+                    nullable: true
+                    description: The auto-linked Parent row, or null when no verified-email match was found.
+                    required:
+                      - id
+                      - firstName
+                      - lastName
+                      - email
+                    properties:
+                      id:
+                        type: string
+                      firstName:
+                        type: string
+                      lastName:
+                        type: string
+                        nullable: true
+                      email:
+                        type: string
   '/fhir/v1/availability/{orgId}/base':
     post:
       tags:
@@ -778,7 +1772,49 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: AvailabilityController.setAllBaseAvailability -> saveBaseAvailability actually replies res.status(201) (spec documents this under the '200' key, not what the code sends).
+                required:
+                  - message
+                  - data
+                properties:
+                  message:
+                    type: string
+                    example: Base availability saved
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - dayOfWeek
+                        - slots
+                      properties:
+                        dayOfWeek:
+                          type: string
+                          enum:
+                            - MONDAY
+                            - TUESDAY
+                            - WEDNESDAY
+                            - THURSDAY
+                            - FRIDAY
+                            - SATURDAY
+                            - SUNDAY
+                        slots:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - startTime
+                              - endTime
+                              - isAvailable
+                            properties:
+                              startTime:
+                                type: string
+                                description: HH:mm
+                              endTime:
+                                type: string
+                                description: HH:mm
+                              isAvailable:
+                                type: boolean
     get:
       tags:
         - FHIR
@@ -803,7 +1839,61 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - _id
+                        - userId
+                        - organisationId
+                        - dayOfWeek
+                        - slots
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        _id:
+                          type: string
+                        userId:
+                          type: string
+                        organisationId:
+                          type: string
+                        dayOfWeek:
+                          type: string
+                          enum:
+                            - MONDAY
+                            - TUESDAY
+                            - WEDNESDAY
+                            - THURSDAY
+                            - FRIDAY
+                            - SATURDAY
+                            - SUNDAY
+                        slots:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - startTime
+                              - endTime
+                              - isAvailable
+                            properties:
+                              startTime:
+                                type: string
+                                description: HH:mm
+                              endTime:
+                                type: string
+                                description: HH:mm
+                              isAvailable:
+                                type: boolean
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
     delete:
       tags:
         - FHIR
@@ -828,7 +1918,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: Base availability deleted
   '/fhir/v1/availability/{orgId}/{userId}/base':
     post:
       tags:
@@ -859,7 +1954,49 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: AvailabilityController.setBaseAvailabilityForUser -> saveBaseAvailability actually replies res.status(201) (spec documents this under the '200' key, not what the code sends). Same shape as POST /{orgId}/base.
+                required:
+                  - message
+                  - data
+                properties:
+                  message:
+                    type: string
+                    example: Base availability saved
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - dayOfWeek
+                        - slots
+                      properties:
+                        dayOfWeek:
+                          type: string
+                          enum:
+                            - MONDAY
+                            - TUESDAY
+                            - WEDNESDAY
+                            - THURSDAY
+                            - FRIDAY
+                            - SATURDAY
+                            - SUNDAY
+                        slots:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - startTime
+                              - endTime
+                              - isAvailable
+                            properties:
+                              startTime:
+                                type: string
+                                description: HH:mm
+                              endTime:
+                                type: string
+                                description: HH:mm
+                              isAvailable:
+                                type: boolean
   '/fhir/v1/availability/{orgId}/weekly':
     post:
       tags:
@@ -885,7 +2022,13 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: AvailabilityController.addWeeklyAvailabilityOverride actually replies res.status(201) (spec documents this under the '200' key, not what the code sends). Only a message is returned, no data.
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: Weekly override added
     get:
       tags:
         - FHIR
@@ -910,7 +2053,66 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - userId
+                      - organisationId
+                      - weekStartDate
+                      - overrides
+                      - createdAt
+                    properties:
+                      _id:
+                        type: string
+                      userId:
+                        type: string
+                      organisationId:
+                        type: string
+                      weekStartDate:
+                        type: string
+                        format: date-time
+                      overrides:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - dayOfWeek
+                            - slots
+                          properties:
+                            dayOfWeek:
+                              type: string
+                              enum:
+                                - MONDAY
+                                - TUESDAY
+                                - WEDNESDAY
+                                - THURSDAY
+                                - FRIDAY
+                                - SATURDAY
+                                - SUNDAY
+                            slots:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - startTime
+                                  - endTime
+                                  - isAvailable
+                                properties:
+                                  startTime:
+                                    type: string
+                                    description: HH:mm
+                                  endTime:
+                                    type: string
+                                    description: HH:mm
+                                  isAvailable:
+                                    type: boolean
+                      createdAt:
+                        type: string
+                        format: date-time
     delete:
       tags:
         - FHIR
@@ -935,7 +2137,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: Override deleted
   '/fhir/v1/availability/{orgId}/occupancy':
     post:
       tags:
@@ -961,7 +2168,13 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: AvailabilityController.addOccupancy actually replies res.status(201) (spec documents this under the '200' key, not what the code sends). Only a message is returned, no data.
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: Occupancy added
     get:
       tags:
         - FHIR
@@ -986,7 +2199,51 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      description: Raw Prisma Occupancy row (AvailabilityService.getOccupancy returns prisma.occupancy.findMany results unmapped).
+                      required:
+                        - id
+                        - userId
+                        - organisationId
+                        - startTime
+                        - endTime
+                        - sourceType
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        userId:
+                          type: string
+                        organisationId:
+                          type: string
+                        startTime:
+                          type: string
+                          format: date-time
+                        endTime:
+                          type: string
+                          format: date-time
+                        sourceType:
+                          type: string
+                          enum:
+                            - APPOINTMENT
+                            - BLOCKED
+                            - SURGERY
+                        referenceId:
+                          type: string
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
   '/fhir/v1/availability/{orgId}/occupancy/bulk':
     post:
       tags:
@@ -1012,7 +2269,13 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: AvailabilityController.addAllOccupancies actually replies res.status(201) (spec documents this under the '200' key, not what the code sends). Only a message is returned, no data.
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: Occupancies added
   '/fhir/v1/availability/{orgId}/final':
     get:
       tags:
@@ -1038,7 +2301,47 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                properties:
+                  data:
+                    type: object
+                    description: "AvailabilityService.getFinalAvailabilityForDate: one day's slots after merging base availability, any weekly override, and occupancies."
+                    required:
+                      - date
+                      - dayOfWeek
+                      - slots
+                    properties:
+                      date:
+                        type: string
+                        description: YYYY-MM-DD
+                      dayOfWeek:
+                        type: string
+                        enum:
+                          - MONDAY
+                          - TUESDAY
+                          - WEDNESDAY
+                          - THURSDAY
+                          - FRIDAY
+                          - SATURDAY
+                          - SUNDAY
+                      slots:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - startTime
+                            - endTime
+                            - isAvailable
+                          properties:
+                            startTime:
+                              type: string
+                              description: HH:mm
+                            endTime:
+                              type: string
+                              description: HH:mm
+                            isAvailable:
+                              type: boolean
   '/fhir/v1/availability/{orgId}/status':
     get:
       tags:
@@ -1064,7 +2367,17 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - status
+                properties:
+                  status:
+                    type: string
+                    description: "AvailabilityService.getCurrentStatus: Consulting when occupied right now, else Available/Unavailable/Off-Duty from today's merged slots."
+                    enum:
+                      - Consulting
+                      - Available
+                      - Off-Duty
+                      - Unavailable
   /v1/chat/mobile/token:
     post:
       tags:
@@ -1080,7 +2393,16 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - token
+                  - expiresAt
+                properties:
+                  token:
+                    type: string
+                    description: Stream Chat user token signed with the server secret (ChatService.generateToken / streamServer.createToken).
+                  expiresAt:
+                    type: number
+                    description: Unix ms timestamp computed as Date.now() + 24h by the server; a client-side refresh hint, not a claim decoded from the token itself.
   '/v1/chat/mobile/appointments/{appointmentId}':
     post:
       tags:
@@ -1102,7 +2424,96 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                    description: Same value as id; a Mongo-shaped alias added by ChatService.toChatSessionDocument for client compatibility.
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - APPOINTMENT
+                      - ORG_DIRECT
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id backing this session, e.g. appointment-<appointmentId>.
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                    description: "Set only for cross-clinic sessions: the other clinic's organisation id."
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                    nullable: true
+                  isPrivate:
+                    type: boolean
+                  members:
+                    type: array
+                    items:
+                      type: string
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape; not populated by any traced code path in ChatService.
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - CLOSED
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/chat/mobile/sessions/{sessionId}/open':
     post:
       tags:
@@ -1124,7 +2535,20 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - channelId
+                  - token
+                  - expiresAt
+                properties:
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id for the requested session.
+                  token:
+                    type: string
+                    description: Stream Chat user token for the calling user.
+                  expiresAt:
+                    type: number
+                    description: Unix ms timestamp computed as Date.now() + 24h by ChatService.generateToken; a client-side refresh hint.
   /v1/chat/mobile/sessions:
     get:
       tags:
@@ -1139,8 +2563,98 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - _id
+                    - id
+                    - type
+                    - channelId
+                    - organisationId
+                    - isPrivate
+                    - members
+                    - supportStaffIds
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    _id:
+                      type: string
+                    id:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                        - APPOINTMENT
+                        - ORG_DIRECT
+                        - ORG_GROUP
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    channelId:
+                      type: string
+                    organisationId:
+                      type: string
+                    counterpartOrganisationId:
+                      type: string
+                      nullable: true
+                      description: Set only for cross-clinic sessions.
+                    patientId:
+                      type: string
+                      nullable: true
+                    parentId:
+                      type: string
+                      nullable: true
+                    vetId:
+                      type: string
+                      nullable: true
+                    supportStaffIds:
+                      type: array
+                      items:
+                        type: string
+                    createdBy:
+                      type: string
+                      nullable: true
+                    title:
+                      type: string
+                      nullable: true
+                    isPrivate:
+                      type: boolean
+                    members:
+                      type: array
+                      items:
+                        type: string
+                    participants:
+                      type: object
+                      additionalProperties: true
+                      nullable: true
+                      description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - ACTIVE
+                        - CLOSED
+                    allowedFrom:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    allowedUntil:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    closedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
+                description: ChatController.listMySessions maps each row through toChatSessionResponse; results are ordered updatedAt desc and scoped to sessions where the caller is a member, matching either organisationId or counterpartOrganisationId (the ?includeClosed=true query param includes CLOSED sessions).
   /v1/chat/pms/token:
     post:
       tags:
@@ -1156,7 +2670,16 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - token
+                  - expiresAt
+                properties:
+                  token:
+                    type: string
+                    description: Stream Chat user token signed with the server secret (ChatService.generateToken / streamServer.createToken).
+                  expiresAt:
+                    type: number
+                    description: Unix ms timestamp computed as Date.now() + 24h by the server; a client-side refresh hint.
   '/v1/chat/pms/appointments/{appointmentId}':
     post:
       tags:
@@ -1178,7 +2701,96 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                    description: Same value as id; Mongo-shaped alias added by ChatService.toChatSessionDocument.
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - APPOINTMENT
+                      - ORG_DIRECT
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id, e.g. appointment-<appointmentId>.
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                    nullable: true
+                  isPrivate:
+                    type: boolean
+                  members:
+                    type: array
+                    items:
+                      type: string
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - CLOSED
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: 'Same handler as the mobile route (ChatController.ensureAppointmentSession -> ChatService.ensureAppointmentChat): creates the session on first call, returns the existing one on repeat calls.'
   /v1/chat/pms/org/direct:
     post:
       tags:
@@ -1194,7 +2806,92 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - ORG_DIRECT
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id, format od_<sha256 hash of orgId+sorted member ids>.
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    description: userA, the caller who initiated the direct chat.
+                  title:
+                    type: string
+                    nullable: true
+                  isPrivate:
+                    type: boolean
+                  members:
+                    type: array
+                    items:
+                      type: string
+                    description: Exactly [userA, userB] sorted lexicographically; used to dedupe repeat calls for the same pair.
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape; not populated by ChatService.createOrgDirectChat.
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: ChatController.createOrgDirectChat actually responds res.status(201).json(session); the spec's existing '200' key is documented here as-is, kept unchanged by this task (status-code correction is out of scope).
   /v1/chat/pms/org/group:
     post:
       tags:
@@ -1210,7 +2907,93 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id, format org-group-<epoch ms>.
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    description: The caller who created the group.
+                  title:
+                    type: string
+                    description: Group chat title supplied in the request body.
+                  isPrivate:
+                    type: boolean
+                    description: Defaults to true when not supplied in the request.
+                  members:
+                    type: array
+                    items:
+                      type: string
+                    description: Deduplicated union of the requested memberIds plus the creator.
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape; not populated by ChatService.createOrgGroupChat.
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: ChatController.createOrgGroupChat actually responds res.status(201).json(session); the spec's existing '200' key is documented here as-is, kept unchanged by this task.
   '/v1/chat/pms/sessions/{sessionId}/open':
     post:
       tags:
@@ -1232,7 +3015,21 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - channelId
+                  - token
+                  - expiresAt
+                properties:
+                  channelId:
+                    type: string
+                    description: Stream Chat channel id for the requested session.
+                  token:
+                    type: string
+                    description: Stream Chat user token for the calling user.
+                  expiresAt:
+                    type: number
+                    description: Unix ms timestamp computed as Date.now() + 24h; a client-side refresh hint.
+                description: Same handler as the mobile open-session route (ChatController.openChat -> ChatService.openChatBySessionId).
   '/v1/chat/pms/sessions/{organisationId}':
     get:
       tags:
@@ -1253,8 +3050,98 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - _id
+                    - id
+                    - type
+                    - channelId
+                    - organisationId
+                    - isPrivate
+                    - members
+                    - supportStaffIds
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    _id:
+                      type: string
+                    id:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                        - APPOINTMENT
+                        - ORG_DIRECT
+                        - ORG_GROUP
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    channelId:
+                      type: string
+                    organisationId:
+                      type: string
+                    counterpartOrganisationId:
+                      type: string
+                      nullable: true
+                      description: Set only for cross-clinic sessions.
+                    patientId:
+                      type: string
+                      nullable: true
+                    parentId:
+                      type: string
+                      nullable: true
+                    vetId:
+                      type: string
+                      nullable: true
+                    supportStaffIds:
+                      type: array
+                      items:
+                        type: string
+                    createdBy:
+                      type: string
+                      nullable: true
+                    title:
+                      type: string
+                      nullable: true
+                    isPrivate:
+                      type: boolean
+                    members:
+                      type: array
+                      items:
+                        type: string
+                    participants:
+                      type: object
+                      additionalProperties: true
+                      nullable: true
+                      description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - ACTIVE
+                        - CLOSED
+                    allowedFrom:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    allowedUntil:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    closedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
+                description: Same handler as GET /v1/chat/mobile/sessions (ChatController.listMySessions), here scoped by the :organisationId path param instead of a session lookup, matching sessions where organisationId or counterpartOrganisationId equals it and the caller is a member (?includeClosed=true includes CLOSED sessions).
   '/v1/chat/pms/sessions/{sessionId}/close':
     post:
       tags:
@@ -1276,7 +3163,14 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Chat closed successfully
+                description: ChatController.closeSession literal success body; ChatService.closeSession marks the session CLOSED and freezes the Stream channel.
   '/v1/chat/pms/groups/{sessionId}/members/add':
     post:
       tags:
@@ -1298,7 +3192,93 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                    nullable: true
+                  isPrivate:
+                    type: boolean
+                  members:
+                    type: array
+                    items:
+                      type: string
+                    description: Updated member list, existing members plus any newly added ids (ids already present are silently ignored).
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - CLOSED
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: ChatController.addGroupMembers returns the updated (or unchanged, if all requested ids were already members) session via ChatService.addMembersToGroup.
   '/v1/chat/pms/groups/{sessionId}/members/remove':
     post:
       tags:
@@ -1320,7 +3300,93 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                    nullable: true
+                  isPrivate:
+                    type: boolean
+                  members:
+                    type: array
+                    items:
+                      type: string
+                    description: Member list with the requested ids removed; the group owner (createdBy) cannot be removed and at least 2 members must remain, or the service rejects the call with 400 before this response is produced.
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - CLOSED
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: ChatController.removeGroupMembers returns the updated session via ChatService.removeMembersFromGroup.
   '/v1/chat/pms/groups/{sessionId}':
     patch:
       tags:
@@ -1342,7 +3408,94 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - _id
+                  - id
+                  - type
+                  - channelId
+                  - organisationId
+                  - isPrivate
+                  - members
+                  - supportStaffIds
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  _id:
+                    type: string
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - ORG_GROUP
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  channelId:
+                    type: string
+                  organisationId:
+                    type: string
+                  counterpartOrganisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  vetId:
+                    type: string
+                    nullable: true
+                  supportStaffIds:
+                    type: array
+                    items:
+                      type: string
+                  createdBy:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                    nullable: true
+                    description: Updated title if supplied in the request body, otherwise unchanged.
+                  isPrivate:
+                    type: boolean
+                    description: Updated visibility if supplied in the request body, otherwise unchanged.
+                  members:
+                    type: array
+                    items:
+                      type: string
+                  participants:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: Prisma Json column (ChatSession.participants) with no fixed shape.
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - CLOSED
+                  allowedFrom:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  allowedUntil:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  closedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: ChatController.updateGroup returns the updated session via ChatService.updateGroup (title/isPrivate patched, only the group owner may call this).
     delete:
       tags:
         - 'Non-FHIR'
@@ -1363,7 +3516,14 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Group deleted successfully
+                description: ChatController.deleteGroup literal success body; ChatService.deleteGroup deletes the Stream channel (best-effort) then hard-deletes the ChatSession row.
   '/v1/companion-organisation/link':
     post:
       tags:
@@ -1795,8 +3955,46 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: 'CompanionOrganisationService.getLinksForOrganisation: every ACTIVE or PENDING PatientOrganisation link for the organisation, with the companion and its primary parent attached.'
+                items:
+                  type: object
+                  required:
+                    - linkId
+                    - organisationType
+                    - status
+                    - companion
+                    - parent
+                  properties:
+                    linkId:
+                      type: string
+                    organisationId:
+                      type: string
+                      description: Omitted when the underlying PatientOrganisation row has no organisationId set.
+                    organisationType:
+                      type: string
+                      enum:
+                        - HOSPITAL
+                        - BREEDER
+                        - BOARDER
+                        - GROOMER
+                    status:
+                      type: string
+                      enum:
+                        - ACTIVE
+                        - PENDING
+                        - REVOKED
+                        - INVITED
+                    companion:
+                      nullable: true
+                      description: FHIR Patient resource for the companion (toFHIRCompanionFromPrisma), or null if no matching Patient row was found.
+                      allOf:
+                        - $ref: '#/components/schemas/Patient'
+                    parent:
+                      nullable: true
+                      description: FHIR RelatedPerson resource for the companion's PRIMARY active parent (toFHIRParentFromPrisma via toLinkParent); address is withheld while the link status is PENDING. Null if no active primary parent link exists.
+                      allOf:
+                        - $ref: '#/components/schemas/RelatedPerson'
         500:
           description: Response
           content:
@@ -1964,7 +4162,16 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - url
+                  - key
+                properties:
+                  url:
+                    type: string
+                    description: Pre-signed S3 upload URL for the companion's profile image, from generatePresignedUrl(mimeType, 'temp') (src/middlewares/upload.ts), shared by getProfileUploadUrl in profile-upload.handler.ts.
+                  key:
+                    type: string
+                    description: Storage key the uploaded object will live at once PUT to `url`.
         500:
           description: Response
           content:
@@ -2265,7 +4472,13 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: ContactController.create sends this body via res.status(201).json({ id }) on success (apps/backend/src/controllers/app/contact-us.controller.ts) - note the real status code is 201, not the 200 this spec entry is filed under.
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                    description: id of the created ContactRequest row (prisma.contactRequest.create).
   '/v1/contact-us/requests':
     get:
       tags:
@@ -2280,8 +4493,157 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: ContactController.list returns res.json(docs) where docs = prisma.contactRequest.findMany(...) (src/services/contact-us.service.ts listRequests), capped at 100 rows, newest first.
+                items:
+                  type: object
+                  required:
+                    - id
+                    - type
+                    - source
+                    - subject
+                    - message
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                        - GENERAL_ENQUIRY
+                        - FEATURE_REQUEST
+                        - DSAR
+                        - COMPLAINT
+                    source:
+                      type: string
+                      enum:
+                        - MOBILE_APP
+                        - PMS_WEB
+                        - MARKETING_SITE
+                    subject:
+                      type: string
+                    message:
+                      type: string
+                    userId:
+                      type: string
+                      nullable: true
+                    email:
+                      type: string
+                      nullable: true
+                    organisationId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                      nullable: true
+                    parentId:
+                      type: string
+                      nullable: true
+                    dsarDetails:
+                      type: object
+                      nullable: true
+                      description: Present only when type=DSAR. Stored as a Prisma Json column but always written in this shape by ContactService.createRequest/createWebRequest (src/models/contect-us.ts DsraDetails).
+                      properties:
+                        requesterType:
+                          type: string
+                          enum:
+                            - SELF
+                            - PARENT_GUARDIAN
+                            - AUTHORIZED_AGENT
+                        lawBasis:
+                          type: string
+                          nullable: true
+                          enum:
+                            - GDPR
+                            - CCPA
+                            - UK_GDPR
+                            - LGPD
+                            - PIPEDA
+                            - POPIA
+                            - PDPA
+                            - PIPL
+                            - PA_1988_AU
+                            - OTHER
+                        otherLawText:
+                          type: string
+                          nullable: true
+                        rightsRequested:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - KNOW_INFORMATION_COLLECTED
+                              - ACCESS_PERSONAL_INFORMATION
+                              - DELETE_DATA
+                              - RECTIFY_INACCURATE_INFORMATION
+                              - RESTRICT_PROCESSING
+                              - PORTABILITY_COPY
+                              - OPT_OUT_SELLING_SHARING
+                              - LIMIT_SENSITIVE_PROCESSING
+                              - OTHER
+                        otherRightText:
+                          type: string
+                          nullable: true
+                        dataSubjectDescription:
+                          type: string
+                          nullable: true
+                        declarationAccepted:
+                          type: boolean
+                        declarationAcceptedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                    complaintContext:
+                      type: object
+                      nullable: true
+                      description: 'Stored as a Prisma Json column. Only createWebRequest populates it, via buildComplaintContext (src/services/contact-us.service.ts): {fullName, phone} - not the {aboutOrganisationId, aboutAppointmentId} shape declared in the ContactRequestMongo TS interface, which no code path actually writes.'
+                      properties:
+                        fullName:
+                          type: string
+                        phone:
+                          type: string
+                          nullable: true
+                    attachments:
+                      type: array
+                      nullable: true
+                      description: Stored as a Prisma Json column; app-level shape from src/models/contect-us.ts ContactAttachment.
+                      items:
+                        type: object
+                        required:
+                          - url
+                          - name
+                        properties:
+                          id:
+                            type: string
+                            nullable: true
+                          url:
+                            type: string
+                          name:
+                            type: string
+                          contentType:
+                            type: string
+                            nullable: true
+                          sizeBytes:
+                            type: number
+                            nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - OPEN
+                        - IN_PROGRESS
+                        - RESOLVED
+                        - CLOSED
+                    internalNotes:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/contact-us/requests/{id}/status':
     patch:
       tags:
@@ -2303,7 +4665,84 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: ContactController.updateStatus returns res.json(updated) where updated = prisma.contactRequest.update({where:{id}, data:{status}}) (src/services/contact-us.service.ts updateStatus) - the full updated ContactRequest row, same shape as one item from GET /v1/contact-us/requests.
+                required:
+                  - id
+                  - type
+                  - source
+                  - subject
+                  - message
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - GENERAL_ENQUIRY
+                      - FEATURE_REQUEST
+                      - DSAR
+                      - COMPLAINT
+                  source:
+                    type: string
+                    enum:
+                      - MOBILE_APP
+                      - PMS_WEB
+                      - MARKETING_SITE
+                  subject:
+                    type: string
+                  message:
+                    type: string
+                  userId:
+                    type: string
+                    nullable: true
+                  email:
+                    type: string
+                    nullable: true
+                  organisationId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  parentId:
+                    type: string
+                    nullable: true
+                  dsarDetails:
+                    type: object
+                    nullable: true
+                    description: Prisma Json column; app-level DsraDetails shape, present only when type=DSAR.
+                    additionalProperties: true
+                  complaintContext:
+                    type: object
+                    nullable: true
+                    description: Prisma Json column; when present it holds {fullName, phone} written by buildComplaintContext.
+                    additionalProperties: true
+                  attachments:
+                    type: array
+                    nullable: true
+                    description: Prisma Json column; app-level ContactAttachment[] shape.
+                    items:
+                      type: object
+                      additionalProperties: true
+                  status:
+                    type: string
+                    enum:
+                      - OPEN
+                      - IN_PROGRESS
+                      - RESOLVED
+                      - CLOSED
+                  internalNotes:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/coparent-invite/sent':
     post:
       tags:
@@ -2753,7 +5192,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    description: Literal 'Device token registered successfully.' on success (see DeviceTokenController.registerDeviceToken).
   '/v1/device-token/unregister':
     post:
       tags:
@@ -2769,7 +5213,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    description: Literal 'Device token unregistered successfully.' on success (see DeviceTokenController.unregisterDeviceToken).
   '/v1/documenso/pms/redirect/{orgId}':
     post:
       tags:
@@ -2797,7 +5246,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - redirectUrl
+                properties:
+                  redirectUrl:
+                    type: string
+                    description: Documenso external embed/redirect URL generated by DocumensoService.generateExternalRedirectUrl for the authenticated user to complete Documenso account access for this organisation.
   '/v1/documenso/pms/store-api-key/{orgId}':
     post:
       tags:
@@ -2817,7 +5271,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - success
+                properties:
+                  success:
+                    type: boolean
+                    description: true once the organisation's Documenso API key has been persisted (DocumensoKeyController.storeApiKey / persistDocumensoApiKey).
   '/v1/document/mobile/upload-url':
     post:
       tags:
@@ -2848,7 +5307,17 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - url
+                  - key
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                    description: Presigned S3 putObject URL, valid 15 minutes (from generatePresignedUrl in src/middlewares/upload.ts).
+                  key:
+                    type: string
+                    description: S3 object key the client must PUT the file to; passed back on document create as an attachment key.
         500:
           description: Response
           content:
@@ -2906,8 +5375,97 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - patientId
+                    - appointmentId
+                    - category
+                    - subcategory
+                    - visitType
+                    - title
+                    - issuingBusinessName
+                    - issueDate
+                    - attachments
+                    - pmsVisible
+                    - syncedFromPms
+                    - uploadedByParentId
+                    - uploadedByPmsUserId
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    patientId:
+                      type: string
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    visitType:
+                      type: string
+                      nullable: true
+                    title:
+                      type: string
+                    issuingBusinessName:
+                      type: string
+                      nullable: true
+                    issueDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    attachments:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - mimeType
+                        properties:
+                          key:
+                            type: string
+                          mimeType:
+                            type: string
+                          size:
+                            type: number
+                    pmsVisible:
+                      type: boolean
+                    syncedFromPms:
+                      type: boolean
+                    uploadedByParentId:
+                      type: string
+                      nullable: true
+                    uploadedByPmsUserId:
+                      type: string
+                      nullable: true
+                    sourceKind:
+                      type: string
+                      description: Present when the row was merged in from RenderedDocument (e-signed/generated docs); plain uploaded Document rows report the literal "DOCUMENT".
+                    sourceId:
+                      type: string
+                    templateId:
+                      type: string
+                      nullable: true
+                    templateVersion:
+                      type: number
+                      nullable: true
+                    signingStatus:
+                      type: string
+                      description: Plain Document rows report SIGNED/NOT_STARTED derived from pmsVisible; RenderedDocument rows pass through their own signing.status value when present, so this is not a fixed enum.
+                    signedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    pdfUrl:
+                      type: string
+                      nullable: true
+                description: DocumentController.listDocumentsForParent -> DocumentService.listForParent, mapped via mapDocumentToDto (document.service.ts).
     delete:
       tags:
         - 'Non-FHIR'
@@ -2930,6 +5488,7 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+                description: "Could not trace a real 200 JSON body: DocumentController.deleteForParent (routers/document.router.ts DELETE /mobile/:documentId) actually calls res.status(204).send() with an empty body on success, and returns a DocumentServiceError JSON ({message}) on failure. The spec's existing 200 slot does not correspond to any real response this handler sends; left opaque rather than inventing a 200 payload."
   '/v1/document/mobile/details/{id}':
     patch:
       tags:
@@ -2950,8 +5509,42 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: 'Partial<DocumentRequestBody'
+              description: Partial<DocumentRequestBody> (controllers/app/document.controller.ts) - every field optional, none validated by a Zod schema; DocumentController.updateDocument passes this straight to DocumentService.update.
+              properties:
+                title:
+                  type: string
+                category:
+                  type: string
+                subcategory:
+                  type: string
+                  nullable: true
+                attachments:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                      - mimeType
+                    properties:
+                      key:
+                        type: string
+                      mimeType:
+                        type: string
+                      size:
+                        type: number
+                appointmentId:
+                  type: string
+                  nullable: true
+                visitType:
+                  type: string
+                  nullable: true
+                issuingBusinessName:
+                  type: string
+                  nullable: true
+                issueDate:
+                  type: string
+                  format: date-time
+                  nullable: true
       responses:
         401:
           description: Response
@@ -3009,8 +5602,96 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - patientId
+                    - appointmentId
+                    - category
+                    - subcategory
+                    - visitType
+                    - title
+                    - issuingBusinessName
+                    - issueDate
+                    - attachments
+                    - pmsVisible
+                    - syncedFromPms
+                    - uploadedByParentId
+                    - uploadedByPmsUserId
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    patientId:
+                      type: string
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    visitType:
+                      type: string
+                      nullable: true
+                    title:
+                      type: string
+                    issuingBusinessName:
+                      type: string
+                      nullable: true
+                    issueDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    attachments:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - mimeType
+                        properties:
+                          key:
+                            type: string
+                          mimeType:
+                            type: string
+                          size:
+                            type: number
+                    pmsVisible:
+                      type: boolean
+                    syncedFromPms:
+                      type: boolean
+                    uploadedByParentId:
+                      type: string
+                      nullable: true
+                    uploadedByPmsUserId:
+                      type: string
+                      nullable: true
+                    sourceKind:
+                      type: string
+                    sourceId:
+                      type: string
+                    templateId:
+                      type: string
+                      nullable: true
+                    templateVersion:
+                      type: number
+                      nullable: true
+                    signingStatus:
+                      type: string
+                      description: Not a fixed enum - see mapDocumentToDto / resolveRenderedSigningStatus in document.service.ts.
+                    signedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    pdfUrl:
+                      type: string
+                      nullable: true
+                description: DocumentController.listForAppointment -> DocumentService.listForAppointmentParent (mobile caller with a parentId) or listForAppointmentPms (org caller), both Promise<DocumentDto[]>.
   '/v1/document/mobile/view/{documentId}':
     get:
       tags:
@@ -3082,8 +5763,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: string
+                format: uri
+                description: DocumentController.getSignedDownloadUrl calls res.status(200).send(url) with a plain string (from DocumentService.getAttachmentUrlByKey), not a JSON object - Content-Type is not application/json on this route.
         500:
           description: Response
           content:
@@ -3176,7 +5858,17 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - url
+                  - key
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                    description: Presigned S3 putObject URL, valid 15 minutes (from generatePresignedUrl in src/middlewares/upload.ts).
+                  key:
+                    type: string
+                    description: S3 object key the client must PUT the file to; passed back on document create as an attachment key.
         500:
           description: Response
           content:
@@ -3213,8 +5905,42 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: unknown
+              description: DocumentRequestBody (controllers/app/document.controller.ts) - not validated by a Zod schema; DocumentController.createDocumentPms passes this to DocumentService.create with title/category read via non-null assertion at runtime, so the type itself still marks them optional.
+              properties:
+                title:
+                  type: string
+                category:
+                  type: string
+                subcategory:
+                  type: string
+                  nullable: true
+                attachments:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                      - mimeType
+                    properties:
+                      key:
+                        type: string
+                      mimeType:
+                        type: string
+                      size:
+                        type: number
+                appointmentId:
+                  type: string
+                  nullable: true
+                visitType:
+                  type: string
+                  nullable: true
+                issuingBusinessName:
+                  type: string
+                  nullable: true
+                issueDate:
+                  type: string
+                  format: date-time
+                  nullable: true
       responses:
         200:
           description: Response
@@ -3222,7 +5948,92 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - patientId
+                  - appointmentId
+                  - category
+                  - subcategory
+                  - visitType
+                  - title
+                  - issuingBusinessName
+                  - issueDate
+                  - attachments
+                  - pmsVisible
+                  - syncedFromPms
+                  - uploadedByParentId
+                  - uploadedByPmsUserId
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  patientId:
+                    type: string
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  visitType:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                  issuingBusinessName:
+                    type: string
+                    nullable: true
+                  issueDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  attachments:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - mimeType
+                      properties:
+                        key:
+                          type: string
+                        mimeType:
+                          type: string
+                        size:
+                          type: number
+                  pmsVisible:
+                    type: boolean
+                  syncedFromPms:
+                    type: boolean
+                  uploadedByParentId:
+                    type: string
+                    nullable: true
+                  uploadedByPmsUserId:
+                    type: string
+                    nullable: true
+                  sourceKind:
+                    type: string
+                  sourceId:
+                    type: string
+                  templateId:
+                    type: string
+                    nullable: true
+                  templateVersion:
+                    type: number
+                    nullable: true
+                  signingStatus:
+                    type: string
+                  signedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  pdfUrl:
+                    type: string
+                    nullable: true
+                description: "NOTE: DocumentController.createDocumentPms actually calls res.status(201).json(created), not 200 - the spec's existing slot is at 200 but the real handler never sends this payload at that status code. Shape shown is the real created DocumentDto (from DocumentService.create) in case the status is corrected; flagging the mismatch rather than silently endorsing it."
   '/v1/document/pms/details/{documentId}':
     get:
       tags:
@@ -3250,7 +6061,92 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - patientId
+                  - appointmentId
+                  - category
+                  - subcategory
+                  - visitType
+                  - title
+                  - issuingBusinessName
+                  - issueDate
+                  - attachments
+                  - pmsVisible
+                  - syncedFromPms
+                  - uploadedByParentId
+                  - uploadedByPmsUserId
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  patientId:
+                    type: string
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  visitType:
+                    type: string
+                    nullable: true
+                  title:
+                    type: string
+                  issuingBusinessName:
+                    type: string
+                    nullable: true
+                  issueDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  attachments:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - mimeType
+                      properties:
+                        key:
+                          type: string
+                        mimeType:
+                          type: string
+                        size:
+                          type: number
+                  pmsVisible:
+                    type: boolean
+                  syncedFromPms:
+                    type: boolean
+                  uploadedByParentId:
+                    type: string
+                    nullable: true
+                  uploadedByPmsUserId:
+                    type: string
+                    nullable: true
+                  sourceKind:
+                    type: string
+                  sourceId:
+                    type: string
+                  templateId:
+                    type: string
+                    nullable: true
+                  templateVersion:
+                    type: number
+                    nullable: true
+                  signingStatus:
+                    type: string
+                  signedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  pdfUrl:
+                    type: string
+                    nullable: true
+                description: DocumentController.getForPms -> DocumentService.getByIdForPms; a null result returns 404 before this point, so 200 always carries a full DocumentDto.
     patch:
       tags:
         - 'Non-FHIR'
@@ -3276,8 +6172,42 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: 'Partial<DocumentRequestBody'
+              description: Partial<DocumentRequestBody> (controllers/app/document.controller.ts) - every field optional, none validated by a Zod schema; DocumentController.updateDocument (same handler as the mobile PATCH) passes this straight to DocumentService.update.
+              properties:
+                title:
+                  type: string
+                category:
+                  type: string
+                subcategory:
+                  type: string
+                  nullable: true
+                attachments:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                      - mimeType
+                    properties:
+                      key:
+                        type: string
+                      mimeType:
+                        type: string
+                      size:
+                        type: number
+                appointmentId:
+                  type: string
+                  nullable: true
+                visitType:
+                  type: string
+                  nullable: true
+                issuingBusinessName:
+                  type: string
+                  nullable: true
+                issueDate:
+                  type: string
+                  format: date-time
+                  nullable: true
       responses:
         401:
           description: Response
@@ -3392,8 +6322,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: string
+                format: uri
+                description: DocumentController.getSignedDownloadUrl (same handler as the mobile POST /view) calls res.status(200).send(url) with a plain string, not a JSON object.
         500:
           description: Response
           content:
@@ -3430,8 +6361,96 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - patientId
+                    - appointmentId
+                    - category
+                    - subcategory
+                    - visitType
+                    - title
+                    - issuingBusinessName
+                    - issueDate
+                    - attachments
+                    - pmsVisible
+                    - syncedFromPms
+                    - uploadedByParentId
+                    - uploadedByPmsUserId
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    patientId:
+                      type: string
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    visitType:
+                      type: string
+                      nullable: true
+                    title:
+                      type: string
+                    issuingBusinessName:
+                      type: string
+                      nullable: true
+                    issueDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    attachments:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - mimeType
+                        properties:
+                          key:
+                            type: string
+                          mimeType:
+                            type: string
+                          size:
+                            type: number
+                    pmsVisible:
+                      type: boolean
+                    syncedFromPms:
+                      type: boolean
+                    uploadedByParentId:
+                      type: string
+                      nullable: true
+                    uploadedByPmsUserId:
+                      type: string
+                      nullable: true
+                    sourceKind:
+                      type: string
+                    sourceId:
+                      type: string
+                    templateId:
+                      type: string
+                      nullable: true
+                    templateVersion:
+                      type: number
+                      nullable: true
+                    signingStatus:
+                      type: string
+                      description: Not a fixed enum - see mapDocumentToDto / resolveRenderedSigningStatus in document.service.ts.
+                    signedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    pdfUrl:
+                      type: string
+                      nullable: true
+                description: DocumentController.listForAppointment (same handler as the mobile POST /appointments/:id) -> DocumentService.listForAppointmentPms for an org caller.
   /v1/expense/:
     post:
       tags:
@@ -4085,7 +7104,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'FormSigningController.startSigning''s catch block: res.status(400).json({ message }) where message = err.message if err is an Error, else the literal fallback "Failed to start signing" (apps/backend/src/controllers/web/formSigning.contorller.ts).'
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
   '/fhir/v1/form/form-submissions/{submissionId}/signed-document':
     get:
       tags:
@@ -4124,7 +7148,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'FormSigningController.getSignedDocument''s catch block: res.status(400).json({ message }) where message = err.message if err is an Error, else the literal fallback "Failed to get signed document" (apps/backend/src/controllers/web/formSigning.contorller.ts).'
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
   '/fhir/v1/form/public/{formId}':
     get:
       tags:
@@ -4424,7 +7453,12 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'FormSigningController.startSigningMobile''s catch block: res.status(400).json({ message }) where message = err.message if err is an Error (e.g. "Unauthorized" when no matching mobile auth user), else the literal fallback "Failed to start signing" (apps/backend/src/controllers/web/formSigning.contorller.ts).'
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
   /v1/inventory/items:
     post:
       tags:
@@ -4439,8 +7473,171 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateInventoryItemInput
+              required:
+                - organisationId
+                - businessType
+                - name
+                - category
+              properties:
+                organisationId:
+                  type: string
+                businessType:
+                  type: string
+                  enum:
+                    - HOSPITAL
+                    - GROOMING
+                    - BOARDING
+                    - BREEDING
+                    - GENERAL
+                itemType:
+                  type: string
+                  enum:
+                    - MEDICAL
+                    - NON_MEDICAL
+                  description: Defaults to a value derived from the category's medical/non-medical classification when omitted.
+                name:
+                  type: string
+                  maxLength: 255
+                sku:
+                  type: string
+                  description: Must be unique within the organisation when provided.
+                category:
+                  type: string
+                subCategory:
+                  type: string
+                description:
+                  type: string
+                imageUrl:
+                  type: string
+                attachments:
+                  type: array
+                  nullable: false
+                  description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                  items:
+                    type: object
+                    additionalProperties: true
+                attributes:
+                  type: object
+                  description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                  additionalProperties:
+                    oneOf:
+                      - type: string
+                      - type: number
+                      - type: boolean
+                      - type: 'null'
+                genericName:
+                  type: string
+                  description: Required when itemType resolves to MEDICAL.
+                atcCode:
+                  type: string
+                  description: Accepted by the type but not persisted by item creation; the ATCvet code is set separately by a backfill job.
+                strength:
+                  type: string
+                  description: Required when itemType resolves to MEDICAL.
+                dosageForm:
+                  type: string
+                  description: Required when itemType resolves to MEDICAL.
+                routeOfAdministration:
+                  type: string
+                  description: Required when itemType resolves to MEDICAL.
+                drugClass:
+                  type: string
+                prescriptionRequired:
+                  type: boolean
+                controlledItem:
+                  type: boolean
+                storageInstructions:
+                  type: string
+                expiryTrackingRequired:
+                  type: boolean
+                  description: When true, every entry in batches must include a valid expiryDate.
+                unitOfMeasure:
+                  type: string
+                stockUnitType:
+                  type: string
+                packageQuantity:
+                  type: integer
+                  minimum: 0
+                unitQuantity:
+                  type: integer
+                  minimum: 0
+                  description: Alias for packageQuantity; whichever is supplied wins.
+                storageLocation:
+                  type: string
+                costPrice:
+                  type: number
+                  minimum: 0
+                  description: Alias for unitCost; costPrice wins when both are supplied.
+                unitCost:
+                  type: number
+                  minimum: 0
+                sellingPrice:
+                  type: number
+                  minimum: 0
+                taxRate:
+                  type: number
+                  minimum: 0
+                currency:
+                  type: string
+                  description: Ignored on create - the organisation's billing currency is used instead.
+                minimumStock:
+                  type: integer
+                  minimum: 0
+                emergencyStockLevel:
+                  type: integer
+                  minimum: 0
+                reorderLevel:
+                  type: integer
+                  minimum: 0
+                allocated:
+                  type: integer
+                  minimum: 0
+                  description: Must not exceed the resulting on-hand quantity.
+                initialOnHand:
+                  type: integer
+                  minimum: 0
+                  description: Used only when no batches are supplied; otherwise on-hand is derived from batch quantities.
+                initialAllocated:
+                  type: integer
+                  minimum: 0
+                vendorId:
+                  type: string
+                status:
+                  type: string
+                  enum:
+                    - ACTIVE
+                    - HIDDEN
+                    - DELETED
+                batches:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - quantity
+                    properties:
+                      batchNumber:
+                        type: string
+                      lotNumber:
+                        type: string
+                      regulatoryTrackingId:
+                        type: string
+                      expiryWarningBefore:
+                        type: string
+                      barcode:
+                        type: string
+                      manufactureDate:
+                        type: string
+                        format: date-time
+                      expiryDate:
+                        type: string
+                        format: date-time
+                      minShelfLifeAlertDate:
+                        type: string
+                        format: date-time
+                      quantity:
+                        type: integer
+                      allocated:
+                        type: integer
       responses:
         201:
           description: Response
@@ -4448,7 +7645,218 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - item
+                  - batches
+                properties:
+                  item:
+                    type: object
+                    required:
+                      - id
+                      - _id
+                      - organisationId
+                      - businessType
+                      - itemType
+                      - name
+                      - category
+                      - onHand
+                      - allocated
+                      - status
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      id:
+                        type: string
+                      _id:
+                        type: string
+                        description: Legacy Mongo-compatible alias for id.
+                      organisationId:
+                        type: string
+                      businessType:
+                        type: string
+                        enum:
+                          - HOSPITAL
+                          - GROOMING
+                          - BOARDING
+                          - BREEDING
+                          - GENERAL
+                      itemType:
+                        type: string
+                        enum:
+                          - MEDICAL
+                          - NON_MEDICAL
+                      name:
+                        type: string
+                      sku:
+                        type: string
+                        nullable: true
+                      category:
+                        type: string
+                      subCategory:
+                        type: string
+                        nullable: true
+                      description:
+                        type: string
+                        nullable: true
+                      imageUrl:
+                        type: string
+                        nullable: true
+                      stockUnitType:
+                        type: string
+                        nullable: true
+                      attachments:
+                        type: array
+                        nullable: true
+                        description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                        items:
+                          type: object
+                          additionalProperties: true
+                      attributes:
+                        type: object
+                        description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                        additionalProperties:
+                          oneOf:
+                            - type: string
+                            - type: number
+                            - type: boolean
+                            - type: 'null'
+                      genericName:
+                        type: string
+                        nullable: true
+                      atcCode:
+                        type: string
+                        nullable: true
+                        description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                      strength:
+                        type: string
+                        nullable: true
+                      dosageForm:
+                        type: string
+                        nullable: true
+                      routeOfAdministration:
+                        type: string
+                        nullable: true
+                      drugClass:
+                        type: string
+                        nullable: true
+                      prescriptionRequired:
+                        type: boolean
+                      controlledItem:
+                        type: boolean
+                      storageInstructions:
+                        type: string
+                        nullable: true
+                      expiryTrackingRequired:
+                        type: boolean
+                      unitOfMeasure:
+                        type: string
+                        nullable: true
+                      packageQuantity:
+                        type: integer
+                        nullable: true
+                      storageLocation:
+                        type: string
+                        nullable: true
+                      onHand:
+                        type: integer
+                      allocated:
+                        type: integer
+                      minimumStock:
+                        type: integer
+                        nullable: true
+                      emergencyStockLevel:
+                        type: integer
+                        nullable: true
+                      reorderLevel:
+                        type: integer
+                        nullable: true
+                      unitCost:
+                        type: number
+                        nullable: true
+                      sellingPrice:
+                        type: number
+                        nullable: true
+                      taxRate:
+                        type: number
+                        nullable: true
+                      currency:
+                        type: string
+                        nullable: true
+                      vendorId:
+                        type: string
+                        nullable: true
+                      status:
+                        type: string
+                        enum:
+                          - ACTIVE
+                          - HIDDEN
+                          - DELETED
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                  batches:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - _id
+                        - itemId
+                        - organisationId
+                        - quantity
+                        - allocated
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        _id:
+                          type: string
+                          description: Legacy Mongo-compatible alias for id.
+                        itemId:
+                          type: string
+                        organisationId:
+                          type: string
+                        batchNumber:
+                          type: string
+                          nullable: true
+                        lotNumber:
+                          type: string
+                          nullable: true
+                        regulatoryTrackingId:
+                          type: string
+                          nullable: true
+                        expiryWarningBefore:
+                          type: string
+                          nullable: true
+                        barcode:
+                          type: string
+                          nullable: true
+                        manufactureDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        expiryDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        minShelfLifeAlertDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        quantity:
+                          type: integer
+                        allocated:
+                          type: integer
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -4476,8 +7884,125 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: UpdateInventoryItemInput
+              description: Partial update; every field is optional and only supplied keys are changed. Fields typed nullable in source (UpdateInventoryItemInput) clear the stored value when sent as null.
+              properties:
+                itemType:
+                  type: string
+                  enum:
+                    - MEDICAL
+                    - NON_MEDICAL
+                name:
+                  type: string
+                sku:
+                  type: string
+                category:
+                  type: string
+                subCategory:
+                  type: string
+                description:
+                  type: string
+                imageUrl:
+                  type: string
+                attachments:
+                  type: array
+                  nullable: true
+                  description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                  items:
+                    type: object
+                    additionalProperties: true
+                attributes:
+                  type: object
+                  description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                  additionalProperties:
+                    oneOf:
+                      - type: string
+                      - type: number
+                      - type: boolean
+                      - type: 'null'
+                genericName:
+                  type: string
+                  nullable: true
+                atcCode:
+                  type: string
+                  nullable: true
+                strength:
+                  type: string
+                  nullable: true
+                dosageForm:
+                  type: string
+                  nullable: true
+                routeOfAdministration:
+                  type: string
+                  nullable: true
+                drugClass:
+                  type: string
+                  nullable: true
+                prescriptionRequired:
+                  type: boolean
+                  nullable: true
+                controlledItem:
+                  type: boolean
+                  nullable: true
+                storageInstructions:
+                  type: string
+                  nullable: true
+                expiryTrackingRequired:
+                  type: boolean
+                  nullable: true
+                unitOfMeasure:
+                  type: string
+                  nullable: true
+                stockUnitType:
+                  type: string
+                  nullable: true
+                packageQuantity:
+                  type: integer
+                  nullable: true
+                unitQuantity:
+                  type: integer
+                  nullable: true
+                  description: Alias for packageQuantity.
+                storageLocation:
+                  type: string
+                  nullable: true
+                costPrice:
+                  type: number
+                  nullable: true
+                  description: Alias for unitCost; costPrice wins when both are supplied.
+                unitCost:
+                  type: number
+                  nullable: true
+                sellingPrice:
+                  type: number
+                  nullable: true
+                taxRate:
+                  type: number
+                  nullable: true
+                currency:
+                  type: string
+                  nullable: true
+                  description: Presence (any value) re-derives currency from the organisation's billing settings; the value itself is not stored verbatim.
+                minimumStock:
+                  type: integer
+                  nullable: true
+                emergencyStockLevel:
+                  type: integer
+                  nullable: true
+                reorderLevel:
+                  type: integer
+                  nullable: true
+                allocated:
+                  type: integer
+                  description: Must not exceed the item's current on-hand quantity.
+                vendorId:
+                  type: string
+                  nullable: true
+                status:
+                  type: string
+                  enum:
+                    - ACTIVE
+                    - HIDDEN
+                    - DELETED
       responses:
         200:
           description: Response
@@ -4485,7 +8010,218 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - item
+                  - batches
+                properties:
+                  item:
+                    type: object
+                    required:
+                      - id
+                      - _id
+                      - organisationId
+                      - businessType
+                      - itemType
+                      - name
+                      - category
+                      - onHand
+                      - allocated
+                      - status
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      id:
+                        type: string
+                      _id:
+                        type: string
+                        description: Legacy Mongo-compatible alias for id.
+                      organisationId:
+                        type: string
+                      businessType:
+                        type: string
+                        enum:
+                          - HOSPITAL
+                          - GROOMING
+                          - BOARDING
+                          - BREEDING
+                          - GENERAL
+                      itemType:
+                        type: string
+                        enum:
+                          - MEDICAL
+                          - NON_MEDICAL
+                      name:
+                        type: string
+                      sku:
+                        type: string
+                        nullable: true
+                      category:
+                        type: string
+                      subCategory:
+                        type: string
+                        nullable: true
+                      description:
+                        type: string
+                        nullable: true
+                      imageUrl:
+                        type: string
+                        nullable: true
+                      stockUnitType:
+                        type: string
+                        nullable: true
+                      attachments:
+                        type: array
+                        nullable: true
+                        description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                        items:
+                          type: object
+                          additionalProperties: true
+                      attributes:
+                        type: object
+                        description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                        additionalProperties:
+                          oneOf:
+                            - type: string
+                            - type: number
+                            - type: boolean
+                            - type: 'null'
+                      genericName:
+                        type: string
+                        nullable: true
+                      atcCode:
+                        type: string
+                        nullable: true
+                        description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                      strength:
+                        type: string
+                        nullable: true
+                      dosageForm:
+                        type: string
+                        nullable: true
+                      routeOfAdministration:
+                        type: string
+                        nullable: true
+                      drugClass:
+                        type: string
+                        nullable: true
+                      prescriptionRequired:
+                        type: boolean
+                      controlledItem:
+                        type: boolean
+                      storageInstructions:
+                        type: string
+                        nullable: true
+                      expiryTrackingRequired:
+                        type: boolean
+                      unitOfMeasure:
+                        type: string
+                        nullable: true
+                      packageQuantity:
+                        type: integer
+                        nullable: true
+                      storageLocation:
+                        type: string
+                        nullable: true
+                      onHand:
+                        type: integer
+                      allocated:
+                        type: integer
+                      minimumStock:
+                        type: integer
+                        nullable: true
+                      emergencyStockLevel:
+                        type: integer
+                        nullable: true
+                      reorderLevel:
+                        type: integer
+                        nullable: true
+                      unitCost:
+                        type: number
+                        nullable: true
+                      sellingPrice:
+                        type: number
+                        nullable: true
+                      taxRate:
+                        type: number
+                        nullable: true
+                      currency:
+                        type: string
+                        nullable: true
+                      vendorId:
+                        type: string
+                        nullable: true
+                      status:
+                        type: string
+                        enum:
+                          - ACTIVE
+                          - HIDDEN
+                          - DELETED
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                  batches:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - _id
+                        - itemId
+                        - organisationId
+                        - quantity
+                        - allocated
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        _id:
+                          type: string
+                          description: Legacy Mongo-compatible alias for id.
+                        itemId:
+                          type: string
+                        organisationId:
+                          type: string
+                        batchNumber:
+                          type: string
+                          nullable: true
+                        lotNumber:
+                          type: string
+                          nullable: true
+                        regulatoryTrackingId:
+                          type: string
+                          nullable: true
+                        expiryWarningBefore:
+                          type: string
+                          nullable: true
+                        barcode:
+                          type: string
+                          nullable: true
+                        manufactureDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        expiryDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        minShelfLifeAlertDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        quantity:
+                          type: integer
+                        allocated:
+                          type: integer
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
     get:
       tags:
         - 'Non-FHIR'
@@ -4504,7 +8240,311 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - item
+                  - batches
+                properties:
+                  item:
+                    type: object
+                    required:
+                      - id
+                      - _id
+                      - organisationId
+                      - businessType
+                      - itemType
+                      - name
+                      - category
+                      - onHand
+                      - allocated
+                      - status
+                      - createdAt
+                      - updatedAt
+                      - currentStock
+                      - stockStatus
+                      - costPrice
+                      - grossProfit
+                      - nearestExpiryDate
+                    properties:
+                      id:
+                        type: string
+                      _id:
+                        type: string
+                        description: Legacy Mongo-compatible alias for id.
+                      organisationId:
+                        type: string
+                      businessType:
+                        type: string
+                        enum:
+                          - HOSPITAL
+                          - GROOMING
+                          - BOARDING
+                          - BREEDING
+                          - GENERAL
+                      itemType:
+                        type: string
+                        enum:
+                          - MEDICAL
+                          - NON_MEDICAL
+                      name:
+                        type: string
+                      sku:
+                        type: string
+                        nullable: true
+                      category:
+                        type: string
+                      subCategory:
+                        type: string
+                        nullable: true
+                      description:
+                        type: string
+                        nullable: true
+                      imageUrl:
+                        type: string
+                        nullable: true
+                      stockUnitType:
+                        type: string
+                        nullable: true
+                      attachments:
+                        type: array
+                        nullable: true
+                        description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                        items:
+                          type: object
+                          additionalProperties: true
+                      attributes:
+                        type: object
+                        description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                        additionalProperties:
+                          oneOf:
+                            - type: string
+                            - type: number
+                            - type: boolean
+                            - type: 'null'
+                      genericName:
+                        type: string
+                        nullable: true
+                      atcCode:
+                        type: string
+                        nullable: true
+                        description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                      strength:
+                        type: string
+                        nullable: true
+                      dosageForm:
+                        type: string
+                        nullable: true
+                      routeOfAdministration:
+                        type: string
+                        nullable: true
+                      drugClass:
+                        type: string
+                        nullable: true
+                      prescriptionRequired:
+                        type: boolean
+                      controlledItem:
+                        type: boolean
+                      storageInstructions:
+                        type: string
+                        nullable: true
+                      expiryTrackingRequired:
+                        type: boolean
+                      unitOfMeasure:
+                        type: string
+                        nullable: true
+                      packageQuantity:
+                        type: integer
+                        nullable: true
+                      storageLocation:
+                        type: string
+                        nullable: true
+                      onHand:
+                        type: integer
+                      allocated:
+                        type: integer
+                      minimumStock:
+                        type: integer
+                        nullable: true
+                      emergencyStockLevel:
+                        type: integer
+                        nullable: true
+                      reorderLevel:
+                        type: integer
+                        nullable: true
+                      unitCost:
+                        type: number
+                        nullable: true
+                      sellingPrice:
+                        type: number
+                        nullable: true
+                      taxRate:
+                        type: number
+                        nullable: true
+                      currency:
+                        type: string
+                        nullable: true
+                      vendorId:
+                        type: string
+                        nullable: true
+                      status:
+                        type: string
+                        enum:
+                          - ACTIVE
+                          - HIDDEN
+                          - DELETED
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                      currentStock:
+                        type: integer
+                        description: Alias for onHand.
+                      stockStatus:
+                        type: string
+                        enum:
+                          - In stock
+                          - Low stock
+                          - Out of stock
+                          - Expiring soon
+                          - Expired
+                          - Inactive
+                      costPrice:
+                        type: number
+                        nullable: true
+                        description: Alias for unitCost.
+                      grossProfit:
+                        type: number
+                        description: sellingPrice - costPrice (0 when either is unset).
+                      marginPercentage:
+                        type: number
+                        nullable: true
+                        description: null when sellingPrice is unset or <= 0.
+                      nearestExpiryDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      vendor:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          organisationId:
+                            type: string
+                          name:
+                            type: string
+                          brand:
+                            type: string
+                            nullable: true
+                          vendorType:
+                            type: string
+                            nullable: true
+                          licenseNumber:
+                            type: string
+                            nullable: true
+                          vendorItemCode:
+                            type: string
+                            nullable: true
+                          purchasePrice:
+                            type: number
+                            nullable: true
+                          lastPurchaseDate:
+                            type: string
+                            format: date-time
+                            nullable: true
+                          notes:
+                            type: string
+                            nullable: true
+                          paymentTerms:
+                            type: string
+                            nullable: true
+                          deliveryFrequency:
+                            type: string
+                            nullable: true
+                          leadTimeDays:
+                            type: integer
+                            nullable: true
+                          contactInfo:
+                            type: object
+                            nullable: true
+                            description: Vendor contact details; stored as a Prisma Json column with no fixed shape.
+                            properties:
+                              phone:
+                                type: string
+                              email:
+                                type: string
+                              address:
+                                type: string
+                            additionalProperties: true
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          _id:
+                            type: string
+                        nullable: true
+                  batches:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - _id
+                        - itemId
+                        - organisationId
+                        - quantity
+                        - allocated
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        _id:
+                          type: string
+                          description: Legacy Mongo-compatible alias for id.
+                        itemId:
+                          type: string
+                        organisationId:
+                          type: string
+                        batchNumber:
+                          type: string
+                          nullable: true
+                        lotNumber:
+                          type: string
+                          nullable: true
+                        regulatoryTrackingId:
+                          type: string
+                          nullable: true
+                        expiryWarningBefore:
+                          type: string
+                          nullable: true
+                        barcode:
+                          type: string
+                          nullable: true
+                        manufactureDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        expiryDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        minShelfLifeAlertDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        quantity:
+                          type: integer
+                        allocated:
+                          type: integer
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
   '/v1/inventory/items/{itemId}/hide':
     post:
       tags:
@@ -4526,7 +8566,153 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  sku:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subCategory:
+                    type: string
+                    nullable: true
+                  description:
+                    type: string
+                    nullable: true
+                  imageUrl:
+                    type: string
+                    nullable: true
+                  stockUnitType:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    nullable: true
+                    description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                    items:
+                      type: object
+                      additionalProperties: true
+                  attributes:
+                    type: object
+                    description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                    additionalProperties:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: boolean
+                        - type: 'null'
+                  genericName:
+                    type: string
+                    nullable: true
+                  atcCode:
+                    type: string
+                    nullable: true
+                    description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                  strength:
+                    type: string
+                    nullable: true
+                  dosageForm:
+                    type: string
+                    nullable: true
+                  routeOfAdministration:
+                    type: string
+                    nullable: true
+                  drugClass:
+                    type: string
+                    nullable: true
+                  prescriptionRequired:
+                    type: boolean
+                  controlledItem:
+                    type: boolean
+                  storageInstructions:
+                    type: string
+                    nullable: true
+                  expiryTrackingRequired:
+                    type: boolean
+                  unitOfMeasure:
+                    type: string
+                    nullable: true
+                  packageQuantity:
+                    type: integer
+                    nullable: true
+                  storageLocation:
+                    type: string
+                    nullable: true
+                  onHand:
+                    type: integer
+                  allocated:
+                    type: integer
+                  minimumStock:
+                    type: integer
+                    nullable: true
+                  emergencyStockLevel:
+                    type: integer
+                    nullable: true
+                  reorderLevel:
+                    type: integer
+                    nullable: true
+                  unitCost:
+                    type: number
+                    nullable: true
+                  sellingPrice:
+                    type: number
+                    nullable: true
+                  taxRate:
+                    type: number
+                    nullable: true
+                  currency:
+                    type: string
+                    nullable: true
+                  vendorId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                    description: Always HIDDEN in this response.
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/inventory/items/{itemId}/archive':
     post:
       tags:
@@ -4548,7 +8734,153 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  sku:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subCategory:
+                    type: string
+                    nullable: true
+                  description:
+                    type: string
+                    nullable: true
+                  imageUrl:
+                    type: string
+                    nullable: true
+                  stockUnitType:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    nullable: true
+                    description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                    items:
+                      type: object
+                      additionalProperties: true
+                  attributes:
+                    type: object
+                    description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                    additionalProperties:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: boolean
+                        - type: 'null'
+                  genericName:
+                    type: string
+                    nullable: true
+                  atcCode:
+                    type: string
+                    nullable: true
+                    description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                  strength:
+                    type: string
+                    nullable: true
+                  dosageForm:
+                    type: string
+                    nullable: true
+                  routeOfAdministration:
+                    type: string
+                    nullable: true
+                  drugClass:
+                    type: string
+                    nullable: true
+                  prescriptionRequired:
+                    type: boolean
+                  controlledItem:
+                    type: boolean
+                  storageInstructions:
+                    type: string
+                    nullable: true
+                  expiryTrackingRequired:
+                    type: boolean
+                  unitOfMeasure:
+                    type: string
+                    nullable: true
+                  packageQuantity:
+                    type: integer
+                    nullable: true
+                  storageLocation:
+                    type: string
+                    nullable: true
+                  onHand:
+                    type: integer
+                  allocated:
+                    type: integer
+                  minimumStock:
+                    type: integer
+                    nullable: true
+                  emergencyStockLevel:
+                    type: integer
+                    nullable: true
+                  reorderLevel:
+                    type: integer
+                    nullable: true
+                  unitCost:
+                    type: number
+                    nullable: true
+                  sellingPrice:
+                    type: number
+                    nullable: true
+                  taxRate:
+                    type: number
+                    nullable: true
+                  currency:
+                    type: string
+                    nullable: true
+                  vendorId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                    description: Always DELETED (soft-archive) in this response.
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/inventory/items/{itemId}/active':
     post:
       tags:
@@ -4570,7 +8902,153 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  sku:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subCategory:
+                    type: string
+                    nullable: true
+                  description:
+                    type: string
+                    nullable: true
+                  imageUrl:
+                    type: string
+                    nullable: true
+                  stockUnitType:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    nullable: true
+                    description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                    items:
+                      type: object
+                      additionalProperties: true
+                  attributes:
+                    type: object
+                    description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                    additionalProperties:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: boolean
+                        - type: 'null'
+                  genericName:
+                    type: string
+                    nullable: true
+                  atcCode:
+                    type: string
+                    nullable: true
+                    description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                  strength:
+                    type: string
+                    nullable: true
+                  dosageForm:
+                    type: string
+                    nullable: true
+                  routeOfAdministration:
+                    type: string
+                    nullable: true
+                  drugClass:
+                    type: string
+                    nullable: true
+                  prescriptionRequired:
+                    type: boolean
+                  controlledItem:
+                    type: boolean
+                  storageInstructions:
+                    type: string
+                    nullable: true
+                  expiryTrackingRequired:
+                    type: boolean
+                  unitOfMeasure:
+                    type: string
+                    nullable: true
+                  packageQuantity:
+                    type: integer
+                    nullable: true
+                  storageLocation:
+                    type: string
+                    nullable: true
+                  onHand:
+                    type: integer
+                  allocated:
+                    type: integer
+                  minimumStock:
+                    type: integer
+                    nullable: true
+                  emergencyStockLevel:
+                    type: integer
+                    nullable: true
+                  reorderLevel:
+                    type: integer
+                    nullable: true
+                  unitCost:
+                    type: number
+                    nullable: true
+                  sellingPrice:
+                    type: number
+                    nullable: true
+                  taxRate:
+                    type: number
+                    nullable: true
+                  currency:
+                    type: string
+                    nullable: true
+                  vendorId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                    description: Always ACTIVE in this response.
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/inventory/organisation/{organisationId}/items':
     get:
       tags:
@@ -4597,8 +9075,348 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                description: 'Returned shape depends on whether page/pageSize query params are supplied: a bare array when neither is set, otherwise a paginated wrapper.'
+                oneOf:
+                  - type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - _id
+                        - organisationId
+                        - businessType
+                        - itemType
+                        - name
+                        - category
+                        - onHand
+                        - allocated
+                        - status
+                        - createdAt
+                        - updatedAt
+                        - stockHealth
+                        - stockStatus
+                        - currentStock
+                      properties:
+                        id:
+                          type: string
+                        _id:
+                          type: string
+                          description: Legacy Mongo-compatible alias for id.
+                        organisationId:
+                          type: string
+                        businessType:
+                          type: string
+                          enum:
+                            - HOSPITAL
+                            - GROOMING
+                            - BOARDING
+                            - BREEDING
+                            - GENERAL
+                        itemType:
+                          type: string
+                          enum:
+                            - MEDICAL
+                            - NON_MEDICAL
+                        name:
+                          type: string
+                        sku:
+                          type: string
+                          nullable: true
+                        category:
+                          type: string
+                        subCategory:
+                          type: string
+                          nullable: true
+                        description:
+                          type: string
+                          nullable: true
+                        imageUrl:
+                          type: string
+                          nullable: true
+                        stockUnitType:
+                          type: string
+                          nullable: true
+                        attachments:
+                          type: array
+                          nullable: true
+                          description: Attachment references; stored as a Prisma Json column with no fixed item shape, the caller decides what each entry holds.
+                          items:
+                            type: object
+                            additionalProperties: true
+                        attributes:
+                          type: object
+                          description: Free-form business-type-specific attributes; stored as a Prisma Json column (default {}), keys are not fixed.
+                          additionalProperties:
+                            oneOf:
+                              - type: string
+                              - type: number
+                              - type: boolean
+                              - type: 'null'
+                        genericName:
+                          type: string
+                          nullable: true
+                        atcCode:
+                          type: string
+                          nullable: true
+                          description: ATCvet substance code, set by a backfill job; not writable by clients today.
+                        strength:
+                          type: string
+                          nullable: true
+                        dosageForm:
+                          type: string
+                          nullable: true
+                        routeOfAdministration:
+                          type: string
+                          nullable: true
+                        drugClass:
+                          type: string
+                          nullable: true
+                        prescriptionRequired:
+                          type: boolean
+                        controlledItem:
+                          type: boolean
+                        storageInstructions:
+                          type: string
+                          nullable: true
+                        expiryTrackingRequired:
+                          type: boolean
+                        unitOfMeasure:
+                          type: string
+                          nullable: true
+                        packageQuantity:
+                          type: integer
+                          nullable: true
+                        storageLocation:
+                          type: string
+                          nullable: true
+                        onHand:
+                          type: integer
+                        allocated:
+                          type: integer
+                        minimumStock:
+                          type: integer
+                          nullable: true
+                        emergencyStockLevel:
+                          type: integer
+                          nullable: true
+                        reorderLevel:
+                          type: integer
+                          nullable: true
+                        unitCost:
+                          type: number
+                          nullable: true
+                        sellingPrice:
+                          type: number
+                          nullable: true
+                        taxRate:
+                          type: number
+                          nullable: true
+                        currency:
+                          type: string
+                          nullable: true
+                        vendorId:
+                          type: string
+                          nullable: true
+                        status:
+                          type: string
+                          enum:
+                            - ACTIVE
+                            - HIDDEN
+                            - DELETED
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        stockHealth:
+                          type: string
+                          enum:
+                            - HEALTHY
+                            - LOW_STOCK
+                            - EXPIRED
+                            - EXPIRING_SOON
+                        stockStatus:
+                          type: string
+                          enum:
+                            - In stock
+                            - Low stock
+                            - Out of stock
+                            - Expiring soon
+                            - Expired
+                            - Inactive
+                        currentStock:
+                          type: integer
+                        costPrice:
+                          type: number
+                          nullable: true
+                        grossProfit:
+                          type: number
+                        marginPercentage:
+                          type: number
+                          nullable: true
+                        nearestExpiryDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        batches:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - _id
+                              - itemId
+                              - organisationId
+                              - quantity
+                              - allocated
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              _id:
+                                type: string
+                                description: Legacy Mongo-compatible alias for id.
+                              itemId:
+                                type: string
+                              organisationId:
+                                type: string
+                              batchNumber:
+                                type: string
+                                nullable: true
+                              lotNumber:
+                                type: string
+                                nullable: true
+                              regulatoryTrackingId:
+                                type: string
+                                nullable: true
+                              expiryWarningBefore:
+                                type: string
+                                nullable: true
+                              barcode:
+                                type: string
+                                nullable: true
+                              manufactureDate:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              expiryDate:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              minShelfLifeAlertDate:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              quantity:
+                                type: integer
+                              allocated:
+                                type: integer
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                  - type: object
+                    required:
+                      - items
+                      - page
+                      - pageSize
+                      - total
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - _id
+                            - organisationId
+                            - businessType
+                            - itemType
+                            - name
+                            - category
+                            - onHand
+                            - allocated
+                            - status
+                            - createdAt
+                            - updatedAt
+                            - stockHealth
+                            - stockStatus
+                            - currentStock
+                          properties:
+                            id:
+                              type: string
+                            _id:
+                              type: string
+                            organisationId:
+                              type: string
+                            businessType:
+                              type: string
+                              enum:
+                                - HOSPITAL
+                                - GROOMING
+                                - BOARDING
+                                - BREEDING
+                                - GENERAL
+                            itemType:
+                              type: string
+                              enum:
+                                - MEDICAL
+                                - NON_MEDICAL
+                            name:
+                              type: string
+                            sku:
+                              type: string
+                              nullable: true
+                            category:
+                              type: string
+                            subCategory:
+                              type: string
+                              nullable: true
+                            onHand:
+                              type: integer
+                            allocated:
+                              type: integer
+                            status:
+                              type: string
+                              enum:
+                                - ACTIVE
+                                - HIDDEN
+                                - DELETED
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            stockHealth:
+                              type: string
+                              enum:
+                                - HEALTHY
+                                - LOW_STOCK
+                                - EXPIRED
+                                - EXPIRING_SOON
+                            stockStatus:
+                              type: string
+                              enum:
+                                - In stock
+                                - Low stock
+                                - Out of stock
+                                - Expiring soon
+                                - Expired
+                                - Inactive
+                            currentStock:
+                              type: integer
+                          description: Same item shape as the array variant above; trimmed here for brevity, see that branch for the complete property list.
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                      total:
+                        type: integer
   '/v1/inventory/organisation/{organisationId}/turnover':
     get:
       tags:
@@ -4678,16 +9496,96 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: InventoryBatchInput
+              required:
+                - quantity
+              properties:
+                batchNumber:
+                  type: string
+                lotNumber:
+                  type: string
+                regulatoryTrackingId:
+                  type: string
+                expiryWarningBefore:
+                  type: string
+                barcode:
+                  type: string
+                manufactureDate:
+                  type: string
+                  format: date-time
+                expiryDate:
+                  type: string
+                  format: date-time
+                minShelfLifeAlertDate:
+                  type: string
+                  format: date-time
+                quantity:
+                  type: integer
+                allocated:
+                  type: integer
       responses:
         200:
           description: Response
           content:
             application/json:
               schema:
+                description: "NOTE: InventoryController.addBatch actually calls res.status(201).json(batch) - this body is real (the created batch) but the spec labels it '200' where the backend sends 201."
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - itemId
+                  - organisationId
+                  - quantity
+                  - allocated
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  itemId:
+                    type: string
+                  organisationId:
+                    type: string
+                  batchNumber:
+                    type: string
+                    nullable: true
+                  lotNumber:
+                    type: string
+                    nullable: true
+                  regulatoryTrackingId:
+                    type: string
+                    nullable: true
+                  expiryWarningBefore:
+                    type: string
+                    nullable: true
+                  barcode:
+                    type: string
+                    nullable: true
+                  manufactureDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  expiryDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  minShelfLifeAlertDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  quantity:
+                    type: integer
+                  allocated:
+                    type: integer
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/inventory/batches/{batchId}':
     patch:
       tags:
@@ -4714,8 +9612,31 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: 'Partial<InventoryBatchInput'
+              description: All fields optional; only supplied fields are updated (Partial<InventoryBatchInput>).
+              properties:
+                batchNumber:
+                  type: string
+                lotNumber:
+                  type: string
+                regulatoryTrackingId:
+                  type: string
+                expiryWarningBefore:
+                  type: string
+                barcode:
+                  type: string
+                manufactureDate:
+                  type: string
+                  format: date-time
+                expiryDate:
+                  type: string
+                  format: date-time
+                minShelfLifeAlertDate:
+                  type: string
+                  format: date-time
+                quantity:
+                  type: integer
+                allocated:
+                  type: integer
       responses:
         200:
           description: Response
@@ -4723,7 +9644,62 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - itemId
+                  - organisationId
+                  - quantity
+                  - allocated
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  itemId:
+                    type: string
+                  organisationId:
+                    type: string
+                  batchNumber:
+                    type: string
+                    nullable: true
+                  lotNumber:
+                    type: string
+                    nullable: true
+                  regulatoryTrackingId:
+                    type: string
+                    nullable: true
+                  expiryWarningBefore:
+                    type: string
+                    nullable: true
+                  barcode:
+                    type: string
+                    nullable: true
+                  manufactureDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  expiryDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  minShelfLifeAlertDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  quantity:
+                    type: integer
+                  allocated:
+                    type: integer
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
     delete:
       tags:
         - 'Non-FHIR'
@@ -4751,6 +9727,7 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+                description: "Could not be traced as a real 200 response: InventoryController.deleteBatch always calls res.status(204).send() with an empty body (confirmed in apps/backend/src/controllers/web/inventory.controller.ts:407-419 and asserted by apps/backend/test/controllers/inventory.controller.test.ts:571-577, which expects res.status(204) and res.send()). This spec's '200' entry for this route/method does not correspond to any body the backend actually sends; there is no real content to document."
   /v1/inventory/stock/consume:
     post:
       tags:
@@ -4765,8 +9742,26 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: ConsumeStockInput
+              required:
+                - itemId
+                - quantity
+                - reason
+              properties:
+                itemId:
+                  type: string
+                quantity:
+                  type: number
+                  exclusiveMinimum: 0
+                reason:
+                  type: string
+                  enum:
+                    - APPOINTMENT_USAGE
+                    - MANUAL_ADJUSTMENT
+                    - GROOMING_USAGE
+                    - BOARDING_USAGE
+                    - OTHER
+                referenceId:
+                  type: string
       responses:
         200:
           description: Response
@@ -4774,7 +9769,152 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Legacy Mongo-compatible alias for id.
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  sku:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subCategory:
+                    type: string
+                    nullable: true
+                  description:
+                    type: string
+                    nullable: true
+                  imageUrl:
+                    type: string
+                    nullable: true
+                  stockUnitType:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    nullable: true
+                    description: Attachment references; stored as a Prisma Json column with no fixed item shape.
+                    items:
+                      type: object
+                      additionalProperties: true
+                  attributes:
+                    type: object
+                    description: Prisma Json column, keys not fixed.
+                    additionalProperties:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: boolean
+                        - type: 'null'
+                  genericName:
+                    type: string
+                    nullable: true
+                  atcCode:
+                    type: string
+                    nullable: true
+                  strength:
+                    type: string
+                    nullable: true
+                  dosageForm:
+                    type: string
+                    nullable: true
+                  routeOfAdministration:
+                    type: string
+                    nullable: true
+                  drugClass:
+                    type: string
+                    nullable: true
+                  prescriptionRequired:
+                    type: boolean
+                  controlledItem:
+                    type: boolean
+                  storageInstructions:
+                    type: string
+                    nullable: true
+                  expiryTrackingRequired:
+                    type: boolean
+                  unitOfMeasure:
+                    type: string
+                    nullable: true
+                  packageQuantity:
+                    type: integer
+                    nullable: true
+                  storageLocation:
+                    type: string
+                    nullable: true
+                  onHand:
+                    type: integer
+                    description: Reflects the FIFO-by-expiry consumption just applied.
+                  allocated:
+                    type: integer
+                  minimumStock:
+                    type: integer
+                    nullable: true
+                  emergencyStockLevel:
+                    type: integer
+                    nullable: true
+                  reorderLevel:
+                    type: integer
+                    nullable: true
+                  unitCost:
+                    type: number
+                    nullable: true
+                  sellingPrice:
+                    type: number
+                    nullable: true
+                  taxRate:
+                    type: number
+                    nullable: true
+                  currency:
+                    type: string
+                    nullable: true
+                  vendorId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -4796,16 +9936,98 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: BulkConsumeStockInput
+              required:
+                - items
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - itemId
+                      - quantity
+                      - reason
+                    properties:
+                      itemId:
+                        type: string
+                      quantity:
+                        type: number
+                        exclusiveMinimum: 0
+                      reason:
+                        type: string
+                        enum:
+                          - APPOINTMENT_USAGE
+                          - MANUAL_ADJUSTMENT
+                          - GROOMING_USAGE
+                          - BOARDING_USAGE
+                          - OTHER
+                      referenceId:
+                        type: string
       responses:
         200:
           description: Response
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: One updated item per entry in the request's items array, in the same order (each processed via the same consumeStock path as POST /stock/consume).
+                items:
+                  type: object
+                  required:
+                    - id
+                    - _id
+                    - organisationId
+                    - businessType
+                    - itemType
+                    - name
+                    - category
+                    - onHand
+                    - allocated
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    _id:
+                      type: string
+                    organisationId:
+                      type: string
+                    businessType:
+                      type: string
+                      enum:
+                        - HOSPITAL
+                        - GROOMING
+                        - BOARDING
+                        - BREEDING
+                        - GENERAL
+                    itemType:
+                      type: string
+                      enum:
+                        - MEDICAL
+                        - NON_MEDICAL
+                    name:
+                      type: string
+                    category:
+                      type: string
+                    onHand:
+                      type: integer
+                    allocated:
+                      type: integer
+                    status:
+                      type: string
+                      enum:
+                        - ACTIVE
+                        - HIDDEN
+                        - DELETED
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
+                  description: Same item shape as POST /v1/inventory/stock/consume's 200 response; trimmed here, see that entry for the complete property list.
       parameters:
         - name: x-org-id
           in: header
@@ -4839,8 +10061,16 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: '{ newOnHand: number; reason: string }'
+              required:
+                - newOnHand
+                - reason
+              properties:
+                newOnHand:
+                  type: integer
+                  description: Target on-hand quantity; the service computes the delta against the current onHand and creates/consumes batch rows to reach it.
+                reason:
+                  type: string
+                  description: Free-text reason recorded on the resulting InventoryStockMovement row(s), e.g. MANUAL_ADJUSTMENT.
       responses:
         200:
           description: Response
@@ -4848,7 +10078,88 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  sku:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subCategory:
+                    type: string
+                    nullable: true
+                  onHand:
+                    type: integer
+                    description: Recomputed from batch quantities after the adjustment.
+                  allocated:
+                    type: integer
+                  minimumStock:
+                    type: integer
+                    nullable: true
+                  emergencyStockLevel:
+                    type: integer
+                    nullable: true
+                  reorderLevel:
+                    type: integer
+                    nullable: true
+                  unitCost:
+                    type: number
+                    nullable: true
+                  sellingPrice:
+                    type: number
+                    nullable: true
+                  currency:
+                    type: string
+                    nullable: true
+                  vendorId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: Full InventoryItem row (same shape as POST /v1/inventory/stock/consume's 200 response); trimmed to the fields most relevant to an adjustment, see that entry for the complete property list.
   '/v1/inventory/items/{itemId}/allocate':
     post:
       tags:
@@ -4875,8 +10186,16 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: '{ quantity: number; referenceId: string }'
+              required:
+                - quantity
+                - referenceId
+              properties:
+                quantity:
+                  type: number
+                  description: Must not exceed onHand - allocated for the item.
+                referenceId:
+                  type: string
+                  description: Id of the appointment/grooming/boarding record this reservation is for; recorded on the resulting InventoryStockMovement row with reason ALLOCATED.
       responses:
         200:
           description: Response
@@ -4884,7 +10203,61 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  category:
+                    type: string
+                  onHand:
+                    type: integer
+                  allocated:
+                    type: integer
+                    description: Incremented by the requested quantity.
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: Full InventoryItem row (same shape as POST /v1/inventory/stock/consume's 200 response); trimmed to the fields most relevant to allocation, see that entry for the complete property list.
   '/v1/inventory/items/{itemId}/release':
     post:
       tags:
@@ -4911,8 +10284,15 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: '{ quantity: number; referenceId: string }'
+              required:
+                - quantity
+                - referenceId
+              properties:
+                quantity:
+                  type: number
+                referenceId:
+                  type: string
+                  description: Recorded on the resulting InventoryStockMovement row with reason UNALLOCATED.
       responses:
         200:
           description: Response
@@ -4920,7 +10300,61 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - _id
+                  - organisationId
+                  - businessType
+                  - itemType
+                  - name
+                  - category
+                  - onHand
+                  - allocated
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                  organisationId:
+                    type: string
+                  businessType:
+                    type: string
+                    enum:
+                      - HOSPITAL
+                      - GROOMING
+                      - BOARDING
+                      - BREEDING
+                      - GENERAL
+                  itemType:
+                    type: string
+                    enum:
+                      - MEDICAL
+                      - NON_MEDICAL
+                  name:
+                    type: string
+                  category:
+                    type: string
+                  onHand:
+                    type: integer
+                  allocated:
+                    type: integer
+                    description: Decremented by the requested quantity, floored at 0.
+                  status:
+                    type: string
+                    enum:
+                      - ACTIVE
+                      - HIDDEN
+                      - DELETED
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: Full InventoryItem row (same shape as POST /v1/inventory/stock/consume's 200 response); trimmed to the fields most relevant to release, see that entry for the complete property list.
   /v1/inventory/vendors:
     post:
       tags:
@@ -4935,8 +10369,70 @@ paths:
           content:
             application/json:
               schema:
+                description: "NOTE: InventoryVendorController.createVendor actually calls res.status(201).json(vendor) - this body is real but the spec labels it '200' where the backend sends 201. The service casts the Prisma create() result to a legacy _id-bearing type but never actually adds an _id field, so none is documented here."
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - organisationId
+                  - name
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  organisationId:
+                    type: string
+                  name:
+                    type: string
+                  brand:
+                    type: string
+                    nullable: true
+                  vendorType:
+                    type: string
+                    nullable: true
+                  licenseNumber:
+                    type: string
+                    nullable: true
+                  vendorItemCode:
+                    type: string
+                    nullable: true
+                  purchasePrice:
+                    type: number
+                    nullable: true
+                  lastPurchaseDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  notes:
+                    type: string
+                    nullable: true
+                  paymentTerms:
+                    type: string
+                    nullable: true
+                  deliveryFrequency:
+                    type: string
+                    nullable: true
+                  leadTimeDays:
+                    type: integer
+                    nullable: true
+                  contactInfo:
+                    type: object
+                    nullable: true
+                    description: Vendor contact details; stored as a Prisma Json column with no fixed shape.
+                    properties:
+                      phone:
+                        type: string
+                      email:
+                        type: string
+                      address:
+                        type: string
+                    additionalProperties: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -4970,8 +10466,72 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - organisationId
+                    - name
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    organisationId:
+                      type: string
+                    name:
+                      type: string
+                    brand:
+                      type: string
+                      nullable: true
+                    vendorType:
+                      type: string
+                      nullable: true
+                    licenseNumber:
+                      type: string
+                      nullable: true
+                    vendorItemCode:
+                      type: string
+                      nullable: true
+                    purchasePrice:
+                      type: number
+                      nullable: true
+                    lastPurchaseDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    notes:
+                      type: string
+                      nullable: true
+                    paymentTerms:
+                      type: string
+                      nullable: true
+                    deliveryFrequency:
+                      type: string
+                      nullable: true
+                    leadTimeDays:
+                      type: integer
+                      nullable: true
+                    contactInfo:
+                      type: object
+                      nullable: true
+                      description: Vendor contact details; stored as a Prisma Json column with no fixed shape.
+                      properties:
+                        phone:
+                          type: string
+                        email:
+                          type: string
+                        address:
+                          type: string
+                      additionalProperties: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
+                  description: Real fields from Prisma's InventoryVendor.findMany, ordered by name asc; no _id field is added.
   '/v1/inventory/vendors/{vendorId}':
     get:
       tags:
@@ -4999,7 +10559,69 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - organisationId
+                  - name
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  organisationId:
+                    type: string
+                  name:
+                    type: string
+                  brand:
+                    type: string
+                    nullable: true
+                  vendorType:
+                    type: string
+                    nullable: true
+                  licenseNumber:
+                    type: string
+                    nullable: true
+                  vendorItemCode:
+                    type: string
+                    nullable: true
+                  purchasePrice:
+                    type: number
+                    nullable: true
+                  lastPurchaseDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  notes:
+                    type: string
+                    nullable: true
+                  paymentTerms:
+                    type: string
+                    nullable: true
+                  deliveryFrequency:
+                    type: string
+                    nullable: true
+                  leadTimeDays:
+                    type: integer
+                    nullable: true
+                  contactInfo:
+                    type: object
+                    nullable: true
+                    description: Vendor contact details; stored as a Prisma Json column with no fixed shape.
+                    properties:
+                      phone:
+                        type: string
+                      email:
+                        type: string
+                      address:
+                        type: string
+                    additionalProperties: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: Real fields from Prisma's InventoryVendor.findFirst; controller returns 404 with {message} when not found, so a 200 always carries this shape.
     patch:
       tags:
         - 'Non-FHIR'
@@ -5026,7 +10648,69 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - organisationId
+                  - name
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  organisationId:
+                    type: string
+                  name:
+                    type: string
+                  brand:
+                    type: string
+                    nullable: true
+                  vendorType:
+                    type: string
+                    nullable: true
+                  licenseNumber:
+                    type: string
+                    nullable: true
+                  vendorItemCode:
+                    type: string
+                    nullable: true
+                  purchasePrice:
+                    type: number
+                    nullable: true
+                  lastPurchaseDate:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  notes:
+                    type: string
+                    nullable: true
+                  paymentTerms:
+                    type: string
+                    nullable: true
+                  deliveryFrequency:
+                    type: string
+                    nullable: true
+                  leadTimeDays:
+                    type: integer
+                    nullable: true
+                  contactInfo:
+                    type: object
+                    nullable: true
+                    description: Vendor contact details; stored as a Prisma Json column with no fixed shape.
+                    properties:
+                      phone:
+                        type: string
+                      email:
+                        type: string
+                      address:
+                        type: string
+                    additionalProperties: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: Real fields from Prisma's InventoryVendor.update; no _id field is added.
     delete:
       tags:
         - 'Non-FHIR'
@@ -5054,6 +10738,7 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+                description: "Could not be traced as a real 200 response: InventoryVendorController.deleteVendor always calls res.status(204).send() with an empty body. This spec's '200' entry for this route/method does not correspond to any body the backend actually sends; there is no real content to document."
   '/v1/inventory/meta-fields':
     post:
       tags:
@@ -5068,8 +10753,35 @@ paths:
           content:
             application/json:
               schema:
+                description: "NOTE: InventoryMetaFieldController.createField actually calls res.status(201).json(field) - this body is real but the spec labels it '200' where the backend sends 201."
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - businessType
+                  - fieldKey
+                  - label
+                  - values
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  businessType:
+                    type: string
+                  fieldKey:
+                    type: string
+                  label:
+                    type: string
+                  values:
+                    type: array
+                    items:
+                      type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -5090,8 +10802,37 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: prisma.inventoryMetaField.findMany, ordered by label asc.
+                items:
+                  type: object
+                  required:
+                    - id
+                    - businessType
+                    - fieldKey
+                    - label
+                    - values
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    businessType:
+                      type: string
+                    fieldKey:
+                      type: string
+                    label:
+                      type: string
+                    values:
+                      type: array
+                      items:
+                        type: string
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -5126,7 +10867,34 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - businessType
+                  - fieldKey
+                  - label
+                  - values
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  businessType:
+                    type: string
+                  fieldKey:
+                    type: string
+                  label:
+                    type: string
+                  values:
+                    type: array
+                    items:
+                      type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                description: prisma.inventoryMetaField.update result.
     delete:
       tags:
         - 'Non-FHIR'
@@ -5154,6 +10922,7 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+                description: "Could not be traced as a real 200 response: InventoryMetaFieldController.deleteField always calls res.status(204).send() with an empty body. This spec's '200' entry for this route/method does not correspond to any body the backend actually sends; there is no real content to document."
   '/v1/inventory/organisation/{organisationId}/alerts/low-stock':
     get:
       tags:
@@ -5180,8 +10949,97 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: Raw InventoryItem rows (Prisma model fields only, no _id or computed fields) filtered in-memory to items with a reorderLevel set where onHand <= reorderLevel.
+                items:
+                  type: object
+                  required:
+                    - id
+                    - organisationId
+                    - businessType
+                    - itemType
+                    - name
+                    - category
+                    - onHand
+                    - allocated
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    organisationId:
+                      type: string
+                    businessType:
+                      type: string
+                      enum:
+                        - HOSPITAL
+                        - GROOMING
+                        - BOARDING
+                        - BREEDING
+                        - GENERAL
+                    itemType:
+                      type: string
+                      enum:
+                        - MEDICAL
+                        - NON_MEDICAL
+                    name:
+                      type: string
+                    sku:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subCategory:
+                      type: string
+                      nullable: true
+                    description:
+                      type: string
+                      nullable: true
+                    imageUrl:
+                      type: string
+                      nullable: true
+                    stockUnitType:
+                      type: string
+                      nullable: true
+                    onHand:
+                      type: integer
+                    allocated:
+                      type: integer
+                    minimumStock:
+                      type: integer
+                      nullable: true
+                    emergencyStockLevel:
+                      type: integer
+                      nullable: true
+                    reorderLevel:
+                      type: integer
+                      nullable: true
+                      description: Guaranteed non-null/non-zero on every row here, since it is the filter criterion.
+                    unitCost:
+                      type: number
+                      nullable: true
+                    sellingPrice:
+                      type: number
+                      nullable: true
+                    currency:
+                      type: string
+                      nullable: true
+                    vendorId:
+                      type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - ACTIVE
+                        - HIDDEN
+                        - DELETED
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/inventory/organisation/{organisationId}/alerts/expiring':
     get:
       tags:
@@ -5208,8 +11066,63 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                description: Raw InventoryBatch rows (Prisma model fields only, no _id) whose expiryDate falls between now and now + days (query param, default 7), ordered by expiryDate asc.
+                items:
+                  type: object
+                  required:
+                    - id
+                    - itemId
+                    - organisationId
+                    - quantity
+                    - allocated
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    itemId:
+                      type: string
+                    organisationId:
+                      type: string
+                    batchNumber:
+                      type: string
+                      nullable: true
+                    lotNumber:
+                      type: string
+                      nullable: true
+                    regulatoryTrackingId:
+                      type: string
+                      nullable: true
+                    expiryWarningBefore:
+                      type: string
+                      nullable: true
+                    barcode:
+                      type: string
+                      nullable: true
+                    manufactureDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    expiryDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                      description: Non-null on every row here, since it is the filter criterion.
+                    minShelfLifeAlertDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    quantity:
+                      type: integer
+                    allocated:
+                      type: integer
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/fhir/v1/invoice/mobile/appointment/{appointmentId}':
     post:
       tags:
@@ -5231,7 +11144,357 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - items
+                        - subtotal
+                        - totalAmount
+                        - currency
+                        - paymentCollectionMethod
+                        - status
+                        - createdAt
+                        - updatedAt
+                        - payments
+                        - receipts
+                        - settlementSummary
+                      properties:
+                        id:
+                          type: string
+                        parentId:
+                          type: string
+                        patientId:
+                          type: string
+                        organisationId:
+                          type: string
+                        appointmentId:
+                          type: string
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - name
+                              - quantity
+                              - unitPrice
+                              - total
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              description:
+                                type: string
+                                nullable: true
+                              quantity:
+                                type: number
+                              unitPrice:
+                                type: number
+                              discountPercent:
+                                type: number
+                              total:
+                                type: number
+                        subtotal:
+                          type: number
+                        totalAmount:
+                          type: number
+                        taxPercent:
+                          type: number
+                        currency:
+                          type: string
+                          description: Lowercase ISO 4217 currency code (e.g. usd).
+                        taxTotal:
+                          type: number
+                        discountTotal:
+                          type: number
+                        billingCollectionMode:
+                          type: string
+                          enum:
+                            - PREPAY_AT_BOOKING
+                            - PAY_AT_VISIT_END
+                            - STAGED_DURING_VISIT
+                            - DEPOSIT_THEN_SETTLE
+                            - MANUAL_OFFLINE
+                        visitBillingStage:
+                          type: string
+                          enum:
+                            - DRAFT
+                            - READY_FOR_BILLING
+                            - SETTLED
+                        readyForBillingAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        readyForBillingActorId:
+                          type: string
+                          nullable: true
+                        depositTargetAmount:
+                          type: number
+                        depositCollectedAmount:
+                          type: number
+                        paymentCollectionMethod:
+                          type: string
+                          enum:
+                            - PAYMENT_INTENT
+                            - PAYMENT_LINK
+                            - PAYMENT_AT_CLINIC
+                        status:
+                          type: string
+                          enum:
+                            - PENDING
+                            - AWAITING_PAYMENT
+                            - PAID
+                            - FAILED
+                            - CANCELLED
+                            - REFUNDED
+                        creditNotes:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - creditNoteNumber
+                              - amount
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              creditNoteNumber:
+                                type: string
+                              reason:
+                                type: string
+                              amount:
+                                type: number
+                              status:
+                                type: string
+                                enum:
+                                  - DRAFT
+                                  - ISSUED
+                                  - VOIDED
+                              metadata:
+                                type: object
+                                additionalProperties: true
+                                description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        metadata:
+                          type: object
+                          additionalProperties: true
+                          description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                        paidAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        payments:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              paymentAttemptId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              collectionMode:
+                                type: string
+                              providerPaymentId:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              status:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              receiptUrl:
+                                type: string
+                                nullable: true
+                              refunds:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - id
+                                    - paymentId
+                                    - provider
+                                    - amount
+                                    - currency
+                                    - status
+                                    - createdAt
+                                    - updatedAt
+                                  properties:
+                                    id:
+                                      type: string
+                                    paymentId:
+                                      type: string
+                                    provider:
+                                      type: string
+                                    providerRefundId:
+                                      type: string
+                                      nullable: true
+                                    amount:
+                                      type: number
+                                    currency:
+                                      type: string
+                                    status:
+                                      type: string
+                                    reason:
+                                      type: string
+                                      nullable: true
+                                    createdAt:
+                                      type: string
+                                      format: date-time
+                                    updatedAt:
+                                      type: string
+                                      format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        receipts:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - paymentId
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              paymentId:
+                                type: string
+                              invoiceId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              receiptUrl:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        settlementSummary:
+                          type: object
+                          required:
+                            - invoiceTotal
+                            - cashPaid
+                            - depositRecordedAmount
+                            - credited
+                            - effectivePaid
+                            - balance
+                            - lineAllocations
+                          properties:
+                            invoiceTotal:
+                              type: number
+                            cashPaid:
+                              type: number
+                            depositRecordedAmount:
+                              type: number
+                            credited:
+                              type: number
+                            effectivePaid:
+                              type: number
+                            balance:
+                              type: number
+                            lineAllocations:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - name
+                                  - total
+                                  - cashApplied
+                                  - creditApplied
+                                  - remaining
+                                properties:
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  description:
+                                    type: string
+                                    nullable: true
+                                  total:
+                                    type: number
+                                  cashApplied:
+                                    type: number
+                                  creditApplied:
+                                    type: number
+                                  remaining:
+                                    type: number
+                        renderedDocumentId:
+                          type: string
+                          description: Only present when a rendered PDF document exists for this invoice.
+                        pdfUrl:
+                          type: string
+                          nullable: true
+                          description: Only present when a rendered PDF document exists for this invoice.
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/mobile/payment-intent/{paymentIntentId}':
     get:
       tags:
@@ -5253,7 +11516,348 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - items
+                      - subtotal
+                      - totalAmount
+                      - currency
+                      - paymentCollectionMethod
+                      - status
+                      - createdAt
+                      - updatedAt
+                      - payments
+                      - receipts
+                      - settlementSummary
+                    properties:
+                      id:
+                        type: string
+                      parentId:
+                        type: string
+                      patientId:
+                        type: string
+                      organisationId:
+                        type: string
+                      appointmentId:
+                        type: string
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - quantity
+                            - unitPrice
+                            - total
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                              nullable: true
+                            quantity:
+                              type: number
+                            unitPrice:
+                              type: number
+                            discountPercent:
+                              type: number
+                            total:
+                              type: number
+                      subtotal:
+                        type: number
+                      totalAmount:
+                        type: number
+                      taxPercent:
+                        type: number
+                      currency:
+                        type: string
+                        description: Lowercase ISO 4217 currency code (e.g. usd).
+                      taxTotal:
+                        type: number
+                      discountTotal:
+                        type: number
+                      billingCollectionMode:
+                        type: string
+                        enum:
+                          - PREPAY_AT_BOOKING
+                          - PAY_AT_VISIT_END
+                          - STAGED_DURING_VISIT
+                          - DEPOSIT_THEN_SETTLE
+                          - MANUAL_OFFLINE
+                      visitBillingStage:
+                        type: string
+                        enum:
+                          - DRAFT
+                          - READY_FOR_BILLING
+                          - SETTLED
+                      readyForBillingAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      readyForBillingActorId:
+                        type: string
+                        nullable: true
+                      depositTargetAmount:
+                        type: number
+                      depositCollectedAmount:
+                        type: number
+                      paymentCollectionMethod:
+                        type: string
+                        enum:
+                          - PAYMENT_INTENT
+                          - PAYMENT_LINK
+                          - PAYMENT_AT_CLINIC
+                      status:
+                        type: string
+                        enum:
+                          - PENDING
+                          - AWAITING_PAYMENT
+                          - PAID
+                          - FAILED
+                          - CANCELLED
+                          - REFUNDED
+                      creditNotes:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - invoiceId
+                            - creditNoteNumber
+                            - amount
+                            - status
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            invoiceId:
+                              type: string
+                            creditNoteNumber:
+                              type: string
+                            reason:
+                              type: string
+                            amount:
+                              type: number
+                            status:
+                              type: string
+                              enum:
+                                - DRAFT
+                                - ISSUED
+                                - VOIDED
+                            metadata:
+                              type: object
+                              additionalProperties: true
+                              description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      metadata:
+                        type: object
+                        additionalProperties: true
+                        description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                      paidAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                      payments:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - invoiceId
+                            - provider
+                            - amount
+                            - currency
+                            - status
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            invoiceId:
+                              type: string
+                            paymentAttemptId:
+                              type: string
+                            provider:
+                              type: string
+                            settlementChannel:
+                              type: string
+                            collectionMode:
+                              type: string
+                            providerPaymentId:
+                              type: string
+                            amount:
+                              type: number
+                            currency:
+                              type: string
+                            status:
+                              type: string
+                            paidAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            receiptUrl:
+                              type: string
+                              nullable: true
+                            refunds:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - id
+                                  - paymentId
+                                  - provider
+                                  - amount
+                                  - currency
+                                  - status
+                                  - createdAt
+                                  - updatedAt
+                                properties:
+                                  id:
+                                    type: string
+                                  paymentId:
+                                    type: string
+                                  provider:
+                                    type: string
+                                  providerRefundId:
+                                    type: string
+                                    nullable: true
+                                  amount:
+                                    type: number
+                                  currency:
+                                    type: string
+                                  status:
+                                    type: string
+                                  reason:
+                                    type: string
+                                    nullable: true
+                                  createdAt:
+                                    type: string
+                                    format: date-time
+                                  updatedAt:
+                                    type: string
+                                    format: date-time
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      receipts:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - paymentId
+                            - invoiceId
+                            - provider
+                            - amount
+                            - currency
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            paymentId:
+                              type: string
+                            invoiceId:
+                              type: string
+                            provider:
+                              type: string
+                            settlementChannel:
+                              type: string
+                            amount:
+                              type: number
+                            currency:
+                              type: string
+                            receiptUrl:
+                              type: string
+                            paidAt:
+                              type: string
+                              format: date-time
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      settlementSummary:
+                        type: object
+                        required:
+                          - invoiceTotal
+                          - cashPaid
+                          - depositRecordedAmount
+                          - credited
+                          - effectivePaid
+                          - balance
+                          - lineAllocations
+                        properties:
+                          invoiceTotal:
+                            type: number
+                          cashPaid:
+                            type: number
+                          depositRecordedAmount:
+                            type: number
+                          credited:
+                            type: number
+                          effectivePaid:
+                            type: number
+                          balance:
+                            type: number
+                          lineAllocations:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - name
+                                - total
+                                - cashApplied
+                                - creditApplied
+                                - remaining
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                description:
+                                  type: string
+                                  nullable: true
+                                total:
+                                  type: number
+                                cashApplied:
+                                  type: number
+                                creditApplied:
+                                  type: number
+                                remaining:
+                                  type: number
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/mobile/{invoiceId}':
     get:
       tags:
@@ -5275,7 +11879,379 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - organistion
+                      - invoice
+                    properties:
+                      organistion:
+                        type: object
+                        required:
+                          - name
+                          - placesId
+                          - address
+                          - image
+                        properties:
+                          name:
+                            type: string
+                          placesId:
+                            type: string
+                          address:
+                            type: object
+                            additionalProperties: true
+                            description: Prisma Organization.address relation, included in full; shape is the Address model and is passed through as-is (falls back to "" when the organisation has no address on file).
+                          image:
+                            type: string
+                      invoice:
+                        type: object
+                        required:
+                          - items
+                          - subtotal
+                          - totalAmount
+                          - currency
+                          - paymentCollectionMethod
+                          - status
+                          - createdAt
+                          - updatedAt
+                          - payments
+                          - receipts
+                          - settlementSummary
+                        properties:
+                          id:
+                            type: string
+                          parentId:
+                            type: string
+                          patientId:
+                            type: string
+                          organisationId:
+                            type: string
+                          appointmentId:
+                            type: string
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - name
+                                - quantity
+                                - unitPrice
+                                - total
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                description:
+                                  type: string
+                                  nullable: true
+                                quantity:
+                                  type: number
+                                unitPrice:
+                                  type: number
+                                discountPercent:
+                                  type: number
+                                total:
+                                  type: number
+                          subtotal:
+                            type: number
+                          totalAmount:
+                            type: number
+                          taxPercent:
+                            type: number
+                          currency:
+                            type: string
+                            description: Lowercase ISO 4217 currency code (e.g. usd).
+                          taxTotal:
+                            type: number
+                          discountTotal:
+                            type: number
+                          billingCollectionMode:
+                            type: string
+                            enum:
+                              - PREPAY_AT_BOOKING
+                              - PAY_AT_VISIT_END
+                              - STAGED_DURING_VISIT
+                              - DEPOSIT_THEN_SETTLE
+                              - MANUAL_OFFLINE
+                          visitBillingStage:
+                            type: string
+                            enum:
+                              - DRAFT
+                              - READY_FOR_BILLING
+                              - SETTLED
+                          readyForBillingAt:
+                            type: string
+                            format: date-time
+                            nullable: true
+                          readyForBillingActorId:
+                            type: string
+                            nullable: true
+                          depositTargetAmount:
+                            type: number
+                          depositCollectedAmount:
+                            type: number
+                          paymentCollectionMethod:
+                            type: string
+                            enum:
+                              - PAYMENT_INTENT
+                              - PAYMENT_LINK
+                              - PAYMENT_AT_CLINIC
+                          status:
+                            type: string
+                            enum:
+                              - PENDING
+                              - AWAITING_PAYMENT
+                              - PAID
+                              - FAILED
+                              - CANCELLED
+                              - REFUNDED
+                          creditNotes:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - invoiceId
+                                - creditNoteNumber
+                                - amount
+                                - status
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                creditNoteNumber:
+                                  type: string
+                                reason:
+                                  type: string
+                                amount:
+                                  type: number
+                                status:
+                                  type: string
+                                  enum:
+                                    - DRAFT
+                                    - ISSUED
+                                    - VOIDED
+                                metadata:
+                                  type: object
+                                  additionalProperties: true
+                                  description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          metadata:
+                            type: object
+                            additionalProperties: true
+                            description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                          paidAt:
+                            type: string
+                            format: date-time
+                            nullable: true
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          payments:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - invoiceId
+                                - provider
+                                - amount
+                                - currency
+                                - status
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                paymentAttemptId:
+                                  type: string
+                                provider:
+                                  type: string
+                                settlementChannel:
+                                  type: string
+                                collectionMode:
+                                  type: string
+                                providerPaymentId:
+                                  type: string
+                                amount:
+                                  type: number
+                                currency:
+                                  type: string
+                                status:
+                                  type: string
+                                paidAt:
+                                  type: string
+                                  format: date-time
+                                  nullable: true
+                                receiptUrl:
+                                  type: string
+                                  nullable: true
+                                refunds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                      - id
+                                      - paymentId
+                                      - provider
+                                      - amount
+                                      - currency
+                                      - status
+                                      - createdAt
+                                      - updatedAt
+                                    properties:
+                                      id:
+                                        type: string
+                                      paymentId:
+                                        type: string
+                                      provider:
+                                        type: string
+                                      providerRefundId:
+                                        type: string
+                                        nullable: true
+                                      amount:
+                                        type: number
+                                      currency:
+                                        type: string
+                                      status:
+                                        type: string
+                                      reason:
+                                        type: string
+                                        nullable: true
+                                      createdAt:
+                                        type: string
+                                        format: date-time
+                                      updatedAt:
+                                        type: string
+                                        format: date-time
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          receipts:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - paymentId
+                                - invoiceId
+                                - provider
+                                - amount
+                                - currency
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                paymentId:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                provider:
+                                  type: string
+                                settlementChannel:
+                                  type: string
+                                amount:
+                                  type: number
+                                currency:
+                                  type: string
+                                receiptUrl:
+                                  type: string
+                                paidAt:
+                                  type: string
+                                  format: date-time
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          settlementSummary:
+                            type: object
+                            required:
+                              - invoiceTotal
+                              - cashPaid
+                              - depositRecordedAmount
+                              - credited
+                              - effectivePaid
+                              - balance
+                              - lineAllocations
+                            properties:
+                              invoiceTotal:
+                                type: number
+                              cashPaid:
+                                type: number
+                              depositRecordedAmount:
+                                type: number
+                              credited:
+                                type: number
+                              effectivePaid:
+                                type: number
+                              balance:
+                                type: number
+                              lineAllocations:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - name
+                                    - total
+                                    - cashApplied
+                                    - creditApplied
+                                    - remaining
+                                  properties:
+                                    id:
+                                      type: string
+                                    name:
+                                      type: string
+                                    description:
+                                      type: string
+                                      nullable: true
+                                    total:
+                                      type: number
+                                    cashApplied:
+                                      type: number
+                                    creditApplied:
+                                      type: number
+                                    remaining:
+                                      type: number
+                          renderedDocumentId:
+                            type: string
+                            description: Only present when a rendered PDF document exists for this invoice.
+                          pdfUrl:
+                            type: string
+                            nullable: true
+                            description: Only present when a rendered PDF document exists for this invoice.
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/appointment/{appointmentId}/charges':
     post:
       tags:
@@ -5297,7 +12273,172 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - items
+                      - subtotal
+                      - totalAmount
+                      - currency
+                      - paymentCollectionMethod
+                      - status
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      id:
+                        type: string
+                      parentId:
+                        type: string
+                      patientId:
+                        type: string
+                      organisationId:
+                        type: string
+                      appointmentId:
+                        type: string
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - quantity
+                            - unitPrice
+                            - total
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                              nullable: true
+                            quantity:
+                              type: number
+                            unitPrice:
+                              type: number
+                            discountPercent:
+                              type: number
+                            total:
+                              type: number
+                      subtotal:
+                        type: number
+                      totalAmount:
+                        type: number
+                      taxPercent:
+                        type: number
+                      currency:
+                        type: string
+                        description: Lowercase ISO 4217 currency code (e.g. usd).
+                      taxTotal:
+                        type: number
+                      discountTotal:
+                        type: number
+                      billingCollectionMode:
+                        type: string
+                        enum:
+                          - PREPAY_AT_BOOKING
+                          - PAY_AT_VISIT_END
+                          - STAGED_DURING_VISIT
+                          - DEPOSIT_THEN_SETTLE
+                          - MANUAL_OFFLINE
+                      visitBillingStage:
+                        type: string
+                        enum:
+                          - DRAFT
+                          - READY_FOR_BILLING
+                          - SETTLED
+                      readyForBillingAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      readyForBillingActorId:
+                        type: string
+                        nullable: true
+                      depositTargetAmount:
+                        type: number
+                      depositCollectedAmount:
+                        type: number
+                      paymentCollectionMethod:
+                        type: string
+                        enum:
+                          - PAYMENT_INTENT
+                          - PAYMENT_LINK
+                          - PAYMENT_AT_CLINIC
+                      status:
+                        type: string
+                        enum:
+                          - PENDING
+                          - AWAITING_PAYMENT
+                          - PAID
+                          - FAILED
+                          - CANCELLED
+                          - REFUNDED
+                      creditNotes:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - invoiceId
+                            - creditNoteNumber
+                            - amount
+                            - status
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            invoiceId:
+                              type: string
+                            creditNoteNumber:
+                              type: string
+                            reason:
+                              type: string
+                            amount:
+                              type: number
+                            status:
+                              type: string
+                              enum:
+                                - DRAFT
+                                - ISSUED
+                                - VOIDED
+                            metadata:
+                              type: object
+                              additionalProperties: true
+                              description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      metadata:
+                        type: object
+                        additionalProperties: true
+                        description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                      paidAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/appointment/{appointmentId}':
     post:
       tags:
@@ -5319,7 +12460,357 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - items
+                        - subtotal
+                        - totalAmount
+                        - currency
+                        - paymentCollectionMethod
+                        - status
+                        - createdAt
+                        - updatedAt
+                        - payments
+                        - receipts
+                        - settlementSummary
+                      properties:
+                        id:
+                          type: string
+                        parentId:
+                          type: string
+                        patientId:
+                          type: string
+                        organisationId:
+                          type: string
+                        appointmentId:
+                          type: string
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - name
+                              - quantity
+                              - unitPrice
+                              - total
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              description:
+                                type: string
+                                nullable: true
+                              quantity:
+                                type: number
+                              unitPrice:
+                                type: number
+                              discountPercent:
+                                type: number
+                              total:
+                                type: number
+                        subtotal:
+                          type: number
+                        totalAmount:
+                          type: number
+                        taxPercent:
+                          type: number
+                        currency:
+                          type: string
+                          description: Lowercase ISO 4217 currency code (e.g. usd).
+                        taxTotal:
+                          type: number
+                        discountTotal:
+                          type: number
+                        billingCollectionMode:
+                          type: string
+                          enum:
+                            - PREPAY_AT_BOOKING
+                            - PAY_AT_VISIT_END
+                            - STAGED_DURING_VISIT
+                            - DEPOSIT_THEN_SETTLE
+                            - MANUAL_OFFLINE
+                        visitBillingStage:
+                          type: string
+                          enum:
+                            - DRAFT
+                            - READY_FOR_BILLING
+                            - SETTLED
+                        readyForBillingAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        readyForBillingActorId:
+                          type: string
+                          nullable: true
+                        depositTargetAmount:
+                          type: number
+                        depositCollectedAmount:
+                          type: number
+                        paymentCollectionMethod:
+                          type: string
+                          enum:
+                            - PAYMENT_INTENT
+                            - PAYMENT_LINK
+                            - PAYMENT_AT_CLINIC
+                        status:
+                          type: string
+                          enum:
+                            - PENDING
+                            - AWAITING_PAYMENT
+                            - PAID
+                            - FAILED
+                            - CANCELLED
+                            - REFUNDED
+                        creditNotes:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - creditNoteNumber
+                              - amount
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              creditNoteNumber:
+                                type: string
+                              reason:
+                                type: string
+                              amount:
+                                type: number
+                              status:
+                                type: string
+                                enum:
+                                  - DRAFT
+                                  - ISSUED
+                                  - VOIDED
+                              metadata:
+                                type: object
+                                additionalProperties: true
+                                description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        metadata:
+                          type: object
+                          additionalProperties: true
+                          description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                        paidAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        payments:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              paymentAttemptId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              collectionMode:
+                                type: string
+                              providerPaymentId:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              status:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              receiptUrl:
+                                type: string
+                                nullable: true
+                              refunds:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - id
+                                    - paymentId
+                                    - provider
+                                    - amount
+                                    - currency
+                                    - status
+                                    - createdAt
+                                    - updatedAt
+                                  properties:
+                                    id:
+                                      type: string
+                                    paymentId:
+                                      type: string
+                                    provider:
+                                      type: string
+                                    providerRefundId:
+                                      type: string
+                                      nullable: true
+                                    amount:
+                                      type: number
+                                    currency:
+                                      type: string
+                                    status:
+                                      type: string
+                                    reason:
+                                      type: string
+                                      nullable: true
+                                    createdAt:
+                                      type: string
+                                      format: date-time
+                                    updatedAt:
+                                      type: string
+                                      format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        receipts:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - paymentId
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              paymentId:
+                                type: string
+                              invoiceId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              receiptUrl:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        settlementSummary:
+                          type: object
+                          required:
+                            - invoiceTotal
+                            - cashPaid
+                            - depositRecordedAmount
+                            - credited
+                            - effectivePaid
+                            - balance
+                            - lineAllocations
+                          properties:
+                            invoiceTotal:
+                              type: number
+                            cashPaid:
+                              type: number
+                            depositRecordedAmount:
+                              type: number
+                            credited:
+                              type: number
+                            effectivePaid:
+                              type: number
+                            balance:
+                              type: number
+                            lineAllocations:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - name
+                                  - total
+                                  - cashApplied
+                                  - creditApplied
+                                  - remaining
+                                properties:
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  description:
+                                    type: string
+                                    nullable: true
+                                  total:
+                                    type: number
+                                  cashApplied:
+                                    type: number
+                                  creditApplied:
+                                    type: number
+                                  remaining:
+                                    type: number
+                        renderedDocumentId:
+                          type: string
+                          description: Only present when a rendered PDF document exists for this invoice.
+                        pdfUrl:
+                          type: string
+                          nullable: true
+                          description: Only present when a rendered PDF document exists for this invoice.
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/payment-intent/{paymentIntentId}':
     get:
       tags:
@@ -5341,7 +12832,348 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - items
+                      - subtotal
+                      - totalAmount
+                      - currency
+                      - paymentCollectionMethod
+                      - status
+                      - createdAt
+                      - updatedAt
+                      - payments
+                      - receipts
+                      - settlementSummary
+                    properties:
+                      id:
+                        type: string
+                      parentId:
+                        type: string
+                      patientId:
+                        type: string
+                      organisationId:
+                        type: string
+                      appointmentId:
+                        type: string
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - quantity
+                            - unitPrice
+                            - total
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                              nullable: true
+                            quantity:
+                              type: number
+                            unitPrice:
+                              type: number
+                            discountPercent:
+                              type: number
+                            total:
+                              type: number
+                      subtotal:
+                        type: number
+                      totalAmount:
+                        type: number
+                      taxPercent:
+                        type: number
+                      currency:
+                        type: string
+                        description: Lowercase ISO 4217 currency code (e.g. usd).
+                      taxTotal:
+                        type: number
+                      discountTotal:
+                        type: number
+                      billingCollectionMode:
+                        type: string
+                        enum:
+                          - PREPAY_AT_BOOKING
+                          - PAY_AT_VISIT_END
+                          - STAGED_DURING_VISIT
+                          - DEPOSIT_THEN_SETTLE
+                          - MANUAL_OFFLINE
+                      visitBillingStage:
+                        type: string
+                        enum:
+                          - DRAFT
+                          - READY_FOR_BILLING
+                          - SETTLED
+                      readyForBillingAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      readyForBillingActorId:
+                        type: string
+                        nullable: true
+                      depositTargetAmount:
+                        type: number
+                      depositCollectedAmount:
+                        type: number
+                      paymentCollectionMethod:
+                        type: string
+                        enum:
+                          - PAYMENT_INTENT
+                          - PAYMENT_LINK
+                          - PAYMENT_AT_CLINIC
+                      status:
+                        type: string
+                        enum:
+                          - PENDING
+                          - AWAITING_PAYMENT
+                          - PAID
+                          - FAILED
+                          - CANCELLED
+                          - REFUNDED
+                      creditNotes:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - invoiceId
+                            - creditNoteNumber
+                            - amount
+                            - status
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            invoiceId:
+                              type: string
+                            creditNoteNumber:
+                              type: string
+                            reason:
+                              type: string
+                            amount:
+                              type: number
+                            status:
+                              type: string
+                              enum:
+                                - DRAFT
+                                - ISSUED
+                                - VOIDED
+                            metadata:
+                              type: object
+                              additionalProperties: true
+                              description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      metadata:
+                        type: object
+                        additionalProperties: true
+                        description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                      paidAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                      payments:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - invoiceId
+                            - provider
+                            - amount
+                            - currency
+                            - status
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            invoiceId:
+                              type: string
+                            paymentAttemptId:
+                              type: string
+                            provider:
+                              type: string
+                            settlementChannel:
+                              type: string
+                            collectionMode:
+                              type: string
+                            providerPaymentId:
+                              type: string
+                            amount:
+                              type: number
+                            currency:
+                              type: string
+                            status:
+                              type: string
+                            paidAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            receiptUrl:
+                              type: string
+                              nullable: true
+                            refunds:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - id
+                                  - paymentId
+                                  - provider
+                                  - amount
+                                  - currency
+                                  - status
+                                  - createdAt
+                                  - updatedAt
+                                properties:
+                                  id:
+                                    type: string
+                                  paymentId:
+                                    type: string
+                                  provider:
+                                    type: string
+                                  providerRefundId:
+                                    type: string
+                                    nullable: true
+                                  amount:
+                                    type: number
+                                  currency:
+                                    type: string
+                                  status:
+                                    type: string
+                                  reason:
+                                    type: string
+                                    nullable: true
+                                  createdAt:
+                                    type: string
+                                    format: date-time
+                                  updatedAt:
+                                    type: string
+                                    format: date-time
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      receipts:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - id
+                            - paymentId
+                            - invoiceId
+                            - provider
+                            - amount
+                            - currency
+                            - createdAt
+                            - updatedAt
+                          properties:
+                            id:
+                              type: string
+                            paymentId:
+                              type: string
+                            invoiceId:
+                              type: string
+                            provider:
+                              type: string
+                            settlementChannel:
+                              type: string
+                            amount:
+                              type: number
+                            currency:
+                              type: string
+                            receiptUrl:
+                              type: string
+                            paidAt:
+                              type: string
+                              format: date-time
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                      settlementSummary:
+                        type: object
+                        required:
+                          - invoiceTotal
+                          - cashPaid
+                          - depositRecordedAmount
+                          - credited
+                          - effectivePaid
+                          - balance
+                          - lineAllocations
+                        properties:
+                          invoiceTotal:
+                            type: number
+                          cashPaid:
+                            type: number
+                          depositRecordedAmount:
+                            type: number
+                          credited:
+                            type: number
+                          effectivePaid:
+                            type: number
+                          balance:
+                            type: number
+                          lineAllocations:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - name
+                                - total
+                                - cashApplied
+                                - creditApplied
+                                - remaining
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                description:
+                                  type: string
+                                  nullable: true
+                                total:
+                                  type: number
+                                cashApplied:
+                                  type: number
+                                creditApplied:
+                                  type: number
+                                remaining:
+                                  type: number
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/organisation/{organisationId}/list':
     get:
       tags:
@@ -5369,7 +13201,350 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - items
+                        - subtotal
+                        - totalAmount
+                        - currency
+                        - paymentCollectionMethod
+                        - status
+                        - createdAt
+                        - updatedAt
+                        - payments
+                        - receipts
+                        - settlementSummary
+                      properties:
+                        id:
+                          type: string
+                        parentId:
+                          type: string
+                        patientId:
+                          type: string
+                        organisationId:
+                          type: string
+                        appointmentId:
+                          type: string
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - name
+                              - quantity
+                              - unitPrice
+                              - total
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              description:
+                                type: string
+                                nullable: true
+                              quantity:
+                                type: number
+                              unitPrice:
+                                type: number
+                              discountPercent:
+                                type: number
+                              total:
+                                type: number
+                        subtotal:
+                          type: number
+                        totalAmount:
+                          type: number
+                        taxPercent:
+                          type: number
+                        currency:
+                          type: string
+                          description: Lowercase ISO 4217 currency code (e.g. usd).
+                        taxTotal:
+                          type: number
+                        discountTotal:
+                          type: number
+                        billingCollectionMode:
+                          type: string
+                          enum:
+                            - PREPAY_AT_BOOKING
+                            - PAY_AT_VISIT_END
+                            - STAGED_DURING_VISIT
+                            - DEPOSIT_THEN_SETTLE
+                            - MANUAL_OFFLINE
+                        visitBillingStage:
+                          type: string
+                          enum:
+                            - DRAFT
+                            - READY_FOR_BILLING
+                            - SETTLED
+                        readyForBillingAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        readyForBillingActorId:
+                          type: string
+                          nullable: true
+                        depositTargetAmount:
+                          type: number
+                        depositCollectedAmount:
+                          type: number
+                        paymentCollectionMethod:
+                          type: string
+                          enum:
+                            - PAYMENT_INTENT
+                            - PAYMENT_LINK
+                            - PAYMENT_AT_CLINIC
+                        status:
+                          type: string
+                          enum:
+                            - PENDING
+                            - AWAITING_PAYMENT
+                            - PAID
+                            - FAILED
+                            - CANCELLED
+                            - REFUNDED
+                        creditNotes:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - creditNoteNumber
+                              - amount
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              creditNoteNumber:
+                                type: string
+                              reason:
+                                type: string
+                              amount:
+                                type: number
+                              status:
+                                type: string
+                                enum:
+                                  - DRAFT
+                                  - ISSUED
+                                  - VOIDED
+                              metadata:
+                                type: object
+                                additionalProperties: true
+                                description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        metadata:
+                          type: object
+                          additionalProperties: true
+                          description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                        paidAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        payments:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - status
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              invoiceId:
+                                type: string
+                              paymentAttemptId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              collectionMode:
+                                type: string
+                              providerPaymentId:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              status:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                                nullable: true
+                              receiptUrl:
+                                type: string
+                                nullable: true
+                              refunds:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - id
+                                    - paymentId
+                                    - provider
+                                    - amount
+                                    - currency
+                                    - status
+                                    - createdAt
+                                    - updatedAt
+                                  properties:
+                                    id:
+                                      type: string
+                                    paymentId:
+                                      type: string
+                                    provider:
+                                      type: string
+                                    providerRefundId:
+                                      type: string
+                                      nullable: true
+                                    amount:
+                                      type: number
+                                    currency:
+                                      type: string
+                                    status:
+                                      type: string
+                                    reason:
+                                      type: string
+                                      nullable: true
+                                    createdAt:
+                                      type: string
+                                      format: date-time
+                                    updatedAt:
+                                      type: string
+                                      format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        receipts:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - id
+                              - paymentId
+                              - invoiceId
+                              - provider
+                              - amount
+                              - currency
+                              - createdAt
+                              - updatedAt
+                            properties:
+                              id:
+                                type: string
+                              paymentId:
+                                type: string
+                              invoiceId:
+                                type: string
+                              provider:
+                                type: string
+                              settlementChannel:
+                                type: string
+                              amount:
+                                type: number
+                              currency:
+                                type: string
+                              receiptUrl:
+                                type: string
+                              paidAt:
+                                type: string
+                                format: date-time
+                              createdAt:
+                                type: string
+                                format: date-time
+                              updatedAt:
+                                type: string
+                                format: date-time
+                        settlementSummary:
+                          type: object
+                          required:
+                            - invoiceTotal
+                            - cashPaid
+                            - depositRecordedAmount
+                            - credited
+                            - effectivePaid
+                            - balance
+                            - lineAllocations
+                          properties:
+                            invoiceTotal:
+                              type: number
+                            cashPaid:
+                              type: number
+                            depositRecordedAmount:
+                              type: number
+                            credited:
+                              type: number
+                            effectivePaid:
+                              type: number
+                            balance:
+                              type: number
+                            lineAllocations:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - name
+                                  - total
+                                  - cashApplied
+                                  - creditApplied
+                                  - remaining
+                                properties:
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  description:
+                                    type: string
+                                    nullable: true
+                                  total:
+                                    type: number
+                                  cashApplied:
+                                    type: number
+                                  creditApplied:
+                                    type: number
+                                  remaining:
+                                    type: number
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/{invoiceId}/checkout-session':
     post:
       tags:
@@ -5391,7 +13566,40 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - checkout
+                      - emailSent
+                    properties:
+                      checkout:
+                        type: object
+                        required:
+                          - sessionId
+                        properties:
+                          sessionId:
+                            type: string
+                          url:
+                            type: string
+                            nullable: true
+                          paymentAttemptId:
+                            type: string
+                            nullable: true
+                      emailSent:
+                        type: boolean
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   '/fhir/v1/invoice/{invoiceId}':
     get:
       tags:
@@ -5413,7 +13621,379 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - data
+                  - meta
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - organistion
+                      - invoice
+                    properties:
+                      organistion:
+                        type: object
+                        required:
+                          - name
+                          - placesId
+                          - address
+                          - image
+                        properties:
+                          name:
+                            type: string
+                          placesId:
+                            type: string
+                          address:
+                            type: object
+                            additionalProperties: true
+                            description: Prisma Organization.address relation, included in full; shape is the Address model and is passed through as-is (falls back to "" when the organisation has no address on file).
+                          image:
+                            type: string
+                      invoice:
+                        type: object
+                        required:
+                          - items
+                          - subtotal
+                          - totalAmount
+                          - currency
+                          - paymentCollectionMethod
+                          - status
+                          - createdAt
+                          - updatedAt
+                          - payments
+                          - receipts
+                          - settlementSummary
+                        properties:
+                          id:
+                            type: string
+                          parentId:
+                            type: string
+                          patientId:
+                            type: string
+                          organisationId:
+                            type: string
+                          appointmentId:
+                            type: string
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - name
+                                - quantity
+                                - unitPrice
+                                - total
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                                description:
+                                  type: string
+                                  nullable: true
+                                quantity:
+                                  type: number
+                                unitPrice:
+                                  type: number
+                                discountPercent:
+                                  type: number
+                                total:
+                                  type: number
+                          subtotal:
+                            type: number
+                          totalAmount:
+                            type: number
+                          taxPercent:
+                            type: number
+                          currency:
+                            type: string
+                            description: Lowercase ISO 4217 currency code (e.g. usd).
+                          taxTotal:
+                            type: number
+                          discountTotal:
+                            type: number
+                          billingCollectionMode:
+                            type: string
+                            enum:
+                              - PREPAY_AT_BOOKING
+                              - PAY_AT_VISIT_END
+                              - STAGED_DURING_VISIT
+                              - DEPOSIT_THEN_SETTLE
+                              - MANUAL_OFFLINE
+                          visitBillingStage:
+                            type: string
+                            enum:
+                              - DRAFT
+                              - READY_FOR_BILLING
+                              - SETTLED
+                          readyForBillingAt:
+                            type: string
+                            format: date-time
+                            nullable: true
+                          readyForBillingActorId:
+                            type: string
+                            nullable: true
+                          depositTargetAmount:
+                            type: number
+                          depositCollectedAmount:
+                            type: number
+                          paymentCollectionMethod:
+                            type: string
+                            enum:
+                              - PAYMENT_INTENT
+                              - PAYMENT_LINK
+                              - PAYMENT_AT_CLINIC
+                          status:
+                            type: string
+                            enum:
+                              - PENDING
+                              - AWAITING_PAYMENT
+                              - PAID
+                              - FAILED
+                              - CANCELLED
+                              - REFUNDED
+                          creditNotes:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - invoiceId
+                                - creditNoteNumber
+                                - amount
+                                - status
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                creditNoteNumber:
+                                  type: string
+                                reason:
+                                  type: string
+                                amount:
+                                  type: number
+                                status:
+                                  type: string
+                                  enum:
+                                    - DRAFT
+                                    - ISSUED
+                                    - VOIDED
+                                metadata:
+                                  type: object
+                                  additionalProperties: true
+                                  description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          metadata:
+                            type: object
+                            additionalProperties: true
+                            description: Prisma Json column normalized to string/number/boolean values only; no fixed keys.
+                          paidAt:
+                            type: string
+                            format: date-time
+                            nullable: true
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          payments:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - invoiceId
+                                - provider
+                                - amount
+                                - currency
+                                - status
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                paymentAttemptId:
+                                  type: string
+                                provider:
+                                  type: string
+                                settlementChannel:
+                                  type: string
+                                collectionMode:
+                                  type: string
+                                providerPaymentId:
+                                  type: string
+                                amount:
+                                  type: number
+                                currency:
+                                  type: string
+                                status:
+                                  type: string
+                                paidAt:
+                                  type: string
+                                  format: date-time
+                                  nullable: true
+                                receiptUrl:
+                                  type: string
+                                  nullable: true
+                                refunds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                      - id
+                                      - paymentId
+                                      - provider
+                                      - amount
+                                      - currency
+                                      - status
+                                      - createdAt
+                                      - updatedAt
+                                    properties:
+                                      id:
+                                        type: string
+                                      paymentId:
+                                        type: string
+                                      provider:
+                                        type: string
+                                      providerRefundId:
+                                        type: string
+                                        nullable: true
+                                      amount:
+                                        type: number
+                                      currency:
+                                        type: string
+                                      status:
+                                        type: string
+                                      reason:
+                                        type: string
+                                        nullable: true
+                                      createdAt:
+                                        type: string
+                                        format: date-time
+                                      updatedAt:
+                                        type: string
+                                        format: date-time
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          receipts:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - id
+                                - paymentId
+                                - invoiceId
+                                - provider
+                                - amount
+                                - currency
+                                - createdAt
+                                - updatedAt
+                              properties:
+                                id:
+                                  type: string
+                                paymentId:
+                                  type: string
+                                invoiceId:
+                                  type: string
+                                provider:
+                                  type: string
+                                settlementChannel:
+                                  type: string
+                                amount:
+                                  type: number
+                                currency:
+                                  type: string
+                                receiptUrl:
+                                  type: string
+                                paidAt:
+                                  type: string
+                                  format: date-time
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                          settlementSummary:
+                            type: object
+                            required:
+                              - invoiceTotal
+                              - cashPaid
+                              - depositRecordedAmount
+                              - credited
+                              - effectivePaid
+                              - balance
+                              - lineAllocations
+                            properties:
+                              invoiceTotal:
+                                type: number
+                              cashPaid:
+                                type: number
+                              depositRecordedAmount:
+                                type: number
+                              credited:
+                                type: number
+                              effectivePaid:
+                                type: number
+                              balance:
+                                type: number
+                              lineAllocations:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                    - name
+                                    - total
+                                    - cashApplied
+                                    - creditApplied
+                                    - remaining
+                                  properties:
+                                    id:
+                                      type: string
+                                    name:
+                                      type: string
+                                    description:
+                                      type: string
+                                      nullable: true
+                                    total:
+                                      type: number
+                                    cashApplied:
+                                      type: number
+                                    creditApplied:
+                                      type: number
+                                    remaining:
+                                      type: number
+                          renderedDocumentId:
+                            type: string
+                            description: Only present when a rendered PDF document exists for this invoice.
+                          pdfUrl:
+                            type: string
+                            nullable: true
+                            description: Only present when a rendered PDF document exists for this invoice.
+                  meta:
+                    type: object
+                    nullable: true
+                    description: "Always null; this endpoint's InvoiceController wraps every response in { data, meta: null, error: null } via toFinanceEnvelope and never populates meta."
+                  error:
+                    type: object
+                    nullable: true
+                    description: Always null on a 200 response; this route uses the HTTP status code for errors, not this field.
   /v1/notification/mobile:
     get:
       tags:
@@ -5449,7 +14029,56 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - notifications
+                properties:
+                  notifications:
+                    type: array
+                    description: "NotificationService.listNotificationsForUser: raw Notification rows for the caller's linked parent id, newest first."
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - userId
+                        - title
+                        - body
+                        - type
+                        - enabled
+                        - isSeen
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        id:
+                          type: string
+                        userId:
+                          type: string
+                        title:
+                          type: string
+                        body:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - CHAT_MESSAGE
+                            - APPOINTMENTS
+                            - REMINDERS
+                            - PROMOTIONS
+                            - PAYMENTS
+                        enabled:
+                          type: boolean
+                        isSeen:
+                          type: boolean
+                        archivedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                          description: Set when the owner archived the notification; null otherwise.
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
         500:
           description: Response
           content:
@@ -5526,8 +14155,89 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                    - category
+                    - fields
+                    - isActive
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    fields:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - label
+                          - type
+                          - required
+                        properties:
+                          key:
+                            type: string
+                          label:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                              - TEXT
+                              - NUMBER
+                              - CHOICE
+                              - BOOLEAN
+                              - PHOTO
+                              - VIDEO
+                          required:
+                            type: boolean
+                          options:
+                            type: array
+                            items:
+                              type: string
+                            nullable: true
+                          scoring:
+                            type: object
+                            nullable: true
+                            properties:
+                              points:
+                                type: number
+                                nullable: true
+                              map:
+                                type: object
+                                additionalProperties:
+                                  type: number
+                                nullable: true
+                    scoringRules:
+                      type: object
+                      nullable: true
+                      properties:
+                        sumFields:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        customFormula:
+                          type: string
+                          nullable: true
+                    isActive:
+                      type: boolean
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/observation-tools/mobile/tools/{toolId}':
     get:
       tags:
@@ -5549,7 +14259,86 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - name
+                  - category
+                  - fields
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  fields:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - label
+                        - type
+                        - required
+                      properties:
+                        key:
+                          type: string
+                        label:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - TEXT
+                            - NUMBER
+                            - CHOICE
+                            - BOOLEAN
+                            - PHOTO
+                            - VIDEO
+                        required:
+                          type: boolean
+                        options:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        scoring:
+                          type: object
+                          nullable: true
+                          properties:
+                            points:
+                              type: number
+                              nullable: true
+                            map:
+                              type: object
+                              additionalProperties:
+                                type: number
+                              nullable: true
+                  scoringRules:
+                    type: object
+                    nullable: true
+                    properties:
+                      sumFields:
+                        type: array
+                        items:
+                          type: string
+                        nullable: true
+                      customFormula:
+                        type: string
+                        nullable: true
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/mobile/tools/{toolId}/submissions':
     post:
       tags:
@@ -5571,7 +14360,45 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - toolId
+                  - patientId
+                  - filledBy
+                  - answers
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  toolId:
+                    type: string
+                  taskId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                  filledBy:
+                    type: string
+                  answers:
+                    type: object
+                    additionalProperties: true
+                    description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  evaluationAppointmentId:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/mobile/submissions/{submissionId}/link-appointment':
     post:
       tags:
@@ -5593,7 +14420,45 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - toolId
+                  - patientId
+                  - filledBy
+                  - answers
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  toolId:
+                    type: string
+                  taskId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                  filledBy:
+                    type: string
+                  answers:
+                    type: object
+                    additionalProperties: true
+                    description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  evaluationAppointmentId:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/mobile/tasks/{taskId}/preview':
     get:
       tags:
@@ -5615,7 +14480,38 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - taskId
+                  - toolId
+                  - toolName
+                  - toolCategory
+                properties:
+                  taskId:
+                    type: string
+                  toolId:
+                    type: string
+                  toolName:
+                    type: string
+                  toolCategory:
+                    type: string
+                  submissionId:
+                    type: string
+                    nullable: true
+                  submittedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  answersPreview:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: The first 5 tool-definition fields' answers from the latest submission for this task, keyed by field key; the underlying answers column is a dynamic Prisma Json value with no fixed shape.
   '/v1/observation-tools/pms/tools':
     get:
       tags:
@@ -5641,8 +14537,89 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                    - category
+                    - fields
+                    - isActive
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    fields:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - key
+                          - label
+                          - type
+                          - required
+                        properties:
+                          key:
+                            type: string
+                          label:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                              - TEXT
+                              - NUMBER
+                              - CHOICE
+                              - BOOLEAN
+                              - PHOTO
+                              - VIDEO
+                          required:
+                            type: boolean
+                          options:
+                            type: array
+                            items:
+                              type: string
+                            nullable: true
+                          scoring:
+                            type: object
+                            nullable: true
+                            properties:
+                              points:
+                                type: number
+                                nullable: true
+                              map:
+                                type: object
+                                additionalProperties:
+                                  type: number
+                                nullable: true
+                    scoringRules:
+                      type: object
+                      nullable: true
+                      properties:
+                        sumFields:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        customFormula:
+                          type: string
+                          nullable: true
+                    isActive:
+                      type: boolean
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
     post:
       tags:
         - 'Non-FHIR'
@@ -5657,7 +14634,86 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - name
+                  - category
+                  - fields
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  fields:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - label
+                        - type
+                        - required
+                      properties:
+                        key:
+                          type: string
+                        label:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - TEXT
+                            - NUMBER
+                            - CHOICE
+                            - BOOLEAN
+                            - PHOTO
+                            - VIDEO
+                        required:
+                          type: boolean
+                        options:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        scoring:
+                          type: object
+                          nullable: true
+                          properties:
+                            points:
+                              type: number
+                              nullable: true
+                            map:
+                              type: object
+                              additionalProperties:
+                                type: number
+                              nullable: true
+                  scoringRules:
+                    type: object
+                    nullable: true
+                    properties:
+                      sumFields:
+                        type: array
+                        items:
+                          type: string
+                        nullable: true
+                      customFormula:
+                        type: string
+                        nullable: true
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/pms/tools/{toolId}':
     get:
       tags:
@@ -5679,7 +14735,86 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - name
+                  - category
+                  - fields
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  fields:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - label
+                        - type
+                        - required
+                      properties:
+                        key:
+                          type: string
+                        label:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - TEXT
+                            - NUMBER
+                            - CHOICE
+                            - BOOLEAN
+                            - PHOTO
+                            - VIDEO
+                        required:
+                          type: boolean
+                        options:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        scoring:
+                          type: object
+                          nullable: true
+                          properties:
+                            points:
+                              type: number
+                              nullable: true
+                            map:
+                              type: object
+                              additionalProperties:
+                                type: number
+                              nullable: true
+                  scoringRules:
+                    type: object
+                    nullable: true
+                    properties:
+                      sumFields:
+                        type: array
+                        items:
+                          type: string
+                        nullable: true
+                      customFormula:
+                        type: string
+                        nullable: true
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
     patch:
       tags:
         - 'Non-FHIR'
@@ -5700,7 +14835,86 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - name
+                  - category
+                  - fields
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  fields:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - key
+                        - label
+                        - type
+                        - required
+                      properties:
+                        key:
+                          type: string
+                        label:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                            - TEXT
+                            - NUMBER
+                            - CHOICE
+                            - BOOLEAN
+                            - PHOTO
+                            - VIDEO
+                        required:
+                          type: boolean
+                        options:
+                          type: array
+                          items:
+                            type: string
+                          nullable: true
+                        scoring:
+                          type: object
+                          nullable: true
+                          properties:
+                            points:
+                              type: number
+                              nullable: true
+                            map:
+                              type: object
+                              additionalProperties:
+                                type: number
+                              nullable: true
+                  scoringRules:
+                    type: object
+                    nullable: true
+                    properties:
+                      sumFields:
+                        type: array
+                        items:
+                          type: string
+                        nullable: true
+                      customFormula:
+                        type: string
+                        nullable: true
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/pms/tools/{toolId}/archive':
     post:
       tags:
@@ -5722,7 +14936,8 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                additionalProperties: false
+                description: Controller sends res.status(204).send() with an empty body; there is no actual JSON payload for this status code, so this schema documents an empty object rather than any real content.
   '/v1/observation-tools/pms/submissions':
     get:
       tags:
@@ -5737,8 +14952,48 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - toolId
+                    - patientId
+                    - filledBy
+                    - answers
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    toolId:
+                      type: string
+                    taskId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                    filledBy:
+                      type: string
+                    answers:
+                      type: object
+                      additionalProperties: true
+                      description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                    score:
+                      type: number
+                      nullable: true
+                    summary:
+                      type: string
+                      nullable: true
+                    evaluationAppointmentId:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -5773,7 +15028,45 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - toolId
+                  - patientId
+                  - filledBy
+                  - answers
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  toolId:
+                    type: string
+                  taskId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                  filledBy:
+                    type: string
+                  answers:
+                    type: object
+                    additionalProperties: true
+                    description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  evaluationAppointmentId:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/pms/submissions/{submissionId}/link-appointment':
     post:
       tags:
@@ -5801,7 +15094,45 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - toolId
+                  - patientId
+                  - filledBy
+                  - answers
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  toolId:
+                    type: string
+                  taskId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                  filledBy:
+                    type: string
+                  answers:
+                    type: object
+                    additionalProperties: true
+                    description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  evaluationAppointmentId:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/pms/appointments/{appointmentId}/submissions':
     post:
       tags:
@@ -5822,8 +15153,48 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - toolId
+                    - patientId
+                    - filledBy
+                    - answers
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    toolId:
+                      type: string
+                    taskId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                    filledBy:
+                      type: string
+                    answers:
+                      type: object
+                      additionalProperties: true
+                      description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                    score:
+                      type: number
+                      nullable: true
+                    summary:
+                      type: string
+                      nullable: true
+                    evaluationAppointmentId:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/observation-tools/pms/tasks/{taskId}/submission':
     get:
       tags:
@@ -5845,7 +15216,45 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - id
+                  - toolId
+                  - patientId
+                  - filledBy
+                  - answers
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  toolId:
+                    type: string
+                  taskId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                  filledBy:
+                    type: string
+                  answers:
+                    type: object
+                    additionalProperties: true
+                    description: answers is a Prisma Json column keyed by the observation tool's field keys (see ObservationToolDefinition.fields); its shape varies per tool definition and has no fixed schema at the database level.
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  evaluationAppointmentId:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/observation-tools/pms/tasks/{taskId}/preview':
     get:
       tags:
@@ -5867,7 +15276,38 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - taskId
+                  - toolId
+                  - toolName
+                  - toolCategory
+                properties:
+                  taskId:
+                    type: string
+                  toolId:
+                    type: string
+                  toolName:
+                    type: string
+                  toolCategory:
+                    type: string
+                  submissionId:
+                    type: string
+                    nullable: true
+                  submittedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  score:
+                    type: number
+                    nullable: true
+                  summary:
+                    type: string
+                    nullable: true
+                  answersPreview:
+                    type: object
+                    additionalProperties: true
+                    nullable: true
+                    description: The first 5 tool-definition fields' answers from the latest submission for this task, keyed by field key; the underlying answers column is a dynamic Prisma Json value with no fixed shape.
   '/v1/observation-tools/pms/appointments/{appointmentId}/task-previews':
     get:
       tags:
@@ -5888,8 +15328,54 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  required:
+                    - taskId
+                    - status
+                    - dueAt
+                    - toolId
+                    - toolName
+                    - toolCategory
+                  properties:
+                    taskId:
+                      type: string
+                    patientId:
+                      type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - IN_PROGRESS
+                        - COMPLETED
+                        - CANCELLED
+                    dueAt:
+                      type: string
+                      format: date-time
+                    toolId:
+                      type: string
+                    toolName:
+                      type: string
+                    toolCategory:
+                      type: string
+                    submissionId:
+                      type: string
+                      nullable: true
+                    submittedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    score:
+                      type: number
+                      nullable: true
+                    summary:
+                      type: string
+                      nullable: true
+                    evaluationAppointmentId:
+                      type: string
+                      nullable: true
   '/v1/organisation-document/pms/{orgId}/documents/upload':
     post:
       tags:
@@ -5966,8 +15452,38 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateOrgDocumentBody
+              required:
+                - title
+                - category
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                category:
+                  type: string
+                  enum:
+                    - TERMS_AND_CONDITIONS
+                    - PRIVACY_POLICY
+                    - CANCELLATION_POLICY
+                    - FIRE_SAFETY
+                    - GENERAL
+                fileUrl:
+                  type: string
+                  description: S3 object key returned by the presigned-upload endpoint; resolved server-side into a signed URL via getURLForKey before being stored/returned.
+                fileName:
+                  type: string
+                fileType:
+                  type: string
+                fileSize:
+                  type: number
+                visibility:
+                  type: string
+                  enum:
+                    - INTERNAL
+                    - PUBLIC
+                  description: Defaults to INTERNAL when omitted (OrganizationDocumentService.createDocument).
+              description: CreateOrgDocumentInput minus organisationId (taken from the :orgId path param). Body is a plain TS interface consumed directly by the controller/service - no Zod schema validates it at the route; only organisationId and title are enforced (as required) by OrganizationDocumentService.createDocument.
       responses:
         200:
           description: Response
@@ -5975,7 +15491,119 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - organisationId
+                      - title
+                      - category
+                      - visibility
+                      - version
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      _id:
+                        type: string
+                      organisationId:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      category:
+                        type: string
+                        enum:
+                          - TERMS_AND_CONDITIONS
+                          - PRIVACY_POLICY
+                          - CANCELLATION_POLICY
+                          - FIRE_SAFETY
+                          - GENERAL
+                      fileUrl:
+                        type: string
+                      fileName:
+                        type: string
+                      fileType:
+                        type: string
+                      fileSize:
+                        type: number
+                      pdfUrl:
+                        type: string
+                        description: Resolved server-side by buildOrganisationDocumentPdfUrl.
+                      visibility:
+                        type: string
+                        enum:
+                          - INTERNAL
+                          - PUBLIC
+                      version:
+                        type: number
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                description: 'This 200 is not actually reachable - the controller returns HTTP 201 for this exact body on success (res.status(201).json({ data: doc })). Documented here anyway since an OpenAPI generator keys off status codes; see the real 201 response below.'
+        201:
+          description: 'Document created (OrganizationDocumentService.createDocument -> res.status(201).json({ data: doc })).'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - organisationId
+                      - title
+                      - category
+                      - visibility
+                      - version
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      _id:
+                        type: string
+                      organisationId:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      category:
+                        type: string
+                        enum:
+                          - TERMS_AND_CONDITIONS
+                          - PRIVACY_POLICY
+                          - CANCELLATION_POLICY
+                          - FIRE_SAFETY
+                          - GENERAL
+                      fileUrl:
+                        type: string
+                      fileName:
+                        type: string
+                      fileType:
+                        type: string
+                      fileSize:
+                        type: number
+                      pdfUrl:
+                        type: string
+                        description: Resolved server-side by buildOrganisationDocumentPdfUrl.
+                      visibility:
+                        type: string
+                        enum:
+                          - INTERNAL
+                          - PUBLIC
+                      version:
+                        type: number
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
     get:
       tags:
         - 'Non-FHIR'
@@ -6002,7 +15630,62 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - _id
+                        - organisationId
+                        - title
+                        - category
+                        - visibility
+                        - version
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        _id:
+                          type: string
+                        organisationId:
+                          type: string
+                        title:
+                          type: string
+                        description:
+                          type: string
+                        category:
+                          type: string
+                          enum:
+                            - TERMS_AND_CONDITIONS
+                            - PRIVACY_POLICY
+                            - CANCELLATION_POLICY
+                            - FIRE_SAFETY
+                            - GENERAL
+                        fileUrl:
+                          type: string
+                        fileName:
+                          type: string
+                        fileType:
+                          type: string
+                        fileSize:
+                          type: number
+                        pdfUrl:
+                          type: string
+                          description: 'Resolved server-side by buildOrganisationDocumentPdfUrl: the stored fileUrl if fileType is application/pdf, otherwise a derived org-docs/{orgId}/{category-slug}-v{version}.pdf key.'
+                        visibility:
+                          type: string
+                          enum:
+                            - INTERNAL
+                            - PUBLIC
+                        version:
+                          type: number
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                description: OrganizationDocumentService.listDocumentsForOrganisation, mapped via toOrganizationDocumentDocumentWithPdfUrl (organisation-document.service.ts). Optional query filters category and visibility (INTERNAL/PUBLIC/ALL) narrow the list but do not change the item shape.
   '/v1/organisation-document/pms/{orgId}/documents/{documentId}':
     patch:
       tags:
@@ -6034,8 +15717,34 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: UpdateOrgDocumentBody
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                category:
+                  type: string
+                  enum:
+                    - TERMS_AND_CONDITIONS
+                    - PRIVACY_POLICY
+                    - CANCELLATION_POLICY
+                    - FIRE_SAFETY
+                    - GENERAL
+                visibility:
+                  type: string
+                  enum:
+                    - INTERNAL
+                    - PUBLIC
+                fileUrl:
+                  type: string
+                  description: Presence of ANY of fileUrl/fileName/fileType/fileSize causes updateDocument to treat this as a file replacement and increment version by 1.
+                fileName:
+                  type: string
+                fileType:
+                  type: string
+                fileSize:
+                  type: number
+              description: UpdateOrgDocumentInput - all fields optional. Plain TS interface, no Zod schema validates the body at this route; OrganizationDocumentService.updateDocument merges only the fields present onto the existing record.
       responses:
         200:
           description: Response
@@ -6043,7 +15752,61 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - organisationId
+                      - title
+                      - category
+                      - visibility
+                      - version
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      _id:
+                        type: string
+                      organisationId:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      category:
+                        type: string
+                        enum:
+                          - TERMS_AND_CONDITIONS
+                          - PRIVACY_POLICY
+                          - CANCELLATION_POLICY
+                          - FIRE_SAFETY
+                          - GENERAL
+                      fileUrl:
+                        type: string
+                      fileName:
+                        type: string
+                      fileType:
+                        type: string
+                      fileSize:
+                        type: number
+                      pdfUrl:
+                        type: string
+                        description: Resolved server-side by buildOrganisationDocumentPdfUrl, same rule as the list/get endpoints.
+                      visibility:
+                        type: string
+                        enum:
+                          - INTERNAL
+                          - PUBLIC
+                      version:
+                        type: number
+                        description: Incremented by 1 if the request body included any file field (fileUrl/fileName/fileType/fileSize).
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                description: OrganizationDocumentService.updateDocument, mapped via toOrganizationDocumentDocumentWithPdfUrl.
     delete:
       tags:
         - 'Non-FHIR'
@@ -6075,7 +15838,10 @@ paths:
             application/json:
               schema:
                 type: object
+                description: Controller actually sends HTTP 204 No Content with an empty body (res.status(204).send()) on success - there is no 200 response for this route/method in source. Documented placeholder cannot be filled with a real 200 body because none exists; see notes.
                 additionalProperties: true
+        204:
+          description: Document deleted (OrganizationDocumentService.deleteDocument -> res.status(204).send(), no response body).
     get:
       tags:
         - 'Non-FHIR'
@@ -6107,7 +15873,60 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - organisationId
+                      - title
+                      - category
+                      - visibility
+                      - version
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      _id:
+                        type: string
+                      organisationId:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      category:
+                        type: string
+                        enum:
+                          - TERMS_AND_CONDITIONS
+                          - PRIVACY_POLICY
+                          - CANCELLATION_POLICY
+                          - FIRE_SAFETY
+                          - GENERAL
+                      fileUrl:
+                        type: string
+                      fileName:
+                        type: string
+                      fileType:
+                        type: string
+                      fileSize:
+                        type: number
+                      pdfUrl:
+                        type: string
+                        description: Resolved server-side by buildOrganisationDocumentPdfUrl.
+                      visibility:
+                        type: string
+                        enum:
+                          - INTERNAL
+                          - PUBLIC
+                      version:
+                        type: number
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                description: OrganizationDocumentService.getDocumentById, mapped via toOrganizationDocumentDocumentWithPdfUrl. 404 with {message} thrown as OrgDocumentServiceError if not found.
   '/v1/organisation-document/pms/{orgId}/documents/policy':
     post:
       tags:
@@ -6134,8 +15953,36 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: UpsertPolicyBody
+              required:
+                - title
+                - category
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                category:
+                  type: string
+                  enum:
+                    - TERMS_AND_CONDITIONS
+                    - PRIVACY_POLICY
+                    - CANCELLATION_POLICY
+                  description: Only these three categories are accepted; OrganizationDocumentService.upsertPolicyDocument throws a 400 OrgDocumentServiceError for FIRE_SAFETY/GENERAL.
+                fileUrl:
+                  type: string
+                fileName:
+                  type: string
+                fileType:
+                  type: string
+                fileSize:
+                  type: number
+                visibility:
+                  type: string
+                  enum:
+                    - INTERNAL
+                    - PUBLIC
+                  description: 'Ignored by the controller: it always forces visibility to PUBLIC before calling the service (upsertPolicy sets visibility: "PUBLIC" unconditionally), so a caller-supplied value here has no effect.'
+              description: UpsertPolicyBody = CreateOrgDocumentInput minus organisationId. No Zod schema validates the body at this route.
       responses:
         200:
           description: Response
@@ -6143,7 +15990,58 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - _id
+                      - organisationId
+                      - title
+                      - category
+                      - visibility
+                      - version
+                      - createdAt
+                      - updatedAt
+                    properties:
+                      _id:
+                        type: string
+                      organisationId:
+                        type: string
+                      title:
+                        type: string
+                      description:
+                        type: string
+                      category:
+                        type: string
+                        enum:
+                          - TERMS_AND_CONDITIONS
+                          - PRIVACY_POLICY
+                          - CANCELLATION_POLICY
+                      fileUrl:
+                        type: string
+                      fileName:
+                        type: string
+                      fileType:
+                        type: string
+                      fileSize:
+                        type: number
+                      pdfUrl:
+                        type: string
+                        description: Resolved server-side by buildOrganisationDocumentPdfUrl.
+                      visibility:
+                        type: string
+                        enum:
+                          - PUBLIC
+                        description: Always PUBLIC for policy docs - controller pins it before calling the service.
+                      version:
+                        type: number
+                      createdAt:
+                        type: string
+                        format: date-time
+                      updatedAt:
+                        type: string
+                        format: date-time
+                description: OrganizationDocumentService.upsertPolicyDocument - creates via createDocument if no doc exists yet for that org+category, otherwise updates via updateDocument (bumping version if any file field is present); response is the same OrganizationDocumentDocument shape either way, mapped via toOrganizationDocumentDocumentWithPdfUrl.
   '/v1/organisation-document/mobile/{orgId}/documents':
     get:
       tags:
@@ -6165,7 +16063,62 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - _id
+                        - organisationId
+                        - title
+                        - category
+                        - visibility
+                        - version
+                        - createdAt
+                        - updatedAt
+                      properties:
+                        _id:
+                          type: string
+                        organisationId:
+                          type: string
+                        title:
+                          type: string
+                        description:
+                          type: string
+                        category:
+                          type: string
+                          enum:
+                            - TERMS_AND_CONDITIONS
+                            - PRIVACY_POLICY
+                            - CANCELLATION_POLICY
+                            - FIRE_SAFETY
+                            - GENERAL
+                        fileUrl:
+                          type: string
+                        fileName:
+                          type: string
+                        fileType:
+                          type: string
+                        fileSize:
+                          type: number
+                        pdfUrl:
+                          type: string
+                          description: Resolved server-side by buildOrganisationDocumentPdfUrl.
+                        visibility:
+                          type: string
+                          enum:
+                            - PUBLIC
+                          description: 'Always PUBLIC - OrganizationDocumentService.listPublicDocumentsForOrganisation hardcodes visibility: "PUBLIC" in its Prisma where clause; visibility is not a caller-supplied filter on this route (see controller comment: an earlier version let a mobile caller request INTERNAL docs, which was a bug).'
+                        version:
+                          type: number
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                description: listPublic controller action -> OrganizationDocumentService.listPublicDocumentsForOrganisation. Optional ?category= query narrows within PUBLIC docs only.
   '/fhir/v1/organisation-invites/{token}/accept':
     post:
       tags:
@@ -6624,7 +16577,14 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: "OrganizationController.checkIsPMSOrganistaion's catch routes through handleOrganizationError, which for any error that is not an OrganizationServiceError logs it and sends res.status(500).json({ message: responseMessage }) with the fixed message this route passes in (apps/backend/src/controllers/web/organization.controller.ts)."
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Unable to search business.
   /fhir/v1/organization/mobile/getNearby:
     get:
       tags:
@@ -6675,7 +16635,14 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'This route is mounted to CatalogController.getCatalogNearbyOrganisations (not OrganizationController). Its catch calls the module-local handleError, which for a plain (non-CatalogServiceError) exception logs it and sends res.status(500).json({ message: defaultMessage }) with the fixed message this route passes in (apps/backend/src/controllers/web/catalog.controller.ts). A CatalogServiceError carrying a `code`/`details` would instead produce {error:{code,message,details?}}, but the underlying query (CatalogService.listOrganisationsProvidingServiceNearby) is a plain Prisma read with no such throws on this path.'
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Unable to fetch nearby catalog organisations.
   '/fhir/v1/organization/logo/presigned-url':
     post:
       tags:
@@ -6727,7 +16694,123 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: 'OrganizationController.onboardBusiness sends res.status(created ? 201 : 200).json(response), where response = buildFHIRResponseFromPrisma(...) built via toFHIROrganisation (packages/types/src/organization.ts) - a FHIR R4 Organization resource. 200 is returned when the request body names an existing organisation (by id/fhirId) that the caller has active membership in, so this is the update branch; 201 covers the create branch with the same body shape.'
+                properties:
+                  resourceType:
+                    type: string
+                    enum:
+                      - Organization
+                  id:
+                    type: string
+                    description: organisation.fhirId if set, else the internal organisation id.
+                  active:
+                    type: boolean
+                  name:
+                    type: string
+                  identifier:
+                    type: array
+                    nullable: true
+                    description: Present only when a tax id and/or DUNS number exist (buildIdentifiers).
+                    items:
+                      type: object
+                      properties:
+                        system:
+                          type: string
+                          description: Fixed URI for the tax-id or DUNS-number identifier system.
+                        value:
+                          type: string
+                        use:
+                          type: string
+                          nullable: true
+                          description: '"official" for the tax-id identifier; absent for DUNS.'
+                  telecom:
+                    type: array
+                    nullable: true
+                    description: 'buildTelecom: one entry each for phone and website, when set.'
+                    items:
+                      type: object
+                      properties:
+                        system:
+                          type: string
+                          enum:
+                            - phone
+                            - url
+                        value:
+                          type: string
+                  type:
+                    type: array
+                    nullable: true
+                    description: "buildType: single-entry CodeableConcept for the organisation's HOSPITAL/BREEDER/BOARDER/GROOMER type."
+                    items:
+                      type: object
+                      properties:
+                        coding:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              system:
+                                type: string
+                              code:
+                                type: string
+                              display:
+                                type: string
+                                nullable: true
+                        text:
+                          type: string
+                          nullable: true
+                  address:
+                    type: array
+                    nullable: true
+                    maxItems: 1
+                    description: toFHIRAddress(organisation.address); present only when the org has a stored address.
+                    items:
+                      type: object
+                      properties:
+                        line:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                        country:
+                          type: string
+                          nullable: true
+                        city:
+                          type: string
+                          nullable: true
+                        state:
+                          type: string
+                          nullable: true
+                        postalCode:
+                          type: string
+                          nullable: true
+                        extension:
+                          type: array
+                          nullable: true
+                          description: 'Present only when both latitude and longitude are set: one geolocation extension (http://hl7.org/fhir/StructureDefinition/geolocation) with nested latitude/longitude valueDecimal child extensions.'
+                          items:
+                            type: object
+                            additionalProperties: true
+                  extension:
+                    type: array
+                    description: 'Top-level Organization extensions (buildExtensions). Each entry has a fixed `url` and exactly one FHIR value[x] field, included only when the underlying value is set. Covers: tax id, isVerified (always present, boolean), imageURL, healthAndSafetyCertNo, animalWelfareComplianceCertNo, fireAndEmergencyCertNo, googlePlacesId, stripeAccountId, petNamePreference, appointmentCheckInBufferMinutes, appointmentCheckInRadiusMeters, appointmentLockWindowOutpatientMinutes, appointmentLockWindowInpatientMinutes, crossOrgMessagingEnabled.'
+                    items:
+                      type: object
+                      properties:
+                        url:
+                          type: string
+                        valueString:
+                          type: string
+                          nullable: true
+                        valueBoolean:
+                          type: boolean
+                          nullable: true
+                        valueUrl:
+                          type: string
+                          nullable: true
+                        valueInteger:
+                          type: number
+                          nullable: true
         500:
           description: Response
           content:
@@ -7098,7 +17181,91 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - links
+                properties:
+                  links:
+                    type: array
+                    description: Every companion link for the requesting parent (ParentCompanionService.getLinksForParent, backed by the ParentPatient table).
+                    items:
+                      type: object
+                      required:
+                        - parentId
+                        - role
+                        - status
+                        - permissions
+                      properties:
+                        parentId:
+                          type: string
+                        role:
+                          type: string
+                          enum:
+                            - PRIMARY
+                            - CO_PARENT
+                        status:
+                          type: string
+                          enum:
+                            - ACTIVE
+                            - PENDING
+                            - REVOKED
+                        permissions:
+                          type: object
+                          required:
+                            - assignAsPrimaryParent
+                            - emergencyBasedPermissions
+                            - appointments
+                            - companionProfile
+                            - documents
+                            - expenses
+                            - tasks
+                            - chatWithVet
+                            - medicalRecords
+                          properties:
+                            assignAsPrimaryParent:
+                              type: boolean
+                            emergencyBasedPermissions:
+                              type: boolean
+                            appointments:
+                              type: boolean
+                            companionProfile:
+                              type: boolean
+                            documents:
+                              type: boolean
+                            expenses:
+                              type: boolean
+                            tasks:
+                              type: boolean
+                            chatWithVet:
+                              type: boolean
+                            medicalRecords:
+                              type: boolean
+                        invitedByParentId:
+                          type: string
+                          nullable: true
+                        acceptedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        parent:
+                          type: object
+                          description: Omitted on the parent-side listing (getLinksForParent never attaches it); present on the companion-side listing.
+                          properties:
+                            firstName:
+                              type: string
+                            lastName:
+                              type: string
+                            email:
+                              type: string
+                            phoneNumber:
+                              type: string
+                            profileImageUrl:
+                              type: string
         500:
           description: Response
           content:
@@ -7138,7 +17305,91 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - links
+                properties:
+                  links:
+                    type: array
+                    description: Every parent link for the requested companion, each with the linked parent's contact details attached (ParentCompanionService.getLinksForCompanion).
+                    items:
+                      type: object
+                      required:
+                        - parentId
+                        - role
+                        - status
+                        - permissions
+                      properties:
+                        parentId:
+                          type: string
+                        role:
+                          type: string
+                          enum:
+                            - PRIMARY
+                            - CO_PARENT
+                        status:
+                          type: string
+                          enum:
+                            - ACTIVE
+                            - PENDING
+                            - REVOKED
+                        permissions:
+                          type: object
+                          required:
+                            - assignAsPrimaryParent
+                            - emergencyBasedPermissions
+                            - appointments
+                            - companionProfile
+                            - documents
+                            - expenses
+                            - tasks
+                            - chatWithVet
+                            - medicalRecords
+                          properties:
+                            assignAsPrimaryParent:
+                              type: boolean
+                            emergencyBasedPermissions:
+                              type: boolean
+                            appointments:
+                              type: boolean
+                            companionProfile:
+                              type: boolean
+                            documents:
+                              type: boolean
+                            expenses:
+                              type: boolean
+                            tasks:
+                              type: boolean
+                            chatWithVet:
+                              type: boolean
+                            medicalRecords:
+                              type: boolean
+                        invitedByParentId:
+                          type: string
+                          nullable: true
+                        acceptedAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        createdAt:
+                          type: string
+                          format: date-time
+                        updatedAt:
+                          type: string
+                          format: date-time
+                        parent:
+                          type: object
+                          description: The linked parent's contact details (toCompanionParentLink attaches this for the companion-side listing).
+                          properties:
+                            firstName:
+                              type: string
+                            lastName:
+                              type: string
+                            email:
+                              type: string
+                            phoneNumber:
+                              type: string
+                            profileImageUrl:
+                              type: string
         500:
           description: Response
           content:
@@ -7458,7 +17709,16 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - url
+                  - key
+                properties:
+                  url:
+                    type: string
+                    description: Pre-signed S3 upload URL for the parent's profile image, from generatePresignedUrl(mimeType, 'temp') (src/middlewares/upload.ts), shared by getProfileUploadUrl in profile-upload.handler.ts (mounted here as ParentController.getProfileUploadUrl).
+                  key:
+                    type: string
+                    description: Storage key the uploaded object will live at once PUT to `url`.
         500:
           description: Response
           content:
@@ -7739,7 +17999,48 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                required:
+                  - success
+                  - data
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    description: Built by CatalogService.getBookableSlotsService / buildBookableWindowsForVets, merging each assigned vet's free windows for the requested service, organisation and date.
+                    required:
+                      - date
+                      - dayOfWeek
+                      - windows
+                    properties:
+                      date:
+                        type: string
+                        description: YYYY-MM-DD, UTC.
+                      dayOfWeek:
+                        type: string
+                        description: Uppercase day name, e.g. MONDAY.
+                      windows:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - startTime
+                            - endTime
+                            - isAvailable
+                          properties:
+                            startTime:
+                              type: string
+                              description: HH:mm, UTC.
+                            endTime:
+                              type: string
+                              description: HH:mm, UTC.
+                            isAvailable:
+                              type: boolean
+                            vetIds:
+                              type: array
+                              items:
+                                type: string
+                              description: Staff assigned to this window. Present only when the caller is authenticated (attachSessionIfPresent); stripped by withoutVetIds for anonymous signed-out discovery requests.
   '/fhir/v1/service/{id}':
     patch:
       tags:
@@ -7764,8 +18065,8 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/HealthcareService'
+                description: ServiceController.updateService returns ServiceService.update's result, which is toServiceResponseDTO(service) - the same FHIR HealthcareService resource shape already documented as a component in this spec (see components.schemas.HealthcareService).
   /fhir/v1/speciality/:
     post:
       tags:
@@ -7965,7 +18266,7 @@ paths:
             schema:
               type: object
               additionalProperties: true
-              description: Buffer
+              description: Raw Stripe webhook event payload. The router mounts this route with bodyParser.raw({type:'application/json'}) (see apps/backend/src/routers/stripe.router.ts) so the body reaches the controller as an unparsed Buffer, verified via StripeService.verifyWebhook against the Stripe-Signature header before use. The event's JSON shape is defined by Stripe and varies per event.type (checkout.session.completed, invoice.paid, etc.) - it is not a schema this codebase owns or validates against, so no fixed properties are documented.
       responses:
         200:
           description: Response
@@ -8392,8 +18693,123 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateCustomTaskRequestBody
+              description: "CreateCustomTaskRequestBody (task.controller.ts): CreateCustomTaskInput with createdBy/assignedBy/assignedTo omitted and assignedTo re-added as optional (server falls back to the caller's parentId when omitted)."
+              required:
+                - audience
+                - category
+                - name
+                - dueAt
+              properties:
+                organisationId:
+                  type: string
+                appointmentId:
+                  type: string
+                patientId:
+                  type: string
+                assignedTo:
+                  type: string
+                  description: Optional; defaults to the authenticated parent's id when omitted.
+                assignedGroupId:
+                  type: string
+                  nullable: true
+                dueAt:
+                  type: string
+                  format: date-time
+                timezone:
+                  type: string
+                medication:
+                  type: object
+                  nullable: true
+                  description: Client-supplied medication details (BaseTaskCreateInput.medication / MedicationInput).
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    notes:
+                      type: string
+                    frequency:
+                      type: string
+                    doses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                          dosage:
+                            type: string
+                          instructions:
+                            type: string
+                observationToolId:
+                  type: string
+                recurrence:
+                  type: object
+                  nullable: true
+                  description: Client-supplied recurrence settings (BaseTaskCreateInput.recurrence).
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ONCE
+                        - DAILY
+                        - WEEKLY
+                        - CUSTOM
+                    endDate:
+                      type: string
+                      format: date-time
+                    cronExpression:
+                      type: string
+                reminder:
+                  type: object
+                  nullable: true
+                  required:
+                    - enabled
+                    - offsetMinutes
+                  properties:
+                    enabled:
+                      type: boolean
+                    offsetMinutes:
+                      type: number
+                syncWithCalendar:
+                  type: boolean
+                attachments:
+                  type: array
+                  description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                priority:
+                  type: string
+                  enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - URGENT
+                audience:
+                  type: string
+                  enum:
+                    - EMPLOYEE_TASK
+                    - PARENT_TASK
+                category:
+                  type: string
+                subcategory:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                additionalNotes:
+                  type: string
       responses:
         403:
           description: Response
@@ -8410,7 +18826,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   /v1/task/mobile/task:
     get:
       tags:
@@ -8425,8 +19028,197 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                  required:
+                    - id
+                    - _id
+                    - createdBy
+                    - assignedTo
+                    - audience
+                    - source
+                    - category
+                    - name
+                    - dueAt
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    _id:
+                      type: string
+                      description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                    organisationId:
+                      type: string
+                      nullable: true
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                      nullable: true
+                    createdBy:
+                      type: string
+                    assignedBy:
+                      type: string
+                      nullable: true
+                    assignedTo:
+                      type: string
+                    assignedGroupId:
+                      type: string
+                      nullable: true
+                    audience:
+                      type: string
+                      enum:
+                        - EMPLOYEE_TASK
+                        - PARENT_TASK
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    libraryTaskId:
+                      type: string
+                      nullable: true
+                    templateId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    additionalNotes:
+                      type: string
+                      nullable: true
+                    medication:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        notes:
+                          type: string
+                        frequency:
+                          type: string
+                        doses:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              time:
+                                type: string
+                              dosage:
+                                type: string
+                              instructions:
+                                type: string
+                    observationToolId:
+                      type: string
+                      nullable: true
+                    dueAt:
+                      type: string
+                      format: date-time
+                    timezone:
+                      type: string
+                      nullable: true
+                    recurrence:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ONCE
+                            - DAILY
+                            - WEEKLY
+                            - CUSTOM
+                        isMaster:
+                          type: boolean
+                          description: True on the master row of a recurring series.
+                        masterTaskId:
+                          type: string
+                          nullable: true
+                          description: Set on non-master occurrence rows; points back to the series master task id.
+                        cronExpression:
+                          type: string
+                          nullable: true
+                        endDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                    reminder:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                      properties:
+                        enabled:
+                          type: boolean
+                        offsetMinutes:
+                          type: number
+                        scheduledNotificationId:
+                          type: string
+                          description: Set by the reminder engine after it sends the notification; absent until then.
+                    syncWithCalendar:
+                      type: boolean
+                      nullable: true
+                    calendarEventId:
+                      type: string
+                      nullable: true
+                    attachments:
+                      type: array
+                      description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                      items:
+                        type: object
+                        required:
+                          - id
+                          - name
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - IN_PROGRESS
+                        - COMPLETED
+                        - CANCELLED
+                    priority:
+                      type: string
+                      enum:
+                        - LOW
+                        - MEDIUM
+                        - HIGH
+                        - URGENT
+                      nullable: true
+                    completedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    completedBy:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/task/mobile/{taskId}':
     get:
       tags:
@@ -8448,7 +19240,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/task/mobile/{taskId}/status':
     post:
       tags:
@@ -8496,8 +19475,197 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                  required:
+                    - id
+                    - _id
+                    - createdBy
+                    - assignedTo
+                    - audience
+                    - source
+                    - category
+                    - name
+                    - dueAt
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    _id:
+                      type: string
+                      description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                    organisationId:
+                      type: string
+                      nullable: true
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                      nullable: true
+                    createdBy:
+                      type: string
+                    assignedBy:
+                      type: string
+                      nullable: true
+                    assignedTo:
+                      type: string
+                    assignedGroupId:
+                      type: string
+                      nullable: true
+                    audience:
+                      type: string
+                      enum:
+                        - EMPLOYEE_TASK
+                        - PARENT_TASK
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    libraryTaskId:
+                      type: string
+                      nullable: true
+                    templateId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    additionalNotes:
+                      type: string
+                      nullable: true
+                    medication:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        notes:
+                          type: string
+                        frequency:
+                          type: string
+                        doses:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              time:
+                                type: string
+                              dosage:
+                                type: string
+                              instructions:
+                                type: string
+                    observationToolId:
+                      type: string
+                      nullable: true
+                    dueAt:
+                      type: string
+                      format: date-time
+                    timezone:
+                      type: string
+                      nullable: true
+                    recurrence:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ONCE
+                            - DAILY
+                            - WEEKLY
+                            - CUSTOM
+                        isMaster:
+                          type: boolean
+                          description: True on the master row of a recurring series.
+                        masterTaskId:
+                          type: string
+                          nullable: true
+                          description: Set on non-master occurrence rows; points back to the series master task id.
+                        cronExpression:
+                          type: string
+                          nullable: true
+                        endDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                    reminder:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                      properties:
+                        enabled:
+                          type: boolean
+                        offsetMinutes:
+                          type: number
+                        scheduledNotificationId:
+                          type: string
+                          description: Set by the reminder engine after it sends the notification; absent until then.
+                    syncWithCalendar:
+                      type: boolean
+                      nullable: true
+                    calendarEventId:
+                      type: string
+                      nullable: true
+                    attachments:
+                      type: array
+                      description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                      items:
+                        type: object
+                        required:
+                          - id
+                          - name
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - IN_PROGRESS
+                        - COMPLETED
+                        - CANCELLED
+                    priority:
+                      type: string
+                      enum:
+                        - LOW
+                        - MEDIUM
+                        - HIGH
+                        - URGENT
+                      nullable: true
+                    completedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    completedBy:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/task/pms/from-library':
     post:
       tags:
@@ -8512,8 +19680,122 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateFromLibraryRequestBody
+              description: 'CreateFromLibraryRequestBody (task.controller.ts): CreateFromLibraryInput with createdBy/assignedBy omitted (set server-side from the authenticated user).'
+              required:
+                - assignedTo
+                - dueAt
+                - audience
+                - libraryTaskId
+              properties:
+                organisationId:
+                  type: string
+                appointmentId:
+                  type: string
+                patientId:
+                  type: string
+                assignedTo:
+                  type: string
+                assignedGroupId:
+                  type: string
+                  nullable: true
+                dueAt:
+                  type: string
+                  format: date-time
+                timezone:
+                  type: string
+                medication:
+                  type: object
+                  nullable: true
+                  description: Client-supplied medication details (BaseTaskCreateInput.medication / MedicationInput).
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    notes:
+                      type: string
+                    frequency:
+                      type: string
+                    doses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                          dosage:
+                            type: string
+                          instructions:
+                            type: string
+                observationToolId:
+                  type: string
+                recurrence:
+                  type: object
+                  nullable: true
+                  description: Client-supplied recurrence settings (BaseTaskCreateInput.recurrence).
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ONCE
+                        - DAILY
+                        - WEEKLY
+                        - CUSTOM
+                    endDate:
+                      type: string
+                      format: date-time
+                    cronExpression:
+                      type: string
+                reminder:
+                  type: object
+                  nullable: true
+                  required:
+                    - enabled
+                    - offsetMinutes
+                  properties:
+                    enabled:
+                      type: boolean
+                    offsetMinutes:
+                      type: number
+                syncWithCalendar:
+                  type: boolean
+                attachments:
+                  type: array
+                  description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                priority:
+                  type: string
+                  enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - URGENT
+                audience:
+                  type: string
+                  enum:
+                    - EMPLOYEE_TASK
+                    - PARENT_TASK
+                libraryTaskId:
+                  type: string
+                categoryOverride:
+                  type: string
+                subcategoryOverride:
+                  type: string
+                nameOverride:
+                  type: string
+                descriptionOverride:
+                  type: string
       responses:
         201:
           description: Response
@@ -8521,7 +19803,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -8543,8 +20012,121 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateFromTemplateRequestBody
+              description: "CreateFromTemplateRequestBody (task.controller.ts): CreateFromTemplateInput with createdBy/assignedBy omitted (set server-side). audience is NOT accepted directly; audienceOverride optionally overrides the template's defaultRole-derived audience."
+              required:
+                - assignedTo
+                - dueAt
+                - templateId
+              properties:
+                organisationId:
+                  type: string
+                appointmentId:
+                  type: string
+                patientId:
+                  type: string
+                assignedTo:
+                  type: string
+                assignedGroupId:
+                  type: string
+                  nullable: true
+                dueAt:
+                  type: string
+                  format: date-time
+                timezone:
+                  type: string
+                medication:
+                  type: object
+                  nullable: true
+                  description: Client-supplied medication details (BaseTaskCreateInput.medication / MedicationInput).
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    notes:
+                      type: string
+                    frequency:
+                      type: string
+                    doses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                          dosage:
+                            type: string
+                          instructions:
+                            type: string
+                observationToolId:
+                  type: string
+                recurrence:
+                  type: object
+                  nullable: true
+                  description: Client-supplied recurrence settings (BaseTaskCreateInput.recurrence).
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ONCE
+                        - DAILY
+                        - WEEKLY
+                        - CUSTOM
+                    endDate:
+                      type: string
+                      format: date-time
+                    cronExpression:
+                      type: string
+                reminder:
+                  type: object
+                  nullable: true
+                  required:
+                    - enabled
+                    - offsetMinutes
+                  properties:
+                    enabled:
+                      type: boolean
+                    offsetMinutes:
+                      type: number
+                syncWithCalendar:
+                  type: boolean
+                attachments:
+                  type: array
+                  description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                priority:
+                  type: string
+                  enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - URGENT
+                templateId:
+                  type: string
+                categoryOverride:
+                  type: string
+                subcategoryOverride:
+                  type: string
+                nameOverride:
+                  type: string
+                descriptionOverride:
+                  type: string
+                audienceOverride:
+                  type: string
+                  enum:
+                    - EMPLOYEE_TASK
+                    - PARENT_TASK
       responses:
         201:
           description: Response
@@ -8552,7 +20134,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -8574,8 +20343,123 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: CreateCustomTaskInput
+              description: CreateCustomTaskInput (task.controller.ts createCustomTaskFromPms). createdBy and assignedBy are accepted by the TS type but always overwritten server-side with the authenticated actor's id before being passed to TaskService.createCustom, so they are omitted here as meaningful client input.
+              required:
+                - assignedTo
+                - dueAt
+                - audience
+                - category
+                - name
+              properties:
+                organisationId:
+                  type: string
+                appointmentId:
+                  type: string
+                patientId:
+                  type: string
+                assignedTo:
+                  type: string
+                assignedGroupId:
+                  type: string
+                  nullable: true
+                dueAt:
+                  type: string
+                  format: date-time
+                timezone:
+                  type: string
+                medication:
+                  type: object
+                  nullable: true
+                  description: Client-supplied medication details (BaseTaskCreateInput.medication / MedicationInput).
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    notes:
+                      type: string
+                    frequency:
+                      type: string
+                    doses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                          dosage:
+                            type: string
+                          instructions:
+                            type: string
+                observationToolId:
+                  type: string
+                recurrence:
+                  type: object
+                  nullable: true
+                  description: Client-supplied recurrence settings (BaseTaskCreateInput.recurrence).
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ONCE
+                        - DAILY
+                        - WEEKLY
+                        - CUSTOM
+                    endDate:
+                      type: string
+                      format: date-time
+                    cronExpression:
+                      type: string
+                reminder:
+                  type: object
+                  nullable: true
+                  required:
+                    - enabled
+                    - offsetMinutes
+                  properties:
+                    enabled:
+                      type: boolean
+                    offsetMinutes:
+                      type: number
+                syncWithCalendar:
+                  type: boolean
+                attachments:
+                  type: array
+                  description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                priority:
+                  type: string
+                  enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - URGENT
+                audience:
+                  type: string
+                  enum:
+                    - EMPLOYEE_TASK
+                    - PARENT_TASK
+                category:
+                  type: string
+                subcategory:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                additionalNotes:
+                  type: string
       responses:
         201:
           description: Response
@@ -8583,7 +20467,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
       parameters:
         - name: x-org-id
           in: header
@@ -8617,8 +20688,197 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                  required:
+                    - id
+                    - _id
+                    - createdBy
+                    - assignedTo
+                    - audience
+                    - source
+                    - category
+                    - name
+                    - dueAt
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    _id:
+                      type: string
+                      description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                    organisationId:
+                      type: string
+                      nullable: true
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                      nullable: true
+                    createdBy:
+                      type: string
+                    assignedBy:
+                      type: string
+                      nullable: true
+                    assignedTo:
+                      type: string
+                    assignedGroupId:
+                      type: string
+                      nullable: true
+                    audience:
+                      type: string
+                      enum:
+                        - EMPLOYEE_TASK
+                        - PARENT_TASK
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    libraryTaskId:
+                      type: string
+                      nullable: true
+                    templateId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    additionalNotes:
+                      type: string
+                      nullable: true
+                    medication:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        notes:
+                          type: string
+                        frequency:
+                          type: string
+                        doses:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              time:
+                                type: string
+                              dosage:
+                                type: string
+                              instructions:
+                                type: string
+                    observationToolId:
+                      type: string
+                      nullable: true
+                    dueAt:
+                      type: string
+                      format: date-time
+                    timezone:
+                      type: string
+                      nullable: true
+                    recurrence:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ONCE
+                            - DAILY
+                            - WEEKLY
+                            - CUSTOM
+                        isMaster:
+                          type: boolean
+                          description: True on the master row of a recurring series.
+                        masterTaskId:
+                          type: string
+                          nullable: true
+                          description: Set on non-master occurrence rows; points back to the series master task id.
+                        cronExpression:
+                          type: string
+                          nullable: true
+                        endDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                    reminder:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                      properties:
+                        enabled:
+                          type: boolean
+                        offsetMinutes:
+                          type: number
+                        scheduledNotificationId:
+                          type: string
+                          description: Set by the reminder engine after it sends the notification; absent until then.
+                    syncWithCalendar:
+                      type: boolean
+                      nullable: true
+                    calendarEventId:
+                      type: string
+                      nullable: true
+                    attachments:
+                      type: array
+                      description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                      items:
+                        type: object
+                        required:
+                          - id
+                          - name
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - IN_PROGRESS
+                        - COMPLETED
+                        - CANCELLED
+                    priority:
+                      type: string
+                      enum:
+                        - LOW
+                        - MEDIUM
+                        - HIGH
+                        - URGENT
+                      nullable: true
+                    completedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    completedBy:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/task/pms/companion/{companionId}':
     get:
       tags:
@@ -8639,8 +20899,197 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                  required:
+                    - id
+                    - _id
+                    - createdBy
+                    - assignedTo
+                    - audience
+                    - source
+                    - category
+                    - name
+                    - dueAt
+                    - status
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    _id:
+                      type: string
+                      description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                    organisationId:
+                      type: string
+                      nullable: true
+                    appointmentId:
+                      type: string
+                      nullable: true
+                    patientId:
+                      type: string
+                      nullable: true
+                    createdBy:
+                      type: string
+                    assignedBy:
+                      type: string
+                      nullable: true
+                    assignedTo:
+                      type: string
+                    assignedGroupId:
+                      type: string
+                      nullable: true
+                    audience:
+                      type: string
+                      enum:
+                        - EMPLOYEE_TASK
+                        - PARENT_TASK
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    libraryTaskId:
+                      type: string
+                      nullable: true
+                    templateId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    subcategory:
+                      type: string
+                      nullable: true
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    additionalNotes:
+                      type: string
+                      nullable: true
+                    medication:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        notes:
+                          type: string
+                        frequency:
+                          type: string
+                        doses:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              time:
+                                type: string
+                              dosage:
+                                type: string
+                              instructions:
+                                type: string
+                    observationToolId:
+                      type: string
+                      nullable: true
+                    dueAt:
+                      type: string
+                      format: date-time
+                    timezone:
+                      type: string
+                      nullable: true
+                    recurrence:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ONCE
+                            - DAILY
+                            - WEEKLY
+                            - CUSTOM
+                        isMaster:
+                          type: boolean
+                          description: True on the master row of a recurring series.
+                        masterTaskId:
+                          type: string
+                          nullable: true
+                          description: Set on non-master occurrence rows; points back to the series master task id.
+                        cronExpression:
+                          type: string
+                          nullable: true
+                        endDate:
+                          type: string
+                          format: date-time
+                          nullable: true
+                    reminder:
+                      type: object
+                      nullable: true
+                      description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                      properties:
+                        enabled:
+                          type: boolean
+                        offsetMinutes:
+                          type: number
+                        scheduledNotificationId:
+                          type: string
+                          description: Set by the reminder engine after it sends the notification; absent until then.
+                    syncWithCalendar:
+                      type: boolean
+                      nullable: true
+                    calendarEventId:
+                      type: string
+                      nullable: true
+                    attachments:
+                      type: array
+                      description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                      items:
+                        type: object
+                        required:
+                          - id
+                          - name
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                      nullable: true
+                    status:
+                      type: string
+                      enum:
+                        - PENDING
+                        - IN_PROGRESS
+                        - COMPLETED
+                        - CANCELLED
+                    priority:
+                      type: string
+                      enum:
+                        - LOW
+                        - MEDIUM
+                        - HIGH
+                        - URGENT
+                      nullable: true
+                    completedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    completedBy:
+                      type: string
+                      nullable: true
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   /v1/task/pms/library:
     get:
       tags:
@@ -8655,8 +21104,104 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: TaskLibraryDefinition row (packages/database/prisma/schema.prisma).
+                  required:
+                    - id
+                    - source
+                    - kind
+                    - category
+                    - name
+                    - schema
+                    - applicableSpecies
+                    - isActive
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    kind:
+                      type: string
+                      enum:
+                        - MEDICATION
+                        - OBSERVATION_TOOL
+                        - HYGIENE
+                        - DIET
+                        - CUSTOM
+                        - CARE
+                        - PROCEDURE
+                        - DIAGNOSTIC
+                        - COMMUNICATION
+                        - BILLING
+                        - RECORD
+                        - ADMIN
+                    category:
+                      type: string
+                    name:
+                      type: string
+                    defaultDescription:
+                      type: string
+                      nullable: true
+                    schema:
+                      type: object
+                      description: TaskLibraryDefinition.schema (Prisma Json column); shape traced from CreateTaskLibraryDefinitionInput['schema'] / TaskLibraryService.create-update.
+                      properties:
+                        medicationFields:
+                          type: object
+                          properties:
+                            hasMedicationName:
+                              type: boolean
+                            hasType:
+                              type: boolean
+                            hasDosage:
+                              type: boolean
+                            hasFrequency:
+                              type: boolean
+                        requiresObservationTool:
+                          type: boolean
+                        recurrence:
+                          type: object
+                          properties:
+                            default:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - ONCE
+                                    - DAILY
+                                    - WEEKLY
+                                    - CUSTOM
+                                cronExpression:
+                                  type: string
+                                editable:
+                                  type: boolean
+                                endAfterDays:
+                                  type: number
+                    applicableSpecies:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                          - dog
+                          - cat
+                          - horse
+                    isActive:
+                      type: boolean
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/task/pms/library/{libraryId}':
     put:
       tags:
@@ -8678,7 +21223,101 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: TaskLibraryDefinition row (packages/database/prisma/schema.prisma).
+                required:
+                  - id
+                  - source
+                  - kind
+                  - category
+                  - name
+                  - schema
+                  - applicableSpecies
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  kind:
+                    type: string
+                    enum:
+                      - MEDICATION
+                      - OBSERVATION_TOOL
+                      - HYGIENE
+                      - DIET
+                      - CUSTOM
+                      - CARE
+                      - PROCEDURE
+                      - DIAGNOSTIC
+                      - COMMUNICATION
+                      - BILLING
+                      - RECORD
+                      - ADMIN
+                  category:
+                    type: string
+                  name:
+                    type: string
+                  defaultDescription:
+                    type: string
+                    nullable: true
+                  schema:
+                    type: object
+                    description: TaskLibraryDefinition.schema (Prisma Json column); shape traced from CreateTaskLibraryDefinitionInput['schema'] / TaskLibraryService.create-update.
+                    properties:
+                      medicationFields:
+                        type: object
+                        properties:
+                          hasMedicationName:
+                            type: boolean
+                          hasType:
+                            type: boolean
+                          hasDosage:
+                            type: boolean
+                          hasFrequency:
+                            type: boolean
+                      requiresObservationTool:
+                        type: boolean
+                      recurrence:
+                        type: object
+                        properties:
+                          default:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - ONCE
+                                  - DAILY
+                                  - WEEKLY
+                                  - CUSTOM
+                              cronExpression:
+                                type: string
+                              editable:
+                                type: boolean
+                              endAfterDays:
+                                type: number
+                  applicableSpecies:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - dog
+                        - cat
+                        - horse
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/task/pms/templates/organisation/{organisationId}':
     get:
       tags:
@@ -8699,8 +21338,111 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                type: array
+                items:
+                  type: object
+                  description: TaskTemplate row (packages/database/prisma/schema.prisma).
+                  required:
+                    - id
+                    - source
+                    - organisationId
+                    - category
+                    - name
+                    - kind
+                    - defaultRole
+                    - inpatientOnly
+                    - isActive
+                    - createdBy
+                    - createdAt
+                    - updatedAt
+                  properties:
+                    id:
+                      type: string
+                    source:
+                      type: string
+                      enum:
+                        - YC_LIBRARY
+                        - ORG_TEMPLATE
+                        - CUSTOM
+                    organisationId:
+                      type: string
+                    libraryTaskId:
+                      type: string
+                      nullable: true
+                    category:
+                      type: string
+                    name:
+                      type: string
+                    description:
+                      type: string
+                      nullable: true
+                    kind:
+                      type: string
+                      enum:
+                        - MEDICATION
+                        - OBSERVATION_TOOL
+                        - HYGIENE
+                        - DIET
+                        - CUSTOM
+                        - CARE
+                        - PROCEDURE
+                        - DIAGNOSTIC
+                        - COMMUNICATION
+                        - BILLING
+                        - RECORD
+                        - ADMIN
+                    defaultRole:
+                      type: string
+                      enum:
+                        - EMPLOYEE
+                        - PARENT
+                    inpatientOnly:
+                      type: boolean
+                    defaultMedication:
+                      type: object
+                      nullable: true
+                      description: TaskTemplate.defaultMedication (Prisma Json column); shape from CreateTaskTemplateInput.defaultMedication.
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                        dosage:
+                          type: string
+                        frequency:
+                          type: string
+                    defaultObservationToolId:
+                      type: string
+                      nullable: true
+                    defaultRecurrence:
+                      type: object
+                      nullable: true
+                      description: TaskTemplate.defaultRecurrence (Prisma Json column); shape from CreateTaskTemplateInput.defaultRecurrence.
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - ONCE
+                            - DAILY
+                            - WEEKLY
+                            - CUSTOM
+                        customCron:
+                          type: string
+                        defaultEndOffsetDays:
+                          type: number
+                    defaultReminderOffsetMinutes:
+                      type: number
+                      nullable: true
+                    isActive:
+                      type: boolean
+                    createdBy:
+                      type: string
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
   '/v1/task/pms/templates/{templateId}':
     get:
       tags:
@@ -8722,7 +21464,108 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: TaskTemplate row (packages/database/prisma/schema.prisma).
+                required:
+                  - id
+                  - source
+                  - organisationId
+                  - category
+                  - name
+                  - kind
+                  - defaultRole
+                  - inpatientOnly
+                  - isActive
+                  - createdBy
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  organisationId:
+                    type: string
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  kind:
+                    type: string
+                    enum:
+                      - MEDICATION
+                      - OBSERVATION_TOOL
+                      - HYGIENE
+                      - DIET
+                      - CUSTOM
+                      - CARE
+                      - PROCEDURE
+                      - DIAGNOSTIC
+                      - COMMUNICATION
+                      - BILLING
+                      - RECORD
+                      - ADMIN
+                  defaultRole:
+                    type: string
+                    enum:
+                      - EMPLOYEE
+                      - PARENT
+                  inpatientOnly:
+                    type: boolean
+                  defaultMedication:
+                    type: object
+                    nullable: true
+                    description: TaskTemplate.defaultMedication (Prisma Json column); shape from CreateTaskTemplateInput.defaultMedication.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      dosage:
+                        type: string
+                      frequency:
+                        type: string
+                  defaultObservationToolId:
+                    type: string
+                    nullable: true
+                  defaultRecurrence:
+                    type: object
+                    nullable: true
+                    description: TaskTemplate.defaultRecurrence (Prisma Json column); shape from CreateTaskTemplateInput.defaultRecurrence.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      customCron:
+                        type: string
+                      defaultEndOffsetDays:
+                        type: number
+                  defaultReminderOffsetMinutes:
+                    type: number
+                    nullable: true
+                  isActive:
+                    type: boolean
+                  createdBy:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
     delete:
       tags:
         - 'Non-FHIR'
@@ -8744,6 +21587,7 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+                description: 'could not trace: TaskTemplateController.archive (apps/backend/src/controllers/web/task.controller.ts) calls res.status(204).send() with no body. The route never sends a 200 response, so no real response schema exists at this status code; documenting it here would be fabricated. The actual response is 204 No Content.'
   /v1/task/pms/templates:
     post:
       tags:
@@ -8759,7 +21603,108 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: "TaskTemplate row created by TaskTemplateController.create/TaskTemplateService.create. Note: the controller actually calls res.status(201).json(doc), not 200 — the spec's response:200 location does not match the real status code, but this is the real body shape the endpoint returns (under 201)."
+                required:
+                  - id
+                  - source
+                  - organisationId
+                  - category
+                  - name
+                  - kind
+                  - defaultRole
+                  - inpatientOnly
+                  - isActive
+                  - createdBy
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  organisationId:
+                    type: string
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  kind:
+                    type: string
+                    enum:
+                      - MEDICATION
+                      - OBSERVATION_TOOL
+                      - HYGIENE
+                      - DIET
+                      - CUSTOM
+                      - CARE
+                      - PROCEDURE
+                      - DIAGNOSTIC
+                      - COMMUNICATION
+                      - BILLING
+                      - RECORD
+                      - ADMIN
+                  defaultRole:
+                    type: string
+                    enum:
+                      - EMPLOYEE
+                      - PARENT
+                  inpatientOnly:
+                    type: boolean
+                  defaultMedication:
+                    type: object
+                    nullable: true
+                    description: TaskTemplate.defaultMedication (Prisma Json column); shape from CreateTaskTemplateInput.defaultMedication.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      dosage:
+                        type: string
+                      frequency:
+                        type: string
+                  defaultObservationToolId:
+                    type: string
+                    nullable: true
+                  defaultRecurrence:
+                    type: object
+                    nullable: true
+                    description: TaskTemplate.defaultRecurrence (Prisma Json column); shape from CreateTaskTemplateInput.defaultRecurrence.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      customCron:
+                        type: string
+                      defaultEndOffsetDays:
+                        type: number
+                  defaultReminderOffsetMinutes:
+                    type: number
+                    nullable: true
+                  isActive:
+                    type: boolean
+                  createdBy:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/task/pms/{taskId}':
     get:
       tags:
@@ -8803,8 +21748,109 @@ paths:
           application/json:
             schema:
               type: object
-              additionalProperties: true
-              description: TaskUpdateInput
+              description: TaskUpdateInput (task.service.ts). All fields optional; only present fields are patched onto the stored row (buildTaskUpdatePatch), and an explicit null clears a nullable field.
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                additionalNotes:
+                  type: string
+                subcategory:
+                  type: string
+                priority:
+                  type: string
+                  enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - URGENT
+                dueAt:
+                  type: string
+                  format: date-time
+                timezone:
+                  type: string
+                  nullable: true
+                assignedTo:
+                  type: string
+                assignedGroupId:
+                  type: string
+                  nullable: true
+                medication:
+                  type: object
+                  nullable: true
+                  description: Client-supplied medication details; explicit null clears the field.
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    notes:
+                      type: string
+                    frequency:
+                      type: string
+                    doses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                          dosage:
+                            type: string
+                          instructions:
+                            type: string
+                observationToolId:
+                  type: string
+                  nullable: true
+                reminder:
+                  type: object
+                  nullable: true
+                  required:
+                    - enabled
+                    - offsetMinutes
+                  properties:
+                    enabled:
+                      type: boolean
+                    offsetMinutes:
+                      type: number
+                  description: Explicit null clears the reminder.
+                syncWithCalendar:
+                  type: boolean
+                attachments:
+                  type: array
+                  description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - name
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                recurrence:
+                  type: object
+                  nullable: true
+                  required:
+                    - type
+                  description: Explicit null clears the recurrence.
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ONCE
+                        - DAILY
+                        - WEEKLY
+                        - CUSTOM
+                    endDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    cronExpression:
+                      type: string
+                      nullable: true
       responses:
         200:
           description: Response
@@ -8812,7 +21858,194 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
+                description: A Task row (packages/database/prisma/schema.prisma model Task), with _id duplicating id (TaskService.toTaskLike).
+                required:
+                  - id
+                  - _id
+                  - createdBy
+                  - assignedTo
+                  - audience
+                  - source
+                  - category
+                  - name
+                  - dueAt
+                  - status
+                  - createdAt
+                  - updatedAt
+                properties:
+                  id:
+                    type: string
+                  _id:
+                    type: string
+                    description: Duplicate of id, added by TaskService.toTaskLike for client compatibility.
+                  organisationId:
+                    type: string
+                    nullable: true
+                  appointmentId:
+                    type: string
+                    nullable: true
+                  patientId:
+                    type: string
+                    nullable: true
+                  createdBy:
+                    type: string
+                  assignedBy:
+                    type: string
+                    nullable: true
+                  assignedTo:
+                    type: string
+                  assignedGroupId:
+                    type: string
+                    nullable: true
+                  audience:
+                    type: string
+                    enum:
+                      - EMPLOYEE_TASK
+                      - PARENT_TASK
+                  source:
+                    type: string
+                    enum:
+                      - YC_LIBRARY
+                      - ORG_TEMPLATE
+                      - CUSTOM
+                  libraryTaskId:
+                    type: string
+                    nullable: true
+                  templateId:
+                    type: string
+                    nullable: true
+                  category:
+                    type: string
+                  subcategory:
+                    type: string
+                    nullable: true
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  additionalNotes:
+                    type: string
+                    nullable: true
+                  medication:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.medication); the service layer types it as MedicationInput.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      notes:
+                        type: string
+                      frequency:
+                        type: string
+                      doses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            time:
+                              type: string
+                            dosage:
+                              type: string
+                            instructions:
+                              type: string
+                  observationToolId:
+                    type: string
+                    nullable: true
+                  dueAt:
+                    type: string
+                    format: date-time
+                  timezone:
+                    type: string
+                    nullable: true
+                  recurrence:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.recurrence); the service layer (buildRecurrence/mergeRecurrence) writes {type, isMaster, masterTaskId, cronExpression, endDate} to track recurring task series.
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ONCE
+                          - DAILY
+                          - WEEKLY
+                          - CUSTOM
+                      isMaster:
+                        type: boolean
+                        description: True on the master row of a recurring series.
+                      masterTaskId:
+                        type: string
+                        nullable: true
+                        description: Set on non-master occurrence rows; points back to the series master task id.
+                      cronExpression:
+                        type: string
+                        nullable: true
+                      endDate:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  reminder:
+                    type: object
+                    nullable: true
+                    description: Stored as a Prisma Json column (Task.reminder); the service layer (buildReminder) writes {enabled, offsetMinutes, scheduledNotificationId}, the last field populated once the reminder engine has dispatched a notification.
+                    properties:
+                      enabled:
+                        type: boolean
+                      offsetMinutes:
+                        type: number
+                      scheduledNotificationId:
+                        type: string
+                        description: Set by the reminder engine after it sends the notification; absent until then.
+                  syncWithCalendar:
+                    type: boolean
+                    nullable: true
+                  calendarEventId:
+                    type: string
+                    nullable: true
+                  attachments:
+                    type: array
+                    description: Stored as a Prisma Json column (Task.attachments); the app writes an array of attachment references.
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum:
+                      - PENDING
+                      - IN_PROGRESS
+                      - COMPLETED
+                      - CANCELLED
+                  priority:
+                    type: string
+                    enum:
+                      - LOW
+                      - MEDIUM
+                      - HIGH
+                      - URGENT
+                    nullable: true
+                  completedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  completedBy:
+                    type: string
+                    nullable: true
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
   '/v1/task/pms/{taskId}/status':
     post:
       tags:
@@ -8944,8 +22177,12 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                description: 'UserOrganizationService.getById: a single FHIR PractitionerRole resource when :id (an id, fhirId, or reference query) resolves to exactly one UserOrganization mapping; an array of PractitionerRole resources when a reference-style query matches more than one mapping.'
+                oneOf:
+                  - $ref: '#/components/schemas/PractitionerRole'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/PractitionerRole'
         500:
           description: Response
           content:
@@ -9558,12 +22795,27 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - message
                 properties:
                   message:
                     type: string
+                    description: "'Invalid request' when the body fails CreateApiKeySchema validation (DeveloperApiKeyController.createApiKey); other DeveloperApiKeyServiceError messages surface here too but share this same {message} shape."
                   errors:
                     type: object
-                    additionalProperties: true
+                    description: zod v4 z.flattenError(parsed.error) output for the CreateApiKeySchema ({name, scopes?, environment?, expiresAt?}) validation failure. Only present on the validation-error path.
+                    properties:
+                      formErrors:
+                        type: array
+                        items:
+                          type: string
+                      fieldErrors:
+                        type: object
+                        description: Keyed by request field name (name, scopes, environment, expiresAt).
+                        additionalProperties:
+                          type: array
+                          items:
+                            type: string
         401:
           description: Unauthorized
           content:

--- a/scripts/ci/openapi-drift-baseline.json
+++ b/scripts/ci/openapi-drift-baseline.json
@@ -2,5 +2,5 @@
   "_comment": "Ratchet ceilings for scripts/ci/openapi-drift.mjs. These are known, tracked debt (#2941-#2944), not a target - the gate fails only if a count goes ABOVE its ceiling, so a PR cannot make the gap wider. Lower a ceiling by hand after doing real completion work, or regenerate with --update-baseline after such work. Never raise a ceiling to make a failing PR pass - that defeats the point of the ratchet.",
   "missingFromSpec": 793,
   "staleInSpec": 34,
-  "placeholderSchemas": 362
+  "placeholderSchemas": 256
 }


### PR DESCRIPTION
## What changed

165 request/response bodies in `openapi.yaml` were documented as bare `additionalProperties: true` placeholders — no properties, nothing telling a developer what to send or expect. Traced every one to its real backend source (router → controller → service → Zod schema / Prisma model / the actual `res.json()` call) across 20 domains: inventory, task, observation-tools, chat, document, organisation-document, adverse-event, contact-us, audit-trail, and the `fhir:` availability/invoice/form/organization/service/companion/parent/user-organization routers, plus authUser, companion-organisation, device-token, documenso, notification, stripe, and the developer API-key plane.

- **106 got a real, field-level schema.**
- **~59 are genuinely opaque at the database level** (Prisma `Json` columns with no fixed shape) and now carry an honest `description` explaining why, matching the existing `DeveloperAppointment` precedent — instead of staying blank.

## Two real defects fixed, not just documented around

- `POST /v1/organisation-document/pms/{orgId}/documents` referenced a `components.schemas` entry that was never defined anywhere in the spec (`$ref` to a name that doesn't exist). Replaced with the real inline shape already used correctly by its five sibling endpoints, and added the `201` response the controller actually sends (`res.status(201).json(...)`) — the existing `200` never fires.
- `DELETE .../documents/{documentId}` is documented as returning `200` with a body; the controller sends `204` with none (`res.status(204).send()`). Added the real `204` response alongside the existing (now honestly-labelled) unreachable `200`.

## Why

Continues #2944 (openapi.yaml request/response bodies are mostly opaque placeholders). `scripts/ci/openapi-drift-baseline.json`'s `placeholderSchemas` ceiling moves **362 → 256**, verified against the real drift script's own JSON output (not hand-counted) — the ratchet now locks in this improvement rather than just not blocking it.

Two documentation-accuracy findings surfaced during tracing are documented in place rather than filed separately, since both fall under the already-tracked `missingFromSpec` debt (793, unchanged by this PR): `GET /v1/audit-trail/companion/{id}` and `GET /v1/audit-trail/appointment/{id}` are mounted and spec'd, but the shared handler unconditionally 405s on `GET` — the real, working call is `POST` with the id in the body, which isn't in the spec at all yet. The schema description for the GET 200 now explains this precisely. `POST /v1/contact-us/contact` replies `201` while documented as `200` — noted the same way.

## Impact area

Docs only: `apps/frontend/public/static/openapi/openapi.yaml`, `scripts/ci/openapi-drift-baseline.json`. No backend or frontend code changes, no API contract changes (only documentation of the existing, real contract).

## Validation performed

- Ran the actual `scripts/ci/openapi-drift.mjs --json` (not a reimplementation) against this branch: `placeholderSchemas: 256`, `missingFromSpec: 793` (unchanged), `staleInSpec: 34` (unchanged), `missingOrgHeader: 0`. Exit code 0 — the CI gate passes with the updated baseline.
- Verified the YAML re-parses cleanly and every one of the 165 target locations resolved to real content (no silent misses) via a path-by-path apply-and-verify pass.
- Grepped every `$ref` introduced across all 165 fixes against the spec's real `components.schemas` — 4 legitimately reused existing FHIR schemas (`Patient`, `RelatedPerson`, `HealthcareService`, `PractitionerRole`); the 1 broken one was fixed as described above.
- Spot-checked content across multiple domains (inventory, chat, invoice, organisation-document, audit-trail) directly against the backend source cited in each schema's description.