### PR TITLE
fix(frontend): close out the hardcoded-hex sweep

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/AuthShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/AuthShell.test.tsx
@@ -130,3 +130,20 @@ describe('brand panel reads ink and glow colours from real tokens', () => {
     expect(source).toMatch(/color-mix\(in srgb, var\(--pink\) 10%, transparent\)/);
   });
 });
+
+describe('the AuthShell story fixtures route their brand-emphasis ink through real tokens', () => {
+  const storiesSource = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/site/AuthShell.stories.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the pet-parent emphasis ink as a frozen literal', () => {
+    expect(storiesSource).not.toContain("color: '#8fb6f5'");
+    expect(storiesSource).toContain("color: 'var(--color-accent-dark)'");
+  });
+
+  it('does not hardcode the developer emphasis ink as a frozen literal', () => {
+    expect(storiesSource).not.toContain("color: '#5ce1e6'");
+    expect(storiesSource).toContain("color: 'var(--cyan)'");
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/marketing/site/SiteFooter.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/SiteFooter.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -57,5 +59,22 @@ describe('SiteFooter', () => {
     starsValue = null;
     render(<SiteFooter />);
     expect(screen.getByText('★')).toBeInTheDocument();
+  });
+});
+
+describe('the version-stat divider routes its tint through --page, not a frozen literal', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/site/SiteFooter.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the borderLeft as a frozen page-background literal', () => {
+    expect(source).not.toContain('rgba(239,232,220');
+  });
+
+  it('routes it through --page via color-mix', () => {
+    expect(source).toContain(
+      "borderLeft: '1px solid color-mix(in srgb, var(--page) 22%, transparent)'"
+    );
   });
 });

--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -629,3 +629,20 @@ describe('motion primitives', () => {
     fireEvent.mouseLeave(spot);
   });
 });
+
+describe('the shared hero scrim routes its fade through --page, not a frozen literal', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/site/motion.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode HERO_SCRIM_STYLE as a frozen page-background literal', () => {
+    expect(source).not.toContain('rgba(239,232,220');
+  });
+
+  it('routes all five HERO_SCRIM_STYLE gradient stops through --page via color-mix', () => {
+    const occurrences =
+      source.match(/color-mix\(in srgb, var\(--page\) \d+%, transparent\)/g) ?? [];
+    expect(occurrences).toHaveLength(5);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -233,5 +235,20 @@ describe('About (marketing)', () => {
       'href',
       '/contact-us'
     );
+  });
+});
+
+describe('the origin-photo frame background routes through --page, not a frozen literal', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/About/About.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode it as a frozen page-background literal', () => {
+    expect(source).not.toContain('rgba(239,232,220');
+  });
+
+  it('routes it through --page via color-mix', () => {
+    expect(source).toContain("background: 'color-mix(in srgb, var(--page) 6%, transparent)'");
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -455,5 +457,43 @@ describe('ContactusPage', () => {
       expect(screen.queryByText('submitting...')).not.toBeInTheDocument();
       expect(screen.getByText('Send message')).toBeInTheDocument();
     });
+  });
+});
+
+describe('ContactusPage routes its danger/blue/success accents through real tokens', () => {
+  // --color-danger-700, --blue and --success all flip per theme; the icon glyphs already
+  // read them via var(), so a frozen literal alongside them (the required-mark asterisk,
+  // the submit error, or an icon's bg/border tint) would silently stop matching the glyph
+  // colour the moment the theme flips. Source-text assertions, not computed-style ones:
+  // color-mix()/var() are opaque strings to jsdom, so getComputedStyle can't resolve them.
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the danger red as a frozen literal', () => {
+    expect(source).not.toContain("'#d53225'");
+  });
+
+  it('routes both danger-red usages through --color-danger-700', () => {
+    const occurrences = source.match(/var\(--color-danger-700\)/g) ?? [];
+    expect(occurrences).toHaveLength(2);
+  });
+
+  it('routes the email channel-card tint through --blue via color-mix', () => {
+    expect(source).toContain('iconBg="color-mix(in srgb, var(--blue) 10%, transparent)"');
+    expect(source).toContain('iconBorder="color-mix(in srgb, var(--blue) 18%, transparent)"');
+  });
+
+  it('routes the phone channel-card tint and the success-confirmation icon through --success via color-mix', () => {
+    expect(source).toContain('iconBg="color-mix(in srgb, var(--success) 10%, transparent)"');
+    expect(source).toContain('iconBorder="color-mix(in srgb, var(--success) 18%, transparent)"');
+    expect(source).toContain("background: 'color-mix(in srgb, var(--success) 12%, transparent)'");
+  });
+
+  it('leaves the Discord channel-card on its own brand colour, unmigrated', () => {
+    // Discord's official blurple - not a design-system token, so it should NOT be touched.
+    expect(source).toContain('iconBg="rgba(88,101,242,0.12)"');
+    expect(source).toContain('iconColor="#5865F2"');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/PetBusinesses.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PetBusinesses.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -195,5 +197,22 @@ describe('PetBusinesses page', () => {
 
     const statement = screen.getByText(/There's a dog-eared notebook next to the keyboard/);
     expect(statement.parentElement).toHaveStyle({ color: 'var(--spot-ink)' });
+  });
+});
+
+describe('the desktop-app status dot pulse routes through --success, not a frozen literal', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the pulse-ring as a frozen success literal', () => {
+    expect(source).not.toContain('rgba(0,143,93');
+  });
+
+  it('routes the pulse-ring through --success via color-mix', () => {
+    expect(source).toContain(
+      "boxShadow: '0 0 0 3px color-mix(in srgb, var(--success) 16%, transparent)'"
+    );
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/PetParents.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PetParents.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -115,5 +117,36 @@ describe('PetParents page', () => {
 
     const statement = screen.getByText(/When Germaine moved from the UK to Barcelona/);
     expect(statement).toHaveStyle({ color: 'var(--spot-ink)' });
+  });
+});
+
+describe('the phone mockup and hero scrim route their tints through real tokens', () => {
+  // color-mix()/var() are opaque strings to jsdom's getComputedStyle, so these are
+  // source-text assertions rather than rendered ones (same technique as Insights.test.tsx).
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/PetParents/PetParents.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the phone bezel/notch as a frozen literal', () => {
+    expect(source).not.toContain("'#1d1c1b'");
+  });
+
+  it('routes the phone bezel and notch pill through --spot', () => {
+    // The phone body's own background and the notch pill are two of the three var(--spot)
+    // background usages in this file (the third, pre-existing one is the Spotlight section
+    // wrapper) - anchoring on the count keeps this sensitive to those two sites reverting.
+    const occurrences = source.match(/background:\s*'var\(--spot\)'/g) ?? [];
+    expect(occurrences).toHaveLength(3);
+  });
+
+  it('does not hardcode the hero scrim fade as a frozen page-background literal', () => {
+    expect(source).not.toContain('rgba(239,232,220');
+  });
+
+  it('routes all eight hero-scrim gradient stops through --page via color-mix', () => {
+    const occurrences =
+      source.match(/color-mix\(in srgb, var\(--page\) \d+%, transparent\)/g) ?? [];
+    expect(occurrences).toHaveLength(8);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Pricing.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Pricing.marketing.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -79,5 +81,17 @@ describe('Pricing (marketing)', () => {
 
     expect(screen.getByText('Do you take a cut of my payments?')).toBeInTheDocument();
     expect(screen.getByText('Is it really free?')).toBeInTheDocument();
+  });
+});
+
+describe('the active billing-toggle pill routes its background through --spot, not a frozen literal', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/features/marketing/pages/Pricing/Pricing.tsx'),
+    'utf8'
+  );
+
+  it('does not hardcode the active pill background as a frozen literal', () => {
+    expect(source).toContain("background: active ? 'var(--spot)' : 'transparent'");
+    expect(source).not.toContain("background: active ? '#1d1c1b' : 'transparent'");
   });
 });

--- a/apps/frontend/src/app/features/marketing/pages/About/About.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/About/About.tsx
@@ -299,7 +299,7 @@ function Origin() {
               aspectRatio: '3 / 2',
               borderRadius: '28px',
               overflow: 'hidden',
-              background: 'rgba(239,232,220,0.06)',
+              background: 'color-mix(in srgb, var(--page) 6%, transparent)',
             }}
           >
             <Image

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -272,7 +272,7 @@ const VISUALLY_HIDDEN_INPUT_STYLE: CSSProperties = {
 };
 
 const requiredMark = (
-  <span aria-hidden="true" style={{ color: '#d53225' }}>
+  <span aria-hidden="true" style={{ color: 'var(--color-danger-700)' }}>
     {' '}
     *
   </span>
@@ -669,8 +669,8 @@ function ContactHero() {
       >
         <ChannelCard
           href="mailto:support@yosemitecrew.com"
-          iconBg="rgba(37,123,237,0.10)"
-          iconBorder="rgba(37,123,237,0.18)"
+          iconBg="color-mix(in srgb, var(--blue) 10%, transparent)"
+          iconBorder="color-mix(in srgb, var(--blue) 18%, transparent)"
           iconColor="var(--blue)"
           icon={<IoAtOutline aria-hidden="true" style={{ fontSize: 22 }} />}
           kicker="Email"
@@ -678,8 +678,8 @@ function ContactHero() {
         />
         <ChannelCard
           href="tel:+4915227763275"
-          iconBg="rgba(0,143,93,0.10)"
-          iconBorder="rgba(0,143,93,0.18)"
+          iconBg="color-mix(in srgb, var(--success) 10%, transparent)"
+          iconBorder="color-mix(in srgb, var(--success) 18%, transparent)"
           iconColor="var(--success)"
           icon={<IoCallOutline aria-hidden="true" style={{ fontSize: 20 }} />}
           kicker="Phone"
@@ -688,6 +688,8 @@ function ContactHero() {
         <ChannelCard
           href={DISCORD_INVITE_URL}
           external
+          // Discord's own brand blurple (#5865F2) - not a design-system colour, so
+          // it stays a literal rather than being pointed at an unrelated token.
           iconBg="rgba(88,101,242,0.12)"
           iconBorder="rgba(88,101,242,0.22)"
           iconColor="#5865F2"
@@ -954,7 +956,7 @@ function SubmitError({ message }: Readonly<{ message: string }>) {
         alignItems: 'center',
         gap: 8,
         fontSize: 14,
-        color: '#d53225',
+        color: 'var(--color-danger-700)',
         letterSpacing: '-0.01em',
       }}
     >
@@ -1178,7 +1180,7 @@ const SUCCESS_ICON_STYLE: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  background: 'rgba(0,143,93,0.12)',
+  background: 'color-mix(in srgb, var(--success) 12%, transparent)',
   color: 'var(--success)',
 };
 

--- a/apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx
@@ -554,7 +554,7 @@ function HeroDownloadRow({ macRef, winRef }: Readonly<HeroDownloadRowProps>) {
             height: 7,
             borderRadius: 9999,
             background: 'var(--success)',
-            boxShadow: '0 0 0 3px rgba(0,143,93,0.16)',
+            boxShadow: '0 0 0 3px color-mix(in srgb, var(--success) 16%, transparent)',
           }}
         />
         {'Runs offline. Get the desktop app'}

--- a/apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx
@@ -362,7 +362,7 @@ function HeroPhone() {
       <div
         style={{
           width: 300,
-          background: '#1d1c1b',
+          background: 'var(--spot)',
           borderRadius: 46,
           padding: 8,
           boxShadow: '0 40px 90px var(--sh20)',
@@ -378,7 +378,9 @@ function HeroPhone() {
             }}
           >
             <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--ink-body)' }}>9:41</span>
-            <span style={{ width: 78, height: 22, borderRadius: 9999, background: '#1d1c1b' }} />
+            <span
+              style={{ width: 78, height: 22, borderRadius: 9999, background: 'var(--spot)' }}
+            />
             <span style={{ display: 'flex', gap: 4, color: 'var(--ink-body)' }}>
               <IoCellular style={{ fontSize: 12 }} aria-hidden="true" />
               <IoBatteryFull style={{ fontSize: 14 }} aria-hidden="true" />
@@ -567,7 +569,7 @@ function Hero() {
           zIndex: 1,
           pointerEvents: 'none',
           background:
-            'radial-gradient(74% 72% at 32% 50%, rgba(239,232,220,0.95) 0%, rgba(239,232,220,0.66) 38%, rgba(239,232,220,0.12) 72%, rgba(239,232,220,0) 86%), linear-gradient(180deg, rgba(239,232,220,0.6) 0%, rgba(239,232,220,0.3) 46%, rgba(239,232,220,0.06) 74%, rgba(239,232,220,0) 92%)',
+            'radial-gradient(74% 72% at 32% 50%, color-mix(in srgb, var(--page) 95%, transparent) 0%, color-mix(in srgb, var(--page) 66%, transparent) 38%, color-mix(in srgb, var(--page) 12%, transparent) 72%, color-mix(in srgb, var(--page) 0%, transparent) 86%), linear-gradient(180deg, color-mix(in srgb, var(--page) 60%, transparent) 0%, color-mix(in srgb, var(--page) 30%, transparent) 46%, color-mix(in srgb, var(--page) 6%, transparent) 74%, color-mix(in srgb, var(--page) 0%, transparent) 92%)',
         }}
       />
       <HeroGlow

--- a/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx
@@ -80,7 +80,7 @@ const billingBtnStyle = (active: boolean): React.CSSProperties => ({
   fontWeight: 600,
   letterSpacing: '-0.01em',
   transition: 'color 200ms, background 200ms',
-  background: active ? '#1d1c1b' : 'transparent',
+  background: active ? 'var(--spot)' : 'transparent',
   color: active ? '#f7f3ec' : 'var(--ink-muted)',
 });
 

--- a/apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx
@@ -94,7 +94,10 @@ const ClinicBrand = () => (
     eyebrow="Open-source operating system for animal health"
     title={
       <>
-        See the <em style={{ fontStyle: 'italic', fontWeight: 500, color: '#8fb6f5' }}>whole</em>{' '}
+        See the{' '}
+        <em style={{ fontStyle: 'italic', fontWeight: 500, color: 'var(--color-accent-dark)' }}>
+          whole
+        </em>{' '}
         animal.
       </>
     }
@@ -109,7 +112,9 @@ const DeveloperBrand = () => (
     title={
       <>
         Build it in{' '}
-        <em style={{ fontStyle: 'italic', fontWeight: 500, color: '#5ce1e6' }}>an afternoon.</em>
+        <em style={{ fontStyle: 'italic', fontWeight: 500, color: 'var(--cyan)' }}>
+          an afternoon.
+        </em>
       </>
     }
     subtitle="A FHIR-native API, a plugin system, and a codebase you can actually read. Publish once and reach every clinic running Yosemite Crew."

--- a/apps/frontend/src/app/features/marketing/site/SiteFooter.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteFooter.tsx
@@ -113,7 +113,7 @@ const STAR_COUNT_STYLE: CSSProperties = {
   gap: 4,
   paddingLeft: 11,
   marginLeft: 2,
-  borderLeft: '1px solid rgba(239,232,220,0.22)',
+  borderLeft: '1px solid color-mix(in srgb, var(--page) 22%, transparent)',
   color: '#e5dccf',
   fontVariantNumeric: 'tabular-nums',
 };

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -37,7 +37,7 @@ const HERO_SCRIM_STYLE: CSSProperties = {
   zIndex: 1,
   pointerEvents: 'none',
   background:
-    'linear-gradient(180deg, rgba(239,232,220,0.66) 0%, rgba(239,232,220,0.54) 40%, rgba(239,232,220,0.22) 64%, rgba(239,232,220,0.04) 92%, rgba(239,232,220,0) 100%)',
+    'linear-gradient(180deg, color-mix(in srgb, var(--page) 66%, transparent) 0%, color-mix(in srgb, var(--page) 54%, transparent) 40%, color-mix(in srgb, var(--page) 22%, transparent) 64%, color-mix(in srgb, var(--page) 4%, transparent) 92%, color-mix(in srgb, var(--page) 0%, transparent) 100%)',
 };
 
 /** Static base for the scroll-progress bar; width is applied inline from scroll state. */

--- a/scripts/ci/hardcoded-colours-baseline.json
+++ b/scripts/ci/hardcoded-colours-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "scripts/ci/check-hardcoded-colours.mjs --update",
-  "generated_at": "31a4286867c80eaab3ca709d499a343fc5b2e600",
-  "total": 65,
+  "generated_at": "dd20db6ed9703b8ee8c5d79bda2b938983dbbae5",
+  "total": 0,
   "justified": {
     "apps/frontend/src/app/(routes)/(app)/chat/page.css": {
       "n": 1,
@@ -239,6 +239,14 @@
       "n": 2,
       "why": "CARD_BG (#faf7f1) and a border colour (#e6ded1) are close to but not exact matches for any token (--color-screen is #f7f3ec, --color-hairline is #e5dccf) - left as literals when PR #2963 tokenised this file's other 8 exact-match literals, and still not exact matches now."
     },
+    "apps/frontend/src/app/features/marketing/pages/About/About.tsx": {
+      "n": 3,
+      "why": "'#454341' is a bespoke faint border on a --spot-ink-tinted button, no exact match in the token set (checked --ink/--ink-body/--divider/--hairline families). '#e0d8ce' (the two borderTop dividers) is likewise a bespoke divider tint close to but distinct from --divider (#d6d1cd) and --hairline (#e5dccf) - checked both, neither is an exact match, so migrating would shift the rendered value rather than preserve it."
+    },
+    "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": {
+      "n": 3,
+      "why": "Discord's own brand blurple (rgb(88,101,242) / #5865F2), used only for the Discord channel-card icon - not a design-system colour, so it stays a literal rather than being pointed at an unrelated token."
+    },
     "apps/frontend/src/app/features/marketing/pages/DevelopersPage/DevelopersPage.tsx": {
       "n": 30,
       "why": "Three unrelated groups of deliberate illustration colours, none derivable from an existing token without changing the rendered value: (1) the fake terminal/code-editor mockup's remaining chrome (traffic-light dots #454341, header rule #302f2e, terminal body text #d6d1cd, '&&' operator #5c5956) - its string colour (#8acbb4) and '$' prompt (#54b492) were tokenised via the fixed --color-success-300/-400 ramp entries once that ramp was discovered to be fixed (see this PR); (2) the '0% platform cut' comparison-bar illustration (track #2c2926, border #35322f, striped fill #4a4643/#423e3b, and the already-investigated #2f6fc0 border - see PR #2977) plus its own bespoke near-black gradient card (#232120 to #1a1918, border #35322f); (3) three icon glyphs at a single-file-only muted grey (#6f6a66, not reused elsewhere), two fixed-white ink spots (#ffffff) on fills that are themselves fixed (the 100%-filled blue bar, and the '0%' hero figure on --spot), and one decorative gloss overlay (rgba(255,255,255,0.18)) - the same justified pattern as ChatContainer.css's white-on-fixed-blue ink, just inline rather than in a stylesheet."
@@ -247,17 +255,57 @@
       "n": 9,
       "why": "The same fake terminal/code-editor mockup chrome justified in DevelopersPage.tsx (traffic-light dots #454341 x3, header rule #302f2e x2, terminal body text #d6d1cd - its string/prompt colours were tokenised via --color-success-300/-500 in this PR, same as DevelopersPage.tsx's). Plus two more single-file bespoke spots: an avatar-stack placeholder background (#e6e3e0) and a phone-mockup bezel (#1d1c1b x2) - the bezel is a physical-device colour on a decorative illustration, not a themed app surface, the same reasoning as the media-overlay literals justified in Guides.tsx and InClinicTodayBand.tsx (PR #2990)."
     },
+    "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": {
+      "n": 1,
+      "why": "FALLBACK_LANGUAGE_COLOUR is a computed-style assertion (documented at the const) - the resolved form of --spot-ink-faint (#a9a39e), asserted against the rendered swatch colour for the one language with no explicit LANG_COLORS entry."
+    },
     "apps/frontend/src/app/features/marketing/pages/Insights/Insights.tsx": {
       "n": 17,
       "why": "Two --spot cards (a live GitHub-stats console, a latest-release card - both background: var(--spot)) carry four DIFFERENT close-but-not-identical muted-grey inks (#8a8074 x5, #6b6155 x2, #a89e90 x2 - the dark-mode value of the flipping --ink-muted, hardcoded because the card itself never flips - plus the already-tokenised #f4efe6 in this PR), none matching --spot-ink-faint's #a9a39e exactly, so each was picked independently rather than drawn from a shared token. Also on the same console: a bespoke near-black panel (#232120, border #302f2e x3, matching DevelopersPage.tsx's EconomicsCard pattern), a 'LIVE' status pair (dot #2bbd86 - --success's dark-mode value, no matching --spot-success-strength token exists - and its paired label #6cd6a3), the shared terminal-mockup text colour #d6d1cd (see DevelopersPage.tsx), and the shared bespoke CTA border #454341 (see DevelopersPage.tsx's CLOSING_PORTAL_LINK_STYLE)."
+    },
+    "apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx": {
+      "n": 2,
+      "why": "'#837d78' is a bespoke faint/secondary label tint (also used identically in SiteFooter.tsx) with no exact match in --ink-faint/--ink-muted/--ink-body. '#e6ded1' is a bespoke section divider on a var(--page) surface, distinct from --divider (#d6d1cd) and --hairline (#e5dccf) - checked both, no exact match."
+    },
+    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.stories.tsx": {
+      "n": 3,
+      "why": "'rgb(29, 28, 27)' and 'rgba(0, 0, 0, 0)' are computed-style assertions pinning the billing toggle's on/off pill background (documented at the const declaration) - getComputedStyle() only ever returns a resolved colour, never a token name, so there is no token-referencing form to migrate to; the value matches the now-tokenized var(--spot) exactly. '#1d1c1b' at line 117 is inside the story's markdown doc-string prose, not a rendered style."
+    },
+    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": {
+      "n": 8,
+      "why": "All eight sit on BusinessPlanCard's var(--spot) always-dark surface as ink/foreground colours, not backgrounds. '#f7f3ec' (the billing-toggle active label and the CTA chip background) is close to but not an exact match for --spot-ink (#eae2d5/#f4efe6) or --screen (which flips) - checked both. The two '#1d1c1b' ink usages (badgeColor on a --spot-blue badge, and the CTA chip's own text) match --spot's value exactly but --spot is a surface token, not an ink token, and reusing it for a foreground role was already rejected as a pattern in DeveloperDocs' .DocsMethod (PR #2984) - same call here for consistency. '#ffffff' is the oversized price figure's intentionally stronger-than-spot-ink emphasis colour. '#d6d1cd' (feature copy + the PlanFeatureList colour prop) coincidentally matches --divider's light-mode value, but --divider flips (to #3a3128) and this is ink on an always-dark card, not a border, so using it would go invisible in dark mode - a false match, not a real one. '#302f2e' is the feature-list's own divider line colour on that same always-dark card; sibling cards use var(--inset) for this, which isn't available here since --inset flips and would vanish against --spot."
+    },
+    "apps/frontend/src/app/features/marketing/site/assets.ts": {
+      "n": 2,
+      "why": "Same GITHUB_STAR_CTA_STYLE pairing as Pricing.tsx's BUSINESS_CTA_STYLE (see that entry) - '#f7f3ec' has no exact fixed-token match and '#1d1c1b' is ink-on-a-light-chip, not the --spot surface role, so it stays a literal for the same reason as .DocsMethod (PR #2984)."
     },
     "apps/frontend/src/app/features/marketing/site/AuthShell.tsx": {
       "n": 8,
       "why": "The brand panel's own bespoke near-black gradient (#2a2723 to #131210, matching DevelopersPage.tsx's EconomicsCard pattern - see PR #2992). The remaining five (subtitle/footer ink #b7ac9d x2, point text #d8cec0, star icon gold #ffd479, 'Star on GitHub' emphasis white #fff) are single-file bespoke choices with no matching token - #fff in particular is a deliberately brighter emphasis colour next to surrounding --spot-ink copy, the same pattern as Pricing.tsx's price figure and DevelopersPage.tsx's '0%' hero figure."
     },
+    "apps/frontend/src/app/features/marketing/site/marketing.css": {
+      "n": 1,
+      "why": "A pure-white gloss/sheen highlight on .yc-btn-primary's hover sweep - a lightening overlay independent of theme, not tied to any ink/surface token."
+    },
     "apps/frontend/src/app/features/marketing/site/MarketingShell.stories.tsx": {
       "n": 2,
       "why": "Every occurrence in this file is a Storybook play-function test assertion (or a local const it is assigned through) comparing a computed style against 'rgba(0, 0, 0, 0)' - the browser's own canonical getComputedStyle() value for 'nothing painted here', not a colour authored in this codebase. A design-token reference would never match a computed style string, so the literal has to stay exactly this to keep testing what it tests."
+    },
+    "apps/frontend/src/app/features/marketing/site/motion.stories.tsx": {
+      "n": 2,
+      "why": "Bespoke demo-only styling for the Spotlight story's illustration box, with no exact match in the token set - not a real page surface."
+    },
+    "apps/frontend/src/app/features/marketing/site/motion.tsx": {
+      "n": 2,
+      "why": "The Spotlight component's cursor-follow glow colour (rgb(90,160,255)) - a distinct, brighter blue chosen for this specific hover effect, not an exact match for --blue (rgb(37,123,237)) or any --glow-b* stop."
+    },
+    "apps/frontend/src/app/features/marketing/site/SiteFooter.stories.tsx": {
+      "n": 2,
+      "why": "Computed-style assertions (documented at the call site) pinning the footer status dot's colours, including 'rgb(29, 107, 79)' which is the resolved form of SiteFooter.tsx's own #1d6b4f literal (see that file's entry above) - getComputedStyle() never returns a token name, so there's nothing to migrate to."
+    },
+    "apps/frontend/src/app/features/marketing/site/SiteFooter.tsx": {
+      "n": 8,
+      "why": "'#e0dcd8' (x2, an outline-pill border and a divider) and '#cfe9dd' (another outline-pill border) are bespoke tints with no exact token match (checked --divider/--hairline/--pill-raised families). '#e5dccf' coincidentally matches --hairline's light-mode value but is used here as text ink, not a border, and --hairline flips - a false match. '#837d78' (x2) is the same bespoke faint-label tint used in PetBusinesses.tsx. '#f5c518' is GitHub's own star-icon yellow, not a design-system colour. '#1d6b4f' is STATUS_TONE_TEXT.success - its siblings (warning/danger) already read var(--amber)/var(--danger), so this one not following the theme looks like a genuine gap, but no existing token matches #1d6b4f exactly (closest is --success-text at #006642/#2bbd86, a different shade) - migrating it would change the rendered colour, not preserve it, so it's flagged here rather than silently changed; worth a follow-up if the mismatch turns out to matter in dark mode."
     },
     "apps/frontend/src/app/features/marketing/site/useRepoInsights.ts": {
       "n": 12,
@@ -364,20 +412,5 @@
       "why": "A warm-brown 8-digit-hex box-shadow (~10% alpha) with no exact match in --sh* or --ink (#1d1c1b) - a distinct bespoke value."
     }
   },
-  "files": {
-    "apps/frontend/src/app/features/marketing/pages/About/About.tsx": 4,
-    "apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx": 10,
-    "apps/frontend/src/app/features/marketing/pages/Insights/Insights.stories.tsx": 1,
-    "apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx": 3,
-    "apps/frontend/src/app/features/marketing/pages/PetParents/PetParents.tsx": 10,
-    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.stories.tsx": 3,
-    "apps/frontend/src/app/features/marketing/pages/Pricing/Pricing.tsx": 9,
-    "apps/frontend/src/app/features/marketing/site/assets.ts": 2,
-    "apps/frontend/src/app/features/marketing/site/AuthShell.stories.tsx": 2,
-    "apps/frontend/src/app/features/marketing/site/marketing.css": 1,
-    "apps/frontend/src/app/features/marketing/site/motion.stories.tsx": 2,
-    "apps/frontend/src/app/features/marketing/site/motion.tsx": 7,
-    "apps/frontend/src/app/features/marketing/site/SiteFooter.stories.tsx": 2,
-    "apps/frontend/src/app/features/marketing/site/SiteFooter.tsx": 9
-  }
+  "files": {}
 }


### PR DESCRIPTION
## What changed

Resolves the last 65 unjustified literals flagged by `check-hardcoded-colours.mjs` (all inside `features/marketing`) - the baseline is now **0 to migrate**, closing out the sweep that started this session at 460+.

28 are real token fixes; 37 are justified (bespoke, or coincidentally matching a token that isn't the right one for the role) with a `why` in the baseline JSON explaining exactly what was checked.

## Real fixes - one confirmed bug pattern, found in three places

A hero-video scrim gradient hardcoded `--page`'s light-mode RGB directly instead of reading the token: `motion.tsx`'s shared `HERO_SCRIM_STYLE`, `PetParents.tsx`'s own local override of the same scrim, and a version-stat divider in `SiteFooter.tsx`. In dark mode the scrim/divider stayed pinned to warm cream while the surrounding page correctly flips to espresso, producing a visible seam - the same class of bug as the marketing hero-video dark-mode fix earlier this week. Routed every gradient stop through `color-mix(in srgb, var(--page) N%, transparent)`; verified live in both themes (screenshots below).

Other real fixes, same "literal frozen at one theme's RGB, next to a sibling that already reads the token" pattern:
- `ContactusPage.tsx`: email/phone channel-card icon tints and the success-confirmation icon hardcoded `--blue`/`--success`'s light RGB right next to an `iconColor` that already read the token directly - verified live via computed style that the icon glyph and its tint now agree in both themes.
- `ContactusPage.tsx`: the required-mark asterisk and submit-error text hardcoded `--color-danger-700`'s light value - verified live it now reads the more legible dark-mode red instead of staying frozen.
- `PetBusinesses.tsx`: the offline-app status dot's pulse ring hardcoded `--success`'s RGB, same pattern already fixed on two other pulse rings earlier in this sweep (#2966, #2979).
- `PetParents.tsx` / `Pricing.tsx`: phone-mockup bezel/notch and the active billing-toggle pill both hardcoded `--spot`'s exact value in its native background/surface role.
- `AuthShell.stories.tsx`: two brand-emphasis `<em>` colours duplicated literals already fixed in the real SignIn/SignUp/AuthShell components (#2990, #2993) but never got the same fix in the story fixture.

## Justified (no exact token match, or role mismatch)

Checked every remaining literal against the full token set before justifying, not just the obvious families:
- Discord's own brand blurple, GitHub's star yellow - not design-system colours.
- Several coincidental matches to tokens that *flip* (`--divider`, `--hairline`, `--ink-body`) but are used here in an **ink** role on an always-dark `--spot` card, not their native border/surface role - using the flipping token would go invisible in dark mode, so these are false matches, not real ones.
- Computed-style test assertions (`getComputedStyle()` only ever returns a resolved colour, never a token name).
- A handful of bespoke tints with no match anywhere in `globals.css`.
- `SiteFooter.tsx`'s `STATUS_TONE_TEXT.success` (`#1d6b4f`) is flagged but deliberately left alone: its warning/danger siblings already flip via tokens and this one doesn't, which reads like a possible latent dark-mode gap - but no existing token is an exact match, so migrating it would change the rendered colour rather than preserve it. Noted in the baseline `why` as worth a follow-up if it turns out to matter.

## Testing

- Added/extended guard tests for every real fix (source-text assertions, since `color-mix()`/`var()` are opaque strings to jsdom's `getComputedStyle`).
- Mutation-checked each one individually, then did a full bulk revert/restore across all eight touched source files at once and confirmed all 17 new/extended assertions fail together, then pass again once restored.
- `npx tsc --noemit`: clean.
- `pnpm --filter frontend run lint`: 0 errors (1 pre-existing warning, unrelated file).
- Full touched-suite: 110/110 passing.
- Live-verified in the browser, both themes: the `PetParents` hero scrim/phone-bezel fix and the `ContactusPage` icon-tint/danger-colour fixes (screenshots taken during development, not attached here - happy to add if useful).

## Impact

Frontend only, CSS/JSON/test changes. No visual change in light mode anywhere (every real fix preserves the exact light-mode pixel value). Dark mode changes are all fixes to a previously-invisible-in-light-mode mismatch.