### PR TITLE
fix(frontend): stop outpatient schedule rows and order notes clipping on phone

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -459,6 +459,24 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
     expect(screen.getByText(/Fasted patient/)).toBeInTheDocument();
   });
 
+  it('wraps the saved order notes instead of truncating the tail on a clipped line (#2790)', () => {
+    const notes =
+      'Fasted sample, collected from the left jugular. Please combine with the pre-med ' +
+      'dose and hold the results for the afternoon consult.';
+    renderStep({ appointmentOrders: [makeOrder({ notes })] });
+
+    // The note span previously sat on `truncate` (`white-space:nowrap` +
+    // `overflow:hidden` + ellipsis), which emptied the tail out of reach at
+    // phone width - the only access to it was the `title` hover, and a phone
+    // has no hover. `break-words` lets the free-text note flow to the lines it
+    // needs. jsdom does not lay out text, so the wrap contract is pinned via
+    // the classes the way the storybook play pins it via scrollWidth.
+    const label = screen.getByText('Order notes:');
+    const note = label.parentElement as HTMLElement;
+    expect(note.className).toMatch(/break-words/);
+    expect(note.className).not.toMatch(/truncate/);
+  });
+
   it('disables create when no tests are queued and renders the empty queue message', () => {
     renderStep({ selectedTests: [] });
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/OutpatientSchedule.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/OutpatientSchedule.test.tsx
@@ -113,6 +113,32 @@ describe('OutpatientSchedule', () => {
     expect(screen.getAllByText('--').length).toBeGreaterThan(0);
   });
 
+  it('wraps long titles and sublines instead of truncating them on a phone (#2790)', () => {
+    const longTitle = 'Photobiomodulation and underwater treadmill rehabilitation review';
+    const { container } = render(
+      <OutpatientSchedule
+        schedule={model({
+          thisWeek: [visit({ id: 'a', title: longTitle })],
+          total: 1,
+        })}
+      />
+    );
+
+    // The title and subline are the two `break-words` spans in the row's title
+    // column. `truncate` is `overflow:hidden; text-overflow:ellipsis;
+    // white-space:nowrap` - the tail of the title and the lead/room line were
+    // clipped out of reach at phone width, where there is no hover for the
+    // `title` tooltip. Wrapping keeps every word reachable and never changes
+    // the pill's geometry, so the contract here is the class, not the text.
+    const row = container.querySelector('li') as HTMLElement;
+    const [title, subline] = row.querySelectorAll('span[title]');
+
+    expect(title.className).toMatch(/break-words/);
+    expect(subline.className).toMatch(/break-words/);
+    expect(title.className).not.toMatch(/truncate/);
+    expect(subline.className).not.toMatch(/truncate/);
+  });
+
   // The series elements are pass-throughs of backend fields nothing populates yet,
   // so each one must be entirely absent until its data is genuinely present.
   describe('series signals', () => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.stories.tsx
@@ -368,12 +368,28 @@ export const Phone: Story = {
       'Photobiomodulation and underwater treadmill rehabilitation review · session 2 of 6'
     );
     const row = title.closest('li') as HTMLElement;
+    const subline = within(row).getByText('09:30 · 20 min · Dr. Ravi Menon · Rehab suite');
     const pill = within(row).getByText('Scheduled');
 
-    // The title column is `min-w-0 flex-1 truncate`: it has to clip rather than
-    // widen the row. Without `min-w-0` the flex item refuses to shrink below its
-    // content and pushes the pill out past the card edge - invisible at 1280px.
-    await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+    /* The title and subline WRAP instead of truncating (#2790). Reintroducing
+       `truncate` here clips the tail of the title and, on a phone, leaves it
+       unreachable - `scrollWidth > clientWidth` is the failure shape, so the
+       fitted assertions below are the guard.
+
+       The control keeps it honest: a title short enough to sit on one line
+       would make `scrollWidth <= clientWidth` pass for free whatever the
+       classes say. Measured with the wrap disabled as its nowrap width, the
+       long title must still overflow the column it ships in. Without `min-w-0`
+       on the flex column the title would also push the pill out past the card
+       edge - invisible at desktop widths - so the pill stays asserted inside. */
+    const columnWidth = title.clientWidth;
+    title.style.whiteSpace = 'nowrap';
+    const singleLineWidth = title.scrollWidth;
+    title.style.whiteSpace = '';
+    await expect(singleLineWidth).toBeGreaterThan(columnWidth);
+
+    await expect(title.scrollWidth).toBeLessThanOrEqual(title.clientWidth);
+    await expect(subline.scrollWidth).toBeLessThanOrEqual(subline.clientWidth);
     await expect(pill.getBoundingClientRect().right).toBeLessThanOrEqual(
       row.getBoundingClientRect().right
     );
@@ -382,9 +398,11 @@ export const Phone: Story = {
     docs: {
       description: {
         story:
-          'The row at phone width with a title long enough to need the clamp. The day marker, the ' +
-          'status pill and the overflow glyph are all `shrink-0`, so the title is the only part ' +
-          'that gives - and it has to.',
+          'The row at phone width with a title long enough to need more than one line. The day ' +
+          'marker, the status pill and the overflow glyph are all `shrink-0`, so the title is ' +
+          'the only part of the row that gives. Since #2790 it wraps rather than truncating: ' +
+          'the column stays the same width, the pill stays inside the card, and the tail of ' +
+          'the title is reachable on a surface that has no hover.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
@@ -97,10 +97,20 @@ const VisitRow = ({ visit, isNext = false }: { visit: OutpatientVisit; isNext?: 
         </span>
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-body-4 font-bold text-text-primary">
+        {/* Wrap, do not truncate: `truncate` clips with an ellipsis and leaves
+            the tail of the title unreachable on a phone, which has no hover for
+            a `title` tooltip (#2790). Free text now flows to the lines it needs;
+            the `title` keeps the hover affordance for the widths where the row
+            still clips. */}
+        <span
+          className="block break-words text-body-4 font-bold text-text-primary"
+          title={visitTitle(visit)}
+        >
           {visitTitle(visit)}
         </span>
-        <span className="block truncate text-caption-1 text-text-tertiary">{subline}</span>
+        <span className="block break-words text-caption-1 text-text-tertiary" title={subline}>
+          {subline}
+        </span>
       </span>
       <VisitStatusPill status={visit.status} />
       <IoEllipsisHorizontal size={15} aria-hidden="true" className="shrink-0 text-text-tertiary" />

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.stories.tsx
@@ -1029,3 +1029,49 @@ export const Phone: Story = {
     await expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
   },
 };
+
+export const OrderNotesOnPhone: Story = {
+  name: 'Phone (375) - order notes wrap',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  /* Same pinned-column pattern as `Phone`: the viewport global reads through the
+     manager, which headless `iframe.html` renders skip, so the 375px column has
+     to be pinned inside the story itself for the measurement to be the phone
+     measurement wherever it runs. */
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] bg-[var(--screen)] p-3">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed({
+    ...BASE,
+    orders: [
+      {
+        ...SUBMITTED_ORDER,
+        notes:
+          'Fasted sample, collected from the left jugular. Please combine with the pre-med ' +
+          'dose and hold the results for the afternoon consult.',
+      },
+    ],
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByTitle('Submitted');
+    const orders = sectionOf(canvas, 'Order Status');
+
+    /* Order notes are free-text clinical content that previously sat on a
+       `truncate` row reachable only by a `title` hover - which a phone does not
+       have (#2790). On the stacked mobile layout the note column is full width,
+       so it now WRAPS to the lines it needs rather than clipping. `scrollWidth
+       > clientWidth` is the failure shape of `truncate`; this assertion is the
+       guard.
+       The measured element is the note SPAN (binding the strong's parent) and
+       not the `Order notes:` label itself, which is short and could never clip;
+       a guard over the label would pass for free whether the note wraps or was
+       dropped. */
+    const label = orders.getByText('Order notes:');
+    const note = label.parentElement as HTMLElement;
+    await expect(note.scrollWidth).toBeLessThanOrEqual(note.clientWidth);
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -593,10 +593,13 @@ const OrderStatusSection = ({ s }: { s: UseLabTestsReturn }) => (
                     )}
                   </span>
                   {/* Order notes are saved at the order level (IDEXX has no per-test notes),
-                      shown here so they remain visible after refreshing or reopening (bug #1973). */}
+                      shown here so they remain visible after refreshing or reopening (bug #1973).
+                      They WRAP rather than truncate: the notes are free-text clinical content,
+                      and `truncate` left the tail reachable only by a `title` hover, which a
+                      phone does not have (#2790). */}
                   {order.notes && (
                     <span
-                      className="truncate text-caption-1 text-text-secondary"
+                      className="break-words text-caption-1 text-text-secondary"
                       title={order.notes}
                     >
                       <strong>Order notes:</strong> {order.notes}


### PR DESCRIPTION
Closes #2790.

## What
The last two clipping spots on the PIMS phone workspace, in the same shape as #2794 (chief complaint) and #2848 (patient name):

- **OutpatientSchedule rows** — the visit title and subline were `truncate` clamped (a long title lost ~476px of tail, the subline ~166px, no way to read them). Both now wrap (`break-words`), reusing the `min-w-0 flex-1` column, so the pill and card edges are unchanged.
- **DiagnosticsStep order notes** — free-text clinical notes sat on a `truncate` line reachable only by a `title` hover, which a phone has no way to trigger. The note span now wraps to the lines it needs.

## Regression guards (storybook interaction plays)
- `OutpatientSchedule > Phone (375)`: title **and** subline assert `scrollWidth <= clientWidth`; a control forces the title to nowrap and asserts it still overflows the shipping column (so a short fixture can't pass the guard for free); the pill-in-card assertion is retained.
- `DiagnosticsStep > Order notes on phone`: new story, long-note fixture, 375px-pinned column, asserts the note span doesn't clip.

## Verification
- Storybook interaction tests: `OutpatientSchedule` suite passes; `DiagnosticsStep` passes all tests except 4 pre-existing harness failures (`getStoryContext` store-init race in `.storybook/test-runner.ts` and shared-store subset ordering) unrelated to this change.
- Mutation-checked both guards: reverting each `break-words` back to `truncate` makes the corresponding play fail (`scrollWidth > clientWidth` observed).
- `tsc --noemit` exit 0; eslint clean on the 4 files; jest `OutpatientSchedule|DiagnosticsStep`: 73/73; prettier clean; husky pre-commit hooks pass.