### PR TITLE
fix(frontend): align developer docs with API key routes

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -73,9 +73,8 @@ describe('DeveloperDocs reader', () => {
   /*
    * These pages documented an API that did not exist: POST /v2/appointments
    * behind `Authorization: Bearer $YC_KEY`, badged "v2 - STABLE", plus a
-   * Webhooks page. The mounted prefixes are /fhir, /v1, /public and /ap, no
-   * route accepts an API key, and there is no WebhookSubscription model - so a
-   * developer following the sample got a 404 from a documented stable endpoint.
+   * Webhooks page. The API-key data plane now lives under /v1/developer, but the
+   * old /v2 sample still never existed and there is no WebhookSubscription model.
    */
   it('does not document surfaces the API does not serve', () => {
     const { container } = render(<DeveloperDocs />);
@@ -84,6 +83,31 @@ describe('DeveloperDocs reader', () => {
     expect(text).not.toContain('/v2/');
     expect(text).not.toContain('Bearer $YC_KEY');
     expect(screen.queryByRole('button', { name: 'Webhooks' })).not.toBeInTheDocument();
+  });
+
+  it('documents the mounted read-only API-key surface and its auth boundaries', () => {
+    const { container } = render(<DeveloperDocs />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    expect(container.textContent).toContain('API-key-authenticated data plane is read-only');
+    for (const path of [
+      '/v1/developer/organizations',
+      '/v1/developer/usage',
+      '/v1/developer/appointments',
+      '/v1/developer/appointments/:appointmentId',
+    ]) {
+      expect(container.textContent).toContain(path);
+    }
+    expect(container.textContent).toContain(
+      'FHIR examples elsewhere in this reader use signed-in sessions'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Authentication' }));
+    expect(container.textContent).toContain('Authorization: Bearer');
+    expect(container.textContent).toContain('appointments:read');
+    expect(container.textContent).toContain('x-org-id');
+    expect(container.textContent).toContain('live active membership');
+    expect(container.textContent).toContain('rather than one permanent practice');
   });
 
   /* The pill and the copyable sample are separate strings, so they can drift.

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
@@ -46,20 +46,19 @@ const meta = {
         component:
           'The in-portal API reference. Two of its states had never been drawn, and both are ' +
           'reachable in one click from the resting page.\n\n' +
-          '`DocsNavEmpty` replaces the **entire** section list - both headings and all seven ' +
+          '`DocsNavEmpty` replaces the **entire** section list - both headings and all five ' +
           'items - the moment the search text matches nothing. It is not a row appended below ' +
           'the nav: `filteredNav` drops any section whose items filter to zero, and an empty ' +
           'array swaps the whole map for a single "No matches" line. The Edit-on-GitHub link ' +
           'survives it, which is the only thing left in the rail.\n\n' +
           "The article body is a two-way branch on `activeId === 'appointments'` and nothing " +
           'else. Appointments gets the endpoint strip, the required-fields paragraph, the FHIR ' +
-          'note and the two code panels; every other one of the seven articles gets a title, a ' +
-          'summary and a "this is seed content" note, with the whole `DocsCode` block ' +
-          'unmounted. Six of the seven articles are therefore that second layout, and it had ' +
+          'note and the two code panels; every other article gets a title, one or two content ' +
+          'paragraphs and a "this is seed content" note, with the whole `DocsCode` block ' +
+          'unmounted. Four of the five articles are therefore that second layout, and it had ' +
           'never been rendered.\n\n' +
-          'The search filters `label` only, so a query that reads like a topic ("auth", ' +
-          '"webhook") works and one that reads like prose ("how do I create a booking") empties ' +
-          'the rail.',
+          'Search covers each article label, category, title, summary, detail and indexed terms, ' +
+          'so route paths and permission names remain discoverable.',
       },
     },
   },
@@ -82,7 +81,7 @@ export const Appointments: Story = {
 
     await expect(canvas.getByRole('heading', { name: 'Appointments' })).toBeInTheDocument();
 
-    // Seven nav items across two sections, all present before any filtering, and
+    // Five nav items across two sections, all present before any filtering, and
     // the highlight sits on the one the article is showing.
     await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(5);
     await expect(canvas.getByText('Getting started')).toBeInTheDocument();
@@ -127,7 +126,7 @@ export const NavEmpty: Story = {
     await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(0);
 
     /* The whole rail is gone, not just the items: both section headings and all
-       seven buttons unmount. Asserting the headings separately matters because a
+       five buttons unmount. Asserting the headings separately matters because a
        filter bug that emptied only the items would leave two orphan headings
        above the "No matches" line and still satisfy a check for the line alone. */
     await expect(canvas.queryByText('Getting started')).not.toBeInTheDocument();
@@ -183,22 +182,39 @@ export const NavFiltered: Story = {
     docs: {
       description: {
         story:
-          'The in-between state. Matching is a case-insensitive `includes` on the label only, ' +
-          'so "api" keeps two items whose titles contain it and drops "Authentication", which ' +
-          'is unambiguously an API topic.',
+          'The in-between state. Matching is a case-insensitive `includes` across article ' +
+          'content, so domain terms can filter the rail even when they are absent from labels.',
       },
     },
   },
 };
 
-export const SeedContentArticle: Story = {
-  name: 'Non-appointments article (seed content)',
+export const DeveloperDataPlane: Story = {
+  name: 'Developer API data plane',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: 'Companions' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Overview' }));
 
-    const heading = await canvas.findByRole('heading', { name: 'Companions' });
+    const heading = await canvas.findByRole('heading', { name: 'Overview' });
     await expect(heading).toBeInTheDocument();
+    for (const path of [
+      '/v1/developer/organizations',
+      '/v1/developer/usage',
+      '/v1/developer/appointments',
+      '/v1/developer/appointments/:appointmentId',
+    ]) {
+      await expect(canvasElement.textContent).toContain(path);
+    }
+    await expect(canvasElement.textContent).toContain('data plane is read-only');
+    await expect(canvasElement.textContent).toContain(
+      'FHIR examples elsewhere in this reader use signed-in sessions'
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Authentication' }));
+    await expect(canvasElement.textContent).toContain('Authorization: Bearer');
+    await expect(canvasElement.textContent).toContain('appointments:read');
+    await expect(canvasElement.textContent).toContain('x-org-id');
+    await expect(canvasElement.textContent).toContain('live active membership');
     await expect(
       canvas.getByText(
         'This reference is seed content. Open the full documentation for the complete API reference.'
@@ -218,16 +234,16 @@ export const SeedContentArticle: Story = {
        labels, so a text query would match the rail and pass with the crumb stale. */
     const crumb = canvasElement.querySelector('.DocsBreadcrumb');
     if (!crumb) throw new Error('The breadcrumb did not render.');
-    await expect(crumb.textContent).toBe('Docs / APIs / Companions');
+    await expect(crumb.textContent).toBe('Docs / Getting started / Authentication');
     await expect(canvas.getByText('v1')).toBeInTheDocument();
   },
   parameters: {
     docs: {
       description: {
         story:
-          'The article column collapses to roughly a third of its height here because ' +
-          '`DocsCode` is gone, so the page bottom moves a long way up between two adjacent nav ' +
-          'items. Worth reviewing next to the appointments story rather than on its own.',
+          'The exact API-key data plane shown to developers: four read-only routes, bearer ' +
+          'authentication, per-request practice selection, and a clear boundary from the ' +
+          'session-authenticated FHIR surface.',
       },
     },
   },

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -51,6 +51,7 @@ type Article = {
   version: string;
   title: string;
   summary: string;
+  detail?: string;
   /*
    * Identifiers that appear in the article's RENDERED detail but not in its
    * summary - the endpoint path, the permission, the stored status.
@@ -70,7 +71,9 @@ const ARTICLES: Record<string, Article> = {
     version: 'v1',
     title: 'Overview',
     summary:
-      'The Yosemite Crew API is a FHIR R4 surface served under /fhir/v1, alongside a set of application endpoints under /v1. Requests are authorised with the session your account already holds. A generated reference is in the full documentation. Treat it as partial rather than complete: it declares four appointment paths where the router serves twenty-one, and it does not list the x-org-id header that organisation-scoped routes require, so a request built straight from it is rejected before reaching a controller.',
+      'Yosemite Crew exposes two separate API surfaces. The API-key-authenticated data plane is read-only and mounted at /v1/developer; the FHIR examples elsewhere in this reader use signed-in sessions and do not accept developer API keys.',
+    detail:
+      'The data plane currently serves GET /v1/developer/organizations, GET /v1/developer/usage, GET /v1/developer/appointments, and GET /v1/developer/appointments/:appointmentId. The generated reference in the full documentation includes these routes, but the backend routers remain the source of truth.',
   },
   authentication: {
     category: 'Getting started',
@@ -78,7 +81,9 @@ const ARTICLES: Record<string, Article> = {
     version: 'v1',
     title: 'Authentication',
     summary:
-      'Requests are authorised with the signed-in session, and organisation-scoped routes read the practice from an x-org-id header. An API key created in this portal is also accepted, on its own dedicated surface: every route under /v1/developer requires a valid key, and the appointment routes additionally require the appointments:read scope. A key created before that scope check shipped carries no scopes and is refused by those routes - create a fresh one. A developer-only account still has no practice membership and no role in the permission model, so the session-authenticated, organisation-scoped routes described elsewhere in this reference answer 400 or 403 for it; /v1/developer is the surface a developer account can actually call.',
+      'Send a key created in this portal as an Authorization: Bearer token to /v1/developer. The session-authenticated management routes under /v1/developers and the FHIR surface do not accept developer API keys.',
+    detail:
+      'GET /organizations discovers every practice where the key owner has a live active membership and needs no x-org-id. GET /usage is developer-owned and also needs no practice header. GET /appointments requires appointments:read, x-org-id, a live active membership, and appointment-read permission. GET /appointments/:appointmentId derives the practice from the record but rechecks the same live membership and permission. Keys belong to their owner rather than one permanent practice; keys created before appointments:read shipped carry no scopes and must be replaced to call appointment routes.',
   },
   appointments: {
     category: 'APIs',
@@ -210,6 +215,7 @@ const DeveloperDocs = () => {
         article?.category,
         article?.title,
         article?.summary,
+        article?.detail,
         ...(article?.searchTerms ?? []),
       ].some((field) => field?.toLowerCase().includes(q));
     };
@@ -225,7 +231,7 @@ const DeveloperDocs = () => {
     });
   };
 
-  const pageText = `${active.title}\n\n${active.summary}`;
+  const pageText = [active.title, active.summary, active.detail].filter(Boolean).join('\n\n');
 
   return (
     <DevRouteGuard>
@@ -316,6 +322,7 @@ const DeveloperDocs = () => {
               <article className="DocsArticle">
                 <h3 className="DocsArticleTitle">{active.title}</h3>
                 <p className="DocsArticleText">{active.summary}</p>
+                {active.detail && <p className="DocsArticleText">{active.detail}</p>}
 
                 {isAppointments ? (
                   <>


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The developer portal still tells readers that developer API keys unlock no route, even though the read-only data plane is mounted at `/v1/developer`.

## What is the new behavior?

Overview now enumerates the four mounted read-only routes. Authentication explains bearer keys, route scopes, per-request practice selection, live membership checks, and the boundary from session-authenticated management and FHIR routes.

The page-copy action and documentation search include the new detail paragraphs. Targeted RTL and Storybook assertions protect the route and authorization contract.

Validation:

- Frontend type-check: exit 0.
- Frontend lint: exit 0 with one unchanged warning outside this diff.
- Targeted Jest: 19 tests passed; component coverage 100% statements, 97.5% branches, 100% functions, and 100% lines.
- Mutation: changing `/v1/developer/usage` to `/v1/developer/users` made the RTL test fail and the scoped Storybook play report FAIL.
- Storybook production build: exit 0.
- Scoped Storybook play: reported PASS; the test runner remained open after reporting and was interrupted.
- Local Storybook visual check: Overview and Authentication at desktop and 390px in light and dark, with no console errors or page-width overflow.
- Aikido: 3 changed files scanned, 0 issues.
- Pre-push monorepo lint: 10/10 tasks successful.
- Pre-push monorepo type-check: 17/17 tasks successful.

## Related Issue(s)

Fixes #2700
