### PR TITLE
fix(frontend): match Packages tab add-CTA to Services tab and theme the severity dropdown

### DIFF
--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ProblemList from '@/app/features/companionHistory/components/ProblemList';
@@ -96,7 +96,8 @@ describe('ProblemList', () => {
     expect(nameInput).toBeInTheDocument();
 
     await userEvent.type(nameInput, 'New skin lesion');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'MODERATE');
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Moderate'));
     fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });
 
     await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ProblemListPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ProblemListPanel from '@/app/features/companionHistory/components/ProblemListPanel';
@@ -91,7 +91,8 @@ describe('ProblemListPanel', () => {
     await userEvent.click(screen.getByRole('button', { name: /Add problem/ }));
     await userEvent.type(screen.getByLabelText('Problem title'), 'New skin lesion');
     await userEvent.type(screen.getByLabelText('Description'), 'left flank');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'MODERATE');
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Moderate'));
     fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });
     await userEvent.click(screen.getByRole('button', { name: 'Save problem' }));
 

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
@@ -252,9 +252,9 @@ describe('PackagesTab', () => {
     expect(screen.getByText('Premium Package')).toBeInTheDocument();
   });
 
-  it('renders "Click to add package" button when draft is not open', () => {
+  it('renders "Add package" button when draft is not open', () => {
     render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
-    expect(screen.getByText('Click to add package')).toBeInTheDocument();
+    expect(screen.getByText('Add package')).toBeInTheDocument();
   });
 
   it('shows empty state message when no packages exist', () => {
@@ -321,20 +321,20 @@ describe('PackagesTab', () => {
 
   // --- Section 2: Add flow ---
 
-  it('opens add draft at bottom when "Click to add package" is clicked', () => {
+  it('opens add draft at bottom when "Add package" is clicked', () => {
     render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
-    fireEvent.click(screen.getByText('Click to add package'));
+    fireEvent.click(screen.getByText('Add package'));
     expect(screen.getByTestId('add-draft')).toBeInTheDocument();
     // Add button should be hidden while draft is open
-    expect(screen.queryByText('Click to add package')).not.toBeInTheDocument();
+    expect(screen.queryByText('Add package')).not.toBeInTheDocument();
   });
 
   it('closes the add draft when Close Draft is clicked', () => {
     render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
-    fireEvent.click(screen.getByText('Click to add package'));
+    fireEvent.click(screen.getByText('Add package'));
     fireEvent.click(screen.getByText('Close Draft'));
     expect(screen.queryByTestId('add-draft')).not.toBeInTheDocument();
-    expect(screen.getByText('Click to add package')).toBeInTheDocument();
+    expect(screen.getByText('Add package')).toBeInTheDocument();
   });
 
   // --- Section 3: Edit flow ---
@@ -438,7 +438,7 @@ describe('PackagesTab', () => {
       ref.current?.openAdd();
     });
     expect(screen.getByTestId('add-draft')).toBeInTheDocument();
-    expect(screen.queryByText('Click to add package')).not.toBeInTheDocument();
+    expect(screen.queryByText('Add package')).not.toBeInTheDocument();
   });
 
   it('does not hydrate when editing a package that already has a breakdown', () => {

--- a/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ProblemList.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import type {
   PatientProblem,
   ProblemSeverity,
@@ -73,6 +74,11 @@ const SEVERITY_TONE: Record<ProblemSeverity, StatusTone> = {
 };
 
 const SEVERITY_OPTIONS: ProblemSeverity[] = ['MILD', 'MODERATE', 'SEVERE'];
+
+const SEVERITY_DROPDOWN_OPTIONS = [
+  { label: 'No severity', value: '' },
+  ...SEVERITY_OPTIONS.map((s) => ({ label: SEVERITY_LABEL[s], value: s })),
+];
 
 const ProblemRow = ({
   problem,
@@ -181,23 +187,12 @@ const CreateProblemForm = ({
         />
       </label>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <label className="flex flex-col gap-1">
-          <span className={fieldLabelClass}>Severity</span>
-          <select
-            className={controlClass}
-            value={values.severity}
-            onChange={(e) =>
-              setValues((v) => ({ ...v, severity: e.target.value as ProblemSeverity | '' }))
-            }
-          >
-            <option value="">No severity</option>
-            {SEVERITY_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {SEVERITY_LABEL[s]}
-              </option>
-            ))}
-          </select>
-        </label>
+        <Dropdown
+          placeholder="Severity"
+          value={values.severity}
+          onChange={(v) => setValues((prev) => ({ ...prev, severity: v as ProblemSeverity | '' }))}
+          options={SEVERITY_DROPDOWN_OPTIONS}
+        />
         <label className="flex flex-col gap-1">
           <span className={fieldLabelClass}>Onset date</span>
           <input

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.tsx
@@ -388,18 +388,20 @@ function PackagesTab({ specialityId, organisationId, ref }: PackagesTabProps) {
       )}
 
       {!draftOpen && (
-        <button
-          type="button"
-          onClick={() => {
-            setActivePackage(null);
-            setDraftAtTop(false);
-            setDraftOpen(true);
-          }}
-          className="w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl border border-dashed border-input-border-active text-body-4 text-text-brand hover:bg-primary-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
-        >
-          <IoAddOutline size={16} aria-hidden="true" />
-          Click to add package
-        </button>
+        <div className="border-t border-[var(--hairline)] px-5! py-[11px]! @3xl:px-[22px]!">
+          <button
+            type="button"
+            onClick={() => {
+              setActivePackage(null);
+              setDraftAtTop(false);
+              setDraftOpen(true);
+            }}
+            className="inline-flex items-center gap-1.5 text-[12.5px] font-semibold text-[var(--blue-text)] hover:text-[var(--nav-active)] transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blue)] rounded"
+          >
+            <IoAddOutline size={14} aria-hidden="true" />
+            Add package
+          </button>
+        </div>
       )}
 
       {actionMode === 'archive' && activePackage && (


### PR DESCRIPTION
## Summary
- Packages tab used a large dashed "Click to add package" button that diverged from the small footer add-link style already established by the Services tab in the same Specialities section.
- The Problem List's Severity field used a native `<select>`, which never picks up the design system's themed dropdown styling (portalled panel, styled trigger) that every other select-like control in the app uses.

## Why
Both were flagged in a live UI sweep against the deployed dev environment as visible style regressions relative to their sibling components.

## Impact area
`apps/frontend` only - Organization > Specialities > Packages tab, and the companion history Problem List panel.

## Validation performed
- Targeted Jest: `PackagesTab.test.tsx`, `ProblemList.test.tsx`, `ProblemListPanel.test.tsx` - 38/38 passing.
- `npx tsc --noemit` clean.
- Verified both fixes live against the deployed dev environment (screenshot comparison before/after) as well as in Storybook.