### PR TITLE
fix(repo): retire inert public booking auto-confirmation

### DIFF
--- a/apps/backend/src/controllers/web/booking-page.controller.ts
+++ b/apps/backend/src/controllers/web/booking-page.controller.ts
@@ -32,7 +32,6 @@ const SettingsSchema = z.object({
   serviceIds: z.array(z.uuid()).max(200),
   bookingWindowDays: z.number().int().min(1).max(180),
   bufferMinutes: z.number().int().min(0).max(240),
-  autoConfirm: z.boolean(),
   welcomeMessage: z.string().trim().max(500).nullish(),
   replyToEmail: z.string().trim().pipe(z.email().max(254)).nullish(),
   // Optional on purpose: a caller that omits it is saving settings, not
@@ -105,7 +104,6 @@ export const BookingPageController = {
         serviceIds: parsed.data.serviceIds,
         bookingWindowDays: parsed.data.bookingWindowDays,
         bufferMinutes: parsed.data.bufferMinutes,
-        autoConfirm: parsed.data.autoConfirm,
         welcomeMessage: parsed.data.welcomeMessage ?? null,
         replyToEmail: parsed.data.replyToEmail ?? null,
         publicBookingEnabled: parsed.data.publicBookingEnabled,

--- a/apps/backend/src/services/booking-page.service.ts
+++ b/apps/backend/src/services/booking-page.service.ts
@@ -404,7 +404,6 @@ export type BookingPageConfig = {
   serviceIds: string[];
   bookingWindowDays: number;
   bufferMinutes: number;
-  autoConfirm: boolean;
   welcomeMessage: string | null;
   replyToEmail: string | null;
 };
@@ -419,7 +418,6 @@ const toConfig = (
     serviceIds: string[];
     bookingWindowDays: number;
     bufferMinutes: number;
-    autoConfirm: boolean;
     welcomeMessage: string | null;
     replyToEmail: string | null;
   } | null,
@@ -435,7 +433,6 @@ const toConfig = (
   serviceIds: settings?.serviceIds ?? [],
   bookingWindowDays: settings?.bookingWindowDays ?? DEFAULT_BOOKING_WINDOW_DAYS,
   bufferMinutes: settings?.bufferMinutes ?? DEFAULT_BUFFER_MINUTES,
-  autoConfirm: settings?.autoConfirm ?? false,
   welcomeMessage: settings?.welcomeMessage ?? null,
   replyToEmail: settings?.replyToEmail ?? null,
 });
@@ -444,7 +441,6 @@ export type BookingPageSettingsInput = {
   serviceIds: string[];
   bookingWindowDays: number;
   bufferMinutes: number;
-  autoConfirm: boolean;
   welcomeMessage?: string | null;
   replyToEmail?: string | null;
   /**
@@ -480,7 +476,6 @@ export const BookingPageService = {
         serviceIds: true,
         bookingWindowDays: true,
         bufferMinutes: true,
-        autoConfirm: true,
         welcomeMessage: true,
         replyToEmail: true,
       },
@@ -557,7 +552,7 @@ export const BookingPageService = {
       serviceIds: requested,
       bookingWindowDays: input.bookingWindowDays,
       bufferMinutes: input.bufferMinutes,
-      autoConfirm: input.autoConfirm,
+      autoConfirm: false,
       welcomeMessage: input.welcomeMessage?.trim() || null,
       replyToEmail: input.replyToEmail?.trim().toLowerCase() || null,
     };

--- a/apps/backend/src/services/public-booking.service.ts
+++ b/apps/backend/src/services/public-booking.service.ts
@@ -126,7 +126,6 @@ type ResolvedPractice = {
     serviceIds: string[];
     bookingWindowDays: number;
     bufferMinutes: number;
-    autoConfirm: boolean;
     welcomeMessage: string | null;
     replyToEmail: string | null;
   } | null;
@@ -160,7 +159,6 @@ export const resolveSlug = async (
           serviceIds: true,
           bookingWindowDays: true,
           bufferMinutes: true,
-          autoConfirm: true,
           welcomeMessage: true,
           replyToEmail: true,
         },
@@ -283,7 +281,7 @@ export const PublicBookingService = {
         practice.settings?.bookingWindowDays ?? 28,
         MAX_BOOKING_WINDOW_DAYS,
       ),
-      requiresConfirmation: !practice.settings?.autoConfirm,
+      requiresConfirmation: true,
       services: offersNothing(practice)
         ? []
         : await loadPublicServices(practice),

--- a/apps/backend/test/controllers/booking-page.controller.test.ts
+++ b/apps/backend/test/controllers/booking-page.controller.test.ts
@@ -56,7 +56,6 @@ const validBody = {
   serviceIds: ["3f6b1a2c-1111-4222-8333-444455556666"],
   bookingWindowDays: 28,
   bufferMinutes: 10,
-  autoConfirm: false,
   welcomeMessage: "Book a visit.",
   replyToEmail: "front@example.com",
 };
@@ -143,9 +142,23 @@ describe("BookingPageController", () => {
 
       expect(mockedService.saveConfig).toHaveBeenCalledWith(
         "org-1",
-        expect.objectContaining({ bookingWindowDays: 28, autoConfirm: false }),
+        expect.objectContaining({ bookingWindowDays: 28 }),
       );
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("ignores the retired auto-confirm field from legacy clients", async () => {
+      mockedService.saveConfig.mockResolvedValueOnce({});
+      const req = {
+        organisationId: "org-1",
+        params: {},
+        body: { ...validBody, autoConfirm: true },
+      } as never;
+
+      await BookingPageController.saveConfig(req, createResponse() as never);
+
+      const [, input] = mockedService.saveConfig.mock.calls[0];
+      expect(input).not.toHaveProperty("autoConfirm");
     });
 
     it("normalises omitted optional text to null", async () => {
@@ -157,7 +170,6 @@ describe("BookingPageController", () => {
           serviceIds: [],
           bookingWindowDays: 14,
           bufferMinutes: 0,
-          autoConfirm: true,
         },
       } as never;
 
@@ -177,7 +189,6 @@ describe("BookingPageController", () => {
       ["a non-uuid service id", { serviceIds: ["not-a-uuid"] }],
       ["a malformed reply-to address", { replyToEmail: "not-an-email" }],
       ["an over-long welcome message", { welcomeMessage: "x".repeat(501) }],
-      ["a missing autoConfirm flag", { autoConfirm: undefined }],
     ])("rejects %s", async (_label, override) => {
       const req = {
         organisationId: "org-1",

--- a/apps/backend/test/services/booking-page.service.test.ts
+++ b/apps/backend/test/services/booking-page.service.test.ts
@@ -329,7 +329,6 @@ describe("booking-page.service", () => {
           serviceIds: [{ not: "" }] as unknown as string[],
           bookingWindowDays: 28,
           bufferMinutes: 10,
-          autoConfirm: false,
         }),
       ).rejects.toMatchObject({ status: 400 });
       expect(pm.productItem.findMany).not.toHaveBeenCalled();
@@ -352,7 +351,6 @@ describe("booking-page.service", () => {
         serviceIds: [],
         bookingWindowDays: 28,
         bufferMinutes: 10,
-        autoConfirm: false,
         welcomeMessage: null,
         replyToEmail: null,
       });
@@ -389,10 +387,13 @@ describe("booking-page.service", () => {
         serviceIds: ["svc-1"],
         bookingWindowDays: 56,
         bufferMinutes: 30,
-        autoConfirm: true,
         welcomeMessage: "Hello",
         replyToEmail: "front@example.com",
       });
+      expect(config).not.toHaveProperty("autoConfirm");
+      const select =
+        pm.publicBookingSettings.findUnique.mock.calls[0][0].select;
+      expect(select).not.toHaveProperty("autoConfirm");
     });
 
     it("reports configured=false when no settings row exists", async () => {
@@ -419,7 +420,6 @@ describe("booking-page.service", () => {
         serviceIds: [],
         bookingWindowDays: 28,
         bufferMinutes: 10,
-        autoConfirm: false,
         welcomeMessage: null,
         replyToEmail: null,
       });
@@ -449,7 +449,6 @@ describe("booking-page.service", () => {
       serviceIds: ["svc-1"],
       bookingWindowDays: 28,
       bufferMinutes: 10,
-      autoConfirm: false,
       welcomeMessage: "  Book a visit.  ",
       replyToEmail: "  Front@Example.COM ",
     };
@@ -499,6 +498,19 @@ describe("booking-page.service", () => {
             welcomeMessage: "Book a visit.",
             replyToEmail: "front@example.com",
           }),
+        }),
+      );
+    });
+
+    it("normalises the retired auto-confirm column to false on save", async () => {
+      pm.productItem.findMany.mockResolvedValue([{ id: "svc-1" }]);
+
+      await BookingPageService.saveConfig("org-1", input);
+
+      expect(pm.publicBookingSettings.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ autoConfirm: false }),
+          update: expect.objectContaining({ autoConfirm: false }),
         }),
       );
     });

--- a/apps/backend/test/services/public-booking.service.test.ts
+++ b/apps/backend/test/services/public-booking.service.test.ts
@@ -71,7 +71,6 @@ const publishedOrg = (over: Record<string, unknown> = {}) => ({
     serviceIds: [SERVICE_ID],
     bookingWindowDays: 28,
     bufferMinutes: 10,
-    autoConfirm: false,
     welcomeMessage: "Book a visit.",
     replyToEmail: "front@example.com",
   },
@@ -230,7 +229,6 @@ describe("public-booking.service", () => {
             serviceIds: [],
             bookingWindowDays: 28,
             bufferMinutes: 10,
-            autoConfirm: false,
             welcomeMessage: null,
             replyToEmail: null,
           },
@@ -307,7 +305,6 @@ describe("public-booking.service", () => {
             serviceIds: [SERVICE_ID],
             bookingWindowDays: 9999,
             bufferMinutes: 10,
-            autoConfirm: true,
             welcomeMessage: null,
             replyToEmail: null,
           },
@@ -317,7 +314,27 @@ describe("public-booking.service", () => {
       const practice =
         await PublicBookingService.getPractice("park-veterinary");
       expect(practice.bookingWindowDays).toBe(180);
-      expect(practice.requiresConfirmation).toBe(false);
+    });
+
+    it("always reports staff confirmation and ignores the retired setting", async () => {
+      pm.organization.findUnique.mockResolvedValue(
+        publishedOrg({
+          bookingSettings: {
+            serviceIds: [SERVICE_ID],
+            bookingWindowDays: 28,
+            bufferMinutes: 10,
+            autoConfirm: true,
+            welcomeMessage: null,
+            replyToEmail: null,
+          },
+        }),
+      );
+
+      const practice =
+        await PublicBookingService.getPractice("park-veterinary");
+      expect(practice.requiresConfirmation).toBe(true);
+      const select = pm.organization.findUnique.mock.calls[0][0].select;
+      expect(select.bookingSettings.select).not.toHaveProperty("autoConfirm");
     });
   });
 
@@ -357,18 +374,9 @@ describe("public-booking.service", () => {
       );
     });
 
-    it("passes a zero buffer when the setting is unset", async () => {
+    it("passes a zero buffer when the practice has no settings row", async () => {
       pm.organization.findUnique.mockResolvedValue(
-        publishedOrg({
-          bookingSettings: {
-            serviceIds: [SERVICE_ID],
-            bookingWindowDays: 28,
-            bufferMinutes: 0,
-            autoConfirm: false,
-            welcomeMessage: null,
-            replyToEmail: null,
-          },
-        }),
+        publishedOrg({ bookingSettings: null }),
       );
 
       await PublicBookingService.getSlots(
@@ -462,7 +470,6 @@ describe("public-booking.service", () => {
             serviceIds: [],
             bookingWindowDays: 28,
             bufferMinutes: 10,
-            autoConfirm: false,
             welcomeMessage: null,
             replyToEmail: null,
           },
@@ -583,7 +590,6 @@ describe("public-booking.service", () => {
             serviceIds: [],
             bookingWindowDays: 28,
             bufferMinutes: 10,
-            autoConfirm: false,
             welcomeMessage: null,
             replyToEmail: null,
           },

--- a/apps/frontend/content/docs/apps/backend/routers/booking-page.md
+++ b/apps/frontend/content/docs/apps/backend/routers/booking-page.md
@@ -22,9 +22,11 @@ Authenticated configuration surface the PIMS (Practice Information Management Sy
 - RBAC: `withOrgPermissions, requirePermission`
 - Params: `organisationId`
 - Body: `SettingsSchema`
-- Body fields: `serviceIds`, `bookingWindowDays`, `bufferMinutes`, `autoConfirm`, `welcomeMessage`, `replyToEmail`, `publicBookingEnabled`
+- Body fields: `serviceIds`, `bookingWindowDays`, `bufferMinutes`, `welcomeMessage`, `replyToEmail`, `publicBookingEnabled`
 - Controller: `BookingPageController.saveConfig`
 - Response: `200`: keys `data`, `400`: keys `message`
+
+Public submissions always enter the staff-reviewed request queue. The configuration API does not expose an automatic-confirmation setting.
 
 ### GET /:organisationId/requests
 

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -86,7 +86,6 @@ const config = (over: Partial<Record<string, unknown>> = {}) => ({
   serviceIds: [],
   bookingWindowDays: 28,
   bufferMinutes: 10,
-  autoConfirm: false,
   welcomeMessage: null,
   replyToEmail: null,
   ...over,
@@ -250,7 +249,7 @@ describe('PublicBookingSetup', () => {
     expect(screen.getByText('What can pet parents book?')).toBeInTheDocument();
   });
 
-  it('updates availability selects and the confirmation toggle', async () => {
+  it('updates availability selects while confirmation remains fixed', async () => {
     await renderSetup();
 
     const windowSelect = screen.getByLabelText('Bookable window') as HTMLSelectElement;
@@ -261,10 +260,10 @@ describe('PublicBookingSetup', () => {
     fireEvent.change(bufferSelect, { target: { value: '30' } });
     expect(bufferSelect.value).toBe('30');
 
-    const toggle = screen.getByRole('switch', { name: 'Requests need confirmation' });
-    expect(toggle).toHaveAttribute('aria-checked', 'true');
-    fireEvent.click(toggle);
-    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByText('Requests need confirmation.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('switch', { name: 'Requests need confirmation' })
+    ).not.toBeInTheDocument();
   });
 
   it('notifies when skipping setup', async () => {
@@ -456,12 +455,11 @@ describe('PublicBookingSetup', () => {
   });
 
   describe('loading stored configuration', () => {
-    it('restores the saved window, buffer, confirmation mode and copy', async () => {
+    it('restores the saved window, buffer and copy', async () => {
       getConfigMock.mockResolvedValue(
         config({
           bookingWindowDays: 56,
           bufferMinutes: 30,
-          autoConfirm: true,
           welcomeMessage: 'Stored welcome',
           replyToEmail: 'stored@example.com',
         })
@@ -474,11 +472,6 @@ describe('PublicBookingSetup', () => {
       expect((screen.getByLabelText('Buffer between visits') as HTMLSelectElement).value).toBe(
         '30'
       );
-      expect(screen.getByRole('switch', { name: 'Requests need confirmation' })).toHaveAttribute(
-        'aria-checked',
-        'false'
-      );
-
       fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
       expect((screen.getByLabelText('Welcome message') as HTMLInputElement).value).toBe(
         'Stored welcome'
@@ -611,7 +604,6 @@ describe('PublicBookingSetup', () => {
       fireEvent.click(screen.getByRole('button', { name: /Wellness & vaccination/ }));
       fireEvent.change(screen.getByLabelText('Bookable window'), { target: { value: '14' } });
       fireEvent.change(screen.getByLabelText('Buffer between visits'), { target: { value: '0' } });
-      fireEvent.click(screen.getByRole('switch', { name: 'Requests need confirmation' }));
       fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
       fireEvent.change(screen.getByLabelText('Welcome message'), {
         target: { value: '  Come and see us  ' },
@@ -629,7 +621,6 @@ describe('PublicBookingSetup', () => {
         serviceIds: expect.not.arrayContaining(['s1']),
         bookingWindowDays: 14,
         bufferMinutes: 0,
-        autoConfirm: true,
         welcomeMessage: 'Come and see us',
         replyToEmail: 'desk@x.vet',
         // Unchanged: the practice did not touch the publish switch, so the save

--- a/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/bookingPageApiService.test.ts
@@ -31,7 +31,6 @@ const config: BookingPageConfig = {
   serviceIds: ['svc-1'],
   bookingWindowDays: 28,
   bufferMinutes: 10,
-  autoConfirm: false,
   welcomeMessage: null,
   replyToEmail: null,
 };
@@ -52,7 +51,6 @@ describe('bookingPageApi', () => {
       serviceIds: ['svc-1'],
       bookingWindowDays: 28,
       bufferMinutes: 10,
-      autoConfirm: false,
       welcomeMessage: 'Hello',
       replyToEmail: 'desk@example.com',
     };
@@ -73,7 +71,6 @@ describe('bookingPageApi', () => {
         serviceIds: [],
         bookingWindowDays: 28,
         bufferMinutes: 10,
-        autoConfirm: false,
         welcomeMessage: null,
         replyToEmail: null,
       })

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -73,7 +73,6 @@ const config = (over: Partial<BookingPageConfig> = {}): BookingPageConfig => ({
   serviceIds: [],
   bookingWindowDays: 28,
   bufferMinutes: 10,
-  autoConfirm: false,
   welcomeMessage: null,
   replyToEmail: null,
   ...over,
@@ -197,7 +196,10 @@ export const ServicesStep: Story = {
     // The selects carry the number the API stores, not the label.
     await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toHaveValue('28');
     await expect(canvas.getByRole('combobox', { name: 'Buffer between visits' })).toHaveValue('10');
-    await expect(canvas.getByRole('switch', { name: 'Requests need confirmation' })).toBeChecked();
+    await expect(canvas.getByText('Requests need confirmation.')).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('switch', { name: 'Requests need confirmation' })
+    ).not.toBeInTheDocument();
 
     // The two selects share one `grid-cols-1 sm:grid-cols-2` row: two tracks and
     // two children here, and the same grid is what drops to one column on a
@@ -213,7 +215,8 @@ export const ServicesStep: Story = {
       description: {
         story:
           'The entry pane. Every bookable service arrives already selected, which is the point of ' +
-          'the derived-selection design - the clinic opts services out rather than in.',
+          'the derived-selection design - the clinic opts services out rather than in. Booking ' +
+          'requests always require staff confirmation.',
       },
     },
   },

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -76,8 +76,6 @@ type ServicesStepProps = {
   onBookingWindowChange: (value: number) => void;
   bufferMinutes: number;
   onBufferChange: (value: number) => void;
-  needsConfirmation: boolean;
-  onToggleConfirmation: () => void;
   onSkip: () => void;
   onContinue: () => void;
 };
@@ -92,8 +90,6 @@ const BookingServicesStep = ({
   onBookingWindowChange,
   bufferMinutes,
   onBufferChange,
-  needsConfirmation,
-  onToggleConfirmation,
   onSkip,
   onContinue,
 }: ServicesStepProps) => (
@@ -197,16 +193,11 @@ const BookingServicesStep = ({
         </label>
       </div>
 
-      <div className="flex items-center justify-between gap-3 px-3.5 py-3 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)]">
+      <div className="px-3.5 py-3 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)]">
         <span className="text-[12.5px] text-[var(--ink-body)]">
           <strong className="text-[var(--ink)]">Requests need confirmation.</strong> New bookings
           arrive as requests, not fixed slots.
         </span>
-        <Switch
-          checked={needsConfirmation}
-          label="Requests need confirmation"
-          onChange={onToggleConfirmation}
-        />
       </div>
     </div>
     <div className="flex items-center justify-between gap-3 px-7! py-4! border-t border-[var(--hairline)]">
@@ -534,7 +525,6 @@ const PublicBookingSetup = () => {
   const [selectionOverride, setSelectionOverride] = useState<Set<string> | null>(null);
   const [bookingWindowDays, setBookingWindowDays] = useState(WINDOW_OPTIONS[1].days);
   const [bufferMinutes, setBufferMinutes] = useState(BUFFER_OPTIONS[1].minutes);
-  const [needsConfirmation, setNeedsConfirmation] = useState(true);
   const [welcome, setWelcome] = useState(`Book a visit for your companion at ${orgName}.`);
   const [replyTo, setReplyTo] = useState('');
   const [copied, setCopied] = useState(false);
@@ -595,7 +585,6 @@ const PublicBookingSetup = () => {
         setConfig(loaded);
         setBookingWindowDays(loaded.bookingWindowDays);
         setBufferMinutes(loaded.bufferMinutes);
-        setNeedsConfirmation(!loaded.autoConfirm);
         setPublishOverride(null);
         if (loaded.welcomeMessage) setWelcome(loaded.welcomeMessage);
         if (loaded.replyToEmail) setReplyTo(loaded.replyToEmail);
@@ -650,7 +639,6 @@ const PublicBookingSetup = () => {
         serviceIds: [...selected].filter((id) => allBookableIds.has(id)),
         bookingWindowDays,
         bufferMinutes,
-        autoConfirm: !needsConfirmation,
         welcomeMessage: welcome.trim() || null,
         replyToEmail: replyTo.trim() || null,
         publicBookingEnabled: publish,
@@ -699,8 +687,6 @@ const PublicBookingSetup = () => {
             onBookingWindowChange={setBookingWindowDays}
             bufferMinutes={bufferMinutes}
             onBufferChange={setBufferMinutes}
-            needsConfirmation={needsConfirmation}
-            onToggleConfirmation={() => setNeedsConfirmation((v) => !v)}
             onSkip={handleSkip}
             onContinue={() => setStep(2)}
           />

--- a/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/bookingPageApiService.ts
@@ -24,7 +24,6 @@ export type BookingPageConfig = {
   serviceIds: string[];
   bookingWindowDays: number;
   bufferMinutes: number;
-  autoConfirm: boolean;
   welcomeMessage: string | null;
   replyToEmail: string | null;
 };
@@ -33,7 +32,6 @@ export type BookingPageSettingsPayload = {
   serviceIds: string[];
   bookingWindowDays: number;
   bufferMinutes: number;
-  autoConfirm: boolean;
   welcomeMessage: string | null;
   replyToEmail: string | null;
   /**

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1168,9 +1168,8 @@ model PublicBookingSettings {
   bookingWindowDays Int      @default(28)
   /// Padding added after a publicly booked slot.
   bufferMinutes     Int      @default(10)
-  /// False - the default - means a public request lands as REQUESTED for a human
-  /// to accept. True writes to the calendar directly, and is only ever honoured
-  /// after the requester has confirmed their email address.
+  /// Retained for schema compatibility. Public submissions always land as
+  /// requests for staff review, and application writes normalize this to false.
   autoConfirm       Boolean  @default(false)
   welcomeMessage    String?
   replyToEmail      String?


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The public-booking admin flow exposes an `autoConfirm` setting even though submissions always enter the request workflow. This creates an inert control and a response contract that can falsely imply direct calendar booking.

## What is the new behavior?

- Remove `autoConfirm` from the admin API and frontend configuration contract.
- Replace the toggle with fixed copy explaining that staff confirmation is required.
- Always report `requiresConfirmation: true` from the public projection.
- Normalize the retained compatibility column to `false` whenever settings are saved.
- Add regression coverage and update the API/schema documentation.

Validation:
- Backend focused suite: 144 tests, 100% statements/branches/functions/lines.
- Frontend focused suite: 49 tests, 100% statements/branches/functions/lines.
- All four production mutations are killed by the regressions.
- Workspace pre-push lint and type-check gates pass.
- Backend dependency build and frontend Storybook production build pass.
- Playwright visual QA confirms the fixed confirmation copy with no toggle or console errors.

## Related Issue(s)

Fixes #2550
