### PR TITLE
fix(frontend): compare consent-inset probe against resolved safe-area term

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
@@ -6,6 +6,7 @@ import {
   describeInsetProbe,
   expectedShellHeight,
   measureConsentInsetResponse,
+  resolveEnvInsetPx,
 } from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
 
 /**
@@ -54,6 +55,28 @@ describe('chooseProbeInset', () => {
     // inset === TAB_BAR_PX changes nothing under max(), so the boundary is <=.
     const height = HEADER_PX + MIN_H_PX + 1 + TAB_BAR_PX;
     expect(chooseProbeInset(height).usable).toBe(false);
+  });
+
+  it('refuses a viewport it would accept with no safe-area inset, once one is present', () => {
+    /* The false-alarm band from issue #2806: at 640px the chosen inset is 105,
+       which beats the bare 72px tab bar but loses to `72 + 34` - the term the
+       CSS `max()` actually competes with on a device with a home indicator. */
+    const bare = chooseProbeInset(640);
+    expect(bare).toEqual({ usable: true, inset: 105 });
+
+    const withHomeIndicator = chooseProbeInset(640, 34);
+    expect(withHomeIndicator.usable).toBe(false);
+    expect(withHomeIndicator.inset).toBe(105);
+    expect('reason' in withHomeIndicator && withHomeIndicator.reason).toContain(
+      '106px tab-bar term (72px bar + 34px safe-area inset)'
+    );
+  });
+
+  it('shifts the unusable boundary by the safe-area inset, not just the bare bar', () => {
+    // inset === TAB_BAR_PX + envInsetPx is still the boundary, moved by envInsetPx.
+    const height = HEADER_PX + MIN_H_PX + 1 + TAB_BAR_PX + 20;
+    expect(chooseProbeInset(height, 20).usable).toBe(false);
+    expect(chooseProbeInset(height, 19).usable).toBe(true);
   });
 });
 
@@ -124,6 +147,17 @@ describe('measureConsentInsetResponse', () => {
     expect(result.reason).toContain('too short');
   });
 
+  it('passes the false-alarm-band viewport with no safe-area inset, refuses it with one', () => {
+    // Same 640px shell that responds correctly to the CSS max() - only the
+    // env(safe-area-inset-bottom) term should change the verdict, not the shell.
+    const { shell, setInset } = fakeShell(640, { responds: true });
+    expect(measureConsentInsetResponse(shell, 640, setInset).ok).toBe(true);
+    expect(measureConsentInsetResponse(shell, 640, setInset, 34).ok).toBe(false);
+    expect(measureConsentInsetResponse(shell, 640, setInset, 34).reason).toContain(
+      'safe-area inset'
+    );
+  });
+
   it('always clears the property it set, including on the refusing path', () => {
     const seen: Array<string | null> = [];
     const shell = { getBoundingClientRect: () => ({ height: 718 }) as DOMRect };
@@ -141,5 +175,19 @@ describe('measureConsentInsetResponse', () => {
     expect(describeInsetProbe(result)).toBe(
       'consent inset 252px: before 718px, with card 718px, expected 538px - did not shrink: 718 is not less than 718; height 718 is not the expected 538'
     );
+  });
+});
+
+describe('resolveEnvInsetPx', () => {
+  it('degrades to 0 rather than NaN when the engine cannot evaluate env()', () => {
+    // jsdom does not implement env(), so this is the "headless browser" case
+    // the rest of the module already assumes as its default.
+    expect(resolveEnvInsetPx()).toBe(0);
+  });
+
+  it('removes the probe element it creates', () => {
+    const before = document.body.childElementCount;
+    resolveEnvInsetPx();
+    expect(document.body.childElementCount).toBe(before);
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/consentInsetAssertion.test.ts
@@ -176,6 +176,12 @@ describe('measureConsentInsetResponse', () => {
       'consent inset 252px: before 718px, with card 718px, expected 538px - did not shrink: 718 is not less than 718; height 718 is not the expected 538'
     );
   });
+
+  it('describes a successful probe as ok', () => {
+    const { shell, setInset } = fakeShell(844, { responds: true });
+    const result = measureConsentInsetResponse(shell, 844, setInset);
+    expect(describeInsetProbe(result)).toContain(' - ok');
+  });
 });
 
 describe('resolveEnvInsetPx', () => {
@@ -183,6 +189,15 @@ describe('resolveEnvInsetPx', () => {
     // jsdom does not implement env(), so this is the "headless browser" case
     // the rest of the module already assumes as its default.
     expect(resolveEnvInsetPx()).toBe(0);
+  });
+
+  it('returns the resolved safe-area inset', () => {
+    const getComputedStyleSpy = jest
+      .spyOn(globalThis, 'getComputedStyle')
+      .mockReturnValue({ paddingBottom: '34px' } as CSSStyleDeclaration);
+
+    expect(resolveEnvInsetPx()).toBe(34);
+    getComputedStyleSpy.mockRestore();
   });
 
   it('removes the probe element it creates', () => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhoneWorkspaceShell.stories.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import type { Appointment } from '@yosemite-crew/types';
-import { describeInsetProbe, measureConsentInsetResponse } from './consentInsetAssertion';
+import {
+  describeInsetProbe,
+  measureConsentInsetResponse,
+  resolveEnvInsetPx,
+} from './consentInsetAssertion';
 
 import PhoneWorkspaceShell from './PhoneWorkspaceShell';
 import {
@@ -266,7 +270,12 @@ export const FitsThePhone: Story = {
       value === null
         ? root.style.removeProperty('--yc-consent-inset')
         : root.style.setProperty('--yc-consent-inset', value);
-    const probe = measureConsentInsetResponse(shell as HTMLElement, window.innerHeight, setInset);
+    const probe = measureConsentInsetResponse(
+      shell as HTMLElement,
+      window.innerHeight,
+      setInset,
+      resolveEnvInsetPx()
+    );
     await expect(probe.ok, describeInsetProbe(probe)).toBe(true);
   },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
@@ -27,17 +27,24 @@ export type InsetChoice =
 /**
  * The inset to probe with.
  *
- * It has to beat `TAB_BAR_PX` (or the `max()` returns the tab-bar term and the
- * calc is never exercised) and stay above `MIN_H_PX` (or the floor answers
- * instead of the calc, which passes while measuring the wrong mechanism).
+ * It has to beat the tab-bar TERM the CSS actually competes with -
+ * `TAB_BAR_PX + envInsetPx`, not the bare `TAB_BAR_PX` - or the `max()`
+ * returns the tab-bar term and the calc is never exercised. It also has to
+ * stay above `MIN_H_PX` (or the floor answers instead of the calc, which
+ * passes while measuring the wrong mechanism).
+ *
+ * `envInsetPx` defaults to 0, matching `env(safe-area-inset-bottom)` in a
+ * headless browser; a real device with a home indicator resolves it higher,
+ * which shrinks the usable band from the tab-bar end.
  */
-export const chooseProbeInset = (viewportHeight: number): InsetChoice => {
+export const chooseProbeInset = (viewportHeight: number, envInsetPx = 0): InsetChoice => {
   const inset = Math.min(PREFERRED_INSET_PX, viewportHeight - HEADER_PX - MIN_H_PX - 1);
-  if (inset <= TAB_BAR_PX) {
+  const tabBarTerm = TAB_BAR_PX + envInsetPx;
+  if (inset <= tabBarTerm) {
     return {
       usable: false,
       inset,
-      reason: `viewport ${viewportHeight}px is too short to exercise the calc above the ${MIN_H_PX}px floor: the largest usable inset is ${inset}px, which does not beat the ${TAB_BAR_PX}px tab-bar term`,
+      reason: `viewport ${viewportHeight}px is too short to exercise the calc above the ${MIN_H_PX}px floor: the largest usable inset is ${inset}px, which does not beat the ${tabBarTerm}px tab-bar term (${TAB_BAR_PX}px bar + ${envInsetPx}px safe-area inset)`,
     };
   }
   return { usable: true, inset };
@@ -67,16 +74,34 @@ export type InsetProbeResult = {
 type Shell = Pick<HTMLElement, 'getBoundingClientRect'>;
 
 /**
+ * Reads the safe-area inset the CSS `max()` term actually competes with,
+ * instead of assuming it is 0. jsdom does not evaluate `env()` (padding-bottom
+ * resolves empty, hence the finite-or-0 fallback), so this is only a real
+ * measurement under an engine that does - Storybook's Playwright runner.
+ */
+export const resolveEnvInsetPx = (): number => {
+  const probe = document.createElement('div');
+  probe.style.position = 'absolute';
+  probe.style.visibility = 'hidden';
+  probe.style.paddingBottom = 'env(safe-area-inset-bottom, 0px)';
+  document.body.appendChild(probe);
+  const parsed = Number.parseFloat(globalThis.getComputedStyle(probe).paddingBottom);
+  document.body.removeChild(probe);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
  * Sets the inset, reads the shell, and puts it back. Returns what it saw rather
  * than asserting, so the discrimination itself can be tested.
  */
 export const measureConsentInsetResponse = (
   shell: Shell,
   viewportHeight: number,
-  setInset: (value: string | null) => void
+  setInset: (value: string | null) => void,
+  envInsetPx = 0
 ): InsetProbeResult => {
   const before = shell.getBoundingClientRect().height;
-  const choice = chooseProbeInset(viewportHeight);
+  const choice = chooseProbeInset(viewportHeight, envInsetPx);
   const expected = expectedShellHeight(viewportHeight, choice.inset);
 
   if (!choice.usable) {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion.ts
@@ -86,7 +86,7 @@ export const resolveEnvInsetPx = (): number => {
   probe.style.paddingBottom = 'env(safe-area-inset-bottom, 0px)';
   document.body.appendChild(probe);
   const parsed = Number.parseFloat(globalThis.getComputedStyle(probe).paddingBottom);
-  document.body.removeChild(probe);
+  probe.remove();
   return Number.isFinite(parsed) ? parsed : 0;
 };
 

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.stories.tsx
@@ -13,6 +13,7 @@ import api from '@/app/services/axios';
 import {
   describeInsetProbe,
   measureConsentInsetResponse,
+  resolveEnvInsetPx,
 } from '@/app/features/appointments/pages/AppointmentWorkspace/phone/consentInsetAssertion';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { formatDisplayDate } from '@/app/lib/date';
@@ -1260,7 +1261,12 @@ export const Phone: Story = {
       value === null
         ? root.style.removeProperty('--yc-consent-inset')
         : root.style.setProperty('--yc-consent-inset', value);
-    const probe = measureConsentInsetResponse(shell as HTMLElement, window.innerHeight, setInset);
+    const probe = measureConsentInsetResponse(
+      shell as HTMLElement,
+      window.innerHeight,
+      setInset,
+      resolveEnvInsetPx()
+    );
     await expect(probe.ok, describeInsetProbe(probe)).toBe(true);
   },
   parameters: {


### PR DESCRIPTION
## Summary
- `chooseProbeInset` refused/accepted a viewport by comparing the candidate inset against the bare 72px tab-bar height, but the CSS `max()` the two phone shells use actually competes against `72px + env(safe-area-inset-bottom)`.
- On a device with a home indicator this created a band of viewport heights where the probe judged an inset usable, the CSS returned the tab-bar term instead, and the resulting height mismatch was reported as a defect that is not one - the shell was behaving correctly.
- Fixed by resolving the safe-area inset at runtime (a probe element read with `getComputedStyle`, same pattern already used elsewhere in this codebase for the same CSS term) and folding it into the boundary math and both Storybook play functions that drive the shared assertion.
- `MIN_H_PX` floor check is unrelated to `env()` and was left as-is.

Closes #2806

## Test plan
- [x] `pnpm --filter frontend run test -- --testPathPatterns="consentInsetAssertion" --coverage` - 17/17 passing, 99.36% statements/100% functions on the touched file
- [x] Mutation-checked: reverting the boundary fix (`tabBarTerm = TAB_BAR_PX` instead of `TAB_BAR_PX + envInsetPx`) fails the 3 new tests
- [x] `pnpm --filter frontend run type-check` - clean
- [x] `pnpm --filter frontend run lint` - clean (pre-existing unrelated warning in `useLazyAuthStore.ts` only)