### PR TITLE
test(frontend): widen timeout on load-failed/no-access panel assertions

### DIFF
--- a/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyListPanel.stories.tsx
@@ -294,7 +294,10 @@ export const LoadFailed: AllergyListPanelStory = {
   beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const alert = await canvas.findByRole('alert');
+    // A generous timeout: the reject -> catch -> setError -> re-render chain is
+    // synchronous in the app, but on a loaded CI/dev machine the default 1s
+    // findBy* window can be too tight for the browser's main thread to commit it.
+    const alert = await canvas.findByRole('alert', {}, { timeout: 10000 });
     await expect(alert).toHaveTextContent('Could not load the allergy list. Please try again.');
     await expect(canvas.queryByText('Penicillin')).not.toBeInTheDocument();
   },
@@ -323,6 +326,6 @@ export const NoAccess: AllergyListPanelStory = {
     revoked: ['appointments:view:any'],
   }),
   play: async ({ canvasElement }) => {
-    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement(), { timeout: 10000 });
   },
 };

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentListPanel.stories.tsx
@@ -336,7 +336,10 @@ export const LoadFailed: Story = {
   beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const alert = await canvas.findByRole('alert');
+    // A generous timeout: the reject -> catch -> setError -> re-render chain is
+    // synchronous in the app, but on a loaded CI/dev machine the default 1s
+    // findBy* window can be too tight for the browser's main thread to commit it.
+    const alert = await canvas.findByRole('alert', {}, { timeout: 10000 });
     await expect(alert).toHaveTextContent('Could not load the consent list. Please try again.');
     await expect(
       canvas.queryByText('No consents recorded for this patient yet.')
@@ -370,6 +373,6 @@ export const Hidden: Story = {
   play: async ({ canvasElement }) => {
     // canView is derived synchronously from the store, seeded by beforeEach
     // before this mounts, so there is no flash of content to wait out.
-    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement(), { timeout: 10000 });
   },
 };

--- a/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagListPanel.stories.tsx
@@ -272,7 +272,10 @@ export const LoadFailed: Story = {
   beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const alert = await canvas.findByRole('alert');
+    // A generous timeout: the reject -> catch -> setError -> re-render chain is
+    // synchronous in the app, but on a loaded CI/dev machine the default 1s
+    // findBy* window can be too tight for the browser's main thread to commit it.
+    const alert = await canvas.findByRole('alert', {}, { timeout: 10000 });
     await expect(alert).toHaveTextContent('Could not load patient flags. Please try again.');
     await expect(canvas.queryByText('Bites when startled')).not.toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemListPanel.stories.tsx
@@ -299,7 +299,10 @@ export const LoadFailed: ProblemListPanelStory = {
   beforeEach: [prepare({ fixture: { kind: 'rejects' } }), muteExpectedFailureLogs],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const alert = await canvas.findByRole('alert');
+    // A generous timeout: the reject -> catch -> setError -> re-render chain is
+    // synchronous in the app, but on a loaded CI/dev machine the default 1s
+    // findBy* window can be too tight for the browser's main thread to commit it.
+    const alert = await canvas.findByRole('alert', {}, { timeout: 10000 });
     await expect(alert).toHaveTextContent('Could not load the problem list. Please try again.');
     await expect(canvas.queryByText('Chronic kidney disease')).not.toBeInTheDocument();
   },
@@ -328,6 +331,6 @@ export const NoAccess: ProblemListPanelStory = {
     revoked: ['appointments:view:any'],
   }),
   play: async ({ canvasElement }) => {
-    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement());
+    await waitFor(() => expect(canvasElement).toBeEmptyDOMElement(), { timeout: 10000 });
   },
 };


### PR DESCRIPTION
## What changed
`ProblemListPanel`, `FlagListPanel`, `AllergyListPanel` and `ConsentListPanel`'s `LoadFailed` stories check for the error alert with a plain `canvas.findByRole('alert')` (default ~1s window), and their `NoAccess`/`Hidden` stories check the panel renders nothing with a plain `waitFor(...toBeEmptyDOMElement())` (same default window). Widened the timeout to 10s on the 7 affected assertions across the four files.

## Why
This is **not an application defect**. While verifying [#2989](https://github.com/YosemiteCrew/Yosemite-Crew/pull/2989) I flagged these as a separate pre-existing issue - `test-storybook` reported "Unable to find role=alert" on `LoadFailed` and a `toBeEmptyDOMElement` mismatch on `NoAccess`. Investigated properly this time: confirmed via direct rendering (navigating straight to each story's iframe, bypassing the test runner entirely) that both states render exactly as intended - the error alert has the right text, the permission-gated panel is genuinely empty.

The `reject -> catch -> setError -> re-render` chain (and the permission check) are synchronous in the app, but on a loaded machine the default ~1s `findBy*`/`waitFor` window is not always enough for the browser's main thread to commit that render before the query gives up. Confirmed this specific flake is resolved by the timeout bump (reliably passing across repeated runs on a heavily-loaded local machine, load average 10-40 during testing). It will not paper over an actually-broken assertion - a real regression still fails, just after waiting longer.

Note: the same local runs surfaced other, unrelated instances of the same class of environment-driven flakiness (unrelated stories timing out under extreme load spikes) - those are why this repo's CI already marks the `Storybook play functions` check as advisory rather than blocking, and are out of scope here.

## Impact area
`apps/frontend` only - Storybook play-function assertions in the four `CompanionHistory/*Panel.stories.tsx` files. No production code touched.

## Validation performed
- `npx tsc --noemit` - clean
- `pnpm --filter frontend run lint` - clean (0 errors; 1 pre-existing warning in an unrelated file)
- Targeted jest: `companionHistory` - 421/421 passing
- Direct browser rendering of `LoadFailed`, `NoAccess` and `Hidden` stories (bypassing the test runner) - confirmed correct DOM output in every case
- `test-storybook` re-run after the fix: the `LoadFailed` alert assertion passed reliably across all four files in a run where several other, unrelated stories still flaked under machine load