### PR TITLE
fix(repo): widen staged secret scanner coverage

### DIFF
--- a/scripts/check-staged-secrets.js
+++ b/scripts/check-staged-secrets.js
@@ -2,9 +2,8 @@
 
 const { execFileSync } = require('node:child_process');
 
-const PROTECTED_ROOTS = ['apps/mobileAppYC/', 'apps/frontend/'];
 const BLOCKED_LOCAL_FILES = [
-  /^apps\/frontend\/\.env(?:$|\.local$|\.(?!example$).+)/,
+  /^(?:.*\/)?\.env(?:$|\.local$|\.(?!example$).+)/,
   /^apps\/mobileAppYC\/android\/app\/google-services\.json$/,
   /^apps\/mobileAppYC\/android\/app\/src\/main\/res\/values\/strings\.xml$/,
   /^apps\/mobileAppYC\/android\/gradle\.properties$/,
@@ -100,7 +99,10 @@ const runGitleaksWhenAvailable = () => {
       stdio: 'inherit',
     });
   } catch (error) {
-    if (error.code === 'ENOENT') return;
+    if (error.code === 'ENOENT') {
+      console.warn('Optional gitleaks scan skipped: gitleaks is not installed.');
+      return;
+    }
     process.exit(error.status ?? 1);
   }
 };
@@ -109,8 +111,6 @@ const getExtension = (file) => {
   const index = file.lastIndexOf('.');
   return index === -1 ? '' : file.slice(index).toLowerCase();
 };
-
-const isProtectedPath = (file) => PROTECTED_ROOTS.some((root) => file.startsWith(root));
 
 const isBlockedLocalFile = (file) => BLOCKED_LOCAL_FILES.some((pattern) => pattern.test(file));
 
@@ -155,7 +155,7 @@ const findLineNumber = (content, index) => content.slice(0, index).split('\n').l
 const findings = [];
 runGitleaksWhenAvailable();
 
-const stagedFiles = getStagedFiles().filter(isProtectedPath);
+const stagedFiles = getStagedFiles();
 
 for (const file of stagedFiles) {
   if (isBlockedLocalFile(file)) {

--- a/scripts/security/check-staged-secrets.test.mjs
+++ b/scripts/security/check-staged-secrets.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const script = fileURLToPath(new URL('../check-staged-secrets.js', import.meta.url));
+const systemPath = '/usr/bin:/bin';
+
+const createRepository = () => {
+  const root = mkdtempSync(join(tmpdir(), 'staged-secret-test-'));
+  execFileSync('git', ['init', '--quiet'], { cwd: root });
+  return root;
+};
+
+const stageFile = (root, file, content = 'ordinary test prose\n') => {
+  const path = join(root, file);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  execFileSync('git', ['add', '-f', file], { cwd: root });
+};
+
+const runScanner = (root) =>
+  spawnSync(process.execPath, [script], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: systemPath },
+  });
+
+test('warns when the optional gitleaks scan is unavailable', (t) => {
+  const root = createRepository();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = runScanner(root);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /Optional gitleaks scan skipped: gitleaks is not installed\./);
+});
+
+test('blocks dotenv derivatives outside frontend and mobile roots', (t) => {
+  const root = createRepository();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  stageFile(root, 'apps/backend/.env.probe');
+
+  const result = runScanner(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /apps\/backend\/\.env\.probe:1 \(local secrets file\)/);
+});
+
+test('allows dotenv examples outside frontend and mobile roots', (t) => {
+  const root = createRepository();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  stageFile(root, 'packages/database/.env.example');
+
+  const result = runScanner(root);
+
+  assert.equal(result.status, 0);
+  assert.doesNotMatch(result.stderr, /local secrets file/);
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The built-in staged-secret scanner only inspects frontend and mobile paths. If the optional `gitleaks` binary is unavailable, its scan is skipped without telling the contributor.

## What is the new behavior?

The built-in scanner now checks staged text files across the repository and blocks `.env` derivatives at any path while retaining the `.env.example` allowance. A missing optional `gitleaks` binary prints a clear warning. Integration tests exercise both fixes and the example-file allowance in temporary Git repositories.

Validation:

- `node --test scripts/security/check-staged-secrets.test.mjs`: 3 tests passed.
- `pnpm run test:scripts`: 483 tests passed.
- Pre-commit gitleaks, ESLint, Prettier, and secretlint checks passed.
- Pre-push monorepo lint and type-check completed successfully.

## Related Issue(s)

Fixes #2769
