### PR TITLE
fix(backend): count staff on duty by every stored organisationReference spelling

### DIFF
--- a/apps/backend/src/services/dashboard.service.ts
+++ b/apps/backend/src/services/dashboard.service.ts
@@ -4,6 +4,7 @@ import dayjs from "dayjs";
 import { Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { AvailabilityService } from "src/services/availability.service";
+import { organisationReferenceMatches } from "src/services/shared/organisation-membership";
 
 export class DashboardServiceError extends Error {
   constructor(
@@ -251,7 +252,7 @@ const mapRevenueTrendRows = (
 
 const getStaffOnDutyCount = async (organisationId: string) => {
   const mappings = await prisma.userOrganization.findMany({
-    where: { organizationReference: organisationId, active: true },
+    where: { active: true, OR: organisationReferenceMatches(organisationId) },
     select: { practitionerReference: true },
   });
 

--- a/apps/backend/test/services/dashboard.service.test.ts
+++ b/apps/backend/test/services/dashboard.service.test.ts
@@ -127,6 +127,37 @@ describe("DashboardService", () => {
       expect(result.staffOnDuty).toBe(1);
     });
 
+    it("queries both stored spellings of organisationReference, not just the bare id", async () => {
+      (
+        AvailabilityService.getCurrentStatusBulk as jest.Mock
+      ).mockResolvedValueOnce(new Map([["staff-1", "Consulting"]]));
+      (prisma.userOrganization.findMany as jest.Mock).mockResolvedValueOnce([
+        { practitionerReference: "staff-1" },
+      ]);
+      (prisma.appointment.count as jest.Mock).mockResolvedValueOnce(0);
+      (prisma.task.count as jest.Mock).mockResolvedValueOnce(0);
+      (prisma.invoice.aggregate as jest.Mock).mockResolvedValueOnce({
+        _sum: { totalAmount: null },
+      });
+
+      const result = await DashboardService.getSummary({
+        organisationId: mockOrgId,
+        range: "today",
+      });
+
+      expect(result.staffOnDuty).toBe(1);
+
+      const where = (prisma.userOrganization.findMany as jest.Mock).mock
+        .calls[0][0].where;
+      expect(where.active).toBe(true);
+      const refs = (where.OR as Array<{ organizationReference: string }>)
+        .map((match) => match.organizationReference)
+        .sort();
+      // A membership stored as `Organization/<id>` from the FHIR path would
+      // otherwise render as zero staff on duty.
+      expect(refs).toEqual(["Organization/org-123", "org-123"]);
+    });
+
     // Test different ranges to cover switch case in resolveRange
     const ranges: SummaryRange[] = [
       "today",


### PR DESCRIPTION
## Summary

Issue #2770: `userOrganization.organizationReference` is persisted verbatim from the inbound FHIR `PractitionerRole`, so a membership can be stored bare or as `Organization/<id>` (also `<fhirId>` / `Organization/<fhirId>`). The super-admin counts were fixed by #2771 to resolve through the shared both-forms predicate (`organisationReferenceMatches`), but the dashboard's `getStaffOnDutyCount` was the one remaining site in the issue's list that still matched the bare id only.

`apps/backend/src/services/dashboard.service.ts:254` used:

```ts
where: { organizationReference: organisationId, active: true }
```

A clinic whose memberships arrived with a conformant reference would render `staffOnDuty: 0`. This change routes the count through the same shared predicate the super-admin counts, the members list, and `filterUserIdsInOrganisation` use, so the dashboard tile and RBAC cannot disagree about who belongs.

## Change

- `dashboard.service.ts`: `getStaffOnDutyCount` now uses `organisationReferenceMatches(organisationId)` wrapped in the active-membership filter, instead of a bare-id equality.
- Test: asserts the query is issued with both stored spellings (`org-123` and `Organization/org-123`).

## Testing

```
pnpm --filter backend run type-check                rc 0, 0 errors
pnpm --filter backend run lint                      0 errors (24 pre-existing warnings elsewhere)
pnpm exec jest test/services/dashboard.service.test.ts --coverage   35 passed, 99.71% stmts / 73.28% branch
```

No local Aikido token on this machine (keychain `aikido-mcp` absent); change has no I/O or injection surface, and the hosted gate will run in CI.

Refs #2770