### PR TITLE
ci(repo): gate new frontend components on having a Storybook story

### DIFF
--- a/.github/workflows/story-coverage.yml
+++ b/.github/workflows/story-coverage.yml
@@ -1,0 +1,54 @@
+name: Story Coverage
+
+# Fails when a pull request adds a new React component under apps/frontend
+# without a sibling Storybook story. Nothing else in CI checks this: Chromatic
+# only visually diffs stories that already exist, and the Storybook
+# interactions job only runs `play` functions on existing stories - neither
+# has any way to notice a component nobody ever gave a story in the first
+# place, which is how real UI bugs (an inconsistent button style, a native
+# <select> nobody themed) sat unreviewed. See scripts/ci/story-coverage.mjs
+# for the detection heuristic and its escape hatch (`// no-story: <reason>`).
+#
+# Scoped to files a PR ADDS, not the whole app: the pre-existing backlog of
+# storyless components is real and this gate does not attempt to clear it,
+# only stop it from growing - the same shape as scripts/ci/diff-coverage.mjs.
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'apps/frontend/src/app/**'
+      - 'scripts/ci/story-coverage.mjs'
+      - '.github/workflows/story-coverage.yml'
+
+concurrency:
+  group: story-coverage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: New components have a Storybook story
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The gate diffs against the PR's merge base, which needs full
+          # history - a shallow checkout would report every added file as
+          # having no base to compare against.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+
+      - name: Check new components for a story
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/ci/story-coverage.mjs --base "$BASE_SHA" --head "$HEAD_SHA"

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -942,6 +942,10 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
   );
 };
 
+// no-story: both ProtectedMerckManuals (below) and EmbeddedMerckManuals are
+// ProtectedRoute/OrgGuard/Suspense compositions with no UI of their own, only
+// a loading skeleton; the real screen is MerckManualsPage, whose visible
+// pieces are covered by MerckReaderPortal.stories.tsx.
 const ProtectedMerckManuals = () => (
   <ProtectedRoute skeleton={MERCK_PAGE_SKELETON}>
     <OrgGuard skeleton={MERCK_PAGE_SKELETON}>

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/DispensaryFilterBar.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/DispensaryFilterBar.stories.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { DispensaryFilterBar } from './index';
+import type { DispensaryStatus } from './types';
+
+/**
+ * `dispensarySearch` and `dispensaryStatusFilter` are owned by the Inventory page as plain
+ * `useState`, so the bar is a pure controlled row - the harness reproduces that ownership
+ * rather than passing static props, which is what lets a `play` click a chip or type into
+ * the search box and see the bar reflect it back.
+ */
+const Harness = () => {
+  const [dispensarySearch, setDispensarySearch] = useState('');
+  const [dispensaryStatusFilter, setDispensaryStatusFilter] = useState<DispensaryStatus | 'ALL'>(
+    'ALL'
+  );
+
+  return (
+    <div className="min-h-[160px] bg-[var(--screen)] p-6">
+      <DispensaryFilterBar
+        dispensarySearch={dispensarySearch}
+        dispensaryStatusFilter={dispensaryStatusFilter}
+        setDispensaryStatusFilter={setDispensaryStatusFilter}
+        setDispensarySearch={setDispensarySearch}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Inventory/DispensaryFilterBar',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The status chip row (All / Pending / Dispensed / Not dispensed) and search input above ' +
+          "the Dispensary tab's record list. Simpler than its sibling `InventoryFilterBar` - no " +
+          'portal, no measured positioning - but it shares the same `chipClass` selected/unselected ' +
+          'styling, so a regression here (for example the `aria-pressed` state losing its visual ' +
+          'pair) would look identical to a passing screenshot at rest.\n\n' +
+          'Each status option carries its own `status()` colour set (warning/success/danger), but ' +
+          'the row deliberately ignores it: `chipClass(active)` renders every chip with the same ' +
+          'generic selected/unselected pair regardless of which status it represents, so there is ' +
+          'no colour-per-status behaviour to assert here.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting state',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const all = canvas.getByRole('button', { name: 'All' });
+    await expect(all).toHaveAttribute('aria-pressed', 'true');
+    for (const label of ['Pending', 'Dispensed', 'Not dispensed']) {
+      await expect(canvas.getByRole('button', { name: label })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    }
+    await expect(canvas.getByLabelText('Search dispensary')).toHaveValue('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '"All" selected and the search box empty, matching the Dispensary tab on first load.',
+      },
+    },
+  },
+};
+
+export const StatusFilterSelection: Story = {
+  name: 'Choosing a status filter',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const all = canvas.getByRole('button', { name: 'All' });
+    const dispensed = canvas.getByRole('button', { name: 'Dispensed' });
+
+    /* The chip is `transition-colors`, so both the weight and the settled fill are
+       polled - a single read lands mid-transition and compares two interpolated
+       colours rather than the two end states (same pattern as InventoryFilterBar's
+       visibility pills). */
+    await expect(getComputedStyle(all).fontWeight).not.toBe(getComputedStyle(dispensed).fontWeight);
+
+    await userEvent.click(dispensed);
+
+    await waitFor(() => {
+      expect(dispensed).toHaveAttribute('aria-pressed', 'true');
+      expect(all).toHaveAttribute('aria-pressed', 'false');
+      expect(getComputedStyle(dispensed).fontWeight).toBe('700');
+      expect(getComputedStyle(dispensed).backgroundColor).not.toBe(
+        getComputedStyle(all).backgroundColor
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selecting a status chip is exclusive - the previously active chip drops both its ' +
+          '`aria-pressed` state and its selected fill/weight as the new one takes them.',
+      },
+    },
+  },
+};
+
+export const SearchInput: Story = {
+  name: 'Typing a search term',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const search = canvas.getByLabelText('Search dispensary');
+
+    await userEvent.type(search, 'amoxicillin');
+    await waitFor(() => {
+      expect(search).toHaveValue('amoxicillin');
+    });
+
+    /* A dropped `onChange` still leaves the freshly-typed value sitting in the
+       DOM - the browser sets it on keystroke independently of React - so the
+       assertion above alone cannot tell "wired to state" from "never wired at
+       all". Forcing an unrelated re-render (clicking a status chip) is the
+       tell: React reasserts a *controlled* input's value on every commit, so
+       a value that only ever lived in the DOM gets stamped back to the empty
+       string the state actually holds, while a value that made it into state
+       survives. */
+    await userEvent.click(canvas.getByRole('button', { name: 'Pending' }));
+    await waitFor(() => {
+      expect(search).toHaveValue('amoxicillin');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The search input is controlled from the same state the page filters records by, so a ' +
+          'value that fails to round-trip through `onChange` would leave the field looking typeable ' +
+          'while silently dropping every keystroke - visible only once something else forces a ' +
+          "re-render and the input's stale DOM value gets overwritten by the real (empty) state.",
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
@@ -284,6 +284,9 @@ const StripeOnboarding = () => {
   );
 };
 
+// no-story: ProtectedRoute/OrgGuard/Suspense composition with no UI of its own;
+// the real screen is the unexported StripeOnboarding it wraps, whose visible
+// pieces are covered by StripeSetupStatus.stories.tsx.
 const ProtectedStripeOnboarding = () => {
   return (
     <ProtectedRoute>

--- a/scripts/ci/story-coverage.mjs
+++ b/scripts/ci/story-coverage.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// Fails when a pull request adds a new React component under apps/frontend
+// without a sibling Storybook story.
+//
+// Why this exists: nothing else in CI checks this. Chromatic only visually
+// diffs stories that already exist (`onlyChanged`), and the Storybook
+// interactions job (storybook-interactions.yml) only runs `play` functions on
+// existing stories - neither one has any way to notice a component that was
+// never given a story in the first place. A 2026-09 documentation/QA pass
+// found real UI bugs (an inconsistent empty-state button, a native <select>
+// that never got themed) that had sat unreviewed because nobody - human or
+// CI - ever looked at the component in isolation. This gate is the fix: it
+// does not require a story from every one of the hundreds of pre-existing
+// components (that backlog is real and this gate does not attempt to clear
+// it), only from files a PR *adds*, so the cost of the gate always matches
+// the size of the change - the same shape as diff-coverage.mjs.
+//
+// Detection is a deliberately simple heuristic, not a TypeScript/AST parse:
+// a component file default- or named-exports a capitalised identifier and
+// its body contains a JSX closing tag ("</"). That is enough to separate a
+// real component from a hook, a service, a type-only file or a barrel
+// re-export, and false positives have a cheap, visible escape hatch (see
+// NO_STORY_MARKER) rather than needing the detector to be perfect.
+//
+//   node scripts/ci/story-coverage.mjs --base <sha> --head <sha> [--dir <app-dir>]
+//   node scripts/ci/story-coverage.mjs --files <path...>   # check specific files, for local/test use
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DEFAULT_APP_DIR = 'apps/frontend/src/app';
+
+// A component opts out with a one-line comment naming why, so a suppression
+// is greppable and reviewable instead of silent - the same shape as a
+// NOSONAR comment elsewhere in this codebase.
+const NO_STORY_MARKER = /\/\/\s*no-story:\s*\S/;
+
+const EXCLUDE_PATTERNS = [/\.stories\.tsx$/, /\.test\.tsx$/, /(^|\/)__tests__\//, /\.d\.ts$/];
+
+// A capitalised name declared as a function or a const, anywhere in the file -
+// deliberately not anchored to `export`, because this codebase commonly
+// declares a component as a plain `const Foo = (...) => ...` and exports it
+// several lines later with a standalone `export default Foo;` (found via a
+// real historical miss: DocumentsListPanel.tsx uses exactly this shape and an
+// export-anchored regex silently never matched it).
+const DECLARATION_PATTERN =
+  /\b(?:async\s+)?function\s+([A-Z]\w*)|\bconst\s+([A-Z]\w*)\s*(?::[^=]+)?=/g;
+
+const isExported = (content, name) =>
+  new RegExp(`export\\s+default\\s+(?:async\\s+)?function\\s+${name}\\b`).test(content) ||
+  new RegExp(`export\\s+const\\s+${name}\\b`).test(content) ||
+  new RegExp(`export\\s+default\\s+${name}\\s*;`).test(content) ||
+  new RegExp(`export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}`).test(content);
+
+/** Every capitalised name this file both declares and actually exports. */
+const exportedComponentNames = (content) => {
+  const names = new Set();
+  for (const match of content.matchAll(DECLARATION_PATTERN)) {
+    const name = match[1] ?? match[2];
+    if (name) names.add(name);
+  }
+  return [...names].filter((name) => isExported(content, name));
+};
+
+function fail(message) {
+  console.error(`story-coverage: ${message}`);
+  process.exit(1);
+}
+
+export function parseArgs(argv) {
+  const args = { base: '', head: '', dir: DEFAULT_APP_DIR, files: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--base') args.base = argv[++i];
+    else if (flag === '--head') args.head = argv[++i];
+    else if (flag === '--dir') args.dir = argv[++i];
+    else if (flag === '--files') {
+      // Consumes every remaining argument, so it must stop the loop rather
+      // than let the next iteration re-read a file path as an unknown flag.
+      args.files = argv.slice(i + 1);
+      break;
+    } else fail(`unknown argument '${flag}'`);
+  }
+  if (args.files.length === 0 && (!args.base || !args.head))
+    fail('usage: --base <sha> --head <sha> [--dir <app-dir>]  OR  --files <path...>');
+  return args;
+}
+
+/** Files added (never present at `base`) between base and head, under `dir`. */
+export function addedFiles({ base, head, dir, cwd = REPO_ROOT }) {
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-status', '--diff-filter=A', `${base}...${head}`, '--', dir],
+    { cwd, encoding: 'utf8' }
+  );
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => line.split('\t').pop())
+    .filter((file) => file.endsWith('.tsx'));
+}
+
+/** True if the file's content looks like a real, exported React component. */
+export function looksLikeComponent(content) {
+  if (NO_STORY_MARKER.test(content)) return false;
+  if (exportedComponentNames(content).length === 0) return false;
+  if (!content.includes('</')) return false; // no JSX closing tag anywhere
+  const codeLines = content.split('\n').filter((l) => l.trim().length > 0).length;
+  return codeLines >= 6;
+}
+
+export function storyPathFor(componentFile) {
+  return componentFile.replace(/\.tsx$/, '.stories.tsx');
+}
+
+export function evaluate({ files, cwd = REPO_ROOT }) {
+  const missing = [];
+  const skipped = [];
+  const checked = [];
+
+  for (const file of files) {
+    if (EXCLUDE_PATTERNS.some((re) => re.test(file))) {
+      skipped.push(file);
+      continue;
+    }
+    const fullPath = path.join(cwd, file);
+    if (!existsSync(fullPath)) {
+      // Added then deleted again within the same PR range - nothing to check.
+      skipped.push(file);
+      continue;
+    }
+    const content = readFileSync(fullPath, 'utf8');
+    if (!looksLikeComponent(content)) {
+      skipped.push(file);
+      continue;
+    }
+    checked.push(file);
+    const storyFile = storyPathFor(file);
+    if (!existsSync(path.join(cwd, storyFile))) {
+      missing.push({ file, expected: storyFile });
+    }
+  }
+
+  return { missing, skipped, checked };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const files = args.files.length > 0 ? args.files : addedFiles(args);
+  const { missing, skipped, checked } = evaluate({ files });
+
+  console.log(
+    `story-coverage: ${files.length} added .tsx file(s), ${checked.length} look like components, ${skipped.length} excluded`
+  );
+
+  if (missing.length === 0) {
+    console.log('story-coverage: every new component has a story');
+    return;
+  }
+
+  console.error(
+    `\nstory-coverage: ${missing.length} new component(s) added with no Storybook story:`
+  );
+  for (const { file, expected } of missing) {
+    console.error(`  ${file}\n    expected: ${expected}`);
+  }
+  console.error(
+    '\nAdd a story next to the component, or if it genuinely does not need one (a trivial ' +
+      'wrapper, something only ever exercised inside a parent story), add a comment explaining ' +
+      'why: // no-story: <reason>'
+  );
+  process.exit(1);
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  main();
+}

--- a/scripts/ci/story-coverage.mjs
+++ b/scripts/ci/story-coverage.mjs
@@ -116,6 +116,18 @@ export function storyPathFor(componentFile) {
   return componentFile.replace(/\.tsx$/, '.stories.tsx');
 }
 
+// `files` comes from `git diff` output or a `--files` CLI argument, neither
+// of which this script should trust to stay under `cwd` - a relative path
+// containing `..` (or an absolute path) could otherwise make readFileSync
+// walk outside the repo. Returns null for anything that escapes `cwd`.
+function resolveWithin(cwd, file) {
+  const base = path.resolve(cwd);
+  const fullPath = path.resolve(base, file);
+  const relative = path.relative(base, fullPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return fullPath;
+}
+
 export function evaluate({ files, cwd = REPO_ROOT }) {
   const missing = [];
   const skipped = [];
@@ -126,8 +138,8 @@ export function evaluate({ files, cwd = REPO_ROOT }) {
       skipped.push(file);
       continue;
     }
-    const fullPath = path.join(cwd, file);
-    if (!existsSync(fullPath)) {
+    const fullPath = resolveWithin(cwd, file);
+    if (!fullPath || !existsSync(fullPath)) {
       // Added then deleted again within the same PR range - nothing to check.
       skipped.push(file);
       continue;
@@ -139,7 +151,8 @@ export function evaluate({ files, cwd = REPO_ROOT }) {
     }
     checked.push(file);
     const storyFile = storyPathFor(file);
-    if (!existsSync(path.join(cwd, storyFile))) {
+    const storyFullPath = resolveWithin(cwd, storyFile);
+    if (!storyFullPath || !existsSync(storyFullPath)) {
       missing.push({ file, expected: storyFile });
     }
   }

--- a/scripts/ci/story-coverage.test.mjs
+++ b/scripts/ci/story-coverage.test.mjs
@@ -193,4 +193,41 @@ describe('evaluate', () => {
       assert.deepEqual(skipped, ['Gone.tsx']);
     });
   });
+
+  it('THE CASE THIS GATE EXISTS FOR: a path escaping cwd via ../ is skipped, not read', () => {
+    // `files` comes from git diff output or a --files argument; the fixture
+    // here plants a real file just outside `dir` and proves it is never
+    // opened by asserting it does not surface as `checked` or `missing`.
+    withFixture((dir) => {
+      const parent = path.dirname(dir);
+      const outside = path.join(parent, `story-coverage-escape-${path.basename(dir)}.tsx`);
+      writeFileSync(outside, REAL_COMPONENT);
+      try {
+        const { missing, checked, skipped } = evaluate({
+          files: [`../${path.basename(outside)}`],
+          cwd: dir,
+        });
+        assert.deepEqual(checked, []);
+        assert.deepEqual(missing, []);
+        assert.deepEqual(skipped, [`../${path.basename(outside)}`]);
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    });
+  });
+
+  it('an absolute path is skipped, not read', () => {
+    withFixture((dir) => {
+      const outside = path.join(tmpdir(), `story-coverage-abs-${Date.now()}.tsx`);
+      writeFileSync(outside, REAL_COMPONENT);
+      try {
+        const { missing, checked, skipped } = evaluate({ files: [outside], cwd: dir });
+        assert.deepEqual(checked, []);
+        assert.deepEqual(missing, []);
+        assert.deepEqual(skipped, [outside]);
+      } finally {
+        rmSync(outside, { force: true });
+      }
+    });
+  });
 });

--- a/scripts/ci/story-coverage.test.mjs
+++ b/scripts/ci/story-coverage.test.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Unit tests for the new-component-needs-a-story gate.
+//
+// Run with `node --test scripts/ci/story-coverage.test.mjs`, or as part of
+// `pnpm run test:scripts`.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { looksLikeComponent, storyPathFor, evaluate, parseArgs } from './story-coverage.mjs';
+
+const REAL_COMPONENT = `
+import React from 'react';
+
+export default function ServicesTab({ specialityId }: { specialityId: string }) {
+  return (
+    <div className="wrapper">
+      <span>{specialityId}</span>
+    </div>
+  );
+}
+`;
+
+const ARROW_COMPONENT = `
+export const PackagesTab = ({ specialityId }: Props) => {
+  if (loading) {
+    return <YosemiteLoader />;
+  }
+  return (
+    <div>
+      <p>packages</p>
+    </div>
+  );
+};
+`;
+
+const HOOK_FILE = `
+import { useState } from 'react';
+
+export function useConsentList(patientId: string) {
+  const [items, setItems] = useState([]);
+  return { items, setItems };
+}
+`;
+
+const BARREL_FILE = `
+export { default } from './PackagesTab';
+export * from './PackagesTab';
+`;
+
+// Long enough to clear the trivial-size floor on its own, so this fixture
+// exercises the // no-story marker specifically, not the size check.
+const OPTED_OUT_COMPONENT = `
+// no-story: pure presentational wrapper exercised only inside PackagesTab's own story
+export default function PackageBadge({ label, tone }: { label: string; tone: string }) {
+  const className = tone === 'warning' ? 'badge badge-warning' : 'badge';
+  return (
+    <span className={className}>
+      {label}
+    </span>
+  );
+}
+`;
+
+// Deliberately has a real closing tag (unlike a self-closing <div />), so this
+// fixture exercises the trivial-size floor itself, not the JSX-detection check.
+const TRIVIAL_COMPONENT = `
+export default function Spacer() {
+  return <div className="spacer"></div>;
+}
+`;
+
+describe('looksLikeComponent', () => {
+  it('recognises a default-exported function component', () => {
+    assert.equal(looksLikeComponent(REAL_COMPONENT), true);
+  });
+
+  it('recognises a named-exported arrow-function component', () => {
+    assert.equal(looksLikeComponent(ARROW_COMPONENT), true);
+  });
+
+  it('rejects a hook with no JSX', () => {
+    assert.equal(looksLikeComponent(HOOK_FILE), false);
+  });
+
+  it('rejects a barrel re-export file', () => {
+    assert.equal(looksLikeComponent(BARREL_FILE), false);
+  });
+
+  it('THE CASE THIS GATE EXISTS FOR: a real component with no export is not flagged as needing a story it cannot receive under its own name', () => {
+    // A component that isn't exported can't be imported by a story either -
+    // this is a different problem than "forgot the story".
+    assert.equal(looksLikeComponent('function Inner() { return <div />; }'), false);
+  });
+
+  it('respects the // no-story escape hatch even on an otherwise-real component', () => {
+    assert.equal(looksLikeComponent(OPTED_OUT_COMPONENT), false);
+  });
+
+  it('rejects a file below the trivial-size floor', () => {
+    assert.equal(looksLikeComponent(TRIVIAL_COMPONENT), false);
+  });
+});
+
+describe('storyPathFor', () => {
+  it('swaps the .tsx extension for .stories.tsx', () => {
+    assert.equal(
+      storyPathFor('apps/frontend/src/app/features/x/Foo.tsx'),
+      'apps/frontend/src/app/features/x/Foo.stories.tsx'
+    );
+  });
+});
+
+describe('parseArgs', () => {
+  it('THE CASE THIS GATE EXISTS FOR: --files consumes every remaining argument, not just the first', () => {
+    // Found via a real run against a historical commit: with a loop that
+    // didn't stop after --files, the second file path was re-read as an
+    // "unknown argument" and the whole command failed.
+    const args = parseArgs(['--files', 'a.tsx', 'b.tsx', 'c.tsx']);
+    assert.deepEqual(args.files, ['a.tsx', 'b.tsx', 'c.tsx']);
+  });
+
+  it('parses --base and --head', () => {
+    const args = parseArgs(['--base', 'sha1', '--head', 'sha2']);
+    assert.equal(args.base, 'sha1');
+    assert.equal(args.head, 'sha2');
+  });
+});
+
+describe('evaluate', () => {
+  // Real temp files rather than a mocked fs: the function under test reads
+  // the filesystem directly, and faking that out would test the mock, not
+  // the gate.
+  const withFixture = (fn) => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'story-coverage-'));
+    try {
+      return fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  it('flags a new component with no sibling story', () => {
+    withFixture((dir) => {
+      writeFileSync(path.join(dir, 'Foo.tsx'), REAL_COMPONENT);
+      const { missing, checked } = evaluate({ files: ['Foo.tsx'], cwd: dir });
+      assert.deepEqual(checked, ['Foo.tsx']);
+      assert.deepEqual(missing, [{ file: 'Foo.tsx', expected: 'Foo.stories.tsx' }]);
+    });
+  });
+
+  it('THE CASE THIS GATE EXISTS FOR: passes when the sibling story exists', () => {
+    withFixture((dir) => {
+      writeFileSync(path.join(dir, 'Foo.tsx'), REAL_COMPONENT);
+      writeFileSync(path.join(dir, 'Foo.stories.tsx'), 'export default {};');
+      const { missing } = evaluate({ files: ['Foo.tsx'], cwd: dir });
+      assert.deepEqual(missing, []);
+    });
+  });
+
+  it('excludes story files, test files and files under __tests__ from the check itself', () => {
+    withFixture((dir) => {
+      mkdirSync(path.join(dir, '__tests__'), { recursive: true });
+      writeFileSync(path.join(dir, 'Foo.stories.tsx'), REAL_COMPONENT);
+      writeFileSync(path.join(dir, 'Foo.test.tsx'), REAL_COMPONENT);
+      writeFileSync(path.join(dir, '__tests__', 'Foo.tsx'), REAL_COMPONENT);
+      const { missing, checked, skipped } = evaluate({
+        files: ['Foo.stories.tsx', 'Foo.test.tsx', '__tests__/Foo.tsx'],
+        cwd: dir,
+      });
+      assert.deepEqual(missing, []);
+      assert.deepEqual(checked, []);
+      assert.equal(skipped.length, 3);
+    });
+  });
+
+  it('skips a hook file (no JSX) without demanding a story', () => {
+    withFixture((dir) => {
+      writeFileSync(path.join(dir, 'useThing.tsx'), HOOK_FILE);
+      const { missing, checked } = evaluate({ files: ['useThing.tsx'], cwd: dir });
+      assert.deepEqual(missing, []);
+      assert.deepEqual(checked, []);
+    });
+  });
+
+  it('treats a file added then deleted in the same range as nothing to check', () => {
+    withFixture((dir) => {
+      const { missing, skipped } = evaluate({ files: ['Gone.tsx'], cwd: dir });
+      assert.deepEqual(missing, []);
+      assert.deepEqual(skipped, ['Gone.tsx']);
+    });
+  });
+});

--- a/scripts/ci/story-coverage.test.mjs
+++ b/scripts/ci/story-coverage.test.mjs
@@ -218,15 +218,19 @@ describe('evaluate', () => {
 
   it('an absolute path is skipped, not read', () => {
     withFixture((dir) => {
-      const outside = path.join(tmpdir(), `story-coverage-abs-${Date.now()}.tsx`);
-      writeFileSync(outside, REAL_COMPONENT);
+      // A private, randomly-named directory (mkdtempSync, same as withFixture)
+      // rather than a predictable name under the shared os temp dir - a fixed
+      // name there is a symlink-race target another process could pre-create.
+      const outsideDir = mkdtempSync(path.join(tmpdir(), 'story-coverage-abs-'));
+      const outside = path.join(outsideDir, 'Foo.tsx');
       try {
+        writeFileSync(outside, REAL_COMPONENT);
         const { missing, checked, skipped } = evaluate({ files: [outside], cwd: dir });
         assert.deepEqual(checked, []);
         assert.deepEqual(missing, []);
         assert.deepEqual(skipped, [outside]);
       } finally {
-        rmSync(outside, { force: true });
+        rmSync(outsideDir, { recursive: true, force: true });
       }
     });
   });


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/story-coverage.mjs` + `.github/workflows/story-coverage.yml`: a diff-scoped CI gate (same shape as `diff-coverage.mjs`) that fails a PR only when a file it *adds* under `apps/frontend/src/app` looks like a real, exported React component and has no sibling `.stories.tsx`. A `// no-story: <reason>` comment is the escape hatch for a genuine exception.
- Backfills the 4 real gaps this gate's own audit found in the existing codebase:
  - `DispensaryFilterBar` (Inventory) had no story at all - added one with 3 `play`-verified stories.
  - `StripeOnboarding`'s and `MerckManuals`' default-exported page components are `ProtectedRoute`/`OrgGuard`/`Suspense` wrappers with no UI of their own beyond a loading skeleton - marked `// no-story` with the reason, since their actual visible pieces already have stories (`StripeSetupStatus.stories.tsx`, `MerckReaderPortal.stories.tsx`).

## Why
Nothing in CI previously noticed a new component shipping without a Storybook story. Chromatic's `onlyChanged` and the advisory `storybook-interactions.yml` job both only ever touch stories that *already exist* - neither can notice a component that never got one in the first place. A recent UI-bug pass found real defects (an inconsistent CTA button, an unthemed native `<select>`) that had gone unreviewed in isolation for exactly this reason.

The gate intentionally does not retroactively require a story from the pre-existing backlog of components - only from what a PR newly adds - so its cost always matches the size of the change.

## Impact area
`apps/frontend` (new Storybook story + two `// no-story` annotations), and CI (`scripts/ci`, `.github/workflows`).

## Validation performed
- `node --test scripts/ci/story-coverage.test.mjs` - 15/15 passing.
- Mutation-tested: broke the detection logic and the `NO_STORY_MARKER`/size-floor checks, confirmed the relevant tests fail, restored.
- Validated the detection heuristic against a real historical commit (`git worktree add --detach`) that predates a story that now exists, confirming it would have caught the gap.
- New `DispensaryFilterBar.stories.tsx`: all 3 stories verified live in Storybook, each `play` function mutation-tested against the real component source.
- `npx tsc --noemit` clean.