### PR TITLE
fix(backend): return JSON for unhandled errors and malformed Documenso signatures

### DIFF
--- a/apps/backend/jest.config.cjs
+++ b/apps/backend/jest.config.cjs
@@ -12,7 +12,6 @@ module.exports = {
     "<rootDir>/src/**/*.ts",
     "!<rootDir>/src/**/*.d.ts",
     "!<rootDir>/src/controllers/merck/merck-response.ts",
-    "!<rootDir>/src/controllers/web/documenso.controller.ts",
     "!<rootDir>/src/controllers/web/organisation-invite.controller.ts",
     "!<rootDir>/src/controllers/web/organisation-room.controller.ts",
     "!<rootDir>/src/middlewares/auth.ts",
@@ -31,7 +30,8 @@ module.exports = {
   ...(collectingCoverage ? { workerIdleMemoryLimit: "512MB" } : {}),
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
   moduleNameMapper: {
-    "^@yosemite-crew/database$": "<rootDir>/../../packages/database/src/client.ts",
+    "^@yosemite-crew/database$":
+      "<rootDir>/../../packages/database/src/client.ts",
     "^@yosemite-crew/lib$": "<rootDir>/../../packages/lib/src/index.ts",
     "^@yosemite-crew/(.*)$": "<rootDir>/../../packages/$1/src",
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { ErrorRequestHandler } from "express";
 import rateLimit from "express-rate-limit";
 import {
   resolveRateLimitMax,
@@ -32,6 +32,7 @@ import {
   validateAuthConfig,
 } from "@yosemite-crew/auth";
 import { authHooks } from "./config/auth-hooks";
+import logger from "./utils/logger";
 
 /**
  * Three states, not two.
@@ -56,6 +57,21 @@ function readAuthGate(): AuthGate {
     ? "enabled"
     : "incomplete";
 }
+
+// Last resort: any error that reaches here escaped every route's own
+// try/catch (and, when auth is on, SuperTokens' own handler too). Without
+// this, Express falls back to its default handler, which answers with an
+// HTML page instead of the JSON shape every other error path in this app
+// uses - the caller can't tell "the server broke" from "the server isn't
+// there" (#2752).
+const handleUnhandledError: ErrorRequestHandler = (err, _req, res, next) => {
+  logger.error("Unhandled application error:", err);
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+  res.status(500).json({ message: "Internal server error." });
+};
 
 export function createApp() {
   const app = express();
@@ -261,5 +277,6 @@ export function createApp() {
   if (superTokensEnabled) {
     registerSuperTokensErrorHandler(app);
   }
+  app.use(handleUnhandledError);
   return app;
 }

--- a/apps/backend/src/controllers/web/documenso.controller.ts
+++ b/apps/backend/src/controllers/web/documenso.controller.ts
@@ -21,6 +21,18 @@ interface DocumensoWebhookBody {
   };
 }
 
+// timingSafeEqual throws on a length mismatch, which would surface a
+// malformed signature as a 500 instead of the 401 it is.
+function isMatchingSignature(expected: string, provided: string): boolean {
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuf, providedBuf);
+}
+
 function verifySignature(
   payload: Buffer,
   signature: string,
@@ -31,15 +43,7 @@ function verifySignature(
     .update(payload)
     .digest("hex");
 
-  const expectedBuf = Buffer.from(expected);
-  const providedBuf = Buffer.from(signature);
-  // timingSafeEqual throws on a length mismatch, which would surface a
-  // malformed signature as a 500 instead of the 401 it is.
-  if (expectedBuf.length !== providedBuf.length) {
-    return false;
-  }
-
-  return crypto.timingSafeEqual(expectedBuf, providedBuf);
+  return isMatchingSignature(expected, signature);
 }
 
 function isDocumensoWebhookBody(body: unknown): body is DocumensoWebhookBody {
@@ -478,9 +482,7 @@ export const DocumensoKeyController = {
         .update(payload)
         .digest("hex");
 
-      if (
-        !crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
-      ) {
+      if (!isMatchingSignature(expected, signature)) {
         logger.warn("Documenso key webhook signature invalid");
         return res.status(401).json({ message: "Invalid signature." });
       }

--- a/apps/backend/test/app.test.ts
+++ b/apps/backend/test/app.test.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { PassThrough } from "node:stream";
-import type { RequestHandler } from "express";
+import type { Express, RequestHandler } from "express";
 
 const mockRegisterRoutes = jest.fn();
 const mockStripeWebhook = jest.fn();
@@ -263,6 +263,26 @@ describe("createApp", () => {
       "http://localhost:3000",
     );
     expect(response.getHeader("access-control-allow-credentials")).toBe("true");
+  });
+
+  // #2752: without a final application-level error handler, an error that
+  // escapes a route falls through to Express's own default handler, which
+  // answers with an HTML page instead of the JSON shape every other error
+  // path in this app uses.
+  it("returns a JSON error, not Express's default HTML page, when a route throws", async () => {
+    mockRegisterRoutes.mockImplementationOnce((app: Express) => {
+      app.get("/test-unhandled-throw", () => {
+        throw new Error("boom");
+      });
+    });
+
+    const app = createApp();
+    const response = await request(app, { path: "/test-unhandled-throw" });
+    const body = JSON.parse(response.body) as { message: string };
+
+    expect(response.statusCode).toBe(500);
+    expect(response.getHeader("content-type")).toContain("application/json");
+    expect(body).toEqual({ message: "Internal server error." });
   });
 });
 

--- a/apps/backend/test/app.test.ts
+++ b/apps/backend/test/app.test.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from "node:http";
 import type { Socket } from "node:net";
 import { PassThrough } from "node:stream";
-import type { Express, RequestHandler } from "express";
+import type { ErrorRequestHandler, Express, RequestHandler } from "express";
 
 const mockRegisterRoutes = jest.fn();
 const mockStripeWebhook = jest.fn();
@@ -283,6 +283,24 @@ describe("createApp", () => {
     expect(response.statusCode).toBe(500);
     expect(response.getHeader("content-type")).toContain("application/json");
     expect(body).toEqual({ message: "Internal server error." });
+  });
+
+  it("delegates unhandled errors after the response headers were sent", () => {
+    const app = createApp();
+    const stack = ((app as unknown as { _router: { stack: Layer[] } })._router
+      .stack ?? []) as Layer[];
+    const errorHandler = stack.at(-1)?.handle as unknown as ErrorRequestHandler;
+    const error = new Error("boom after headers");
+    const next = jest.fn();
+
+    errorHandler(
+      error,
+      {} as Parameters<ErrorRequestHandler>[1],
+      { headersSent: true } as Parameters<ErrorRequestHandler>[2],
+      next,
+    );
+
+    expect(next).toHaveBeenCalledWith(error);
   });
 });
 

--- a/apps/backend/test/controllers/web/documenso.auth-key.controller.test.ts
+++ b/apps/backend/test/controllers/web/documenso.auth-key.controller.test.ts
@@ -647,6 +647,24 @@ describe("Documenso controllers", () => {
       expect(statusMock).toHaveBeenCalledWith(401);
     });
 
+    // #2742: a signature of a different length than expected used to throw
+    // inside timingSafeEqual and surface as a 500 rather than the 401 a
+    // malformed-but-rejected signature should be.
+    it("returns 401, not 500, when the signature has a different length than expected", async () => {
+      req.params = { orgId: "org-1" };
+      req.body = { apiToken: "token-1" };
+      req.headers = { "x-documenso-signature": "too-short" };
+
+      await DocumensoKeyController.storeApiKey(
+        req as Request<{ orgId: string }>,
+        res as Response,
+      );
+
+      expect(statusMock).toHaveBeenCalledWith(401);
+      expect(jsonMock).toHaveBeenCalledWith({ message: "Invalid signature." });
+      expect(statusMock).not.toHaveBeenCalledWith(500);
+    });
+
     it("returns 400 when apiToken is missing", async () => {
       req.params = { orgId: "org-1" };
       req.body = {};


### PR DESCRIPTION
## Summary
- Adds a final application-level error handler in `createApp()` so an error that escapes every route's own try/catch answers with the app's JSON shape instead of Express's default HTML page.
- Guards the PMS key-storage signature check in `DocumensoKeyController.storeApiKey` against a length-mismatched signature the same way the webhook helper already did, so a malformed signature returns 401 instead of crashing `timingSafeEqual` into a 500.

Closes #2752
Closes #2742

## Test plan
- [x] `pnpm --filter backend run test` - 489/489 suites, 11645/11645 tests pass
- [x] `pnpm --filter backend run type-check` - clean
- [x] `pnpm --filter backend run lint` - 0 errors (pre-existing warnings elsewhere, untouched)
- [x] New tests in `app.test.ts` assert a thrown route error returns JSON and an error after headers are sent delegates to Express; both mutation-checked
- [x] New test in `documenso.auth-key.controller.test.ts` asserts a length-mismatched signature returns 401, not 500; mutation-checked
