### PR TITLE
fix(frontend): route Insights page and LANG_COLORS through real tokens

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/useRepoInsights.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useRepoInsights.test.ts
@@ -1,4 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { useRepoInsights } from '@/app/features/marketing/site/useRepoInsights';
 
 type FetchLike = typeof fetch;
@@ -75,7 +77,10 @@ describe('useRepoInsights', () => {
     expect(result.current.facts?.issues).toBe('12');
 
     await waitFor(() => expect(result.current.languages?.[0].name).toBe('TypeScript'));
-    expect(result.current.languages?.[0].color).toBe('#257bed');
+    // Was the literal '#257bed'; now reads the fixed --blue token instead (see
+    // the guard test below), so this asserts the value langColor() actually
+    // returns rather than the colour it resolves to once painted.
+    expect(result.current.languages?.[0].color).toBe('var(--blue)');
     expect(Math.round(result.current.languages?.[0].pct ?? 0)).toBe(80);
 
     await waitFor(() => expect(result.current.commits?.[0].message).toBe('feat: add insights'));
@@ -306,5 +311,25 @@ describe('useRepoInsights', () => {
 
     await waitFor(() => expect(result.current.heartbeat).toEqual([4, 8]), { timeout: 4000 });
     expect(activityCalls).toBe(2);
+  });
+});
+
+describe('LANG_COLORS reads TypeScript and HTML from the fixed --blue/--pink tokens', () => {
+  // These two are the only LANG_COLORS entries that happen to coincide with
+  // an existing token that is genuinely fixed across both theme blocks -
+  // the rest are a deliberate categorical palette with no token match.
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/site/useRepoInsights.ts'),
+    'utf8'
+  );
+
+  it('does not hardcode the TypeScript/HTML swatches as frozen literals', () => {
+    expect(source).not.toContain("'#257bed'");
+    expect(source).not.toContain("'#ff90d4'");
+  });
+
+  it('routes TypeScript through --blue and HTML through --pink', () => {
+    expect(source).toMatch(/TypeScript:\s*'var\(--blue\)'/);
+    expect(source).toMatch(/HTML:\s*'var\(--pink\)'/);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -155,5 +157,30 @@ describe('Insights page', () => {
 
     const line = screen.getByText(/What you measure is what you actually care about/);
     expect(line).toHaveStyle({ color: 'var(--spot-ink)' });
+  });
+});
+
+describe('the console and release cards read their primary ink from --spot-ink', () => {
+  // ConsoleMiniStats/MiniStat and LatestReleaseCard both sit on background:
+  // var(--spot), which never flips, so their headline ink must read
+  // var(--spot-ink) rather than a frozen copy of its dark-mode value.
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/Insights/Insights.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the console/release ink as a frozen literal', () => {
+    expect(source).not.toContain("color: '#f4efe6'");
+  });
+
+  it('routes the console/release ink through --spot-ink', () => {
+    // Both MiniStat's value and LatestReleaseCard's tag share this exact
+    // `letterSpacing: '-0.03em'` immediately before `color`, which no other
+    // --spot-ink call site in this file uses - anchoring on it (rather than
+    // a bare count) keeps the assertion sensitive to reverting these two
+    // specific sites, not just any --spot-ink usage already in the file.
+    const occurrences =
+      source.match(/letterSpacing:\s*'-0\.03em',\s*color:\s*'var\(--spot-ink\)'/g) ?? [];
+    expect(occurrences).toHaveLength(2);
   });
 });

--- a/apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx
@@ -184,7 +184,7 @@ function MiniStat({ value, label }: Readonly<{ value: string; label: string }>) 
           fontSize: 26,
           fontWeight: 500,
           letterSpacing: '-0.03em',
-          color: '#f4efe6',
+          color: 'var(--spot-ink)',
         }}
       >
         {value}
@@ -852,7 +852,7 @@ function LatestReleaseCard() {
               fontSize: 'clamp(30px, 4vw, 44px)',
               fontWeight: 500,
               letterSpacing: '-0.03em',
-              color: '#f4efe6',
+              color: 'var(--spot-ink)',
             }}
           >
             {release.tag ?? 'Loading...'}

--- a/apps/frontend/src/app/features/marketing/site/useRepoInsights.ts
+++ b/apps/frontend/src/app/features/marketing/site/useRepoInsights.ts
@@ -56,11 +56,11 @@ const EMPTY: RepoInsights = {
 const GITHUB_ACCEPT = 'application/vnd.github+json';
 
 const LANG_COLORS: Record<string, string> = {
-  TypeScript: '#257bed',
+  TypeScript: 'var(--blue)',
   JavaScript: '#d99a2b',
   CSS: '#38ccd8',
   SCSS: '#38ccd8',
-  HTML: '#ff90d4',
+  HTML: 'var(--pink)',
   Kotlin: '#8a6fb0',
   Swift: '#c98a5e',
   'Objective-C': '#7c9bb5',

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "f4fbd219def4e02ae69e7ce92b70bd833cef8229",
-  "total": 98,
+  "generated_at": "31a4286867c80eaab3ca709d499a343fc5b2e600",
+  "total": 65,
   "justified": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": {
       "n": 1,
@@ -247,6 +247,10 @@
       "n": 9,
       "why": "The same fake terminal/code-editor mockup chrome justified in DevelopersPage.tsx (traffic-light dots #454341 x3, header rule #302f2e x2, terminal body text #d6d1cd - its string/prompt colours were tokenised via --color-success-300/-500 in this PR, same as DevelopersPage.tsx's). Plus two more single-file bespoke spots: an avatar-stack placeholder background (#e6e3e0) and a phone-mockup bezel (#1d1c1b x2) - the bezel is a physical-device colour on a decorative illustration, not a themed app surface, the same reasoning as the media-overlay literals justified in Guides.tsx and InClinicTodayBand.tsx (PR #2990)."
     },
+    "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": {
+      "n": 17,
+      "why": "Two --spot cards (a live GitHub-stats console, a latest-release card - both background: var(--spot)) carry four DIFFERENT close-but-not-identical muted-grey inks (#8a8074 x5, #6b6155 x2, #a89e90 x2 - the dark-mode value of the flipping --ink-muted, hardcoded because the card itself never flips - plus the already-tokenised #f4efe6 in this PR), none matching --spot-ink-faint's #a9a39e exactly, so each was picked independently rather than drawn from a shared token. Also on the same console: a bespoke near-black panel (#232120, border #302f2e x3, matching DevelopersPage.tsx's EconomicsCard pattern), a 'LIVE' status pair (dot #2bbd86 - --success's dark-mode value, no matching --spot-success-strength token exists - and its paired label #6cd6a3), the shared terminal-mockup text colour #d6d1cd (see DevelopersPage.tsx), and the shared bespoke CTA border #454341 (see DevelopersPage.tsx's CLOSING_PORTAL_LINK_STYLE)."
+    },
     "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": {
       "n": 8,
       "why": "The brand panel's own bespoke near-black gradient (#2a2723 to #131210, matching DevelopersPage.tsx's EconomicsCard pattern - see PR #2992). The remaining five (subtitle/footer ink #b7ac9d x2, point text #d8cec0, star icon gold #ffd479, 'Star on GitHub' emphasis white #fff) are single-file bespoke choices with no matching token - #fff in particular is a deliberately brighter emphasis colour next to surrounding --spot-ink copy, the same pattern as Pricing.tsx's price figure and DevelopersPage.tsx's '0%' hero figure."
@@ -254,6 +258,10 @@
     "apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx": {
       "n": 2,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
+    },
+    "apps/frontend/src/app/features/marketing/site/useRepoInsights.ts": {
+      "n": 12,
+      "why": "LANG_COLORS is a deliberate categorical palette (GitHub-style per-language repo-stats colours) - each language needs a visually distinct swatch, and only two of the thirteen (TypeScript, HTML) happened to coincide with an existing fixed token (--blue, --pink respectively, tokenised in this PR). The rest (JavaScript, CSS/SCSS, Kotlin, Swift, Objective-C, Java, Ruby, Shell, Dockerfile, Python) and the LANG_FALLBACK tail colour are bespoke hues with no match anywhere in the token set - a qualitative palette, not derivable from the design system."
     },
     "apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx": {
       "n": 1,
@@ -360,7 +368,6 @@
     "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 4,
     "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": 10,
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": 1,
-    "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": 19,
     "apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx": 3,
     "apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx": 10,
     "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.stories.tsx": 3,
@@ -371,7 +378,6 @@
     "apps/frontend/src/app/features/marketing/site/motion.stories.tsx": 2,
     "apps/frontend/src/app/features/marketing/site/motion.tsx": 7,
     "apps/frontend/src/app/features/marketing/site/SiteFooter.stories.tsx": 2,
-    "apps/frontend/src/app/features/marketing/site/SiteFooter.tsx": 9,
-    "apps/frontend/src/app/features/marketing/site/useRepoInsights.ts": 14
+    "apps/frontend/src/app/features/marketing/site/SiteFooter.tsx": 9
   }
 }


### PR DESCRIPTION
Continues the hardcoded-hex-color sweep into the Insights page (the last
largest file, 19 literals) and its data hook (14 literals).

**Real fixes**, live-verified in the dev server (dark mode: computed
colour unchanged at `rgb(244, 239, 230)`; light app-theme now correctly
resolves to `--spot-ink`'s light-tuned cream, `rgb(234, 226, 213)`,
instead of always showing the dark-tuned value):

- `Insights.tsx`: the live GitHub-stats console and the latest-release
  card (both `background: var(--spot)`) hardcoded `#f4efe6` —
  `--spot-ink`'s own dark-mode value — for their headline ink instead of
  reading the token.
- `useRepoInsights.ts`: `LANG_COLORS` is a deliberate per-language
  palette for the repo-language bar, but two of its thirteen entries
  happened to coincide with an existing fixed token — TypeScript's
  `#257bed` is `--blue`, HTML's `#ff90d4` is `--pink`, both declared
  identically in every theme block.

Guard-tested and mutation-checked. The first assertion for the
`Insights.tsx` fix used a bare "at least 2 `var(--spot-ink)` occurrences"
count, which the mutation-check caught as too weak (3 pre-existing,
unrelated occurrences already satisfied it) — rewritten to anchor on the
exact `letterSpacing` value shared only by these two call sites.
Reverting both source files now correctly fails all 4 new/updated
assertions (the pre-existing `useRepoInsights` test asserting the literal
`#257bed` was updated to `var(--blue)`, since that's the actual value the
hook returns, not something a browser resolves); restored, 18/18 pass.

The remaining 29 literals (17 in `Insights.tsx`, 12 in
`useRepoInsights.ts`) are justified: four different close-but-not-identical
muted-ink choices on the same two `--spot` cards (none matching
`--spot-ink-faint` exactly), a near-black console panel matching
`DevelopersPage.tsx`'s `EconomicsCard` pattern, a "LIVE" status dot/label
pair, the shared terminal-mockup text colour, a shared bespoke CTA
border, and eleven remaining `LANG_COLORS` entries with no token match at
all — a qualitative palette, not derivable from the design system.

Baseline regenerated via `--update`: 98 → 65.