### PR TITLE
fix(frontend): stop check-in board claiming empty when the load failed

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
@@ -439,4 +439,12 @@ describe('FrontDeskBoard', () => {
 
     expect(within(screen.getByRole('alert')).getByText('Boom')).toBeInTheDocument();
   });
+
+  it('does not also claim the board is empty when the load failed', () => {
+    render(<FrontDeskBoard entries={[]} error="Boom" {...handlers()} />);
+
+    expect(within(screen.getByRole('alert')).getByText('Boom')).toBeInTheDocument();
+    expect(screen.queryByText('No patients are checked in')).not.toBeInTheDocument();
+    expect(screen.queryByText('No check-ins yet')).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
@@ -565,6 +565,16 @@ const FrontDeskBoard = ({
 
   const body = (() => {
     if (loading) return <PanelLoadingRows rowClass={rowClass} />;
+    if (error) {
+      return (
+        <div
+          role="alert"
+          className="border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
+        >
+          {error}
+        </div>
+      );
+    }
     if (sorted.length === 0) {
       return (
         <PanelEmptyState message={showAll ? 'No check-ins yet' : 'No patients are checked in'} />
@@ -597,15 +607,6 @@ const FrontDeskBoard = ({
         onToggleShowAll={onToggleShowAll}
         onToggleAdd={onAdd ? () => setAddOpen((open) => !open) : undefined}
       />
-
-      {error && (
-        <div
-          role="alert"
-          className="border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-3 text-[12.5px] font-semibold text-[var(--danger-text)]"
-        >
-          {error}
-        </div>
-      )}
 
       {onAdd && addOpen && (
         <AddCheckInForm companions={companions} onAdd={onAdd} onClose={() => setAddOpen(false)} />

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoardPanel.stories.tsx
@@ -537,9 +537,9 @@ export const LoadFailed: FrontDeskBoardPanelStory = {
     await expect(await canvas.findByRole('alert')).toHaveTextContent(
       'Unable to load the check-in board right now.'
     );
-    // The error banner and the empty body are not mutually exclusive - both
-    // render at once, since `checkIns` never left its initial empty array.
-    await expect(canvas.getByText('No patients are checked in')).toBeVisible();
+    // The error banner and the empty body are mutually exclusive: an unsuccessful
+    // read must not also claim the board is confirmed empty.
+    await expect(canvas.queryByText('No patients are checked in')).not.toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
## What changed
`FrontDeskBoard`'s check-in board rendered its error banner and the "No patients are checked in" / "No check-ins yet" empty state at the same time when the check-in fetch failed. The body's empty-state check only looked at `sorted.length === 0`, never at `error`, so a failed load (which leaves `entries` at its initial `[]`) rendered the error and an "empty" claim together.

## Why
An unsuccessful read cannot establish that the board is actually empty - this can mislead front-desk/clinical staff into treating unknown data as confirmed-absent. `ProblemList.tsx` and `FlagList.tsx` already implement this correctly (`if (loading) -> else if (error) -> else if (empty) -> else (content)`); this change brings the check-in board's body into the same mutually-exclusive shape.

## Impact area
`apps/frontend` - Appointments / Front desk check-in board only. No other surface touched (problem list and patient flags were already correct on `dev`).

## Validation performed
- New Jest test reproducing the exact failure shape (`entries: []` + `error` set): asserts the alert renders and neither empty-state string renders. Mutation-checked - reverted only the source fix and confirmed this exact test fails against the unfixed component; restored the fix and it passes.
- `pnpm --filter frontend run test -- --testPathPatterns="FrontDeskBoard"`: 42/42 passing (2 suites).
- `npx tsc --noemit` (apps/frontend): clean.
- `pnpm --filter frontend run lint`: 0 errors, 1 pre-existing unrelated warning (`useLazyAuthStore.ts`, not touched here).
- Updated the existing `FrontDeskBoardPanel.stories.tsx` `LoadFailed` story, which previously asserted the bug as expected behavior, to assert the fixed (mutually-exclusive) behavior instead.
- Full monorepo pre-push gate (lint + type-check across all workspaces) ran clean via the repo's pre-push hook.

Closes #2751.