### PR TITLE
fix(repo): scan every staged file for secrets

### DIFF
--- a/apps/backend/test/scripts/check-staged-secrets.test.ts
+++ b/apps/backend/test/scripts/check-staged-secrets.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const checker = resolve(
+  __dirname,
+  "../../../../scripts/check-staged-secrets.js",
+);
+const git = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+
+const runChecker = (files: Record<string, string>) => {
+  const repository = mkdtempSync(join(tmpdir(), "yc-staged-secret-"));
+
+  try {
+    const bin = join(repository, "bin");
+    mkdirSync(bin);
+    symlinkSync(git, join(bin, "git"));
+    const env = { ...process.env, PATH: bin };
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+
+    for (const [file, content] of Object.entries(files)) {
+      const target = join(repository, file);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, content);
+      execFileSync("git", ["add", "-f", "--", file], { cwd: repository });
+    }
+
+    const gitControl = spawnSync("git", ["--version"], { env });
+    expect(gitControl.status).toBe(0);
+
+    return spawnSync(process.execPath, [checker], {
+      cwd: repository,
+      encoding: "utf8",
+      env,
+    });
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
+};
+
+test("scans staged text files outside frontend and mobile", () => {
+  const value = ["fixture", "only", "not", "credential", "7Q9Z2X8M4"].join("-");
+  const result = runChecker({
+    "apps/backend/config.js": `const token = "${value}";`,
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toMatch(
+    /apps\/backend\/config\.js:1 \(generic secret assignment\)/,
+  );
+});
+
+test("blocks local env files outside frontend and mobile", () => {
+  const result = runChecker({
+    "packages/database/.env.local": "ordinary fixture prose",
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toMatch(
+    /packages\/database\/\.env\.local:1 \(local secrets file\)/,
+  );
+});
+
+test("warns when gitleaks is unavailable", () => {
+  const result = runChecker({});
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toMatch(/gitleaks is not installed/);
+});
+
+test("keeps env examples stageable", () => {
+  const result = runChecker({
+    "packages/auth/.env.example": "ordinary fixture prose",
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).not.toMatch(/local secrets file/);
+});

--- a/scripts/check-staged-secrets.js
+++ b/scripts/check-staged-secrets.js
@@ -2,9 +2,8 @@
 
 const { execFileSync } = require('node:child_process');
 
-const PROTECTED_ROOTS = ['apps/mobileAppYC/', 'apps/frontend/'];
 const BLOCKED_LOCAL_FILES = [
-  /^apps\/frontend\/\.env(?:$|\.local$|\.(?!example$).+)/,
+  /^(?:.*\/)?\.env(?:$|\.local$|\.(?!example$).+)/,
   /^apps\/mobileAppYC\/android\/app\/google-services\.json$/,
   /^apps\/mobileAppYC\/android\/app\/src\/main\/res\/values\/strings\.xml$/,
   /^apps\/mobileAppYC\/android\/gradle\.properties$/,
@@ -100,7 +99,12 @@ const runGitleaksWhenAvailable = () => {
       stdio: 'inherit',
     });
   } catch (error) {
-    if (error.code === 'ENOENT') return;
+    if (error.code === 'ENOENT') {
+      console.warn(
+        'Warning: gitleaks is not installed; continuing with the repository staged-secret scan.'
+      );
+      return;
+    }
     process.exit(error.status ?? 1);
   }
 };
@@ -109,8 +113,6 @@ const getExtension = (file) => {
   const index = file.lastIndexOf('.');
   return index === -1 ? '' : file.slice(index).toLowerCase();
 };
-
-const isProtectedPath = (file) => PROTECTED_ROOTS.some((root) => file.startsWith(root));
 
 const isBlockedLocalFile = (file) => BLOCKED_LOCAL_FILES.some((pattern) => pattern.test(file));
 
@@ -155,7 +157,7 @@ const findLineNumber = (content, index) => content.slice(0, index).split('\n').l
 const findings = [];
 runGitleaksWhenAvailable();
 
-const stagedFiles = getStagedFiles().filter(isProtectedPath);
+const stagedFiles = getStagedFiles();
 
 for (const file of stagedFiles) {
   if (isBlockedLocalFile(file)) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The repository-specific staged-secret scanner only inspects frontend and mobile paths. Staged backend, package, and root text files therefore rely on gitleaks alone, while a missing gitleaks binary is skipped without any warning.

## What is the new behavior?

The scanner now checks every staged text file, blocks local `.env` variants across the repository while preserving `.env.example`, and warns when gitleaks is unavailable. Backend Jest coverage exercises both gaps and the allowed example case.

## Related Issue(s)

Fixes #2769
