### PR TITLE
fix(frontend): make secondary screens usable on phones

### DIFF
--- a/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/federation/NetworkDirectory.test.tsx
@@ -25,12 +25,14 @@ jest.mock('@/app/ui/primitives/Buttons', () => ({
     text,
     onClick,
     isDisabled,
+    size,
   }: {
     text: string;
     onClick: () => void;
     isDisabled?: boolean;
+    size?: string;
   }) => (
-    <button type="button" onClick={onClick} disabled={isDisabled ?? false}>
+    <button type="button" onClick={onClick} disabled={isDisabled ?? false} data-size={size}>
       {text}
     </button>
   ),
@@ -96,6 +98,25 @@ describe('NetworkDirectory', () => {
     expect(screen.getByText('a.example')).toBeInTheDocument();
     expect(screen.getByText('Beta Animal Hospital')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Follow' })).toHaveLength(2);
+  });
+
+  it('keeps long identifiers readable and gives Follow a phone-sized target', async () => {
+    const longClinic: APDirectoryClinic = {
+      ...clinicA,
+      orgName: 'Veterinary Referral and Emergency Centre of the Northern Highlands',
+      handle: '@northern-highlands-referral-reception@veterinary-referral.example',
+      instanceHost: 'veterinary-referral-and-emergency-centre.example',
+    };
+    (listDirectory as jest.Mock).mockResolvedValue({ clinics: [longClinic], unavailable: false });
+
+    render(<NetworkDirectory />);
+
+    const name = await screen.findByText(longClinic.orgName);
+    expect(name).toHaveClass('break-words');
+    expect(name).not.toHaveClass('truncate');
+    expect(screen.getByText(longClinic.handle)).toHaveClass('[overflow-wrap:anywhere]');
+    expect(screen.getByText(longClinic.instanceHost)).toHaveClass('[overflow-wrap:anywhere]');
+    expect(screen.getByRole('button', { name: 'Follow' })).toHaveAttribute('data-size', 'large');
   });
 
   it('notifies error when the directory fails to load', async () => {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
@@ -410,6 +410,14 @@
 }
 
 @media (max-width: 767px) {
+  .DocsBackLink,
+  .DocsOpenLink,
+  .DocsNavItem,
+  .DocsCopyBtn,
+  .DocsCodeCopy {
+    min-height: 44px;
+  }
+
   .DocsShell {
     flex-direction: column;
     height: auto;
@@ -438,6 +446,23 @@
     width: auto;
     flex: none;
     white-space: nowrap;
+  }
+
+  .DocsEndpoint {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .DocsEndpointPath {
+    flex: 1 1 180px;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .DocsEndpointScope {
+    flex-basis: 100%;
+    margin-left: 0;
+    overflow-wrap: anywhere;
   }
 
   .DocsMainHead {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
@@ -112,6 +112,44 @@ export const Appointments: Story = {
   },
 };
 
+export const Phone: Story = {
+  name: 'Phone: appointment reference',
+  tags: ['issue-2780'],
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const endpoint = canvas.getByText('/fhir/v1/appointment/pms');
+    const permission = canvas.getByText('appointments:edit:any', {
+      selector: '.DocsEndpointScope',
+    });
+    const controls = [
+      canvas.getByRole('link', { name: /Back to portal/i }),
+      canvas.getByRole('link', { name: /Open full docs/i }),
+      canvas.getByRole('button', { name: 'Appointments' }),
+      canvas.getByRole('button', { name: /Copy page/i }),
+      ...canvas.getAllByRole('button', { name: 'Copy' }),
+    ];
+
+    for (const control of controls) {
+      await expect(control.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    }
+    await expect(endpoint.scrollWidth).toBeLessThanOrEqual(endpoint.clientWidth);
+    await expect(permission.scrollWidth).toBeLessThanOrEqual(permission.clientWidth);
+    await expect(globalThis.document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      globalThis.window.innerWidth
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The populated appointment reference at phone width. The endpoint metadata wraps inside ' +
+          'the article while navigation and copy controls retain 44px touch targets.',
+      },
+    },
+  },
+};
+
 export const NavEmpty: Story = {
   name: 'No matches (nav emptied)',
   play: async ({ canvasElement }) => {

--- a/apps/frontend/src/app/features/federation/components/NetworkDirectory.stories.tsx
+++ b/apps/frontend/src/app/features/federation/components/NetworkDirectory.stories.tsx
@@ -35,10 +35,7 @@ const CLINICS: APDirectoryClinic[] = [
   },
 ];
 
-/**
- * Every line on a clinic card is `truncate`, and the handle is one unbroken token.
- * Drop the class and this fixture widens its grid track instead of ellipsing.
- */
+/** The handle and host are unbroken tokens that must wrap without widening the card. */
 const LONG_HOST = 'veterinary-referral-and-emergency-centre-of-the-northern-highlands.example';
 const LONG_CLINICS: APDirectoryClinic[] = [
   {
@@ -147,7 +144,7 @@ const meta = {
           'listed yet" and the feature looked like it was simply doing nothing. They are one ' +
           '`unavailable` flag apart and identical in shape, which is exactly the sort of split that ' +
           'silently collapses back into one.\n\n' +
-          'A card carries three lines - organisation, handle, instance host - each `truncate`, and ' +
+          'A card carries three readable lines - organisation, handle, instance host - and ' +
           "one Follow pill. Pressing it stores that clinic's **actor URI** in `followingUri`, so " +
           'only the pressed card relabels to `Following...` and disables; the rest stay live. Both ' +
           'outcomes are toasts rather than inline state, and the failure path resets `followingUri` ' +
@@ -403,6 +400,7 @@ export const FollowFailed: Story = {
 
 export const Phone: Story = {
   name: 'Phone: long clinic names',
+  tags: ['issue-2780'],
   globals: { viewport: { value: 'mobile', isRotated: false } },
   beforeEach: stubDirectoryApi(async () => ({ clinics: LONG_CLINICS })),
   play: async ({ canvasElement }) => {
@@ -411,25 +409,33 @@ export const Phone: Story = {
     const card = cardFor(canvasElement, LONG_CLINICS[0].orgName);
     const grid = card.parentElement as HTMLElement;
 
-    /* A handle is one unbroken token with no wrap opportunity. Measured rather
-       than asserted on the class name: `truncate` going missing does not throw,
-       it just pushes the grid track wider than the panel and the whole page
-       starts scrolling sideways. */
+    const identifiers = LONG_CLINICS.slice(0, 1).flatMap((clinic) => [
+      canvas.getByText(clinic.orgName),
+      canvas.getByText(clinic.handle),
+      canvas.getByText(clinic.instanceHost),
+    ]);
+
+    /* These values must remain fully readable rather than being replaced by an
+       ellipsis. The overflow measurement separately guards long unbroken tokens. */
+    for (const identifier of identifiers) {
+      await expect(globalThis.getComputedStyle(identifier).textOverflow).not.toBe('ellipsis');
+    }
     await expect(card.scrollWidth).toBeLessThanOrEqual(card.clientWidth);
     await expect(grid.scrollWidth).toBeLessThanOrEqual(grid.clientWidth);
     await expect(globalThis.document.documentElement.scrollWidth).toBeLessThanOrEqual(
       globalThis.window.innerWidth
     );
-    // The pill keeps its full label rather than being squeezed by the long lines.
-    await expect(within(card).getByRole('button')).toHaveTextContent('Follow');
+    const follow = within(card).getByRole('button');
+    await expect(follow).toHaveTextContent('Follow');
+    await expect(follow.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
   },
   parameters: {
     docs: {
       description: {
         story:
           'A referral centre with a name and a handle far longer than the column. On a phone the ' +
-          'grid is a single column, so this is where the three truncating lines have the least room ' +
-          'and where a missing `truncate` shows first.',
+          'grid is a single column, so this checks that every identifier wraps in full, the card ' +
+          'does not widen the page, and the Follow action keeps a 44px touch target.',
       },
     },
   },

--- a/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
+++ b/apps/frontend/src/app/features/federation/components/NetworkDirectory.tsx
@@ -88,14 +88,18 @@ const ClinicCard = ({
 }) => (
   <div className="flex flex-col gap-3 rounded-[20px] border border-[var(--hairline)] bg-[var(--screen)] p-4 shadow-[0_1px_2px_var(--sh03)]">
     <div className="flex min-w-0 flex-col gap-0.5">
-      <div className="truncate text-[14px] font-bold text-[var(--ink)]">{clinic.orgName}</div>
-      <div className="truncate text-[12.5px] text-[var(--ink-muted)]">{clinic.handle}</div>
-      <div className="truncate text-[12px] text-[var(--ink-faint)]">{clinic.instanceHost}</div>
+      <div className="break-words text-[14px] font-bold text-[var(--ink)]">{clinic.orgName}</div>
+      <div className="[overflow-wrap:anywhere] text-[12.5px] text-[var(--ink-muted)]">
+        {clinic.handle}
+      </div>
+      <div className="[overflow-wrap:anywhere] text-[12px] text-[var(--ink-faint)]">
+        {clinic.instanceHost}
+      </div>
     </div>
     <div className="flex justify-end">
       <Primary
         href="#"
-        size="small"
+        size="large"
         text={following ? 'Following...' : 'Follow'}
         onClick={() => onFollow(clinic)}
         isDisabled={following}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

At phone width, long Network clinic identifiers are truncated without a touch-accessible way to read them. The Developer Docs appointment endpoint metadata can overflow its card, and phone-visible navigation and copy controls render below the 44px touch-target baseline.

## What is the new behavior?

Network clinic names, federation handles, and hosts wrap within their cards, and the Follow action uses the existing 44px large button size. Developer Docs wraps endpoint paths and permissions below 768px and gives phone-visible links, navigation, and copy controls a 44px minimum height.

The phone Storybook stories now measure identifier overflow, page overflow, and rendered control heights for both surfaces.

Validation:

- `npx tsc --noemit` from `apps/frontend`: exit 0.
- `pnpm --filter frontend run lint`: exit 0 with one pre-existing warning in `useLazyAuthStore.ts`.
- `pnpm --filter frontend run test -- --testPathPatterns="NetworkDirectory|DeveloperDocs"`: 3 suites and 38 tests passed.
- Scoped Chromium Storybook run reported PASS for both changed story files. The runner remained open after reporting both results and was interrupted.
- Pre-push monorepo lint: 10/10 tasks successful.
- Pre-push monorepo type-check: 17/17 tasks successful.

## Related Issue(s)

Fixes #2780
