### PR TITLE
fix(repo): close Documenso consent-visibility and signing-completion gaps

### DIFF
--- a/apps/backend/src/controllers/web/documenso.controller.ts
+++ b/apps/backend/src/controllers/web/documenso.controller.ts
@@ -4,6 +4,7 @@ import {
   DocumensoExternalRole,
   DocumensoService,
 } from "src/services/documenso.service";
+import { AuditTrailService } from "src/services/audit-trail.service";
 import { FormAssignmentService } from "src/services/form-assignment.service";
 import { completePersistedRenderedDocumentSigning } from "src/services/rendered-document.service";
 import { notifyOwnerOfPassportUpdate } from "src/services/pet-clinical-records.service";
@@ -259,7 +260,11 @@ async function handlePassportRecordEvent(
       supersededById: null,
       artifact: { status: { not: "VOID" } },
     },
-    select: { id: true, artifactId: true },
+    select: {
+      id: true,
+      artifactId: true,
+      artifact: { select: { organisationId: true, kind: true } },
+    },
   });
   if (!attestation) return false;
   const signedAt = new Date();
@@ -283,9 +288,30 @@ async function handlePassportRecordEvent(
   // Already handled, or revoked in flight: ack the webhook, notify nobody.
   if (claimed.count === 0) return true;
 
+  // Best-effort: a download failure must not block flipping the artifact to
+  // SIGNED (the state the passport actually reads) - it only leaves
+  // signedPdfUrl unset, same as before this fetch existed.
+  const apiKey = await DocumensoService.resolveOrganisationApiKey(
+    attestation.artifact.organisationId,
+  );
+  const signedPdf = apiKey
+    ? await DocumensoService.downloadSignedDocument({
+        documentId: Number.parseInt(documentId, 10),
+        apiKey,
+      })
+    : undefined;
+
   const artifact = await prisma.clinicalArtifact.update({
     where: { id: attestation.artifactId },
-    data: { attestation: { update: { signingStatus: "SIGNED", signedAt } } },
+    data: {
+      attestation: {
+        update: {
+          signingStatus: "SIGNED",
+          signedAt,
+          signedPdfUrl: signedPdf?.downloadUrl,
+        },
+      },
+    },
     select: { encounterId: true },
   });
   // Tell the owner their passport gained a verified record (best-effort).
@@ -294,7 +320,22 @@ async function handlePassportRecordEvent(
       where: { id: artifact.encounterId },
       select: { patientId: true },
     });
-    if (encounter) await notifyOwnerOfPassportUpdate(encounter.patientId);
+    if (encounter) {
+      await notifyOwnerOfPassportUpdate(encounter.patientId);
+      await AuditTrailService.recordSafely({
+        organisationId: attestation.artifact.organisationId,
+        patientId: encounter.patientId,
+        eventType: "DOCUMENT_UPDATED",
+        actorType: "SYSTEM",
+        entityType: "DOCUMENT",
+        entityId: attestation.artifactId,
+        metadata: {
+          clinicalArtifactId: attestation.artifactId,
+          kind: attestation.artifact.kind,
+          documensoDocumentId: documentId,
+        },
+      });
+    }
   }
   return true;
 }

--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -442,9 +442,85 @@ const loadRenderedDocumentsForAppointments = async (params: {
   return renderedDocuments.map(mapRenderedDocumentToDto);
 };
 
+/**
+ * Rendered documents for every one of a patient's clinical records - not just
+ * their appointments. A TemplateInstance (or ClinicalArtifact) that generated
+ * a signed document can be linked by appointmentId, caseId, or encounterId -
+ * `case-encounter.service.ts`'s package-expansion path sets all three it has,
+ * and a case-only or encounter-only record leaves appointmentId null. Filtering
+ * on appointmentId alone silently drops a signed consent document whenever the
+ * record that produced it was never tied to a specific appointment - found via
+ * a real report that a patient's signed consent form did not appear on their
+ * Consents panel despite completePersistedRenderedDocumentSigning having run.
+ */
+const loadRenderedDocumentsForPatientRecords = async (params: {
+  appointmentIds: string[];
+  caseIds: string[];
+  encounterIds: string[];
+  organisationId: string;
+  kind?: TemplateKind;
+  excludeKind?: TemplateKind;
+}) => {
+  if (
+    params.appointmentIds.length === 0 &&
+    params.caseIds.length === 0 &&
+    params.encounterIds.length === 0
+  ) {
+    return [];
+  }
+
+  const linkClauses = (relation: "templateInstance" | "clinicalArtifact") => {
+    const clauses = [];
+    if (params.appointmentIds.length > 0) {
+      clauses.push({
+        [relation]: { is: { appointmentId: { in: params.appointmentIds } } },
+      });
+    }
+    if (params.caseIds.length > 0) {
+      clauses.push({ [relation]: { is: { caseId: { in: params.caseIds } } } });
+    }
+    if (params.encounterIds.length > 0) {
+      clauses.push({
+        [relation]: { is: { encounterId: { in: params.encounterIds } } },
+      });
+    }
+    return clauses;
+  };
+
+  const renderedDocuments = (await prisma.renderedDocument.findMany({
+    where: {
+      organisationId: params.organisationId,
+      ...(params.kind ? { kind: params.kind } : {}),
+      ...(params.excludeKind ? { kind: { not: params.excludeKind } } : {}),
+      OR: [
+        ...linkClauses("templateInstance"),
+        ...linkClauses("clinicalArtifact"),
+      ],
+    },
+    include: {
+      templateInstance: {
+        select: {
+          appointmentId: true,
+          encounterId: true,
+        },
+      },
+      clinicalArtifact: {
+        select: {
+          appointmentId: true,
+          encounterId: true,
+        },
+      },
+    },
+    orderBy: { updatedAt: "desc" },
+  })) as unknown as RenderedDocumentRow[];
+
+  return renderedDocuments.map(mapRenderedDocumentToDto);
+};
+
 // Appointment.patient is a JSON blob (no relational FK), so every other
 // patient-scoped appointment lookup in the codebase matches it the same way
-// - see appointmentService.getAppointmentsForCompanion.
+// - see appointmentService.getAppointmentsForCompanion. Case and Encounter
+// carry a real patientId column, so those are plain equality lookups.
 const loadAppointmentIdsForPatient = async (params: {
   patientId: string;
   organisationId: string;
@@ -458,6 +534,33 @@ const loadAppointmentIdsForPatient = async (params: {
   });
 
   return appointments.map((appointment) => appointment.id);
+};
+
+const loadCaseAndEncounterIdsForPatient = async (params: {
+  patientId: string;
+  organisationId: string;
+}): Promise<{ caseIds: string[]; encounterIds: string[] }> => {
+  const [cases, encounters] = await Promise.all([
+    prisma.case.findMany({
+      where: {
+        organisationId: params.organisationId,
+        patientId: params.patientId,
+      },
+      select: { id: true },
+    }),
+    prisma.encounter.findMany({
+      where: {
+        organisationId: params.organisationId,
+        patientId: params.patientId,
+      },
+      select: { id: true },
+    }),
+  ]);
+
+  return {
+    caseIds: cases.map((c) => c.id),
+    encounterIds: encounters.map((e) => e.id),
+  };
 };
 
 const createDocumentRecord = async (
@@ -771,18 +874,36 @@ export const DocumentService = {
       }) as unknown as Promise<PrismaDocumentRow[]>,
       (async () => {
         // Signed/generated documents (Documenso e-signing) live on
-        // RenderedDocument, reached only via the appointment/encounter it was
-        // rendered for - there is no direct patientId column to filter by, so
-        // every one of the patient's own appointments has to be resolved first.
+        // RenderedDocument, reached only via the appointment/case/encounter it
+        // was rendered for - there is no direct patientId column to filter by,
+        // so every one of the patient's own records has to be resolved first.
+        // Case/encounter expansion is skipped when the caller names a specific
+        // appointmentId: that filter means "just this appointment", and a
+        // record linked only by case or encounter is not part of it.
         const patientAppointmentIds = await loadAppointmentIdsForPatient({
           patientId,
           organisationId: params.organisationId,
         });
-        const scopedAppointmentIds = appointmentId
-          ? patientAppointmentIds.filter((id) => id === appointmentId)
-          : patientAppointmentIds;
-        return loadRenderedDocumentsForAppointments({
-          appointmentIds: scopedAppointmentIds,
+        if (appointmentId) {
+          return loadRenderedDocumentsForPatientRecords({
+            appointmentIds: patientAppointmentIds.filter(
+              (id) => id === appointmentId,
+            ),
+            caseIds: [],
+            encounterIds: [],
+            organisationId: params.organisationId,
+            excludeKind: params.excludeKind,
+          });
+        }
+        const { caseIds, encounterIds } =
+          await loadCaseAndEncounterIdsForPatient({
+            patientId,
+            organisationId: params.organisationId,
+          });
+        return loadRenderedDocumentsForPatientRecords({
+          appointmentIds: patientAppointmentIds,
+          caseIds,
+          encounterIds,
           organisationId: params.organisationId,
           excludeKind: params.excludeKind,
         });
@@ -812,13 +933,21 @@ export const DocumentService = {
     const patientId = normalizeStringId(params.patientId, "patientId");
     await assertPmsCanAccessCompanion(params.organisationId, patientId);
 
-    const appointmentIds = await loadAppointmentIdsForPatient({
-      patientId,
-      organisationId: params.organisationId,
-    });
+    const [appointmentIds, { caseIds, encounterIds }] = await Promise.all([
+      loadAppointmentIdsForPatient({
+        patientId,
+        organisationId: params.organisationId,
+      }),
+      loadCaseAndEncounterIdsForPatient({
+        patientId,
+        organisationId: params.organisationId,
+      }),
+    ]);
 
-    return loadRenderedDocumentsForAppointments({
+    return loadRenderedDocumentsForPatientRecords({
       appointmentIds,
+      caseIds,
+      encounterIds,
       organisationId: params.organisationId,
       kind: "CONSENT",
     });

--- a/apps/backend/src/services/rendered-document.service.ts
+++ b/apps/backend/src/services/rendered-document.service.ts
@@ -22,8 +22,10 @@ import {
 import type { ClinicalPdfSignaturePlacement } from "@yosemite-crew/lib";
 import { prisma } from "src/config/prisma";
 import { uploadBufferAsFile } from "src/middlewares/upload";
+import { AuditTrailService } from "src/services/audit-trail.service";
 import { DocumensoService } from "src/services/documenso.service";
 import { renderRenderedDocumentPdfWithMetadata } from "src/services/rendered-document-renderer.service";
+import type { AuditEventType } from "src/models/audit-trail";
 import {
   INVALID_OUTBOUND_DOCUMENT_URL_MESSAGE,
   readValidatedPdfResponse,
@@ -63,7 +65,13 @@ export type {
 
 type RenderedDocumentWriteClient = Pick<
   Prisma.TransactionClient,
-  "renderedDocument" | "documentSignature"
+  | "renderedDocument"
+  | "documentSignature"
+  | "templateInstance"
+  | "clinicalArtifact"
+  | "case"
+  | "encounter"
+  | "appointment"
 >;
 
 type PersistedRenderedDocument = Prisma.RenderedDocumentGetPayload<{
@@ -736,11 +744,125 @@ export const signPersistedRenderedDocument = async (
           signerEmail: input.signerEmail,
           signerName: input.signerName,
           signingUrl,
+          signatureText: input.signatureText ?? null,
         },
       },
       include: { signature: true },
     }),
   );
+};
+
+/** The RenderedDocumentKind-shaped audit event for the (rare) kinds that have one; every
+ * other kind still gets audited, just under the generic DOCUMENT_UPDATED event. */
+const RENDERED_DOCUMENT_SIGNED_AUDIT_EVENT: Partial<
+  Record<PersistedRenderedDocument["kind"], AuditEventType>
+> = {
+  CONSENT: "CONSENT_FORM_SIGNED",
+  PRESCRIPTION: "PRESCRIPTION_SIGNED",
+};
+
+const extractAppointmentPatientId = (patient: unknown): string | null => {
+  if (patient && typeof patient === "object" && "id" in patient) {
+    const id = (patient as { id?: unknown }).id;
+    return typeof id === "string" && id.trim() ? id : null;
+  }
+  return null;
+};
+
+type ClinicalRecordLinkage = {
+  appointmentId: string | null;
+  caseId: string | null;
+  encounterId: string | null;
+};
+
+/**
+ * A RenderedDocument carries no patientId of its own - only the TemplateInstance
+ * or ClinicalArtifact it is linked to does, and even then only via
+ * appointmentId/caseId/encounterId (the same three-way linkage
+ * loadRenderedDocumentsForPatientRecords in document.service.ts reads on the
+ * way back out). Best-effort: a signed document with no resolvable patient -
+ * an org-level template with no clinical linkage at all - audits nothing
+ * rather than fabricating an id.
+ */
+const resolvePatientIdForSignedDocument = async (
+  client: RenderedDocumentWriteClient,
+  linkage: ClinicalRecordLinkage,
+): Promise<string | null> => {
+  if (linkage.caseId) {
+    const found = await client.case.findUnique({
+      where: { id: linkage.caseId },
+      select: { patientId: true },
+    });
+    if (found?.patientId) return found.patientId;
+  }
+  if (linkage.encounterId) {
+    const found = await client.encounter.findUnique({
+      where: { id: linkage.encounterId },
+      select: { patientId: true },
+    });
+    if (found?.patientId) return found.patientId;
+  }
+  if (linkage.appointmentId) {
+    const found = await client.appointment.findUnique({
+      where: { id: linkage.appointmentId },
+      select: { patient: true },
+    });
+    const patientId = extractAppointmentPatientId(found?.patient);
+    if (patientId) return patientId;
+  }
+  return null;
+};
+
+/**
+ * Marks the TemplateInstance/ClinicalArtifact a just-signed RenderedDocument is
+ * linked to (at most one of the two - the FKs are mutually exclusive by
+ * construction) as SIGNED too, and returns its clinical linkage in the same
+ * round trip so the caller can resolve a patient for the audit event without a
+ * second read. A document with neither link (FORM_SUBMISSION/TASK_SCHEDULE/
+ * INVOICE-sourced) has nothing to propagate to and no linkage to resolve.
+ */
+const propagateSigningCompletionToLinkedRecord = async (
+  client: RenderedDocumentWriteClient,
+  existing: PersistedRenderedDocument,
+  signedBy: string | undefined,
+  signedAt: Date,
+): Promise<ClinicalRecordLinkage | null> => {
+  if (existing.templateInstanceId) {
+    return client.templateInstance.update({
+      where: { id: existing.templateInstanceId },
+      data: { status: "SIGNED", signedBy, signedAt },
+      select: { appointmentId: true, caseId: true, encounterId: true },
+    });
+  }
+  if (existing.clinicalArtifactId) {
+    return client.clinicalArtifact.update({
+      where: { id: existing.clinicalArtifactId },
+      data: { status: "SIGNED", signedBy, signedAt },
+      select: { appointmentId: true, caseId: true, encounterId: true },
+    });
+  }
+  return null;
+};
+
+const recordRenderedDocumentSignedAuditSafely = async (
+  client: RenderedDocumentWriteClient,
+  existing: PersistedRenderedDocument,
+  linkage: ClinicalRecordLinkage | null,
+): Promise<void> => {
+  if (!linkage) return;
+  const patientId = await resolvePatientIdForSignedDocument(client, linkage);
+  if (!patientId) return;
+
+  await AuditTrailService.recordSafely({
+    organisationId: existing.organisationId,
+    patientId,
+    eventType:
+      RENDERED_DOCUMENT_SIGNED_AUDIT_EVENT[existing.kind] ?? "DOCUMENT_UPDATED",
+    actorType: "PMS_USER",
+    entityType: "DOCUMENT",
+    entityId: existing.id,
+    metadata: { renderedDocumentId: existing.id, kind: existing.kind },
+  });
 };
 
 export const completePersistedRenderedDocumentSigning = async (
@@ -797,33 +919,51 @@ export const completePersistedRenderedDocumentSigning = async (
     );
   }
 
+  const signedAt = new Date();
+  const signedBy = signing.signerId ?? existing.signedBy ?? undefined;
+  const signature = buildDocumentSignature(existing.id, {
+    signerId:
+      signing.signerId ?? signing.signerEmail ?? existing.signedBy ?? "",
+    signerType: signing.signerType ?? "PMS_USER",
+    signatureText: signing.signatureText,
+    signedAt,
+  });
+
   await client.documentSignature.create({
     data: {
       renderedDocumentId: existing.id,
-      signerId:
-        signing.signerId ?? signing.signerEmail ?? existing.signedBy ?? "",
-      signerType: signing.signerType ?? "PMS_USER",
-      signedAt: new Date(),
+      signerId: signature.signerId,
+      signerType: signature.signerType,
+      signatureText: signature.signatureText,
+      signedAt: signature.signedAt,
     },
   });
 
-  return normalizePersistedRenderedDocument(
-    await client.renderedDocument.update({
-      where: { id: existing.id },
-      data: {
+  const updated = await client.renderedDocument.update({
+    where: { id: existing.id },
+    data: {
+      status: "SIGNED",
+      signedBy,
+      signedAt,
+      pdfUrl: signedPdf.downloadUrl ?? existing.pdfUrl ?? undefined,
+      signing: {
+        ...signing,
         status: "SIGNED",
-        signedBy: signing.signerId ?? existing.signedBy ?? undefined,
-        signedAt: new Date(),
-        pdfUrl: signedPdf.downloadUrl ?? existing.pdfUrl ?? undefined,
-        signing: {
-          ...signing,
-          status: "SIGNED",
-          pdf: {
-            url: signedPdf.downloadUrl ?? null,
-          },
+        pdf: {
+          url: signedPdf.downloadUrl ?? null,
         },
       },
-      include: { signature: true },
-    }),
+    },
+    include: { signature: true },
+  });
+
+  const linkage = await propagateSigningCompletionToLinkedRecord(
+    client,
+    existing,
+    signedBy,
+    signedAt,
   );
+  await recordRenderedDocumentSignedAuditSafely(client, existing, linkage);
+
+  return normalizePersistedRenderedDocument(updated);
 };

--- a/apps/backend/test/controllers/web/documenso.controller.test.ts
+++ b/apps/backend/test/controllers/web/documenso.controller.test.ts
@@ -15,6 +15,7 @@ import { FormAssignmentService } from "../../../src/services/form-assignment.ser
 import { DocumensoService } from "../../../src/services/documenso.service";
 import { WorkspaceDocumentPacketService } from "../../../src/services/workspace-document-packet.service";
 import { notifyOwnerOfPassportUpdate } from "../../../src/services/pet-clinical-records.service";
+import { AuditTrailService } from "../../../src/services/audit-trail.service";
 import logger from "../../../src/utils/logger";
 
 jest.mock("../../../src/utils/logger");
@@ -65,6 +66,11 @@ jest.mock("../../../src/config/prisma", () => ({
 }));
 jest.mock("../../../src/services/pet-clinical-records.service", () => ({
   notifyOwnerOfPassportUpdate: jest.fn(),
+}));
+jest.mock("../../../src/services/audit-trail.service", () => ({
+  AuditTrailService: {
+    recordSafely: jest.fn(),
+  },
 }));
 
 const mockedLogger = jest.mocked(logger);
@@ -204,12 +210,25 @@ describe("DocumensoWebhookController", () => {
       payload: { id: "doc-pass-1" },
     });
     const mockedPrisma = prisma as any;
+    const mockedDocumensoService = DocumensoService as jest.Mocked<
+      typeof DocumensoService
+    >;
+    const mockedAuditTrailService = AuditTrailService as jest.Mocked<
+      typeof AuditTrailService
+    >;
     mockedPrisma.clinicalArtifactAttestation.findFirst.mockResolvedValueOnce({
       id: "att-1",
       artifactId: "art-1",
+      artifact: { organisationId: "org-1", kind: "PRESCRIPTION" },
     });
     mockedPrisma.clinicalArtifact.updateMany.mockResolvedValueOnce({
       count: 1,
+    });
+    mockedDocumensoService.resolveOrganisationApiKey.mockResolvedValueOnce(
+      "api-key-1",
+    );
+    mockedDocumensoService.downloadSignedDocument.mockResolvedValueOnce({
+      downloadUrl: "https://signed.example/passport.pdf",
     });
     mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
       encounterId: "enc-1",
@@ -236,9 +255,83 @@ describe("DocumensoWebhookController", () => {
         data: expect.objectContaining({ status: "SIGNED" }),
       }),
     );
+    // THE CASE THIS GATE EXISTS FOR: signedPdfUrl existed on the schema but was
+    // never written - a signed passport attestation had no stored link to its
+    // own signed PDF.
+    expect(mockedDocumensoService.downloadSignedDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "api-key-1" }),
+    );
+    expect(mockedPrisma.clinicalArtifact.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          attestation: {
+            update: expect.objectContaining({
+              signingStatus: "SIGNED",
+              signedPdfUrl: "https://signed.example/passport.pdf",
+            }),
+          },
+        },
+      }),
+    );
     expect(notifyOwnerOfPassportUpdate).toHaveBeenCalledWith("pat-1");
+    // A second gap this same fix closes: no audit trail entry existed for a
+    // passport attestation ever being signed at all.
+    expect(mockedAuditTrailService.recordSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        entityId: "art-1",
+      }),
+    );
     expect(statusMock).toHaveBeenCalledWith(200);
     expect(mockedPrisma.formSubmission.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("still completes a passport record when the signed PDF download fails", async () => {
+    // Best-effort: DocumensoService.downloadSignedDocument already swallows its
+    // own errors and resolves undefined, so this only exercises that the
+    // caller does not treat a missing PDF as a reason to fail the webhook.
+    req = signedPassportRequest({
+      event: "DOCUMENT_COMPLETED",
+      payload: { id: "doc-pass-3" },
+    });
+    const mockedPrisma = prisma as any;
+    const mockedDocumensoService = DocumensoService as jest.Mocked<
+      typeof DocumensoService
+    >;
+    mockedPrisma.clinicalArtifactAttestation.findFirst.mockResolvedValueOnce({
+      id: "att-3",
+      artifactId: "art-3",
+      artifact: { organisationId: "org-1", kind: "PRESCRIPTION" },
+    });
+    mockedPrisma.clinicalArtifact.updateMany.mockResolvedValueOnce({
+      count: 1,
+    });
+    mockedDocumensoService.resolveOrganisationApiKey.mockResolvedValueOnce(
+      "api-key-1",
+    );
+    mockedDocumensoService.downloadSignedDocument.mockResolvedValueOnce(
+      undefined,
+    );
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      encounterId: null,
+    });
+
+    await DocumensoWebhookController.handle(req as Request, res as Response);
+
+    expect(mockedPrisma.clinicalArtifact.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          attestation: {
+            update: expect.objectContaining({
+              signingStatus: "SIGNED",
+              signedPdfUrl: undefined,
+            }),
+          },
+        },
+      }),
+    );
+    expect(statusMock).toHaveBeenCalledWith(200);
   });
 
   it("never resurrects a record revoked while its signature was outstanding", async () => {
@@ -373,6 +466,7 @@ describe("DocumensoWebhookController", () => {
     mockedPrisma.clinicalArtifactAttestation.findFirst.mockResolvedValueOnce({
       id: "att-2",
       artifactId: "art-2",
+      artifact: { organisationId: "org-1", kind: "PRESCRIPTION" },
     });
     mockedPrisma.clinicalArtifact.updateMany.mockResolvedValueOnce({
       count: 1,

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -54,6 +54,12 @@ jest.mock("src/config/prisma", () => ({
       findUnique: jest.fn(),
       findMany: jest.fn(),
     },
+    case: {
+      findMany: jest.fn(),
+    },
+    encounter: {
+      findMany: jest.fn(),
+    },
     $transaction: jest.fn(async (fn: any) => fn(prisma)),
   },
 }));
@@ -150,6 +156,8 @@ describe("DocumentService", () => {
       id: uuidDocumentId,
     } as any);
     mockedPrisma.renderedDocument.findMany.mockResolvedValue([]);
+    mockedPrisma.case.findMany.mockResolvedValue([]);
+    mockedPrisma.encounter.findMany.mockResolvedValue([]);
     mockedPrisma.appointment.findUnique.mockResolvedValue({
       organisationId: uuidOrganisationId,
       patient: { id: uuidPatientId },
@@ -509,8 +517,10 @@ describe("DocumentService", () => {
       });
     });
 
-    it("returns nothing for a patient with no appointments, without querying rendered documents", async () => {
+    it("returns nothing for a patient with no appointments, cases or encounters, without querying rendered documents", async () => {
       mockedPrisma.appointment.findMany.mockResolvedValue([]);
+      mockedPrisma.case.findMany.mockResolvedValue([]);
+      mockedPrisma.encounter.findMany.mockResolvedValue([]);
 
       const result = await DocumentService.listConsentDocumentsForPms({
         patientId: uuidPatientId,
@@ -519,6 +529,60 @@ describe("DocumentService", () => {
 
       expect(mockedPrisma.renderedDocument.findMany).not.toHaveBeenCalled();
       expect(result).toEqual([]);
+    });
+
+    it("THE CASE THIS GATE EXISTS FOR: resolves a signed consent document whose TemplateInstance is linked only by caseId/encounterId, with no appointmentId", async () => {
+      // case-encounter.service.ts's package-expansion path can create a
+      // TemplateInstance with appointmentId left null and only caseId/
+      // encounterId set. Filtering the rendered-document lookup on
+      // appointmentId alone silently dropped exactly this document - the real
+      // report that started this fix.
+      mockedPrisma.appointment.findMany.mockResolvedValue([]);
+      mockedPrisma.case.findMany.mockResolvedValue([{ id: "case-1" }] as any);
+      mockedPrisma.encounter.findMany.mockResolvedValue([
+        { id: "enc-1" },
+      ] as any);
+      mockedPrisma.renderedDocument.findMany.mockResolvedValue([
+        {
+          id: "rd-consent-case-linked",
+          organisationId: uuidOrganisationId,
+          sourceKind: "TEMPLATE_INSTANCE",
+          sourceId: "ti-2",
+          templateId: "tmpl-2",
+          templateVersion: 1,
+          kind: "CONSENT",
+          title: "Anaesthesia consent",
+          status: "SIGNED",
+          pdfUrl: "https://cdn/anaesthesia-consent.pdf",
+          signing: { status: "SIGNED" },
+          signedAt: now,
+          createdAt: now,
+          updatedAt: now,
+          templateInstance: { appointmentId: null, encounterId: "enc-1" },
+          clinicalArtifact: null,
+        },
+      ] as any);
+
+      const result = await DocumentService.listConsentDocumentsForPms({
+        patientId: uuidPatientId,
+        organisationId: uuidOrganisationId,
+      });
+
+      expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: expect.arrayContaining([
+              { templateInstance: { is: { caseId: { in: ["case-1"] } } } },
+              { templateInstance: { is: { encounterId: { in: ["enc-1"] } } } },
+            ]),
+          }),
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: "rd-consent-case-linked",
+        category: "CONSENT",
+      });
     });
 
     it("rejects a patient the caller's organisation cannot access", async () => {

--- a/apps/backend/test/services/rendered-document.service.test.ts
+++ b/apps/backend/test/services/rendered-document.service.test.ts
@@ -19,6 +19,7 @@ import {
 import { DocumensoService } from "../../src/services/documenso.service";
 import { renderRenderedDocumentPdfWithMetadata } from "../../src/services/rendered-document-renderer.service";
 import { uploadBufferAsFile } from "../../src/middlewares/upload";
+import { AuditTrailService } from "../../src/services/audit-trail.service";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -29,6 +30,21 @@ jest.mock("src/config/prisma", () => ({
     },
     documentSignature: {
       create: jest.fn(),
+    },
+    templateInstance: {
+      update: jest.fn(),
+    },
+    clinicalArtifact: {
+      update: jest.fn(),
+    },
+    case: {
+      findUnique: jest.fn(),
+    },
+    encounter: {
+      findUnique: jest.fn(),
+    },
+    appointment: {
+      findUnique: jest.fn(),
     },
   },
 }));
@@ -46,6 +62,11 @@ jest.mock("../../src/services/rendered-document-renderer.service", () => ({
 jest.mock("../../src/middlewares/upload", () => ({
   uploadBufferAsFile: jest.fn(),
 }));
+jest.mock("../../src/services/audit-trail.service", () => ({
+  AuditTrailService: {
+    recordSafely: jest.fn(),
+  },
+}));
 jest.mock("axios", () => ({
   get: jest.fn(),
 }));
@@ -61,6 +82,11 @@ describe("rendered-document service", () => {
     documentSignature: {
       create: jest.Mock;
     };
+    templateInstance: { update: jest.Mock };
+    clinicalArtifact: { update: jest.Mock };
+    case: { findUnique: jest.Mock };
+    encounter: { findUnique: jest.Mock };
+    appointment: { findUnique: jest.Mock };
   };
   const mockedDocumensoService = DocumensoService as unknown as {
     resolveOrganisationApiKey: jest.Mock;
@@ -72,6 +98,9 @@ describe("rendered-document service", () => {
     renderRenderedDocumentPdfWithMetadata as jest.Mock;
   const mockedUploadBufferAsFile = uploadBufferAsFile as jest.Mock;
   const mockedAxiosGet = axios.get as jest.Mock;
+  const mockedAuditTrailService = AuditTrailService as unknown as {
+    recordSafely: jest.Mock;
+  };
 
   let lookupSpy: jest.SpyInstance;
 
@@ -90,6 +119,17 @@ describe("rendered-document service", () => {
       .mockResolvedValue([
         { address: "203.0.113.10", family: 4 },
       ] as unknown as dns.LookupAddress);
+    // These are only exercised by the signing-completion tests, but their
+    // call counts otherwise survive between `it` blocks in this describe
+    // (nothing here resets mocks globally), which would make a later
+    // `not.toHaveBeenCalled()` false-fail on a call left over from an
+    // earlier test.
+    mockedPrisma.templateInstance.update.mockClear();
+    mockedPrisma.clinicalArtifact.update.mockClear();
+    mockedPrisma.case.findUnique.mockClear();
+    mockedPrisma.encounter.findUnique.mockClear();
+    mockedPrisma.appointment.findUnique.mockClear();
+    mockedAuditTrailService.recordSafely.mockClear();
   });
 
   afterEach(() => {
@@ -1025,6 +1065,14 @@ describe("rendered-document service", () => {
     mockedPrisma.documentSignature.create.mockResolvedValueOnce({
       id: "sig-1",
     });
+    mockedPrisma.templateInstance.update.mockResolvedValueOnce({
+      appointmentId: null,
+      caseId: "case-1",
+      encounterId: null,
+    });
+    mockedPrisma.case.findUnique.mockResolvedValueOnce({
+      patientId: "patient-1",
+    });
     mockedPrisma.renderedDocument.update.mockResolvedValueOnce({
       id: "doc-1",
       organisationId: "org-123",
@@ -1100,5 +1148,176 @@ describe("rendered-document service", () => {
       }),
     );
     expect(result.status).toBe("SIGNED");
+
+    // THE CASE THIS GATE EXISTS FOR: the linked TemplateInstance never advanced
+    // past COMPLETED before this fix, so a query keyed on its status could
+    // never find a document RenderedDocument itself already calls signed.
+    expect(mockedPrisma.templateInstance.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "instance-123" },
+        data: expect.objectContaining({ status: "SIGNED", signedBy: "user-1" }),
+      }),
+    );
+    expect(mockedPrisma.clinicalArtifact.update).not.toHaveBeenCalled();
+    expect(mockedPrisma.case.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "case-1" } }),
+    );
+    expect(mockedAuditTrailService.recordSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisationId: "org-123",
+        patientId: "patient-1",
+        eventType: "DOCUMENT_UPDATED",
+        entityId: "doc-1",
+      }),
+    );
+  });
+
+  it("signs a CONSENT document with a signature text and emits CONSENT_FORM_SIGNED", async () => {
+    mockedDocumensoService.resolveOrganisationApiKey.mockResolvedValueOnce(
+      "api-key-1",
+    );
+    mockedDocumensoService.downloadSignedDocument.mockResolvedValueOnce({
+      downloadUrl: "https://signed.example/consent.pdf",
+    });
+    mockedPrisma.renderedDocument.findUnique.mockResolvedValueOnce({
+      id: "doc-2",
+      organisationId: "org-123",
+      sourceKind: "CLINICAL_ARTIFACT",
+      sourceId: "artifact-1",
+      templateInstanceId: null,
+      clinicalArtifactId: "artifact-1",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      kind: "CONSENT",
+      version: 1,
+      title: "Surgical Consent",
+      mimeType: "application/pdf",
+      status: "DRAFT",
+      signable: true,
+      pdfUrl: null,
+      pdf: null,
+      signing: {
+        required: true,
+        provider: "DOCUMENSO",
+        status: "IN_PROGRESS",
+        documentId: "43",
+        signerId: "parent-1",
+        signerType: "PARENT",
+        signatureText: "Jane Owner",
+      },
+      signedBy: null,
+      signedAt: null,
+      createdAt: new Date("2026-06-13T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-13T00:00:00.000Z"),
+      signature: null,
+    });
+    mockedPrisma.documentSignature.create.mockResolvedValueOnce({
+      id: "sig-2",
+    });
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      appointmentId: null,
+      caseId: null,
+      encounterId: "encounter-1",
+    });
+    mockedPrisma.encounter.findUnique.mockResolvedValueOnce({
+      patientId: "patient-2",
+    });
+    mockedPrisma.renderedDocument.update.mockResolvedValueOnce({
+      id: "doc-2",
+      status: "SIGNED",
+      signing: { status: "SIGNED" },
+      signature: { signatureText: "Jane Owner" },
+    });
+
+    await completePersistedRenderedDocumentSigning("doc-2");
+
+    // THE CASE THIS GATE EXISTS FOR: `signatureText` reaches the FHIR sign
+    // endpoint and is typed all the way through, but was silently dropped
+    // between initiation and this completion call - the column was always
+    // null until this fix threaded it back out of the `signing` JSON.
+    expect(mockedPrisma.documentSignature.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          signerId: "parent-1",
+          signerType: "PARENT",
+          signatureText: "Jane Owner",
+        }),
+      }),
+    );
+    expect(mockedPrisma.clinicalArtifact.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "artifact-1" },
+        data: expect.objectContaining({ status: "SIGNED" }),
+      }),
+    );
+    expect(mockedPrisma.templateInstance.update).not.toHaveBeenCalled();
+    expect(mockedAuditTrailService.recordSafely).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patientId: "patient-2",
+        eventType: "CONSENT_FORM_SIGNED",
+      }),
+    );
+  });
+
+  it("skips the audit event when no patient can be resolved from the linked record", async () => {
+    mockedDocumensoService.resolveOrganisationApiKey.mockResolvedValueOnce(
+      "api-key-1",
+    );
+    mockedDocumensoService.downloadSignedDocument.mockResolvedValueOnce({
+      downloadUrl: "https://signed.example/org-doc.pdf",
+    });
+    mockedPrisma.renderedDocument.findUnique.mockResolvedValueOnce({
+      id: "doc-3",
+      organisationId: "org-123",
+      sourceKind: "TEMPLATE_INSTANCE",
+      sourceId: "instance-999",
+      templateInstanceId: "instance-999",
+      clinicalArtifactId: null,
+      kind: "FORM",
+      version: 1,
+      title: "Org-level form",
+      mimeType: "application/pdf",
+      status: "DRAFT",
+      signable: true,
+      pdfUrl: null,
+      pdf: null,
+      signing: {
+        required: true,
+        provider: "DOCUMENSO",
+        status: "IN_PROGRESS",
+        documentId: "44",
+        signerId: "user-9",
+        signerType: "PMS_USER",
+      },
+      signedBy: null,
+      signedAt: null,
+      createdAt: new Date("2026-06-13T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-13T00:00:00.000Z"),
+      signature: null,
+    });
+    mockedPrisma.documentSignature.create.mockResolvedValueOnce({
+      id: "sig-3",
+    });
+    // No appointmentId, caseId or encounterId at all - an org-level template
+    // instance with no clinical linkage.
+    mockedPrisma.templateInstance.update.mockResolvedValueOnce({
+      appointmentId: null,
+      caseId: null,
+      encounterId: null,
+    });
+    mockedPrisma.renderedDocument.update.mockResolvedValueOnce({
+      id: "doc-3",
+      status: "SIGNED",
+      signing: { status: "SIGNED" },
+      signature: null,
+    });
+
+    await completePersistedRenderedDocumentSigning("doc-3");
+
+    expect(mockedPrisma.case.findUnique).not.toHaveBeenCalled();
+    expect(mockedPrisma.encounter.findUnique).not.toHaveBeenCalled();
+    expect(mockedPrisma.appointment.findUnique).not.toHaveBeenCalled();
+    expect(mockedAuditTrailService.recordSafely).not.toHaveBeenCalled();
   });
 });

--- a/packages/types/src/rendered-document.ts
+++ b/packages/types/src/rendered-document.ts
@@ -13,11 +13,7 @@ export type RenderedDocumentKind =
   | 'INVOICE';
 
 export type RenderedDocumentSourceKind =
-  | 'TEMPLATE_INSTANCE'
-  | 'CLINICAL_ARTIFACT'
-  | 'FORM_SUBMISSION'
-  | 'TASK_SCHEDULE'
-  | 'INVOICE';
+  'TEMPLATE_INSTANCE' | 'CLINICAL_ARTIFACT' | 'FORM_SUBMISSION' | 'TASK_SCHEDULE' | 'INVOICE';
 
 export type RenderedDocumentStatus = 'DRAFT' | 'SIGNED';
 export type DocumentSignatureSignerType = 'PMS_USER' | 'PARENT' | 'SYSTEM';
@@ -62,6 +58,12 @@ export type RenderedDocumentSigning = {
   signerEmail?: string | null;
   signerName?: string | null;
   signingUrl?: string | null;
+  /**
+   * Carried from the sign-initiation request through to completion: the
+   * webhook that later finalises signing has no other way to recover what
+   * the signer typed, since Documenso itself is only asked for a PDF.
+   */
+  signatureText?: string | null;
   pdf?: {
     url?: string | null;
   } | null;


### PR DESCRIPTION
## Summary
- `listForPms`/`listConsentDocumentsForPms` only ever found a signed consent document through its `appointmentId`; one linked to a patient only via `caseId` or `encounterId` (no appointment at all) never showed up in the patient's Consents panel. Extends the existing appointment-only linkage to all three legs (`loadRenderedDocumentsForPatientRecords` + `loadCaseAndEncounterIdsForPatient`).
- `completePersistedRenderedDocumentSigning` (`rendered-document.service.ts`) and `handlePassportRecordEvent` (`documenso.controller.ts`) are the two places a Documenso webhook actually completes a signature. Both had real gaps at their shared call sites:
  - Signing never propagated to the linked `TemplateInstance`/`ClinicalArtifact` - both already have their own `SIGNED` status value, unused until now.
  - Zero audit trail events fired on either completion path, despite the audit service being used ~140 other places in this codebase. Added with a best-effort patientId resolver (case → encounter → appointment) that skips the audit rather than fabricating a patient when nothing resolves (e.g. an org-level template with no clinical link).
  - `DocumentSignature.signatureText` was accepted by the FHIR sign endpoint and typed end-to-end, but silently dropped before reaching the database - it never survived from sign-initiation to the later webhook-driven completion. Also reused `buildDocumentSignature`, an already-tested builder that existing code had never actually called.
  - `ClinicalArtifactAttestation.signedPdfUrl` existed on the schema specifically for this and was never written - the passport completion path never called the existing PDF-download helper at all.

## Why
Follow-up to the consent-visibility fix in #2939: a user report that a signed consent document still wasn't showing for a specific patient led to finding the narrower case/encounter-only gap. Digging further into the same signing-completion code surfaced the other four gaps above.

## Impact area
`apps/backend` (`document.service.ts`, `rendered-document.service.ts`, `documenso.controller.ts`) and `packages/types` (`RenderedDocumentSigning` gains a `signatureText` field to carry it through to completion).

## Validation performed
- Targeted Jest: `document.service.test.ts`, `rendered-document.service.test.ts`, `documenso.controller.test.ts` - 149/149 passing.
- Every new/changed assertion mutation-tested: broke the corresponding source line, confirmed the test fails, restored, re-confirmed green.
- `npx tsc --noEmit` clean on both `apps/backend` and `packages/types`.

## Not included
A "Requested" lifecycle tab stays permanently empty on the frontend - that's a documented, deliberate gap (`recordLifecycle.ts`'s own comment says as much), not something fixed here, since closing it needs a product decision on what "requested" means before any backend work.