### PR TITLE
fix(backend): log unconfigured SuperAdmin contact mirroring

### DIFF
--- a/apps/backend/src/services/superadmin-contact.service.ts
+++ b/apps/backend/src/services/superadmin-contact.service.ts
@@ -26,7 +26,14 @@ export const SuperadminContactService = {
   ): Promise<void> {
     const url = process.env.SUPERADMIN_CONTACT_INTAKE_URL;
     const key = process.env.SUPERADMIN_CONTACT_INTAKE_KEY;
-    if (!url || !key) return;
+    if (!url || !key) {
+      logger.warn("SuperAdmin contact mirroring is not configured", {
+        missing: !url
+          ? "SUPERADMIN_CONTACT_INTAKE_URL"
+          : "SUPERADMIN_CONTACT_INTAKE_KEY",
+      });
+      return;
+    }
 
     try {
       const response = await fetch(url, {

--- a/apps/backend/test/services/superadmin-contact.service.test.ts
+++ b/apps/backend/test/services/superadmin-contact.service.test.ts
@@ -49,22 +49,29 @@ describe("SuperadminContactService.forwardWebContact", () => {
     process.env.SUPERADMIN_CONTACT_INTAKE_KEY = "shared-secret";
   };
 
-  it("does nothing when the URL is unset", async () => {
+  it("warns naming the missing var and does not fetch when the URL is unset", async () => {
     process.env.SUPERADMIN_CONTACT_INTAKE_KEY = "shared-secret";
     delete process.env.SUPERADMIN_CONTACT_INTAKE_URL;
     await SuperadminContactService.forwardWebContact(PAYLOAD);
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(warnMock).not.toHaveBeenCalled();
     expect(errorMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(
+      "SuperAdmin contact mirroring is not configured",
+      { missing: "SUPERADMIN_CONTACT_INTAKE_URL" },
+    );
   });
 
-  it("does nothing when the key is unset", async () => {
+  it("warns naming the missing var and does not fetch when the key is unset", async () => {
     process.env.SUPERADMIN_CONTACT_INTAKE_URL =
       "https://panel.example.com/api/contact";
     delete process.env.SUPERADMIN_CONTACT_INTAKE_KEY;
     await SuperadminContactService.forwardWebContact(PAYLOAD);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(errorMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(
+      "SuperAdmin contact mirroring is not configured",
+      { missing: "SUPERADMIN_CONTACT_INTAKE_KEY" },
+    );
   });
 
   it("posts the payload verbatim with the shared key and a timeout", async () => {


### PR DESCRIPTION
## Summary
- `SuperadminContactService.forwardWebContact` returned silently when the mirror env vars were unset, unlike every other outcome on this path (rejected/errored are both logged).
- Adds one `logger.warn` naming the missing var, matching the pattern already used on the SuperAdmin receiving side (`intakeGuard.ts`).
- Updates the two existing tests that previously asserted the silence.

Closes #2767.

## Test plan
- [x] `apps/backend`: targeted jest run for `superadmin-contact.service` — 5/5 pass, 100% statement/branch/func/line coverage on the changed file
- [x] `pnpm --filter backend run lint` — 0 errors (24 pre-existing warnings, same as dev)
- [x] `pnpm --filter backend run type-check` — clean
- [x] pre-push hook (full monorepo lint + type-check) — clean