### PR TITLE
fix(backend): make tax previews currency-aware

### DIFF
--- a/apps/backend/src/services/finance/tax.ts
+++ b/apps/backend/src/services/finance/tax.ts
@@ -4,6 +4,10 @@ import {
   TaxBehavior as PrismaTaxBehavior,
   TaxProvider as PrismaTaxProvider,
 } from "@prisma/client";
+import {
+  fromStripeMinorUnits,
+  toStripeMinorUnits,
+} from "src/utils/stripe-minor-units";
 
 import type { InvoiceDiscountInput, InvoicePricingBreakdown } from "./pricing";
 import { roundMoney } from "./pricing";
@@ -154,32 +158,38 @@ const buildFallbackInvoiceTaxSnapshot = (
 const allocateInvoiceDiscountAcrossLines = (
   netAmounts: number[],
   invoiceDiscountTotal: number,
+  currency: string,
 ): number[] => {
   const lineBases = netAmounts.map((amount) => Math.max(0, roundMoney(amount)));
-  const totalBaseCents = lineBases.reduce(
-    (sum, amount) => sum + Math.round(amount * 100),
+  const totalBaseMinorUnits = lineBases.reduce(
+    (sum, amount) => sum + toStripeMinorUnits(amount, currency),
     0,
   );
-  const totalDiscountCents = Math.min(
-    Math.round(roundMoney(invoiceDiscountTotal) * 100),
-    totalBaseCents,
+  const totalDiscountMinorUnits = Math.min(
+    toStripeMinorUnits(roundMoney(invoiceDiscountTotal), currency),
+    totalBaseMinorUnits,
   );
 
-  if (!totalBaseCents || !totalDiscountCents) {
+  if (!totalBaseMinorUnits || !totalDiscountMinorUnits) {
     return lineBases.map(() => 0);
   }
 
   const allocations = lineBases.map((amount) => {
-    const cents = Math.round(amount * 100);
-    return Math.floor((cents * totalDiscountCents) / totalBaseCents);
+    const minorUnits = toStripeMinorUnits(amount, currency);
+    return Math.floor(
+      (minorUnits * totalDiscountMinorUnits) / totalBaseMinorUnits,
+    );
   });
 
-  const allocatedCents = allocations.reduce((sum, amount) => sum + amount, 0);
-  let remainder = totalDiscountCents - allocatedCents;
+  const allocatedMinorUnits = allocations.reduce(
+    (sum, amount) => sum + amount,
+    0,
+  );
+  let remainder = totalDiscountMinorUnits - allocatedMinorUnits;
 
   for (let index = 0; remainder > 0 && index < allocations.length; index += 1) {
-    const lineCents = Math.round(lineBases[index] * 100);
-    if (allocations[index] >= lineCents) {
+    const lineMinorUnits = toStripeMinorUnits(lineBases[index], currency);
+    if (allocations[index] >= lineMinorUnits) {
       continue;
     }
     allocations[index] += 1;
@@ -197,7 +207,7 @@ const allocateInvoiceDiscountAcrossLines = (
     }
   }
 
-  return allocations.map((amount) => amount / 100);
+  return allocations.map((amount) => fromStripeMinorUnits(amount, currency));
 };
 
 const buildAutomaticTaxLineItems = (
@@ -208,6 +218,7 @@ const buildAutomaticTaxLineItems = (
   const invoiceDiscountAllocations = allocateInvoiceDiscountAcrossLines(
     netAmounts,
     pricing.invoiceDiscountTotal,
+    input.currency,
   );
 
   return pricing.lines.map((line, index) => {
@@ -216,7 +227,7 @@ const buildAutomaticTaxLineItems = (
     );
 
     return {
-      amount: Math.round(discountedAmount * 100),
+      amount: toStripeMinorUnits(discountedAmount, input.currency),
       description: input.lineItems[index]?.description ?? `Line ${index + 1}`,
       currency: input.currency,
       tax_behavior:
@@ -298,10 +309,17 @@ const buildAutomaticTaxSnapshot = async (
 
   const totalTaxes = preview.total_taxes ?? [];
   const taxAmount = roundMoney(
-    totalTaxes.reduce((sum, tax) => sum + tax.amount, 0) / 100,
+    fromStripeMinorUnits(
+      totalTaxes.reduce((sum, tax) => sum + tax.amount, 0),
+      input.currency,
+    ),
   );
   const taxableSubtotal = roundMoney(
-    (preview.total_excluding_tax ?? pricing.totalAmount * 100) / 100,
+    fromStripeMinorUnits(
+      preview.total_excluding_tax ??
+        toStripeMinorUnits(pricing.totalAmount, input.currency),
+      input.currency,
+    ),
   );
   const jurisdictionCountry = input.customerAddress?.country ?? null;
   const jurisdictionState = input.customerAddress?.state ?? null;

--- a/apps/backend/src/utils/stripe-minor-units.ts
+++ b/apps/backend/src/utils/stripe-minor-units.ts
@@ -56,3 +56,12 @@ export const toStripeMinorUnits = (amount: number, currency: string): number =>
   ZERO_DECIMAL_CURRENCIES.has(currency.trim().toLowerCase())
     ? Math.round(amount)
     : Math.round(amount * 100);
+
+/** Convert an amount returned by Stripe to its major currency unit. */
+export const fromStripeMinorUnits = (
+  amount: number,
+  currency: string,
+): number =>
+  ZERO_DECIMAL_CURRENCIES.has(currency.trim().toLowerCase())
+    ? amount
+    : amount / 100;

--- a/apps/backend/test/services/finance.tax.test.ts
+++ b/apps/backend/test/services/finance.tax.test.ts
@@ -324,6 +324,77 @@ describe("finance tax helpers", () => {
     expect(snapshot.providerReferenceId).toBe("upcoming_in_2");
   });
 
+  it("uses the currency minor unit throughout a zero-decimal tax preview", async () => {
+    const createPreview = jest.fn().mockResolvedValue({
+      id: "upcoming_in_jpy",
+      total_excluding_tax: 1997,
+      total_taxes: [{ amount: 300 }],
+      automatic_tax: { enabled: true },
+    });
+    __setFinanceTaxStripeClientForTests({
+      invoices: { createPreview } as any,
+    } as any);
+
+    const snapshot = await previewInvoiceTaxSnapshot(undefined, {
+      provider: DEFAULT_TAX_PROVIDER,
+      taxBehavior: "EXCLUSIVE",
+      taxRatePercent: 15,
+      currency: "jpy",
+      invoiceDiscount: { type: "FIXED_AMOUNT", value: 3 },
+      pricing: {
+        subtotal: 2000,
+        lineDiscountTotal: 0,
+        taxableSubtotal: 1997,
+        taxTotal: 0,
+        invoiceDiscountTotal: 3,
+        totalAmount: 1997,
+        lines: [
+          {
+            grossAmount: 1000,
+            lineDiscountAmount: 0,
+            netAmount: 1000,
+            taxableAmount: 1000,
+            taxAmount: 0,
+            totalAmount: 1000,
+          },
+          {
+            grossAmount: 1000,
+            lineDiscountAmount: 0,
+            netAmount: 1000,
+            taxableAmount: 1000,
+            taxAmount: 0,
+            totalAmount: 1000,
+          },
+        ],
+      },
+      lineItems: [
+        { description: "Consultation", quantity: 1, unitPrice: 1000 },
+        { description: "Follow-up", quantity: 1, unitPrice: 1000 },
+      ],
+      customerAddress: {
+        line1: "1 Main St",
+        city: "Tokyo",
+        postal_code: "100-0001",
+        country: "JP",
+      },
+    });
+
+    expect(createPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: "jpy",
+        invoice_items: [
+          expect.objectContaining({ amount: 998 }),
+          expect.objectContaining({ amount: 999 }),
+        ],
+      }),
+    );
+    expect(snapshot.taxableSubtotal).toBe(1997);
+    expect(snapshot.taxAmount).toBe(300);
+    expect(snapshot.taxBreakdown).toEqual(
+      expect.objectContaining({ totalAmount: 2297 }),
+    );
+  });
+
   it("throws when the Stripe secret key is missing for automatic tax previews", async () => {
     await expect(
       previewInvoiceTaxSnapshot(undefined, {

--- a/apps/backend/test/utils/stripe-minor-units.test.ts
+++ b/apps/backend/test/utils/stripe-minor-units.test.ts
@@ -1,4 +1,7 @@
-import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
+import {
+  fromStripeMinorUnits,
+  toStripeMinorUnits,
+} from "src/utils/stripe-minor-units";
 
 describe("toStripeMinorUnits", () => {
   it("scales a two-decimal currency by a hundred", () => {
@@ -54,5 +57,15 @@ describe("toStripeMinorUnits", () => {
 
   it("treats an unknown currency as two-decimal", () => {
     expect(toStripeMinorUnits(1, "zzz")).toBe(100);
+  });
+});
+
+describe("fromStripeMinorUnits", () => {
+  it("converts a two-decimal Stripe amount to major units", () => {
+    expect(fromStripeMinorUnits(1234, "usd")).toBe(12.34);
+  });
+
+  it("keeps a zero-decimal Stripe amount unscaled", () => {
+    expect(fromStripeMinorUnits(1000, " JPY ")).toBe(1000);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Stripe automatic-tax previews assume every currency has two decimal places. That submits zero-decimal amounts at 100 times their value, allocates invoice discounts below the currency's smallest unit, and scales Stripe preview totals down incorrectly.

## What is the new behavior?

Tax previews now use the shared Stripe minor-unit converter for line amounts and discount allocation, and the matching inverse conversion for preview totals. Focused tests cover two-decimal behavior and an end-to-end zero-decimal preview with a multi-line discount.

## Related Issue(s)

Fixes #2754
