### PR TITLE
fix(ci): stop cancelling frontend deploy runs

### DIFF
--- a/.github/workflows/cd-frontend.yaml
+++ b/.github/workflows/cd-frontend.yaml
@@ -10,7 +10,9 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A run only checks its own push range. Cancelling it can permanently skip
+  # frontend work that a later, unrelated push does not see.
+  cancel-in-progress: false
 
 env:
   NODE_VERSION: '20'
@@ -97,11 +99,9 @@ jobs:
     # `== 'true'` would have turned an infrastructure failure into a silent
     # skipped release.
     #
-    # Cancellation is the one case that must not deploy. This workflow sets
-    # cancel-in-progress, so a superseded push leaves detect-frontend cancelled
-    # with no output; under a bare always() the empty output reads as "not
-    # false" and would ship the older, superseded commit. !cancelled() excludes
-    # that while still deploying on a genuine detection failure.
+    # A cancelled detect job has no output; under a bare always() the empty
+    # output reads as "not false". !cancelled() excludes a manually cancelled
+    # run while still deploying on a genuine detection failure.
     if: ${{ !cancelled() && needs.detect-frontend.outputs.should-deploy != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -110,9 +110,9 @@ jobs:
         id: webhook
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "url=${{ secrets.AMPLIFY_WEBHOOK_URL }}" >> $GITHUB_OUTPUT
+            echo "url=${{ secrets.AMPLIFY_WEBHOOK_URL }}" >> "$GITHUB_OUTPUT"
           else
-            echo "url=${{ secrets.AMPLIFY_WEBHOOK_URL_DEV }}" >> $GITHUB_OUTPUT
+            echo "url=${{ secrets.AMPLIFY_WEBHOOK_URL_DEV }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Call Amplify webhook
         id: call-webhook

--- a/scripts/ci/cd-frontend.test.mjs
+++ b/scripts/ci/cd-frontend.test.mjs
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('frontend deploy runs serialize without cancelling earlier push ranges', () => {
+  const source = readFileSync('.github/workflows/cd-frontend.yaml', 'utf8');
+  const concurrency = /^concurrency:\n(?: {2}.*\n)+/m.exec(source)?.[0];
+
+  assert.ok(concurrency, 'top-level concurrency block is missing');
+  assert.match(concurrency, /^ {2}cancel-in-progress: false$/m);
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The frontend deployment workflow cancels an in-progress run when a newer push arrives on the same branch. Because each run calculates affected frontend work from only its own push range, a later backend-only push can cancel the one run that saw a frontend change and then skip deployment itself.

## What is the new behavior?

Frontend deployment runs now serialize instead of cancelling one another, so every push range is evaluated and frontend changes cannot be lost between runs. A workflow regression test locks the concurrency policy, and the touched shell redirects are quoted so `actionlint` remains clean.

Validation:

- `node --test scripts/ci/cd-frontend.test.mjs` (1 passed)
- `pnpm run test:scripts` (480 passed)
- `actionlint .github/workflows/cd-frontend.yaml`
- repository pre-push lint and type-check hooks
- Aikido scan of both changed files (0 issues)

The regression test was mutation-checked by restoring `cancel-in-progress: true` and observing the intended assertion fail.

## Related Issue(s)

Fixes #2499
